### PR TITLE
Generate DTOs for updating, and listing and editing the entity, and mapp...

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -680,6 +680,7 @@ JhipsterGenerator.prototype.app = function app() {
     this.template('src/main/java/package/service/_UserService.java', javaDir + 'service/UserService.java', this, {});
     this.template('src/main/java/package/service/_MailService.java', javaDir + 'service/MailService.java', this, {});
     this.template('src/main/java/package/service/util/_RandomUtil.java', javaDir + 'service/util/RandomUtil.java', this, {});
+    this.template('src/main/java/package/service/dto/_PageDTO.java', javaDir + 'service/dto/PageDTO.java', this, {});
 
     this.template('src/main/java/package/web/filter/_package-info.java', javaDir + 'web/filter/package-info.java', this, {});
     this.template('src/main/java/package/web/filter/_CachingHttpHeadersFilter.java', javaDir + 'web/filter/CachingHttpHeadersFilter.java', this, {});
@@ -702,6 +703,12 @@ JhipsterGenerator.prototype.app = function app() {
     this.template('src/main/java/package/web/rest/dto/_LoggerDTO.java', javaDir + 'web/rest/dto/LoggerDTO.java', this, {});
     this.template('src/main/java/package/web/rest/dto/_UserDTO.java', javaDir + 'web/rest/dto/UserDTO.java', this, {});
     this.template('src/main/java/package/web/rest/util/_PaginationUtil.java', javaDir + 'web/rest/util/PaginationUtil.java', this, {});
+    this.template('src/main/java/package/web/rest/dto/_AbstractAuditingDetailsDTO.java', javaDir + 'web/rest/dto/AbstractAuditingDetailsDTO.java', this, {});
+    this.template('src/main/java/package/web/rest/dto/_IdDTO.java', javaDir + 'web/rest/dto/IdDTO.java', this, {});
+    this.template('src/main/java/package/web/rest/mapper/_AbstractMapper.java', javaDir + 'web/rest/mapper/AbstractMapper.java', this, {});
+    this.template('src/main/java/package/web/rest/mapper/_BaseMapper.java', javaDir + 'web/rest/mapper/BaseMapper.java', this, {});
+    this.template('src/main/java/package/web/rest/mapper/_Merger.java', javaDir + 'web/rest/mapper/Merger.java', this, {});
+    
     this.template('src/main/java/package/web/rest/_package-info.java', javaDir + 'web/rest/package-info.java', this, {});
     this.template('src/main/java/package/web/rest/_AccountResource.java', javaDir + 'web/rest/AccountResource.java', this, {});
     if (this.databaseType == 'sql' || this.databaseType == 'mongodb') {

--- a/app/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/app/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -25,7 +25,9 @@ public class LoggingAspect {
     @Inject
     private Environment env;
 
-    @Pointcut("within(<%=packageName%>.repository..*) || within(<%=packageName%>.service..*) || within(<%=packageName%>.web.rest..*)")
+    // Skip proxying of the mappers, which cause spring exceptions on autowiring
+    @Pointcut("within(<%=packageName%>.repository..*) || within(<%=packageName%>.service..*) || "
+             + "(within(<%=packageName%>.web.rest..*) && !within(<%=packageName%>.web.rest.mapper..*))")
     public void loggingPointcut() {}
 
     @AfterThrowing(pointcut = "loggingPointcut()", throwing = "e")

--- a/app/templates/src/main/java/package/service/dto/_PageDTO.java
+++ b/app/templates/src/main/java/package/service/dto/_PageDTO.java
@@ -1,0 +1,53 @@
+package <%=packageName%>.service.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * DTO for storing one page of information for a listing.
+ */
+public class PageDTO<ENTITY> implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private final long totalElements;
+    private final int size;
+    private final int totalPages;
+    private final int currentPageNumber;
+    private final List<ENTITY> entities;
+
+    public PageDTO(long totalElements, int size, int totalPages, int pageNumber, List<ENTITY> entities) {
+        super();
+        this.totalElements = totalElements;
+        this.size = size;
+        this.totalPages = totalPages;
+        this.currentPageNumber = pageNumber;
+        this.entities = entities;
+    }
+
+    public long getTotalElements() {
+        return totalElements;
+    }
+
+    public int getSize() {
+        return size;
+    }
+
+    public int getTotalPages() {
+        return totalPages;
+    }
+
+    public int getCurrentPageNumber() {
+        return currentPageNumber;
+    }
+
+    public List<ENTITY> getEntities() {
+        return entities;
+    }
+
+    @Override
+    public String toString() {
+        return "PageDTO [totalElements=" + totalElements + ", size=" + size + ", totalPages=" + totalPages + ", currentPageNumber=" + currentPageNumber
+                + ", entities=" + entities + "]";
+    }
+
+}

--- a/app/templates/src/main/java/package/web/rest/dto/_AbstractAuditingDetailsDTO.java
+++ b/app/templates/src/main/java/package/web/rest/dto/_AbstractAuditingDetailsDTO.java
@@ -1,0 +1,59 @@
+package <%=packageName%>.web.rest.dto;
+
+import org.joda.time.DateTime;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import <%=packageName%>.domain.util.CustomDateTimeDeserializer;
+import <%=packageName%>.domain.util.CustomDateTimeSerializer;
+
+/**
+ * Base DTO class to hold auditing informations
+ */
+public class AbstractAuditingDetailsDTO {
+
+    private String createdBy;
+
+    @JsonSerialize(using = CustomDateTimeSerializer.class)
+    @JsonDeserialize(using = CustomDateTimeDeserializer.class)
+    private DateTime createdDate;
+
+    private String lastModifiedBy;
+
+    @JsonSerialize(using = CustomDateTimeSerializer.class)
+    @JsonDeserialize(using = CustomDateTimeDeserializer.class)
+    private DateTime lastModifiedDate;
+
+    public String getCreatedBy() {
+        return createdBy;
+    }
+
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
+    public DateTime getCreatedDate() {
+        return createdDate;
+    }
+
+    public void setCreatedDate(DateTime createdDate) {
+        this.createdDate = createdDate;
+    }
+
+    public String getLastModifiedBy() {
+        return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
+    }
+
+    public DateTime getLastModifiedDate() {
+        return lastModifiedDate;
+    }
+
+    public void setLastModifiedDate(DateTime lastModifiedDate) {
+        this.lastModifiedDate = lastModifiedDate;
+    }
+
+}

--- a/app/templates/src/main/java/package/web/rest/dto/_IdDTO.java
+++ b/app/templates/src/main/java/package/web/rest/dto/_IdDTO.java
@@ -1,0 +1,39 @@
+package <%=packageName%>.web.rest.dto;
+
+import java.io.Serializable;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+
+/**
+ * Container class to hold one ID. Used for receiving objects from the client side, 
+ * where only the ID is relevant.
+ *
+ */
+<% 
+  var idType = (databaseType == 'sql' ? "Long" : "String");
+%>@JsonIgnoreProperties(ignoreUnknown = true)
+public class IdDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    private <%= idType %> id;
+
+    public IdDTO() {
+    }
+
+    public IdDTO(<%= idType %> id) {
+        this.id = id;
+    }
+
+    public <%= idType %> getId() {
+        return id;
+    }
+
+    public void setId(<%= idType %> id) {
+        this.id = id;
+    }
+
+    @Override
+    public String toString() {
+        return "Id[" + id + ']';
+    }
+}

--- a/app/templates/src/main/java/package/web/rest/mapper/_AbstractMapper.java
+++ b/app/templates/src/main/java/package/web/rest/mapper/_AbstractMapper.java
@@ -1,0 +1,81 @@
+package <%=packageName%>.web.rest.mapper;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+import org.springframework.data.domain.Page;
+
+import <%=packageName%>.service.dto.PageDTO;
+
+/**
+ * Mapper between source and destination type.
+ *
+ * @param <SOURCE>
+ *            the database entity
+ * @param <DETAILS>
+ *            the view sent to the client
+ */
+public abstract class AbstractMapper<SOURCE, DESTINATION> {
+
+    /**
+     * Create DESTINATION object from the SOURCE object.
+     * 
+     * @param object
+     *            the source object
+     * @return the converted object 
+     */
+    public abstract DESTINATION map(SOURCE object);
+
+    /**
+     * Map a collection of source objects to a list of destination objects.
+     *
+     * @param objects
+     *            the collection of source objects
+     * @return the list of mapped objects.
+     */
+    public List<DESTINATION> mapList(Collection<SOURCE> objects) {
+        if (objects == null) {
+            return null;
+        }
+        final List<DESTINATION> details = new ArrayList<>(objects.size());
+        for (final SOURCE entity : objects) {
+            details.add(map(entity));
+        }
+        return details;
+    }
+
+    /**
+     * Map a collection of source objects to a set of destination objects.
+     *
+     * @param objects
+     *            the collection of source objects
+     * @return the set of mapped objects.
+     */
+    public Set<DESTINATION> mapSet(Set<SOURCE> objects) {
+        final Set<DESTINATION> details = new HashSet<>(objects.size());
+        for (final SOURCE entity : objects) {
+            details.add(map(entity));
+        }
+        return details;
+    }
+
+    /**
+     * Map a spring data page of objects to a PageDTO which contains the destination objects.
+     *
+     * @param pageOfObjects
+     *            a page of objects coming from Spring Data.
+     * @return the page dto containing the mapped DTOs.
+     */
+    public PageDTO<DESTINATION> mapPage(Page<SOURCE> pageOfObjects) {
+        return new PageDTO<DESTINATION>(
+            pageOfObjects.getTotalElements(),
+            pageOfObjects.getSize(),
+            pageOfObjects.getTotalPages(),
+            pageOfObjects.getNumber(),
+            mapList(pageOfObjects.getContent()));
+    }
+
+}

--- a/app/templates/src/main/java/package/web/rest/mapper/_BaseMapper.java
+++ b/app/templates/src/main/java/package/web/rest/mapper/_BaseMapper.java
@@ -1,0 +1,54 @@
+package <%=packageName%>.web.rest.mapper;
+<% if (databaseType == 'sql') { %>
+import org.springframework.data.jpa.repository.JpaRepository;<% } else { %>
+import org.springframework.data.repository.PagingAndSortingRepository;<% } %>
+import <%=packageName%>.web.rest.dto.IdDTO;
+
+/**
+ * Mapper between the entity, the update dto, and the details dto.
+ *
+ * @param <ENTITY>
+ *            the database entity
+ * @param <UPDATE>
+ *            the dto used for updating the entity
+ * @param <DETAILS>
+ *            the detailed view for the client
+ */
+public abstract class BaseMapper<ENTITY, UPDATE, DETAILS> extends
+        AbstractMapper<ENTITY, DETAILS> implements Merger<ENTITY, UPDATE> {
+
+<% if (databaseType == 'sql') { %>
+    /**
+     * Return a reference for an entity - without querying the database.
+     *
+     * @param repository
+     *            the repository to ask for
+     * @param id
+     *            the id of the entity.
+     * @return the reference
+     */
+    protected <X> X getReference(JpaRepository<X, Long> repository, IdDTO id) {
+        if (id != null) {
+            return repository.getOne(id.getId());
+        }
+        return null;
+    }
+<% } else { %>
+    /**
+     * Load an entity - with querying the database.
+     *
+     * @param repository
+     *            the repository to ask for
+     * @param id
+     *            the id of the entity.
+     * @return the reference
+     */
+    protected <X> X getReference(PagingAndSortingRepository<X, String> repository, IdDTO id) {
+        if (id != null) {
+            return repository.findOne(id.getId());
+        }
+        return null;
+    }
+<% } %>
+}
+

--- a/app/templates/src/main/java/package/web/rest/mapper/_Merger.java
+++ b/app/templates/src/main/java/package/web/rest/mapper/_Merger.java
@@ -1,0 +1,24 @@
+package <%=packageName%>.web.rest.mapper;
+
+/**
+ * Interface to merge an update DTO to an entity
+ *
+ * @param <ENTITY>
+ *            the entity type
+ * @param <DTO>
+ *            the update dto type
+ */
+public interface Merger<ENTITY, DTO> {
+
+    /**
+     * Updates the entity from the DTO.
+     *
+     * @param dto
+     *            the dto coming from the client
+     * @param entity
+     *            the entity to be updated
+     * @return the updated entity
+     */
+    public abstract ENTITY merge(DTO dto, ENTITY entity);
+
+}

--- a/entity/index.js
+++ b/entity/index.js
@@ -619,6 +619,33 @@ EntityGenerator.prototype.askForRelationships = function askForRelationships() {
         }
     }.bind(this));
 };
+EntityGenerator.prototype.askForDtos = function askForDtos() {
+    if (this.useConfigurationFile == true) { // don't prompt if data are imported from a file
+        return;
+    }
+    var cb = this.async();
+    var prompts = [
+        {
+            type: 'list',
+            name: 'generateDto',
+            message: 'Do you want to have separate DTO classes for communicating with the clients ?',
+            choices: [
+                {
+                    value: 'no',
+                    name: 'No, using entities is fine'
+                },
+                {
+                    value: 'yes',
+                    name: 'Yes, I prefer to use a separate DTO, for a better control of the communication'
+                }],
+            default: 'no'
+        }
+    ];
+    this.prompt(prompts, function (props) {
+      this.generateDto = props.generateDto;
+      cb();
+    }.bind(this));
+}
 
 EntityGenerator.prototype.askForPagination = function askForPagination() {
     if (this.useConfigurationFile == true) { // don't prompt if data are imported from a file
@@ -661,7 +688,6 @@ EntityGenerator.prototype.askForPagination = function askForPagination() {
     }.bind(this));
 };
 
-
 EntityGenerator.prototype.files = function files() {
     if (this.databaseType == "sql" || this.databaseType == "cassandra") {
         this.changelogDate = this.dateFormatForLiquibase();
@@ -681,6 +707,7 @@ EntityGenerator.prototype.files = function files() {
         this.data.changelogDate = this.changelogDate;
         this.data.pagination = this.pagination;
         this.data.validation = this.validation;
+        this.data.generateDto = this.generateDto;
         this.write(this.filename, JSON.stringify(this.data, null, 4));
     } else  {
         this.relationships = this.fileData.relationships;
@@ -700,6 +727,7 @@ EntityGenerator.prototype.files = function files() {
         this.fieldsContainDateTime = this.fileData.fieldsContainDateTime;
         this.fieldsContainDate = this.fileData.fieldsContainDate;
         this.changelogDate = this.fileData.changelogDate;
+        this.generateDto = this.fileData.generateDto;
         for (var idx in this.relationships) {
           var rel = this.relationships[idx];
           rel.relationshipName = rel.relationshipName || rel.otherEntityName;
@@ -732,6 +760,7 @@ EntityGenerator.prototype.files = function files() {
     insight.track('entity/fields', this.fields.length);
     insight.track('entity/relationships', this.relationships.length);
     insight.track('entity/pagination', this.pagination);
+    insight.track('entity/generateDto', this.generateDto);
 
     var resourceDir = 'src/main/resources/';
 
@@ -746,8 +775,21 @@ EntityGenerator.prototype.files = function files() {
             'src/main/java/' + this.packageFolder + '/repository/search/' +    this.entityClass + 'SearchRepository.java', this, {});
     }
 
-    this.template('src/main/java/package/web/rest/_EntityResource.java',
-        'src/main/java/' + this.packageFolder + '/web/rest/' +    this.entityClass + 'Resource.java', this, {});
+    this.template('src/main/java/package/web/rest/_EntityResource.java', 
+        'src/main/java/' + this.packageFolder + '/web/rest/' +  this.entityClass + 'Resource.java', this, {});
+
+    if (this.generateDto) {
+      this.template('src/main/java/package/web/rest/mapper/_EntityMapper.java', 
+          'src/main/java/' + this.packageFolder + '/web/rest/mapper/' +  this.entityClass + 'Mapper.java', this, {});
+      this.template('src/main/java/package/web/rest/mapper/_EntityDetailMapper.java', 
+          'src/main/java/' + this.packageFolder + '/web/rest/mapper/' +  this.entityClass + 'DetailMapper.java', this, {});
+      this.template('src/main/java/package/web/rest/dto/_EntityListDTO.java', 
+          'src/main/java/' + this.packageFolder + '/web/rest/dto/' +  this.entityClass + 'ListDTO.java', this, {});
+      this.template('src/main/java/package/web/rest/dto/_EntityDetailsDTO.java', 
+          'src/main/java/' + this.packageFolder + '/web/rest/dto/' +  this.entityClass + 'DetailsDTO.java', this, {});
+      this.template('src/main/java/package/web/rest/dto/_EntityUpdateDTO.java', 
+          'src/main/java/' + this.packageFolder + '/web/rest/dto/' +  this.entityClass + 'UpdateDTO.java', this, {});
+    }
 
     if (this.databaseType == "sql") {
         this.template(resourceDir + '/config/liquibase/changelog/_added_entity.xml',

--- a/entity/templates/src/main/java/package/repository/_EntityRepository.java
+++ b/entity/templates/src/main/java/package/repository/_EntityRepository.java
@@ -71,15 +71,20 @@ public class <%= entityClass %>Repository {
         return <%= entityInstance %>s;
     }
 
+    public <%= entityClass %> findOne(String id) {
+        return findOne(UUID.fromString(id));
+    }
+
     public <%= entityClass %> findOne(UUID id) {
         return mapper.get(id);
     }
 
-    public void save(<%= entityClass %> <%= entityInstance %>) {
+    public <%= entityClass %> save(<%= entityClass %> <%= entityInstance %>) {
         if (<%= entityInstance %>.getId() == null) {
             <%= entityInstance %>.setId(UUID.randomUUID());
         }
         mapper.save(<%= entityInstance %>);
+        return <%= entityInstance %>;
     }
 
     public void delete(UUID id) {

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -4,14 +4,21 @@ import com.codahale.metrics.annotation.Timed;
 import <%=packageName%>.domain.<%= entityClass %>;
 import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine == 'elasticsearch') { %>
 import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %><% if (pagination != 'no') { %>
-import <%=packageName%>.web.rest.util.PaginationUtil;<% } %>
+import <%=packageName%>.web.rest.util.PaginationUtil;<% } %><% if (generateDto == 'yes') { %>
+import <%=packageName%>.web.rest.dto.<%= entityClass %>DetailsDTO;
+import <%=packageName%>.web.rest.dto.<%= entityClass %>ListDTO;
+import <%=packageName%>.web.rest.dto.<%= entityClass %>UpdateDTO;
+import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;
+import <%=packageName%>.web.rest.mapper.<%= entityClass %>DetailMapper;<% } %>
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;<% if (pagination != 'no') { %>
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;<% } %>
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
+import org.springframework.http.ResponseEntity;<% if (databaseType == 'sql') { %>
+import org.springframework.transaction.annotation.Transactional;<% } %>
 import org.springframework.web.bind.annotation.*;
 
 import javax.inject.Inject;<% if (validation) { %>
@@ -27,6 +34,18 @@ import java.util.stream.StreamSupport;
 
 import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
 
+<%
+  var inputParam, listResultType, detailResultType;
+  if (generateDto == 'yes') {
+    inputParam = entityClass + 'UpdateDTO';
+    listResultType = entityClass + 'ListDTO';
+    detailResultType = entityClass + 'DetailsDTO';
+  } else {
+    inputParam = entityClass;
+    listResultType = entityClass;
+    detailResultType = entityClass;
+  }
+%>
 /**
  * REST controller for managing <%= entityClass %>.
  */
@@ -40,23 +59,32 @@ public class <%= entityClass %>Resource {
     private <%= entityClass %>Repository <%= entityInstance %>Repository;<% if (searchEngine == 'elasticsearch') { %>
 
     @Inject
-    private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;<% } %>
+    private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;<% } %><% if (generateDto == 'yes') { %>
 
+    @Inject
+    private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
+
+    @Inject
+    private <%= entityClass %>DetailMapper <%= entityInstance %>DetailMapper;<% } %>
+    
     /**
      * POST  /<%= entityInstance %>s -> Create a new <%= entityInstance %>.
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
             method = RequestMethod.POST,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @Timed
-    public ResponseEntity<Void> create(<% if (validation) { %>@Valid <% } %>@RequestBody <%= entityClass %> <%= entityInstance %>) throws URISyntaxException {
-        log.debug("REST request to save <%= entityClass %> : {}", <%= entityInstance %>);
-        if (<%= entityInstance %>.getId() != null) {
+    @Timed<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = false)<% } %>
+    public ResponseEntity<Void> create(<% if (validation) { %>@Valid <% } %>@RequestBody <%= inputParam %> input) throws URISyntaxException {
+        log.debug("REST request to save <%= entityClass %> : {}", input);
+        if (input.getId() != null) {
             return ResponseEntity.badRequest().header("Failure", "A new <%= entityInstance %> cannot already have an ID").build();
-        }
-        <%= entityInstance %>Repository.save(<%= entityInstance %>);<% if (searchEngine == 'elasticsearch') { %>
-        <%= entityInstance %>SearchRepository.save(<%= entityInstance %>);<% } %>
-        return ResponseEntity.created(new URI("/api/<%= entityInstance %>s/" + <%= entityInstance %>.getId())).build();
+        }<% if (generateDto == 'yes') { %>
+        final <%= entityClass %> updated = <%= entityInstance %>Mapper.merge(input, new <%= entityClass %>());
+        final <%= entityClass %> persisted = <%= entityInstance %>Repository.save(updated);<% } else { %>
+        final <%= entityClass %> persisted = <%= entityInstance %>Repository.save(input);<% } %><% if (searchEngine == 'elasticsearch') { %>
+        <%= entityInstance %>SearchRepository.save(<%= persisted %>);<% } %>
+        return ResponseEntity.created(new URI("/api/<%= entityInstance %>s/" + persisted.getId())).build();
     }
 
     /**
@@ -65,14 +93,19 @@ public class <%= entityClass %>Resource {
     @RequestMapping(value = "/<%= entityInstance %>s",
         method = RequestMethod.PUT,
         produces = MediaType.APPLICATION_JSON_VALUE)
-    @Timed
-    public ResponseEntity<Void> update(<% if (validation) { %>@Valid <% } %>@RequestBody <%= entityClass %> <%= entityInstance %>) throws URISyntaxException {
-        log.debug("REST request to update <%= entityClass %> : {}", <%= entityInstance %>);
-        if (<%= entityInstance %>.getId() == null) {
-            return create(<%= entityInstance %>);
-        }
-        <%= entityInstance %>Repository.save(<%= entityInstance %>);<% if (searchEngine == 'elasticsearch') { %>
-        <%= entityInstance %>SearchRepository.save(<%= entityInstance %>);<% } %>
+    @Timed<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = false)<% } %>
+    public ResponseEntity<Void> update(<% if (validation) { %>@Valid <% } %>@RequestBody <%= inputParam %> input) throws URISyntaxException {
+        log.debug("REST request to update <%= entityClass %> : {}", input);
+        if (input.getId() == null) {
+            return create(input);
+        }<% if (generateDto == 'yes') { %>
+        final <%= entityClass %> entity = <%= entityInstance %>Repository.findOne(input.getId());
+        final <%= entityClass %> updated = <%= entityInstance %>Mapper.merge(input, entity);
+        <%= entityInstance %>Repository.save(updated);<% if (searchEngine == 'elasticsearch') { %>
+        <%= entityInstance %>SearchRepository.save(updated);<% } %><% } else { %>
+        <%= entityInstance %>Repository.save(input);<% if (searchEngine == 'elasticsearch') { %>
+        <%= entityInstance %>SearchRepository.save(input);<% } %><% } %>
         return ResponseEntity.ok().build();
     }
 
@@ -83,15 +116,16 @@ public class <%= entityClass %>Resource {
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed<% if (pagination == 'no') { %>
-    public List<<%= entityClass %>> getAll() {
+    public List<<%= listResultType %>> getAll() {
         log.debug("REST request to get all <%= entityClass %>s");
-        return <%= entityInstance %>Repository.findAll();<% } %><% if (pagination != 'no') { %>
-    public ResponseEntity<List<<%= entityClass %>>> getAll(@RequestParam(value = "page" , required = false) Integer offset,
+        return <%= entityInstance %>Mapper.mapList(<%= entityInstance %>Repository.findAll());<% } %><% if (pagination != 'no') { %>
+    public ResponseEntity<List<<%= listResultType %>>> getAll(@RequestParam(value = "page" , required = false) Integer offset,
                                   @RequestParam(value = "per_page", required = false) Integer limit)
         throws URISyntaxException {
         Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(PaginationUtil.generatePageRequest(offset, limit));
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityInstance %>s", offset, limit);
-        return new ResponseEntity<<% if (javaVersion == '7') { %>List<<%= entityClass %>><% } %>>(page.getContent(), headers, HttpStatus.OK);<% } %>
+        final List<<%= listResultType %>> result = <% if (generateDto == 'yes') { %><%= entityInstance %>Mapper.mapList(page.getContent());<% } else { %>page.getContent();<% } %>
+        return new ResponseEntity<<% if (javaVersion == '7') { %>List<<%= listResultType %>><% } %>>(result, headers, HttpStatus.OK);<% } %>
     }
 
     /**
@@ -100,20 +134,20 @@ public class <%= entityClass %>Resource {
     @RequestMapping(value = "/<%= entityInstance %>s/{id}",
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @Timed
-    public ResponseEntity<<%= entityClass %>> get(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id<% if (javaVersion == '7') { %>, HttpServletResponse response<% } %>) {
+    @Timed<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = true)<% } %>
+    public ResponseEntity<<%= detailResultType %>> get(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id<% if (javaVersion == '7') { %>, HttpServletResponse response<% } %>) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<% if (javaVersion == '8') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         return Optional.ofNullable(<%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id))<% } %><% if (databaseType == 'cassandra') { %>
-        return Optional.ofNullable(<%= entityInstance %>Repository.findOne(UUID.fromString(id)))<% } %>
-            .map(<%= entityInstance %> -> new ResponseEntity<>(
-                <%= entityInstance %>,
-                HttpStatus.OK))
+        return Optional.ofNullable(<%= entityInstance %>Repository.findOne(UUID.fromString(id)))<% } %><% if (generateDto == 'yes') { %>
+            .map(<%= entityInstance %>DetailMapper::map)<% } %>
+            .map(<%= entityInstance %> -> new ResponseEntity<>(<%= entityInstance %>,HttpStatus.OK))
             .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));<% } else { %>
         <%= entityClass %> <%= entityInstance %> = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id);
         if (<%= entityInstance %> == null) {
             return new ResponseEntity<>(HttpStatus.NOT_FOUND);
         }
-        return new ResponseEntity<>(<%= entityInstance %>, HttpStatus.OK);<% } %>
+        return new ResponseEntity<>(<% if (generateDto == 'yes') { %><%= entityInstance %>DetailMapper.map(<%= entityInstance %>)<% } else {%><%= entityInstance %><% } %>, HttpStatus.OK);<% } %>
     }
 
     /**
@@ -122,7 +156,8 @@ public class <%= entityClass %>Resource {
     @RequestMapping(value = "/<%= entityInstance %>s/{id}",
             method = RequestMethod.DELETE,
             produces = MediaType.APPLICATION_JSON_VALUE)
-    @Timed
+    @Timed<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = false)<% } %>
     public void delete(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>Repository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>

--- a/entity/templates/src/main/java/package/web/rest/dto/_EntityDetailsDTO.java
+++ b/entity/templates/src/main/java/package/web/rest/dto/_EntityDetailsDTO.java
@@ -1,0 +1,46 @@
+package <%=packageName%>.web.rest.dto;
+
+import java.io.Serializable;
+import java.util.List;
+
+/**
+ * A <%= entityClass %>DetailsDTO used to send a <%= entityClass %> to the client for a detail screen or editing.
+ * It will contain all the relations additionaly to the simple attributes.
+ *
+ */
+public class <%= entityClass %>DetailsDTO extends <%= entityClass %>ListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+<% for (relationshipId in relationships) { 
+     var rType = relationships[relationshipId].relationshipType;
+     var multi = rType=='one-to-many' || rType == 'many-to-many';
+     var jType = relationships[relationshipId].otherEntityNameCapitalized+'DetailsDTO';
+     var fieldName = relationships[relationshipId].relationshipName;
+     if (multi) {
+       jType = 'List<'+jType+'>';
+       fieldName = fieldName + 's';
+     }
+     %>
+    private <%= jType %> <%= fieldName %>;<% } %>
+
+<%  
+   for (relationshipId in relationships) { 
+     var rType = relationships[relationshipId].relationshipType;
+     var multi = rType=='one-to-many' || rType == 'many-to-many';
+     var jType = relationships[relationshipId].otherEntityNameCapitalized+'DetailsDTO';
+     var fieldName = relationships[relationshipId].relationshipName;
+     var methodName = relationships[relationshipId].relationshipNameCapitalized;
+     if (multi) {
+       jType = 'List<'+jType+'>';
+       fieldName = fieldName + 's';
+       methodName = methodName + 's';
+     }%>
+    public <%= jType %> get<%= methodName %>() {
+        return <%= fieldName %>;
+    }
+
+    public void set<%= methodName %>(<%= jType %> <%= fieldName %>) {
+        this.<%= fieldName %> = <%= fieldName %>;
+    }
+<% } %>
+}

--- a/entity/templates/src/main/java/package/web/rest/dto/_EntityListDTO.java
+++ b/entity/templates/src/main/java/package/web/rest/dto/_EntityListDTO.java
@@ -1,0 +1,57 @@
+package <%=packageName%>.web.rest.dto;
+
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import <%=packageName%>.domain.util.CustomDateTimeDeserializer;
+import <%=packageName%>.domain.util.CustomDateTimeSerializer;
+import <%=packageName%>.domain.util.CustomLocalDateSerializer;
+import <%=packageName%>.domain.util.ISO8601LocalDateDeserializer;
+import org.joda.time.LocalDate;
+import org.joda.time.DateTime;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import java.io.Serializable;<% if (fieldsContainBigDecimal == true) { %>
+import java.math.BigDecimal;<% } %>
+
+/**
+ * A <%= entityClass %>ListDTO used to send a list of entities to the client, 
+ * For performance reasons no relation is sent - to avoid extra selects.
+ *
+ */<% var pkType = (databaseType == 'sql') ? "Long" : "String"; %>
+public class <%= entityClass %>ListDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    protected <%= pkType %> id;
+<% for (fieldId in fields) { %><% if (fields[fieldId].fieldType == 'LocalDate') { %>
+    @JsonSerialize(using = CustomLocalDateSerializer.class)
+    @JsonDeserialize(using = ISO8601LocalDateDeserializer.class)<% } else if (fields[fieldId].fieldType == 'DateTime') { %>
+    @JsonDeserialize(using = CustomDateTimeDeserializer.class)
+    @JsonSerialize(using = CustomDateTimeSerializer.class)<% } %>
+    protected <%= fields[fieldId].fieldType %> <%= fields[fieldId].fieldName %>;
+<% } %>
+    public <%= pkType %> getId() {
+        return id;
+    }
+
+    public void setId(<%= pkType %> id) {
+        this.id = id;
+    }
+<% for (fieldId in fields) { %>
+    public <%= fields[fieldId].fieldType %> get<%= fields[fieldId].fieldNameCapitalized %>() {
+        return <%= fields[fieldId].fieldName %>;
+    }
+
+    public void set<%= fields[fieldId].fieldNameCapitalized %>(<%= fields[fieldId].fieldType %> <%= fields[fieldId].fieldName %>) {
+        this.<%= fields[fieldId].fieldName %> = <%= fields[fieldId].fieldName %>;
+    }
+<% } %>
+
+    @Override
+    public String toString() {
+        return this.getClass().getSimpleName() + "{" +
+                "id=" + id + <% for (fieldId in fields) { %>
+                ",<%= fields[fieldId].fieldName %>=" + <%= fields[fieldId].fieldName %> + <% } %>
+                '}';
+    }
+}

--- a/entity/templates/src/main/java/package/web/rest/dto/_EntityUpdateDTO.java
+++ b/entity/templates/src/main/java/package/web/rest/dto/_EntityUpdateDTO.java
@@ -1,0 +1,99 @@
+package <%=packageName%>.web.rest.dto;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
+import com.fasterxml.jackson.databind.annotation.JsonSerialize;
+import <%=packageName%>.domain.util.CustomDateTimeDeserializer;
+import <%=packageName%>.domain.util.CustomDateTimeSerializer;
+import <%=packageName%>.domain.util.CustomLocalDateSerializer;
+import <%=packageName%>.domain.util.ISO8601LocalDateDeserializer;
+import org.joda.time.LocalDate;
+import org.joda.time.DateTime;
+import java.io.Serializable;<% if (fieldsContainBigDecimal == true) { %>
+import java.math.BigDecimal;<% } %><% if (relationships.length > 0) { %>
+import java.util.List;<% } %><% if (validation) { %>
+import javax.validation.constraints.*;<% } %>
+
+/**
+ * A DTO object sent by the client to update a <%= entityClass %> instance.
+ */
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class <%= entityClass %>UpdateDTO implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+    <% if (databaseType == 'sql') { %>
+    private Long id;<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>
+    private String id;<% } %>
+<% for (fieldId in fields) { %><% if (fields[fieldId].fieldValidate == true) {
+    var required = false;
+    if (fields[fieldId].fieldValidate == true && fields[fieldId].fieldValidateRules.indexOf('required') != -1) {
+        required = true;
+    }
+    if (required) { %>
+    @NotNull<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxlength') == -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('minlength') == -1) { %>
+    @Size(max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>, max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
+    @Min(value = <%= fields[fieldId].fieldValidateRulesMin %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
+    @Max(value = <%= fields[fieldId].fieldValidateRulesMax %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
+    @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPattern %>")<% } } %><% if (fields[fieldId].fieldType == 'LocalDate') { %>
+    @JsonSerialize(using = CustomLocalDateSerializer.class)
+    @JsonDeserialize(using = ISO8601LocalDateDeserializer.class)<% } else if (fields[fieldId].fieldType == 'DateTime') { %>
+    @JsonSerialize(using = CustomDateTimeSerializer.class)
+    @JsonDeserialize(using = CustomDateTimeDeserializer.class)<% } %>
+    private <%= fields[fieldId].fieldType %> <%= fields[fieldId].fieldName %>;
+<% } 
+   for (relationshipId in relationships) { 
+     var rType = relationships[relationshipId].relationshipType;
+     var multi = rType=='one-to-many' || rType == 'many-to-many';
+     var jType = 'IdDTO';
+     var fieldName = relationships[relationshipId].relationshipName;
+     if (multi) {
+       jType = 'List<'+jType+'>';
+       fieldName = fieldName + 's';
+     }%>
+    private <%= jType %> <%= fieldName %>;<% } %>
+
+    public <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> getId() {
+        return id;
+    }
+
+    public void setId(<% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+        this.id = id;
+    }
+<% for (fieldId in fields) { %>
+    public <%= fields[fieldId].fieldType %> get<%= fields[fieldId].fieldNameCapitalized %>() {
+        return <%= fields[fieldId].fieldName %>;
+    }
+
+    public void set<%= fields[fieldId].fieldNameCapitalized %>(<%= fields[fieldId].fieldType %> <%= fields[fieldId].fieldName %>) {
+        this.<%= fields[fieldId].fieldName %> = <%= fields[fieldId].fieldName %>;
+    }
+<% } 
+   for (relationshipId in relationships) { 
+     var rType = relationships[relationshipId].relationshipType;
+     var multi = rType=='one-to-many' || rType == 'many-to-many';
+     var jType = 'IdDTO';
+     var fieldName = relationships[relationshipId].relationshipName;
+     var methodName = relationships[relationshipId].relationshipNameCapitalized;
+     if (multi) {
+       jType = 'List<'+jType+'>';
+       fieldName = fieldName + 's';
+       methodName = methodName + 's';
+     }%>
+    public <%= jType %> get<%= methodName %>() {
+        return <%= fieldName%>;
+    }
+
+    public void set<%= methodName %>(<%= jType %> <%= fieldName %>) {
+        this.<%= fieldName %> = <%= fieldName %>;
+    }
+<% } %>
+    @Override
+    public String toString() {
+        return "<%= entityClass %>UpdateDTO{" +
+                "id=" + id + <% for (fieldId in fields) { %>
+                ",<%= fields[fieldId].fieldName %>=" + <%= fields[fieldId].fieldName %> + <% } %>
+                '}';
+    }
+}

--- a/entity/templates/src/main/java/package/web/rest/mapper/_EntityDetailMapper.java
+++ b/entity/templates/src/main/java/package/web/rest/mapper/_EntityDetailMapper.java
@@ -1,0 +1,52 @@
+package <%=packageName%>.web.rest.mapper;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+import <%=packageName%>.web.rest.dto.<%= entityClass %>DetailsDTO;
+import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;<%
+  for (idx in differentTypes) { 
+    var dtype = differentTypes[idx];
+    if (dtype != entityClass) { %>
+import <%=packageName%>.web.rest.mapper.<%= dtype %>DetailMapper;<% } %>
+import <%=packageName%>.domain.<%= dtype %>;<% } %>
+
+/**
+ * Mapper between <%= entityClass %> and <%= entityClass %>DetailsDTO, which recursively load all the related entities.
+ */
+@Component
+public class <%= entityClass %>DetailMapper extends AbstractMapper<<%= entityClass %>,<%= entityClass %>DetailsDTO> {
+
+    @Inject
+    private <%= entityClass %>Mapper listMapper;
+<%
+for (idx in differentTypes) { 
+    var dtype = differentTypes[idx];
+    if (dtype != entityClass) { %>
+    @Inject
+    private <%= dtype %>DetailMapper <%= dtype.toLowerCase() %>Mapper;<% } } %>
+
+    @Override
+    public <%= entityClass %>DetailsDTO map(<%= entityClass %> entity) {
+        if (entity == null) {
+            return null;
+        }
+        <%= entityClass %>DetailsDTO dto = listMapper.mapToDto(entity, new <%= entityClass %>DetailsDTO());<%
+  for (relationshipId in relationships) { 
+    var jType = relationships[relationshipId].otherEntityNameCapitalized;
+    var fieldName = relationships[relationshipId].otherEntityName; 
+    var rType = relationships[relationshipId].relationshipType;
+    var relationNameCapitalized = relationships[relationshipId].relationshipNameCapitalized;
+    var multi = rType=='one-to-many' || rType == 'many-to-many';
+    var mapMethod = 'map';
+    if (multi) {
+      relationNameCapitalized = relationNameCapitalized + 's';
+      mapMethod = 'mapList';
+    }  
+    var mapperName = (jType != entityClass ? fieldName + "Mapper." : "");
+    %>
+        dto.set<%= relationNameCapitalized %>(<%= mapperName %><%= mapMethod %>(entity.get<%= relationNameCapitalized %>()));<% 
+  }%>
+        return dto;
+    }
+}

--- a/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
+++ b/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
@@ -1,0 +1,66 @@
+package <%=packageName%>.web.rest.mapper;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+import <%=packageName%>.web.rest.dto.<%= entityClass %>UpdateDTO;
+import <%=packageName%>.web.rest.dto.<%= entityClass %>ListDTO;<% if (relationships.length > 0) { %>
+import java.util.HashSet;
+import java.util.Set;
+import <%=packageName%>.web.rest.dto.IdDTO;<% } %><%   
+  for (idx in differentTypes) { 
+    var dtype = differentTypes[idx];
+    if (dtype != entityClass) { %>
+import <%=packageName%>.web.rest.mapper.<%= dtype %>Mapper;<% } %>
+import <%=packageName%>.domain.<%= dtype %>;
+import <%=packageName%>.repository.<%= dtype %>Repository;<% } %>
+
+/**
+ * Mapper between <%= entityClass %> and <%= entityClass %>UpdateDTO and <%= entityClass %>ListDTO.
+ */
+@Component
+public class <%= entityClass %>Mapper extends BaseMapper<<%= entityClass %>,<%= entityClass %>UpdateDTO,<%= entityClass %>ListDTO> {<%   
+  for (idx in differentTypes) { 
+    var dtype = differentTypes[idx]; %>
+    @Inject
+    private <%= dtype %>Repository <%= dtype.toLowerCase() %>Repository;<% } %>
+
+    @Override
+    public <%= entityClass %> merge(<%= entityClass %>UpdateDTO dto, <%= entityClass %> entity) {
+        // do not map id<% for (fieldId in fields) { %>
+        entity.set<%= fields[fieldId].fieldNameCapitalized %>(dto.get<%= fields[fieldId].fieldNameCapitalized %>());<% } 
+  for (relationshipId in relationships) { 
+    var jType = relationships[relationshipId].otherEntityNameCapitalized;
+    var fieldName = relationships[relationshipId].otherEntityName; 
+    var rType = relationships[relationshipId].relationshipType;
+    var relationName = relationships[relationshipId].relationshipFieldName;
+    var relationNameCapitalized = relationships[relationshipId].relationshipNameCapitalized;
+    var multi = rType=='one-to-many' || rType == 'many-to-many';
+    if (multi) { %>
+        Set<<%= jType %>> <%= relationName %> = new HashSet<>();
+        if (dto.get<%= relationNameCapitalized %>s() != null) {
+            for (IdDTO id : dto.get<%= relationNameCapitalized %>s()) {
+                <%= relationName %>.add(getReference(<%= jType.toLowerCase() %>Repository, id));
+            }
+        }
+        entity.set<%= relationNameCapitalized %>s(<%= relationName %>);<% } else { %>
+        entity.set<%= relationNameCapitalized %>(getReference(<%= jType.toLowerCase() %>Repository, dto.get<%= relationNameCapitalized %>())); <% 
+    }
+  }%>
+        return entity;
+    }
+
+    public <X extends <%= entityClass %>ListDTO> X mapToDto(<%= entityClass %> entity, X dto) { 
+        dto.setId(entity.getId()<% if (databaseType == 'cassandra') { %>.toString()<% } %>);<% for (fieldId in fields) { %>
+        dto.set<%= fields[fieldId].fieldNameCapitalized %>(entity.get<%= fields[fieldId].fieldNameCapitalized %>());<% } %>
+        return dto;
+    }
+
+    @Override
+    public <%= entityClass %>ListDTO map(<%= entityClass %> entity) {
+        if (entity == null) {
+            return null;
+        }
+        return mapToDto(entity, new <%= entityClass %>ListDTO());
+    }
+}


### PR DESCRIPTION
...ers to handle the conversions between.

This way, it is much easier to validate that what field is sent to the client,
and what can be updated by the client.
 This separation ensures, that the same json could be generated, no matter what kind of entities are generated, either with mongodb/cassandra or jpa, and helps users to implement a fine-grained change control: for example 'only allow editing if the entitiy state is not final', or 'allow changing of amount, when the user has X role', etc.