### PR TITLE
Fix null pointer issue in hashCode method

### DIFF
--- a/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/entity/templates/src/main/java/package/domain/_Entity.java
@@ -22,6 +22,7 @@ import java.io.Serializable;<% if (fieldsContainBigDecimal == true) { %>
 import java.math.BigDecimal;<% } %><% if (fieldsContainDate == true) { %>
 import java.util.Date;<% } %><% if (relationships.length > 0) { %>
 import java.util.HashSet;
+import java.util.Objects;
 import java.util.Set;<% } %><% if (databaseType == 'cassandra') { %>
 import java.util.UUID;<% } %>
 
@@ -118,14 +119,14 @@ public class <%= entityClass %> implements Serializable {
 
         <%= entityClass %> <%= entityInstance %> = (<%= entityClass %>) o;
 
-        if (id != null ? !id.equals(<%= entityInstance %>.id) : <%= entityInstance %>.id != null) return false;
+        if ( ! Objects.equals(id, <%= entityInstance %>.id)) return false;
 
         return true;
     }
 
     @Override
     public int hashCode() {
-        return <% if (databaseType == 'sql') { %>(int) (id ^ (id >>> 32));<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra' ) { %>id != null ? id.hashCode() : 0;<% } %>
+        return Objects.hashCode(id);
     }
 
     @Override


### PR DESCRIPTION
Currently the generated hashCode method of the entities is not null safe. When a sql entity is created, and the hashCode method is called (for example, when adding it to a HashSet), the method throws a null pointer exception since the id field is not yet set.
To fix the issue I have changed the hashCode method to use the java Objects.hashCode helper method that by default is null safe. It is also slightly more readable.
I have also changed the equals method to use the Objects helper method to make it slightly more readable.