### PR TITLE
Fix pluralization for words ending in y

### DIFF
--- a/entity/index.js
+++ b/entity/index.js
@@ -318,6 +318,12 @@ EntityGenerator.prototype.files = function files() {
     }
     this.entityClass = _s.capitalize(this.name);
     this.entityInstance = this.name.charAt(0).toLowerCase() + this.name.slice(1);
+    
+    if (this.entityInstance.slice(-1) == "y") {
+        this.entityInstances = this.entityInstance.str.slice(0, - 1) + "ies";
+    } else {
+        this.entityInstances = this.entityInstance + "s";
+    }
 
     var insight = this.insight();
     insight.track('generator', 'entity');
@@ -343,7 +349,7 @@ EntityGenerator.prototype.files = function files() {
     }
 
     this.template('src/main/webapp/app/_entities.html',
-        'src/main/webapp/scripts/app/entities/' +    this.entityInstance  + '/' + this.entityInstance + 's.html', this, {});
+        'src/main/webapp/scripts/app/entities/' +    this.entityInstance  + '/' + this.entityInstances + '.html', this, {});
     this.template('src/main/webapp/app/_entity-detail.html',
         'src/main/webapp/scripts/app/entities/' +    this.entityInstance  + '/' + this.entityInstance + '-detail.html', this, {});
 

--- a/entity/index.js
+++ b/entity/index.js
@@ -321,8 +321,10 @@ EntityGenerator.prototype.files = function files() {
 
     if (this.entityInstance.slice(-1) == "y") {
         this.entityInstances = this.entityInstance.slice(0, - 1) + "ies";
+        this.entityClasses = this.entityClass.slice(0, -1) + "ies";
     } else {
         this.entityInstances = this.entityInstance + "s";
+        this.entityClasses = this.entityClass + "s";
     }
 
     var insight = this.insight();

--- a/entity/index.js
+++ b/entity/index.js
@@ -318,9 +318,9 @@ EntityGenerator.prototype.files = function files() {
     }
     this.entityClass = _s.capitalize(this.name);
     this.entityInstance = this.name.charAt(0).toLowerCase() + this.name.slice(1);
-    
+
     if (this.entityInstance.slice(-1) == "y") {
-        this.entityInstances = this.entityInstance.str.slice(0, - 1) + "ies";
+        this.entityInstances = this.entityInstance.slice(0, - 1) + "ies";
     } else {
         this.entityInstances = this.entityInstance + "s";
     }

--- a/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/entity/templates/src/main/java/package/domain/_Entity.java
@@ -59,7 +59,7 @@ public class <%= entityClass %> implements Serializable {
     private Set<<%= relationships[relationshipId].otherEntityNameCapitalized %>> <%= relationships[relationshipId].otherEntityName %>s = new HashSet<>();<% } else if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
     @ManyToOne
     private <%= relationships[relationshipId].otherEntityNameCapitalized %> <%= relationships[relationshipId].otherEntityName %>;<% } else if (relationships[relationshipId].relationshipType == 'many-to-many') { %>
-    @ManyToMany<% if (relationships[relationshipId].ownerSide == false) { %>(mappedBy = "<%= entityInstance %>s")
+    @ManyToMany<% if (relationships[relationshipId].ownerSide == false) { %>(mappedBy = "<%= entityInstances %>")
     @JsonIgnore<% } %><% if (hibernateCache != 'no') { %>
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)<% } %>
     private Set<<%= relationships[relationshipId].otherEntityNameCapitalized %>> <%= relationships[relationshipId].otherEntityName %>s = new HashSet<>();<% } else { %>

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -47,7 +47,7 @@ public class <%= entityClass %>Resource {
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
     public List<<%= entityClass %>> getAll() {
-        log.debug("REST request to get all <%= entityClass %>s");
+        log.debug("REST request to get all <%= entityClasses %>");
         return <%= entityInstance %>Repository.findAll();
     }
 

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -28,9 +28,9 @@ public class <%= entityClass %>Resource {
     private <%= entityClass %>Repository <%= entityInstance %>Repository;
 
     /**
-     * POST  /<%= entityInstance %>s -> Create a new <%= entityInstance %>.
+     * POST  /<%= entityInstances %> -> Create a new <%= entityInstance %>.
      */
-    @RequestMapping(value = "/<%= entityInstance %>s",
+    @RequestMapping(value = "/<%= entityInstances %>",
             method = RequestMethod.POST,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
@@ -40,9 +40,9 @@ public class <%= entityClass %>Resource {
     }
 
     /**
-     * GET  /<%= entityInstance %>s -> get all the <%= entityInstance %>s.
+     * GET  /<%= entityInstances %> -> get all the <%= entityInstances %>.
      */
-    @RequestMapping(value = "/<%= entityInstance %>s",
+    @RequestMapping(value = "/<%= entityInstances %>",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
@@ -52,9 +52,9 @@ public class <%= entityClass %>Resource {
     }
 
     /**
-     * GET  /<%= entityInstance %>s/:id -> get the "id" <%= entityInstance %>.
+     * GET  /<%= entityInstances %>/:id -> get the "id" <%= entityInstance %>.
      */
-    @RequestMapping(value = "/<%= entityInstance %>s/{id}",
+    @RequestMapping(value = "/<%= entityInstances %>/{id}",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
@@ -73,9 +73,9 @@ public class <%= entityClass %>Resource {
     }
 
     /**
-     * DELETE  /<%= entityInstance %>s/:id -> delete the "id" <%= entityInstance %>.
+     * DELETE  /<%= entityInstances %>/:id -> delete the "id" <%= entityInstance %>.
      */
-    @RequestMapping(value = "/<%= entityInstance %>s/{id}",
+    @RequestMapping(value = "/<%= entityInstances %>/{id}",
             method = RequestMethod.DELETE,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -112,7 +112,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr ng-repeat="<%=entityInstance %> in <%=entityInstance %>s">
+                <tr ng-repeat="<%=entityInstance %> in <%=entityInstances %>">
                     <td><a ui-sref="<%= entityInstance %>Details({id:<%= entityInstance %>.id})">{{<%=entityInstance %>.id}}</a></td><% for (fieldId in fields) { %>
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') { %>

--- a/entity/templates/src/main/webapp/app/_entity-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-controller.js
@@ -2,11 +2,11 @@
 
 angular.module('<%=angularAppName%>')
     .controller('<%= entityClass %>Controller', function ($scope, <%= entityClass %><% for (relationshipId in relationships) { %>, <%= relationships[relationshipId].otherEntityNameCapitalized %><% } %>) {
-        $scope.<%= entityInstance %>s = [];<% for (relationshipId in relationships) { %>
+        $scope.<%= entityInstances %> = [];<% for (relationshipId in relationships) { %>
         $scope.<%= relationships[relationshipId].otherEntityName %>s = <%= relationships[relationshipId].otherEntityNameCapitalized %>.query();<% } %>
         $scope.loadAll = function() {
             <%= entityClass %>.query(function(result) {
-               $scope.<%= entityInstance %>s = result;
+               $scope.<%= entityInstances %> = result;
             });
         };
         $scope.loadAll();

--- a/entity/templates/src/main/webapp/app/_entity.js
+++ b/entity/templates/src/main/webapp/app/_entity.js
@@ -11,7 +11,7 @@ angular.module('<%=angularAppName%>')
                 },
                 views: {
                     'content@': {
-                        templateUrl: 'scripts/app/entities/<%= entityInstance %>/<%= entityInstance %>s.html',
+                        templateUrl: 'scripts/app/entities/<%= entityInstance %>/<%= entityInstances %>.html',
                         controller: '<%= entityClass %>Controller'
                     }
                 },

--- a/entity/templates/src/main/webapp/components/_entity-service.js
+++ b/entity/templates/src/main/webapp/components/_entity-service.js
@@ -2,7 +2,7 @@
 
 angular.module('<%=angularAppName%>')
     .factory('<%= entityClass %>', function ($resource) {
-        return $resource('api/<%= entityInstance %>s/:id', {}, {
+        return $resource('api/<%= entityInstances %>/:id', {}, {
             'query': { method: 'GET', isArray: true},
             'get': {
                 method: 'GET',

--- a/entity/templates/src/main/webapp/i18n/_entity_ca.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ca.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_da.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_da.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_de.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_de.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_en.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_en.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_es.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_es.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_fr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_fr.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Créer un nouveau <%= entityClass %>",
                 "createOrEditLabel": "Créer ou éditer un <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_kr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_kr.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_pl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pl.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-ru.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-ru.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-sv.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-sv.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-tr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-tr.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-zh-tw.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-zh-tw.json
@@ -2,7 +2,7 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
+                "title": "<%= entityClasses %>",
                 "createLabel": "Create a new <%= entityClass %>",
                 "createOrEditLabel": "Create or edit a <%= entityClass %>"
             },

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -99,15 +99,15 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         assertThat(<%= entityInstance %>Repository.findAll()).hasSize(0);
 
         // Create the <%= entityClass %>
-        rest<%= entityClass %>MockMvc.perform(post("/api/<%= entityInstance %>s")
+        rest<%= entityClass %>MockMvc.perform(post("/api/<%= entityInstances %>")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(<%= entityInstance %>)))
                 .andExpect(status().isOk());
 
         // Validate the <%= entityClass %> in the database
-        List<<%= entityClass %>> <%= entityInstance %>s = <%= entityInstance %>Repository.findAll();
-        assertThat(<%= entityInstance %>s).hasSize(1);
-        <%= entityClass %> test<%= entityClass %> = <%= entityInstance %>s.iterator().next();<% for (fieldId in fields) { if (fields[fieldId].fieldType == 'DateTime') { %>
+        List<<%= entityClass %>> <%= entityInstances %> = <%= entityInstance %>Repository.findAll();
+        assertThat(<%= entityInstances %>).hasSize(1);
+        <%= entityClass %> test<%= entityClass %> = <%= entityInstances %>.iterator().next();<% for (fieldId in fields) { if (fields[fieldId].fieldType == 'DateTime') { %>
         assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>().toDateTime(DateTimeZone.UTC)).isEqualTo(<%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } else { %>
         assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>()).isEqualTo(<%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% }} %>
     }
@@ -118,8 +118,8 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         // Initialize the database
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 
-        // Get all the <%= entityInstance %>s
-        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s"))
+        // Get all the <%= entityInstances %>
+        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstances %>"))
                 .andExpect(status().isOk())
                 .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
                 .andExpect(jsonPath("$.[0].id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'mongodb') { %>
@@ -134,7 +134,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 
         // Get the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s/{id}", <%= entityInstance %>.getId()))
+        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstances %>/{id}", <%= entityInstance %>.getId()))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'mongodb') { %>
@@ -146,7 +146,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
     @Transactional<% } %>
     public void getNonExisting<%= entityClass %>() throws Exception {
         // Get the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s/{id}", 1L))
+        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstances %>/{id}", 1L))
                 .andExpect(status().isNotFound());
     }
 
@@ -158,15 +158,15 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
 
         // Update the <%= entityInstance %><% for (fieldId in fields) { %>
         <%= entityInstance %>.set<%= fields[fieldId].fieldNameCapitalized %>(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } %>
-        rest<%= entityClass %>MockMvc.perform(post("/api/<%= entityInstance %>s")
+        rest<%= entityClass %>MockMvc.perform(post("/api/<%= entityInstances %>")
                 .contentType(TestUtil.APPLICATION_JSON_UTF8)
                 .content(TestUtil.convertObjectToJsonBytes(<%= entityInstance %>)))
                 .andExpect(status().isOk());
 
         // Validate the <%= entityClass %> in the database
-        List<<%= entityClass %>> <%= entityInstance %>s = <%= entityInstance %>Repository.findAll();
-        assertThat(<%= entityInstance %>s).hasSize(1);
-        <%= entityClass %> test<%= entityClass %> = <%= entityInstance %>s.iterator().next();<% for (fieldId in fields) { if (fields[fieldId].fieldType == 'DateTime') { %>
+        List<<%= entityClass %>> <%= entityInstances %> = <%= entityInstance %>Repository.findAll();
+        assertThat(<%= entityInstances %>).hasSize(1);
+        <%= entityClass %> test<%= entityClass %> = <%= entityInstances %>.iterator().next();<% for (fieldId in fields) { if (fields[fieldId].fieldType == 'DateTime') { %>
         assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>().toDateTime(DateTimeZone.UTC)).isEqualTo(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } else { %>
         assertThat(test<%= entityClass %>.get<%=fields[fieldId].fieldNameCapitalized%>()).isEqualTo(<%='UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%>);<% } } %>
     }
@@ -178,12 +178,12 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 
         // Get the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(delete("/api/<%= entityInstance %>s/{id}", <%= entityInstance %>.getId())
+        rest<%= entityClass %>MockMvc.perform(delete("/api/<%= entityInstances %>/{id}", <%= entityInstance %>.getId())
                 .accept(TestUtil.APPLICATION_JSON_UTF8))
                 .andExpect(status().isOk());
 
         // Validate the database is empty
-        List<<%= entityClass %>> <%= entityInstance %>s = <%= entityInstance %>Repository.findAll();
-        assertThat(<%= entityInstance %>s).hasSize(0);
+        List<<%= entityClass %>> <%= entityInstances %> = <%= entityInstance %>Repository.findAll();
+        assertThat(<%= entityInstances %>).hasSize(0);
     }
 }

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -114,7 +114,7 @@ public class <%= entityClass %>ResourceTest {<% if (fieldsContainDateTime == tru
 
     @Test<% if (databaseType == 'sql') { %>
     @Transactional<% } %>
-    public void getAll<%= entityClass %>s() throws Exception {
+    public void getAll<%= entityClasses %>() throws Exception {
         // Initialize the database
         <%= entityInstance %>Repository.save<% if (databaseType == 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
 

--- a/script-base.js
+++ b/script-base.js
@@ -147,7 +147,7 @@ Generator.prototype.addNewEntityToMenu = function(language, key, value) {
     try {
         jhipsterUtils.rewriteFile({
             file: fullPath,
-            needle: '"additionalEntity": "JHipster will add addtional entities"',
+            needle: '"additionalEntity": "JHipster will add additional entities"',
             splicable: [
                     '"' + key + '": "' + value + '",'
             ]


### PR DESCRIPTION
I have fixed the pluralization for entities ending in y. So for instance category is now pluralized as categories. The code should work, I tested it with several entities. The pluralization is centralized, so it could be enhanced later (for instance using one of the js libraries for that purpose).

What remains to be done is pluralization in many-relationships, I'll try to do that later. For now they remain as they where before (s attached to the end).