### PR TITLE
Fix error when password was put in an object

### DIFF
--- a/app/gitignore
+++ b/app/gitignore
@@ -7,4 +7,5 @@ node_modules
 .project
 .settings
 .merge_file*
+.DS_Store
 src/main/webapp/dist


### PR DESCRIPTION
If the ng-model of the password was in an object (ng-model="user.password"), the scope[attr.password] didn't work.
And since $watch return the value of the watched object, it's much cleaner to use it.
