### PR TITLE
Atmosphere: fix long-polling issue by simply using broadcast

### DIFF
--- a/app/templates/src/main/java/package/web/websocket/_ActivityService.java
+++ b/app/templates/src/main/java/package/web/websocket/_ActivityService.java
@@ -36,9 +36,7 @@ public class ActivityService {
         activityDTO.setUuid(event.getResource().uuid());
         activityDTO.setPage("logout");
         String json = jsonMapper.writeValueAsString(activityDTO);
-        for (AtmosphereResource trackerResource : b.getAtmosphereResources()) {
-            trackerResource.getResponse().write(json);
-        }
+        b.broadcast(json);
     }
 
     @Message(decoders = {ActivityDTOJacksonDecoder.class})
@@ -49,8 +47,6 @@ public class ActivityService {
         activityDTO.setTime(dateTimeFormatter.print(Calendar.getInstance().getTimeInMillis()));
         String json = jsonMapper.writeValueAsString(activityDTO);
         log.debug("Sending user tracking data {}", json);
-        for (AtmosphereResource trackerResource : b.getAtmosphereResources()) {
-            trackerResource.getResponse().write(json);
-        }
+        b.broadcast(json);
     }
 }


### PR DESCRIPTION
Actually, writing directly with the AtmosphereResource is tricky because the API behave differently regarding the transport used behind the scene. That's why the code worked with websocket but did not with long-polling transport. Better approach is to use a Broadcaster#broadcast method.
