### PR TITLE
Change window title according to current state/view.

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -21,8 +21,19 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', 'tmh.dynamicLocale'
         });
 
         $rootScope.$on('$stateChangeSuccess',  function(event, toState, toParams, fromState, fromParams) {
+            var titleKey = 'global.title';
+
             $rootScope.previousStateName = fromState.name;
             $rootScope.previousStateParams = fromParams;
+
+            // Set the page title key to the one configured in state or use default one
+            if (toState.data.pageTitle) {
+                titleKey = toState.data.pageTitle;
+            }
+            $translate(titleKey).then(function (title) {
+                // Change window title with translated one
+                $window.document.title = title;
+            });
         });
 
         $rootScope.back = function() {

--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -3,7 +3,7 @@
 angular.module('<%=angularAppName%>', ['LocalStorageModule', 'tmh.dynamicLocale',
     'ngResource', 'ui.router', 'ngCookies', 'pascalprecht.translate', 'ngCacheBuster'])
 
-    .run(function ($rootScope, $location, $http, $state, $translate, Auth, Principal, Language, ENV, VERSION) {
+    .run(function ($rootScope, $location, $window, $http, $state, $translate, Auth, Principal, Language, ENV, VERSION) {
         $rootScope.ENV = ENV;
         $rootScope.VERSION = VERSION;
         $rootScope.$on('$stateChangeStart', function (event, toState, toStateParams) {

--- a/app/templates/src/main/webapp/scripts/app/account/activate/_activate.js
+++ b/app/templates/src/main/webapp/scripts/app/account/activate/_activate.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'account',
                 url: '/activate?key',
                 data: {
-                    roles: []
+                    roles: [],
+                    pageTitle: 'activate.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/account/login/_login.js
+++ b/app/templates/src/main/webapp/scripts/app/account/login/_login.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'account',
                 url: '/login',
                 data: {
-                    roles: []
+                    roles: [], 
+                    pageTitle: 'login.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/account/password/_password.js
+++ b/app/templates/src/main/webapp/scripts/app/account/password/_password.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'account',
                 url: '/password',
                 data: {
-                    roles: ['ROLE_USER']
+                    roles: ['ROLE_USER'],
+                    pageTitle: 'global.menu.account.password'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/account/register/_register.js
+++ b/app/templates/src/main/webapp/scripts/app/account/register/_register.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'account',
                 url: '/register',
                 data: {
-                    roles: []
+                    roles: [],
+                    pageTitle: 'register.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/account/sessions/_sessions.js
+++ b/app/templates/src/main/webapp/scripts/app/account/sessions/_sessions.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'account',
                 url: '/sessions',
                 data: {
-                    roles: ['ROLE_USER']
+                    roles: ['ROLE_USER'],
+                    pageTitle: 'global.menu.account.sessions'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/account/settings/_settings.js
+++ b/app/templates/src/main/webapp/scripts/app/account/settings/_settings.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'account',
                 url: '/settings',
                 data: {
-                    roles: ['ROLE_USER']
+                    roles: ['ROLE_USER'],
+                    pageTitle: 'global.menu.account.settings'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/admin/audits/_audits.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/audits/_audits.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'admin',
                 url: '/audits',
                 data: {
-                    roles: ['ROLE_ADMIN']
+                    roles: ['ROLE_ADMIN'],
+                    pageTitle: 'audits.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/admin/configuration/_configuration.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/configuration/_configuration.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'admin',
                 url: '/configuration',
                 data: {
-                    roles: ['ROLE_ADMIN']
+                    roles: ['ROLE_ADMIN'],
+                    pageTitle: 'configuration.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/admin/docs/_docs.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/docs/_docs.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'admin',
                 url: '/docs',
                 data: {
-                    roles: ['ROLE_ADMIN']
+                    roles: ['ROLE_ADMIN'],
+                    pageTitle: 'global.menu.admin.apidocs'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/admin/health/_health.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/health/_health.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'admin',
                 url: '/health',
                 data: {
-                    roles: ['ROLE_ADMIN']
+                    roles: ['ROLE_ADMIN'],
+                    pageTitle: 'health.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/admin/logs/_logs.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/logs/_logs.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'admin',
                 url: '/logs',
                 data: {
-                    roles: ['ROLE_ADMIN']
+                    roles: ['ROLE_ADMIN'],
+                    pageTitle: 'logs.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/admin/metrics/_metrics.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/metrics/_metrics.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'admin',
                 url: '/metrics',
                 data: {
-                    roles: ['ROLE_ADMIN']
+                    roles: ['ROLE_ADMIN'],
+                    pageTitle: 'metrics.title'
                 },
                 views: {
                     'content@': {

--- a/app/templates/src/main/webapp/scripts/app/error/_error.js
+++ b/app/templates/src/main/webapp/scripts/app/error/_error.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'site',
                 url: '/error',
                 data: {
-                    roles: []
+                    roles: [],
+                    pageTitle: 'errors.title'
                 },
                 views: {
                     'content@': {

--- a/entity/templates/src/main/webapp/app/_entity.js
+++ b/entity/templates/src/main/webapp/app/_entity.js
@@ -7,7 +7,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'entity',
                 url: '/<%= entityInstance %>',
                 data: {
-                    roles: ['ROLE_USER']
+                    roles: ['ROLE_USER'],
+                    pageTitle: '<%= angularAppName %>.<%= entityInstance %>.home.title'
                 },
                 views: {
                     'content@': {
@@ -26,7 +27,8 @@ angular.module('<%=angularAppName%>')
                 parent: 'entity',
                 url: '/<%= entityInstance %>/:id',
                 data: {
-                    roles: ['ROLE_USER']
+                    roles: ['ROLE_USER'],
+                    pageTitle: '<%= angularAppName %>.<%= entityInstance %>.detail.title'
                 },
                 views: {
                     'content@': {


### PR DESCRIPTION
This is done by setting the `pageTitle` property of the state data to a translation key.
If this attribute is not found then the application name is used.

Future improvements:
- support parameters in translated titles
- service to change title programmatically

Fix #1056