### PR TITLE
Should not ignore the gradle wrapper. Needs to be checked into source control

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -116,3 +116,9 @@ Desktop.ini
 *.*~
 *~
 .merge_file*
+
+######################
+# Gradle Wrapper
+######################
+!gradle/wrapper/gradle-wrapper.jar
+


### PR DESCRIPTION
Ensuring that the gradle-wrapper jar is checked into git. 

From http://gradle.org/docs/current/dsl/org.gradle.api.tasks.wrapper.Wrapper.html : 


*Generates scripts (for *nix and windows) which allow you to build your project with Gradle, without having to install Gradle.*

*When a user executes a wrapper script the first time, the script downloads and installs the appropriate Gradle distribution and runs the build against this downloaded distribution. Any installed Gradle distribution is ignored when using the wrapper scripts.*

*The scripts generated by this task are intended to be committed to your version control system. This task also generates a small gradle-wrapper.jar bootstrap JAR file and properties file which should also be committed to your VCS. The scripts delegates to this JAR.*