### PR TITLE
Testing js when starting prod profile

### DIFF
--- a/app/templates/_profile_prod.gradle
+++ b/app/templates/_profile_prod.gradle
@@ -16,3 +16,4 @@ grunt_build.dependsOn 'npmInstall'
 grunt_build.dependsOn 'bower'
 processResources.dependsOn grunt_build
 test.dependsOn grunt_test
+bootRun.dependsOn grunt_test


### PR DESCRIPTION
The gradle build starts JS test when using the prod profile (as the maven build does)
