### PR TITLE
Change order of liquibase exludeObjects parameter

### DIFF
--- a/app/templates/_liquibase.gradle
+++ b/app/templates/_liquibase.gradle
@@ -19,8 +19,8 @@ task liquibaseDiffChangelog(dependsOn: compileJava, type: JavaExec) {
   args "--password="
   args "--url=<% if (devDatabaseType == 'mysql') { %>jdbc:mysql://localhost:3306/<%= baseName %><% } else if (devDatabaseType == 'postgresql') { %>jdbc:postgresql://localhost/<%= baseName %><% } %>"
   args "--driver=<% if (devDatabaseType == 'mysql') { %>com.mysql.jdbc.Driver<% } else if (devDatabaseType == 'postgresql') { %>org.postgresql.Driver<% } %>"
-  <% if (authenticationType == 'oauth2') { %>args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details, oauth_client_token, oauth_code, oauth_refresh_token"<% } %>
   args "diffChangeLog"
+  <% if (authenticationType == 'oauth2') { %>args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details, oauth_client_token, oauth_code, oauth_refresh_token"<% } %>
 
 }
 


### PR DESCRIPTION
excludeObjects is a parameter for diffChangelog so it must be used after diffChangelog

Fix #1021