### PR TITLE
Keep closing slash in html element during htmlmin grunt task

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -324,7 +324,8 @@ module.exports = function (grunt) {
                     removeAttributeQuotes: true,
                     removeRedundantAttributes: true,
                     useShortDoctype: true,
-                    removeEmptyAttributes: true
+                    removeEmptyAttributes: true,
+                    keepClosingSlash: true
                 },
                 files: [{
                     expand: true,


### PR DESCRIPTION
Some html element are broken during minification because of closing slash removal:
example : `<input ... />` will break.
The also break inline svg elements.
