### PR TITLE
spring-milestones added as pluginRepository

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -143,6 +143,11 @@
             <url>http://repo.spring.io/libs-snapshot</url>
             <snapshots><enabled>true</enabled></snapshots>
         </pluginRepository>
+        <pluginRepository>
+            <id>spring-milestones</id>
+            <url>http://repo.spring.io/milestone</url>
+            <snapshots><enabled>true</enabled></snapshots>
+        </pluginRepository>
     </pluginRepositories>
 
     <prerequisites>


### PR DESCRIPTION
To get the spring-boot-maven-plugin in version 1.0.0.RC1 from a repository the milestone-repository should be used.
