### PR TITLE
Cleaner MongoConfiguration for tests

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -575,6 +575,7 @@ JhipsterGenerator.prototype.app = function app() {
     this.mkdir(testDir);
 
     if (this.databaseType == "nosql") {
+        this.template('src/test/java/package/config/_MongoFactoryConfiguration.java', testDir + 'config/MongoFactoryConfiguration.java');
         this.template('src/test/java/package/config/_MongoConfiguration.java', testDir + 'config/MongoConfiguration.java');
     }
 

--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -135,7 +135,7 @@ dependencies {
     testCompile group: 'junit', name: 'junit', version:'4.11'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'1.9.5'<% if (databaseType == 'sql') { %>
     testCompile group: 'com.mattbertolini', name: 'liquibase-slf4j', version: liquibase_slf4j_version<% } %><% if (databaseType == 'nosql') { %>
-    testCompile group: 'cz.jirutka.spring', name: 'embedmongo-spring', version: embedmongo_spring_version<% } %>
+    testCompile group: 'de.flapdoodle.embed', name: 'de.flapdoodle.embed.mongo', version: embed_mongo_version<% } %>
     testCompile group: 'org.hamcrest', name: 'hamcrest-library', version:'1.3'
 }
 

--- a/app/templates/_gradle.properties
+++ b/app/templates/_gradle.properties
@@ -21,7 +21,7 @@ HikariCP_version=1.4.0<% if (databaseType == 'sql') { %>
 liquibase_slf4j_version=1.2.1
 liquibase_core_version=3.1.1
 liquibase_hibernate_version=3.3<% } %><% if (databaseType == 'nosql') { %>
-embedmongo_spring_version=1.3.0
+embed_mongo_version=1.46.1
 mongeez_version=0.9.4<% } %>
 hibernate_validator_version=5.0.3.Final
 metrics_spring_version=3.0.1<% if (devDatabaseType == 'postgresql' || prodDatabaseType == 'postgresql') { %>

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -202,9 +202,9 @@
             <version>${commons-lang.version}</version>
         </dependency><% if (databaseType == 'nosql') { %>
         <dependency>
-            <groupId>cz.jirutka.spring</groupId>
-            <artifactId>embedmongo-spring</artifactId>
-            <version>1.3.0</version>
+            <groupId>de.flapdoodle.embed</groupId>
+            <artifactId>de.flapdoodle.embed.mongo</artifactId>
+            <version>1.46.1</version>
             <scope>test</scope>
         </dependency><% } %>
         <dependency>

--- a/app/templates/src/test/java/package/config/_MongoConfiguration.java
+++ b/app/templates/src/test/java/package/config/_MongoConfiguration.java
@@ -1,34 +1,24 @@
 package <%=packageName%>.config;
 
-import com.mongodb.Mongo;
-import cz.jirutka.spring.embedmongo.EmbeddedMongoBuilder;
+import java.net.UnknownHostException;
+
+import javax.inject.Inject;
+
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
-import java.io.IOException;
-import java.net.ServerSocket;
+import com.mongodb.Mongo;
+import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
 
 @Configuration
 public class MongoConfiguration {
 
-    @Bean
-    public Mongo mongo() throws IOException {
-        System.setProperty("DB.TRACE","true");
-        return new EmbeddedMongoBuilder()
-                .version("2.6.0")
-                .bindIp("127.0.0.1")
-                .port(allocateRandomPort())
-                .build();
-    }
+    @Inject
+    private MongodForTestsFactory mongodForTestsFactory;
 
-    public static int allocateRandomPort() {
-        try {
-            ServerSocket server = new ServerSocket(0);
-            int port = server.getLocalPort();
-            server.close();
-            return port;
-        } catch (IOException e) {
-            throw new RuntimeException("Failed to acquire a random free port", e);
-        }
+    @Bean
+    public Mongo mongo() throws UnknownHostException {
+        System.setProperty("DB.TRACE","true");
+        return mongodForTestsFactory.newMongo();
     }
 }

--- a/app/templates/src/test/java/package/config/_MongoFactoryConfiguration.java
+++ b/app/templates/src/test/java/package/config/_MongoFactoryConfiguration.java
@@ -1,0 +1,18 @@
+package <%=packageName%>.config;
+
+import java.io.IOException;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import de.flapdoodle.embed.mongo.distribution.Version;
+import de.flapdoodle.embed.mongo.tests.MongodForTestsFactory;
+
+@Configuration
+public class MongoFactoryConfiguration {
+
+    @Bean
+    public MongodForTestsFactory mongodForTestsFactory() throws IOException {
+        return MongodForTestsFactory.with(Version.Main.PRODUCTION);
+    }
+}

--- a/app/templates/src/test/java/package/service/_UserServiceTest.java
+++ b/app/templates/src/test/java/package/service/_UserServiceTest.java
@@ -1,7 +1,6 @@
 package <%=packageName%>.service;
 
-import <%=packageName%>.Application;<% if (databaseType == 'nosql') { %>
-import <%=packageName%>.config.MongoConfiguration;<% } %>
+import <%=packageName%>.Application;
 import <%=packageName%>.domain.PersistentToken;
 import <%=packageName%>.domain.User;
 import <%=packageName%>.repository.PersistentTokenRepository;
@@ -10,8 +9,7 @@ import org.joda.time.DateTime;
 import org.joda.time.LocalDate;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.SpringApplicationConfiguration;<% if (databaseType == 'nosql') { %>
-import org.springframework.context.annotation.Import;<% } %><% if (databaseType == 'sql') { %>
+import org.springframework.boot.test.SpringApplicationConfiguration;<% if (databaseType == 'sql') { %>
 import org.springframework.transaction.annotation.Transactional;<% } %>
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
@@ -30,9 +28,7 @@ import static org.assertj.core.api.Assertions.*;
  */
 @RunWith(SpringJUnit4ClassRunner.class)
 @SpringApplicationConfiguration(classes = Application.class)
-@WebAppConfiguration
-<% if (databaseType == 'nosql') { %>
-@Import(MongoConfiguration.class)<% } %><% if (databaseType == 'sql') { %>
+@WebAppConfiguration<% if (databaseType == 'sql') { %>
 @Transactional<% } %>
 public class UserServiceTest {
 

--- a/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
@@ -1,7 +1,6 @@
 package <%=packageName%>.web.rest;
 
-import <%=packageName%>.Application;<% if (databaseType == 'nosql') { %>
-import <%=packageName%>.config.MongoConfiguration;<% } %>
+import <%=packageName%>.Application;
 import <%=packageName%>.domain.Authority;
 import <%=packageName%>.domain.User;
 import <%=packageName%>.repository.UserRepository;
@@ -12,8 +11,7 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.boot.test.SpringApplicationConfiguration;<% if (databaseType == 'nosql') { %>
-import org.springframework.context.annotation.Import;<% } %>
+import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.mock.web.MockHttpServletRequest;
 import org.springframework.test.annotation.DirtiesContext;
@@ -44,8 +42,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringApplicationConfiguration(classes = Application.class)
 @WebAppConfiguration
 @DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_CLASS)
-<% if (databaseType == 'nosql') { %>
-@Import(MongoConfiguration.class)<% } %>
 public class AccountResourceTest {
 
     @Inject

--- a/app/templates/src/test/java/package/web/rest/_UserResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_UserResourceTest.java
@@ -1,13 +1,11 @@
 package <%=packageName%>.web.rest;
 
-import <%=packageName%>.Application;<% if (databaseType == 'nosql') { %>
-import <%=packageName%>.config.MongoConfiguration;<% } %>
+import <%=packageName%>.Application;
 import <%=packageName%>.repository.UserRepository;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
-import org.springframework.boot.test.SpringApplicationConfiguration;<% if (databaseType == 'nosql') { %>
-import org.springframework.context.annotation.Import;<% } %>
+import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.annotation.DirtiesContext;
@@ -31,8 +29,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @SpringApplicationConfiguration(classes = Application.class)
 @WebAppConfiguration
 @DirtiesContext(classMode= DirtiesContext.ClassMode.AFTER_CLASS)
-<% if (databaseType == 'nosql') { %>
-@Import(MongoConfiguration.class)<% } %>
 public class UserResourceTest {
 
     @Inject


### PR DESCRIPTION
This pull request fix some problems with current unit test with MongoDB:
- MongoDB temporary instances where never shutdown properly, leaving old .exe files in the temp directory forever.
- embedmongo-spring has no added value compared to de.flapdoodle.embed.mongo (it depends on it).
- @Import(MongoConfiguration.class) on top of test cases was useless because of @ComponentScan annotation on Application class.
