### PR TITLE
Concat before revision files

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -204,8 +204,8 @@ gulp.task('usemin', ['images', 'styles'], function(){
         prefix.apply(),
         replace(/[0-9a-zA-Z\-_\s\.\/]*\/([a-zA-Z\-_\.0-9]*\.(woff|eot|ttf|svg))/g, '/fonts/$1'),
         //minifyCss(),
-        rev(),
-        'concat'
+        'concat',
+        rev()
       ],
       html: [
         minifyHtml({empty: true, conditionals:true})
@@ -213,8 +213,8 @@ gulp.task('usemin', ['images', 'styles'], function(){
       js: [
         ngmin(),
         uglify(),
-        rev(),
-        'concat'
+        'concat',
+        rev()
       ]
     })).
     pipe(gulp.dest(yeoman.dist));


### PR DESCRIPTION
Otherwise the revisioned files are again replaced by normal filenames like scripts.js
With such names caching is not possible
