### PR TITLE
Use new transaction when saving AuditEvent to prevent rollback

### DIFF
--- a/app/templates/src/main/java/package/repository/_CustomAuditEventRepository.java
+++ b/app/templates/src/main/java/package/repository/_CustomAuditEventRepository.java
@@ -7,6 +7,8 @@ import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.context.annotation.Bean;
 import org.springframework.stereotype.Repository;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
 
 import javax.inject.Inject;
 import java.util.Date;
@@ -43,6 +45,7 @@ public class CustomAuditEventRepository {
             }
 
             @Override
+            @Transactional(propagation = Propagation.REQUIRES_NEW)
             public void add(AuditEvent event) {
                 PersistentAuditEvent persistentAuditEvent = new PersistentAuditEvent();
                 persistentAuditEvent.setPrincipal(event.getPrincipal());


### PR DESCRIPTION
If the ```CustomAuditEventRepository``` reuses a transaction that is marked for rollback then the ```AuditEvent``` is never saved. The solution is to annotate ```add()``` with:

```
@Transactional(propagation = Propagation.REQUIRES_NEW)
```