### PR TITLE
Update gatling to latest version

### DIFF
--- a/app/templates/_gradle.properties
+++ b/app/templates/_gradle.properties
@@ -40,4 +40,4 @@ spring_cloud_version=1.1.1.RELEASE
 usertype_core_version=3.2.0.GA<% if (devDatabaseType == 'mysql' || prodDatabaseType == 'mysql') { %>
 mysql_connector_java_version=5.1.34<% } %>
 h2_version=1.4.185
-gatling_version=2.1.4
+gatling_version=2.1.5

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -28,8 +28,8 @@
         <cassandra.version>2.0.12</cassandra.version><% } %>
         <commons-io.version>2.4</commons-io.version>
         <commons-lang.version>2.6</commons-lang.version>
-        <gatling.version>2.1.4</gatling.version>
-        <gatling-maven-plugin.version>2.1.2</gatling-maven-plugin.version><% if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast') { %>
+        <gatling.version>2.1.5</gatling.version>
+        <gatling-maven-plugin.version>2.1.5</gatling-maven-plugin.version><% if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast') { %>
         <hazelcast.version>3.4</hazelcast.version><% } %><% if (databaseType == 'sql') { %>
         <hibernate.version>4.3.6.Final</hibernate.version><% } %><% if (databaseType == 'cassandra') { %>
         <datastax-driver.version>2.1.4</datastax-driver.version><% } %>


### PR DESCRIPTION
Update gatling and gatling maven to latest 2.1.5 release.
2.1.5 is not yet in maven central, but it should be available during the day: https://groups.google.com/forum/#!topic/gatling/BViFx0TqU0E

Fix #1344