### PR TITLE
Allow to customize primary keys

### DIFF
--- a/entity/templates/src/main/java/package/repository/_EntityRepository.java
+++ b/entity/templates/src/main/java/package/repository/_EntityRepository.java
@@ -4,17 +4,20 @@ import <%=packageName%>.domain.<%= entityClass %>;<% if (databaseType == 'sql') 
 import org.springframework.data.jpa.repository.JpaRepository;<% if (fieldsContainOwnerManyToMany == true) { %>
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;<% } } %><% if (databaseType == 'nosql') { %>
-import org.springframework.data.mongodb.repository.MongoRepository;<% } %>
-
+import org.springframework.data.mongodb.repository.MongoRepository;<% } %><% if (primaryKeyField.fieldType == 'LocalDate') { %>
+import org.joda.time.LocalDate;<% } %><% if (primaryKeyField.fieldType == 'DateTime') { %>
+import org.joda.time.DateTime;<% } %><% if (primaryKeyField.fieldType == 'BigDecimal') { %>
+import java.math.BigDecimal;<% } %>
 <% if (databaseType == 'sql') { %>/**
  * Spring Data JPA repository for the <%= entityClass %> entity.
  */<% } %><% if (databaseType == 'nosql') { %>/**
  * Spring Data MongoDB repository for the <%= entityClass %> entity.
  */<% } %>
-public interface <%= entityClass %>Repository extends <% if (databaseType == 'sql') { %>JpaRepository<% } %><% if (databaseType == 'nosql') { %>MongoRepository<% } %><<%= entityClass %>, <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'nosql') { %>String<% } %>> {
+
+public interface <%= entityClass %>Repository extends <% if (databaseType == 'sql') { %>JpaRepository<% } %><% if (databaseType == 'nosql') { %>MongoRepository<% } %><<%= entityClass %>, <% if (databaseType == 'sql') { %><%= primaryKeyField.fieldType %><% } %><% if (databaseType == 'nosql') { %>String<% } %>> {
 <% if (fieldsContainOwnerManyToMany == true) { %>
     @Query("select <%= entityInstance %> from <%= entityClass %> <%= entityInstance %> <% for (relationshipId in relationships) {
-        if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) { %>left join fetch <%= entityInstance %>.<%= relationships[relationshipId].otherEntityName %>s <% } } %>where <%= entityInstance %>.id = :id")
-    <%= entityClass %> findOneWithEagerRelationships(@Param("id") Long id);
+        if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) { %>left join fetch <%= entityInstance %>.<%= relationships[relationshipId].otherEntityName %>s <% } } %>where <%= entityInstance %>.<%= primaryKeyField.fieldName %> = :<%= primaryKeyField.fieldName %>")
+    <%= entityClass %> findOneWithEagerRelationships(@Param("<%= primaryKeyField.fieldName %>") <%= primaryKeyField.fieldType %> <%= primaryKeyField.fieldName %>);
 <% } %>
 }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -13,7 +13,12 @@ import org.springframework.web.bind.annotation.*;
 import javax.inject.Inject;<% if (javaVersion == '7') { %>
 import javax.servlet.http.HttpServletResponse;<% } %>
 import java.util.List;<% if (javaVersion == '8') { %>
-import java.util.Optional;<% } %>
+import java.util.Optional;<% } %><% if (primaryKeyField.fieldType == 'LocalDate') { %>
+import org.joda.time.LocalDate;
+import org.springframework.format.annotation.DateTimeFormat;<% } %><% if (primaryKeyField.fieldType == 'DateTime') { %>
+import org.joda.time.DateTime;
+import org.springframework.format.annotation.DateTimeFormat;<% } %><% if (primaryKeyField.fieldType == 'BigDecimal') { %>
+import java.math.BigDecimal;<% } %>
 
 /**
  * REST controller for managing <%= entityClass %>.
@@ -52,20 +57,20 @@ public class <%= entityClass %>Resource {
     }
 
     /**
-     * GET  /rest/<%= entityInstance %>s/:id -> get the "id" <%= entityInstance %>.
+     * GET  /rest/<%= entityInstance %>s/:<%= primaryKeyField.fieldName %> -> get the "<%= primaryKeyField.fieldName %>" <%= entityInstance %>.
      */
-    @RequestMapping(value = "/rest/<%= entityInstance %>s/{id}",
+    @RequestMapping(value = "/rest/<%= entityInstance %>s/{<%= primaryKeyField.fieldName %>}",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public ResponseEntity<<%= entityClass %>> get(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'nosql') { %>String<% } %> id<% if (javaVersion == '7') { %>, HttpServletResponse response<% } %>) {
-        log.debug("REST request to get <%= entityClass %> : {}", id);<% if (javaVersion == '8') { %>
-        return Optional.ofNullable(<%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id))
+    public ResponseEntity<<%= entityClass %>> get(@PathVariable <% if (databaseType == 'sql') { %><% if (primaryKeyField.fieldType == 'LocalDate') { %>@DateTimeFormat(pattern="yyyy-MM-dd")<% } %><% if (primaryKeyField.fieldType == 'DateTime') { %>@DateTimeFormat(pattern="yyyy-MM-dd'T'HH:mm:ss")<% } %><%= primaryKeyField.fieldType %><% } %><% if (databaseType == 'nosql') { %>String<% } %> <%= primaryKeyField.fieldName %><% if (javaVersion == '7') { %>, HttpServletResponse response<% } %>) {
+        log.debug("REST request to get <%= entityClass %> : {}", <%= primaryKeyField.fieldName %>);<% if (javaVersion == '8') { %>
+        return Optional.ofNullable(<%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(<%= primaryKeyField.fieldName %>))
             .map(<%= entityInstance %> -> new ResponseEntity<>(
                 <%= entityInstance %>,
                 HttpStatus.OK))
             .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));<% } else { %>
-        <%= entityClass %> <%= entityInstance %> = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id);
+        <%= entityClass %> <%= entityInstance %> = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(<%= primaryKeyField.fieldName %>);
         if (<%= entityInstance %> == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
@@ -73,14 +78,14 @@ public class <%= entityClass %>Resource {
     }
 
     /**
-     * DELETE  /rest/<%= entityInstance %>s/:id -> delete the "id" <%= entityInstance %>.
+     * DELETE  /rest/<%= entityInstance %>s/:<%= primaryKeyField.fieldName %> -> delete the "<%= primaryKeyField.fieldName %>" <%= entityInstance %>.
      */
-    @RequestMapping(value = "/rest/<%= entityInstance %>s/{id}",
+    @RequestMapping(value = "/rest/<%= entityInstance %>s/{<%= primaryKeyField.fieldName %>}",
             method = RequestMethod.DELETE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public void delete(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'nosql') { %>String<% } %> id) {
-        log.debug("REST request to delete <%= entityClass %> : {}", id);
-        <%= entityInstance %>Repository.delete(id);
+    public void delete(@PathVariable <% if (databaseType == 'sql') { %><% if (primaryKeyField.fieldType == 'LocalDate') { %>@DateTimeFormat(pattern="yyyy-MM-dd")<% } %><% if (primaryKeyField.fieldType == 'DateTime') { %>@DateTimeFormat(pattern="yyyy-MM-dd'T'HH:mm:ss")<% } %><%= primaryKeyField.fieldType %><% } %><% if (databaseType == 'nosql') { %>String<% } %> <%= primaryKeyField.fieldName %>) {
+        log.debug("REST request to delete <%= entityClass %> : {}", <%= primaryKeyField.fieldName %>);
+        <%= entityInstance %>Repository.delete(<%= primaryKeyField.fieldName %>);
     }
 }

--- a/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -11,18 +11,32 @@
         Added the entity <%= entityClass %>.
     -->
     <changeSet id="<%= changelogDate %>" author="jhipster">
-        <createTable tableName="T_<%= name.toUpperCase() %>">
+        <createTable tableName="T_<%= name.toUpperCase() %>"><%if (pkManagedByJHipster == true) { %>
             <column name="id" type="bigint" autoIncrement="true">
                 <constraints primaryKey="true" nullable="false"/>
-            </column><% for (fieldId in fields) {
+            </column><% } %><% for (fieldId in fields) {
             if (fields[fieldId].fieldType == 'String') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="varchar(255)"/><% } else if (fields[fieldId].fieldType == 'Integer') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="integer"/><% } else if (fields[fieldId].fieldType == 'Long') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bigint"/><% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="decimal(10,2)"/><% } else if (fields[fieldId].fieldType == 'LocalDate') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="date"/><% } else if (fields[fieldId].fieldType == 'DateTime') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="timestamp"/><% } else if (fields[fieldId].fieldType == 'Boolean') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bit"/><% } } %><% for (relationshipId in relationships) { %><% if ((relationships[relationshipId].relationshipType == 'many-to-one') || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="varchar(255)"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } else if (fields[fieldId].fieldType == 'Integer') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="integer"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } else if (fields[fieldId].fieldType == 'Long') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bigint"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="decimal(10,2)"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } else if (fields[fieldId].fieldType == 'LocalDate') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="date"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } else if (fields[fieldId].fieldType == 'DateTime') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="timestamp"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } else if (fields[fieldId].fieldType == 'Boolean') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bit"><%if (fields[fieldId].isPk == true) { %>
+                <constraints primaryKey="true" nullable="false"/><% } %>
+            </column><% } } %><% for (relationshipId in relationships) { %><% if ((relationships[relationshipId].relationshipType == 'many-to-one') || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) { %>
             <column name="<%=relationships[relationshipId].otherEntityName.toLowerCase() %>_id" type="bigint"/><% } } %>
         </createTable>
         <% for (relationshipId in relationships) { %><% if ((relationships[relationshipId].relationshipType == 'many-to-one') || ((relationships[relationshipId].relationshipType == 'one-to-one')) && (relationships[relationshipId].ownerSide == true)) { %>

--- a/entity/templates/src/main/webapp/scripts/_entity-controller.js
+++ b/entity/templates/src/main/webapp/scripts/_entity-controller.js
@@ -14,19 +14,19 @@
                 });
         };
 
-        $scope.update = function (id) {
-            $scope.<%= entityInstance %> = <%= entityClass %>.get({id: id});
+        $scope.update = function (<%=primaryKeyField.fieldName %>) {
+            $scope.<%= entityInstance %> = <%= entityClass %>.get({<%=primaryKeyField.fieldName %>: <%=primaryKeyField.fieldName %>});
             $('#save<%= entityClass %>Modal').modal('show');
         };
 
-        $scope.delete = function (id) {
-            <%= entityClass %>.delete({id: id},
+        $scope.delete = function (<%=primaryKeyField.fieldName %>) {
+            <%= entityClass %>.delete({<%=primaryKeyField.fieldName %>: <%=primaryKeyField.fieldName %>},
                 function () {
                     $scope.<%= entityInstance %>s = <%= entityClass %>.query();
                 });
         };
 
         $scope.clear = function () {
-            $scope.<%= entityInstance %> = {<% for (fieldId in fields) { %><%= fields[fieldId].fieldName %>: null, <% } %>id: null};
+            $scope.<%= entityInstance %> = {<% for (fieldId in fields) { %><%= fields[fieldId].fieldName %>: null, <% } %><% if (pkManagedByJHipster == true) { %>id: null<% } %>};
         };
     });

--- a/entity/templates/src/main/webapp/scripts/_entity-service.js
+++ b/entity/templates/src/main/webapp/scripts/_entity-service.js
@@ -1,7 +1,7 @@
 'use strict';
 
 <%= angularAppName %>.factory('<%= entityClass %>', function ($resource) {
-        return $resource('app/rest/<%= entityInstance %>s/:id', {}, {
+        return $resource('app/rest/<%= entityInstance %>s/:<%=primaryKeyField.fieldName %>', {}, {
             'query': { method: 'GET', isArray: true},
             'get': { method: 'GET'}
         });

--- a/entity/templates/src/main/webapp/views/_entities.html
+++ b/entity/templates/src/main/webapp/views/_entities.html
@@ -18,12 +18,12 @@
                                 ng-click="clear()">&times;</button>
                         <h4 class="modal-title" id="my<%= entityClass %>Label">Create or edit a <%= entityClass %></h4>
                     </div>
-                    <div class="modal-body">
+                    <div class="modal-body"><% if (pkManagedByJHipster == true) { %>
                         <div class="form-group">
                             <label>ID</label>
                             <input type="text" class="form-control" name="id"
                                    ng-model="<%=entityInstance %>.id" readonly>
-                        </div>
+                        </div><% } %>
 <% for (fieldId in fields) {
     var fieldInputType = 'text';
     if (fields[fieldId].fieldType == 'Integer' || fields[fieldId].fieldType == 'Long') {
@@ -74,8 +74,8 @@
     <div class="table-responsive">
         <table class="table table-striped">
             <thead>
-                <tr>
-                    <th>ID</th><% for (fieldId in fields) { %>
+                <tr><% if (pkManagedByJHipster == true) { %>
+                    <th>ID</th><% } %><% for (fieldId in fields) { %>
                     <th><%=fields[fieldId].fieldNameCapitalized%></th><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
                     <th><%=relationships[relationshipId].otherEntityName%></th><% } } %>
@@ -83,19 +83,19 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="<%=entityInstance %> in <%=entityInstance %>s">
-                    <td>{{<%=entityInstance %>.id}}</td><% for (fieldId in fields) { %>
+                <tr ng-repeat="<%=entityInstance %> in <%=entityInstance %>s"><% if (pkManagedByJHipster == true) { %>
+                    <td>{{<%=entityInstance %>.id}}</td><% } %><% for (fieldId in fields) { %>
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
                     <td>{{<%=entityInstance %>.<%=relationships[relationshipId].otherEntityName%>.<%=relationships[relationshipId].otherEntityField%>}}</td><% } } %>
                     <td>
                         <button type="submit"
-                                ng-click="update(<%=entityInstance %>.id)"
+                                ng-click="update(<%=entityInstance %>.<%=primaryKeyField.fieldName %>)"
                                 class="btn btn-default">
                             <span class="glyphicon glyphicon-pencil"></span> Edit
                         </button>
                         <button type="submit"
-                                ng-click="delete(<%=entityInstance %>.id)"
+                                ng-click="delete(<%=entityInstance %>.<%=primaryKeyField.fieldName %>)"
                                 class="btn btn-danger">
                             <span class="glyphicon glyphicon-remove-circle"></span> Delete
                         </button>

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -117,7 +117,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         rest<%= entityClass %>MockMvc.perform(get("/app/rest/<%= entityInstance %>s"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql' && pkManagedByJHipster == true) { %>
                 .andExpect(jsonPath("$.[0].id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'nosql') { %>
                 .andExpect(jsonPath("$.[0].id").value(<%= entityInstance %>.getId()))<% } %><% for (fieldId in fields) {%>
                 .andExpect(jsonPath("$.[0].<%=fields[fieldId].fieldName%>").value(<%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%><% if (fields[fieldId].fieldType == 'Integer') { %><% } else if (fields[fieldId].fieldType == 'Long') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[fieldId].fieldType == 'DateTime') { %>_STR<% } else { %>.toString()<% } %>))<% } %>;
@@ -130,9 +130,9 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 
         // Get the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(get("/app/rest/<%= entityInstance %>s/{id}", <%= entityInstance %>.getId()))
+        rest<%= entityClass %>MockMvc.perform(get("/app/rest/<%= entityInstance %>s/{<%= primaryKeyField.fieldName %>}", <%= entityInstance %>.get<%= primaryKeyField.fieldNameCapitalized %>()))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql' && pkManagedByJHipster == true) { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'nosql') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId()))<% } %><% for (fieldId in fields) {%>
             .andExpect(jsonPath("$.<%=fields[fieldId].fieldName%>").value(<%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%><% if (fields[fieldId].fieldType == 'Integer') { %><% } else if (fields[fieldId].fieldType == 'Long') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[fieldId].fieldType == 'DateTime') { %>_STR<% } else { %>.toString()<% } %>))<% } %>;
@@ -142,7 +142,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
     @Transactional<% } %>
     public void getNonExisting<%= entityClass %>() throws Exception {
         // Get the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(get("/app/rest/<%= entityInstance %>s/{id}", 1L))
+        rest<%= entityClass %>MockMvc.perform(get("/app/rest/<%= entityInstance %>s/{<%= primaryKeyField.fieldName %>}", 1L))
                 .andExpect(status().isNotFound());
     }
 
@@ -152,9 +152,9 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         // Initialize the database
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 
-        // Update the <%= entityInstance %><% for (fieldId in fields) { %>
+        // Update the <%= entityInstance %><% for (fieldId in fields) { %><% if (fields[fieldId].isPk == false) { %>
         <%= entityInstance %>.set<%= fields[fieldId].fieldNameCapitalized %>(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } %>
-        rest<%= entityClass %>MockMvc.perform(post("/app/rest/<%= entityInstance %>s")
+        <% } %>rest<%= entityClass %>MockMvc.perform(post("/app/rest/<%= entityInstance %>s")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(<%= entityInstance %>)))
                 .andExpect(status().isOk());
@@ -162,8 +162,8 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         // Validate the <%= entityClass %> in the database
         List<<%= entityClass %>> <%= entityInstance %>s = <%= entityInstance %>Repository.findAll();
         assertThat(<%= entityInstance %>s).hasSize(1);
-        <%= entityClass %> test<%= entityClass %> = <%= entityInstance %>s.iterator().next();<% for (fieldId in fields) {%>
-        assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>()).isEqualTo(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } %>;
+        <%= entityClass %> test<%= entityClass %> = <%= entityInstance %>s.iterator().next();<% for (fieldId in fields) {%><% if (fields[fieldId].isPk == false) { %>
+        assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>()).isEqualTo(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } %>;<% } %>
     }
 
     @Test<% if (databaseType == 'sql') { %>
@@ -173,7 +173,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 
         // Get the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(delete("/app/rest/<%= entityInstance %>s/{id}", <%= entityInstance %>.getId())
+        rest<%= entityClass %>MockMvc.perform(delete("/app/rest/<%= entityInstance %>s/{<%= primaryKeyField.fieldName %>}", <%= entityInstance %>.get<%= primaryKeyField.fieldNameCapitalized %>())
                 .accept(TestUtil.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk());
 

--- a/entity/util.js
+++ b/entity/util.js
@@ -1,0 +1,14 @@
+'use strict';
+
+module.exports = {
+    getPrimaryKeyField: getPrimaryKeyField
+};
+
+function getPrimaryKeyField(fields) {
+    var fieldId;
+    for (fieldId in fields) {
+        if (fields[fieldId].isPk == true) {
+            return fields[fieldId];
+        }
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "generator-jhipster",
+  "name": "generator-jhipsterFork",
   "version": "1.8.1",
   "description": "Java + Spring + JPA + AngularJS complete dev stack",
   "keywords": [


### PR DESCRIPTION
Hi,
First of all, sorry if there is something wrong in the way I create this pull request, it's my first pull request ever !! :)
Regarding to the issue #730 I created few days ago, I've implemented on my side the ability for a user to choose a custom primary key during the entity generator.
For now, only a unique PK is allowed (maybe I'll try later to add composite PK, which is my final goal).
I'm not sure for the nosql part, as I don't know nosql ...
I've also noticed that when we update the primary key of an entity, it creates a whole new entity with the new primary key (the old entity is not deleted). I haven't changed this behavior, as it implies a lot of code, and maybe the behavior could be acceptable (means this could be the default behavior, and let the user changes this if he's not happy with that).
I'm available for any questions/comments/ ...
Best regards
