### PR TITLE
Make grunt hot reload .js files again

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -30,7 +30,8 @@ module.exports = function (grunt) {
                     'src/main/webapp/**/*.html',
                     'src/main/webapp/**/*.json',
                     '.tmp/styles/**/*.css',
-                    '{.tmp/,}src/main/webapp/scripts/**/*.js',
+                    '{.tmp/,}src/main/webapp/app/**/*.js',
+                    '{.tmp/,}src/main/webapp/components/**/*.js',
                     'src/main/webapp/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
             }


### PR DESCRIPTION
grunt didn't watch js files in the new modular frontend this fix makes js hot reload working again.
