### PR TITLE
added git ignore for bower fetched data

### DIFF
--- a/app/gitignore
+++ b/app/gitignore
@@ -9,3 +9,4 @@ node_modules
 .merge_file*
 .DS_Store
 src/main/webapp/dist
+src/main/webapp/bower_components


### PR DESCRIPTION
I might be missing something but here we go : 

I noticed that in the example project there is bower_components folder with the frontend dependency data.
Everything in this folder is "dead" code since it should be replaced if we change the version of library in bower.json.
In my opinion this should be git ignored since it is not really project code but a library code. 
