### PR TITLE
Integration tests with maven failsafe plugin

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -578,10 +578,10 @@ JhipsterGenerator.prototype.app = function app() {
         this.template('src/test/java/package/config/_MongoConfiguration.java', testDir + 'config/MongoConfiguration.java');
     }
 
-    this.template('src/test/java/package/service/_UserServiceTest.java', testDir + 'service/UserServiceTest.java');
-    this.template('src/test/java/package/web/rest/_AccountResourceTest.java', testDir + 'web/rest/AccountResourceTest.java');
+    this.template('src/test/java/package/service/_UserServiceIT.java', testDir + 'service/UserServiceIT.java');
+    this.template('src/test/java/package/web/rest/_AccountResourceIT.java', testDir + 'web/rest/AccountResourceIT.java');
     this.template('src/test/java/package/web/rest/_TestUtil.java', testDir + 'web/rest/TestUtil.java');
-    this.template('src/test/java/package/web/rest/_UserResourceTest.java', testDir + 'web/rest/UserResourceTest.java');
+    this.template('src/test/java/package/web/rest/_UserResourceIT.java', testDir + 'web/rest/UserResourceIT.java');
 
     this.template(testResourceDir + 'config/_application.yml', testResourceDir + 'config/application.yml');
     this.template(testResourceDir + '_logback-test.xml', testResourceDir + 'logback-test.xml');

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -482,6 +482,17 @@
                 </executions>
             </plugin>
             <plugin>
+                <artifactId>maven-failsafe-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <goals>
+                            <goal>integration-test</goal>
+                            <goal>verify</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>

--- a/app/templates/src/test/java/package/service/_UserServiceIT.java
+++ b/app/templates/src/test/java/package/service/_UserServiceIT.java
@@ -34,7 +34,7 @@ import static org.assertj.core.api.Assertions.*;
 <% if (databaseType == 'nosql') { %>
 @Import(MongoConfiguration.class)<% } %><% if (databaseType == 'sql') { %>
 @Transactional<% } %>
-public class UserServiceTest {
+public class UserServiceIT {
 
     @Inject
     private PersistentTokenRepository persistentTokenRepository;

--- a/app/templates/src/test/java/package/web/rest/_AccountResourceIT.java
+++ b/app/templates/src/test/java/package/web/rest/_AccountResourceIT.java
@@ -46,7 +46,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
 <% if (databaseType == 'nosql') { %>
 @Import(MongoConfiguration.class)<% } %>
-public class AccountResourceTest {
+public class AccountResourceIT {
 
     @Inject
     private UserRepository userRepository;

--- a/app/templates/src/test/java/package/web/rest/_UserResourceIT.java
+++ b/app/templates/src/test/java/package/web/rest/_UserResourceIT.java
@@ -33,7 +33,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_CLASS)
 <% if (databaseType == 'nosql') { %>
 @Import(MongoConfiguration.class)<% } %>
-public class UserResourceTest {
+public class UserResourceIT {
 
     @Inject
     private UserRepository userRepository;


### PR DESCRIPTION
Adding maven failsafe plugin and renaming integration tests to *IT in order to have them executed during integration-test phase.
To run integration tests, use "mvn verify", or "mvn failsafe:integration-test".
