### PR TITLE
User registration API tweaks & tests

### DIFF
--- a/app/templates/src/main/java/package/domain/_User.java
+++ b/app/templates/src/main/java/package/domain/_User.java
@@ -10,6 +10,7 @@ import org.springframework.data.mongodb.core.mapping.Field;
 <% } %><% if (databaseType == 'sql') { %>
 import javax.persistence.*;<% } %>
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Pattern;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.HashSet;
@@ -30,27 +31,29 @@ public class User extends AbstractAuditingEntity implements Serializable {
     private String id;<% } %>
 
     @NotNull
-    @Size(min = 0, max = 50)<% if (databaseType == 'sql') { %>
+    @Pattern(regexp = "^[a-z0-9]*$")
+    @Size(min = 1, max = 50)<% if (databaseType == 'sql') { %>
     @Column(length = 50, unique = true)<% } %>
     private String login;
 
     @JsonIgnore
-    @Size(min = 0, max = 100)<% if (databaseType == 'sql') { %>
+    @NotNull
+    @Size(min = 6, max = 100)<% if (databaseType == 'sql') { %>
     @Column(length = 100)<% } %>
     private String password;
 
-    @Size(min = 0, max = 50)<% if (databaseType == 'sql') { %>
+    @Size(max = 50)<% if (databaseType == 'sql') { %>
     @Column(name = "first_name", length = 50)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("first_name")<% } %>
     private String firstName;
 
-    @Size(min = 0, max = 50)<% if (databaseType == 'sql') { %>
+    @Size(max = 50)<% if (databaseType == 'sql') { %>
     @Column(name = "last_name", length = 50)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("last_name")<% } %>
     private String lastName;
 
     @Email
-    @Size(min = 0, max = 100)<% if (databaseType == 'sql') { %>
+    @Size(max = 100)<% if (databaseType == 'sql') { %>
     @Column(length = 100, unique = true)<% } %>
     private String email;
 <% if (databaseType == 'sql') { %>
@@ -62,7 +65,7 @@ public class User extends AbstractAuditingEntity implements Serializable {
     @Field("lang_key")<% } %>
     private String langKey;
 
-    @Size(min = 0, max = 20)<% if (databaseType == 'sql') { %>
+    @Size(max = 20)<% if (databaseType == 'sql') { %>
     @Column(name = "activation_key", length = 20)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("activation_key")<% } %>
     private String activationKey;

--- a/app/templates/src/main/java/package/web/rest/dto/_UserDTO.java
+++ b/app/templates/src/main/java/package/web/rest/dto/_UserDTO.java
@@ -1,21 +1,34 @@
 package <%=packageName%>.web.rest.dto;
 
+import org.hibernate.validator.constraints.Email;
+
+import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Pattern;
+import javax.validation.constraints.Size;
 import java.util.List;
 
 public class UserDTO {
 
     @Pattern(regexp = "^[a-z0-9]*$")
+    @NotNull
+    @Size(min = 1, max = 50)
     private String login;
 
+    @NotNull
+    @Size(min = 6, max = 100)
     private String password;
 
+    @Size(max = 50)
     private String firstName;
 
+    @Size(max = 50)
     private String lastName;
 
+    @Email
+    @Size(max = 100)
     private String email;
 
+    @Size(min = 2, max = 5)
     private String langKey;
 
     private List<String> roles;

--- a/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
@@ -6,7 +6,9 @@ import <%=packageName%>.domain.Authority;
 import <%=packageName%>.domain.User;
 import <%=packageName%>.repository.UserRepository;
 import <%=packageName%>.security.AuthoritiesConstants;
+import <%=packageName%>.service.MailService;
 import <%=packageName%>.service.UserService;
+import <%=packageName%>.web.rest.dto.UserDTO;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -26,14 +28,20 @@ import org.springframework.test.web.servlet.request.RequestPostProcessor;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
 import javax.inject.Inject;
-import java.util.HashSet;
+import javax.transaction.Transactional;
+import java.util.Arrays;
+import java.util.HashSet;<% if (javaVersion == '8') { %>
+import java.util.Optional;<% } %>
 import java.util.Set;
 
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.anyObject;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Mockito.doNothing;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
-import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 
 /**
  * Test class for the AccountResource REST controller.
@@ -50,18 +58,36 @@ public class AccountResourceTest {
     @Inject
     private UserRepository userRepository;
 
-    @Mock
+    @Inject
     private UserService userService;
 
+    @Mock
+    private UserService mockUserService;
+
+    @Mock
+    private MailService mockMailService;
+
     private MockMvc restUserMockMvc;
+
+    private MockMvc restMvc;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
+        doNothing().when(mockMailService).sendActivationEmail(<% if (javaVersion != '8') { %>(User) <% } %>anyObject(), anyString());
+
         AccountResource accountResource = new AccountResource();
         ReflectionTestUtils.setField(accountResource, "userRepository", userRepository);
         ReflectionTestUtils.setField(accountResource, "userService", userService);
-        this.restUserMockMvc = MockMvcBuilders.standaloneSetup(accountResource).build();
+        ReflectionTestUtils.setField(accountResource, "mailService", mockMailService);
+
+        AccountResource accountUserMockResource = new AccountResource();
+        ReflectionTestUtils.setField(accountUserMockResource, "userRepository", userRepository);
+        ReflectionTestUtils.setField(accountUserMockResource, "userService", mockUserService);
+        ReflectionTestUtils.setField(accountUserMockResource, "mailService", mockMailService);
+
+        this.restMvc = MockMvcBuilders.standaloneSetup(accountResource).build();
+        this.restUserMockMvc = MockMvcBuilders.standaloneSetup(accountUserMockResource).build();
     }
 
     @Test
@@ -70,7 +96,6 @@ public class AccountResourceTest {
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(""));
-
     }
 
     @Test
@@ -102,7 +127,7 @@ public class AccountResourceTest {
         user.setLastName("doe");
         user.setEmail("john.doe@jhipter.com");
         user.setAuthorities(authorities);
-        when(userService.getUserWithAuthorities()).thenReturn(user);
+        when(mockUserService.getUserWithAuthorities()).thenReturn(user);
 
         restUserMockMvc.perform(get("/api/account")
                 .accept(MediaType.APPLICATION_JSON))
@@ -117,10 +142,180 @@ public class AccountResourceTest {
 
     @Test
     public void testGetUnknownAccount() throws Exception {
-        when(userService.getUserWithAuthorities()).thenReturn(null);
+        when(mockUserService.getUserWithAuthorities()).thenReturn(null);
 
         restUserMockMvc.perform(get("/api/account")
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isInternalServerError());
+    }
+
+    @Test
+    @Transactional
+    public void testRegisterValid() throws Exception {
+        UserDTO u = new UserDTO(
+            "joe",                  // login
+            "password",             // password
+            "Joe",                  // firstName
+            "Shmoe",                // lastName
+            "joe@example.com",      // e-mail
+            "en",                   // langKey
+            Arrays.asList(AuthoritiesConstants.USER)
+        );
+
+        restMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(u)))
+            .andExpect(status().isCreated());
+
+        <% if (javaVersion == '8') { %>Optional<User> user = userRepository.findOneByLogin("joe");
+        assertThat(user.isPresent()).isTrue();<% } else { %>User user = userRepository.findOneByLogin("joe");
+        assertThat(user).isNotNull();<% } %>
+    }
+
+    @Test
+    @Transactional
+    public void testRegisterInvalidLogin() throws Exception {
+        UserDTO u = new UserDTO(
+            "funky-log!n",          // login <-- invalid
+            "password",             // password
+            "Funky",                // firstName
+            "One",                  // lastName
+            "funky@example.com",    // e-mail
+            "en",                   // langKey
+            Arrays.asList(AuthoritiesConstants.USER)
+        );
+
+        restUserMockMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(u)))
+            .andExpect(status().isBadRequest());
+
+        <% if (javaVersion == '8') { %>Optional<User> user = userRepository.findOneByEmail("funky@example.com");
+        assertThat(user.isPresent()).isFalse();<% } else { %>User user = userRepository.findOneByEmail("funky@example.com");
+        assertThat(user).isNull();<% } %>
+    }
+
+    @Test
+    @Transactional
+    public void testRegisterInvalidEmail() throws Exception {
+        UserDTO u = new UserDTO(
+            "bob",              // login
+            "password",         // password
+            "Bob",              // firstName
+            "Green",            // lastName
+            "invalid",          // e-mail <-- invalid
+            "en",               // langKey
+            Arrays.asList(AuthoritiesConstants.USER)
+        );
+
+        restUserMockMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(u)))
+            .andExpect(status().isBadRequest());
+
+        <% if (javaVersion == '8') { %>Optional<User> user = userRepository.findOneByLogin("bob");
+        assertThat(user.isPresent()).isFalse();<% } else { %>User user = userRepository.findOneByLogin("bob");
+        assertThat(user).isNull();<% } %>
+    }
+
+    @Test
+    @Transactional
+    public void testRegisterDuplicateLogin() throws Exception {
+        // Good
+        UserDTO u = new UserDTO(
+            "alice",                // login
+            "password",             // password
+            "Alice",                // firstName
+            "Something",            // lastName
+            "alice@example.com",    // e-mail
+            "en",                   // langKey
+            Arrays.asList(AuthoritiesConstants.USER)
+        );
+
+        // Duplicate login, diff e-mail
+        UserDTO dup = new UserDTO(u.getLogin(), u.getPassword(), u.getLogin(), u.getLastName(),
+            "alicejr@example.com", u.getLangKey(), u.getRoles());
+
+        // Good
+        restMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(u)))
+            .andExpect(status().isCreated());
+
+        // Duplicate
+        restMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(dup)))
+            .andExpect(status().is4xxClientError());
+
+        <% if (javaVersion == '8') { %>Optional<User> userDup = userRepository.findOneByEmail("alicejr@example.com");
+        assertThat(userDup.isPresent()).isFalse();<% } else { %>User userDup = userRepository.findOneByEmail("alicejr@example.com");
+        assertThat(userDup).isNull();<% } %>
+    }
+
+    @Test
+    @Transactional
+    public void testRegisterDuplicateEmail() throws Exception {
+        // Good
+        UserDTO u = new UserDTO(
+            "john",                 // login
+            "password",             // password
+            "John",                 // firstName
+            "Doe",                  // lastName
+            "john@example.com",     // e-mail
+            "en",                   // langKey
+            Arrays.asList(AuthoritiesConstants.USER)
+        );
+
+        // Duplicate e-mail, diff login
+        UserDTO dup = new UserDTO("johnjr", u.getPassword(), u.getLogin(), u.getLastName(),
+            u.getEmail(), u.getLangKey(), u.getRoles());
+
+        // Good
+        restMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(u)))
+            .andExpect(status().isCreated());
+
+        // Duplicate e-mail
+        restMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(dup)))
+            .andExpect(status().is4xxClientError());
+
+        <% if (javaVersion == '8') { %>Optional<User> userDup = userRepository.findOneByLogin("johnjr");
+        assertThat(userDup.isPresent()).isFalse();<% } else { %>User userDup = userRepository.findOneByLogin("johnjr");
+        assertThat(userDup).isNull();<% } %>
+    }
+
+    @Test
+    @Transactional
+    public void testRegisterAdminUnauthorized() throws Exception {
+        UserDTO u = new UserDTO(
+            "badguy",               // login
+            "password",             // password
+            "Bad",                  // firstName
+            "Guy",                  // lastName
+            "badguy@example.com",   // e-mail
+            "en",                   // langKey
+            Arrays.asList(AuthoritiesConstants.ADMIN) // <-- only admin should be able to do that
+        );
+
+        restUserMockMvc.perform(
+            post("/api/register")
+                .contentType(TestUtil.APPLICATION_JSON_UTF8)
+                .content(TestUtil.convertObjectToJsonBytes(u)))
+            .andExpect(status().is4xxClientError());
+
+        <% if (javaVersion == '8') { %>Optional<User> userDup = userRepository.findOneByLogin("badguy");
+        assertThat(userDup.isPresent()).isFalse();<% } else { %>User userDup = userRepository.findOneByLogin("badguy");
+        assertThat(userDup).isNull();<% } %>
     }
 }


### PR DESCRIPTION
This PR does the following:
* Adds tests for user registration API (one of them correctly fails, more below)
* Adds bean validation annotations to the user registration DTO (reasons below)

After I wrote the tests initially, two tests failed which are for the following scenarios:

1. Sending an anonymous registration request with `roles=['ROLE_ADMIN']` works, I wanted to get feedback before fixing this test. IMHO the simplest fix is to simply remove `roles` from the DTO and hardcode it as `['ROLE_USER']` as I believe the `/register` endpoint isn't meant for admin registrations. This should be very simply to adjust and I can include it in the PR, it will probably mean I will remove that relevant test altogether since it won't be possible to pass a different role.

2. Saving with **invalid e-mail** worked, even though we use the `@Email` constraint on the entity. This is actually a testing-specific issue. The root cause is that bean validation kicks in for the entity when the session is being flushed, not when the entity is being saved (i.e. through `userRepository.save(..)`) which would happen with a real request/response transaction, but won't occur in time in our unit tests. I didn't find an easy way to get the same semantics in tests. The other thing is that the entities validation exception (`ConstraintViolationException`) is hard to control or propagate cleanly up and through to the REST API, it currently results in a 500 internal server error. The simple fix for both concerns is to validate on the DTO level, which this PR does, so that when a 500 occurs, it would really be a server issue.
