### PR TITLE
Use liquibase-slf4j to redirect Liquibase logs to Slf4j

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -110,6 +110,7 @@
         <jhipsterloaded.version>0.3</jhipsterloaded.version><% if (websocket == 'atmosphere') { %>
         <atmosphere-spring.version>2.1.0</atmosphere-spring.version><% } %><% if (devDatabaseType == 'postgresql' || prodDatabaseType == 'postgresql') { %>
         <postgresql.version>9.3-1100-jdbc41</postgresql.version><% } %>
+        <liquibase-slf4j.version>1.2.1</liquibase-slf4j.version>
     </properties>
 
     <repositories>
@@ -445,6 +446,11 @@
             <artifactId>assertj-core</artifactId>
             <version><%= _.unescape('\${assertj-core.version}')%></version>
             <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.mattbertolini</groupId>
+            <artifactId>liquibase-slf4j</artifactId>
+            <version><%= _.unescape('\${liquibase-slf4j.version}')%></version>
         </dependency>
     </dependencies>
     <build>

--- a/app/templates/src/main/resources/_logback.xml
+++ b/app/templates/src/main/resources/_logback.xml
@@ -24,6 +24,7 @@
     <logger name="org.springframework.security" level="WARN"/>
     <logger name="org.springframework.cache" level="WARN"/>
     <logger name="org.thymeleaf" level="WARN"/>
+    <logger name="liquibase" level="warn"/>
 
     <root level="<%= _.unescape('\$\{logback.loglevel}')%>">
         <appender-ref ref="CONSOLE"/>


### PR DESCRIPTION
So all logging are consitent and we can control liquibase logging level via logback config
