### PR TITLE
Add private flag to package.json

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -2,6 +2,7 @@
   "name": "<%= _.slugify(baseName) %>",
   "version": "0.0.0",
   "description": "Description for <%= baseName %>",
+  "private": true,
   "dependencies": {
   },
   "devDependencies": {<% if(frontendBuilder == 'grunt') { %>


### PR DESCRIPTION
This gets rid of warnings such as "npm WARN package.json jhipster@0.0.0 No repository field." and similar.