### PR TITLE
Use pointer cursor when hovering top-level menu items

### DIFF
--- a/app/templates/src/main/scss/main.scss
+++ b/app/templates/src/main/scss/main.scss
@@ -52,6 +52,11 @@ body {
   background-repeat: no-repeat;
 }
 
+/* make sure browsers use the pointer cursor for anchors, even with no href */
+a:hover {
+  cursor: pointer;
+}
+
 
 /* start Password strength bar style */
 ul#strength {


### PR DESCRIPTION
When hovering some of the top-level menu items, the mouse cursor doesn't change to a pointer, as the anchor tag for them doesn't have the `href` attribute. This CSS tweak ensures that a pointer cursor is always used regardless of the existence of the `href` attribute on the anchor.
