### PR TITLE
Gradle's bower task now uses bower global command

### DIFF
--- a/app/templates/_yeoman.gradle
+++ b/app/templates/_yeoman.gradle
@@ -2,9 +2,8 @@ apply plugin: 'com.moowork.node'<% if(frontendBuilder == 'grunt') {%>
 apply plugin: 'grunt'<% } if(frontendBuilder == 'gulp') {%>
 apply plugin: 'com.moowork.gulp'<% } %>
 
-task bower(dependsOn: 'npmInstall', type: NodeTask){
-    script = file('node_modules/bower/bin/bower')
-    args = ['install']
+task bower(type: Exec) {
+   commandLine 'bower', 'install'
 }
 
 <% if(frontendBuilder == 'grunt') {%>


### PR DESCRIPTION
Gradle's bower task now uses bower global command to remove dependency on local bower installed in project's node_modules directory.

This aligns Gradle on how jhipster yeoman generator and maven build work.

Fix PR #1142 for issue #1138