### PR TITLE
Mini fix for pattern mixup

### DIFF
--- a/app/templates/src/main/java/package/web/rest/dto/_package-info.java
+++ b/app/templates/src/main/java/package/web/rest/dto/_package-info.java
@@ -1,4 +1,4 @@
 /**
- * Data Access Objects used by Spring MVC REST controllers.
+ * Data Transfer Objects used by Spring MVC REST controllers.
  */
 package <%=packageName%>.web.rest.dto;


### PR DESCRIPTION
Changed documentation to correctly call DTOs "Transfer" objects instead of "Access" objects.
