### PR TITLE
Fix grunt live-reload for styles (sass + css)

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -49,10 +49,8 @@ module.exports = function (grunt) {
                 files: [
                     'src/main/webapp/**/*.html',
                     'src/main/webapp/**/*.json',
-                    '.tmp/assets/styles/**/*.css',
-                    '{.tmp/,}src/main/webapp/scripts/app.js',
-                    '{.tmp/,}src/main/webapp/scripts/app/**/*.js',
-                    '{.tmp/,}src/main/webapp/scripts/components/**/*.js',
+                    '{.tmp/,}src/main/webapp/assets/styles/**/*.css',
+                    '{.tmp/,}src/main/webapp/scripts/**/*.js',
                     'src/main/webapp/assets/images/**/*.{png,jpg,jpeg,gif,webp,svg}'
                 ]
             }


### PR DESCRIPTION
`grunt server` currently live-reloads HTML & JS but not styles (although it attempts to). This PR fixes that.
