### PR TITLE
Use bootstrap's navbar instead of custom nav

### DIFF
--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -33,95 +33,95 @@
                   <a class="navbar-brand" href="#"><span translate="global.title"><%= baseName %></span></a>
                 </div>
                 <div class="collapse navbar-collapse" id="navbar-collapse" ng-switch="authenticated">
-                <ul class="nav navbar-nav nav-pills navbar-right">
-                    <li>
-                        <a href="#">
-                            <span class="glyphicon glyphicon-home"></span>
-                            <span translate="global.menu.home">Home</span>
-                        </a>
-                    </li>
-                    <li class="dropdown pointer">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
-                            <span>
-                                <span class="glyphicon glyphicon-user"></span>
-                                <span class="hidden-tablet" translate="global.menu.account.main">
-                                    Account
+                    <ul class="nav navbar-nav nav-pills navbar-right">
+                        <li>
+                            <a href="#">
+                                <span class="glyphicon glyphicon-home"></span>
+                                <span translate="global.menu.home">Home</span>
+                            </a>
+                        </li>
+                        <li class="dropdown pointer">
+                            <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
+                                <span>
+                                    <span class="glyphicon glyphicon-user"></span>
+                                    <span class="hidden-tablet" translate="global.menu.account.main">
+                                        Account
+                                    </span>
+                                    <b class="caret"></b>
                                 </span>
-                                <b class="caret"></b>
-                            </span>
-                        </a>
-                        <ul class="dropdown-menu" ng-controller="MenuController">
-                            <li ng-switch-when="true"><a href="#/settings"><span class="glyphicon glyphicon-wrench"></span>
-                                &nbsp;<span translate="global.menu.account.settings">Settings</span></a></li>
-                            <li ng-switch-when="true"><a href="#/password"><span class="glyphicon glyphicon-lock"></span>
-                                &nbsp;<span translate="global.menu.account.password">Password</span></a></li>
-                            <li ng-switch-when="true"><a href="#/sessions"><span class="glyphicon glyphicon-cloud"></span>
-                                &nbsp;<span translate="global.menu.account.sessions">Sessions</span></a></li>
-                            <li ng-switch-when="true"><a href="#/logout"><span class="glyphicon glyphicon-log-out"></span>
-                                &nbsp;<span translate="global.menu.account.logout">Log out</span></a></li>
-                            <li ng-switch-when="false"><a href="#/login"><span class="glyphicon glyphicon-log-in"></span>
-                                &nbsp;<span translate="global.menu.account.login">Authenticate</span></a></li>
-                        </ul>
-                    </li>
-                    <li ng-switch-when="true" ng-show="isAuthorized(userRoles.admin)" class="dropdown pointer" ng-controller="AdminController">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
-                            <span>
-                                <span class="glyphicon glyphicon-tower"></span>
-                                <span class="hidden-tablet" translate="global.menu.admin">Admin</span>
-                                <b class="caret"></b>
-                            </span>
-                        </a>
-                        <ul class="dropdown-menu">
- <% if (websocket == 'atmosphere') { %>                            <li><a href="#/tracker"><span class="glyphicon glyphicon-eye-open"></span>
-                                &nbsp;<span translate="global.menu.account.tracker">User tracking</span></a></li>
- <% } %>                           <li><a href="#/metrics"><span class="glyphicon glyphicon-dashboard"></span>
-                                &nbsp;<span translate="global.menu.account.metrics">Metrics</span></a></li>
-                            <li><a href="#/audits"><span class="glyphicon glyphicon-bell"></span>
-                                &nbsp;<span translate="global.menu.account.audits">Audits</span></a></li>
-                            <li><a href="#/logs"><span class="glyphicon glyphicon-tasks"></span>
-                                &nbsp;<span translate="global.menu.account.logs">Logs</span></a></li>
-                            <li><a href="#/docs"><span class="glyphicon glyphicon-book"></span>
-                                &nbsp;<span translate="global.menu.account.apidocs">API Docs</span></a></li>
-                        </ul>
-                    </li>
-                    <li class="dropdown pointer" ng-controller="LanguageController">
-                        <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
-                            <span>
-                                <span class="glyphicon glyphicon-flag"></span>
-                                <span class="hidden-tablet" translate="global.menu.language">Language</span>
-                                <b class="caret"></b>
-                            </span>
-                        </a>
-                        <ul class="dropdown-menu">
-                            <li active-menu="da">
-                                <a href="#" ng-click="changeLanguage('da')"><span class="famfamfam-flag-dk"></span>
-                                    &nbsp;<span translate="global.language.da">Danish</span></a>
-                            </li>
-                            <li active-menu="en">
-                                <a href="#" ng-click="changeLanguage('en')"><span class="famfamfam-flag-gb"></span>
-                                    &nbsp;<span translate="global.language.en">English</span></a>
-                            </li>
-                            <li active-menu="fr">
-                                <a href="#" ng-click="changeLanguage('fr')"><span class="famfamfam-flag-fr"></span>
-                                    &nbsp;<span translate="global.language.fr">French</span></a>
-                            </li>
-                            <li active-menu="de">
-                                <a href="#" ng-click="changeLanguage('de')"><span class="famfamfam-flag-de"></span>
-                                    &nbsp;<span translate="global.language.de">German</span></a>
-                            </li>
-                            <li active-menu="pl">
-                                <a href="#" ng-click="changeLanguage('pl')"><span class="famfamfam-flag-pl"></span>
-                                    &nbsp;<span translate="global.language.pl">Polish</span></a>
-                            </li>
-                            <li active-menu="ru">
-                                <a href="#" ng-click="changeLanguage('ru')"><span class="famfamfam-flag-ru"></span>
-                                    &nbsp;<span translate="global.language.ru">Russian</span></a>
-                            </li>
-                        </ul>
-                    </li>
-                </ul>
+                            </a>
+                            <ul class="dropdown-menu" ng-controller="MenuController">
+                                <li ng-switch-when="true"><a href="#/settings"><span class="glyphicon glyphicon-wrench"></span>
+                                    &nbsp;<span translate="global.menu.account.settings">Settings</span></a></li>
+                                <li ng-switch-when="true"><a href="#/password"><span class="glyphicon glyphicon-lock"></span>
+                                    &nbsp;<span translate="global.menu.account.password">Password</span></a></li>
+                                <li ng-switch-when="true"><a href="#/sessions"><span class="glyphicon glyphicon-cloud"></span>
+                                    &nbsp;<span translate="global.menu.account.sessions">Sessions</span></a></li>
+                                <li ng-switch-when="true"><a href="#/logout"><span class="glyphicon glyphicon-log-out"></span>
+                                    &nbsp;<span translate="global.menu.account.logout">Log out</span></a></li>
+                                <li ng-switch-when="false"><a href="#/login"><span class="glyphicon glyphicon-log-in"></span>
+                                    &nbsp;<span translate="global.menu.account.login">Authenticate</span></a></li>
+                            </ul>
+                        </li>
+                        <li ng-switch-when="true" ng-show="isAuthorized(userRoles.admin)" class="dropdown pointer" ng-controller="AdminController">
+                            <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
+                                <span>
+                                    <span class="glyphicon glyphicon-tower"></span>
+                                    <span class="hidden-tablet" translate="global.menu.admin">Admin</span>
+                                    <b class="caret"></b>
+                                </span>
+                            </a>
+                            <ul class="dropdown-menu">
+    <% if (websocket == 'atmosphere') { %>                            <li><a href="#/tracker"><span class="glyphicon glyphicon-eye-open"></span>
+                                    &nbsp;<span translate="global.menu.account.tracker">User tracking</span></a></li>
+    <% } %>                            <li><a href="#/metrics"><span class="glyphicon glyphicon-dashboard"></span>
+                                    &nbsp;<span translate="global.menu.account.metrics">Metrics</span></a></li>
+                                <li><a href="#/audits"><span class="glyphicon glyphicon-bell"></span>
+                                    &nbsp;<span translate="global.menu.account.audits">Audits</span></a></li>
+                                <li><a href="#/logs"><span class="glyphicon glyphicon-tasks"></span>
+                                    &nbsp;<span translate="global.menu.account.logs">Logs</span></a></li>
+                                <li><a href="#/docs"><span class="glyphicon glyphicon-book"></span>
+                                    &nbsp;<span translate="global.menu.account.apidocs">API Docs</span></a></li>
+                            </ul>
+                        </li>
+                        <li class="dropdown pointer" ng-controller="LanguageController">
+                            <a class="dropdown-toggle" data-toggle="dropdown" href="javascript:;">
+                                <span>
+                                    <span class="glyphicon glyphicon-flag"></span>
+                                    <span class="hidden-tablet" translate="global.menu.language">Language</span>
+                                    <b class="caret"></b>
+                                </span>
+                            </a>
+                            <ul class="dropdown-menu">
+                                <li active-menu="da">
+                                    <a href="#" ng-click="changeLanguage('da')"><span class="famfamfam-flag-dk"></span>
+                                        &nbsp;<span translate="global.language.da">Danish</span></a>
+                                </li>
+                                <li active-menu="en">
+                                    <a href="#" ng-click="changeLanguage('en')"><span class="famfamfam-flag-gb"></span>
+                                        &nbsp;<span translate="global.language.en">English</span></a>
+                                </li>
+                                <li active-menu="fr">
+                                    <a href="#" ng-click="changeLanguage('fr')"><span class="famfamfam-flag-fr"></span>
+                                        &nbsp;<span translate="global.language.fr">French</span></a>
+                                </li>
+                                <li active-menu="de">
+                                    <a href="#" ng-click="changeLanguage('de')"><span class="famfamfam-flag-de"></span>
+                                        &nbsp;<span translate="global.language.de">German</span></a>
+                                </li>
+                                <li active-menu="pl">
+                                    <a href="#" ng-click="changeLanguage('pl')"><span class="famfamfam-flag-pl"></span>
+                                        &nbsp;<span translate="global.language.pl">Polish</span></a>
+                                </li>
+                                <li active-menu="ru">
+                                    <a href="#" ng-click="changeLanguage('ru')"><span class="famfamfam-flag-ru"></span>
+                                        &nbsp;<span translate="global.language.ru">Russian</span></a>
+                                </li>
+                            </ul>
+                        </li>
+                    </ul>
+                </div>
             </div>
-        </div>
         </nav>
         <div class="container">
             <div class="well" ng-view></div>


### PR DESCRIPTION
This PR changes the navigation to use bootstrap's standard navbar instead of the custom nav with nav-pills.
This will change the look from the bluish menu links to bootstrap's default navbar links.
I'm not sure whether it is ok to change the look.
Nevertheless, I think the standard navbar should be used since the look can be customized, anyways.
Furthermore, this navbar is responsive.
