### PR TITLE
Fix using long at the wrong location

### DIFF
--- a/app/templates/src/main/java/package/config/_CacheConfiguration.java
+++ b/app/templates/src/main/java/package/config/_CacheConfiguration.java
@@ -79,7 +79,7 @@ public class CacheConfiguration {
             
             net.sf.ehcache.Cache cache = cacheManager.getCache(name);
             if (cache != null) {
-                cache.getCacheConfiguration().setTimeToLiveSeconds(env.getProperty("cache.timeToLiveSeconds", Integer.class, 3600));
+                cache.getCacheConfiguration().setTimeToLiveSeconds(env.getProperty("cache.timeToLiveSeconds", Long.class, 3600L));
                 net.sf.ehcache.Ehcache decoratedCache = InstrumentedEhcache.instrument(metricRegistry, cache);
                 cacheManager.replaceCacheWithDecoratedCache(cache, decoratedCache);
             }
@@ -169,7 +169,7 @@ public class CacheConfiguration {
         MapConfig mapConfig = new MapConfig();
 
         mapConfig.setBackupCount(env.getProperty("cache.hazelcast.backupCount", Integer.class, 1));
-        mapConfig.setTimeToLiveSeconds(env.getProperty("cache.timeToLiveSeconds", Long.class, 3600L));
+        mapConfig.setTimeToLiveSeconds(env.getProperty("cache.timeToLiveSeconds", Integer.class, 3600));
         return mapConfig;
     }<% } %><% if (hibernateCache == 'hazelcast' || clusteredHttpSession == 'hazelcast') { %>
     


### PR DESCRIPTION
mapConfig.setTimeToLiveSeconds expects int but cacheConfiguration.setTimeToLiveSeconds expects long
