### PR TITLE
Make "grunt jshint" scan all JS files not just the first 2 levels

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -193,8 +193,8 @@ module.exports = function (grunt) {
             all: [
                 'Gruntfile.js',
                 'src/main/webapp/scripts/app.js',
-                'src/main/webapp/scripts/app/{,*/}*.js',
-                'src/main/webapp/scripts/components/{,*/}*.js'
+                'src/main/webapp/scripts/app/**/*.js',
+                'src/main/webapp/scripts/components/**/*.js'
             ]
         },
         coffee: {
@@ -293,7 +293,7 @@ module.exports = function (grunt) {
                 files: [{
                     expand: true,
                     cwd: 'src/main/webapp/assets/images',
-                src: '**/*.{jpg,jpeg}', // we don't optimize PNG files as it doesn't work on Linux. If you are not on Linux, feel free to use '{,*/}*.{png,jpg,jpeg}'
+                src: '**/*.{jpg,jpeg}', // we don't optimize PNG files as it doesn't work on Linux. If you are not on Linux, feel free to use '**/*.{png,jpg,jpeg}'
                     dest: '<%%= yeoman.dist %>/assets/images'
                 }]
             }
@@ -315,8 +315,8 @@ module.exports = function (grunt) {
             // dist: {
             //     files: {
             //         '<%%= yeoman.dist %>/styles/main.css': [
-            //             '.tmp/styles/{,*/}*.css',
-            //             'styles/{,*/}*.css'
+            //             '.tmp/styles/**/*.css',
+            //             'styles/**/*.css'
             //         ]
             //     }
             // }


### PR DESCRIPTION
The grunt jshint task were using the pattern `{,*/}*.js` instead of `**/*.js` so it only reached as far as `app/account/*.js` but not `app/account/activate/*.js`.
