### PR TITLE
Updated the ngmin grunt task to run on the concated js files

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -312,9 +312,9 @@ module.exports = function (grunt) {
       dist: {
         files: [{
           expand: true,
-          cwd: '<%%= yeoman.dist %>/scripts',
+          cwd: '.tmp/concat/scripts',
           src: '*.js',
-          dest: '<%%= yeoman.dist %>/scripts'
+          dest: '.tmp/concat/scripts'
         }]
       }
     },


### PR DESCRIPTION
To my understanding, ngmin isn't doing any changes in the code. The task is supposed to keep dependency injection in Angular from breaking when minifying the code. 

In the sample generated project, the array syntax is used, specifying every dependency as a string so it won't be minified. Since this syntax is used everywhere in the sample project, ngmin doesn't need to do anything. But for projects using the shorter syntax, ngmin is needed.

_Original in the generated project_

``` JavaScript
jhipsterApp.controller('LanguageController', ['$scope', '$translate',
    function ($scope, $translate) {
        $scope.changeLanguage = function (languageKey) {
            $translate.uses(languageKey);
        };
    }]);
```

This short syntax below works before minifying, but breaks after. Ngmin is supposed to turn code like this into the one above:

``` JavaScript
jhipsterApp.controller('LanguageController', 
    function ($scope, $translate) {
        $scope.changeLanguage = function (languageKey) {
            $translate.uses(languageKey);
        };
    });
```

Minifying the second example, gives this as the result:

``` JavaScript
jhipsterApp.controller("LanguageController",function(a,b){a.changeLanguage=function(a){b.uses(a)}})
```

Which of course makes it hard for Angular to wire in dependencies, so it doesn't work.

Running ngmin normally shows a list of the files it has fixed, for instance:

```
Running "ngmin:dist" (ngmin) task
ngminifying .tmp/concat/js/main.js
```

But running grunt in the generated project gives

```
Running "ngmin:dist" (ngmin) task
ngminifying
```

e.g. no files touched.

I think updating the Gruntfile.js to run ngmin on the concated files would solve the problem. Now it tries to do it in the dist folder, but there is no js files there at the time of running. Not until after uglify has run, and then it's too late.
