### PR TITLE
  Fast profile should not disable liquibase when using H2

### DIFF
--- a/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
+++ b/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
@@ -114,7 +114,13 @@ public class DatabaseConfiguration <% if (databaseType == 'sql') { %>implements 
         liquibase.setChangeLog("classpath:config/liquibase/master.xml");
         liquibase.setContexts("development, production");
         if (env.acceptsProfiles(Constants.SPRING_PROFILE_FAST)) {
-            liquibase.setShouldRun(false);
+            if ("org.h2.jdbcx.JdbcDataSource".equals(propertyResolver.getProperty("dataSourceClassName"))) {
+                liquibase.setShouldRun(true);
+                log.warn("Using '{}' profile with H2 database in memory is not optimal, you should consider switching to" +
+                    " MySQl or Postgresql to avoid rebuilding your database upon each start.", Constants.SPRING_PROFILE_FAST);
+            } else {
+                liquibase.setShouldRun(false);
+            }
         } else {
             log.debug("Configuring Liquibase");
         }

--- a/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
+++ b/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
@@ -117,7 +117,7 @@ public class DatabaseConfiguration <% if (databaseType == 'sql') { %>implements 
             if ("org.h2.jdbcx.JdbcDataSource".equals(propertyResolver.getProperty("dataSourceClassName"))) {
                 liquibase.setShouldRun(true);
                 log.warn("Using '{}' profile with H2 database in memory is not optimal, you should consider switching to" +
-                    " MySQl or Postgresql to avoid rebuilding your database upon each start.", Constants.SPRING_PROFILE_FAST);
+                    " MySQL or Postgresql to avoid rebuilding your database upon each start.", Constants.SPRING_PROFILE_FAST);
             } else {
                 liquibase.setShouldRun(false);
             }


### PR DESCRIPTION
When H2 database is configured and fast profile is active, run liquibase but warn the user about this sub optimal combination.

Fix #1042 