### PR TITLE
Add gradle working folders in gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -11,3 +11,5 @@ node_modules
 .sass-cache
 .DS_Store
 src/main/webapp/dist
+.gradle
+build


### PR DESCRIPTION
Gradle creates these folders for its internal needs.k. I think they should be excluded from source control.
