### PR TITLE
Fix tests for issue in PR 1033

### DIFF
--- a/app/templates/src/test/javascript/spec/app/account/password/_passwordDirectiveSpec.js
+++ b/app/templates/src/test/javascript/spec/app/account/password/_passwordDirectiveSpec.js
@@ -14,7 +14,7 @@ describe('Directive Tests ', function () {
         elm = angular.element(html);
         $compile(elm)(scope);
 
-        $httpBackend.expectGET('api/account').respond({});
+        $httpBackend.expectGET(/api\/account\?cacheBuster=\d+/).respond({});
         $httpBackend.expectGET('i18n/en/global.json').respond({});
         $httpBackend.expectGET('i18n/en/language.json').respond({});
         $httpBackend.expectGET('scripts/components/navbar/navbar.html').respond({});

--- a/app/templates/src/test/javascript/spec/components/auth/_authServicesSpec.js
+++ b/app/templates/src/test/javascript/spec/components/auth/_authServicesSpec.js
@@ -13,7 +13,7 @@ describe('Services Tests ', function () {
             authService = Auth;
             spiedAuthServerProvider = AuthServerProvider;
             //Request on app init<% if (authenticationType == 'session' || authenticationType == 'oauth2') { %>
-            $httpBackend.expectPOST('api/logout').respond(200, '');<% } %>
+            $httpBackend.expectPOST(/api\/logout\?cacheBuster=\d+/).respond(200, ''); <% } %>
 
             $httpBackend.expectGET('i18n/en/global.json').respond(200, '');
             $httpBackend.expectGET('i18n/en/language.json').respond(200, '');
@@ -22,7 +22,10 @@ describe('Services Tests ', function () {
             $httpBackend.expectGET('i18n/en/language.json').respond(200, '');
             $httpBackend.expectGET('i18n/en/main.json').respond(200, '');
             $httpBackend.expectGET('scripts/app/main/main.html').respond({});
-        }));
+            <% if (authenticationType == 'session' || authenticationType == 'oauth2') { %>
+            $httpBackend.expectGET(/api\/account\?cacheBuster=\d+/).respond({});
+            <% } %>
+          }));
         //make sure no expectations were missed in your tests.
         //(e.g. expectGET or expectPOST)
         afterEach(function() {


### PR DESCRIPTION
Now that the cache buster is enabled on /api, the specs should expect requests to API to use cacheBuster query parameter.

Fix PR #1033