### PR TITLE
Moved data folder for elasticsearch under "target" when using dev profile

### DIFF
--- a/app/templates/src/main/resources/config/_application-dev.yml
+++ b/app/templates/src/main/resources/config/_application-dev.yml
@@ -47,7 +47,11 @@ spring:
     data:
         elasticsearch:
             cluster-name: 
-            cluster-nodes: <% } %>
+            cluster-nodes: 
+            properties:
+                path:
+                  logs: target/elasticsearch/log
+                  data: target/elasticsearch/data <% } %>
     messages:
         cache-seconds: 1
     thymeleaf:


### PR DESCRIPTION
Moved data folder for elasticsearch under "target" when using dev profile to be coherent with the volatile aspect of the data just like h2 mem usage, Otherwise we have desynchronization between ES and H2 unless you don't forget to delete the data/ folder in your project home.