### PR TITLE
Avoids double Optional wrapping by enabling transaction in the REST controller

### DIFF
--- a/app/templates/src/main/java/package/service/_UserService.java
+++ b/app/templates/src/main/java/package/service/_UserService.java
@@ -130,13 +130,11 @@ public class UserService {
         log.debug("Changed password for User: {}", currentUser);<% } %>
     }
 <% if (databaseType == 'sql') { %>
-    @Transactional(readOnly = true)<% } %>
-    public User getUserWithAuthorities() {<% if (javaVersion == '8') { %>
-        User currentUser = userRepository.findOneByLogin(SecurityUtils.getCurrentLogin()).get();
-        currentUser.getAuthorities().size(); // eagerly load the association<% } else { %>
-        User currentUser = userRepository.findOneByLogin(SecurityUtils.getCurrentLogin());
-        currentUser.getAuthorities().size(); // eagerly load the association<% } %>
-        return currentUser;
+    @Transactional(readOnly = true)<% } %><% if (javaVersion == '8') { %>
+    public Optional<User> getUserWithAuthorities(){
+        return userRepository.findOneByLogin(SecurityUtils.getCurrentLogin());<%} else { %>
+    public User getUserWithAuthorities() {
+        return userRepository.findOneByLogin(SecurityUtils.getCurrentLogin());<% } %>
     }<% if ((databaseType == 'sql' || databaseType == 'mongodb') && authenticationType == 'session') { %>
 
     /**

--- a/app/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -16,6 +16,7 @@ import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.bind.annotation.*;
 
 import javax.inject.Inject;
@@ -130,8 +131,10 @@ public class AccountResource {
             method = RequestMethod.GET,
             produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public ResponseEntity<UserDTO> getAccount() {<% if (javaVersion == '8') { %>
-        return Optional.ofNullable(userService.getUserWithAuthorities())
+<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = true)
+<% } %>    public ResponseEntity<UserDTO> getAccount() {<% if (javaVersion == '8') { %>
+        return userService.getUserWithAuthorities()
             .map(user -> new ResponseEntity<>(
                 new UserDTO(
                     user.getLogin(),

--- a/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
@@ -133,8 +133,8 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
         user.setLastName("doe");
         user.setEmail("john.doe@jhipter.com");
         user.setAuthorities(authorities);
-        when(mockUserService.getUserWithAuthorities()).thenReturn(user);
-
+        <% if(javaVersion == '8') { %>when(mockUserService.getUserWithAuthorities()).thenReturn(Optional.of(user));
+        <% } else {%>when(mockUserService.getUserWithAuthorities()).thenReturn(user);<% } %>
         restUserMockMvc.perform(get("/api/account")
                 .accept(MediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
@@ -147,8 +147,9 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
     }
 
     @Test
-    public void testGetUnknownAccount() throws Exception {
-        when(mockUserService.getUserWithAuthorities()).thenReturn(null);
+    public void testGetUnknownAccount() throws Exception{
+        <%if(javaVersion=='8'){%>when(mockUserService.getUserWithAuthorities()).thenReturn(Optional.empty());<% } else
+        { %>when(mockUserService.getUserWithAuthorities()).thenReturn(null);<% } %>
 
         restUserMockMvc.perform(get("/api/account")
                 .accept(MediaType.APPLICATION_JSON))


### PR DESCRIPTION
In `UserService#getUserWithAuthorities` there was 

```java
User currentUser = userRepository.findOneByLogin(SecurityUtils.getCurrentLogin()).get();
currentUser.getAuthorities().size(); // eagerly load the association
```

And in the `AccountResource#getAccount` : 

```java
 Optional.ofNullable(userService.getUserWithAuthorities())
```

And that looked ugly (no offense) because the `size()` is a trick and it implies unwrapping the Optional and then rewrap into an Optional in the controller.

By annotating the controller method with `@Transactional` , it allows to keep the Hibernate session opened in order to safely access to the lazy authorities collection.

Another approach could be to hint the Repository in order to eagerly fetch, but as authorities are cached and are quite static data, it would be faster only on the first call and slower after.