### PR TITLE
Exclude transitive mapstruct dependency

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -144,7 +144,9 @@ dependencies {
     compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2', version: spring_security_oauth2_version<% } %><% if (databaseType == 'mongodb') { %>
     compile group: 'org.mongeez', name: 'mongeez', version: mongeez_version<% } %>
     compile(group: 'io.springfox', name: 'springfox-swagger-ui', version: springfox_version)
-    compile(group: 'io.springfox', name: 'springfox-swagger2', version: springfox_version)
+    compile(group: 'io.springfox', name: 'springfox-swagger2', version: springfox_version){
+        exclude module: 'org.mapstruct.mapstruct'
+    }
     <% if (devDatabaseType == 'mysql' || prodDatabaseType == 'mysql') { %>
     compile group: 'mysql', name: 'mysql-connector-java'<% } %><% if (devDatabaseType == 'postgresql' || prodDatabaseType == 'postgresql') { %>
     compile group: 'org.postgresql', name: 'postgresql', version: postgresql_version<% } %><% if (devDatabaseType == 'h2Memory') { %>


### PR DESCRIPTION
I had no compile errors, but for clarity also excluding it explicitly. See #1680 