### PR TITLE
Do not use external config for tests

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -524,7 +524,7 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-surefire-plugin</artifactId>
                 <configuration>
-                    <argLine><% if (javaVersion == '7') { %>-XX:MaxPermSize=128m <% } %>-Xmx256m</argLine>
+                    <argLine><% if (javaVersion == '7') { %>-XX:MaxPermSize=128m <% } %>-Xmx256m -Dspring.config.location=classpath:/config/</argLine>
                     <forkCount>1</forkCount>
                     <reuseForks>true</reuseForks>
                     <!-- Force alphabetical order to have a reproducible build -->


### PR DESCRIPTION
Spring boot usually tries to load `application.yml` from the local file system (`./application.yml` and `./config/application.yml`) which is very useful for externalizing configuration.

However, tests also read the external configuration which is almost always not what we would want. This PR makes tests stick to the `classpath:/config/` for loading its configuration.
