### PR TITLE
using correct project name for all artifacts instead of gradle default

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -432,6 +432,7 @@ JhipsterGenerator.prototype.app = function app() {
     switch (this.buildTool) {
         case 'gradle':
             this.template('_build.gradle', 'build.gradle', this, {});
+            this.template('_settings.gradle', 'settings.gradle', this, {});
             this.template('_gradle.properties', 'gradle.properties', this, {});
             this.template('_yeoman.gradle', 'yeoman.gradle', this, {});
             this.template('_profile_dev.gradle', 'profile_dev.gradle', this, {});

--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -59,11 +59,6 @@ configurations {
     providedRuntime
 }
 
-war {
-    baseName = '<%= _.slugify(baseName) %>'
-    version =  '0.1-SNAPSHOT'
-}
-
 repositories {
     maven { url 'http://repo.spring.io/milestone' }
     maven { url 'http://repo.spring.io/snapshot' }

--- a/app/templates/_settings.gradle
+++ b/app/templates/_settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = '<%= _.slugify(baseName) %>'


### PR DESCRIPTION
Because we don't specify a name in our gradle build file, it assumes the name of project is the name of the top-level folder

Our WAR file on the other hand does use the correct project name (provided by baseName through its config).

This fix generates a ```settings.gradle``` file that contains the project name (rootProject.name)

The war configuration becomes obsolete as both baseName and version have already been provided.removed completely.

	war {
	    baseName = 'ixortalkconfigmgmt'
	    version =  '0.1-SNAPSHOT'
	}

This avoid artifacts like ```workspace-0.1-SNAPSHOT*``` getting uploaded in maven repositories. (workspace being the default folder where each job is built)
