### PR TITLE
Fix #1165: Use assertj-core-java8 on Java 8

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -155,7 +155,7 @@ dependencies {
     }<% } %>
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: spring_boot_version
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-jetty', version: spring_boot_version<% if (javaVersion == '8') { %>
-    testCompile group: 'org.assertj', name: 'assertj-core-java8', version: assertj_core_version<% } else { %>
+    testCompile group: 'org.assertj', name: 'assertj-core-java8', version: assertj_core_version<% } %><% if (javaVersion == '7') { %>
     testCompile group: 'org.assertj', name: 'assertj-core', version: assertj_core_version<% } %>
     testCompile group: 'junit', name: 'junit', version:'4.11'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'1.9.5'<% if (databaseType == 'sql') { %>

--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -154,8 +154,9 @@ dependencies {
         exclude(module: 'org.slf4j')
     }<% } %>
     testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test', version: spring_boot_version
-    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-jetty', version: spring_boot_version
-    testCompile group: 'org.assertj', name: 'assertj-core', version: assertj_core_version
+    testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-jetty', version: spring_boot_version<% if (javaVersion == '8') { %>
+    testCompile group: 'org.assertj', name: 'assertj-core-java8', version: assertj_core_version<% } else { %>
+    testCompile group: 'org.assertj', name: 'assertj-core', version: assertj_core_version<% } %>
     testCompile group: 'junit', name: 'junit', version:'4.11'
     testCompile group: 'org.mockito', name: 'mockito-core', version:'1.9.5'<% if (databaseType == 'sql') { %>
     testCompile group: 'com.mattbertolini', name: 'liquibase-slf4j', version: liquibase_slf4j_version<% } %><% if (databaseType == 'mongodb') { %>

--- a/app/templates/_gradle.properties
+++ b/app/templates/_gradle.properties
@@ -1,7 +1,7 @@
 rootProject.name=<%= _.slugify(baseName) %>
 profile=dev
 <% if (javaVersion == '8') { %>
-assertj_core_version=1.0.0m1<% } else { %>
+assertj_core_version=1.0.0m1<% } %><% if (javaVersion == '7') { %>
 assertj_core_version=1.6.1<% } %>
 awaility_version=1.4.0
 commons_lang_version=2.6

--- a/app/templates/_gradle.properties
+++ b/app/templates/_gradle.properties
@@ -1,7 +1,8 @@
 rootProject.name=<%= _.slugify(baseName) %>
 profile=dev
-
-assertj_core_version=1.6.1
+<% if (javaVersion == '8') { %>
+assertj_core_version=1.0.0m1<% } else { %>
+assertj_core_version=1.6.1<% } %>
 awaility_version=1.4.0
 commons_lang_version=2.6
 commons_io_version=2.4<% if (databaseType == 'cassandra') { %>

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -22,7 +22,7 @@
 
     <properties>
         <HikariCP.version>2.2.5</HikariCP.version><% if (javaVersion == '8') { %>
-        <assertj-core.version>1.0.0m1</assertj-core.version><% } else { %>
+        <assertj-core.version>1.0.0m1</assertj-core.version><% } %><% if (javaVersion == '7') { %>
         <assertj-core.version>1.6.1</assertj-core.version><% } %>
         <awaitility.version>1.4.0</awaitility.version><% if (databaseType == 'cassandra') { %>
         <cassandra.version>2.0.12</cassandra.version><% } %>
@@ -260,7 +260,7 @@
         </dependency><% } %>
         <dependency>
             <groupId>org.assertj</groupId><% if (javaVersion == '8') { %>
-            <artifactId>assertj-core-java8</artifactId></version><% } else { %>
+            <artifactId>assertj-core-java8</artifactId></version><% } %><% if (javaVersion == '7') { %>
             <artifactId>assertj-core</artifactId><% } %>
             <version>${assertj-core.version}</version>
             <scope>test</scope>

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -21,8 +21,9 @@
     </prerequisites>
 
     <properties>
-        <HikariCP.version>2.2.5</HikariCP.version>
-        <assertj-core.version>1.6.1</assertj-core.version>
+        <HikariCP.version>2.2.5</HikariCP.version><% if (javaVersion == '8') { %>
+        <assertj-core.version>1.0.0m1</assertj-core.version><% } else { %>
+        <assertj-core.version>1.6.1</assertj-core.version><% } %>
         <awaitility.version>1.4.0</awaitility.version><% if (databaseType == 'cassandra') { %>
         <cassandra.version>2.0.12</cassandra.version><% } %>
         <commons-io.version>2.4</commons-io.version>
@@ -258,8 +259,9 @@
             <version>${lz4.version}</version>
         </dependency><% } %>
         <dependency>
-            <groupId>org.assertj</groupId>
-            <artifactId>assertj-core</artifactId>
+            <groupId>org.assertj</groupId><% if (javaVersion == '8') { %>
+            <artifactId>assertj-core-java8</artifactId></version><% } else { %>
+            <artifactId>assertj-core</artifactId><% } %>
             <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency><% if (databaseType == 'cassandra') { %>


### PR DESCRIPTION
Should not impact the existing Java code as the `jassertj-core-java8` is only set when Java 8 is activated. Using the Java8 branch of assertJ enables specific assertions for `Optional` for instance.