### PR TITLE
Fix unresolved data with huge result set

### DIFF
--- a/entity/templates/src/main/webapp/scripts/_entity-router.js
+++ b/entity/templates/src/main/webapp/scripts/_entity-router.js
@@ -8,11 +8,11 @@
                     controller: '<%= entityClass %>Controller',
                     resolve:{
                         resolved<%= entityClass %>: ['<%= entityClass %>', function (<%= entityClass %>) {
-                            return <%= entityClass %>.query();
+                            return <%= entityClass %>.query().$promise;
                         }]<% for (relationshipId in relationships) {
                             var relationshipClass = relationships[relationshipId].otherEntityNameCapitalized;%>,
                         resolved<%=relationshipClass%>: ['<%=relationshipClass%>', function (<%=relationshipClass%>) {
-                            return <%=relationshipClass%>.query();
+                            return <%=relationshipClass%>.query().$promise;
                         }]<% } %>
                     },
                     access: {


### PR DESCRIPTION
on some case with many data / many services (mainly due to load activity on client site), $resource query is solved but data are not yet attached and mapped to resolved object. 
adding .$promise garanty that the service is done and data are fully mapped.

You can reproduce the case by displaying a search result on main page and doing a clean cache refresh.
