### PR TITLE
Issue #114 - sessionId is lost with Atmosphere : Add SessionSupport list...

### DIFF
--- a/app/templates/src/main/java/package/config/_WebConfigurer.java
+++ b/app/templates/src/main/java/package/config/_WebConfigurer.java
@@ -237,6 +237,7 @@ public class WebConfigurer implements ServletContextInitializer {
         atmosphereServlet.setInitParameter("org.atmosphere.cpr.broadcaster.shareableThreadPool", "true");
         atmosphereServlet.setInitParameter("org.atmosphere.cpr.broadcaster.maxProcessingThreads", "10");
         atmosphereServlet.setInitParameter("org.atmosphere.cpr.broadcaster.maxAsyncWriteThreads", "10");
+        servletContext.addListener(new org.atmosphere.cpr.SessionSupport());
 
         atmosphereServlet.addMapping("/websocket/*");
         atmosphereServlet.setLoadOnStartup(3);


### PR DESCRIPTION
Add SessionSupport listener manually instead of using the init parameter (advocated by official doc)

Now sessionId is well tracked with the websockets.
