### PR TITLE
Atmosphere won't work when packaged as self-hosted war

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -76,13 +76,13 @@
                     <plugin>
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
-                        <configuration>
+                        <configuration><% if (websocket == 'atmosphere') { %>
                             <requiresUnpack>
                                 <dependency>
                                     <groupId>org.atmosphere</groupId>
                                     <artifactId>atmosphere-runtime</artifactId>
                                 </dependency>
-                            </requiresUnpack>
+                            </requiresUnpack><% } %>
                             <arguments>
                                 <argument>--spring.profiles.active=prod</argument>
                             </arguments>


### PR DESCRIPTION
Due to how the org.atmosphere.util.annotation.AnnotationDetector works, classpath scanning for annotations in a file stored in a war fails with an exception (AssertionError: Not a File). Extracting the file before launching fixes this [1].

Atmosphere won't work when the war is launched via:
java -jar jhipster.war

Resulting in the following error:
java.lang.AssertionError: Not a File: file:/Users/buttercup/Coding/Java/blabla/target/blabla-0.7-SNAPSHOT.war!/WEB-INF/lib/atmosphere-runtime-2.1.4.jar!/org/atmosphere/annotation

[1] http://docs.spring.io/spring-boot/docs/1.1.4.RELEASE/reference/htmlsingle/#howto-extract-specific-libraries-when-an-executable-jar-runs
[2] http://stackoverflow.com/questions/24117886/jhipster-executable-war-not-executable-in-combination-with-atmosphere
