### PR TITLE
Make DB integration tests cleaner with @Transactional

### DIFF
--- a/app/templates/src/test/java/package/service/_UserServiceTest.java
+++ b/app/templates/src/test/java/package/service/_UserServiceTest.java
@@ -16,8 +16,6 @@ import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 
-import ca.intelliware.ihtsdo.mlds.domain.User;
-
 import javax.inject.Inject;
 import javax.transaction.Transactional;
 


### PR DESCRIPTION
Adding @Transactional causes the test to run inside a transaction, and rollback on teardown.  Leaves the db in the original state.
Also updated the test to not break with an active login session.
