### PR TITLE
update swagger-ui 2.0.18

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -18,7 +18,7 @@
     "angular-translate-loader-static-files": "2.2.0",
     "angular-dynamic-locale": "0.1.1",
     "angular-i18n": "1.2.5",
-    "swagger-ui": "2.0.17"
+    "swagger-ui": "2.0.18"
   },
   "devDependencies": {
     "angular-mocks": "1.2.18",


### PR DESCRIPTION
the Model Schema is displayed by default (more relevant for the user)
