### PR TITLE
Bugfix: password like test%123 doesn't work

### DIFF
--- a/app/templates/src/main/webapp/scripts/_services.js
+++ b/app/templates/src/main/webapp/scripts/_services.js
@@ -125,7 +125,7 @@
 <%= angularAppName %>.factory('AuthenticationSharedService', function ($rootScope, $http, authService, Session, Account<% if (authenticationType == 'token') { %>, Base64Service, AccessToken<% } %>) {
         return {
             login: function (param) {<% if (authenticationType == 'cookie') { %>
-                var data ="j_username=" + param.username +"&j_password=" + param.password +"&_spring_security_remember_me=" + param.rememberMe +"&submit=Login";
+                var data ="j_username=" + encodeURIComponent(param.username) +"&j_password=" + encodeURIComponent(param.password) +"&_spring_security_remember_me=" + param.rememberMe +"&submit=Login";
                 $http.post('app/authentication', data, {
                     headers: {
                         "Content-Type": "application/x-www-form-urlencoded"


### PR DESCRIPTION
We used an older version of JHipster, but it seems the bug is also in the code here.

The password is not escaped properly. Using for example 'test%123' resolves to 'test3' which of course doesn't work.
