### PR TITLE
use packageName instead of com.mycompany for componentScan in configuration

### DIFF
--- a/app/templates/src/main/java/package/conf/_DatabaseConfiguration.java
+++ b/app/templates/src/main/java/package/conf/_DatabaseConfiguration.java
@@ -74,7 +74,7 @@ public class DatabaseConfiguration {
 
         lcemfb.setJpaProperties(jpaProperties);
 
-        lcemfb.setPackagesToScan("com.mycompany.myapp.domain");
+        lcemfb.setPackagesToScan("<%=packageName%>.domain");
         lcemfb.afterPropertiesSet();
         return lcemfb.getObject();
     }


### PR DESCRIPTION
In th database configuration file, the default example package was still used.
