### PR TITLE
Add support for x-auth-token

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -86,6 +86,10 @@ JhipsterGenerator.prototype.askFor = function askFor() {
                 {
                     value: 'token',
                     name: 'Token-Based Authentication (Oauth2)'
+                },
+                {
+                    value: 'xauth',
+                    name: 'Token-Based Authentication (XAuth)'
                 }
             ],
             default: 0
@@ -483,6 +487,10 @@ JhipsterGenerator.prototype.app = function app() {
         this.template('src/main/java/package/config/_OAuth2ServerConfiguration.java', javaDir + 'config/OAuth2ServerConfiguration.java', this, {});
     }
 
+    if (this.authenticationType == 'xauth') {
+      this.template('src/main/java/package/config/_XAuthConfiguration.java', javaDir + 'config/XAuthConfiguration.java', this, {});
+    }
+
     if (this.databaseType == 'nosql' &&  this.authenticationType == 'token') {
         this.template('src/main/java/package/config/oauth2/_OAuth2AuthenticationReadConverter.java', javaDir + 'config/oauth2/OAuth2AuthenticationReadConverter.java', this, {});
         this.template('src/main/java/package/config/oauth2/_MongoDBTokenStore.java', javaDir + 'config/oauth2/MongoDBTokenStore.java', this, {});
@@ -537,7 +545,12 @@ JhipsterGenerator.prototype.app = function app() {
     this.template('src/main/java/package/security/_package-info.java', javaDir + 'security/package-info.java', this, {});
     this.template('src/main/java/package/security/_AjaxAuthenticationFailureHandler.java', javaDir + 'security/AjaxAuthenticationFailureHandler.java', this, {});
     this.template('src/main/java/package/security/_AjaxAuthenticationSuccessHandler.java', javaDir + 'security/AjaxAuthenticationSuccessHandler.java', this, {});
-    this.template('src/main/java/package/security/_AjaxLogoutSuccessHandler.java', javaDir + 'security/AjaxLogoutSuccessHandler.java', this, {});
+    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
+        this.template('src/main/java/package/security/_AjaxLogoutSuccessHandler.java', javaDir + 'security/AjaxLogoutSuccessHandler.java', this, {});
+    }
+    if (this.authenticationType == 'xauth'){
+        this.template('src/main/java/package/security/_AuthenticationProvider.java', javaDir + 'security/AuthenticationProvider.java', this, {});
+    }
     this.template('src/main/java/package/security/_AuthoritiesConstants.java', javaDir + 'security/AuthoritiesConstants.java', this, {});
     if (this.authenticationType == 'cookie') {
         this.template('src/main/java/package/security/_CustomPersistentRememberMeServices.java', javaDir + 'security/CustomPersistentRememberMeServices.java', this, {});
@@ -547,6 +560,14 @@ JhipsterGenerator.prototype.app = function app() {
     this.template('src/main/java/package/security/_SpringSecurityAuditorAware.java', javaDir + 'security/SpringSecurityAuditorAware.java', this, {});
     this.template('src/main/java/package/security/_UserDetailsService.java', javaDir + 'security/UserDetailsService.java', this, {});
     this.template('src/main/java/package/security/_UserNotActivatedException.java', javaDir + 'security/UserNotActivatedException.java', this, {});
+
+    if (this.authenticationType == 'xauth'){
+      this.template('src/main/java/package/security/xauth/_Token.java', javaDir + 'security/xauth/Token.java', this, {});
+      this.template('src/main/java/package/security/xauth/_TokenProvider.java', javaDir + 'security/xauth/TokenProvider.java', this, {});
+      this.template('src/main/java/package/security/xauth/_UserXAuthTokenController.java', javaDir + 'security/xauth/UserXAuthTokenController.java', this, {});
+      this.template('src/main/java/package/security/xauth/_XAuthTokenConfigurer.java', javaDir + 'security/xauth/XAuthTokenConfigurer.java', this, {});
+      this.template('src/main/java/package/security/xauth/_XAuthTokenFilter.java', javaDir + 'security/xauth/XAuthTokenFilter.java', this, {});
+    }
 
     this.template('src/main/java/package/service/_package-info.java', javaDir + 'service/package-info.java', this, {});
     this.template('src/main/java/package/service/_AuditEventService.java', javaDir + 'service/AuditEventService.java', this, {});
@@ -655,6 +676,8 @@ JhipsterGenerator.prototype.app = function app() {
     this.template(webappDir + '/scripts/components/auth/_principal.service.js', webappDir + 'scripts/components/auth/principal.service.js', this, {});
     if (this.authenticationType == 'token') {
         this.template(webappDir + '/scripts/components/auth/provider/_auth.oauth2.service.js', webappDir + 'scripts/components/auth/provider/auth.oauth2.service.js', this, {});
+    } else if (this.authenticationType == 'xauth') {
+        this.template(webappDir + '/scripts/components/auth/provider/_auth.xauth.service.js', webappDir + 'scripts/components/auth/provider/auth.xauth.service.js', this, {});
     } else {
         this.template(webappDir + '/scripts/components/auth/provider/_auth.session.service.js', webappDir + 'scripts/components/auth/provider/auth.session.service.js', this, {});
     }
@@ -743,7 +766,9 @@ JhipsterGenerator.prototype.app = function app() {
     this.template(testJsDir + 'spec/app/account/login/_loginControllerSpec.js', testJsDir + 'spec/app/account/login/loginControllerSpec.js', this, {});
     this.template(testJsDir + 'spec/app/account/password/_passwordControllerSpec.js', testJsDir + 'spec/app/account/password/passwordControllerSpec.js', this, {});
     this.template(testJsDir + 'spec/app/account/password/_passwordDirectiveSpec.js', testJsDir + 'spec/app/account/password/passwordDirectiveSpec.js', this, {});
-    this.template(testJsDir + 'spec/app/account/sessions/_sessionsControllerSpec.js', testJsDir + 'spec/app/account/sessions/sessionsControllerSpec.js', this, {});
+    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
+        this.template(testJsDir + 'spec/app/account/sessions/_sessionsControllerSpec.js', testJsDir + 'spec/app/account/sessions/sessionsControllerSpec.js', this, {});
+    }
     this.template(testJsDir + 'spec/app/account/settings/_settingsControllerSpec.js', testJsDir + 'spec/app/account/settings/settingsControllerSpec.js', this, {});
     this.template(testJsDir + 'spec/components/auth/_authServicesSpec.js', testJsDir + 'spec/components/auth/authServicesSpec.js', this, {});
 
@@ -762,8 +787,16 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/components/auth/services/account.service.js',
         'scripts/components/auth/services/activate.service.js',
         'scripts/components/auth/services/password.service.js',
-        'scripts/components/auth/services/register.service.js',
-        'scripts/components/auth/services/sessions.service.js',
+        'scripts/components/auth/services/register.service.js'
+        ];
+
+    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
+        appScripts = appScripts.concat([
+            'scripts/components/auth/services/sessions.service.js'
+            ]);
+    }
+
+    appScripts = appScripts.concat([
         'scripts/components/form/form.directive.js',
         'scripts/components/language/language.service.js',
         'scripts/components/language/language.controller.js',
@@ -786,9 +819,17 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/app/account/password/password.controller.js',
         'scripts/app/account/password/password.directive.js',
         'scripts/app/account/register/register.js',
-        'scripts/app/account/register/register.controller.js',
-        'scripts/app/account/sessions/sessions.js',
-        'scripts/app/account/sessions/sessions.controller.js',
+        'scripts/app/account/register/register.controller.js'
+        ]);
+
+    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
+        appScripts = appScripts.concat([
+            'scripts/app/account/sessions/sessions.js',
+            'scripts/app/account/sessions/sessions.controller.js'
+            ]);
+    }
+
+    appScripts = appScripts.concat([
         'scripts/app/account/settings/settings.js',
         'scripts/app/account/settings/settings.controller.js',
         'scripts/app/admin/admin.js',
@@ -807,16 +848,18 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/app/error/error.js',
         'scripts/app/main/main.js',
         'scripts/app/main/main.controller.js'
-        ];
+        ]);
 
     if (this.authenticationType == 'token') {
         appScripts = appScripts.concat([
             'scripts/components/auth/provider/auth.oauth2.service.js']);
-    } else {
+    } else if (this.authenticationType == 'xauth'){
+        appScripts = appScripts.concat([
+            'scripts/components/auth/provider/auth.xauth.service.js']);
+    } else{
         appScripts = appScripts.concat([
             'scripts/components/auth/provider/auth.session.service.js']);
     }
-
     if (this.websocket == 'atmosphere') {
         appScripts = appScripts.concat([
             'scripts/app/admin/tracker/tracker.js',

--- a/app/index.js
+++ b/app/index.js
@@ -766,7 +766,7 @@ JhipsterGenerator.prototype.app = function app() {
     this.template(testJsDir + 'spec/app/account/login/_loginControllerSpec.js', testJsDir + 'spec/app/account/login/loginControllerSpec.js', this, {});
     this.template(testJsDir + 'spec/app/account/password/_passwordControllerSpec.js', testJsDir + 'spec/app/account/password/passwordControllerSpec.js', this, {});
     this.template(testJsDir + 'spec/app/account/password/_passwordDirectiveSpec.js', testJsDir + 'spec/app/account/password/passwordDirectiveSpec.js', this, {});
-    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
+    if (this.authenticationType == 'cookie') {
         this.template(testJsDir + 'spec/app/account/sessions/_sessionsControllerSpec.js', testJsDir + 'spec/app/account/sessions/sessionsControllerSpec.js', this, {});
     }
     this.template(testJsDir + 'spec/app/account/settings/_settingsControllerSpec.js', testJsDir + 'spec/app/account/settings/settingsControllerSpec.js', this, {});
@@ -787,16 +787,7 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/components/auth/services/account.service.js',
         'scripts/components/auth/services/activate.service.js',
         'scripts/components/auth/services/password.service.js',
-        'scripts/components/auth/services/register.service.js'
-        ];
-
-    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
-        appScripts = appScripts.concat([
-            'scripts/components/auth/services/sessions.service.js'
-            ]);
-    }
-
-    appScripts = appScripts.concat([
+        'scripts/components/auth/services/register.service.js',
         'scripts/components/form/form.directive.js',
         'scripts/components/language/language.service.js',
         'scripts/components/language/language.controller.js',
@@ -819,17 +810,7 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/app/account/password/password.controller.js',
         'scripts/app/account/password/password.directive.js',
         'scripts/app/account/register/register.js',
-        'scripts/app/account/register/register.controller.js'
-        ]);
-
-    if (this.authenticationType == 'cookie' || this.authenticationType == 'token') {
-        appScripts = appScripts.concat([
-            'scripts/app/account/sessions/sessions.js',
-            'scripts/app/account/sessions/sessions.controller.js'
-            ]);
-    }
-
-    appScripts = appScripts.concat([
+        'scripts/app/account/register/register.controller.js',
         'scripts/app/account/settings/settings.js',
         'scripts/app/account/settings/settings.controller.js',
         'scripts/app/admin/admin.js',
@@ -848,18 +829,27 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/app/error/error.js',
         'scripts/app/main/main.js',
         'scripts/app/main/main.controller.js'
-        ]);
+        ];
+
+    if (this.authenticationType == 'xauth'){
+        appScripts = appScripts.concat([
+            'scripts/components/auth/provider/auth.xauth.service.js']);
+    }
 
     if (this.authenticationType == 'token') {
         appScripts = appScripts.concat([
             'scripts/components/auth/provider/auth.oauth2.service.js']);
-    } else if (this.authenticationType == 'xauth'){
-        appScripts = appScripts.concat([
-            'scripts/components/auth/provider/auth.xauth.service.js']);
-    } else{
-        appScripts = appScripts.concat([
-            'scripts/components/auth/provider/auth.session.service.js']);
     }
+
+    if (this.authenticationType == 'cookie'){
+        appScripts = appScripts.concat([
+            'scripts/components/auth/provider/auth.session.service.js',
+            'scripts/components/auth/services/sessions.service.js',
+            'scripts/app/account/sessions/sessions.js',
+            'scripts/app/account/sessions/sessions.controller.js',
+            ]);
+    }
+
     if (this.websocket == 'atmosphere') {
         appScripts = appScripts.concat([
             'scripts/app/admin/tracker/tracker.js',

--- a/app/templates/src/main/java/package/config/_XAuthConfiguration.java
+++ b/app/templates/src/main/java/package/config/_XAuthConfiguration.java
@@ -1,0 +1,32 @@
+package <%=packageName%>.config;
+
+import <%=packageName%>.security.xauth.TokenProvider;
+import org.springframework.boot.bind.RelaxedPropertyResolver;
+import org.springframework.context.EnvironmentAware;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+* Created by jboulay on 21/12/14.
+*/
+@Configuration
+public class XAuthConfiguration implements EnvironmentAware {
+
+  private RelaxedPropertyResolver propertyResolver;
+
+  @Override
+  public void setEnvironment(Environment environment) {
+    this.propertyResolver = new RelaxedPropertyResolver(environment, "authentication.xauth.");
+  }
+
+  @Bean
+  public TokenProvider tokenProvider(){
+
+    String secret = propertyResolver.getProperty("secret", String.class, "mySecretXAuthSecret");
+    int validityInSeconds = propertyResolver.getProperty("tokenValidityInSeconds", Integer.class, 3600);
+
+    return new TokenProvider(secret, validityInSeconds);
+  }
+
+}

--- a/app/templates/src/main/java/package/security/_AuthenticationProvider.java
+++ b/app/templates/src/main/java/package/security/_AuthenticationProvider.java
@@ -1,0 +1,62 @@
+package <%=packageName%>.security;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.security.authentication.BadCredentialsException;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.security.crypto.password.PasswordEncoder;
+
+import java.util.Collection;
+
+/**
+ * Created by Julien BOULAY on 21/12/14.
+ */
+public class AuthenticationProvider implements org.springframework.security.authentication.AuthenticationProvider {
+
+    final Logger logger = LoggerFactory.getLogger(this.getClass());
+
+
+    //    private final UserDetailsService userDetailsService;
+    private final PasswordEncoder passwordEncoder;;
+    private final UserDetailsService userDetailsService;
+
+    public AuthenticationProvider(UserDetailsService userDetailsService, PasswordEncoder passwordEncoder) {
+        this.userDetailsService = userDetailsService;
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public Authentication authenticate(Authentication authentication) throws AuthenticationException {
+        UsernamePasswordAuthenticationToken token =
+                (UsernamePasswordAuthenticationToken) authentication;
+        String login = token.getName();
+
+
+        UserDetails user = userDetailsService.loadUserByUsername(login);
+
+        if (user == null) {
+            throw new UsernameNotFoundException("Invalid username/password");
+        }
+        String password = user.getPassword();
+        String tokenPassword = (String) token.getCredentials();
+
+        if (!passwordEncoder.matches(tokenPassword, password)) {
+            throw new BadCredentialsException("Invalid username/password");
+        }
+
+        return new UsernamePasswordAuthenticationToken(user, password,
+            user.getAuthorities());
+    }
+
+    @Override
+    public boolean supports(Class<?> authentication) {
+        return UsernamePasswordAuthenticationToken
+                .class.equals(authentication);
+    }
+}

--- a/app/templates/src/main/java/package/security/xauth/_Token.java
+++ b/app/templates/src/main/java/package/security/xauth/_Token.java
@@ -1,0 +1,23 @@
+package <%=packageName%>.security.xauth;
+
+/**
+ * Created by jboulay on 21/12/14.
+ */
+public class Token {
+
+    String token;
+    long expires;
+
+    public Token(String token, long expires){
+        this.token = token;
+        this.expires = expires;
+    }
+
+    public String getToken() {
+        return token;
+    }
+
+    public long getExpires() {
+        return expires;
+    }
+}

--- a/app/templates/src/main/java/package/security/xauth/_TokenProvider.java
+++ b/app/templates/src/main/java/package/security/xauth/_TokenProvider.java
@@ -1,0 +1,60 @@
+package <%=packageName%>.security.xauth;
+
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.crypto.codec.Hex;
+
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+
+/**
+ * @author Philip W. Sorst (philip@sorst.net)
+ * @author Josh Long (josh@joshlong.com)
+ */
+public class TokenProvider {
+
+    private final String secretKey;
+    private final int tokenValidity;
+
+    public TokenProvider(String secretKey, int tokenValidity)
+    {
+        this.secretKey = secretKey;
+        this.tokenValidity = tokenValidity;
+    }
+    public Token createToken(UserDetails userDetails) {
+        long expires = System.currentTimeMillis() + 1000L * tokenValidity;
+        String token = userDetails.getUsername() + ":" + expires + ":" + computeSignature(userDetails, expires);
+        return new Token(token, expires);
+    }
+
+    public String computeSignature(UserDetails userDetails, long expires) {
+        StringBuilder signatureBuilder = new StringBuilder();
+        signatureBuilder.append(userDetails.getUsername()).append(":");
+        signatureBuilder.append(expires).append(":");
+        signatureBuilder.append(userDetails.getPassword()).append(":");
+        signatureBuilder.append(secretKey);
+
+        MessageDigest digest;
+        try {
+            digest = MessageDigest.getInstance("MD5");
+        } catch (NoSuchAlgorithmException e) {
+            throw new IllegalStateException("No MD5 algorithm available!");
+        }
+        return new String(Hex.encode(digest.digest(signatureBuilder.toString().getBytes())));
+    }
+
+    public String getUserNameFromToken(String authToken) {
+        if (null == authToken) {
+            return null;
+        }
+        String[] parts = authToken.split(":");
+        return parts[0];
+    }
+
+    public boolean validateToken(String authToken, UserDetails userDetails) {
+        String[] parts = authToken.split(":");
+        long expires = Long.parseLong(parts[1]);
+        String signature = parts[2];
+        String signatureToMatch = computeSignature(userDetails, expires);
+        return expires >= System.currentTimeMillis() && signature.equals(signatureToMatch);
+    }
+}

--- a/app/templates/src/main/java/package/security/xauth/_UserXAuthTokenController.java
+++ b/app/templates/src/main/java/package/security/xauth/_UserXAuthTokenController.java
@@ -1,0 +1,53 @@
+package <%=packageName%>.security.xauth;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * This controller generates the token that must be present in subsequent REST
+ * invocations.
+ *
+ * @author Philip W. Sorst (philip@sorst.net)
+ * @author Josh Long (josh@joshlong.com)
+ */
+@RestController
+public class UserXAuthTokenController {
+
+    private final TokenProvider tokenProvider;
+    private final AuthenticationManager authenticationManager;
+    private final UserDetailsService userDetailsService;
+
+    @Autowired
+    public UserXAuthTokenController(AuthenticationManager am, UserDetailsService userDetailsService, TokenProvider tokenProvider) {
+        this.authenticationManager = am;
+        this.userDetailsService = userDetailsService;
+        this.tokenProvider = tokenProvider;
+    }
+
+    @RequestMapping(value = "/api/authenticate", method = { RequestMethod.POST })
+    public Token authorize(@RequestParam String username, @RequestParam String password) {
+
+        UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(username, password);
+        Authentication authentication = this.authenticationManager.authenticate(token);
+        SecurityContextHolder.getContext().setAuthentication(authentication);
+
+        UserDetails details = this.userDetailsService.loadUserByUsername(username);
+
+        return tokenProvider.createToken(details);
+    }
+
+}

--- a/app/templates/src/main/java/package/security/xauth/_XAuthTokenConfigurer.java
+++ b/app/templates/src/main/java/package/security/xauth/_XAuthTokenConfigurer.java
@@ -1,0 +1,29 @@
+package <%=packageName%>.security.xauth;
+
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+/**
+ * @author Philip W. Sorst (philip@sorst.net)
+ * @author Josh Long (josh@joshlong.com)
+ */
+public class XAuthTokenConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final TokenProvider tokenProvider;
+    private UserDetailsService detailsService;
+
+    public XAuthTokenConfigurer(UserDetailsService detailsService, TokenProvider tokenProvider) {
+        this.detailsService = detailsService;
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        XAuthTokenFilter customFilter = new XAuthTokenFilter(detailsService, tokenProvider);
+        http.addFilterBefore(customFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+
+}

--- a/app/templates/src/main/java/package/security/xauth/_XAuthTokenFilter.java
+++ b/app/templates/src/main/java/package/security/xauth/_XAuthTokenFilter.java
@@ -1,0 +1,57 @@
+package <%=packageName%>.security.xauth;
+
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.GenericFilterBean;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+
+/**
+ * Sifts through all incoming requests and installs a Spring Security principal
+ * if a header corresponding to a valid user is found.
+ *
+ * @author Philip W. Sorst (philip@sorst.net)
+ * @author Josh Long (josh@joshlong.com)
+ */
+public class XAuthTokenFilter extends GenericFilterBean {
+
+    private final UserDetailsService detailsService;
+    private final TokenProvider tokenProvider;
+    private String XAUTH_TOKEN_HEADER_NAME = "x-auth-token";
+
+    public XAuthTokenFilter(UserDetailsService userDetailsService, TokenProvider tokenProvider) {
+        this.detailsService = userDetailsService;
+        this.tokenProvider = tokenProvider;
+    }
+
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        try {
+            HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
+            String authToken = httpServletRequest.getHeader(this.XAUTH_TOKEN_HEADER_NAME);
+
+            if (StringUtils.hasText(authToken)) {
+                String username = this.tokenProvider.getUserNameFromToken(authToken);
+
+                UserDetails details = this.detailsService.loadUserByUsername(username);
+
+                if (this.tokenProvider.validateToken(authToken, details)) {
+                    UsernamePasswordAuthenticationToken token = new UsernamePasswordAuthenticationToken(details, details.getPassword(), details.getAuthorities());
+                    SecurityContextHolder.getContext().setAuthentication(token);
+                }
+            }
+            filterChain.doFilter(servletRequest, servletResponse);
+        } catch (Exception ex) {
+            throw new RuntimeException(ex);
+        }
+    }
+
+}

--- a/app/templates/src/main/resources/config/_application.yml
+++ b/app/templates/src/main/resources/config/_application.yml
@@ -28,10 +28,11 @@ spring:
         cacheSeconds: 1<% if (authenticationType == 'token' || authenticationType == 'xauth') { %>
 
 authentication:<% if (authenticationType == 'xauth') { %>
-    xauth:<% } %><% if (authenticationType == 'token') { %>
+    xauth:
+        secret: myXAuthSecret<% } %><% if (authenticationType == 'token') { %>
     oauth:
-        clientid: <%= baseName %>app<% } %>
-        secret: mySecretAuthSecret
+        clientid: <%= baseName %>app
+        secret: mySecretOAuthSecret<% } %>
         # Token is valid 30 minutes
         tokenValidityInSeconds: 1800<% } %>
 

--- a/app/templates/src/main/resources/config/_application.yml
+++ b/app/templates/src/main/resources/config/_application.yml
@@ -25,12 +25,13 @@ spring:
         from: <%= baseName %>@localhost
 
     messageSource:
-        cacheSeconds: 1<% if (authenticationType == 'token') { %>
+        cacheSeconds: 1<% if (authenticationType == 'token' || authenticationType == 'xauth') { %>
 
-authentication:
+authentication:<% if (authenticationType == 'xauth') { %>
+    xauth:<% } %><% if (authenticationType == 'token') { %>
     oauth:
-        clientid: <%= baseName %>app
-        secret: mySecretOAuthSecret
+        clientid: <%= baseName %>app<% } %>
+        secret: mySecretAuthSecret
         # Token is valid 30 minutes
         tokenValidityInSeconds: 1800<% } %>
 

--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -40,16 +40,22 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', 'tmh.dynamicLocale'
             }
         };
     })
-    <% if (authenticationType == 'token') { %>
+    <% if (authenticationType == 'token' || authenticationType == 'xauth') { %>
     .factory('authInterceptor', function ($rootScope, $q, $location, localStorageService) {
         return {
             // Add authorization token to headers
             request: function (config) {
                 config.headers = config.headers || {};
                 var token = localStorageService.get('token');
+                <% if (authenticationType == 'token') { %>
                 if (token && token.expires_at && token.expires_at > new Date().getTime()) {
                     config.headers.Authorization = 'Bearer ' + token.access_token;
                 }
+                <% } %><% if (authenticationType == 'xauth') { %>
+                if (token && token.expires && token.expires > new Date().getTime()) {
+                  config.headers['x-auth-token'] = token.token;
+                }
+                <% } %>
                 return config;
             }
         };
@@ -59,7 +65,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', 'tmh.dynamicLocale'
         <% if (authenticationType == 'cookie') { %>//enable CSRF
         $httpProvider.defaults.xsrfCookieName= 'CSRF-TOKEN';
         $httpProvider.defaults.xsrfHeaderName= 'X-CSRF-TOKEN';<% } %>
-    
+
         //Cache everything except rest api requests
         httpRequestInterceptorCacheBusterProvider.setMatchlist([/.*rest.*/, /.*protected.*/], true);
 
@@ -85,10 +91,10 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', 'tmh.dynamicLocale'
                 }]
             }
         });
-        <% if (authenticationType == 'token') { %>
+        <% if (authenticationType == 'token' || authenticationType == 'xauth') { %>
         $httpProvider.interceptors.push('authInterceptor');<% } %>
 
-        // Initialize angular-translate    
+        // Initialize angular-translate
         $translateProvider.useLoader('$translatePartialLoader', {
             urlTemplate: 'i18n/{lang}/{part}.json'
         });

--- a/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.xauth.service.js
+++ b/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.xauth.service.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('<%=angularAppName%>')
+    .factory('AuthServerProvider', function loginService($http, localStorageService, Base64) {
+        return {
+            login: function(credentials) {
+                var data = "username=" + credentials.username + "&password="
+                    + credentials.password;
+                return $http.post('api/authenticate', data, {
+                    headers: {
+                        "Content-Type": "application/x-www-form-urlencoded",
+                        "Accept": "application/json",
+                    }
+                }).success(function (response) {
+                    localStorageService.set('token', response);
+                    return response;
+                });
+            },
+            logout: function() {
+                //Stateless API : No server logout
+                localStorageService.clearAll();
+            },
+            getToken: function () {
+                return localStorageService.get('token');
+            },
+            hasValidToken: function () {
+                var token = this.getToken();
+                return token && token.expires && token.expires > new Date().getTime();
+            }
+        };
+    });

--- a/app/templates/src/main/webapp/swagger-ui/_index.html
+++ b/app/templates/src/main/webapp/swagger-ui/_index.html
@@ -61,6 +61,8 @@
             <% if (authenticationType == 'token') { %>var authToken = JSON.parse(localStorage.getItem("token")).access_token;
             window.authorizations.add("key", new ApiKeyAuthorization("Authorization",
                             "Bearer " + authToken, "header"));<% } %>
+            <% if (authenticationType == 'xauth') { %>var authToken = JSON.parse(localStorage.getItem("ls.token")).token;
+            window.authorizations.add("key", new ApiKeyAuthorization("X-Auth-Token", authToken, "header"));<% } %>
             window.swaggerUi.load();
         });
     </script>

--- a/app/templates/src/test/javascript/spec/components/auth/_authServicesSpec.js
+++ b/app/templates/src/test/javascript/spec/components/auth/_authServicesSpec.js
@@ -13,7 +13,8 @@ describe('Services Tests ', function () {
             authService = Auth;
             spiedAuthServerProvider = AuthServerProvider;
             //Request on app init
-            $httpBackend.expectPOST('api/logout').respond(200, '');
+            <% if (authenticationType == 'cookie' || authenticationType == 'token') { %>
+            $httpBackend.expectPOST('api/logout').respond(200, '');<% } %>
             var req = 'protected/authentication_check.gif';
             var regex_friendly_req = req.replace(/\//g, '\\/');
             var expected = new RegExp(regex_friendly_req + '\\?cacheBuster=[0-9]+');
@@ -33,7 +34,7 @@ describe('Services Tests ', function () {
             $httpBackend.verifyNoOutstandingExpectation();
             $httpBackend.verifyNoOutstandingRequest();
         });
-
+        <% if (authenticationType == 'cookie' || authenticationType == 'token') { %>
         it('should call backend on logout then call authServerProvider.logout', function(){
             //GIVEN
             //Set spy
@@ -48,7 +49,20 @@ describe('Services Tests ', function () {
             //THEN
             expect(spiedAuthServerProvider.logout).toHaveBeenCalled();
             expect(spiedLocalStorageService.clearAll).toHaveBeenCalled();
-        });
+        });<% } %><% if (authenticationType == 'xauth') { %>
+          it('should call LocalStorageService.clearAll on logout', function(){
+            //GIVEN
+            //Set spy
+            spyOn(spiedLocalStorageService, "clearAll").and.callThrough();
+
+            //WHEN
+            authService.logout();
+            //flush the backend to "execute" the request to do the expectedGET assertion.
+            $httpBackend.flush();
+
+            //THEN
+            expect(spiedLocalStorageService.clearAll).toHaveBeenCalled();
+          });<% } %>
 
     });
 });


### PR DESCRIPTION
X-Auth-Token implementation to enable stateless configuration of jhipster.

Switching between the generator options is done explicitely (as shown below) for better code understanding (cookie/token/xauth).
> if (this.authenticationType == 'cookie' || this.authenticationType == 'token')
is more explicit than
> if (this.authenticationType != 'xauth')
For more clarity, 'token' could also be renamed to 'oauth2'

Implement #892 