### PR TITLE
Fixed generated angular app name when the baseName contains dashes.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -2,7 +2,8 @@
 var util = require('util'),
     path = require('path'),
     yeoman = require('yeoman-generator'),
-    chalk = require('chalk');
+    chalk = require('chalk'),
+    _s = require('underscore.string');
 
 var JhipsterGenerator = module.exports = function JhipsterGenerator(args, options, config) {
   yeoman.generators.Base.apply(this, arguments);
@@ -227,6 +228,7 @@ JhipsterGenerator.prototype.app = function app() {
   this.copy(webappDir + 'htaccess.txt', webappDir + '.htaccess');
 
   // Angular JS views
+  this.angularAppName = _s.camelize(this.baseName) + 'App';
   this.copy(webappDir + '/views/main.html', webappDir + '/views/main.html');
   this.copy(webappDir + '/views/login.html', webappDir + '/views/login.html');
   this.copy(webappDir + '/views/logs.html', webappDir + '/views/logs.html');

--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -18,7 +18,7 @@
         <script src="bower_components/modernizr/modernizr.js"></script>
         <!-- endbuild -->
     </head>
-    <body ng-app="<%= baseName %>App">
+    <body ng-app="<%= angularAppName %>">
         <!--[if lt IE 10]>
             <p class="browsehappy">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->

--- a/app/templates/src/main/webapp/scripts/_app.js
+++ b/app/templates/src/main/webapp/scripts/_app.js
@@ -2,9 +2,9 @@
 
 /* App Module */
 
-var <%= baseName %>App = angular.module('<%= baseName %>App', ['ngResource', 'ngRoute']);
+var <%= angularAppName %> = angular.module('<%= angularAppName %>', ['ngResource', 'ngRoute']);
 
-<%= baseName %>App
+<%= angularAppName %>
     .config(function ($routeProvider) {
         $routeProvider
             .when('/login', {

--- a/app/templates/src/main/webapp/scripts/_controllers.js
+++ b/app/templates/src/main/webapp/scripts/_controllers.js
@@ -2,11 +2,11 @@
 
 /* Controllers */
 
-<%= baseName %>App.controller('MainController', function MainController($scope) {
+<%= angularAppName %>.controller('MainController', function MainController($scope) {
 
 });
 
-<%= baseName %>App.controller('MenuController', function MenuController($rootScope, $scope, $location, Account, AuthenticationSharedService) {
+<%= angularAppName %>.controller('MenuController', function MenuController($rootScope, $scope, $location, Account, AuthenticationSharedService) {
     $scope.init = function () {
         $rootScope.account = Account.get({}, function () {
             $rootScope.authenticated = true;
@@ -23,7 +23,7 @@
     $scope.init();
 });
 
-<%= baseName %>App.controller('LoginController', function LoginController($scope, $location, AuthenticationSharedService) {
+<%= angularAppName %>.controller('LoginController', function LoginController($scope, $location, AuthenticationSharedService) {
     $scope.rememberMe = true;
     $scope.login = function () {
         AuthenticationSharedService.login({
@@ -37,7 +37,7 @@
     };
 });
 
-<%= baseName %>App.controller('SettingsController', function SettingsController($scope, Account) {
+<%= angularAppName %>.controller('SettingsController', function SettingsController($scope, Account) {
     $scope.success = null;
     $scope.error = null;
     $scope.init = function () {
@@ -57,7 +57,7 @@
     };
 });
 
-<%= baseName %>App.controller('PasswordController', function PasswordController($scope, Password) {
+<%= angularAppName %>.controller('PasswordController', function PasswordController($scope, Password) {
     $scope.success = null;
     $scope.error = null;
     $scope.doNotMatch = null;
@@ -79,7 +79,7 @@
     };
 });
 
-<%= baseName %>App.controller('SessionsController', function SessionsController($scope, Sessions) {
+<%= angularAppName %>.controller('SessionsController', function SessionsController($scope, Sessions) {
     $scope.success = null;
     $scope.error = null;
     $scope.sessions = Sessions.get();
@@ -97,13 +97,13 @@
     };
 });
 
-<%= baseName %>App.controller('MetricsController', function MetricsController($scope, $timeout, Metrics) {
+<%= angularAppName %>.controller('MetricsController', function MetricsController($scope, $timeout, Metrics) {
     $scope.init = function () {
         $scope.metrics = Metrics.get();
     };
 });
 
-<%= baseName %>App.controller('LogoutController', function LogoutController($scope, $http, $location, AuthenticationSharedService) {
+<%= angularAppName %>.controller('LogoutController', function LogoutController($scope, $http, $location, AuthenticationSharedService) {
     $http.get('/app/logout')
         .success(function (data, status, headers, config) {
             AuthenticationSharedService.prepForBroadcast("logout");
@@ -114,7 +114,7 @@
         });
 });
 
-<%= baseName %>App.controller('LogsController', function LogsController($scope, LogsService) {
+<%= angularAppName %>.controller('LogsController', function LogsController($scope, LogsService) {
     $scope.findAll = function () {
         LogsService.findAll().
             success(function (loggers) {

--- a/app/templates/src/main/webapp/scripts/_services.js
+++ b/app/templates/src/main/webapp/scripts/_services.js
@@ -2,30 +2,30 @@
 
 /* Services */
 
-<%= baseName %>App.factory('Account', function($resource){
+<%= angularAppName %>.factory('Account', function($resource){
         return $resource('app/rest/account', {}, {
         });
     });
 
-<%= baseName %>App.factory('Password', function($resource){
+<%= angularAppName %>.factory('Password', function($resource){
     return $resource('app/rest/account/change_password', {}, {
     });
 });
 
-<%= baseName %>App.factory('Sessions', function($resource){
+<%= angularAppName %>.factory('Sessions', function($resource){
     return $resource('app/rest/account/sessions/:series', {}, {
         'get': { method: 'GET', isArray: true}
     });
 });
 
-<%= baseName %>App.factory('Metrics', function($resource){
+<%= angularAppName %>.factory('Metrics', function($resource){
     return $resource('/metrics/metrics', {}, {
         'get': { method: 'GET'}
     });
 });
 
 
-<%= baseName %>App.factory('AuthenticationSharedService', function($rootScope, $http) {
+<%= angularAppName %>.factory('AuthenticationSharedService', function($rootScope, $http) {
     return {
         message: '',
         prepForBroadcast: function(msg) {
@@ -57,7 +57,7 @@
     };
 });
 
-<%= baseName %>App.factory('LogsService', function($http) {
+<%= angularAppName %>.factory('LogsService', function($http) {
     return {
         findAll: function () {
             return $http.get('app/rest/logs');

--- a/package.json
+++ b/package.json
@@ -29,7 +29,8 @@
   },
   "dependencies": {
     "yeoman-generator": "~0.13.1",
-    "chalk": "~0.2.1"
+    "chalk": "~0.2.1",
+    "underscore.string": "~2.3.3"
   },
   "devDependencies": {
     "mocha": "~1.12.0"


### PR DESCRIPTION
The generated angular app name was an illegal JavaScript variable name when the project name contained dashes and the app could therefore not be started. I just 'camelized' the project name and appended App to it and used this as angularAppName in the templates.
