### PR TITLE
Fix password strenghbar style

### DIFF
--- a/app/templates/src/main/webapp/assets/styles/main.css
+++ b/app/templates/src/main/webapp/assets/styles/main.css
@@ -124,7 +124,7 @@ only screen and (                min-resolution: 2dppx) {
 .voffset9 { margin-top: 150px; }
 
 /* start Password strength bar style */
-ul#strength {
+ul#strengthBar {
     display:inline;
     list-style:none;
     margin:0;


### PR DESCRIPTION
The css selector was incorrect, such that the password strength bar looked strange before.

![bildschirmfoto vom 2015-06-17 07-22-56](https://cloud.githubusercontent.com/assets/203401/8200212/d54c265a-14c1-11e5-8768-0bb98437d491.png)
![bildschirmfoto vom 2015-06-17 07-21-19](https://cloud.githubusercontent.com/assets/203401/8200213/d572125c-14c1-11e5-8ee4-b30ba4850fb2.png)
