### PR TITLE
Replace grunt plugin with command execution

### DIFF
--- a/app/templates/_profile_prod.gradle
+++ b/app/templates/_profile_prod.gradle
@@ -1,8 +1,6 @@
 apply plugin: 'spring-boot'
 apply plugin: 'com.moowork.node'
-<% if(frontendBuilder == 'grunt') {%>
-apply plugin: 'grunt'
-<% }  if(frontendBuilder == 'gulp') {%>
+<% if(frontendBuilder == 'gulp') {%>
 apply plugin: 'com.moowork.gulp'
 <% } %>
 
@@ -21,11 +19,17 @@ task setProdProperties(dependsOn: bootRun) << {
 }
 
 <% if(frontendBuilder == 'grunt') {%>
-grunt_build.dependsOn 'npmInstall'
-grunt_build.dependsOn 'bower'
-processResources.dependsOn grunt_build
-test.dependsOn grunt_test
-bootRun.dependsOn grunt_test
+task gruntBuild(type: Exec) {
+   commandLine 'grunt', '--force', 'build'
+}
+task gruntTest(type: Exec) {
+   commandLine 'grunt', 'test'
+}
+gruntBuild.dependsOn 'npmInstall'
+gruntBuild.dependsOn 'bower'
+processResources.dependsOn gruntBuild
+test.dependsOn gruntTest
+bootRun.dependsOn gruntTest
 <% }  if(frontendBuilder == 'gulp') {%>
 gulp_build.dependsOn 'npmInstall'
 gulp_build.dependsOn 'bower'


### PR DESCRIPTION
This will be consistent with the way bower is handled. It also
solves an issue with `grunt build` stopping because of a warning.

Fix PR #1142 for issue #1138