### PR TITLE
Remove unnecessary configuration of error view for thymeleaf

### DIFF
--- a/app/templates/src/main/resources/config/_application-dev.yml
+++ b/app/templates/src/main/resources/config/_application-dev.yml
@@ -46,7 +46,6 @@ spring:
     thymeleaf:
         mode: XHTML
         cache: false
-        viewNames: error
 
 metrics:
     jmx.enabled: true

--- a/app/templates/src/main/resources/config/_application-prod.yml
+++ b/app/templates/src/main/resources/config/_application-prod.yml
@@ -45,8 +45,6 @@ spring:
     thymeleaf:
         mode: XHTML
         cache: true
-        viewNames: error
-
 
 metrics:
     jmx.enabled: true


### PR DESCRIPTION
If the spring configuration property spring.thymeleaf.viewNames have 1 or more views listed then the ThymeleafViewResolver won't handle other added views unless explicitly listed in the property. The error view is resolved even if not listed in the property.
