### PR TITLE
IE9 compatibility

### DIFF
--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -1,8 +1,5 @@
 <!doctype html>
-<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
-<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
-<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
-<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+<html class="no-js">
     <head>
         <meta charset="utf-8">
         <meta http-equiv="X-UA-Compatible" content="IE=edge">

--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -16,7 +16,7 @@
         <!-- endbuild -->
     </head>
     <body ng-app="<%= angularAppName %>">
-        <!--[if lt IE 10]>
+        <!--[if lt IE 9]>
             <p class="browserupgrade">You are using an <strong>outdated</strong> browser. Please <a href="http://browsehappy.com/">upgrade your browser</a> to improve your experience.</p>
         <![endif]-->
         <div ng-show="{{ENV === 'dev'}}" class="development" ng-cloak></div>


### PR DESCRIPTION
I'm adding IE9 compatibility to the documentation. Therefore, I'm removing the "browserupgrade" message in the header when accessing the site with IE9.

I'm also removing the lt-ie7 lt-ie8 lt-ie9 classes. IE9 doesn't need any specific CSS rules, unlike IE7 and IE8 did.