### PR TITLE
Removing property for MySQL datasource setup

### DIFF
--- a/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
+++ b/app/templates/src/main/java/package/config/_DatabaseConfiguration.java
@@ -102,7 +102,6 @@ public class DatabaseConfiguration <% if (databaseType == 'sql') { %>implements 
             config.addDataSourceProperty("cachePrepStmts", propertyResolver.getProperty("cachePrepStmts", "true"));
             config.addDataSourceProperty("prepStmtCacheSize", propertyResolver.getProperty("prepStmtCacheSize", "250"));
             config.addDataSourceProperty("prepStmtCacheSqlLimit", propertyResolver.getProperty("prepStmtCacheSqlLimit", "2048"));
-            config.addDataSourceProperty("useServerPrepStmts", propertyResolver.getProperty("useServerPrepStmts", "true"));
         }<% } %>
         if (metricRegistry != null) {
             config.setMetricRegistry(metricRegistry);


### PR DESCRIPTION
Hikari seems to have change it's guideline for optimal MySQL configuration.

Copied from the link : https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration

~~`useServerPrepStmts` : No longer recommended due to MySQL stability issues
Newer versions of MySQL support server-side prepared statements, this can provide a substantial performance boost. Set this property to true.~~


