### PR TITLE
Configured wiredep to inject the vendor assets into index.html, fixes #956

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -34,7 +34,11 @@ module.exports = function (grunt) {
             app: require('./bower.json').appPath || 'app',
             dist: 'src/main/webapp/dist'
         },
-        watch: {<% if (useCompass) { %>
+        watch: {
+            bower: {
+                files: ['bower.json'],
+                tasks: ['wiredep']
+            },<% if (useCompass) { %>
             compass: {
                 files: ['src/main/scss/**/*.{scss,sass}'],
                 tasks: ['compass:server']
@@ -66,6 +70,30 @@ module.exports = function (grunt) {
         //            dest: '.tmp/styles/'
         //        }]
         //    }
+        },
+        wiredep: {
+            app: {
+                src: ['src/main/webapp/index.html'<% if (useCompass) { %>,, 'src/main/scss/main.scss'<% } %>],
+                exclude: [/angular-i18n/, /swagger-ui/]<% if (useCompass) { %>,
+                ignorePath: /\.\.\/webapp\/bower_components\// // remove ../webapp/bower_components/ from paths of injected sass files<% } %>
+            },
+            test: {
+                src: 'src/test/javascript/karma.conf.js',
+                exclude: [/angular-i18n/, /swagger-ui/, /angular-scenario/],
+                ignorePath: /\.\.\/\.\.\//, // remove ../../ from paths of injected javascripts
+                devDependencies: true,
+                fileTypes: {
+                    js: {
+                        block: /(([\s\t]*)\/\/\s*bower:*(\S*))(\n|\r|.)*?(\/\/\s*endbower)/gi,
+                        detect: {
+                            js: /'(.*\.js)'/gi
+                        },
+                        replace: {
+                            js: '\'{{filePath}}\','
+                        }
+                    }
+                }
+            }
         },
         connect: {
             proxies: [
@@ -488,6 +516,7 @@ module.exports = function (grunt) {
 
         grunt.task.run([
             'clean:server',
+            'wiredep',
             'concurrent:server',
             'configureProxies',
             'connect:livereload',
@@ -502,6 +531,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('test', [
         'clean:server',
+        'wiredep:test',
         'concurrent:test',
         'connect:test',
         'karma'
@@ -509,6 +539,7 @@ module.exports = function (grunt) {
 
     grunt.registerTask('build', [
         'clean:dist',
+        'wiredep:app',
         'useminPrepare',
         'ngtemplates',
         'concurrent:dist',

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -64,7 +64,8 @@
     "bower": "1.3.12",
     "generator-jhipster": "<%= packagejs.version %>",
     "lodash": "2.4.1",
-    "zeparser": "0.0.7"
+    "zeparser": "0.0.7",
+    "wiredep": "1.8.6"
   },
   "engines": {
     "node": ">=0.10.0"

--- a/app/templates/src/main/scss/main.scss
+++ b/app/templates/src/main/scss/main.scss
@@ -1,6 +1,7 @@
 $icon-font-path: "../../bower_components/bootstrap-sass/vendor/assets/fonts/bootstrap/";
 
-@import './bootstrap-sass/vendor/assets/stylesheets/bootstrap.scss';
+// bower:scss
+// endbower
 
 body {
     background: #fafafa;

--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -10,6 +10,10 @@
         <meta name="description" content="">
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
+        <!-- build:css assets/styles/vendor.css -->
+        <!-- bower:css -->
+        <!-- endbower -->
+        <!-- endbuild -->
         <!-- build:css assets/styles/main.css -->
         <% if (!useCompass) { %><link rel="stylesheet" href="assets/styles/bootstrap.css">
         <% } %><link rel="stylesheet" href="assets/styles/main.css">
@@ -38,6 +42,11 @@
             r.parentNode.insertBefore(e,r)}(window,document,'script','ga'));
             ga('create','UA-XXXXX-X');ga('send','pageview');
         </script>-->
+
+        <!-- build:js scripts/vendor.js -->
+        <!-- bower:js -->
+        <!-- endbower -->
+        <!-- endbuild -->
 
     </body>
 </html>

--- a/app/templates/src/test/javascript/_karma.conf.js
+++ b/app/templates/src/test/javascript/_karma.conf.js
@@ -11,22 +11,8 @@ module.exports = function (config) {
 
         // list of files / patterns to load in the browser
         files: [
-            'main/webapp/bower_components/modernizr/modernizr.js',
-            'main/webapp/bower_components/jquery/dist/jquery.js',
-            'main/webapp/bower_components/angular/angular.js',
-            'main/webapp/bower_components/angular-mocks/angular-mocks.js',
-            'main/webapp/bower_components/angular-ui-router/release/angular-ui-router.js',
-            'main/webapp/bower_components/angular-resource/angular-resource.js',
-            'main/webapp/bower_components/angular-cookies/angular-cookies.js',
-            'main/webapp/bower_components/angular-sanitize/angular-sanitize.js',
-            'main/webapp/bower_components/angular-translate/angular-translate.js',
-            'main/webapp/bower_components/angular-translate-storage-cookie/angular-translate-storage-cookie.js',
-            'main/webapp/bower_components/angular-translate-loader-partial/angular-translate-loader-partial.js',
-            'main/webapp/bower_components/angular-dynamic-locale/src/tmhDynamicLocale.js',
-            'main/webapp/bower_components/angular-local-storage/dist/angular-local-storage.min.js',
-            'main/webapp/bower_components/angular-cache-buster/angular-cache-buster.js',<% if (websocket == 'spring-websocket') { %>
-            'main/webapp/bower_components/stomp-websocket/lib/stomp.js',
-            'main/webapp/bower_components/sockjs-client/dist/sockjs.js',<% } %>
+            // bower:js
+            // endbower
             'main/webapp/scripts/app/app.js',
             'main/webapp/scripts/app/**/*.js',
             'main/webapp/scripts/components/**/*.js',


### PR DESCRIPTION
Solution was copied from [generator-angular](https://github.com/yeoman/generator-angular) project.
Instead of letting the yeoman generator append the script tags to the index.html file it is now done by wiredep.

After these changes there is no need to manually add the `<script>`-tags to `index.html`after installing bower packages with `bower install --save packagename`. it is now done automatically with the `grunt wiredep` task wich is configured to run on `grunt serve`.