### PR TITLE
Remove the user redefinition (cause compile error)

### DIFF
--- a/app/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -81,7 +81,7 @@ public class AccountResource {
             if (userRepository.findOneByEmail(userDTO.getEmail()) != null) {
                 return ResponseEntity.badRequest().contentType(MediaType.TEXT_PLAIN).body("e-mail address already in use");
             }
-            User user = userService.createUserInformation(userDTO.getLogin(), userDTO.getPassword(),
+            user = userService.createUserInformation(userDTO.getLogin(), userDTO.getPassword(),
             userDTO.getFirstName(), userDTO.getLastName(), userDTO.getEmail().toLowerCase(),
             userDTO.getLangKey());
 


### PR DESCRIPTION
user is defined twice :
User user = userRepository.findOne(userDTO.getLogin());
User user = userService.createUserInformation(userDTO.getLogin(), [...]
The redefinition cause compile error on java 1.7
