### PR TITLE
fix spring injection in security config

### DIFF
--- a/app/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/app/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -52,8 +52,8 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
         return new BCryptPasswordEncoder();
     }
 
-    @Inject
-    public void configureGlobal(AuthenticationManagerBuilder auth) throws Exception {
+    @Override
+    public void configure(AuthenticationManagerBuilder auth) throws Exception {
         auth
             .userDetailsService(userDetailsService)
                 .passwordEncoder(passwordEncoder());


### PR DESCRIPTION
Hello,

the spring configuration with @Inject on the configureGlobal method provoke bean factory exception. I suggest a fix by overriding "configure" method.

Solution already seen here : http://stackoverflow.com/questions/26348877/can-not-apply-daoauthenticationconfigurer-to-already-built-object

Regards.