### PR TITLE
Add subpackage support

### DIFF
--- a/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/entity/templates/src/main/java/package/domain/_Entity.java
@@ -1,4 +1,4 @@
-package <%=packageName%>.domain;
+package <%= makePackage(packageName, 'domain', entityPackage) %>;
 
 <% if (relationships.length > 0) { %>import com.fasterxml.jackson.annotation.JsonIgnore;<% } %><% if (fieldsContainLocalDate == true) { %>
 import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
@@ -22,9 +22,9 @@ import java.util.Set;<% } %>
  * A <%= entityClass %>.
  */
 <% if (databaseType == 'sql') { %>@Entity
-@Table(name = "T_<%= name.toUpperCase() %>")<% } %><% if (hibernateCache != 'no' && databaseType == 'sql') { %>
+@Table(name = "T_<%= entityClass.toUpperCase() %>")<% } %><% if (hibernateCache != 'no' && databaseType == 'sql') { %>
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)<% } %><% if (databaseType == 'nosql') { %>
-@Document(collection = "T_<%= name.toUpperCase() %>")<% } %>
+@Document(collection = "T_<%= entityClass.toUpperCase() %>")<% } %>
 public class <%= entityClass %> implements Serializable {
 
     @Id<% if (databaseType == 'sql') { %>
@@ -45,9 +45,9 @@ public class <%= entityClass %> implements Serializable {
     @OneToMany(cascade = CascadeType.ALL, orphanRemoval = true, mappedBy = "<%= entityInstance %>")
     @JsonIgnore<% if (hibernateCache != 'no') { %>
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)<% } %>
-    private Set<<%= relationships[relationshipId].otherEntityNameCapitalized %>> <%= relationships[relationshipId].otherEntityName %>s = new HashSet<>();<% } else { %>
+    private Set<<%= relationships[relationshipId].otherEntityClass %>> <%= relationships[relationshipId].relationshipName %>s = new HashSet<>();<% } else { %>
     @ManyToOne
-    private <%= relationships[relationshipId].otherEntityNameCapitalized %> <%= relationships[relationshipId].otherEntityName %>;<% } %>
+    private <%= relationships[relationshipId].otherEntityClass %> <%= relationships[relationshipId].relationshipName %>;<% } %>
 <% } %>
     public <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'nosql') { %>String<% } %> getId() {
         return id;
@@ -65,19 +65,19 @@ public class <%= entityClass %> implements Serializable {
         this.<%= fields[fieldId].fieldName %> = <%= fields[fieldId].fieldName %>;
     }
 <% } %><% for (relationshipId in relationships) { %><% if (relationships[relationshipId].relationshipType == 'one-to-many') { %>
-    public Set<<%= relationships[relationshipId].otherEntityNameCapitalized %>> get<%= relationships[relationshipId].otherEntityNameCapitalized %>s() {
-        return <%= relationships[relationshipId].otherEntityName %>s;
+    public Set<<%= relationships[relationshipId].otherEntityClass %>> get<%= relationships[relationshipId].otherEntityClass %>s() {
+        return <%= relationships[relationshipId].relationshipName %>s;
     }
 
-    public void set<%= relationships[relationshipId].otherEntityNameCapitalized %>s(Set<<%= relationships[relationshipId].otherEntityNameCapitalized %>> <%= relationships[relationshipId].otherEntityName %>s) {
-        this.<%= relationships[relationshipId].otherEntityName %>s = <%= relationships[relationshipId].otherEntityName %>s;
+    public void set<%= relationships[relationshipId].otherEntityClass %>s(Set<<%= relationships[relationshipId].otherEntityClass %>> <%= relationships[relationshipId].relationshipName %>s) {
+        this.<%= relationships[relationshipId].relationshipName %>s = <%= relationships[relationshipId].relationshipName %>s;
     }<% } else { %>
-    public <%= relationships[relationshipId].otherEntityNameCapitalized %> get<%= relationships[relationshipId].otherEntityNameCapitalized %>() {
-        return <%= relationships[relationshipId].otherEntityName %>;
+    public <%= relationships[relationshipId].otherEntityClass %> get<%= relationships[relationshipId].otherEntityClass %>() {
+        return <%= relationships[relationshipId].relationshipName %>;
     }
 
-    public void set<%= relationships[relationshipId].otherEntityNameCapitalized %>(<%= relationships[relationshipId].otherEntityNameCapitalized %> <%= relationships[relationshipId].otherEntityName %>) {
-        this.<%= relationships[relationshipId].otherEntityName %> = <%= relationships[relationshipId].otherEntityName %>;
+    public void set<%= relationships[relationshipId].otherEntityClass %>(<%= relationships[relationshipId].otherEntityClass %> <%= relationships[relationshipId].relationshipName %>) {
+        this.<%= relationships[relationshipId].relationshipName %> = <%= relationships[relationshipId].relationshipName %>;
     }<% } %>
 <% } %>
     @Override

--- a/entity/templates/src/main/java/package/repository/_EntityRepository.java
+++ b/entity/templates/src/main/java/package/repository/_EntityRepository.java
@@ -1,8 +1,8 @@
-package <%=packageName%>.repository;
+package <%= makePackage(packageName, 'repository', entityPackage) %>;
 
-import <%=packageName%>.domain.<%= entityClass %>;<% if (databaseType == 'sql') { %>
-        import org.springframework.data.jpa.repository.JpaRepository;<% } %><% if (databaseType == 'nosql') { %>
-        import org.springframework.data.mongodb.repository.MongoRepository;<% } %>
+import <%= makePackage(packageName, 'domain', entityPackage, entityClass) %>;<% if (databaseType == 'sql') { %>
+import org.springframework.data.jpa.repository.JpaRepository;<% } %><% if (databaseType == 'nosql') { %>
+import org.springframework.data.mongodb.repository.MongoRepository;<% } %>
 
 <% if (databaseType == 'sql') { %>/**
  * Spring Data JPA repository for the <%= entityClass %> entity.

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -1,8 +1,8 @@
-package <%=packageName%>.web.rest;
+package <%= packageName %>.web.rest<%= entityPackageSuffix %>;
 
 import com.codahale.metrics.annotation.Timed;
-import <%=packageName%>.domain.<%= entityClass %>;
-import <%=packageName%>.repository.<%= entityClass %>Repository;
+import <%=packageName%>.domain<%= entityPackageSuffix %>.<%= entityClass %>;
+import <%=packageName%>.repository<%= entityPackageSuffix %>.<%= entityClass %>Repository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;

--- a/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -21,13 +21,13 @@
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bigint"/><% } else if (fields[fieldId].fieldType == 'LocalDate') { %>
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="date"/><% } else if (fields[fieldId].fieldType == 'Boolean') { %>
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bit"/><% } } %><% for (relationshipId in relationships) { %><% if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
-            <column name="<%=relationships[relationshipId].otherEntityName.toLowerCase() %>_id" type="bigint"/><% } } %>
+            <column name="<%=relationships[relationshipId].relationshipName.toLowerCase() %>_id" type="bigint"/><% } } %>
         </createTable>
         <% for (relationshipId in relationships) { %><% if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
-        <addForeignKeyConstraint baseColumnNames="<%= relationships[relationshipId].otherEntityName.toLowerCase() %>_id"
+        <addForeignKeyConstraint baseColumnNames="<%= relationships[relationshipId].relationshipName.toLowerCase() %>_id"
                                  baseTableName="T_<%= name.toUpperCase() %>"
-                                 constraintName="fk_<%= name.toLowerCase() %>_<%= relationships[relationshipId].otherEntityName.toLowerCase() %>_id"
+                                 constraintName="fk_<%= name.toLowerCase() %>_<%= relationships[relationshipId].relationshipName.toLowerCase() %>_id"
                                  referencedColumnNames="id"
-                                 referencedTableName="T_<%= relationships[relationshipId].otherEntityName.toUpperCase() %>"/><% } } %>
+                                 referencedTableName="T_<%= relationships[relationshipId].relationshipName.toUpperCase() %>"/><% } } %>
     </changeSet>
 </databaseChangeLog>

--- a/entity/templates/src/main/webapp/scripts/_entity-controller.js
+++ b/entity/templates/src/main/webapp/scripts/_entity-controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
-<%= angularAppName %>.controller('<%= entityClass %>Controller', function ($scope, resolved<%= entityClass %>, <%= entityClass %><% for (relationshipId in relationships) { %>, resolved<%= relationships[relationshipId].otherEntityNameCapitalized %><% } %>) {
+<%= angularAppName %>.controller('<%= entityClass %>Controller', function ($scope, resolved<%= entityClass %>, <%= entityClass %><% for (relationshipId in relationships) { %>, resolved<%= relationships[relationshipId].otherEntityClass %><% } %>) {
 
         $scope.<%= entityInstance %>s = resolved<%= entityClass %>;<% for (relationshipId in relationships) { %>
-        $scope.<%= relationships[relationshipId].otherEntityName %>s = resolved<%= relationships[relationshipId].otherEntityNameCapitalized %>;<% } %>
+        $scope.<%= relationships[relationshipId].relationshipName %>s = resolved<%= relationships[relationshipId].otherEntityClass %>;<% } %>
 
         $scope.create = function () {
             <%= entityClass %>.save($scope.<%= entityInstance %>,

--- a/entity/templates/src/main/webapp/scripts/_entity-router.js
+++ b/entity/templates/src/main/webapp/scripts/_entity-router.js
@@ -10,7 +10,7 @@
                         resolved<%= entityClass %>: ['<%= entityClass %>', function (<%= entityClass %>) {
                             return <%= entityClass %>.query();
                         }]<% for (relationshipId in relationships) {
-                            var relationshipClass = relationships[relationshipId].otherEntityNameCapitalized;%>,
+                            var relationshipClass = relationships[relationshipId].otherEntityClass;%>,
                         resolved<%=relationshipClass%>: ['<%=relationshipClass%>', function (<%=relationshipClass%>) {
                             return <%=relationshipClass%>.query();
                         }]<% } %>

--- a/entity/templates/src/main/webapp/views/_entities.html
+++ b/entity/templates/src/main/webapp/views/_entities.html
@@ -40,11 +40,11 @@
                         </div><% } %>
 <% for (relationshipId in relationships) {
     if (relationships[relationshipId].relationshipType == 'many-to-one') {
-        var otherEntityName = relationships[relationshipId].otherEntityName;
+        var relationshipName = relationships[relationshipId].relationshipName;
                         %>
                         <div class="form-group">
-                            <label><%=otherEntityName %></label>
-                            <select class="form-control" ng-model="<%=entityInstance %>.<%=otherEntityName %>.id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName %>s">
+                            <label><%=relationshipName %></label>
+                            <select class="form-control" ng-model="<%=entityInstance %>.<%=relationshipName %>.id" ng-options="<%=relationshipName %>.id as <%=relationshipName %> | json for <%=relationshipName %> in <%=relationshipName %>s">
                             </select>
                         </div><% } } %>
 
@@ -69,7 +69,7 @@
                     <th>ID</th><% for (fieldId in fields) { %>
                     <th><%=fields[fieldId].fieldName%></th><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
-                    <th><%=relationships[relationshipId].otherEntityName%></th><% } } %>
+                    <th><%=relationships[relationshipId].relationshipName%></th><% } } %>
                     <th></th>
                 </tr>
             </thead>
@@ -78,7 +78,7 @@
                     <td>{{<%=entityInstance %>.id}}</td><% for (fieldId in fields) { %>
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
-                    <td>{{<%=entityInstance %>.<%=relationships[relationshipId].otherEntityName%>.<%=relationships[relationshipId].otherEntityField%>}}</td><% } } %>
+                    <td>{{<%=entityInstance %>.<%=relationships[relationshipId].relationshipName%>.<%=relationships[relationshipId].otherEntityField%>}}</td><% } } %>
                     <td>
                         <button type="submit"
                                 ng-click="update(<%=entityInstance %>.id)"

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -1,4 +1,4 @@
-package <%=packageName%>.web.rest;
+package <%=packageName%>.web.rest<%= entityPackageSuffix %>;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -27,9 +27,10 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import <%=packageName%>.Application;
-import <%=packageName%>.domain.<%= entityClass %>;
-import <%=packageName%>.repository.<%= entityClass %>Repository;
+import <%= packageName %>.Application;
+import <%= packageName %>.domain<%= entityPackageSuffix %>.<%= entityClass %>;
+import <%= packageName %>.repository<%= entityPackageSuffix %>.<%= entityClass %>Repository;
+import <%= packageName %>.web.rest.TestUtil;
 
 
 /**

--- a/script-base.js
+++ b/script-base.js
@@ -45,6 +45,10 @@ Generator.prototype.addRouterToMenu = function (entityName) {
     }
 };
 
+Generator.prototype.makePackage = function() {
+    return Array.prototype.slice.call(arguments, 0).filter(function(e) { return e; }).join('.');
+}
+
 Generator.prototype.addChangelogToLiquibase = function (changelogName) {
     try {
         var appPath = this.env.options.appPath;


### PR DESCRIPTION
As project grows keeping all entities/repositories/etc at the same folder level makes it hard to focus on the functional groups of the project. Therefore I added a second parameter to the entity generator that allows us to specify sub-packages:

```
$ yo jhipster:entity EntityA
The entity EntityA is being created.
   create src\main\java\com\mycompany\myapp\domain\EntityA .java
   create src\main\java\com\mycompany\myapp\repository\EntityARepository.java
  ...
 $ yo jhipster:entity EntityB packageb
The entity package.b.EntityB is being created.
  create src\main\java\com\mycompany\myapp\domain\packageb\EntityB.java
  create src\main\java\com\mycompany\myapp\repository\packageb\EntityBRepository.java
```

Also moved the User, PersistentToken and Authority to the "security" sub-package
