### PR TITLE
Add mapstruct processor to gradle build

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -468,6 +468,7 @@ JhipsterGenerator.prototype.app = function app() {
             this.template('_profile_dev.gradle', 'profile_dev.gradle', this, { 'interpolate': interpolateRegex });
             this.template('_profile_prod.gradle', 'profile_prod.gradle', this, { 'interpolate': interpolateRegex });
             this.template('_profile_fast.gradle', 'profile_fast.gradle', this, { 'interpolate': interpolateRegex });
+            this.template('_mapstruct.gradle', 'mapstruct.gradle', this, { 'interpolate': interpolateRegex });
             this.template('_gatling.gradle', 'gatling.gradle', this, {});
           if (this.databaseType == "sql") {
             this.template('_liquibase.gradle', 'liquibase.gradle', this, {});

--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -36,9 +36,10 @@ bootRun {
 apply from: 'yeoman.gradle'
 
 <% if (databaseType == 'sql') { %>
-apply from: 'liquibase.gradle'
-<% } %>
+apply from: 'liquibase.gradle'<% } %>
 apply from: 'gatling.gradle'
+<% if (javaVersion == '8') { %>
+apply from: 'mapstruct.gradle'<% } %>
 
 if (project.hasProperty('prod')) {
     apply from: 'profile_prod.gradle'
@@ -152,7 +153,8 @@ dependencies {
     compile group: 'mysql', name: 'mysql-connector-java'<% } %><% if (devDatabaseType == 'postgresql' || prodDatabaseType == 'postgresql') { %>
     compile group: 'org.postgresql', name: 'postgresql', version: postgresql_version<% } %><% if (devDatabaseType == 'h2Memory') { %>
     compile group: 'com.h2database', name: 'h2'<% } %><% if (javaVersion == '8') { %>
-    compile group: 'fr.ippon.spark.metrics', name: 'metrics-spark-reporter', version: metrics_spark_reporter_version<% } %>
+    compile group: 'fr.ippon.spark.metrics', name: 'metrics-spark-reporter', version: metrics_spark_reporter_version<% } %><% if (javaVersion == '8') { %>
+    compile group: 'org.mapstruct', name: 'mapstruct-jdk8', version: mapstruct_version<% } %>
     testCompile group: 'com.jayway.awaitility', name: 'awaitility', version: awaility_version
     testCompile group: 'com.jayway.jsonpath', name: 'json-path'<% if (databaseType == 'cassandra') { %>
     testCompile(group: 'org.cassandraunit', name: 'cassandra-unit-spring', version: cassandra_unit_spring_version) {

--- a/app/templates/_gradle.properties
+++ b/app/templates/_gradle.properties
@@ -41,3 +41,4 @@ usertype_core_version=3.2.0.GA<% if (devDatabaseType == 'mysql' || prodDatabaseT
 mysql_connector_java_version=5.1.34<% } %>
 h2_version=1.4.185
 gatling_version=2.1.5
+mapstruct_version=1.0.0.Beta4

--- a/app/templates/_mapstruct.gradle
+++ b/app/templates/_mapstruct.gradle
@@ -1,0 +1,52 @@
+ext {
+    javaLanguageLevel = 1.<%= javaVersion %>
+    generatedMapperSourcesDir = "${buildDir}/generated-src"
+}
+
+configurations {
+    mapstruct
+}
+
+dependencies {
+    compile group: 'org.mapstruct', name: 'mapstruct', version: mapstruct_version
+    mapstruct group: 'org.mapstruct', name: 'mapstruct-processor', version: mapstruct_version
+}
+
+sourceSets.main {
+    ext.originalJavaSrcDirs = java.srcDirs
+    java.srcDir "${generatedMapperSourcesDir}"
+}
+
+task generateMainMapperClasses(type: JavaCompile) {
+    ext.aptDumpDir = file( "${buildDir}/tmp/apt/mapstruct" )
+    destinationDir = aptDumpDir
+
+    classpath = compileJava.classpath + configurations.mapstruct
+    source = sourceSets.main.originalJavaSrcDirs
+    ext.sourceDestDir = file ( "$generatedMapperSourcesDir" )
+
+    options.define(
+        compilerArgs: [
+            "-nowarn",
+            "-proc:only",
+            "-encoding", "UTF-8",
+            "-processor", "org.mapstruct.ap.MappingProcessor",
+            "-s", sourceDestDir.absolutePath,
+            "-source", rootProject.javaLanguageLevel,
+            "-target", rootProject.javaLanguageLevel,
+            "-Amapstruct.defaultComponentModel=spring",
+            "-Amapstruct.suppressGeneratorTimestamp=true"
+        ]
+    );
+
+    inputs.dir source
+    outputs.dir generatedMapperSourcesDir;
+    doFirst {
+        sourceDestDir.mkdirs()
+    }
+    doLast {
+        aptDumpDir.delete()
+    }
+}
+
+compileJava.dependsOn generateMainMapperClasses

--- a/entity/index.js
+++ b/entity/index.js
@@ -640,9 +640,6 @@ EntityGenerator.prototype.askForDTO = function askForDTO() {
     if (this.javaVersion == '7') {
         return;
     }
-    if (this.buildTool == 'gradle') {
-        return;
-    }
     var cb = this.async();
     var prompts = [
         {


### PR DESCRIPTION
Mapstrcut can be used with gradle and java 8. Mapstruct dependencies are not added for java 7. Still using the same mapstruct version as the current maven build, should maybe consider an update to ``1.0.0.CR1`` released on june 3th.