### PR TITLE
Fixed #662 removed '.class' from name

### DIFF
--- a/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
+++ b/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
@@ -67,7 +67,7 @@ public class DatabaseConfiguration <% if (databaseType == 'sql') { %>implements 
     }
 
     @Bean(destroyMethod = "shutdown")
-    @ConditionalOnMissingClass(name = "<%=packageName%>.config.HerokuDatabaseConfiguration.class")
+    @ConditionalOnMissingClass(name = "<%=packageName%>.config.HerokuDatabaseConfiguration")
     public DataSource dataSource() {
         log.debug("Configuring Datasource");
         if (propertyResolver.getProperty("url") == null && propertyResolver.getProperty("databaseName") == null) {


### PR DESCRIPTION
Related to #662, removed the .class ending.
