### PR TITLE
Bootstrap Node/npm/grunt

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -5,6 +5,7 @@
   "dependencies": {},
   "devDependencies": {
     "grunt": "~0.4.2",
+    "grunt-cli": "~0.1.11",
     "grunt-autoprefixer": "~0.4.1",
     "grunt-bower-install": "~0.7.0",
     "grunt-contrib-copy": "~0.4.1",

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -111,18 +111,30 @@
             <build>
                 <plugins>
                     <plugin>
-                        <groupId>com.github.trecloux</groupId>
-                        <artifactId>yeoman-maven-plugin</artifactId>
-                        <version>0.1</version>
-                        <configuration>
-                            <yeomanProjectDirectory><%= _.unescape('\$\{project.basedir}')%></yeomanProjectDirectory>
-                        </configuration>
+                        <groupId>com.github.eirslett</groupId>
+                        <artifactId>frontend-maven-plugin</artifactId>
+                        <version>0.0.9</version>
                         <executions>
                             <execution>
-                                <id>run-grunt</id>
-                                <phase>generate-resources</phase>
+                                <id>install node and npm</id>
                                 <goals>
-                                    <goal>build</goal>
+                                    <goal>install-node-and-npm</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v0.10.22</nodeVersion>
+                                    <npmVersion>1.3.14</npmVersion>
+                                </configuration>
+                            </execution>
+                            <execution>
+                                <id>npm install</id>
+                                <goals>
+                                    <goal>npm</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>grunt build</id>
+                                <goals>
+                                    <goal>grunt</goal>
                                 </goals>
                             </execution>
                         </executions>

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,4 +1,5 @@
 target
+node
 node_modules
 .idea
 *.iml


### PR DESCRIPTION
Would you accept a pull request that uses [frontend-maven-plugin](https://github.com/eirslett/frontend-maven-plugin) instead of yeoman-maven-plugin, so that Node and npm doesn't have to be installed globally?
