### PR TITLE
genericModelSubstitutes for ResponseEntity

### DIFF
--- a/app/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
+++ b/app/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
@@ -9,6 +9,7 @@ import org.springframework.context.EnvironmentAware;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.env.Environment;
+import org.springframework.http.ResponseEntity;
 
 @Configuration
 @EnableSwagger
@@ -29,6 +30,7 @@ public class SwaggerConfiguration implements EnvironmentAware {
     public SwaggerSpringMvcPlugin swaggerSpringMvcPlugin(SpringSwaggerConfig springSwaggerConfig) {
         return new SwaggerSpringMvcPlugin(springSwaggerConfig)
                 .apiInfo(apiInfo())
+                .genericModelSubstitutes(ResponseEntity.class)
                 .includePatterns(DEFAULT_INCLUDE_PATTERN);
     }
 

--- a/app/templates/src/main/webapp/swagger-ui/_index.html
+++ b/app/templates/src/main/webapp/swagger-ui/_index.html
@@ -59,4 +59,3 @@
 <div id="swagger-ui-container" class="swagger-ui-wrap"></div>
 </body>
 </html>
-</html>


### PR DESCRIPTION
The PR: In the swagger generated documentation replace all the ResponseEntity«T» by T (ex: ResponseEntity«UserDTO» becomes UserDTO).

For my point view of ResponseEntity is just part of the code to wrap the "real" returned object including the response code. The user of the documentation is not interested by this "internal type". In addition the content of the response is usually a "T" and not a "ResponseEntity".

It basically removes all this kind of documentation:

```
ResponseEntity«UserDTO» {
statusCode (string, optional) = ['100' or '101' or '102' or '103' or '200' or '201' or '202' or '203' or '204' or '205' or '206' or '207' or '208' or '226' or '300' or '301' or '302' or '302' or '303' or '304' or '305' or '307' or '308' or '400' or '401' or '402' or '403' or '404' or '405' or '406' or '407' or '408' or '409' or '410' or '411' or '412' or '413' or '414' or '415' or '416' or '417' or '418' or '419' or '420' or '421' or '422' or '423' or '424' or '426' or '428' or '429' or '431' or '500' or '501' or '502' or '503' or '504' or '505' or '506' or '507' or '508' or '509' or '510' or '511'],
headers (HttpHeaders, optional),
body (UserDTO, optional)
}
```
