### PR TITLE
Replace NULL cause with exception message

### DIFF
--- a/app/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/app/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -32,10 +32,10 @@ public class LoggingAspect {
     public void logAfterThrowing(JoinPoint joinPoint, Throwable e) {
         if (env.acceptsProfiles(Constants.SPRING_PROFILE_DEVELOPMENT)) {
             log.error("Exception in {}.{}() with cause = {}", joinPoint.getSignature().getDeclaringTypeName(),
-                    joinPoint.getSignature().getName(), e.getCause(), e);
+                    joinPoint.getSignature().getName(), e.getCause() == null ? e.getMessage() : e.getCause(), e);
         } else {
             log.error("Exception in {}.{}() with cause = {}", joinPoint.getSignature().getDeclaringTypeName(),
-                    joinPoint.getSignature().getName(), e.getCause());
+                    joinPoint.getSignature().getName(), e.getCause() == null ? e.getMessage() : e.getCause());
         }
     }
 


### PR DESCRIPTION
Log exception message in case exception cause is null. Sometimes when exception cause is NULL, it will save exception message in logs.

Example: When user login is rejected, its difficult to find whether the account was locked or bad credentials or credentials expired