### PR TITLE
Fix bug with sub-html file during prod deployment

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -343,7 +343,7 @@ module.exports = function (grunt) {
                     dest: '<%%= yeoman.dist %>',
                     src: [
                         '*.html',
-                        'views/*.html',
+                        'views/**/*.html',
                         'images/**/*.{png,gif,webp}',
                         'fonts/*'
                     ]


### PR DESCRIPTION
During prod deployment, .html file in subfolder such as views/something/myfile.html was ignored. 
