### PR TITLE
Unnecessary semicolon ';'

### DIFF
--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -163,7 +163,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         List<<%= entityClass %>> <%= entityInstance %>s = <%= entityInstance %>Repository.findAll();
         assertThat(<%= entityInstance %>s).hasSize(1);
         <%= entityClass %> test<%= entityClass %> = <%= entityInstance %>s.iterator().next();<% for (fieldId in fields) {%>
-        assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>()).isEqualTo(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } %>;
+        assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>()).isEqualTo(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } %>
     }
 
     @Test<% if (databaseType == 'sql') { %>


### PR DESCRIPTION
Line 146 in IntelliJ
Line 166 in GitHub

Result:

Unnecessary semicolon ';'

```
    assertThat(testAuthor.getBirthDate()).isEqualTo(UPDATED_BIRTH_DATE);;
```

Apply for all entities!
