### PR TITLE
Refactoring of the edit/new dialogs

### DIFF
--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -11,6 +11,7 @@
     "modernizr": "2.8.3",
     "jquery": "2.1.3",
     "json3": "3.3.2",
+    "angular-bootstrap": "0.13.0",
     "angular-ui-router": "0.2.13",
     "angular": "1.4.0",
     "angular-resource": "1.4.0",

--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -1,6 +1,7 @@
 'use strict';
 
 angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTranslation) { %>'tmh.dynamicLocale', 'pascalprecht.translate', <% } %>
+               'ui.bootstrap', // for modal dialogs
     'ngResource', 'ui.router', 'ngCookies', 'ngCacheBuster', 'infinite-scroll'])
 
     .run(function ($rootScope, $location, $window, $http, $state, <% if (enableTranslation) { %>$translate, Language,<% } %> Auth, Principal, ENV, VERSION) {

--- a/entity/index.js
+++ b/entity/index.js
@@ -907,6 +907,8 @@ EntityGenerator.prototype.files = function files() {
         'src/main/webapp/scripts/app/entities/' +    this.entityInstance  + '/' + this.entityInstance + 's.html', this, {}, true);
     this.copyHtml('src/main/webapp/app/_entity-detail.html',
         'src/main/webapp/scripts/app/entities/' +    this.entityInstance  + '/' + this.entityInstance + '-detail.html', this, {}, true);
+    this.copyHtml('src/main/webapp/app/_entity-dialog.html',
+        'src/main/webapp/scripts/app/entities/' +    this.entityInstance  + '/' + this.entityInstance + '-dialog.html', this, {}, true);
 
     this.addRouterToMenu(this.entityInstance, this.enableTranslation);
 
@@ -916,6 +918,9 @@ EntityGenerator.prototype.files = function files() {
     this.template('src/main/webapp/app/_entity-controller.js',
         'src/main/webapp/scripts/app/entities/' +    this.entityInstance + '/' + this.entityInstance + '.controller' + '.js', this, {});
     this.addAppScriptToIndex(this.entityInstance + '/' + this.entityInstance + '.controller' + '.js');
+    this.template('src/main/webapp/app/_entity-dialog-controller.js',
+        'src/main/webapp/scripts/app/entities/' +    this.entityInstance + '/' + this.entityInstance + '-dialog.controller' + '.js', this, {});
+    this.addAppScriptToIndex(this.entityInstance + '/' + this.entityInstance + '-dialog.controller' + '.js');
 
     this.template('src/main/webapp/app/_entity-detail-controller.js',
         'src/main/webapp/scripts/app/entities/' +    this.entityInstance + '/' + this.entityInstance + '-detail.controller' + '.js', this, {});

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -5,7 +5,7 @@
     <div class="container">
         <div class="row">
             <div class="col-md-4">
-                <button class="btn btn-primary" data-toggle="modal" data-target="#save<%= entityClass %>Modal" ng-click="clear()">
+                <button class="btn btn-primary" ui-sref="<%= entityInstance %>.new">
                     <span class="glyphicon glyphicon-flash"></span> <span translate="<%= keyPrefix %>home.createLabel">Create a new <%= entityClass %></span>
                 </button>
             </div><% if (searchEngine == 'elasticsearch') { %>
@@ -18,127 +18,6 @@
                     </button>
                 </form>
             </div><% } %>
-        </div>
-    </div>
-
-    <div class="modal fade" id="save<%= entityClass %>Modal" tabindex="-1" role="dialog" aria-labelledby="my<%= entityClass %>Label"
-         aria-hidden="true">
-        <div class="modal-dialog">
-            <div class="modal-content">
-                <form name="editForm" role="form" novalidate ng-submit="save()"<% if (validation) { %> show-validation<% } %>>
-
-                    <div class="modal-header">
-                        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                                ng-click="clear()">&times;</button>
-                        <h4 class="modal-title" id="my<%= entityClass %>Label" translate="<%= keyPrefix %>home.createOrEditLabel">Create or edit a <%= entityClass %></h4>
-                    </div>
-                    <div class="modal-body">
-                        <div class="form-group">
-                            <label translate="global.field.id">ID</label>
-                            <input type="text" class="form-control" name="id"
-                                   ng-model="<%=entityInstance %>.id" readonly>
-                        </div>
-<% for (fieldId in fields) {
-    var fieldInputType = 'text';
-    var ngModelOption = '';
-    var translationKey = keyPrefix + fields[fieldId].fieldName;
-    if (fields[fieldId].fieldType == 'Integer' || fields[fieldId].fieldType == 'Long' || fields[fieldId].fieldType == 'BigDecimal') {
-        fieldInputType = 'number';
-    } else if (fields[fieldId].fieldType == 'LocalDate') {
-        fieldInputType = 'date';
-    } else if (fields[fieldId].fieldType == 'DateTime') {
-        fieldInputType = 'datetime-local';
-    } else if (fields[fieldId].fieldType == 'Boolean') {
-        fieldInputType = 'checkbox';
-    } %>
-                        <div class="form-group">
-                            <label translate="<%= translationKey %>"><%=fields[fieldId].fieldNameCapitalized%></label><% if (fields[fieldId].fieldIsEnum) { %>
-                            <select class="form-control" name="<%= fields[fieldId].fieldName %>" ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldValidate == true && fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %> required<% } %>><%
-                                var values = fields[fieldId].fieldValues.split(",");
-                                for (key in values) {
-                                    var value = values[key]; %>
-                                <option value="<%= value %>"><%= value %></option><%
-                                } %>
-                            </select><% } else { %>
-                            <input type="<%= fieldInputType %>" class="form-control" name="<%= fields[fieldId].fieldName %>"
-                                   ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldType == 'DateTime') { %> ng-model-options="{timezone: 'UTC'}"<% } %><% if (fields[fieldId].fieldValidate == true) {
-                                       if (fields[fieldId].fieldValidateRules.indexOf('required') != -1) {
-                                       %> required<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1) {
-                                       %> ng-minlength="<%= fields[fieldId].fieldValidateRulesMinlength %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) {
-                                       %> ng-maxlength="<%= fields[fieldId].fieldValidateRulesMaxlength %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) {
-                                       %> min="<%= fields[fieldId].fieldValidateRulesMin %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) {
-                                       %> max="<%= fields[fieldId].fieldValidateRulesMax %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) {
-                                       %> ng-pattern="/<%= fields[fieldId].fieldValidateRulesPattern %>/"<% } } %>><% } %>
-<% if (fields[fieldId].fieldValidate == true) { %>
-                            <div ng-show="editForm.<%= fields[fieldId].fieldName %>.$invalid"><% if (fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.required" translate="entity.validation.required">
-                                    This field is required.
-                                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1) { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.minlength" translate="entity.validation.minlength" translate-value-min="<%= fields[fieldId].fieldValidateRulesMinlength %>">
-                                    This field is required to be at least <%= fields[fieldId].fieldValidateRulesMinlength %> characters.
-                                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.maxlength" translate="entity.validation.maxlength" translate-value-max="<%= fields[fieldId].fieldValidateRulesMaxlength %>">
-                                    This field cannot be longer than <%= fields[fieldId].fieldValidateRulesMaxlength %> characters.
-                                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.min" translate="entity.validation.min" translate-value-min="<%= fields[fieldId].fieldValidateRulesMin %>">
-                                    This field should be more than <%= fields[fieldId].fieldValidateRulesMin %>.
-                                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.max" translate="entity.validation.max" translate-value-max="<%= fields[fieldId].fieldValidateRulesMax %>">
-                                    This field cannot be more than <%= fields[fieldId].fieldValidateRulesMax %>.
-                                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.pattern" translate="entity.validation.pattern" translate-value-pattern="<%= fields[fieldId].fieldValidateRulesPattern %>">
-                                    This field should follow pattern "<%= fields[fieldId].fieldValidateRulesPattern %>".
-                                </p><% } %><% if (fields[fieldId].fieldType == 'Integer' || fields[fieldId].fieldType == 'Long' || fields[fieldId].fieldType == 'BigDecimal') { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.number" translate="entity.validation.number">
-                                    This field should be a number.
-                                </p><% } %><% if (fields[fieldId].fieldType == 'DateTime') { %>
-                                <p class="help-block"
-                                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.datetimelocal" translate="entity.validation.datetimelocal">
-                                    This field should be a date and time.
-                                </p><% } %>
-                            </div><% } %>
-                        </div><% } %>
-<% for (relationshipId in relationships) {
-    var otherEntityName = relationships[relationshipId].otherEntityName;
-    var relationshipName = relationships[relationshipId].relationshipName;
-    var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
-    var translationKey = keyPrefix + relationshipName;
-    var relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + ".id";
-    if (dto == 'mapstruct') {
-        relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "Id";
-    }
-    if (relationships[relationshipId].relationshipType == 'many-to-one') {
-                        %>
-                        <div class="form-group">
-                            <label translate="<%= translationKey %>"><%=relationshipName %></label>
-                            <select class="form-control" name="<%= relationshipName %>" ng-model="<%=relationShipValue %>" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
-                            </select>
-                        </div><% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) {
-                            relationShipValue = entityInstance + "." + relationshipFieldName + "s";
-                            %>
-                        <div class="form-group">
-                            <label translate="<%= translationKey %>"><%=relationshipName %></label>
-                            <select class="form-control" multiple name="<%= relationshipName %>" ng-model="<%=relationShipValue %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id">
-                            </select>
-                        </div><% } } %>
-                    </div>
-                    <div class="modal-footer">
-                        <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="clear()">
-                            <span class="glyphicon glyphicon-ban-circle"></span>&nbsp;<span translate="entity.action.cancel">Cancel</span>
-                        </button>
-                        <button type="submit" ng-disabled="editForm.$invalid" class="btn btn-primary">
-                            <span class="glyphicon glyphicon-save"></span>&nbsp;<span translate="entity.action.save">Save</span>
-                        </button>
-                    </div>
-                </form>
-            </div>
         </div>
     </div>
 
@@ -195,7 +74,7 @@
                             <span class="glyphicon glyphicon-eye-open"></span>&nbsp;<span translate="entity.action.view"> View</span>
                         </button>
                         <button type="submit"
-                                ng-click="showUpdate(<%=entityInstance %>.id)"
+                                ui-sref="<%= entityInstance %>.edit({id:<%=entityInstance %>.id})"
                                 class="btn btn-primary btn-sm">
                             <span class="glyphicon glyphicon-pencil"></span>&nbsp;<span translate="entity.action.edit"> Edit</span>
                         </button>

--- a/entity/templates/src/main/webapp/app/_entity-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-controller.js
@@ -1,9 +1,8 @@
 'use strict';
 
 angular.module('<%=angularAppName%>')
-    .controller('<%= entityClass %>Controller', function ($scope<% for (idx in differentTypes) { %>, <%= differentTypes[idx] %><% } %><% if (searchEngine == 'elasticsearch') { %>, <%= entityClass %>Search<% } %><% if (pagination != 'no') { %>, ParseLinks<% } %>) {
-        $scope.<%= entityInstance %>s = [];<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) { %>
-        $scope.<%= differentTypes[idx].toLowerCase() %>s = <%= differentTypes[idx] %>.query();<% } } %><% if (pagination == 'pager' || pagination == 'pagination') { %>
+    .controller('<%= entityClass %>Controller', function ($scope, <%= entityClass %><% if (searchEngine == 'elasticsearch') { %>, <%= entityClass %>Search<% } %><% if (pagination != 'no') { %>, ParseLinks<% } %>) {
+        $scope.<%= entityInstance %>s = [];<% if (pagination == 'pager' || pagination == 'pagination') { %>
         $scope.page = 1;
         $scope.loadAll = function() {
             <%= entityClass %>.query({page: $scope.page, per_page: 20}, function(result, headers) {
@@ -36,27 +35,6 @@ angular.module('<%=angularAppName%>')
         };<% } %>
         $scope.loadAll();
 
-        $scope.showUpdate = function (id) {
-            <%= entityClass %>.get({id: id}, function(result) {
-                $scope.<%= entityInstance %> = result;
-                $('#save<%= entityClass %>Modal').modal('show');
-            });
-        };
-
-        $scope.save = function () {
-            if ($scope.<%= entityInstance %>.id != null) {
-                <%= entityClass %>.update($scope.<%= entityInstance %>,
-                    function () {
-                        $scope.refresh();
-                    });
-            } else {
-                <%= entityClass %>.save($scope.<%= entityInstance %>,
-                    function () {
-                        $scope.refresh();
-                    });
-            }
-        };
-
         $scope.delete = function (id) {
             <%= entityClass %>.get({id: id}, function(result) {
                 $scope.<%= entityInstance %> = result;
@@ -87,13 +65,10 @@ angular.module('<%=angularAppName%>')
         $scope.refresh = function () {<% if (pagination != 'infinite-scroll') { %>
             $scope.loadAll();<% } else { %>
             $scope.reset();<% } %>
-            $('#save<%= entityClass %>Modal').modal('hide');
             $scope.clear();
         };
 
         $scope.clear = function () {
             $scope.<%= entityInstance %> = {<% for (fieldId in fields) { %><%= fields[fieldId].fieldName %>: null, <% } %>id: null};
-            $scope.editForm.$setPristine();
-            $scope.editForm.$setUntouched();
         };
     });

--- a/entity/templates/src/main/webapp/app/_entity-detail-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-detail-controller.js
@@ -1,12 +1,14 @@
 'use strict';
 
 angular.module('<%=angularAppName%>')
-    .controller('<%= entityClass %>DetailController', function ($scope, $stateParams<% for (idx in differentTypes) { %>, <%= differentTypes[idx] %><% } %>) {
-        $scope.<%= entityInstance %> = {};
+    .controller('<%= entityClass %>DetailController', function ($scope, $rootScope, $stateParams, entity<% for (idx in differentTypes) { %>, <%= differentTypes[idx] %><% } %>) {
+        $scope.<%= entityInstance %> = entity;
         $scope.load = function (id) {
             <%= entityClass %>.get({id: id}, function(result) {
               $scope.<%= entityInstance %> = result;
             });
         };
-        $scope.load($stateParams.id);
+        $rootScope.$on('<%=angularAppName%>:<%= entityInstance %>Update', function(event, result) {
+          $scope.<%= entityInstance %> = result;
+        });
     });

--- a/entity/templates/src/main/webapp/app/_entity-detail.html
+++ b/entity/templates/src/main/webapp/app/_entity-detail.html
@@ -1,6 +1,7 @@
 <% var keyPrefix = angularAppName + '.'+ entityInstance; %>
 <div>
     <h2><span translate="<%= keyPrefix %>.detail.title"><%= entityClass %></span> {{<%= entityInstance %>.id}}</h2>
+
     <div class="table-responsive">
         <table class="table table-striped">
             <thead>

--- a/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
@@ -1,0 +1,31 @@
+'use strict';
+
+angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogController',
+    ['$scope', '$stateParams', '$modalInstance', 'entity', '<%= entityClass %>'<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, '<%= differentTypes[idx] %>'<% } } %>,
+        function($scope, $stateParams, $modalInstance, entity, <%= entityClass %><% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, <%= differentTypes[idx] %><% } } %>) {
+
+      $scope.<%= entityInstance %> = entity;<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) { %>
+      $scope.<%= differentTypes[idx].toLowerCase() %>s = <%= differentTypes[idx] %>.query();<% } } %>
+      $scope.load = function(id) {
+        <%= entityClass %>.get({id : id}, function(result) {
+          $scope.<%= entityInstance %> = result;
+        });
+      };
+
+      var onSaveFinished = function (result) {
+        $scope.$emit('<%=angularAppName%>:<%= entityInstance %>Update', result);
+        $modalInstance.close(result);
+      };
+
+      $scope.save = function () {
+        if ($scope.<%= entityInstance %>.id != null) {
+          <%= entityClass %>.update($scope.<%= entityInstance %>, onSaveFinished);
+        } else {
+          <%= entityClass %>.save($scope.<%= entityInstance %>, onSaveFinished);
+        }
+      };
+
+      $scope.clear = function() {
+        $modalInstance.dismiss('cancel');
+      };
+}]);

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -1,0 +1,111 @@
+<% var keyPrefix = angularAppName + '.'+ entityInstance + '.'; %>
+<form name="editForm" role="form" novalidate ng-submit="save()"<% if (validation) { %> show-validation<% } %>>
+
+    <div class="modal-header">
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
+                ng-click="clear()">&times;</button>
+        <h4 class="modal-title" id="my<%= entityClass %>Label" translate="<%= keyPrefix %>home.createOrEditLabel">Create or edit a <%= entityClass %></h4>
+    </div>
+    <div class="modal-body">
+        <div class="form-group">
+            <label translate="global.field.id">ID</label>
+            <input type="text" class="form-control" name="id"
+                    ng-model="<%=entityInstance %>.id" readonly>
+        </div>
+<% for (fieldId in fields) {
+    var fieldInputType = 'text';
+    var ngModelOption = '';
+    var translationKey = keyPrefix + fields[fieldId].fieldName;
+    if (fields[fieldId].fieldType == 'Integer' || fields[fieldId].fieldType == 'Long' || fields[fieldId].fieldType == 'BigDecimal') {
+        fieldInputType = 'number';
+    } else if (fields[fieldId].fieldType == 'LocalDate') {
+        fieldInputType = 'date';
+    } else if (fields[fieldId].fieldType == 'DateTime') {
+        fieldInputType = 'datetime-local';
+    } else if (fields[fieldId].fieldType == 'Boolean') {
+        fieldInputType = 'checkbox';
+    } %>
+        <div class="form-group">
+            <label translate="<%= translationKey %>" for="field_<%= fields[fieldId].fieldName %>"><%=fields[fieldId].fieldNameCapitalized%></label><%
+            if (fields[fieldId].fieldIsEnum) { %>
+            <select class="form-control" name="<%= fields[fieldId].fieldName %>" ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldValidate == true && fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %> required<% } %>><%
+               var values = fields[fieldId].fieldValues.split(",");
+               for (key in values) {
+                 var value = values[key]; %>
+               <option value="<%= value %>"><%= value %></option><%
+               } %>
+            </select><% } else { %>
+            <input type="<%= fieldInputType %>" class="form-control" name="<%= fields[fieldId].fieldName %>" id="field_<%= fields[fieldId].fieldName %>"
+                    ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldType == 'DateTime') { %> ng-model-options="{timezone: 'UTC'}"<% } %><% if (fields[fieldId].fieldValidate == true) {
+                        if (fields[fieldId].fieldValidateRules.indexOf('required') != -1) {
+                        %> required<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1) {
+                        %> ng-minlength="<%= fields[fieldId].fieldValidateRulesMinlength %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) {
+                        %> ng-maxlength="<%= fields[fieldId].fieldValidateRulesMaxlength %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) {
+                        %> min="<%= fields[fieldId].fieldValidateRulesMin %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) {
+                        %> max="<%= fields[fieldId].fieldValidateRulesMax %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) {
+                        %> ng-pattern="/<%= fields[fieldId].fieldValidateRulesPattern %>/"<% } } %>><% } %>
+<% if (fields[fieldId].fieldValidate == true) { %>
+            <div ng-show="editForm.<%= fields[fieldId].fieldName %>.$invalid"><% if (fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.required" translate="entity.validation.required">
+                    This field is required.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1) { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.minlength" translate="entity.validation.minlength" translate-value-min="<%= fields[fieldId].fieldValidateRulesMinlength %>">
+                    This field is required to be at least <%= fields[fieldId].fieldValidateRulesMinlength %> characters.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.maxlength" translate="entity.validation.maxlength" translate-value-max="<%= fields[fieldId].fieldValidateRulesMaxlength %>">
+                    This field cannot be longer than <%= fields[fieldId].fieldValidateRulesMaxlength %> characters.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.min" translate="entity.validation.min" translate-value-min="<%= fields[fieldId].fieldValidateRulesMin %>">
+                    This field should be more than <%= fields[fieldId].fieldValidateRulesMin %>.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.max" translate="entity.validation.max" translate-value-max="<%= fields[fieldId].fieldValidateRulesMax %>">
+                    This field cannot be more than <%= fields[fieldId].fieldValidateRulesMax %>.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.pattern" translate="entity.validation.pattern" translate-value-pattern="<%= fields[fieldId].fieldValidateRulesPattern %>">
+                    This field should follow pattern "<%= fields[fieldId].fieldValidateRulesPattern %>".
+                </p><% } %><% if (fields[fieldId].fieldType == 'Integer' || fields[fieldId].fieldType == 'Long' || fields[fieldId].fieldType == 'BigDecimal') { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.number" translate="entity.validation.number">
+                    This field should be a number.
+                </p><% } %><% if (fields[fieldId].fieldType == 'DateTime') { %>
+                <p class="help-block"
+                    ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.datetimelocal" translate="entity.validation.datetimelocal">
+                    This field should be a date and time.
+                </p><% } %>
+            </div><% } %>
+        </div><% } %>
+<% for (relationshipId in relationships) {
+    var otherEntityName = relationships[relationshipId].otherEntityName;
+    var relationshipName = relationships[relationshipId].relationshipName;
+    var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
+    var translationKey = keyPrefix + relationshipName;
+     if (relationships[relationshipId].relationshipType == 'many-to-one') {
+                        %>
+        <div class="form-group">
+            <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>.id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
+            </select>
+        </div><% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) {
+            %>
+        <div class="form-group">
+            <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
+            <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>s" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id">
+            </select>
+        </div><% } } %>
+    </div>
+    <div class="modal-footer">
+        <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="clear()">
+            <span class="glyphicon glyphicon-ban-circle"></span>&nbsp;<span translate="entity.action.cancel">Cancel</span>
+        </button>
+        <button type="submit" ng-disabled="editForm.$invalid" class="btn btn-primary">
+            <span class="glyphicon glyphicon-save"></span>&nbsp;<span translate="entity.action.save">Save</span>
+        </button>
+    </div>
+</form>
+

--- a/entity/templates/src/main/webapp/app/_entity.js
+++ b/entity/templates/src/main/webapp/app/_entity.js
@@ -5,7 +5,7 @@ angular.module('<%=angularAppName%>')
         $stateProvider
             .state('<%= entityInstance %>', {
                 parent: 'entity',
-                url: '/<%= entityInstance %>',
+                url: '/<%= entityInstance %>s',
                 data: {
                     roles: ['ROLE_USER'],
                     pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityInstance %>.home.title'<% }else{ %>'<%= entityClass %>s'<% } %>
@@ -26,7 +26,7 @@ angular.module('<%=angularAppName%>')
             })
             .state('<%= entityInstance %>Detail', {
                 parent: 'entity',
-                url: '/<%= entityInstance %>/:id',
+                url: '/<%= entityInstance %>/{id}',
                 data: {
                     roles: ['ROLE_USER'],
                     pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityInstance %>.detail.title'<% }else{ %>'<%= entityClass %>'<% } %>
@@ -41,7 +41,56 @@ angular.module('<%=angularAppName%>')
                     translatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
                         $translatePartialLoader.addPart('<%= entityInstance %>');
                         return $translate.refresh();
-                    }]<% } %>
+                    }],<% } %>
+                    entity: ['$stateParams', '<%= entityClass %>', function($stateParams, <%= entityClass %>) {
+                        return <%= entityClass %>.get({id : $stateParams.id});
+                    }]
                 }
+            })
+            .state('<%= entityInstance %>.new', {
+              parent: '<%= entityInstance %>',
+              url: '/new',
+              data: {
+                  roles: ['ROLE_USER'],
+              },
+              onEnter: ['$stateParams', '$state', '$modal', function($stateParams, $state, $modal) {
+                $modal.open({
+                  templateUrl: 'scripts/app/entities/<%= entityInstance %>/<%= entityInstance %>-dialog.html',
+                  controller: '<%= entityClass %>DialogController',
+                  size: 'lg',
+                  resolve: {
+                      entity: function () {
+                          return {<% for (fieldId in fields) { %><%= fields[fieldId].fieldName %>: null, <% } %>id: null};
+                      }
+                  }
+                }).result.then(function(result) {
+                  $state.go('<%= entityInstance %>Detail', {id: result.id});
+                }, function() {
+                  $state.go('<%= entityInstance %>');
+                })
+              }]
+            })
+            .state('<%= entityInstance %>.edit', {
+              parent: '<%= entityInstance %>',
+              url: '/{id}/edit',
+              data: {
+                  roles: ['ROLE_USER'],
+              },
+              onEnter: ['$stateParams', '$state', '$modal', function($stateParams, $state, $modal) {
+                $modal.open({
+                  templateUrl: 'scripts/app/entities/<%= entityInstance %>/<%= entityInstance %>-dialog.html',
+                  controller: '<%= entityClass %>DialogController',
+                  size: 'lg',
+                  resolve: {
+                      entity: ['<%= entityClass %>', function(<%= entityClass %>) {
+                          return <%= entityClass %>.get({id : $stateParams.id});
+                      }]
+                  }
+                }).result.then(function(result) {
+                  $state.go('<%= entityInstance %>Detail', {id: result.id});
+                }, function() {
+                  $state.go('^');
+                })
+              }]
             });
     });


### PR DESCRIPTION
Advantages: 
 - separate the entity listing functionality, from the editing/creating functionality. So no need to load every related entities on the listing page, only when the dialog needs it. 
 - the edit / create dialog have a proper URL, so it is easy to link from other parts of the application
 - less html magic in the controllers (currently only the delete dialog needs jquery, but it can be fixed in a separate commit)
 - emitting events when an entity is modified, which can be used in other parts of the application
