### PR TITLE
Change style for ng-style to fix progress bars not working with IE

### DIFF
--- a/app/templates/src/main/webapp/app/admin/metrics/_metrics.html
+++ b/app/templates/src/main/webapp/app/admin/metrics/_metrics.html
@@ -15,7 +15,7 @@
                  aria-valuenow="{{metrics.gauges['jvm.memory.total.used'].value / 1000000 | number:0}}"
                  aria-valuemin="0"
                  aria-valuemax="{{metrics.gauges['jvm.memory.total.max'].value / 1000000 | number:0}}"
-                 style="width: {{metrics.gauges['jvm.memory.total.used'].value * 100 / metrics.gauges['jvm.memory.total.max'].value  | number:0}}%">
+                 ng-style="{width: (metrics.gauges['jvm.memory.total.used'].value * 100 / metrics.gauges['jvm.memory.total.max'].value | number:0) + '%'}">
                 {{metrics.gauges['jvm.memory.total.used'].value * 100 / metrics.gauges['jvm.memory.total.max'].value  | number:0}}%
             </div>
         </div>
@@ -25,7 +25,7 @@
                  aria-valuenow="{{metrics.gauges['jvm.memory.heap.used'].value / 1000000 | number:0}}"
                  aria-valuemin="0"
                  aria-valuemax="{{metrics.gauges['jvm.memory.heap.max'].value / 1000000 | number:0}}"
-                 style="width: {{metrics.gauges['jvm.memory.heap.usage'].value * 100 | number:0}}%">
+                 ng-style="{width: (metrics.gauges['jvm.memory.heap.usage'].value * 100 | number:0) + '%'}">
                 {{(metrics.gauges['jvm.memory.heap.usage'].value * 100 | number:0)}}%
             </div>
         </div>
@@ -35,7 +35,7 @@
                 aria-valuenow="{{metrics.gauges['jvm.memory.non-heap.used'].value / 1000000 | number:0}}"
                 aria-valuemin="0"
                 aria-valuemax="{{metrics.gauges['jvm.memory.non-heap.committed'].value / 1000000 | number:0}}"
-                style="width: {{metrics.gauges['jvm.memory.non-heap.committed'].value / 1000000 | number:0}}%">
+                ng-style="{width: (metrics.gauges['jvm.memory.non-heap.committed'].value / 1000000 | number:0) + '%'}">
                 {{(metrics.gauges['jvm.memory.non-heap.used'].value * 100 / metrics.gauges['jvm.memory.non-heap.committed'].value | number:0)}}%
             </div>
         </div>
@@ -48,7 +48,7 @@
                  aria-valuenow="{{metrics.gauges['jvm.threads.runnable.count'].value}}"
                  aria-valuemin="0"
                  aria-valuemax="{{metrics.gauges['jvm.threads.count'].value}}"
-                 style="width: {{metrics.gauges['jvm.threads.runnable.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%">
+                 ng-style="{width: (metrics.gauges['jvm.threads.runnable.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0) + '%'}">
                 {{metrics.gauges['jvm.threads.runnable.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
@@ -58,7 +58,7 @@
                  aria-valuenow="{{metrics.gauges['jvm.threads.timed_waiting.count'].value}}"
                  aria-valuemin="0"
                  aria-valuemax="{{metrics.gauges['jvm.threads.count'].value}}"
-                 style="width: {{metrics.gauges['jvm.threads.timed_waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%">
+                 ng-style="{width: (metrics.gauges['jvm.threads.timed_waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0) + '%'}">
                 {{metrics.gauges['jvm.threads.timed_waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
@@ -68,7 +68,7 @@
                  aria-valuenow="{{metrics.gauges['jvm.threads.waiting.count'].value}}"
                  aria-valuemin="0"
                  aria-valuemax="{{metrics.gauges['jvm.threads.count'].value}}"
-                 style="width: {{metrics.gauges['jvm.threads.waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%">
+                 ng-style="{width: (metrics.gauges['jvm.threads.waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0) + '%'}">
                 {{metrics.gauges['jvm.threads.waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
@@ -78,7 +78,7 @@
                  aria-valuenow="{{metrics.gauges['jvm.threads.blocked.count'].value}}"
                  aria-valuemin="0"
                  aria-valuemax="{{metrics.gauges['jvm.threads.count'].value}}"
-                 style="width: {{metrics.gauges['jvm.threads.blocked.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%">
+                 ng-style="{width: (metrics.gauges['jvm.threads.blocked.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0) + '%'}">
                 {{metrics.gauges['jvm.threads.blocked.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
@@ -128,7 +128,7 @@
                          aria-valuenow="{{metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.ok'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count}}"
                          aria-valuemin="0"
                          aria-valuemax="{{metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count}}"
-                         style="width: {{(metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.ok'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count) | number:0}}%">
+                         ng-style="{width: ((metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.ok'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count) | number:0) + '%'}">
                         {{metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.ok'].count}}
                     </div>
             </td>
@@ -151,7 +151,7 @@
                          aria-valuenow="{{metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.notFound'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count}}"
                          aria-valuemin="0"
                          aria-valuemax="{{metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count}}"
-                         style="width:{{(metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.notFound'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count) | number:0}}%">
+                         ng-style="{width: ((metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.notFound'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count) | number:0) + '%'}">
                         {{metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.notFound'].count}}
                     </div>
                 </div>
@@ -177,7 +177,7 @@
                          aria-valuenow="{{metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.serverError'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count}}"
                          aria-valuemin="0"
                          aria-valuemax="{{metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count}}"
-                         style="width:{{(metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.serverError'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count) | number:0}}%">
+                         ng-style="{width: ((metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.serverError'].count * 100 / metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count) | number:0) + '%'}">
                         {{metrics.meters['com.codahale.metrics.servlet.InstrumentedFilter.responseCodes.serverError'].count}}
                     </div>
                 </div>
@@ -281,7 +281,7 @@
                              aria-valuenow="{{metrics.gauges['HikariPool-0.pool.ActiveConnections'].value | number:0}}"
                              aria-valuemin="0"
                              aria-valuemax="{{metrics.gauges['HikariPool-0.pool.TotalConnections'].value | number:0}}"
-                             style="width: {{metrics.gauges['HikariPool-0.pool.ActiveConnections'].value * 100 / metrics.gauges['HikariPool-0.pool.TotalConnections'].value | number:0}}%">
+                             ng-style="{width: (metrics.gauges['HikariPool-0.pool.ActiveConnections'].value * 100 / metrics.gauges['HikariPool-0.pool.TotalConnections'].value | number:0) + '%'}">
                             {{metrics.gauges['HikariPool-0.pool.ActiveConnections'].value * 100 / metrics.gauges['HikariPool-0.pool.TotalConnections'].value  | number:0}}%
                         </div>
                     </div>


### PR DESCRIPTION
As stated in angularjs official docs : "Use ng-style tags instead of style="{{ someCss }}". The latter works in Chrome and Firefox but does not work in Internet Explorer <= 11 (the most recent version at time of writing)."

fix  #793
