### PR TITLE
Fix title l10n in some account pages

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/account/password/password.html
+++ b/app/templates/src/main/webapp/scripts/app/account/password/password.html
@@ -1,7 +1,7 @@
 <div>
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
-            <h2 translate="password.title" translate-values="{username: '{{account.login}}'}">Password for [<b>{{account.login}}</b>]</h2>
+            <h2 translate="password.title" translate-values="{username: '{{account.login}}'}">Password for [<b>account.login</b>]</h2>
 
             <div class="alert alert-success" ng-show="success" translate="password.messages.success">
                 <strong>Password changed!</strong>

--- a/app/templates/src/main/webapp/scripts/app/account/sessions/sessions.html
+++ b/app/templates/src/main/webapp/scripts/app/account/sessions/sessions.html
@@ -1,6 +1,6 @@
 <div>
 
-    <h2 translate="sessions.title" translate-values="{username: '{{account.login}}'}">Active sessions for [<b>{{account.login}}</b>]</h2>
+    <h2 translate="sessions.title" translate-values="{username: '{{account.login}}'}">Active sessions for [<b>account.login</b>]</h2>
 
     <div class="alert alert-success" ng-show="success" translate="sessions.messages.success">
         <strong>Session invalidated!</strong>

--- a/app/templates/src/main/webapp/scripts/app/account/settings/settings.html
+++ b/app/templates/src/main/webapp/scripts/app/account/settings/settings.html
@@ -1,7 +1,7 @@
 <div>
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
-            <h2 translate="settings.title" translate-values="{username: '{{settingsAccount.login}}'}">User settings for [<b>{{settingsAccount.login}}</b>]</h2>
+            <h2 translate="settings.title" translate-values="{username: '{{settingsAccount.login}}'}">User settings for [<b>settingsAccount.login</b>]</h2>
 
             <div class="alert alert-success" ng-show="success" translate="settings.messages.success">
                 <strong>Settings saved!</strong>

--- a/entity/templates/src/main/webapp/i18n/_entity_pl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pl.json
@@ -2,12 +2,12 @@
     "<%= angularAppName %>": {
         "<%= entityInstance %>" : {
             "home": {
-                "title": "<%= entityClass %>s",
-                "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "title": "<%= entityClass %>",
+                "createLabel": "Dodaj <%= entityClass %>",
+                "createOrEditLabel": "Dodaj lub edytuj: <%= entityClass %>"
             },
             "delete": {
-                "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"
+                "question": "Czy na pewno chcesz usunąć <%= entityClass %> {{ id }}?"
             },
             "detail": {
                 "title": "<%= entityClass %>"


### PR DESCRIPTION
Title localization on 3 account pages didn't work because of "{{...}}" used in default texts inside &lt;h2&gt;&lt;/h2&gt; tags. Additionally localized pl-PL i18n template for a new entity.