### PR TITLE
Increase event_type size to 255

### DIFF
--- a/app/templates/src/main/resources/config/liquibase/changelog/_db-changelog-001.xml
+++ b/app/templates/src/main/resources/config/liquibase/changelog/_db-changelog-001.xml
@@ -110,7 +110,7 @@
             </column>
             <column name="principal" type="varchar(50)"/>
             <column name="event_date" type="timestamp"/>
-            <column name="event_type" type="varchar(50)"/>
+            <column name="event_type" type="varchar(255)"/>
         </createTable>
 
         <createTable tableName="T_PERSISTENT_AUDIT_EVENT_DATA">


### PR DESCRIPTION
The entity does not constrain the field to a length of 50
