### PR TITLE
Use @Bean for AsyncExecutor

### DIFF
--- a/app/templates/src/main/java/package/config/_AsyncConfiguration.java
+++ b/app/templates/src/main/java/package/config/_AsyncConfiguration.java
@@ -4,6 +4,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.bind.RelaxedPropertyResolver;
 import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
@@ -28,6 +29,7 @@ public class AsyncConfiguration implements AsyncConfigurer, EnvironmentAware {
     }
 
     @Override
+    @Bean
     public Executor getAsyncExecutor() {
         log.debug("Creating Async Task Executor");
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
@@ -35,7 +37,6 @@ public class AsyncConfiguration implements AsyncConfigurer, EnvironmentAware {
         executor.setMaxPoolSize(propertyResolver.getProperty("corePoolSize", Integer.class, 50));
         executor.setQueueCapacity(propertyResolver.getProperty("corePoolSize", Integer.class, 10000));
         executor.setThreadNamePrefix("<%= _.slugify(baseName) %>-Executor-");
-        executor.initialize();
         return executor;
     }
 }


### PR DESCRIPTION
With `@Bean` initialize and destroy are automatically called
