### PR TITLE
Fix generator update configuration

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -4,7 +4,8 @@ var util = require('util'),
     yeoman = require('yeoman-generator'),
     chalk = require('chalk'),
     _s = require('underscore.string'),
-    shelljs = require('shelljs');
+    shelljs = require('shelljs'),
+    packagejs = require(__dirname + '/../package.json');
 
 var JhipsterGenerator = module.exports = function JhipsterGenerator(args, options, config) {
     yeoman.generators.Base.apply(this, arguments);
@@ -306,6 +307,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
 	this.javaVersion = this.config.get('javaVersion');
 	this.buildTool = this.config.get('buildTool');
 	this.frontendBuilder = this.config.get('frontendBuilder');
+    this.packagejs = packagejs;
 
 	if (this.baseName != null &&
 	    this.packageName != null &&

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -57,7 +57,7 @@
     "karma-phantomjs-launcher": "0.1.2",
     "karma": "0.12.1",
     "bower": "1.3.3",
-    "generator-jhipster": "0.16.0"
+    "generator-jhipster": "<%= packagejs.version %>"
   },
   "engines": {
     "node": ">=0.10.0"


### PR DESCRIPTION
The JHipster generator is now a dependency in nodejs.
When using a subgenerator, nodejs will rather take the local version than the global one.
Changes in the subgenerators won't cause issues like #360 because the version of JHipster the project was generated with is used for the subgenerator, instead of the globally available one, even if the globally available one is more recent.
