### PR TITLE
fix(Grunt): package external css

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -3,6 +3,27 @@
 
 var proxySnippet = require('grunt-connect-proxy/lib/utils').proxyRequest;
 
+// usemin custom step
+var path = require('path');
+var useminAutoprefixer = {
+    name: 'autoprefixer',
+    createConfig: function(context, block) {
+        var cfg = { files: [] };
+        var outfile = path.join(context.outDir, block.dest);
+
+        var files = {};
+        files.dest = outfile;
+        files.src = [];
+        context.inFiles.forEach(function (f) {
+            files.src.push(path.join(context.inDir, f));
+        });
+        cfg.files.push(files);
+        context.outFiles = [block.dest];
+
+        return cfg;
+    }
+};
+
 module.exports = function (grunt) {
     require('load-grunt-tasks')(grunt);
     require('time-grunt')(grunt);
@@ -16,11 +37,10 @@ module.exports = function (grunt) {
         watch: {<% if (useCompass) { %>
             compass: {
                 files: ['src/main/scss/**/*.{scss,sass}'],
-                tasks: ['compass:server', 'autoprefixer']
+                tasks: ['compass:server']
             },<% } %>
             styles: {
-                files: ['src/main/webapp/styles/**/*.css'],
-                tasks: ['copy:styles', 'autoprefixer']
+                files: ['src/main/webapp/styles/**/*.css']
             },
             livereload: {
                 options: {
@@ -36,15 +56,16 @@ module.exports = function (grunt) {
             }
         },
         autoprefixer: {
-            options: ['last 1 version'],
-            dist: {
-                files: [{
-                    expand: true,
-                    cwd: '.tmp/styles/',
-                    src: '**/*.css',
-                    dest: '.tmp/styles/'
-                }]
-            }
+        // not used since Uglify task does autoprefixer,
+        //    options: ['last 1 version'],
+        //    dist: {
+        //        files: [{
+        //            expand: true,
+        //            cwd: '.tmp/styles/',
+        //            src: '**/*.css',
+        //            dest: '.tmp/styles/'
+        //        }]
+        //    }
         },
         connect: {
             proxies: [
@@ -237,7 +258,16 @@ module.exports = function (grunt) {
         useminPrepare: {
             html: 'src/main/webapp/**/*.html',
             options: {
-                dest: '<%%= yeoman.dist %>'
+                dest: '<%%= yeoman.dist %>',
+                flow: {
+                    html: {
+                        steps: {
+                            js: ['concat', 'uglifyjs'],
+                            css: ['concat', useminAutoprefixer, 'cssmin']
+                        },
+                            post: {}
+                        }
+                    }
             }
         },
         usemin: {
@@ -325,12 +355,6 @@ module.exports = function (grunt) {
                     ]
                 }]
             },
-            styles: {
-                expand: true,
-                cwd: 'src/main/webapp/styles',
-                dest: '.tmp/styles/',
-                src: '{,*/}*.css'
-            },
             generateHerokuDirectory: {
                     expand: true,
                     dest: 'deploy/heroku',
@@ -350,16 +374,13 @@ module.exports = function (grunt) {
         },
         concurrent: {
             server: [<% if (useCompass) { %>
-                'compass:server',<% } %>
-                'copy:styles'
+                'compass:server'<% } %>
             ],
             test: [<% if (useCompass) { %>
-                'compass',<% } %>
-                'copy:styles'
+                'compass'<% } %>
             ],
             dist: [<% if (useCompass) { %>
                 'compass:dist',<% } %>
-                'copy:styles',
                 'imagemin',
                 'svgmin'
             ]
@@ -436,7 +457,6 @@ module.exports = function (grunt) {
         grunt.task.run([
             'clean:server',
             'concurrent:server',
-            'autoprefixer',
             'configureProxies',
             'connect:livereload',
             'watch'
@@ -446,7 +466,6 @@ module.exports = function (grunt) {
     grunt.registerTask('test', [
         'clean:server',
         'concurrent:test',
-        'autoprefixer',
         'connect:test',
         'karma'
     ]);
@@ -455,8 +474,8 @@ module.exports = function (grunt) {
         'clean:dist',
         'useminPrepare',
         'concurrent:dist',
-        'autoprefixer',
         'concat',
+        'autoprefixer',
         'copy:dist',
         'ngAnnotate',
         'cssmin',

--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -10,7 +10,7 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
-        <!-- build:css(.tmp) styles/main.css -->
+        <!-- build:css styles/main.css -->
         <% if (!useCompass) { %><link rel="stylesheet" href="styles/bootstrap.css">
         <% } %><link rel="stylesheet" href="styles/main.css">
         <!-- endbuild -->


### PR DESCRIPTION
add custom step to usemin:css flow to allow packaging of custom and  external CSS in one file while being able to run the autoprefixer task

issue #748
