### PR TITLE
Validation of application base name and package name

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -40,7 +40,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
             name: 'baseName',
             validate: function(input) {
                 if((input.indexOf('<')<0) && (input.indexOf('>')<0)) return true;
-                return 'Your application name contains either <, > or both.'
+                return 'Your application name contains either <, > or both.';
             },
             message: '(1/9) What is the base name of your application?',
             default: 'jhipster'
@@ -50,7 +50,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
             name: 'packageName',
             validate: function(input) {
                 if(/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(input)) return true;
-                return 'The package name you have provided is not a valid Java package name.'
+                return 'The package name you have provided is not a valid Java package name.';
             },
             message: '(2/9) What is your default Java package name?',
             default: 'com.mycompany.myapp'


### PR DESCRIPTION
The input in the application base name and the application package name is not validated. This can be helpful, if people think dashes or other special characters are allowed in Java package names.
Also with the validation I added, you cannot include < or > in the application name, so no XML errors can be created in the pom.xml
