### PR TITLE
Use relative paths when minify css

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -222,9 +222,6 @@ module.exports = function (grunt) {
             }
         },
         cssmin: {
-            options: {
-                root: 'src/main/webapp' // Replace relative paths for static resources with absolute path
-            }
             // src and dest is configured in a subtask called "generated" by usemin
         },
         ngtemplates:    {
@@ -273,6 +270,18 @@ module.exports = function (grunt) {
         },
         // Put files not handled in other tasks here
         copy: {
+            fonts: {
+                files: [{
+                    expand: true,
+                    dot: true,
+                    flatten: true,
+                    cwd: 'src/main/webapp',
+                    dest: '<%%= yeoman.dist %>/assets/fonts',
+                    src: [
+                      'bower_components/bootstrap/fonts/*.*'
+                    ]
+                }]
+            },
             dist: {
                 files: [{
                     expand: true,
@@ -393,6 +402,7 @@ module.exports = function (grunt) {
         'imagemin',
         'svgmin',
         'concat',
+        'copy:fonts',
         'copy:dist',
         'ngAnnotate',
         'cssmin',


### PR DESCRIPTION
Use relative paths in minified files. This works with context path different from root context and in root context. Need to copy fonts separately otherwise they can't be found.

Fix #1555 