### PR TITLE
Add remote debug configuration to Spring Boot for dev profile

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -593,6 +593,9 @@
                 <groupId>org.springframework.boot</groupId>
                 <artifactId>spring-boot-maven-plugin</artifactId>
                 <configuration>
+                    <jvmArguments>
+                        -Xdebug -Xrunjdwp:transport=dt_socket,server=y,suspend=n,address=5005
+                    </jvmArguments>
                     <arguments>
                         <argument>--spring.profiles.active=dev</argument>
                     </arguments>


### PR DESCRIPTION
To be able to debug with Spring Boot, we have to configure the plugin with some jvm arguments.
suspend=n makes it non blocking if we do not create any debug session.
