### PR TITLE
The authentication.oauth.clientid must match the one in services.js

### DIFF
--- a/app/templates/src/main/resources/config/_application.yml
+++ b/app/templates/src/main/resources/config/_application.yml
@@ -28,7 +28,7 @@ spring:
 <% if (authenticationType == 'token') { %>
 authentication:
     oauth:
-        clientid: <%= baseName %>app
+        clientid: jhipsterapp
         secret: mySecretOAuthSecret
         # Token is valid 30 minutes
         tokenValidityInSeconds: 1800<% } %>


### PR DESCRIPTION
The client_id is present twice in services.js and in application.yml. It needs to be the same value everywhere. I've hardcoded `jhipsterapp` everywhere.

The other solution would be to use `<%= baseName %>app` everywhere. However, if there's a space in the baseName, we also need to escape it in the url contained in the var data.
