### PR TITLE
fix bower integration for windows os

### DIFF
--- a/app/templates/_yeoman.gradle
+++ b/app/templates/_yeoman.gradle
@@ -1,9 +1,14 @@
+import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.moowork.node'<% if(frontendBuilder == 'grunt') {%>
 apply plugin: 'grunt'<% } if(frontendBuilder == 'gulp') {%>
 apply plugin: 'com.moowork.gulp'<% } %>
 
 task bower(type: Exec) {
-   commandLine 'bower', 'install'
+    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
+        commandLine 'cmd', '/c', 'bower', 'install'
+    }else{
+        commandLine 'bower', 'install'
+    }
 }
 
 <% if(frontendBuilder == 'grunt') {%>


### PR DESCRIPTION
Fix bower integration on windows OS as otherwise it errors with a CreateProcess error=2 as it can't find file to launch