### PR TITLE
Use project name in account activation e-mail

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -427,10 +427,10 @@ JhipsterGenerator.prototype.app = function app() {
     }
 
     // i18n resources used by thymeleaf
+    this.template(resourceDir + '/i18n/_messages_en.properties', resourceDir + 'i18n/messages_en.properties', this, {});
     this.copy(resourceDir + '/i18n/messages_ca.properties', resourceDir + 'i18n/messages_ca.properties');
     this.copy(resourceDir + '/i18n/messages_da.properties', resourceDir + 'i18n/messages_da.properties');
     this.copy(resourceDir + '/i18n/messages_de.properties', resourceDir + 'i18n/messages_de.properties');
-    this.copy(resourceDir + '/i18n/messages_en.properties', resourceDir + 'i18n/messages_en.properties');
     this.copy(resourceDir + '/i18n/messages_es.properties', resourceDir + 'i18n/messages_es.properties');
     this.copy(resourceDir + '/i18n/messages_fr.properties', resourceDir + 'i18n/messages_fr.properties');
     this.copy(resourceDir + '/i18n/messages_kr.properties', resourceDir + 'i18n/messages_kr.properties');

--- a/app/templates/src/main/resources/i18n/_messages_en.properties
+++ b/app/templates/src/main/resources/i18n/_messages_en.properties
@@ -5,8 +5,8 @@ error.status=Status:
 error.message=Message:
 
 # Activation e-mail
-email.activation.title=JHipster activation
+email.activation.title=<%= baseName %> account activation
 email.activation.greeting=Dear {0}
-email.activation.text1=Your JHipster account has been created, please click on the URL below to activate it:
+email.activation.text1=Your <%= baseName %> account has been created, please click on the URL below to activate it:
 email.activation.text2=Regards,
-email.signature=JHipster.
+email.signature=<%= baseName %> Team.


### PR DESCRIPTION
For a project named "Github", this changes the current activation e-mail from:

> Subject: JHipster activation
> 
> Dear AmrMostafa,
> Your JHipster account has been created, please click on the URL below to activate it:
> ...
> Regards,
> JHipster.

To:

> Subject: Github account activation
> 
> Dear AmrMostafa,
> Your Github account has been created, please click on the URL below to activate it:
> ...
> Regards,
> Github Team.

**Note**: The PR is for English only. I realize I will need to handle the rest, not sure how to collaborate on i18n though.
