### PR TITLE
fix wrong input group button height

### DIFF
--- a/app/templates/src/main/scss/main.scss
+++ b/app/templates/src/main/scss/main.scss
@@ -1,5 +1,5 @@
 $icon-font-path: "../bower_components/bootstrap-sass/vendor/assets/fonts/bootstrap/";
-
+$line-height-base: 1.42858;
 @import './bootstrap-sass/vendor/assets/stylesheets/bootstrap.scss';
 
 body {


### PR DESCRIPTION
The default line height value of '1.428571429' is for some reason cut of so that the last four digist of the fraction aren't used by chrome for example. This leads to wrong heights of input group buttons by one pixel. Increasing the base height by 0.00001 solve the problem.
