### PR TITLE
Improved Heroku generator

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -339,18 +339,6 @@ module.exports = function (grunt) {
                     ]
                 }]
             },
-            generateHerokuDirectory: {
-                    expand: true,
-                    dest: 'deploy/heroku',
-                    src: [
-                        'pom.xml',
-                        'gradlew',
-                        '*.gradle',
-                        'gradle.properties',
-                        'gradle/**',
-                        'src/main/**'
-                ]
-            },
             generateOpenshiftDirectory: {
                     expand: true,
                     dest: 'deploy/openshift',
@@ -400,13 +388,6 @@ module.exports = function (grunt) {
                 push: false,
                 connectCommits: false,
                 message: 'Built %sourceName% from commit %sourceCommit% on branch %sourceBranch%'
-            },
-            heroku: {
-                options: {
-                    dir: 'deploy/heroku',
-                    remote: 'heroku',
-                    branch: 'master'
-                }
             },
             openshift: {
                 options: {
@@ -484,7 +465,6 @@ module.exports = function (grunt) {
     ]);
 
 	grunt.registerTask('appendSkipBower', 'Force skip of bower for Gradle', function () {
-		var filepath = 'deploy/heroku/gradle.properties';
 
 		if (!grunt.file.exists(filepath)) {
 			// Assume this is a maven project
@@ -500,21 +480,6 @@ module.exports = function (grunt) {
 
 		grunt.file.write(filepath, fileContent + "\nskipBower=true\n");
 	});
-
-    grunt.registerTask('buildHeroku', [
-        'test',
-        'build',
-        'copy:generateHerokuDirectory',
-        'appendSkipBower'
-    ]);
-
-    grunt.registerTask('deployHeroku', [
-        'test',
-        'build',
-        'copy:generateHerokuDirectory',
-        'appendSkipBower',
-        'buildcontrol:heroku'
-    ]);
 
     grunt.registerTask('buildOpenshift', [
         'test',

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -815,5 +815,40 @@
                 <logback.loglevel>INFO</logback.loglevel>
             </properties>
         </profile>
+        <profile>
+            <id>heroku</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-clean-plugin</artifactId>
+                        <version>2.5</version>
+                        <executions>
+                            <execution>
+                                <id>clean-build-artifacts</id>
+                                <phase>install</phase>
+                                <goals><goal>clean</goal></goals>
+                                <configuration>
+                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
+                                    <filesets>
+                                        <fileset>
+                                            <directory>node_modules</directory>
+                                        </fileset>
+                                        <fileset>
+                                            <directory>.heroku/node</directory>
+                                        </fileset>
+                                        <fileset>
+                                            <directory>target</directory>
+                                            <excludes>
+                                              <exclude>*.war</exclude>
+                                            </excludes>
+                                        </fileset>
+                                    </filesets>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
     </profiles>
 </project>

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -815,40 +815,5 @@
                 <logback.loglevel>INFO</logback.loglevel>
             </properties>
         </profile>
-        <profile>
-            <id>heroku</id>
-            <build>
-                <plugins>
-                    <plugin>
-                        <artifactId>maven-clean-plugin</artifactId>
-                        <version>2.5</version>
-                        <executions>
-                            <execution>
-                                <id>clean-build-artifacts</id>
-                                <phase>install</phase>
-                                <goals><goal>clean</goal></goals>
-                                <configuration>
-                                    <excludeDefaultDirectories>true</excludeDefaultDirectories>
-                                    <filesets>
-                                        <fileset>
-                                            <directory>node_modules</directory>
-                                        </fileset>
-                                        <fileset>
-                                            <directory>.heroku/node</directory>
-                                        </fileset>
-                                        <fileset>
-                                            <directory>target</directory>
-                                            <excludes>
-                                              <exclude>*.war</exclude>
-                                            </excludes>
-                                        </fileset>
-                                    </filesets>
-                                </configuration>
-                            </execution>
-                        </executions>
-                    </plugin>
-                </plugins>
-            </build>
-        </profile>
     </profiles>
 </project>

--- a/heroku/USAGE
+++ b/heroku/USAGE
@@ -1,13 +1,9 @@
 Description:
-    Initalizes a Heroku app and generates a `deploy/heroku` folder which is ready to push to Heroku.
+    Initializes a Heroku app and generates a WAR file that is ready to push to Heroku.
 
 Example:
     yo jhipster:heroku
 
     This will create:
-        deploy/heroku/Procfile
-        deploy/heroku/.slugignore
-        deploy/heroku/system.properties
-        deploy/heroku/src/main/java/your_package_name/config/HerokuDatabaseConfiguration.java
-
-    And it will copy the "production" code to deploy/heroku
+        Procfile
+        src/main/java/your_package_name/config/HerokuDatabaseConfiguration.java

--- a/heroku/index.js
+++ b/heroku/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util'),
 path = require('path'),
+fs = require('fs'),
 yeoman = require('yeoman-generator'),
 exec = require('child_process').exec,
 chalk = require('chalk'),
@@ -41,26 +42,11 @@ HerokuGenerator.prototype.askFor = function askFor() {
         message: 'On which region do you want to deploy ?',
         choices: [ "us", "eu"],
         default: 0
-    },
-    {
-      type: "list",
-      name: 'herokuType',
-      message: 'Which method of deployment do you want ?',
-      choices: [{
-        value: 'CLI',
-        name: 'CLI (recommended)'
-      },
-      {
-        value: 'Git',
-        name: 'Git'
-      }],
-      default: 0
     }];
 
     this.prompt(prompts, function (props) {
         this.herokuDeployedName = this._.slugify(props.herokuDeployedName);
         this.herokuRegion = props.herokuRegion;
-        this.herokuType = props.herokuType;
         done();
     }.bind(this));
 };
@@ -81,7 +67,6 @@ HerokuGenerator.prototype.checkInstallation = function checkInstallation() {
 
 HerokuGenerator.prototype.gitInit = function gitInit() {
     if(this.abort) return;
-    if(this.herokuType != "Git") return;
     var done = this.async();
 
     try {
@@ -113,22 +98,8 @@ HerokuGenerator.prototype.herokuCreate = function herokuCreate() {
 
     var regionParams = (this.herokuRegion !== 'us') ? ' --region ' + this.herokuRegion : '';
 
-    this.log(chalk.bold('Creating Heroku application and setting up node environment'));
+    this.log(chalk.bold('\nCreating Heroku application and setting up node environment'));
     var herokuCreateCmd = 'heroku apps:create ' + this.herokuDeployedName + regionParams + ' --addons heroku-postgresql:hobby-dev';
-
-    if (this.herokuType == 'Git') {
-      herokuCreateCmd += ' && heroku buildpacks:add https://github.com/heroku/heroku-buildpack-nodejs --app ' + this.herokuDeployedName;
-
-      if (this.buildTool == 'gradle') {
-        herokuCreateCmd += ' && heroku buildpacks:add https://github.com/heroku/heroku-buildpack-gradle --app ' + this.herokuDeployedName;
-        herokuCreateCmd += ' && heroku config:set --app ' + this.herokuDeployedName;
-      } else {
-        herokuCreateCmd += ' && heroku buildpacks:add https://github.com/heroku/heroku-buildpack-java --app ' + this.herokuDeployedName;
-        herokuCreateCmd += ' && heroku config:set MAVEN_CUSTOM_OPTS="-Pprod,heroku -DskipTests=true" --app ' + this.herokuDeployedName;
-      }
-    } else {
-      herokuCreateCmd += ' --no-remote';
-    }
 
     console.log(herokuCreateCmd);
     var child = exec(herokuCreateCmd, {}, function (err, stdout, stderr) {
@@ -154,37 +125,22 @@ HerokuGenerator.prototype.copyHerokuFiles = function copyHerokuFiles() {
     this.template('src/main/java/package/config/_HerokuDatabaseConfiguration.java', 'src/main/java/' + this.packageFolder + '/config/HerokuDatabaseConfiguration.java');
     this.template('_Procfile', 'Procfile');
 
-    if(this.herokuType == "Git") {
-      this.npmInstall(['bower', 'grunt-cli'], { 'saveDev': true }, function (err, stdout, stderr) {
-        if (err) {
-          this.abort = true;
-          this.log.error(err);
-        }
-        this.conflicter.resolve(function (err) {
-          done();
-        });
-      }.bind(this));
-    } else {
-      this.conflicter.resolve(function (err) {
-        done();
-      });
-    }
+    this.conflicter.resolve(function (err) {
+      done();
+    });
 };
 
 HerokuGenerator.prototype.productionBuild = function productionBuild() {
   if(this.abort) return;
-  if(this.herokuType == "Git") return;
-
-  if (this.buildTool == 'gradle') {
-    this.abort = true;
-    this.log.error("Gradle is not yet supported with Heroku CLI deployment");
-    done()
-    return;
-  }
-
   var done = this.async();
   this.log(chalk.bold('\nBuilding application'));
-  var child = exec('mvn package -Pprod -DskipTests=true', function (err, stdout) {
+
+  var buildCmd = 'mvn package -Pprod -DskipTests=true'
+  if (this.buildTool == 'gradle') {
+    buildCmd = 'gradlew -Pprod bootRepackage'
+  }
+
+  var child = exec(buildCmd, function (err, stdout) {
     if (err) {
       this.abort = true;
       this.log.error(err);
@@ -199,7 +155,6 @@ HerokuGenerator.prototype.productionBuild = function productionBuild() {
 
 HerokuGenerator.prototype.installHerokuDeployPlugin = function installHerokuDeployPlugin() {
   if(this.abort) return;
-  if(this.herokuType != 'CLI') return;
   var done = this.async();
   this.log(chalk.bold('\nInstalling Heroku CLI deployment plugin'));
   var child = exec('heroku plugins:install https://github.com/heroku/heroku-deploy', function (err, stdout) {
@@ -217,12 +172,15 @@ HerokuGenerator.prototype.installHerokuDeployPlugin = function installHerokuDepl
 
 HerokuGenerator.prototype.herokuCliDeploy = function herokuCliDeploy() {
   if(this.abort) return;
-  if(this.herokuType != 'CLI') return;
   var done = this.async();
 
-  var herokuDeployCommand = 'heroku deploy:jar --jar target/*.war --app ' + this.herokuDeployedName
+  var herokuDeployCommand = 'heroku deploy:jar --jar target/*.war';
+  if (this.buildTool == 'gradle') {
+    herokuDeployCommand = 'heroku deploy:jar --jar build/libs/*.war'
+  }
+
   this.log(chalk.bold("\nUploading your application code.\n This may take " + chalk.cyan('several minutes') + " depending on your connection speed..."));
-  var child = exec(herokuDeployCommand, function (err, stdout) {
+  var child = exec(herokuDeployCommand + ' -a ' + this.herokuDeployedName, function (err, stdout) {
     if (err) {
       this.abort = true;
       this.log.error(err);
@@ -231,8 +189,13 @@ HerokuGenerator.prototype.herokuCliDeploy = function herokuCliDeploy() {
     if (err) {
       console.log(chalk.red(err));
     } else {
-      console.log(chalk.green('\nYour app should now be live. To view it run\n\t' + chalk.bold('heroku open --app ' + this.herokuDeployedName)));
-      console.log(chalk.yellow('After application modification, repackage it with\n\t' + chalk.bold('mvn package -Pprod -DskipTests')));
+      console.log(chalk.green('\nYour app should now be live. To view it run\n\t' + chalk.bold('heroku open')));
+      console.log(chalk.yellow('And you can view the logs with this command\n\t' + chalk.bold('heroku logs --tail')));
+      if (this.buildTool == 'gradle') {
+        console.log(chalk.yellow('After application modification, repackage it with\n\t' + chalk.bold('gradlew -Pprod bootRepackage')));
+      } else {
+        console.log(chalk.yellow('After application modification, repackage it with\n\t' + chalk.bold('mvn package -Pprod -DskipTests')));
+      }
       console.log(chalk.yellow('And then re-deploy it with\n\t' + chalk.bold(herokuDeployCommand)));
     }
     done();
@@ -242,54 +205,4 @@ HerokuGenerator.prototype.herokuCliDeploy = function herokuCliDeploy() {
   child.stdout.on('data', function(data) {
     this.log(data.toString());
   }.bind(this));
-};
-
-HerokuGenerator.prototype.gitCommit = function gitCommit() {
-    if(this.abort) return;
-    if(this.herokuType != "Git") return;
-    var done = this.async();
-
-    this.log(chalk.bold('\nAdding files for deployment'));
-    var child = exec('git add -A && git commit -m "Deploying to Heroku"', { maxBuffer: 500*1024 }, function (err, stdout, stderr) {
-        if (stdout.search('nothing to commit') >= 0) {
-            this.log('Re-pushing the existing build...');
-        } else if (err) {
-            this.log.error(err);
-        } else {
-            this.log(chalk.green('Done, without errors.'));
-        }
-        done();
-    }.bind(this));
-
-    child.stdout.on('data', function(data) {
-        console.log(data.toString());
-    });
-};
-
-HerokuGenerator.prototype.gitForcePush = function gitForcePush() {
-    if(this.abort) return;
-    if(this.herokuType != "Git") return;
-    var done = this.async();
-
-    this.log(chalk.bold("\nUploading your application code.\n This may take " + chalk.cyan('several minutes') + " depending on your connection speed..."));
-        var insight = this.insight();
-        insight.track('generator', 'heroku');
-
-    var child = exec('git push -f heroku master', { maxBuffer: 500*1024 }, function (err, stdout, stderr) {
-        console.log(stdout);
-        if (err) {
-            console.log(chalk.red(err));
-        } else {
-            console.log(chalk.green('\nYour app should now be live. To view it run\n\t' + chalk.bold('heroku open')));
-            console.log(chalk.yellow('After application modification, re-deploy it with\n\t' + chalk.bold('git push heroku')));
-        }
-        done();
-    }.bind(this));
-
-    child.stdout.on('data', function(data) {
-        console.log(data.toString());
-    });
-    child.stderr.on('data', function(data) {
-        console.log(chalk.white(data.toString()));
-    });
 };

--- a/heroku/index.js
+++ b/heroku/index.js
@@ -183,6 +183,7 @@ HerokuGenerator.prototype.productionBuild = function productionBuild() {
   }
 
   var done = this.async();
+  this.log(chalk.bold('\nBuilding application'));
   var child = exec('mvn package -Pprod -DskipTests=true', function (err, stdout) {
     if (err) {
       this.abort = true;
@@ -231,7 +232,8 @@ HerokuGenerator.prototype.herokuCliDeploy = function herokuCliDeploy() {
       console.log(chalk.red(err));
     } else {
       console.log(chalk.green('\nYour app should now be live. To view it run\n\t' + chalk.bold('heroku open --app ' + this.herokuDeployedName)));
-      console.log(chalk.yellow('After application modification, re-deploy it with\n\t' + chalk.bold(herokuDeployCommand)));
+      console.log(chalk.yellow('After application modification, repackage it with\n\t' + chalk.bold('mvn package -Pprod -DskipTests')));
+      console.log(chalk.yellow('And then re-deploy it with\n\t' + chalk.bold(herokuDeployCommand)));
     }
     done();
     done();

--- a/heroku/index.js
+++ b/heroku/index.js
@@ -174,6 +174,14 @@ HerokuGenerator.prototype.copyHerokuFiles = function copyHerokuFiles() {
 HerokuGenerator.prototype.productionBuild = function productionBuild() {
   if(this.abort) return;
   if(this.herokuType == "Git") return;
+
+  if (this.buildTool == 'gradle') {
+    this.abort = true;
+    this.log.error("Gradle is not yet supported with Heroku CLI deployment");
+    done()
+    return;
+  }
+
   var done = this.async();
   var child = exec('mvn package -Pprod -DskipTests=true', function (err, stdout) {
     if (err) {

--- a/heroku/templates/_Procfile
+++ b/heroku/templates/_Procfile
@@ -1,6 +1,6 @@
 <% if (buildTool == 'maven') { %>
-web:    java -Xmx384m -Xss512k -XX:+UseCompressedOops -jar target/*.war --spring.profiles.active=prod --server.port=$PORT  --spring.datasource.heroku-url=$DATABASE_URL
+web:    java -jar target/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL
 <% } %>
 <% if(buildTool == 'gradle') {%>
-web:    java -Xmx384m -Xss512k -XX:+UseCompressedOops -jar build/libs/*.war --spring.profiles.active=prod --server.port=$PORT  --spring.datasource.heroku-url=$DATABASE_URL
+web:    java -jar build/libs/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL
 <% } %>

--- a/heroku/templates/_Procfile
+++ b/heroku/templates/_Procfile
@@ -1,6 +1,1 @@
-<% if (buildTool == 'maven') { %>
-web:    java -jar target/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL --metrics.jmx.enabled=false
-<% } %>
-<% if(buildTool == 'gradle') {%>
-web:    java -jar build/libs/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL --metrics.jmx.enabled=false
-<% } %>
+web: java -jar <% if (buildTool == 'maven') { %>target<% } %><% if (buildTool == 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL --metrics.jmx.enabled=false --spring.datasource.jmx-enabled=false --spring.jmx.enabled=false --management.security.enabled=false --endpoints.jmx.enabled=false

--- a/heroku/templates/_Procfile
+++ b/heroku/templates/_Procfile
@@ -1,6 +1,6 @@
 <% if (buildTool == 'maven') { %>
-web:    java -jar target/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL
+web:    java -jar target/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL --metrics.jmx.enabled=false
 <% } %>
 <% if(buildTool == 'gradle') {%>
-web:    java -jar build/libs/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL
+web:    java -jar build/libs/*.war --spring.profiles.active=prod --server.port=$PORT --spring.datasource.heroku-url=$DATABASE_URL --metrics.jmx.enabled=false
 <% } %>

--- a/heroku/templates/slugignore
+++ b/heroku/templates/slugignore
@@ -1,1 +1,0 @@
-package.json

--- a/heroku/templates/system.properties
+++ b/heroku/templates/system.properties
@@ -1,1 +1,0 @@
-java.runtime.version=1.8


### PR DESCRIPTION
This PR improves the existing Heroku generator by adding two new methods of deployment: Git-based and CLI-based. 

```
? Which method of deployment do you want ?
> CLI (recommended)
  Git 
```

I will add support for Maven deployment in another PR. 

## Summary of Changes

* Removed Heroku Grunt tasks in favor of "native" commands like `git push` and `heroku deploy`
* Added "heroku" profile to `pom.xml` to clean build artifacts from slug.
* Improved Git init to use root dir, and check for existing repo
* Added generator function to install CLI tool
* Separated `heroku create` into two commands for each deployment type
* Removed default JVM opts (Heroku picks good defaults based on dyno size)
* Removed `slugignore` and `system.properties` templates (not needed with new method)


## Future work

* Use grunt-shell to wrap `heroku deploy` command to make it simpler 
* Maven deploy type
* Update docs 

In particular, I would like feedback on the grunt-shell idea. I would like to create a grunt task, ` grunt deployHeroku` that executes the `heroku deploy:jar ...` command with all options in place. If this sounds acceptable, I will work on it.