### PR TITLE
Provide created_date for our system users as that is mandatory

### DIFF
--- a/app/templates/src/main/resources/config/liquibase/users.csv
+++ b/app/templates/src/main/resources/config/liquibase/users.csv
@@ -1,5 +1,5 @@
-id;login;password;first_name;last_name;email;activated;lang_key;created_by
-1;system;$2a$10$mE.qmcV0mFU5NcKh73TZx.z4ueI/.bDWbj0T1BYyqP481kGGarKLG;NULL;System;NULL;true;en;system
-2;anonymousUser;$2a$10$j8S5d7Sr7.8VTOYNviDPOeWX8KcYILUVJBsYV83Y5NtECayypx9lO;Anonymous;User;NULL;true;en;system
-3;admin;$2a$10$gSAhZrxMllrbgj/kkK9UceBPpChGWJA7SYIb1Mqo.n5aNLq1/oRrC;NULL;Administrator;NULL;true;en;system
-4;user;$2a$10$VEjxo0jq2YG9Rbk2HmX9S.k1uZBGYUHdUcid3g/vfiEl7lwWgOH/K;NULL;User;NULL;true;en;system
+id;login;password;first_name;last_name;email;activated;lang_key;created_by;created_date
+1;system;$2a$10$mE.qmcV0mFU5NcKh73TZx.z4ueI/.bDWbj0T1BYyqP481kGGarKLG;NULL;System;NULL;true;en;system;1970-01-01 00:00:00
+2;anonymousUser;$2a$10$j8S5d7Sr7.8VTOYNviDPOeWX8KcYILUVJBsYV83Y5NtECayypx9lO;Anonymous;User;NULL;true;en;system;1970-01-01 00:00:00
+3;admin;$2a$10$gSAhZrxMllrbgj/kkK9UceBPpChGWJA7SYIb1Mqo.n5aNLq1/oRrC;NULL;Administrator;NULL;true;en;system;1970-01-01 00:00:00
+4;user;$2a$10$VEjxo0jq2YG9Rbk2HmX9S.k1uZBGYUHdUcid3g/vfiEl7lwWgOH/K;NULL;User;NULL;true;en;system;1970-01-01 00:00:00


### PR DESCRIPTION
Currently the migration fails with:

```
Caused by: org.h2.jdbc.JdbcSQLException: NULL not allowed for column "CREATED_DATE"; SQL statement:
INSERT INTO PUBLIC.T_USER (id, login, password, first_name, last_name, email, activated, lang_key, created_by) VALUES ('1', 'system', '$2a$10$mE.qmcV0mFU5NcKh73TZx.z4ueI/.bDWbj0T1BYyqP481kGGarKLG', NULL, 'System', NULL, TRUE, 'en', 'system') [23502-182]
```
