### PR TITLE
Added yeoman-maven-plugin execution of grunt compass:server task to dev profile, fixes #952

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -637,7 +637,32 @@
                     <groupId>org.springframework.boot</groupId>
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </dependency>
-            </dependencies>
+            </dependencies><% if(frontendBuilder == 'grunt' && useCompass) { %>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>com.github.trecloux</groupId>
+                        <artifactId>yeoman-maven-plugin</artifactId>
+                        <version>0.2</version>
+                        <executions>
+                            <execution>
+                                <id>run-grunt</id>
+                                <phase>generate-resources</phase>
+                                <goals>
+                                    <goal>build</goal>
+                                </goals>
+                                <configuration>
+                                    <skipTests>true</skipTests>
+                                    <gruntBuildArgs>compass:server --force</gruntBuildArgs>
+                                </configuration>
+                            </execution>
+                        </executions>
+                        <configuration>
+                            <yeomanProjectDirectory>${project.basedir}</yeomanProjectDirectory>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build><% } %>
         </profile>
         <profile>
             <id>fast</id>


### PR DESCRIPTION
Note that this will add 7 seconds to the startup time when starting the server with `mvn spring-boot:run`