### PR TITLE
Moved the prod profile's tomcat7-maven-plugin's configuration section.

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -138,6 +138,10 @@
                         <groupId>org.apache.tomcat.maven</groupId>
                         <artifactId>tomcat7-maven-plugin</artifactId>
                         <version>2.1</version>
+                        <configuration>
+                           <path>/</path>
+                           <protocol>org.apache.coyote.http11.Http11NioProtocol</protocol>
+                        </configuration>
                         <executions>
                             <execution>
                                 <id>tomcat-run</id>
@@ -145,10 +149,6 @@
                                     <goal>exec-war-only</goal>
                                 </goals>
                                 <phase>package</phase>
-                                <configuration>
-                                    <path>/</path>
-                                    <protocol>org.apache.coyote.http11.Http11NioProtocol</protocol>
-                                </configuration>
                             </execution>
                         </executions>
                     </plugin>


### PR DESCRIPTION
New to Git/GitHub; hope this is the right way to do things...

Moved the prod profile's tomcat7-maven-plugin's configuration section out of the executions section and into the plugin section. IntelliJ IDEA was indicating that the pom.xml wasn't matching up with the maven pom schema.
