### PR TITLE
Correct translation mismatch in html files

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -432,6 +432,7 @@ JhipsterGenerator.prototype.app = function app() {
     var javaDir = 'src/main/java/' + packageFolder + '/';
     var resourceDir = 'src/main/resources/';
     var webappDir = 'src/main/webapp/';
+    var interpolateRegex = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
 
     // Remove old files
 
@@ -461,9 +462,9 @@ JhipsterGenerator.prototype.app = function app() {
             this.template('_settings.gradle', 'settings.gradle', this, {});
             this.template('_gradle.properties', 'gradle.properties', this, {});
             this.template('_yeoman.gradle', 'yeoman.gradle', this, {});
-            this.template('_profile_dev.gradle', 'profile_dev.gradle', this, { 'interpolate': /<%=([\s\S]+?)%>/g });
-            this.template('_profile_prod.gradle', 'profile_prod.gradle', this, { 'interpolate': /<%=([\s\S]+?)%>/g });
-            this.template('_profile_fast.gradle', 'profile_fast.gradle', this, { 'interpolate': /<%=([\s\S]+?)%>/g });
+            this.template('_profile_dev.gradle', 'profile_dev.gradle', this, { 'interpolate': interpolateRegex });
+            this.template('_profile_prod.gradle', 'profile_prod.gradle', this, { 'interpolate': interpolateRegex });
+            this.template('_profile_fast.gradle', 'profile_fast.gradle', this, { 'interpolate': interpolateRegex });
             this.template('_gatling.gradle', 'gatling.gradle', this, {});
           if (this.databaseType == "sql") {
             this.template('_liquibase.gradle', 'liquibase.gradle', this, {});
@@ -475,7 +476,7 @@ JhipsterGenerator.prototype.app = function app() {
             break;
         case 'maven':
         default :
-            this.template('_pom.xml', 'pom.xml', null, { 'interpolate': /<%=([\s\S]+?)%>/g });
+            this.template('_pom.xml', 'pom.xml', null, { 'interpolate': interpolateRegex });
     }
 
     // Create Java resource files
@@ -492,7 +493,7 @@ JhipsterGenerator.prototype.app = function app() {
     // Thymeleaf templates
     this.copy(resourceDir + '/templates/error.html', resourceDir + 'templates/error.html');
 
-    this.template(resourceDir + '_logback.xml', resourceDir + 'logback.xml', this, { 'interpolate': /<%=([\s\S]+?)%>/g });
+    this.template(resourceDir + '_logback.xml', resourceDir + 'logback.xml', this, { 'interpolate': interpolateRegex });
 
     this.template(resourceDir + '/config/_application.yml', resourceDir + 'config/application.yml', this, {});
     this.template(resourceDir + '/config/_application-dev.yml', resourceDir + 'config/application-dev.yml', this, {});
@@ -731,7 +732,7 @@ JhipsterGenerator.prototype.app = function app() {
     }
     this.template('src/test/java/package/security/_SecurityUtilsTest.java', testDir + 'security/SecurityUtilsTest.java', this, {});
     if (this.databaseType == "sql" || this.databaseType == "mongodb") {
-    this.template('src/test/java/package/service/_UserServiceTest.java', testDir + 'service/UserServiceTest.java', this, {});
+        this.template('src/test/java/package/service/_UserServiceTest.java', testDir + 'service/UserServiceTest.java', this, {});
     }
     this.template('src/test/java/package/web/rest/_AccountResourceTest.java', testDir + 'web/rest/AccountResourceTest.java', this, {});
     this.template('src/test/java/package/web/rest/_TestUtil.java', testDir + 'web/rest/TestUtil.java', this, {});

--- a/app/templates/src/main/webapp/i18n/en/register.json
+++ b/app/templates/src/main/webapp/i18n/en/register.json
@@ -8,9 +8,9 @@
             "validate": {
                 "login": {
                     "required": "Your login is required.",
-                    "minlength": "Your login is required to be at least 1 character",
-                    "maxlength": "Your login cannot be longer than 50 characters",
-                    "pattern": "Your login can only contain lower-case letters and digits"
+                    "minlength": "Your login is required to be at least 1 character.",
+                    "maxlength": "Your login cannot be longer than 50 characters.",
+                    "pattern": "Your login can only contain lower-case letters and digits."
                 }
             },
             "success": "<strong>Registration saved!</strong> Please check your email for confirmation.",

--- a/app/templates/src/main/webapp/scripts/app/account/activate/activate.html
+++ b/app/templates/src/main/webapp/scripts/app/account/activate/activate.html
@@ -1,14 +1,14 @@
 <div>
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
-            <h1 translate="activate.title">E-mail validation</h1>
+            <h1 translate="activate.title">Activation</h1>
 
             <div class="alert alert-success" ng-show="success" translate="activate.messages.success">
-                <strong>Your username has been validated.</strong> Please authenticate.
+                <strong>Your user has been activated.</strong> Please authenticate.
             </div>
 
             <div class="alert alert-danger" ng-show="error" translate="activate.messages.error">
-                <strong>Your username could not be validated.</strong> Please use the registration form to register your username.
+                <strong>Your user could not be activated.</strong> Please use the registration form to sign up.
             </div>
 
         </div>

--- a/app/templates/src/main/webapp/scripts/app/account/login/login.html
+++ b/app/templates/src/main/webapp/scripts/app/account/login/login.html
@@ -19,7 +19,7 @@
                 <div class="form-group">
                     <label for="rememberMe">
                         <input type="checkbox" id="rememberMe" ng-model="rememberMe" checked>
-                        {{"login.form.rememberme" | translate}}
+                        <span translate="login.form.rememberme">Automatic Login</span>
                     </label>
                 </div><% } %>
                 <button type="submit" class="btn btn-primary" translate="login.form.button">Authenticate</button>

--- a/app/templates/src/main/webapp/scripts/app/account/password/password.html
+++ b/app/templates/src/main/webapp/scripts/app/account/password/password.html
@@ -1,7 +1,7 @@
 <div>
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
-            <h2 translate="password.title" translate-values="{username: '{{account.login}}'}">Password</h2>
+            <h2 translate="password.title" translate-values="{username: '{{account.login}}'}">Password for [<b>{{account.login}}</b>]</h2>
 
             <div class="alert alert-success" ng-show="success" translate="password.messages.success">
                 <strong>Password changed!</strong>
@@ -27,11 +27,11 @@
                         </p>
                         <p class="help-block"
                            ng-show="form.password.$error.minlength" translate="global.messages.validate.newpassword.minlength">
-                            Your password is required to be at least 5 characters
+                            Your password is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                            ng-show="form.password.$error.maxlength" translate="global.messages.validate.newpassword.maxlength">
-                            Your password cannot be longer than 50 characters
+                            Your password cannot be longer than 50 characters.
                         </p>
                     </div>
                     <password-strength-bar password-to-check="password"></password-strength-bar>
@@ -43,15 +43,15 @@
                     <div ng-show="form.confirmPassword.$dirty && form.confirmPassword.$invalid">
                         <p class="help-block"
                            ng-show="form.confirmPassword.$error.required" translate="global.messages.validate.confirmpassword.required">
-                            Your password confirmation is required.
+                            Your confirmation password is required.
                         </p>
                         <p class="help-block"
                            ng-show="form.confirmPassword.$error.minlength" translate="global.messages.validate.confirmpassword.minlength">
-                            Your password confirmation is required to be at least 5 characters
+                            Your confirmation password is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                            ng-show="form.confirmPassword.$error.maxlength" translate="global.messages.validate.confirmpassword.maxlength">
-                            Your password confirmation cannot be longer than 50 characters
+                            Your confirmation password cannot be longer than 50 characters.
                         </p>
                     </div>
                 </div>

--- a/app/templates/src/main/webapp/scripts/app/account/register/register.html
+++ b/app/templates/src/main/webapp/scripts/app/account/register/register.html
@@ -8,7 +8,7 @@
             </div>
 
             <div class="alert alert-danger" ng-show="error" translate="register.messages.error.fail">
-                <strong>Registration failed!</strong> Please check your input and try again.
+                <strong>Registration failed!</strong> Please try again later.
             </div>
 
             <div class="alert alert-danger" ng-show="errorUserExists" translate="register.messages.error.userexists">
@@ -36,15 +36,15 @@
                         </p>
                         <p class="help-block"
                                ng-show="form.login.$error.minlength" translate="register.messages.validate.login.minlength">
-                            Your login is required to be at least 1 character
+                            Your login is required to be at least 1 character.
                         </p>
                         <p class="help-block"
                                ng-show="form.login.$error.maxlength" translate="register.messages.validate.login.maxlength">
-                            Your login cannot be longer than 50 characters
+                            Your login cannot be longer than 50 characters.
                         </p>
                         <p class="help-block"
                                ng-show="form.login.$error.pattern" translate="register.messages.validate.login.pattern">
-                            Your login can only contain lower-case letters and digits
+                            Your login can only contain lower-case letters and digits.
                     </p>
                     </div>
                 </div>
@@ -63,11 +63,11 @@
                         </p>
                         <p class="help-block"
                                ng-show="form.email.$error.minlength" translate="global.messages.validate.email.minlength">
-                            Your e-mail is required to be at least 5 characters
+                            Your e-mail is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                                ng-show="form.email.$error.maxlength" translate="global.messages.validate.email.maxlength">
-                            Your e-mail cannot be longer than 100 characters
+                            Your e-mail cannot be longer than 100 characters.
                         </p>
                     </div>
                 </div>
@@ -82,11 +82,11 @@
                         </p>
                         <p class="help-block"
                                ng-show="form.password.$error.minlength" translate="global.messages.validate.newpassword.minlength">
-                            Your password is required to be at least 5 characters
+                            Your password is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                                ng-show="form.password.$error.maxlength" translate="global.messages.validate.newpassword.maxlength">
-                            Your password cannot be longer than 50 characters
+                            Your password cannot be longer than 50 characters.
                         </p>
                     </div>
                     <password-strength-bar password-to-check="registerAccount.password"></password-strength-bar>
@@ -98,15 +98,15 @@
                     <div ng-show="form.confirmPassword.$dirty && form.confirmPassword.$invalid">
                         <p class="help-block"
                                ng-show="form.confirmPassword.$error.required" translate="global.messages.validate.confirmpassword.required">
-                            Your password confirmation is required.
+                            Your confirmation password is required.
                         </p>
                         <p class="help-block"
                                ng-show="form.confirmPassword.$error.minlength" translate="global.messages.validate.confirmpassword.minlength">
-                            Your password confirmation is required to be at least 5 characters
+                            Your confirmation password is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                                ng-show="form.confirmPassword.$error.maxlength" translate="global.messages.validate.confirmpassword.maxlength">
-                            Your password confirmation cannot be longer than 50 characters
+                            Your confirmation password cannot be longer than 50 characters.
                         </p>
                     </div>
                 </div>
@@ -115,8 +115,7 @@
             </form>
             <p></p>
             <div class="alert alert-warning" translate="global.messages.info.authenticated">
-                If you want to <a href="#/login">authenticate</a>, you can try the default login="admin" and
-                password="admin".
+                If you want to <a href="#/login">authenticate</a>, you can try the default accounts:<br/>- Administrator (login="admin" and password="admin") <br/>- User (login="user" and password="user").
             </div>
         </div>
     </div>

--- a/app/templates/src/main/webapp/scripts/app/account/reset/finish/reset.finish.html
+++ b/app/templates/src/main/webapp/scripts/app/account/reset/finish/reset.finish.html
@@ -16,7 +16,7 @@
             </div>
 
             <div class="alert alert-success" ng-show="success">
-                <p translate="reset.finish.messages.success"><strong>Your password has been reset.</strong> Please <a href=\"#/login\">authenticate</a>.</p>
+                <p translate="reset.finish.messages.success"><strong>Your password has been reset.</strong> Please <a href="#/login">authenticate</a>.</p>
             </div>
 
             <div class="alert alert-danger" ng-show="doNotMatch" translate="global.messages.error.dontmatch">
@@ -36,11 +36,11 @@
                             </p>
                             <p class="help-block"
                                ng-show="form.password.$error.minlength" translate="global.messages.validate.newpassword.minlength">
-                                Your password is required to be at least 5 characters
+                                Your password is required to be at least 5 characters.
                             </p>
                             <p class="help-block"
                                ng-show="form.password.$error.maxlength" translate="global.messages.validate.newpassword.maxlength">
-                                Your password cannot be longer than 50 characters
+                                Your password cannot be longer than 50 characters.
                             </p>
                         </div>
                         <password-strength-bar password-to-check="resetAccount.password"></password-strength-bar>
@@ -57,11 +57,11 @@
                             </p>
                             <p class="help-block"
                                ng-show="form.confirmPassword.$error.minlength" translate="global.messages.validate.confirmpassword.minlength">
-                                Your password confirmation is required to be at least 5 characters
+                                Your password confirmation is required to be at least 5 characters.
                             </p>
                             <p class="help-block"
                                ng-show="form.confirmPassword.$error.maxlength" translate="global.messages.validate.confirmpassword.maxlength">
-                                Your password confirmation cannot be longer than 50 characters
+                                Your password confirmation cannot be longer than 50 characters.
                             </p>
                         </div>
                     </div>

--- a/app/templates/src/main/webapp/scripts/app/account/reset/request/reset.request.html
+++ b/app/templates/src/main/webapp/scripts/app/account/reset/request/reset.request.html
@@ -31,11 +31,11 @@
                         </p>
                         <p class="help-block"
                            ng-show="form.email.$error.minlength" translate="global.messages.validate.email.minlength">
-                            Your e-mail is required to be at least 5 characters
+                            Your e-mail is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                            ng-show="form.email.$error.maxlength" translate="global.messages.validate.email.maxlength">
-                            Your e-mail cannot be longer than 100 characters
+                            Your e-mail cannot be longer than 100 characters.
                         </p>
                     </div>
                 </div>

--- a/app/templates/src/main/webapp/scripts/app/account/sessions/sessions.html
+++ b/app/templates/src/main/webapp/scripts/app/account/sessions/sessions.html
@@ -1,6 +1,6 @@
 <div>
 
-    <h2 translate="sessions.title" translate-values="{username: '{{account.login}}'}">Active sessions</h2>
+    <h2 translate="sessions.title" translate-values="{username: '{{account.login}}'}">Active sessions for [<b>{{account.login}}</b>]</h2>
 
     <div class="alert alert-success" ng-show="success" translate="sessions.messages.success">
         <strong>Session invalidated!</strong>

--- a/app/templates/src/main/webapp/scripts/app/account/settings/settings.html
+++ b/app/templates/src/main/webapp/scripts/app/account/settings/settings.html
@@ -1,7 +1,7 @@
 <div>
     <div class="row">
         <div class="col-md-8 col-md-offset-2">
-            <h2 translate="settings.title" translate-values="{username: '{{settingsAccount.login}}'}">User settings</h2>
+            <h2 translate="settings.title" translate-values="{username: '{{settingsAccount.login}}'}">User settings for [<b>{{settingsAccount.login}}</b>]</h2>
 
             <div class="alert alert-success" ng-show="success" translate="settings.messages.success">
                 <strong>Settings saved!</strong>
@@ -28,11 +28,11 @@
                         </p>
                         <p class="help-block"
                                ng-show="form.firstName.$error.minlength" translate="settings.messages.validate.firstname.minlength">
-                            Your first name is required to be at least 1 character
+                            Your first name is required to be at least 1 character.
                         </p>
                         <p class="help-block"
                                ng-show="form.firstName.$error.maxlength" translate="settings.messages.validate.firstname.maxlength">
-                            Your first name cannot be longer than 50 characters
+                            Your first name cannot be longer than 50 characters.
                         </p>
                     </div>
                 </div>
@@ -47,11 +47,11 @@
                         </p>
                         <p class="help-block"
                                ng-show="form.lastName.$error.minlength" translate="settings.messages.validate.lastname.minlength">
-                            Your last name is required to be at least 1 character
+                            Your last name is required to be at least 1 character.
                         </p>
                         <p class="help-block"
                                ng-show="form.lastName.$error.maxlength" translate="settings.messages.validate.lastname.maxlength">
-                            Your last name cannot be longer than 50 characters
+                            Your last name cannot be longer than 50 characters.
                         </p>
                     </div>
                 </div>
@@ -70,11 +70,11 @@
                         </p>
                         <p class="help-block"
                                ng-show="form.email.$error.minlength" translate="global.messages.validate.email.minlength">
-                            Your e-mail is required to be at least 5 characters
+                            Your e-mail is required to be at least 5 characters.
                         </p>
                         <p class="help-block"
                                ng-show="form.email.$error.maxlength" translate="global.messages.validate.email.maxlength">
-                            Your e-mail cannot be longer than 100 characters
+                            Your e-mail cannot be longer than 100 characters.
                         </p>
                     </div>
                 </div>

--- a/app/templates/src/main/webapp/scripts/app/admin/audits/_audits.controller.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/audits/_audits.controller.js
@@ -1,7 +1,7 @@
 'use strict';
 
 angular.module('<%=angularAppName%>')
-    .controller('AuditsController', function ($scope, $translate, $filter, AuditsService) {
+    .controller('AuditsController', function ($scope, $filter, AuditsService) {
         $scope.onChangeDate = function () {
             var dateFormat = 'yyyy-MM-dd';
             var fromDate = $filter('date')($scope.fromDate, dateFormat);

--- a/app/templates/src/main/webapp/scripts/app/admin/audits/audits.html
+++ b/app/templates/src/main/webapp/scripts/app/admin/audits/audits.html
@@ -17,10 +17,10 @@
     <table class="table table-condensed table-striped table-bordered table-responsive">
         <thead>
         <tr>
-            <th ng-click="predicate = 'timestamp'; reverse=!reverse">{{'audits.table.header.date' | translate}}</th>
-            <th ng-click="predicate = 'principal'; reverse=!reverse">{{'audits.table.header.principal' | translate}}</th>
-            <th ng-click="predicate = 'type'; reverse=!reverse">{{'audits.table.header.status' | translate}}</th>
-            <th ng-click="predicate = 'data.message'; reverse=!reverse">{{'audits.table.header.data' | translate}}</th>
+            <th ng-click="predicate = 'timestamp'; reverse=!reverse"><span translate="audits.table.header.date">Date</span></th>
+            <th ng-click="predicate = 'principal'; reverse=!reverse"><span translate="audits.table.header.principal">User</span></th>
+            <th ng-click="predicate = 'type'; reverse=!reverse"><span translate="audits.table.header.status">State</span></th>
+            <th ng-click="predicate = 'data.message'; reverse=!reverse"><span translate="audits.table.header.data">Extra data</span></th>
         </tr>
         </thead>
 
@@ -30,7 +30,7 @@
             <td>{{audit.type}}</td>
             <td>
                 <span ng-show="audit.data.message">{{audit.data.message}}</span>
-                <span ng-show="audit.data.remoteAddress">{{'audits.table.data.remoteAddress' | translate}} {{audit.data.remoteAddress}}</span>
+                <span ng-show="audit.data.remoteAddress"><span translate="audits.table.data.remoteAddress">Remote Address</span> {{audit.data.remoteAddress}}</span>
             </td>
         </tr>
     </table>

--- a/app/templates/src/main/webapp/scripts/app/admin/configuration/configuration.html
+++ b/app/templates/src/main/webapp/scripts/app/admin/configuration/configuration.html
@@ -1,13 +1,13 @@
 <div>
     <h2 translate="configuration.title">configuration</h2>
 
-    {{'configuration.filter' | translate}} <input type="text" ng-model="filter" class="form-control">
+    <span translate="configuration.filter">Filter (by prefix)</span> <input type="text" ng-model="filter" class="form-control">
 
     <table class="table table-condensed table-striped table-bordered table-responsive" style="table-layout:fixed">
         <thead>
         <tr>
-            <th ng-click="predicate = 'prefix'; reverse=!reverse">{{'configuration.table.prefix' | translate}}</th>
-            <th>{{'configuration.table.properties' | translate}}</th>
+            <th ng-click="predicate = 'prefix'; reverse=!reverse"><span translate="configuration.table.prefix">Prefix</span></th>
+            <th translate="configuration.table.properties">Properties</th>
         </tr>
         </thead>
         

--- a/app/templates/src/main/webapp/scripts/app/admin/health/health.html
+++ b/app/templates/src/main/webapp/scripts/app/admin/health/health.html
@@ -1,6 +1,6 @@
 <div>
 
-    <h2 translate="health.title">Application Health Check</h2>
+    <h2 translate="health.title">Health Check</h2>
 
     <div class="modal fade" id="showHealthModal" tabindex="-1" role="dialog" aria-labelledby="showHealthLabel"
          aria-hidden="true">
@@ -20,12 +20,12 @@
                     </div>
                     <div class="modal-body">
                         <div ng-show="currentHealth.details">
-                            <h4>{{'health.details.properties' | translate}}</h4>
+                            <h4 translate="health.details.properties">Properties</h4>
                             <table class="table table-striped">
                                 <thead>
                                     <tr>
-                                        <th class="col-md-6 text-left">{{'health.details.name' | translate}}</th>
-                                        <th class="col-md-6 text-left">{{'health.details.value' | translate}}</th>
+                                        <th class="col-md-6 text-left" translate="health.details.name">Name</th>
+                                        <th class="col-md-6 text-left" translate="health.details.value">Value</th>
                                     </tr>
                                 </thead>
                                 <tbody>
@@ -37,7 +37,7 @@
                             </table>
                         </div>
                         <div ng-show="currentHealth.error">
-                            <h4>{{'health.details.error' | translate}}</h4>
+                            <h4 translate="health.details.error">Error</h4>
                                 <pre>{{currentHealth.error}}</pre>
                         </div>
                     </div>
@@ -47,17 +47,16 @@
     </div>
 
     <p>
-        <button type="button" class="btn btn-primary" ng-click="refresh()"><span
-                class="glyphicon glyphicon-refresh"></span>&nbsp;{{'health.refresh.button' | translate}}
+        <button type="button" class="btn btn-primary" ng-click="refresh()"><span class="glyphicon glyphicon-refresh"></span>&nbsp;<span translate="health.refresh.button">Refresh</span>
         </button>
     </p>
 
     <table id="healthCheck" class="table table-striped">
         <thead>
             <tr>
-                <th class="col-md-7">{{'health.table.service' | translate}}</th>
-                <th class="col-md-2 text-center">{{'health.table.status' | translate}}</th>
-                <th class="col-md-2 text-center">{{'health.details.details' | translate}}</th>
+                <th class="col-md-7" translate="health.table.service">Service Name</th>
+                <th class="col-md-2 text-center" translate="health.table.status">Status</th>
+                <th class="col-md-2 text-center" translate="health.details.details">Details</th>
                 <th class="col-md-1 text-center"></th>
             </tr>
         </thead>

--- a/app/templates/src/main/webapp/scripts/app/admin/logs/logs.html
+++ b/app/templates/src/main/webapp/scripts/app/admin/logs/logs.html
@@ -1,15 +1,15 @@
 <div>
     <h2 translate="logs.title">Logs</h2>
 
-    <p translate="logs.nbloggers" translate-values="{total: '{{ loggers.length }}'}">There are 0 loggers.</p>
+    <p translate="logs.nbloggers" translate-values="{total: '{{ loggers.length }}'}">There are {{ loggers.length }} loggers.</p>
 
-    {{'logs.filter' | translate}} <input type="text" ng-model="filter" class="form-control">
+    <span translate="logs.filter">Filter</span> <input type="text" ng-model="filter" class="form-control">
 
     <table class="table table-condensed table-striped table-bordered table-responsive">
         <thead>
         <tr title="click to order">
-            <th ng-click="predicate = 'name'; reverse=!reverse" >{{'logs.table.name' | translate}}</th>
-            <th ng-click="predicate = 'level'; reverse=!reverse">{{'logs.table.level' | translate}}</th>
+            <th ng-click="predicate = 'name'; reverse=!reverse"><span translate="logs.table.name">Name</span></th>
+            <th ng-click="predicate = 'level'; reverse=!reverse"><span translate="logs.table.level">Level</span></th>
         </tr>
         </thead>
 

--- a/app/templates/src/main/webapp/scripts/app/admin/metrics/_metrics.html
+++ b/app/templates/src/main/webapp/scripts/app/admin/metrics/_metrics.html
@@ -2,14 +2,14 @@
 
 <h2 translate="metrics.title">Application Metrics</h2>
 <p>
-    <button type="button" class="btn btn-primary" ng-click="refresh()"><span class="glyphicon glyphicon-refresh"></span>&nbsp;{{'metrics.refresh.button' | translate}}</button>
+    <button type="button" class="btn btn-primary" ng-click="refresh()"><span class="glyphicon glyphicon-refresh"></span>&nbsp;<span translate="metrics.refresh.button">Refresh</span></button>
 </p>
 
 <h3 translate="metrics.jvm.title">JVM Metrics</h3>
 <div class="row" ng-hide="updatingMetrics">
     <div class="col-md-4">
         <b translate="metrics.jvm.memory.title">Memory</b>
-        <p>{{'metrics.jvm.memory.total' | translate}} ({{metrics.gauges['jvm.memory.total.used'].value / 1000000 | number:0}}M / {{metrics.gauges['jvm.memory.total.max'].value / 1000000 | number:0}}M)</p>
+        <p><span translate="metrics.jvm.memory.total">Total Memory</span> ({{metrics.gauges['jvm.memory.total.used'].value / 1000000 | number:0}}M / {{metrics.gauges['jvm.memory.total.max'].value / 1000000 | number:0}}M)</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-success" role="progressbar"
                  aria-valuenow="{{metrics.gauges['jvm.memory.total.used'].value / 1000000 | number:0}}"
@@ -19,7 +19,7 @@
                 {{metrics.gauges['jvm.memory.total.used'].value * 100 / metrics.gauges['jvm.memory.total.max'].value  | number:0}}%
             </div>
         </div>
-        <p>{{'metrics.jvm.memory.heap' | translate}} ({{metrics.gauges['jvm.memory.heap.used'].value / 1000000 | number:0}}M / {{metrics.gauges['jvm.memory.heap.max'].value / 1000000 | number:0}}M)</p>
+        <p><span translate="metrics.jvm.memory.heap">Heap Memory</span> ({{metrics.gauges['jvm.memory.heap.used'].value / 1000000 | number:0}}M / {{metrics.gauges['jvm.memory.heap.max'].value / 1000000 | number:0}}M)</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-success" role="progressbar"
                  aria-valuenow="{{metrics.gauges['jvm.memory.heap.used'].value / 1000000 | number:0}}"
@@ -29,7 +29,7 @@
                 {{(metrics.gauges['jvm.memory.heap.usage'].value * 100 | number:0)}}%
             </div>
         </div>
-        <p>{{'metrics.jvm.memory.nonheap' | translate}} ({{metrics.gauges['jvm.memory.non-heap.used'].value / 1000000 | number:0}}M / {{metrics.gauges['jvm.memory.non-heap.committed'].value / 1000000 | number:0}}M)</p>
+        <p><span translate="metrics.jvm.memory.nonheap">Non-Heap Memory</span> ({{metrics.gauges['jvm.memory.non-heap.used'].value / 1000000 | number:0}}M / {{metrics.gauges['jvm.memory.non-heap.committed'].value / 1000000 | number:0}}M)</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-success" role="progressbar"
                 aria-valuenow="{{metrics.gauges['jvm.memory.non-heap.used'].value / 1000000 | number:0}}"
@@ -42,7 +42,7 @@
     </div>
     <div class="col-md-4">
         <b translate="metrics.jvm.threads.title">Threads</b> (Total: {{metrics.gauges['jvm.threads.count'].value}}) <a class="hand" ng-click="refreshThreadDumpData()" data-toggle="modal" data-target="#threadDump"><i class="glyphicon glyphicon-eye-open"></i></a>
-        <p>{{'metrics.jvm.threads.runnable' | translate}} {{metrics.gauges['jvm.threads.runnable.count'].value}}</p>
+        <p><span translate="metrics.jvm.threads.runnable">Runnable</span> {{metrics.gauges['jvm.threads.runnable.count'].value}}</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-success" role="progressbar"
                  aria-valuenow="{{metrics.gauges['jvm.threads.runnable.count'].value}}"
@@ -52,7 +52,7 @@
                 {{metrics.gauges['jvm.threads.runnable.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
-        <p>{{'metrics.jvm.threads.timedwaiting' | translate}} ({{metrics.gauges['jvm.threads.timed_waiting.count'].value}})</p>
+        <p><span translate="metrics.jvm.threads.timedwaiting">Timed Waiting</span> ({{metrics.gauges['jvm.threads.timed_waiting.count'].value}})</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-warning" role="progressbar"
                  aria-valuenow="{{metrics.gauges['jvm.threads.timed_waiting.count'].value}}"
@@ -62,7 +62,7 @@
                 {{metrics.gauges['jvm.threads.timed_waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
-        <p>{{'metrics.jvm.threads.waiting' | translate}} ({{metrics.gauges['jvm.threads.waiting.count'].value}})</p>
+        <p><span translate="metrics.jvm.threads.waiting">Waiting</span> ({{metrics.gauges['jvm.threads.waiting.count'].value}})</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-warning" role="progressbar"
                  aria-valuenow="{{metrics.gauges['jvm.threads.waiting.count'].value}}"
@@ -72,7 +72,7 @@
                 {{metrics.gauges['jvm.threads.waiting.count'].value * 100 / metrics.gauges['jvm.threads.count'].value | number:0}}%
             </div>
         </div>
-        <p>{{'metrics.jvm.threads.blocked' | translate}}  ({{metrics.gauges['jvm.threads.blocked.count'].value}})</p>
+        <p><span translate="metrics.jvm.threads.blocked">Blocked</span> ({{metrics.gauges['jvm.threads.blocked.count'].value}})</p>
         <div class="progress progress-striped">
             <div class="progress-bar progress-bar-danger" role="progressbar"
                  aria-valuenow="{{metrics.gauges['jvm.threads.blocked.count'].value}}"
@@ -106,7 +106,7 @@
 <div class="well well-lg" ng-show="updatingMetrics" translate="metrics.updating">Updating...</div>
 
 <h3 translate="metrics.jvm.http.title">HTTP requests (events per second)</h3>
-<p>{{'metrics.jvm.http.active' | translate}} <b>{{metrics.counters['com.codahale.metrics.servlet.InstrumentedFilter.activeRequests'].count | number:0}}</b> - {{'metrics.jvm.http.total' | translate}} <b>{{metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count | number:0}}</b></p>
+    <p><span translate="metrics.jvm.http.active">Active requests</span> <b>{{metrics.counters['com.codahale.metrics.servlet.InstrumentedFilter.activeRequests'].count | number:0}}</b> - <span translate="metrics.jvm.http.total">Total requests</span> <b>{{metrics.timers['com.codahale.metrics.servlet.InstrumentedFilter.requests'].count | number:0}}</b></p>
 <div class="table-responsive">
     <table class="table table-striped">
         <thead>
@@ -114,9 +114,9 @@
             <th translate="metrics.jvm.http.table.code">Code</th>
             <th translate="metrics.jvm.http.table.count">Count</th>
             <th class="text-right" translate="metrics.jvm.http.table.mean">Mean</th>
-            <th class="text-right">{{'metrics.jvm.http.table.average' | translate}} (1 min)</th>
-            <th class="text-right">{{'metrics.jvm.http.table.average' | translate}} (5 min)</th>
-            <th class="text-right">{{'metrics.jvm.http.table.average' | translate}} (15 min)</th>
+            <th class="text-right"><span translate="metrics.jvm.http.table.average">Average</span> (1 min)</th>
+            <th class="text-right"><span translate="metrics.jvm.http.table.average">Average</span> (5 min)</th>
+            <th class="text-right"><span translate="metrics.jvm.http.table.average">Average</span> (15 min)</th>
         </tr>
         </thead>
         <tbody>
@@ -257,20 +257,20 @@
     </table>
 </div>
 <% } %>
-<h3 translate="metrics.datasource.title" ng-show="metrics.gauges['HikariPool-0.pool.TotalConnections'].value > 0">DataSource statistics</h3>
+<h3 translate="metrics.datasource.title" ng-show="metrics.gauges['HikariPool-0.pool.TotalConnections'].value > 0">DataSource statistics (time in millisecond)</h3>
 <div class="table-responsive" ng-show="metrics.gauges['HikariPool-0.pool.TotalConnections'].value > 0">
     <table class="table table-striped">
         <thead>
             <tr>
-                <th>{{'metrics.datasource.usage' | translate}} ({{metrics.gauges['HikariPool-0.pool.ActiveConnections'].value}} / {{metrics.gauges['HikariPool-0.pool.TotalConnections'].value}})</th>
-                <th class="text-right">{{'metrics.datasource.count' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.mean' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.min' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.p50' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.p75' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.p95' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.p99' | translate}}</th>
-                <th class="text-right">{{'metrics.datasource.max' | translate}}</th>
+                <th><span translate="metrics.datasource.usage">Usage</span> ({{metrics.gauges['HikariPool-0.pool.ActiveConnections'].value}} / {{metrics.gauges['HikariPool-0.pool.TotalConnections'].value}})</th>
+                <th class="text-right" translate="metrics.datasource.count">Count</th>
+                <th class="text-right" translate="metrics.datasource.mean">Mean</th>
+                <th class="text-right" translate="metrics.datasource.min">Min</th>
+                <th class="text-right" translate="metrics.datasource.p50">p50</th>
+                <th class="text-right" translate="metrics.datasource.p75">p75</th>
+                <th class="text-right" translate="metrics.datasource.p95">p95</th>
+                <th class="text-right" translate="metrics.datasource.p99">p99</th>
+                <th class="text-right" translate="metrics.datasource.max">Max</th>
             </tr>
         </thead>
         <tbody>
@@ -310,14 +310,14 @@
                 <h4 class="modal-title" id="myModalLabel" translate="metrics.jvm.threads.dump.title">Threads dump</h4>
             </div>
             <div class="modal-body well">
-                <span class="label label-primary" ng-click="threadDumpFilter = {}">{{'metrics.jvm.threads.all' | translate}}&nbsp;<span class="badge">{{threadDumpAll}}</span></span>&nbsp;
-                <span class="label label-success" ng-click="threadDumpFilter = {threadState: 'RUNNABLE'}">{{'metrics.jvm.threads.runnable' | translate}}&nbsp;<span class="badge">{{threadDumpRunnable}}</span></span>&nbsp;
-                <span class="label label-info" ng-click="threadDumpFilter = {threadState: 'WAITING'}">{{'metrics.jvm.threads.waiting' | translate}}&nbsp;<span class="badge">{{threadDumpWaiting}}</span></span>&nbsp;
-                <span class="label label-warning" ng-click="threadDumpFilter = {threadState: 'TIMED_WAITING'}">{{'metrics.jvm.threads.timedwaiting' | translate}}&nbsp;<span class="badge">{{threadDumpTimedWaiting}}</span></span>&nbsp;
-                <span class="label label-danger" ng-click="threadDumpFilter = {threadState: 'BLOCKED'}">{{'metrics.jvm.threads.blocked' | translate}}&nbsp;<span class="badge">{{threadDumpBlocked}}</span></span>&nbsp;
+                <span class="label label-primary" ng-click="threadDumpFilter = {}"><span translate="metrics.jvm.threads.all">All</span>&nbsp;<span class="badge">{{threadDumpAll}}</span></span>&nbsp;
+                <span class="label label-success" ng-click="threadDumpFilter = {threadState: 'RUNNABLE'}"><span translate="metrics.jvm.threads.runnable">Runnable</span>&nbsp;<span class="badge">{{threadDumpRunnable}}</span></span>&nbsp;
+                <span class="label label-info" ng-click="threadDumpFilter = {threadState: 'WAITING'}"><span translate="metrics.jvm.threads.waiting">Waiting</span>&nbsp;<span class="badge">{{threadDumpWaiting}}</span></span>&nbsp;
+                <span class="label label-warning" ng-click="threadDumpFilter = {threadState: 'TIMED_WAITING'}"><span translate="metrics.jvm.threads.timedwaiting">Timed Waiting</span>&nbsp;<span class="badge">{{threadDumpTimedWaiting}}</span></span>&nbsp;
+                <span class="label label-danger" ng-click="threadDumpFilter = {threadState: 'BLOCKED'}"><span translate="metrics.jvm.threads.blocked">Blocked</span>&nbsp;<span class="badge">{{threadDumpBlocked}}</span></span>&nbsp;
                 <div class="voffset2">&nbsp;</div>
                 <div class="row" ng-repeat="(k, v) in threadDump | filter:threadDumpFilter">
-                    <h5><span class="label" ng-class="getLabelClass(v.threadState)">&nbsp;</span>&nbsp;{{v.threadName}} ({{'metrics.jvm.threads.dump.id' | translate}} {{v.threadId}})</h5>
+                    <h5><span class="label" ng-class="getLabelClass(v.threadState)">&nbsp;</span>&nbsp;{{v.threadName}} (<span translate="metrics.jvm.threads.dump.id">Id</span> {{v.threadId}})</h5>
                     <table class="table table-condensed">
                         <thead>
                         <tr>
@@ -343,7 +343,7 @@
                                 </a>
                                 <div class="popover left" ng-show="show">
                                     <div class="popover-title">
-                                        <h4>{{'metrics.jvm.threads.dump.stacktrace' | translate}}<button type="button" class="close" ng-click="show = !show">&times;</button></h4>
+                                        <h4><span translate="metrics.jvm.threads.dump.stacktrace">Stacktrace</span><button type="button" class="close" ng-click="show = !show">&times;</button></h4>
                                     </div>
                                     <div class="popover-content">
                                         <div ng-repeat="(stK, stV) in v.stackTrace">

--- a/app/templates/src/main/webapp/scripts/app/error/accessdenied.html
+++ b/app/templates/src/main/webapp/scripts/app/error/accessdenied.html
@@ -6,7 +6,7 @@
         <div class="col-md-8">
             <h1 translate="errors.title">Error Page!</h1>
 
-            <div class="alert alert-danger" translate="errors.403" >
+            <div class="alert alert-danger" translate="errors.403">You are not authorized to access the page.
             </div>
         </div>
     </div>

--- a/app/templates/src/main/webapp/scripts/app/error/error.html
+++ b/app/templates/src/main/webapp/scripts/app/error/error.html
@@ -7,7 +7,7 @@
             <h1 translate="errors.title">Error Page!</h1>
 
             <div ng-show="errorMessage">
-                <div class="alert alert-danger" translate="{{errorMessage}}" >
+                <div class="alert alert-danger">{{errorMessage}}
                 </div>
             </div>
         </div>

--- a/app/templates/src/main/webapp/scripts/app/main/main.html
+++ b/app/templates/src/main/webapp/scripts/app/main/main.html
@@ -8,18 +8,16 @@
             <p class="lead" translate="main.subtitle">This is your homepage</p>
 
             <div ng-switch="isAuthenticated()">
-                <div class="alert alert-success" ng-switch-when="true"
-                     translate="main.logged.message" translate-values="{username: '{{account.login}}'}">
-                    You are logged in as user "Admin".
+                <div class="alert alert-success" ng-switch-when="true" translate="main.logged.message" translate-values="{username: '{{account.login}}'}">
+                    You are logged in as user "{{account.login}}".
                 </div>
 
                 <div class="alert alert-warning" ng-switch-when="false" translate="global.messages.info.authenticated">
-                    If you want to <a href="#/login">authenticate</a>, you can try the default login="admin" and
-                    password="admin".
+                    If you want to <a href="#/login">authenticate</a>, you can try the default accounts:<br/>- Administrator (login="admin" and password="admin") <br/>- User (login="user" and password="user").
                 </div>
 
                 <div class="alert alert-warning" ng-switch-when="false" translate="global.messages.info.register">
-                    Don't have an account? <a href=\"#/register\">Register</a>
+                    You don't have an account yet? <a href="#/register">Register a new account</a>
                 </div>
             </div>
 

--- a/app/templates/src/main/webapp/scripts/components/navbar/navbar.html
+++ b/app/templates/src/main/webapp/scripts/components/navbar/navbar.html
@@ -61,13 +61,13 @@
                     <a class="dropdown-toggle" data-toggle="dropdown" href="">
                                 <span>
                                     <span class="glyphicon glyphicon-tower"></span>
-                                    <span class="hidden-tablet" translate="global.menu.admin.main">Admin</span>
+                                    <span class="hidden-tablet" translate="global.menu.admin.main">Administration</span>
                                     <b class="caret"></b>
                                 </span>
                     </a>
                     <ul class="dropdown-menu"><% if (websocket == 'spring-websocket') { %>
                         <li ui-sref-active="active"><a ui-sref="tracker"><span class="glyphicon glyphicon-eye-open"></span>
-                                &nbsp;<span translate="global.menu.admin.tracker">User tracking</span></a></li><% } %>
+                                &nbsp;<span translate="global.menu.admin.tracker">User tracker</span></a></li><% } %>
                         <li ui-sref-active="active"><a ui-sref="metrics"><span class="glyphicon glyphicon-dashboard"></span>
                             &#xA0;<span translate="global.menu.admin.metrics">Metrics</span></a></li>
                         <li ui-sref-active="active"><a ui-sref="health"><span class="glyphicon glyphicon-heart"></span>
@@ -79,7 +79,7 @@
                         <li ui-sref-active="active"><a ui-sref="logs"><span class="glyphicon glyphicon-tasks"></span>
                             &#xA0;<span translate="global.menu.admin.logs">Logs</span></a></li>
                         <li ui-sref-active="active"><a ui-sref="docs"><span class="glyphicon glyphicon-book"></span>
-                            &#xA0;<span translate="global.menu.admin.apidocs">API Docs</span></a></li><% if (devDatabaseType == 'h2Memory') { %>
+                            &#xA0;<span translate="global.menu.admin.apidocs">API</span></a></li><% if (devDatabaseType == 'h2Memory') { %>
                         <li ng-show="{{ENV === 'dev'}}"><a href='/console' target="_tab"><span class="glyphicon glyphicon-hdd"></span>
                             &#xA0;<span translate="global.menu.admin.database">Database</span></a></li><% } %>
                     </ul>

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -1,6 +1,6 @@
 <div>
 <% var keyPrefix = angularAppName + '.'+ entityInstance + '.'; %>
-    <h2 translate="<%= keyPrefix %>home.title"><%= entityClass %></h2>
+    <h2 translate="<%= keyPrefix %>home.title"><%= entityClass %>s</h2>
 
     <div class="container">
         <div class="row">


### PR DESCRIPTION
Corrected all translation content in HTML to reflect same as in json
files, also changed to use translation directive instead of the filter
where possible. First PR to clean up codebase before merging changes to
make i18n optional