### PR TITLE
Propagate level changes made to a logback logger into the equivalent logger in j.u.l.

### DIFF
--- a/app/templates/src/main/resources/_logback.xml
+++ b/app/templates/src/main/resources/_logback.xml
@@ -25,6 +25,10 @@
     <logger name="org.springframework.cache" level="WARN"/>
     <logger name="org.thymeleaf" level="WARN"/>
 
+    <contextListener class="ch.qos.logback.classic.jul.LevelChangePropagator">
+        <resetJUL>true</resetJUL>
+    </contextListener>
+
     <root level="<%= _.unescape('\$\{logback.loglevel}')%>">
         <appender-ref ref="CONSOLE"/>
     </root>


### PR DESCRIPTION
Without this, logs made to java.util.log do not appear in logback config
