### PR TITLE
Move colon in AuthenticationSharedService sign.

### DIFF
--- a/app/templates/src/main/webapp/scripts/_services.js
+++ b/app/templates/src/main/webapp/scripts/_services.js
@@ -103,7 +103,7 @@
         user: 'ROLE_USER'
     });
 
-<%= angularAppName %>.factory('AuthenticationSharedService', ['$rootScope', '$http', '$cookieStore', 'authService', 'Session', 'Account'<% if (authenticationType == 'token') { %>, 'Base64Service', <% } %>
+<%= angularAppName %>.factory('AuthenticationSharedService', ['$rootScope', '$http', '$cookieStore', 'authService', 'Session', 'Account',<% if (authenticationType == 'token') { %> 'Base64Service', <% } %>
     function ($rootScope, $http, $cookieStore, authService, Session, Account<% if (authenticationType == 'token') { %>, Base64Service<% } %>) {
         return {
             login: function (param) {<% if (authenticationType == 'cookie') { %>


### PR DESCRIPTION
Move colon after 'Account' prior to authenticationType check to avoid syntax error if no token auth. is used. Otherwise it's "no worky" ;-)
