### PR TITLE
Fix error in angularJS app when application name has a dot in it

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -351,7 +351,7 @@ JhipsterGenerator.prototype.app = function app() {
     this.template(webappDir + '/i18n/_de.json', webappDir + 'i18n/de.json');
 
     // Angular JS views
-    this.angularAppName = _s.camelize(_s.slugify(_s.humanize(this.baseName))) + 'App';
+    this.angularAppName = _s.camelize(_s.slugify(this.baseName)) + 'App';
     this.copy(webappDir + '/views/audits.html', webappDir + 'views/audits.html');
     this.copy(webappDir + '/views/error.html', webappDir + 'views/error.html');
     this.copy(webappDir + '/views/main.html', webappDir + 'views/main.html');


### PR DESCRIPTION
- use slugify method to remove the unnecessary dot
  To reproduce, create an app and choose this name: "foo.bar" and run it.
