### PR TITLE
Add jshint task to gulp

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -53,6 +53,7 @@
     "gulp-compass": "1.1.8",<% } %>
     "proxy-middleware": "0.5.0", <% } %>
     "event-stream": "3.1.5",
+    "jshint-stylish": "^1.0.0",
     "karma-script-launcher": "0.1.0",
     "karma-chrome-launcher": "0.1.4",
     "karma-html2js-preprocessor": "0.1.0",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -248,6 +248,12 @@ gulp.task('usemin', ['images', 'styles'], function(){
         pipe(gulp.dest(yeoman.dist));
 });
 
+gulp.task('jshint', function() {
+    return gulp.src(['gulpfile.js', yeoman.app + 'scripts/**/*.js'])
+        .pipe(jshint())
+        .pipe(jshint.reporter('jshint-stylish'));
+});
+
 gulp.task('default', function() {
     gulp.run('test');
     gulp.run('build');


### PR DESCRIPTION
Similar to our default grunt build file, this adds a 'jshint' task to our gulp build file. It looks like this:

![gulp-jshint](https://cloud.githubusercontent.com/assets/35434/5562413/75a26942-8e22-11e4-84e6-0cb939dadd7f.png)
