### PR TITLE
Fix maven project error in STS:

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -639,29 +639,31 @@
                 </dependency>
             </dependencies><% if(frontendBuilder == 'grunt' && useCompass) { %>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>com.github.trecloux</groupId>
-                        <artifactId>yeoman-maven-plugin</artifactId>
-                        <version>0.2</version>
-                        <executions>
-                            <execution>
-                                <id>run-grunt</id>
-                                <phase>generate-resources</phase>
-                                <goals>
-                                    <goal>build</goal>
-                                </goals>
-                                <configuration>
-                                    <skipTests>true</skipTests>
-                                    <gruntBuildArgs>compass:server --force</gruntBuildArgs>
-                                </configuration>
-                            </execution>
-                        </executions>
-                        <configuration>
-                            <yeomanProjectDirectory>${project.basedir}</yeomanProjectDirectory>
-                        </configuration>
-                    </plugin>
-                </plugins>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>com.github.trecloux</groupId>
+                            <artifactId>yeoman-maven-plugin</artifactId>
+                            <version>0.2</version>
+                            <executions>
+                                <execution>
+                                    <id>run-grunt</id>
+                                    <phase>generate-resources</phase>
+                                    <goals>
+                                        <goal>build</goal>
+                                    </goals>
+                                    <configuration>
+                                        <skipTests>true</skipTests>
+                                        <gruntBuildArgs>compass:server --force</gruntBuildArgs>
+                                    </configuration>
+                                </execution>
+                            </executions>
+                            <configuration>
+                                <yeomanProjectDirectory>${project.basedir}</yeomanProjectDirectory>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build><% } %>
         </profile>
         <profile>


### PR DESCRIPTION
Plugin execution not covered by lifecycle configuration: com.github.trecloux:yeoman-maven-plugin:0.2:build (execution: run-grunt, phase: generate-resources)

on line 565 of pom.xml
(Maven Project Build Lifecycle Mapping Problem)

Solution is from http://stackoverflow.com/a/13733232/1098564