### PR TITLE
Check whether AccessToken is not null

### DIFF
--- a/app/templates/src/main/webapp/scripts/_services.js
+++ b/app/templates/src/main/webapp/scripts/_services.js
@@ -159,7 +159,9 @@
                 });<% } %>
             },
             valid: function (authorizedRoles) {<% if (authenticationType == 'token') { %>
-                httpHeaders.common['Authorization'] = 'Bearer ' + AccessToken.get();<% } %>
+                if(AccessToken.get() !== null) {
+                    httpHeaders.common['Authorization'] = 'Bearer ' + AccessToken.get();
+                }<% } %>
 
                 $http.get('protected/transparent.gif', {
                     ignoreAuthModule: 'ignoreAuthModule'


### PR DESCRIPTION
Otherwise the following header will be sent:
Authorization: Bearer null
