### PR TITLE
Allows to update the javascript with revved images.

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -275,8 +275,14 @@ module.exports = function (grunt) {
         usemin: {
             html: ['<%%= yeoman.dist %>/**/*.html'],
             css: ['<%%= yeoman.dist %>/styles/**/*.css'],
+            js: '<%= yeoman.dist %>/scripts/**/*.js',
             options: {
                 assetsDirs: ['<%%= yeoman.dist %>/**/'],
+                patterns: {
+                    js: [
+                        [/(images\/.*?\.(?:gif|jpeg|jpg|png|webp|svg))/gm, 'Update the JS to reference our revved images']
+                    ]
+                },
                 dirs: ['<%%= yeoman.dist %>']
             }
         },


### PR DESCRIPTION
When images are referenced in javascript, grunt usemin task break the reference because it is not replaced with revved images
