### PR TITLE
fix for handling IndexOutOfBoundsException

### DIFF
--- a/app/templates/src/main/resources/templates/error.html
+++ b/app/templates/src/main/resources/templates/error.html
@@ -148,7 +148,7 @@
 
     <span th:text="#{error.status}">Status:</span>&nbsp;<span th:text="${error}"></span>&nbsp;(<span th:text="${error}"></span>)<br/>
     <span th:if="${!#strings.isEmpty(message)}">
-        <span th:text="#{error.message}">Message:</span>&nbsp;<span th:text="${error.message}"></span><br/>
+        <span th:text="#{message}">Message:</span>&nbsp;<span th:text="${message}"></span><br/>
     </span>
 
     <script th:inline="text">


### PR DESCRIPTION
I got an exception from EL parser  when it tried to resolve #{error.message}. It complained that String has no message method. I guest we're supposed to display message that is in the context not error.message ... 
Anyway after  it started to display correct error page after i've changed it to #{message}
