### PR TITLE
Gulp: Do not show development ribbon in production

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -40,6 +40,7 @@
     "gulp-minify-css": "0.3.3",
     "gulp-uglify": "0.2.1",
     "gulp-minify-html": "0.1.3",
+    "gulp-if": "^1.2.5",
     "gulp-imagemin": "0.5.0",
     "gulp-flatten": "0.0.2",
     "gulp-ng-annotate": "0.3.0",

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -21,7 +21,8 @@ var gulp = require('gulp'),
     clean = require('gulp-clean'),
     replace = require('gulp-replace'),
     url = require('url'),
-    wiredep = require('wiredep').stream;
+    wiredep = require('wiredep').stream,
+    gulpif = require('gulp-if');
 
 var karma = require('gulp-karma')({configFile: 'src/test/javascript/karma.conf.js'});
 
@@ -204,6 +205,7 @@ gulp.task('build', ['copy', 'wiredep:app'], function () {
 
 gulp.task('usemin', ['images', 'styles'], function() {
     return gulp.src(yeoman.app + '**/*.html').
+        pipe(gulpif('**/' + yeoman.app + 'index.html', replace('<div class="development"></div>', ''))).
         pipe(usemin({
             css: [
                 prefix.apply(),


### PR DESCRIPTION
@andidev mentioend in #1010 that the development ribbon makes it to gulp production builds, this PR fixes that.