### PR TITLE
Fix hardcoded package import of Constans class

### DIFF
--- a/app/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/app/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -1,6 +1,6 @@
 package <%=packageName%>.aop.logging;
 
-import com.mycompany.myapp.config.Constants;
+import <%=packageName%>.config.Constants;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.AfterThrowing;


### PR DESCRIPTION
Was originally "import com.mycompany.myapp.config.Constants;"
