### PR TITLE
Fixed cache buster interceptor matcher to '/api'

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -60,7 +60,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', 'tmh.dynamicLocale'
         $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-TOKEN';
 <% } %>
         //Cache everything except rest api requests
-        httpRequestInterceptorCacheBusterProvider.setMatchlist([/.*rest.*/, /.*protected.*/], true);
+        httpRequestInterceptorCacheBusterProvider.setMatchlist([/.*api.*/, /.*protected.*/], true);
 
         $urlRouterProvider.otherwise('/');
         $stateProvider.state('site', {


### PR DESCRIPTION
The initialization was matching /rest old mapping for REST API that has been replaced by /api.