### PR TITLE
@Mapping.target based on relationshipFieldName instead of otherEntityName

### DIFF
--- a/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
+++ b/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
@@ -16,8 +16,8 @@ public interface <%= entityClass %>Mapper {
 for (relationshipId in relationships) {
         if (relationships[relationshipId].relationshipType == 'many-to-one') {
         %>
-    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.id", target = "<%= relationships[relationshipId].relationshipName %>Id")<% if (relationships[relationshipId].otherEntityFieldCapitalized != '') { %>
-    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.<%=relationships[relationshipId].otherEntityField %>", target = "<%= relationships[relationshipId].relationshipName %><%= relationships[relationshipId].otherEntityFieldCapitalized %>")<% } } } %>
+    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.id", target = "<%= relationships[relationshipId].relationshipFieldName %>Id")<% if (relationships[relationshipId].otherEntityFieldCapitalized != '') { %>
+    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.<%=relationships[relationshipId].otherEntityField %>", target = "<%= relationships[relationshipId].relationshipFieldName %><%= relationships[relationshipId].otherEntityFieldCapitalized %>")<% } } } %>
     <%= entityClass %>DTO <%= entityInstance %>To<%= entityClass %>DTO(<%= entityClass %> <%= entityInstance %>);
 <%
 // DTO -> entity mapping

--- a/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
+++ b/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
@@ -16,8 +16,8 @@ public interface <%= entityClass %>Mapper {
 for (relationshipId in relationships) {
         if (relationships[relationshipId].relationshipType == 'many-to-one') {
         %>
-    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.id", target = "<%= relationships[relationshipId].otherEntityName %>Id")<% if (relationships[relationshipId].otherEntityFieldCapitalized != '') { %>
-    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.<%=relationships[relationshipId].otherEntityField %>", target = "<%= relationships[relationshipId].otherEntityName %><%= relationships[relationshipId].otherEntityFieldCapitalized %>")<% } } } %>
+    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.id", target = "<%= relationships[relationshipId].relationshipName %>Id")<% if (relationships[relationshipId].otherEntityFieldCapitalized != '') { %>
+    @Mapping(source = "<%= relationships[relationshipId].relationshipName %>.<%=relationships[relationshipId].otherEntityField %>", target = "<%= relationships[relationshipId].relationshipName %><%= relationships[relationshipId].otherEntityFieldCapitalized %>")<% } } } %>
     <%= entityClass %>DTO <%= entityInstance %>To<%= entityClass %>DTO(<%= entityClass %> <%= entityInstance %>);
 <%
 // DTO -> entity mapping


### PR DESCRIPTION
When otherEntityName="dealership" differs from relationshipFieldName="shop" generator based on _Mapper.java produces the following lines:

@Mapping(source = "shop.id", target = "dealershipId")
@Mapping(source = "shop.name", target = "dealershipName")

instead of:

@Mapping(source = "shop.id", target = "shopId")
@Mapping(source = "shop.name", target = "shopName")

and maven build throws exception.

This PR fixes the issue.