### PR TITLE
Added more binary flags for git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -12,3 +12,8 @@
 *.png binary
 *.jpg binary
 *.jar binary
+*.pdf binary
+*.eot binary
+*.ttf binary
+*.gzip binary
+*.gz binary

--- a/app/templates/gitattributes
+++ b/app/templates/gitattributes
@@ -12,3 +12,8 @@
 *.png binary
 *.jpg binary
 *.jar binary
+*.pdf binary
+*.eot binary
+*.ttf binary
+*.gzip binary
+*.gz binary


### PR DESCRIPTION
Added *.pdf, *.eot, *.ttf, *.gzip and *.gz as extensions to treat as
binary when a generated project is checked into git.