### PR TITLE
Rename gulp server task to gulp serve

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -34,6 +34,7 @@
     "time-grunt": "0.3.2",<% if (useCompass) { %>
     "grunt-contrib-compass": "0.7.2",<% }} if(frontendBuilder == 'gulp') { %>
     "gulp": "3.8.9",
+    "gulp-util": "3.0.2",
     "gulp-usemin": "0.3.1",
     "gulp-autoprefixer": "0.0.7",
     "gulp-minify-css": "0.3.3",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -3,6 +3,7 @@
 'use strict';
 
 var gulp = require('gulp'),
+    gutil = require('gulp-util'),
     prefix = require('gulp-autoprefixer'),
     minifyCss = require('gulp-minify-css'),
     usemin = require('gulp-usemin'),
@@ -90,7 +91,7 @@ gulp.task('scripts', function () {
         pipe(connect.reload());
 });
 
-gulp.task('server', ['watch'<% if(useCompass) { %>, 'compass'<% } %>], function() {
+gulp.task('serve', ['watch'<% if(useCompass) { %>, 'compass'<% } %>], function() {
     var baseUri = 'http://localhost:' + yeoman.apiPort;
     // Routes to proxy to the backend
     var proxyRoutes = [
@@ -128,7 +129,7 @@ gulp.task('watch', function() {
     gulp.watch('src/images/**', ['images']);
 });
 
-gulp.task('server:dist', ['build'], function() {
+gulp.task('serve:dist', ['build'], function() {
     var baseUri = 'http://localhost:' + yeoman.apiPort;
     // Routes to proxy to the backend
     var proxyRoutes = [
@@ -189,6 +190,10 @@ gulp.task('jshint', function() {
     return gulp.src(['gulpfile.js', yeoman.app + 'scripts/**/*.js'])
         .pipe(jshint())
         .pipe(jshint.reporter('jshint-stylish'));
+});
+
+gulp.task('server', ['serve'], function () {
+    gutil.log('The `server` task has been deprecated. Use `gulp serve` to start a server');
 });
 
 gulp.task('default', function() {


### PR DESCRIPTION
Following #960, this renames `gulp server` to `gulp serve`, executing gulp server still works but prints a deprecation note.

Fixes #985