### PR TITLE
change remember-me form request parameter to fix session login

### DIFF
--- a/app/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/app/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -99,6 +99,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
         .and()
             .rememberMe()
             .rememberMeServices(rememberMeServices)
+            .rememberMeParameter("remember-me")
             .key(env.getProperty("jhipster.security.rememberme.key"))
         .and()
             .formLogin()

--- a/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.session.service.js
+++ b/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.session.service.js
@@ -6,7 +6,7 @@ angular.module('<%=angularAppName%>')
             login: function(credentials) {
                 var data = 'j_username=' + encodeURIComponent(credentials.username) +
                     '&j_password=' + encodeURIComponent(credentials.password) +
-                    '&_spring_security_remember_me=' + credentials.rememberMe + '&submit=Login';
+                    '&remember-me=' + credentials.rememberMe + '&submit=Login';
                 return $http.post('api/authentication', data, {
                     headers: {
                         'Content-Type': 'application/x-www-form-urlencoded'

--- a/entity/templates/src/test/gatling/simulations/_EntityGatlingTest.scala
+++ b/entity/templates/src/test/gatling/simulations/_EntityGatlingTest.scala
@@ -74,7 +74,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
         .headers(headers_http_authenticated)
         .formParam("j_username", "admin")
         .formParam("j_password", "admin")
-        .formParam("_spring_security_remember_me", "true")
+        .formParam("remember-me", "true")
         .formParam("submit", "Login")<% } %><% if (authenticationType == 'oauth2') { %>
         .post("/oauth/token")
         .headers(headers_http_authentication)


### PR DESCRIPTION
I'm not so familiar with this part of Spring Security, but with some debugging I found out that the remember-me form request parameter changed in Spring Security 4 from **_spring_security_remember_me** to **remember-me** 

I've changed the form parameter and explicitly set the parameter name in the SecurityConfiguration so if this changes again in the future it won't have impact anymore. Now the session screen seems to work again. 

Let me know if there are any other issues with this.

More information can be found here:
Docs: http://docs.spring.io/spring-security/site/migrate/current/3-to-4/html5/migrate-3-to-4-xml.html#m3to4-xmlnamespace-remember-me
GitHub: https://github.com/spring-projects/spring-security/commit/5f57e5b0c3726466db4f5d0521ac26423f0d9cd4) 
