### PR TITLE
Enabling snapshot plugins for spring-plugin-milestone

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -14,7 +14,10 @@
             <id>spring-plugin-milestone</id>
             <name>Spring Framework Maven Milestone Repository</name>
             <url>http://repo.spring.io/milestone/</url>
-        </pluginRepository>
+			<snapshots>
+				<enabled>true</enabled>
+			</snapshots>
+		</pluginRepository>
     </pluginRepositories>
 
     <parent>


### PR DESCRIPTION
Fixing issue https://github.com/jhipster/generator-jhipster/issues/829 on 1.10.0 where a new machine without the RC2 version of the plugin cannot resolve the maven dependency.
