### PR TITLE
Re-add bower in package.json for gradle

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -61,7 +61,8 @@
     "karma-jasmine": "0.3.5",
     "karma-requirejs": "0.2.2",
     "karma-phantomjs-launcher": "0.1.4",
-    "karma": "0.12.31",
+    "karma": "0.12.31",<% if (buildTool == 'gradle') { %>
+    "bower": "1.3.12",<% } %>
     "generator-jhipster": "<%= packagejs.version %>",
     "lodash": "2.4.1",<% if (buildTool == 'maven') { %>
     "xml2js": "0.4.4",<% } %>


### PR DESCRIPTION
Gradle uses a Node plugin requiring to give the path to the
actual bower script. Removing bower from `package.json` broke
the build with gradle. This commit re-add it as a workaround.

Kinda fix #1138