### PR TITLE
Add a postinstall script so 'bower install' is run by 'npm install'

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,7 +4,7 @@
   "description": "Description for <%= baseName %>",
   "private": true,
   "dependencies": {
-    "bower": "~1.4.0"
+    "bower": "1.4.0"
   },
   "devDependencies": {<% if(frontendBuilder == 'grunt') { %>
     "grunt": "0.4.5",

--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -4,6 +4,7 @@
   "description": "Description for <%= baseName %>",
   "private": true,
   "dependencies": {
+    "bower": "~1.4.0"
   },
   "devDependencies": {<% if(frontendBuilder == 'grunt') { %>
     "grunt": "0.4.5",
@@ -73,5 +74,8 @@
   },
   "engines": {
     "node": ">=0.10.0"
+  },
+  "scripts": {
+    "postinstall": "./node_modules/bower/bin/bower install"
   }
 }


### PR DESCRIPTION
This will allow users to run 'npm install' without having to run 'npm install && bower install'.