### PR TITLE
Add field type blob to entity generator, fix #1651

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -853,6 +853,8 @@ JhipsterGenerator.prototype.app = function app() {
         this.template(webappDir + '/scripts/components/auth/services/_sessions.service.js', webappDir + 'scripts/components/auth/services/sessions.service.js', this, {});
     }
     this.template(webappDir + '/scripts/components/form/_form.directive.js', webappDir + 'scripts/components/form/form.directive.js', this, {});
+    this.template(webappDir + '/scripts/components/form/_maxbytes.directive.js', webappDir + 'scripts/components/form/maxbytes.directive.js', this, {});
+    this.template(webappDir + '/scripts/components/form/_minbytes.directive.js', webappDir + 'scripts/components/form/minbytes.directive.js', this, {});
     this.template(webappDir + '/scripts/components/form/_pager.directive.js', webappDir + 'scripts/components/form/pager.directive.js', this, {});
     this.template(webappDir + '/scripts/components/form/_pager.html', webappDir + 'scripts/components/form/pager.html', this, {});
     this.template(webappDir + '/scripts/components/form/_pagination.directive.js', webappDir + 'scripts/components/form/pagination.directive.js', this, {});
@@ -970,6 +972,8 @@ JhipsterGenerator.prototype.app = function app() {
         'scripts/components/auth/services/password.service.js',
         'scripts/components/auth/services/register.service.js',
         'scripts/components/form/form.directive.js',
+        'scripts/components/form/maxbytes.directive.js',
+        'scripts/components/form/minbytes.directive.js',
         'scripts/components/form/pager.directive.js',
         'scripts/components/form/pagination.directive.js',
         'scripts/components/admin/audits.service.js',

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -24,7 +24,8 @@
     "angular-dynamic-locale": "0.1.27",<% } %>
     "angular-local-storage": "0.2.0",
     "angular-cache-buster": "0.4.3",
-    "ngInfiniteScroll": "1.2.0"
+    "ngInfiniteScroll": "1.2.0",
+    "ng-file-upload": "5.0.9"
   },
   "devDependencies": {
     "angular-mocks": "1.4.0",

--- a/app/templates/src/main/webapp/i18n/en/_global.json
+++ b/app/templates/src/main/webapp/i18n/en/_global.json
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",

--- a/app/templates/src/main/webapp/i18n/en/_global.json
+++ b/app/templates/src/main/webapp/i18n/en/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/app/templates/src/main/webapp/i18n/fr/_global.json
+++ b/app/templates/src/main/webapp/i18n/fr/_global.json
@@ -67,7 +67,7 @@
                     "invalid": "Votre email n'est pas valide."
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Ajouter blob",
+            "addimage": "ajouter image",
             "back": "Retour",
             "cancel": "Annuler",
             "edit": "Editer",

--- a/app/templates/src/main/webapp/i18n/fr/_global.json
+++ b/app/templates/src/main/webapp/i18n/fr/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Ajouter blob",
             "back": "Retour",
             "cancel": "Annuler",
             "edit": "Editer",
@@ -94,6 +95,8 @@
             "maxlength": "Ce champs doit faire moins de {{max}} caractères.",
             "min": "Ce champs doit être inférieur à {{min}}.",
             "max": "Ce champs doit être supérieur à {{max}}.",
+            "minbytes": "Ce champs doit être inférieur à {{min}} bytes.",
+            "maxbytes": "Ce champs doit être supérieur à {{max}} bytes.",
             "pattern": "Ce champs doit suivre l'expression régulière {{pattern}}.",
             "number": "Ce champs doit être un nombre.",
             "datetimelocal": "Ce champs doit être une date et une heure."

--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -2,7 +2,7 @@
 
 angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTranslation) { %>'tmh.dynamicLocale', 'pascalprecht.translate', <% } %>
                'ui.bootstrap', // for modal dialogs
-    'ngResource', 'ui.router', 'ngCookies', 'ngCacheBuster', 'infinite-scroll'])
+    'ngResource', 'ui.router', 'ngCookies', 'ngCacheBuster', 'ngFileUpload', 'infinite-scroll'])
 
     .run(function ($rootScope, $location, $window, $http, $state, <% if (enableTranslation) { %>$translate, Language,<% } %> Auth, Principal, ENV, VERSION) {
         $rootScope.ENV = ENV;
@@ -89,7 +89,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
             responseError: function(response) {
                 // If we have an unauthorized request we redirect to the login page
                 // Don't do this check on the account API to avoid infinite loop
-                if (response.status == 401 && response.data.path !== undefined && response.data.path.indexOf("/api/account") == -1){  
+                if (response.status == 401 && response.data.path !== undefined && response.data.path.indexOf("/api/account") == -1){
                     var Auth = $injector.get('Auth');
                     var $state = $injector.get('$state');
                     var to = $rootScope.toState;
@@ -97,8 +97,8 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
                     Auth.logout();
                     $rootScope.returnToState = to;
                     $rootScope.returnToStateParams = params;
-                    $state.go('login');    
-                }       
+                    $state.go('login');
+                }
                 return $q.reject(response);
             }
         };

--- a/app/templates/src/main/webapp/scripts/components/form/_maxbytes.directive.js
+++ b/app/templates/src/main/webapp/scripts/components/form/_maxbytes.directive.js
@@ -1,0 +1,35 @@
+/* globals $ */
+'use strict';
+
+angular.module('jhipsterApp')
+    .directive('maxbytes', function ($q) {
+        function endsWith(suffix, str) {
+            return str.indexOf(suffix, str.length - suffix.length) !== -1;
+        }
+
+        function paddingSize(base64String) {
+            if (endsWith('==', base64String)) {
+                return 2;
+            }
+            if (endsWith('=', base64String)) {
+                return 1;
+            }
+            return 0;
+        }
+
+        function numberOfBytes(base64String) {
+            return base64String.length / 4 * 3 - paddingSize(base64String);
+        }
+
+        return {
+            restrict: 'A',
+            require: '?ngModel',
+            link: function (scope, element, attrs, ngModel) {
+                if (!ngModel) return;
+
+                ngModel.$validators.maxbytes = function (modelValue) {
+                    return ngModel.$isEmpty(modelValue) || numberOfBytes(modelValue) <= attrs.maxbytes;
+                };
+            }
+        };
+    });

--- a/app/templates/src/main/webapp/scripts/components/form/_maxbytes.directive.js
+++ b/app/templates/src/main/webapp/scripts/components/form/_maxbytes.directive.js
@@ -1,7 +1,7 @@
 /* globals $ */
 'use strict';
 
-angular.module('jhipsterApp')
+angular.module('<%=angularAppName%>')
     .directive('maxbytes', function ($q) {
         function endsWith(suffix, str) {
             return str.indexOf(suffix, str.length - suffix.length) !== -1;

--- a/app/templates/src/main/webapp/scripts/components/form/_minbytes.directive.js
+++ b/app/templates/src/main/webapp/scripts/components/form/_minbytes.directive.js
@@ -1,0 +1,35 @@
+/* globals $ */
+'use strict';
+
+angular.module('jhipsterApp')
+    .directive('minbytes', function ($q) {
+        function endsWith(suffix, str) {
+            return str.indexOf(suffix, str.length - suffix.length) !== -1;
+        }
+
+        function paddingSize(base64String) {
+            if (endsWith('==', base64String)) {
+                return 2;
+            }
+            if (endsWith('=', base64String)) {
+                return 1;
+            }
+            return 0;
+        }
+
+        function numberOfBytes(base64String) {
+            return base64String.length / 4 * 3 - paddingSize(base64String);
+        }
+
+        return {
+            restrict: 'A',
+            require: '?ngModel',
+            link: function (scope, element, attrs, ngModel) {
+                if (!ngModel) return;
+
+                ngModel.$validators.minbytes = function (modelValue) {
+                    return ngModel.$isEmpty(modelValue) || numberOfBytes(modelValue) >= attrs.minbytes;
+                };
+            }
+        };
+    });

--- a/app/templates/src/main/webapp/scripts/components/form/_minbytes.directive.js
+++ b/app/templates/src/main/webapp/scripts/components/form/_minbytes.directive.js
@@ -1,7 +1,7 @@
 /* globals $ */
 'use strict';
 
-angular.module('jhipsterApp')
+angular.module('<%=angularAppName%>')
     .directive('minbytes', function ($q) {
         function endsWith(suffix, str) {
             return str.indexOf(suffix, str.length - suffix.length) !== -1;

--- a/entity/index.js
+++ b/entity/index.js
@@ -205,7 +205,7 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                 },
                 {
                     value: 'byte[]',
-                    name: 'Blob'
+                    name: '[BETA] Blob'
                 }
             ],
             default: 0

--- a/entity/index.js
+++ b/entity/index.js
@@ -99,6 +99,7 @@ var EntityGenerator = module.exports = function EntityGenerator(args, options, c
     this.fieldsContainDateTime = false; // JodaTime
     this.fieldsContainCustomTime = false;
     this.fieldsContainBigDecimal = false;
+    this.fieldsContainBlob = false;
     this.fieldsContainOwnerManyToMany = false;
     this.fieldsContainOwnerOneToOne = false;
     this.fieldsContainOneToMany = false;
@@ -201,6 +202,10 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                 {
                     value: 'enum',
                     name: 'Enumeration (Java enum type)'
+                },
+                {
+                    value: 'byte[]',
+                    name: 'Blob'
                 }
             ],
             default: 0
@@ -346,6 +351,22 @@ EntityGenerator.prototype.askForFields = function askForFields() {
             when: function (response) {
                 return response.fieldAdd == true &&
                     response.fieldValidate == true &&
+                    response.fieldType == 'byte[]';
+            },
+            type: 'checkbox',
+            name: 'fieldValidateRules',
+            message: 'Which validation rules do you want to add?',
+            choices: [
+                {name: 'Required', value: 'required'},
+                {name: 'Minimum byte size', value: 'minbytes'},
+                {name: 'Maximum byte size', value: 'maxbytes'}
+            ],
+            default: 0
+        },
+        {
+            when: function (response) {
+                return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
                     (response.fieldType == 'LocalDate' ||
                     response.fieldType == 'DateTime' ||
                     response.fieldType == 'UUID' ||
@@ -436,6 +457,38 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                 return 'Maximum size must be a number';
             },
             default: 100
+        },
+        {
+            when: function (response) {
+                return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('minbytes') != -1 &&
+                    response.fieldType == 'byte[]';
+            },
+            type: 'input',
+            name: 'fieldValidateRulesMinbytes',
+            message: 'What is the minimum byte size of your field?',
+            validate: function (input) {
+                if (/^([0-9]*)$/.test(input)) return true;
+                return 'Minimum byte size must be a number';
+            },
+            default: 0
+        },
+        {
+            when: function (response) {
+                return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('maxbytes') != -1 &&
+                    response.fieldType == 'byte[]';
+            },
+            type: 'input',
+            name: 'fieldValidateRulesMaxbytes',
+            message: 'What is the maximum byte size of your field?',
+            validate: function (input) {
+                if (/^([0-9]*)$/.test(input)) return true;
+                return 'Maximum byte size must be a number';
+            },
+            default: 5000000
         }
     ];
     this.prompt(prompts, function (props) {
@@ -475,8 +528,10 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                 fieldValidateRulesMaxlength: props.fieldValidateRulesMaxlength,
                 fieldValidateRulesPattern: props.fieldValidateRulesPattern,
                 fieldValidateRulesMin: props.fieldValidateRulesMin,
-                fieldValidateRulesMax: props.fieldValidateRulesMax
-            };
+                fieldValidateRulesMax: props.fieldValidateRulesMax,
+                fieldValidateRulesMinbytes: props.fieldValidateRulesMinbytes,
+                fieldValidateRulesMaxbytes: props.fieldValidateRulesMaxbytes
+                }
 
             fieldNamesUnderscored.push(_s.underscored(props.fieldName));
             this.fields.push(field);
@@ -494,6 +549,9 @@ EntityGenerator.prototype.askForFields = function askForFields() {
             if (props.fieldType == 'Date') {
                 this.fieldsContainDate = true;
                 this.fieldsContainCustomTime = true;
+            }
+            if (props.fieldType == 'byte[]') {
+                this.fieldsContainBlob = true;
             }
             if (props.fieldValidate) {
                 this.validation = true;
@@ -520,6 +578,12 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                 }
                 if (this.fields[id].fieldValidateRules.indexOf('max') != -1) {
                     validationDetails += 'max=\'' + this.fields[id].fieldValidateRulesMax + '\' ';
+                }
+                if (this.fields[id].fieldValidateRules.indexOf('minbytes') != -1) {
+                    validationDetails += 'minbytes=\'' + this.fields[id].fieldValidateRulesMinbytes + '\' ';
+                }
+                if (this.fields[id].fieldValidateRules.indexOf('maxbytes') != -1) {
+                    validationDetails += 'maxbytes=\'' + this.fields[id].fieldValidateRulesMaxbytes + '\' ';
                 }
             }
             console.log(chalk.red(this.fields[id].fieldName) + chalk.white(' (' + this.fields[id].fieldType + ') ') + chalk.cyan(validationDetails));
@@ -806,6 +870,7 @@ EntityGenerator.prototype.files = function files() {
         this.data.fieldsContainBigDecimal = this.fieldsContainBigDecimal;
         this.data.fieldsContainDateTime = this.fieldsContainDateTime;
         this.data.fieldsContainDate = this.fieldsContainDate;
+        this.data.fieldsContainBlob = this.fieldsContainBlob;
         this.data.changelogDate = this.changelogDate;
         this.data.dto = this.dto;
         this.data.pagination = this.pagination;
@@ -835,6 +900,7 @@ EntityGenerator.prototype.files = function files() {
         this.fieldsContainBigDecimal = this.fileData.fieldsContainBigDecimal;
         this.fieldsContainDateTime = this.fileData.fieldsContainDateTime;
         this.fieldsContainDate = this.fileData.fieldsContainDate;
+        this.fieldsContainBlob = this.fileData.fieldsContainBlob;
         this.changelogDate = this.fileData.changelogDate;
         for (var idx in this.relationships) {
           var rel = this.relationships[idx];

--- a/entity/index.js
+++ b/entity/index.js
@@ -301,6 +301,26 @@ EntityGenerator.prototype.askForFields = function askForFields() {
         },
         {
             when: function (response) {
+                return response.fieldAdd == true &&
+                    response.fieldType == 'byte[]';
+            },
+            type: 'list',
+            name: 'fieldTypeBlobContent',
+            message: 'What is the content of the blob field?',
+            choices: [
+                {
+                    value: 'image',
+                    name: 'Image'
+                },
+                {
+                    value: 'any',
+                    name: 'Any'
+                }
+            ],
+            default: 0
+        },
+        {
+            when: function (response) {
                 if (response.fieldType == 'Boolean') {
                     response.fieldValidate = false;
                     return false;
@@ -517,6 +537,7 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                 fieldId: this.fieldId,
                 fieldName: props.fieldName,
                 fieldType: props.fieldType,
+                fieldTypeBlobContent: props.fieldTypeBlobContent,
                 fieldIsEnum: props.fieldIsEnum,
                 fieldValues: props.fieldValues,
                 fieldNameCapitalized: _s.capitalize(props.fieldName),
@@ -586,7 +607,7 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                     validationDetails += 'maxbytes=\'' + this.fields[id].fieldValidateRulesMaxbytes + '\' ';
                 }
             }
-            console.log(chalk.red(this.fields[id].fieldName) + chalk.white(' (' + this.fields[id].fieldType + ') ') + chalk.cyan(validationDetails));
+            console.log(chalk.red(this.fields[id].fieldName) + chalk.white(' (' + this.fields[id].fieldType + (this.fields[id].fieldTypeBlobContent ? ' ' + this.fields[id].fieldTypeBlobContent : '') + ') ') + chalk.cyan(validationDetails));
         }
         if (props.fieldAdd) {
             this.askForFields();
@@ -766,7 +787,7 @@ EntityGenerator.prototype.askForRelationships = function askForRelationships() {
         }
         console.log(chalk.red('===========' + _s.capitalize(this.name) + '=============='));
         for (var id in this.fields) {
-            console.log(chalk.red(this.fields[id].fieldName + ' (' + this.fields[id].fieldType + ')'));
+            console.log(chalk.red(this.fields[id].fieldName + ' (' + this.fields[id].fieldType + (this.fields[id].fieldTypeBlobContent ? ' ' + this.fields[id].fieldTypeBlobContent : '') + ')'));
         }
         console.log(chalk.red('-------------------'));
         for (var id in this.relationships) {

--- a/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/entity/templates/src/main/java/package/domain/_Entity.java
@@ -76,11 +76,15 @@ public class <%= entityClass %> implements Serializable {
     @NotNull<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxlength') == -1) { %>
     @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('minlength') == -1) { %>
     @Size(max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) { %>
-    @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>, max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>, max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxbytes') == -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('minbytes') == -1) { %>
+    @Size(max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinbytes %>, max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
     @Min(value = <%= fields[fieldId].fieldValidateRulesMin %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
     @Max(value = <%= fields[fieldId].fieldValidateRulesMax %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
     @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPattern %>")<% } } %><% if (databaseType == 'sql') { %><% if (fields[fieldId].fieldIsEnum) { %>
-    @Enumerated(EnumType.STRING)<% } %><% if (fields[fieldId].fieldType == 'DateTime') { %>
+    @Enumerated(EnumType.STRING)<% } %><% if (fields[fieldId].fieldType == 'byte[]') { %>
+    @Lob<% } %><% if (fields[fieldId].fieldType == 'DateTime') { %>
     @Type(type = "org.jadira.usertype.dateandtime.joda.PersistentDateTime")
     @JsonSerialize(using = CustomDateTimeSerializer.class)
     @JsonDeserialize(using = CustomDateTimeDeserializer.class)

--- a/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -36,10 +36,14 @@ public class <%= entityClass %>DTO implements Serializable {
     @NotNull<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxlength') == -1) { %>
     @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('minlength') == -1) { %>
     @Size(max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minlength') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) { %>
-    @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>, max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinlength %>, max = <%= fields[fieldId].fieldValidateRulesMaxlength %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxbytes') == -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('minbytes') == -1) { %>
+    @Size(max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1) { %>
+    @Size(min = <%= fields[fieldId].fieldValidateRulesMinbytes %>, max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
     @Min(value = <%= fields[fieldId].fieldValidateRulesMin %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
     @Max(value = <%= fields[fieldId].fieldValidateRulesMax %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
-    @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPattern %>")<% } } %><% if (fields[fieldId].fieldType == 'DateTime') { %>
+    @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPattern %>")<% } } %><% if (fields[fieldId].fieldType == 'DateTime') { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
+    @Lob<% } %>
     @JsonSerialize(using = CustomDateTimeSerializer.class)
     @JsonDeserialize(using = CustomDateTimeDeserializer.class)<% } else if (fields[fieldId].fieldType == 'LocalDate') { %>
     @JsonSerialize(using = CustomLocalDateSerializer.class)

--- a/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -34,7 +34,8 @@
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bigint"<% } else if (fieldType == 'BigDecimal') { %>
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="decimal(10,2)"<% } else if (fieldType == 'LocalDate') { %>
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="date"<% } else if (fieldType == 'DateTime') { %>
-            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="timestamp"<% } else if (fieldType == 'Boolean') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="timestamp"<% } else if (fieldType == 'byte[]') { %>
+            <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="blob"<% } else if (fieldType == 'Boolean') { %>
             <column name="<%=fields[fieldId].fieldNameUnderscored %>" type="bit"<% } %><% if (required == false) {
                  %>/><% } else { %>>
                 <constraints nullable="false" />
@@ -46,7 +47,7 @@
             if (fields[fieldId].fieldType == 'DateTime') { %>
         <dropDefaultValue tableName="<%= name.toUpperCase() %>" columnName="<%=fields[fieldId].fieldNameUnderscored %>" columnDataType="datetime"/>
 <% } } %>
-        <% for (relationshipId in relationships) { %><% if ((relationships[relationshipId].relationshipType == 'many-to-one') || ((relationships[relationshipId].relationshipType == 'one-to-one')) && (relationships[relationshipId].ownerSide == true)) { 
+        <% for (relationshipId in relationships) { %><% if ((relationships[relationshipId].relationshipType == 'many-to-one') || ((relationships[relationshipId].relationshipType == 'one-to-one')) && (relationships[relationshipId].ownerSide == true)) {
             var constraintName = 'fk_' + name.toLowerCase() + '_' + relationships[relationshipId].relationshipName.toLowerCase() + '_id';
             if(prodDatabaseType === 'oracle' && constraintName.length > 30) {
                 constraintName = 'fk_' + name.toLowerCase().substring(0, 3) + '_' + relationships[relationshipId].relationshipName.toLowerCase().substring(0, 3) + '_id';

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -60,7 +60,11 @@
             <tbody<% if (pagination == 'infinite-scroll') { %> infinite-scroll="loadPage(page + 1)" infinite-scroll-disabled="links['last'] == page"<% } %>>
                 <tr ng-repeat="<%=entityInstance %> in <%=entityInstance %>s">
                     <td><a ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})">{{<%=entityInstance %>.id}}</a></td><% for (fieldId in fields) { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
-                    <td>{{formatBase64String(<%=entityInstance %>.<%=fields[fieldId].fieldName%>)}}</td><% } else { %>
+                    <td><% if (fields[fieldId].fieldTypeBlobContent == 'image') { %>
+                        <img data-ng-src="{{'data:image/*;base64,' + <%=entityInstance %>.<%=fields[fieldId].fieldName%>}}" style="max-height: 30px;" ng-if="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"/><% } %><% if (fields[fieldId].fieldTypeBlobContent == 'any') { %>
+                        {{abbreviate(<%= entityInstance %>.<%= fields[fieldId].fieldName %>) + ' ' + byteSize(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}<% } else { %>
+                        {{byteSize(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}<% } %>
+                    </td><% } else { %>
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') {
                             var relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -59,8 +59,9 @@
             </thead>
             <tbody<% if (pagination == 'infinite-scroll') { %> infinite-scroll="loadPage(page + 1)" infinite-scroll-disabled="links['last'] == page"<% } %>>
                 <tr ng-repeat="<%=entityInstance %> in <%=entityInstance %>s">
-                    <td><a ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})">{{<%=entityInstance %>.id}}</a></td><% for (fieldId in fields) { %>
-                    <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% for (relationshipId in relationships) {
+                    <td><a ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})">{{<%=entityInstance %>.id}}</a></td><% for (fieldId in fields) { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
+                    <td>{{formatBase64String(<%=entityInstance %>.<%=fields[fieldId].fieldName%>)}}</td><% } else { %>
+                    <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one') {
                             var relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
                             if (dto == 'mapstruct') {

--- a/entity/templates/src/main/webapp/app/_entity-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-controller.js
@@ -72,9 +72,19 @@ angular.module('<%=angularAppName%>')
             $scope.<%= entityInstance %> = {<% for (fieldId in fields) { %><%= fields[fieldId].fieldName %>: null, <% } %>id: null};
         };<% if (fieldsContainBlob) { %>
 
-        $scope.formatBase64String = function (base64String) {
+        $scope.abbreviate = function (text) {
+            if (!angular.isString(text)) {
+                return '';
+            }
+            if (text.length < 30) {
+                return text;
+            }
+            return text ? (text.substring(0, 15) + '...' + text.slice(-10)) : '';
+        };
+
+        $scope.byteSize = function (base64String) {
             if (!angular.isString(base64String)) {
-                return base64String;
+                return '';
             }
             function endsWith(suffix, str) {
                 return str.indexOf(suffix, str.length - suffix.length) !== -1;
@@ -88,13 +98,13 @@ angular.module('<%=angularAppName%>')
                 }
                 return 0;
             }
-            var bytes = base64String.length / 4 * 3 - paddingSize(base64String);
-            var size = bytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") + " bytes";
-
-            if (base64String.length < 30) {
-                return base64String + ' size:' + size;
+            function size(base64String) {
+                return base64String.length / 4 * 3 - paddingSize(base64String);
+            }
+            function formatAsBytes(size) {
+                return size.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") + " bytes";
             }
 
-            return base64String.substring(0, 10) + '...' + base64String.slice(-10) + ' size:' + size;
+            return formatAsBytes(size(base64String));
         };<% } %>
     });

--- a/entity/templates/src/main/webapp/app/_entity-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-controller.js
@@ -70,5 +70,31 @@ angular.module('<%=angularAppName%>')
 
         $scope.clear = function () {
             $scope.<%= entityInstance %> = {<% for (fieldId in fields) { %><%= fields[fieldId].fieldName %>: null, <% } %>id: null};
-        };
+        };<% if (fieldsContainBlob) { %>
+
+        $scope.formatBase64String = function (base64String) {
+            if (!angular.isString(base64String)) {
+                return base64String;
+            }
+            function endsWith(suffix, str) {
+                return str.indexOf(suffix, str.length - suffix.length) !== -1;
+            }
+            function paddingSize(base64String) {
+                if (endsWith('==', base64String)) {
+                    return 2;
+                }
+                if (endsWith('=', base64String)) {
+                    return 1;
+                }
+                return 0;
+            }
+            var bytes = base64String.length / 4 * 3 - paddingSize(base64String);
+            var size = bytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") + " bytes";
+
+            if (base64String.length < 30) {
+                return base64String + ' size:' + size;
+            }
+
+            return base64String.substring(0, 10) + '...' + base64String.slice(-10) + ' size:' + size;
+        };<% } %>
     });

--- a/entity/templates/src/main/webapp/app/_entity-detail.html
+++ b/entity/templates/src/main/webapp/app/_entity-detail.html
@@ -15,8 +15,9 @@
                     <td>
                         <span translate="<%= keyPrefix %>.<%=fields[fieldId].fieldName%>"><%=fields[fieldId].fieldNameCapitalized%></span>
                     </td>
-                    <td>
-                        <input type="text" class="input-sm form-control" value="{{<%= entityInstance %>.<%=fields[fieldId].fieldName%>}}" readonly>
+                    <td><% if (fields[fieldId].fieldType == 'byte[]' && fields[fieldId].fieldTypeBlobContent == 'image') { %>
+                        <img data-ng-src="{{'data:image/*;base64,' + <%=entityInstance %>.<%=fields[fieldId].fieldName%>}}" style="max-width: 100%;" ng-if="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"/><% } else { %>
+                        <input type="text" class="input-sm form-control" value="{{<%= entityInstance %>.<%=fields[fieldId].fieldName%>}}" readonly><% } %>
                     </td>
                 </tr><% } %><% for (relationshipId in relationships) {
                                  if (relationships[relationshipId].relationshipType == 'many-to-one') {

--- a/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
@@ -29,9 +29,19 @@ angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogContro
             $modalInstance.dismiss('cancel');
         };<% if (fieldsContainBlob) { %>
 
-        $scope.formatBase64String = function (base64String) {
+        $scope.abbreviate = function (text) {
+            if (!angular.isString(text)) {
+                return '';
+            }
+            if (text.length < 30) {
+                return text;
+            }
+            return text ? (text.substring(0, 15) + '...' + text.slice(-10)) : '';
+        };
+
+        $scope.byteSize = function (base64String) {
             if (!angular.isString(base64String)) {
-                return base64String;
+                return '';
             }
             function endsWith(suffix, str) {
                 return str.indexOf(suffix, str.length - suffix.length) !== -1;
@@ -45,14 +55,14 @@ angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogContro
                 }
                 return 0;
             }
-            var bytes = base64String.length / 4 * 3 - paddingSize(base64String);
-            var size = bytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") + " bytes";
-
-            if (base64String.length < 30) {
-                return base64String + ' size:' + size;
+            function size(base64String) {
+                return base64String.length / 4 * 3 - paddingSize(base64String);
+            }
+            function formatAsBytes(size) {
+                return size.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") + " bytes";
             }
 
-            return base64String.substring(0, 10) + '...' + base64String.slice(-10) + ' size:' + size;
+            return formatAsBytes(size(base64String));
         };<% } %><% for (fieldId in fields) { if (fields[fieldId].fieldType === 'byte[]') { %>
 
         $scope.set<%= fields[fieldId].fieldNameCapitalized %> = function ($files, <%= entityInstance %>) {

--- a/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
@@ -27,5 +27,46 @@ angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogContro
 
         $scope.clear = function() {
             $modalInstance.dismiss('cancel');
-        };
+        };<% if (fieldsContainBlob) { %>
+
+        $scope.formatBase64String = function (base64String) {
+            if (!angular.isString(base64String)) {
+                return base64String;
+            }
+            function endsWith(suffix, str) {
+                return str.indexOf(suffix, str.length - suffix.length) !== -1;
+            }
+            function paddingSize(base64String) {
+                if (endsWith('==', base64String)) {
+                    return 2;
+                }
+                if (endsWith('=', base64String)) {
+                    return 1;
+                }
+                return 0;
+            }
+            var bytes = base64String.length / 4 * 3 - paddingSize(base64String);
+            var size = bytes.toString().replace(/\B(?=(\d{3})+(?!\d))/g, " ") + " bytes";
+
+            if (base64String.length < 30) {
+                return base64String + ' size:' + size;
+            }
+
+            return base64String.substring(0, 10) + '...' + base64String.slice(-10) + ' size:' + size;
+        };<% } %><% for (fieldId in fields) { if (fields[fieldId].fieldType === 'byte[]') { %>
+
+        $scope.set<%= fields[fieldId].fieldNameCapitalized %> = function ($files, <%= entityInstance %>) {
+            if ($files[0]) {
+                var file = $files[0];
+                var fileReader = new FileReader();
+                fileReader.readAsDataURL(file);
+                fileReader.onload = function (e) {
+                    var data = e.target.result;
+                    var base64Data = data.substr(data.indexOf('base64,') + 'base64,'.length);
+                    $scope.$apply(function() {
+                        <%= entityInstance %>.<%= fields[fieldId].fieldName %> = base64Data;
+                    });
+                };
+            }
+        };<% } } %>
 }]);

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -24,8 +24,10 @@
         fieldInputType = 'datetime-local';
     } else if (fields[fieldId].fieldType == 'Boolean') {
         fieldInputType = 'checkbox';
+    } else if (fields[fieldId].fieldType == 'byte[]') {
+        fieldInputType = 'hidden';
     } %>
-        <div class="form-group">
+        <div class="form-group"<% if (fields[fieldId].fieldType == 'byte[]') { %> ngf-drop ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)"<% } %>>
             <label translate="<%= translationKey %>" for="field_<%= fields[fieldId].fieldName %>"><%=fields[fieldId].fieldNameCapitalized%></label><%
             if (fields[fieldId].fieldIsEnum) { %>
             <select class="form-control" name="<%= fields[fieldId].fieldName %>" ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>" id="field_<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldValidate == true && fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %> required<% } %>><%
@@ -34,7 +36,19 @@
                  var value = values[key]; %>
                <option value="<%= value %>"><%= value %></option><%
                } %>
-            </select><% } else { %>
+            </select><% } else { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
+            <div>
+                <div class="help-block clearfix">
+                    <span class="pull-left">{{formatBase64String(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}</span>
+                    <button ng-click="<%= entityInstance %>.<%= fields[fieldId].fieldName %>=null"
+                            ng-if="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"
+                            class="btn btn-default btn-xs pull-right">
+                        <span class="glyphicon glyphicon-remove"></span>
+                    </button>
+                </div>
+                <button type="file" ngf-select class="btn btn-default btn-block"
+                        ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)" translate="entity.action.addblob">Add blob</button>
+            </div><% } %>
             <input type="<%= fieldInputType %>" class="form-control" name="<%= fields[fieldId].fieldName %>" id="field_<%= fields[fieldId].fieldName %>"
                     ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldType == 'DateTime') { %> ng-model-options="{timezone: 'UTC'}"<% } %><% if (fields[fieldId].fieldValidate == true) {
                         if (fields[fieldId].fieldValidateRules.indexOf('required') != -1) {
@@ -42,7 +56,9 @@
                         %> ng-minlength="<%= fields[fieldId].fieldValidateRulesMinlength %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxlength') != -1) {
                         %> ng-maxlength="<%= fields[fieldId].fieldValidateRulesMaxlength %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) {
                         %> min="<%= fields[fieldId].fieldValidateRulesMin %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) {
-                        %> max="<%= fields[fieldId].fieldValidateRulesMax %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) {
+                        %> max="<%= fields[fieldId].fieldValidateRulesMax %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1) {
+                        %> minbytes="<%= fields[fieldId].fieldValidateRulesMinbytes %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1) {
+                        %> maxbytes="<%= fields[fieldId].fieldValidateRulesMaxbytes %>"<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) {
                         %> ng-pattern="/<%= fields[fieldId].fieldValidateRulesPattern %>/"<% } } %>><% } %>
 <% if (fields[fieldId].fieldValidate == true) { %>
             <div ng-show="editForm.<%= fields[fieldId].fieldName %>.$invalid"><% if (fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %>
@@ -65,6 +81,14 @@
                 <p class="help-block"
                     ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.max" translate="entity.validation.max" translate-value-max="<%= fields[fieldId].fieldValidateRulesMax %>">
                     This field cannot be more than <%= fields[fieldId].fieldValidateRulesMax %>.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1) { %>
+                <p class="help-block"
+                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.minbytes" translate="entity.validation.minbytes" translate-value-min="<%= fields[fieldId].fieldValidateRulesMinbytes %>">
+                    This field should be more than <%= fields[fieldId].fieldValidateRulesMinbytes %>.
+                </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1) { %>
+                <p class="help-block"
+                   ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.maxbytes" translate="entity.validation.maxbytes" translate-value-max="<%= fields[fieldId].fieldValidateRulesMaxbytes %>">
+                    This field cannot be more than <%= fields[fieldId].fieldValidateRulesMaxbytes %>.
                 </p><% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
                 <p class="help-block"
                     ng-show="editForm.<%= fields[fieldId].fieldName %>.$error.pattern" translate="entity.validation.pattern" translate-value-pattern="<%= fields[fieldId].fieldValidateRulesPattern %>">

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -27,7 +27,7 @@
     } else if (fields[fieldId].fieldType == 'byte[]') {
         fieldInputType = 'hidden';
     } %>
-        <div class="form-group"<% if (fields[fieldId].fieldType == 'byte[]') { %> ngf-drop ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)"<% } %>>
+        <div class="form-group"<% if (fields[fieldId].fieldType == 'byte[]') { %> ngf-drop ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)"<% if (fields[fieldId].fieldTypeBlobContent == 'image') { %> ngf-accept="'image/*'"<% } %><% } %>>
             <label translate="<%= translationKey %>" for="field_<%= fields[fieldId].fieldName %>"><%=fields[fieldId].fieldNameCapitalized%></label><%
             if (fields[fieldId].fieldIsEnum) { %>
             <select class="form-control" name="<%= fields[fieldId].fieldName %>" ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>" id="field_<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldValidate == true && fields[fieldId].fieldValidateRules.indexOf('required') != -1) { %> required<% } %>><%
@@ -37,9 +37,11 @@
                <option value="<%= value %>"><%= value %></option><%
                } %>
             </select><% } else { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
-            <div>
-                <div class="help-block clearfix">
-                    <span class="pull-left">{{formatBase64String(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}</span>
+            <div><% if (fields[fieldId].fieldTypeBlobContent == 'image') { %>
+                <img data-ng-src="{{'data:image/*;base64,' + <%=entityInstance %>.<%=fields[fieldId].fieldName%>}}" style="max-height: 100px;" ng-if="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"/><% } %>
+                <div class="help-block clearfix"><% if (fields[fieldId].fieldTypeBlobContent == 'any') { %>
+                    <span class="pull-left">{{abbreviate(<%= entityInstance %>.<%= fields[fieldId].fieldName %>) + ' ' + byteSize(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}</span><% } else { %>
+                    <span class="pull-left">{{byteSize(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}</span><% } %>
                     <button ng-click="<%= entityInstance %>.<%= fields[fieldId].fieldName %>=null"
                             ng-if="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"
                             class="btn btn-default btn-xs pull-right">
@@ -47,7 +49,7 @@
                     </button>
                 </div>
                 <button type="file" ngf-select class="btn btn-default btn-block"
-                        ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)" translate="entity.action.addblob">Add blob</button>
+                        ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)" <% if (fields[fieldId].fieldTypeBlobContent == 'image') { %> accept="image/*"<% } %> translate="entity.action.addblob">Add blob</button>
             </div><% } %>
             <input type="<%= fieldInputType %>" class="form-control" name="<%= fields[fieldId].fieldName %>" id="field_<%= fields[fieldId].fieldName %>"
                     ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldType == 'DateTime') { %> ng-model-options="{timezone: 'UTC'}"<% } %><% if (fields[fieldId].fieldValidate == true) {

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -49,7 +49,9 @@
                     </button>
                 </div>
                 <button type="file" ngf-select class="btn btn-default btn-block"
-                        ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)" <% if (fields[fieldId].fieldTypeBlobContent == 'image') { %> accept="image/*"<% } %> translate="entity.action.addblob">Add blob</button>
+                        ngf-change="set<%= fields[fieldId].fieldNameCapitalized %>($files, <%= entityInstance %>)"<% if (fields[fieldId].fieldTypeBlobContent == 'image') { %> accept="image/*" translate="entity.action.addimage"<% } else { %> translate="entity.action.addblob"<% } %>>
+                    <% if (fields[fieldId].fieldTypeBlobContent == 'image') { %>Add image<% } else { %>Add blob<% } %>
+                </button>
             </div><% } %>
             <input type="<%= fieldInputType %>" class="form-control" name="<%= fields[fieldId].fieldName %>" id="field_<%= fields[fieldId].fieldName %>"
                     ng-model="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"<% if (fields[fieldId].fieldType == 'DateTime') { %> ng-model-options="{timezone: 'UTC'}"<% } %><% if (fields[fieldId].fieldValidate == true) {

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -20,7 +20,8 @@ import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;<% if (databaseType == 'sql') { %>
-import org.springframework.transaction.annotation.Transactional;<% } %>
+import org.springframework.transaction.annotation.Transactional;<% } %><% if (fieldsContainBlob == true) { %>
+import org.springframework.util.Base64Utils;<% } %>
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;<% if (fieldsContainLocalDate == true) { %>
@@ -114,7 +115,10 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
     private static final String <%=defaultValueName %>_STR = dateTimeFormatter.print(<%= defaultValueName %>);<% } else if (fieldType == 'Boolean') { %>
 
     private static final Boolean <%=defaultValueName %> = false;
-    private static final Boolean <%=updatedValueName %> = true;<% } else if (isEnum) { %>
+    private static final Boolean <%=updatedValueName %> = true;<% } else if (fieldType == 'byte[]') { %>
+
+    private static final byte[] <%=defaultValueName %> = new byte[]{1,2,3};
+    private static final byte[] <%=updatedValueName %> = new byte[]{3,2,1};<% } else if (isEnum) { %>
 
     private static final <%=fieldType %> <%=defaultValueName %> = <%=fieldType %>.<%=enumValue1 %>;
     private static final <%=fieldType %> <%=updatedValueName %> = <%=fieldType %>.<%=enumValue2 %>;<% } } %>
@@ -203,7 +207,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().intValue())))<% } %><% if (databaseType == 'mongodb') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId())))<% } %><% if (databaseType == 'cassandra') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().toString())))<% } %><% for (fieldId in fields) {%>
-                .andExpect(jsonPath("$.[*].<%=fields[fieldId].fieldName%>").value(hasItem(<%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%><% if (fields[fieldId].fieldType == 'Integer') { %><% } else if (fields[fieldId].fieldType == 'Long') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[fieldId].fieldType == 'DateTime') { %>_STR<% } else if (fields[fieldId].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>)))<% } %>;
+                .andExpect(jsonPath("$.[*].<%=fields[fieldId].fieldName%>").value(hasItem(<% if (fields[fieldId].fieldType == 'byte[]') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%><% if (fields[fieldId].fieldType == 'byte[]') { %>)<% } else if (fields[fieldId].fieldType == 'Integer') { %><% } else if (fields[fieldId].fieldType == 'Long') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[fieldId].fieldType == 'DateTime') { %>_STR<% } else if (fields[fieldId].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>)))<% } %>;
     }
 
     @Test<% if (databaseType == 'sql') { %>
@@ -219,7 +223,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'mongodb') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId()))<% } %><% if (databaseType == 'cassandra') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().toString()))<% } %><% for (fieldId in fields) {%>
-            .andExpect(jsonPath("$.<%=fields[fieldId].fieldName%>").value(<%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%><% if (fields[fieldId].fieldType == 'Integer') { %><% } else if (fields[fieldId].fieldType == 'Long') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[fieldId].fieldType == 'DateTime') { %>_STR<% } else if (fields[fieldId].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>))<% } %>;
+            .andExpect(jsonPath("$.<%=fields[fieldId].fieldName%>").value(<% if (fields[fieldId].fieldType == 'byte[]') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase()%><% if (fields[fieldId].fieldType == 'byte[]') { %>)<% } else if (fields[fieldId].fieldType == 'Integer') { %><% } else if (fields[fieldId].fieldType == 'Long') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[fieldId].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[fieldId].fieldType == 'DateTime') { %>_STR<% } else if (fields[fieldId].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>))<% } %>;
     }
 
     @Test<% if (databaseType == 'sql') { %>

--- a/languages/templates/src/main/webapp/i18n/ca/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ca/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "El seu compte de correu electrònic no pot tenir més de 50 caràcters"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",

--- a/languages/templates/src/main/webapp/i18n/ca/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ca/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/da/_global.json
+++ b/languages/templates/src/main/webapp/i18n/da/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Din e-mail adresse må ikke overskride 50 tegn"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Tilbage",
             "cancel": "Annuller",
             "delete": "Slet",

--- a/languages/templates/src/main/webapp/i18n/da/_global.json
+++ b/languages/templates/src/main/webapp/i18n/da/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Tilbage",
             "cancel": "Annuller",
             "delete": "Slet",
@@ -94,6 +95,8 @@
             "maxlength": "Dette felt kan ikke være længere end {{max}} karakterer.",
             "min": "Dette felt skal være større end {{min}}.",
             "max": "Dette felt kan ikke være større end {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "Dette felt skal følge mønsteret {{pattern}}.",
             "number": "Dette felt skal være et nummer.",
             "datetimelocal": "Dette felt skal være dato og tid."

--- a/languages/templates/src/main/webapp/i18n/de/_global.json
+++ b/languages/templates/src/main/webapp/i18n/de/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Ihre E-Mail Adresse darf nicht länger als 50 Zeichen sein"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Zurück",
             "cancel": "Abbrechen",
             "delete": "Löschen",

--- a/languages/templates/src/main/webapp/i18n/de/_global.json
+++ b/languages/templates/src/main/webapp/i18n/de/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Zurück",
             "cancel": "Abbrechen",
             "delete": "Löschen",
@@ -94,6 +95,8 @@
             "maxlength": "Dieses Feld darf max. {{max}} Zeichen lang sein.",
             "min": "Dieses Feld muss größer als {{min}} sein.",
             "max": "Dieses Feld muss kleiner als {{max}} sein.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "Dieses Feld muss das Muster {{pattern}} erfüllen.",
             "number": "Dieses Feld muss eine Zahl sein.",
             "datetimelocal": "Dieses Feld muss eine Datums- und Zeitangabe enthalten."

--- a/languages/templates/src/main/webapp/i18n/es/_global.json
+++ b/languages/templates/src/main/webapp/i18n/es/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/es/_global.json
+++ b/languages/templates/src/main/webapp/i18n/es/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Su correo electrónico no puede tener mas de 50 carácteres"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",

--- a/languages/templates/src/main/webapp/i18n/hu/_global.json
+++ b/languages/templates/src/main/webapp/i18n/hu/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Az email cím nem lehet hosszabb mint 50 betű"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Vissza",
             "cancel": "Mégsem",
             "delete": "Törlés",

--- a/languages/templates/src/main/webapp/i18n/hu/_global.json
+++ b/languages/templates/src/main/webapp/i18n/hu/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Vissza",
             "cancel": "Mégsem",
             "delete": "Törlés",
@@ -94,6 +95,8 @@
             "maxlength": "Ez a mező nem lehet hosszabb mint {{max}} karakter.",
             "min": "Ennek a mezőnek a megengedett minimum értéke {{min}}.",
             "max": "Ennek a mezőnek a megengedett maximum értéke {{max}}.",
+            "minbytes": "Ennek a mezőnek a megengedett minimum értéke {{min}} bytes.",
+            "maxbytes": "Ennek a mezőnek a megengedett maximum értéke {{max}} bytes.",
             "pattern": "Ennek a mezőnek meg kell felelni a {{pattern}} mintának.",
             "number": "Ennek a mezőnek számnak kéne lennie.",
             "datetimelocal": "Ennek a mezőnek dátumnak vagy időpontnak kéne lennie."

--- a/languages/templates/src/main/webapp/i18n/it/_global.json
+++ b/languages/templates/src/main/webapp/i18n/it/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Il tuo indirizzo email non può essere più di 50 caratteri"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Indietro",
             "cancel": "Annulla",
             "delete": "Elimina",

--- a/languages/templates/src/main/webapp/i18n/it/_global.json
+++ b/languages/templates/src/main/webapp/i18n/it/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Indietro",
             "cancel": "Annulla",
             "delete": "Elimina",
@@ -94,6 +95,8 @@
             "maxlength": "Questo campo non può essere più lungo di {{max}} caratteri.",
             "min": "Questo campo dovrebbe essere più di {{min}}..",
             "max": "Questo campo non può essere superiore a {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "Questo campo dovrebbe seguire pattern pattern {{}}.",
             "number": "Questo campo deve essere un numero.",
             "datetimelocal": "Questo campo dovrebbe essere una data e l'ora."

--- a/languages/templates/src/main/webapp/i18n/ja/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ja/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "戻る",
             "cancel": "キャンセル",
             "delete": "削除",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/ja/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ja/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "メールアドレスは50文字以下で入力してください。"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "戻る",
             "cancel": "キャンセル",
             "delete": "削除",

--- a/languages/templates/src/main/webapp/i18n/kr/_global.json
+++ b/languages/templates/src/main/webapp/i18n/kr/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "이메일은 최대 50자 까지입니다."
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",

--- a/languages/templates/src/main/webapp/i18n/kr/_global.json
+++ b/languages/templates/src/main/webapp/i18n/kr/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Back",
             "cancel": "Cancel",
             "delete": "Delete",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/pl/_global.json
+++ b/languages/templates/src/main/webapp/i18n/pl/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Twój e-mail nie może być dłuższy niż 50 znaków"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Wstecz",
             "cancel": "Anuluj",
             "delete": "Usuń",

--- a/languages/templates/src/main/webapp/i18n/pl/_global.json
+++ b/languages/templates/src/main/webapp/i18n/pl/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Wstecz",
             "cancel": "Anuluj",
             "delete": "Usuń",
@@ -94,6 +95,8 @@
             "maxlength": "Wartość nie może być dłuższa niż {{max}} znaków.",
             "min": "Wartość powinna być większa niż {{min}}.",
             "max": "Wartość nie może być większa niż {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "Wartość powinna być zgodna ze wzorem {{pattern}}.",
             "number": "Wartość powinna być liczbowa.",
             "datetimelocal": "Wartość powinna zawierać datę i czas."

--- a/languages/templates/src/main/webapp/i18n/pt-br/_global.json
+++ b/languages/templates/src/main/webapp/i18n/pt-br/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "O e-mail não pode ter mais de 50 caracteres"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "Código"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Voltar",
             "cancel": "Cancelar",
             "delete": "Excluir",

--- a/languages/templates/src/main/webapp/i18n/pt-br/_global.json
+++ b/languages/templates/src/main/webapp/i18n/pt-br/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Voltar",
             "cancel": "Cancelar",
             "delete": "Excluir",
@@ -94,6 +95,8 @@
             "maxlength": "Este campo não pode ter mais que {{max}} caracteres.",
             "min": "Este campo deve ser maior que {{min}}.",
             "max": "Este campo não pode ser maior que {{max}}.",
+            "minbytes": "Este campo deve ter ao menos {{min}} bytes.",
+            "maxbytes": "Este campo não pode ter mais que {{max}} bytes.",
             "pattern": "Este campo deve estar dentro do seguinte padrão {{pattern}}.",
             "number": "Este campo é do tipo número.",
             "datetimelocal": "Este campo é do tipo data/hora."

--- a/languages/templates/src/main/webapp/i18n/ro/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ro/_global.json
@@ -83,6 +83,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Înapoi",
             "cancel": "Anulează",
             "delete": "Șterge",
@@ -103,6 +104,8 @@
             "maxlength": "Acest câmp nu poate să fie mai lung decât {{max}} caractere.",
             "min": "Acest câmp trebuie să fie mai mult decât {{min}}.",
             "max": "Acest câmp nu poate să fie mai mult decât {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "Acest câmp trebuie să corespundă șablonului {{pattern}}.",
             "number": "Acest câmp trebuie să fie numeric.",
             "datetimelocal": "Acest câmp trebuie să conțină data si ora."

--- a/languages/templates/src/main/webapp/i18n/ro/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ro/_global.json
@@ -76,7 +76,7 @@
                     "maxlength": "E-mailul dumneavoastră nu poate avea mai mult de 50 de caractere."
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -84,6 +84,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Înapoi",
             "cancel": "Anulează",
             "delete": "Șterge",

--- a/languages/templates/src/main/webapp/i18n/ru/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ru/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Назад",
             "cancel": "Отмена",
             "delete": "Удалить",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/ru/_global.json
+++ b/languages/templates/src/main/webapp/i18n/ru/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "E-mail не может быть длиннее чем 50 символов"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Назад",
             "cancel": "Отмена",
             "delete": "Удалить",

--- a/languages/templates/src/main/webapp/i18n/sv/_global.json
+++ b/languages/templates/src/main/webapp/i18n/sv/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "Din e-post får inte vara längre än 50 tecken"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Lägg till blob",
+            "addimage": "Lägg till bild",
             "back": "Tillbaka",
             "cancel": "Avbryt",
             "delete": "Ta bort",

--- a/languages/templates/src/main/webapp/i18n/sv/_global.json
+++ b/languages/templates/src/main/webapp/i18n/sv/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Lägg till blob",
             "back": "Tillbaka",
             "cancel": "Avbryt",
             "delete": "Ta bort",
@@ -94,6 +95,8 @@
             "maxlength": "Detta fält kan inte vara längre än {{max}} tecken.",
             "min": "Detta fält måste vara större än {{min}}.",
             "max": "Detta fält måste vara mindre än {{max}}.",
+            "minbytes": "Detta fält måste vara större än {{min}} bytes.",
+            "maxbytes": "Detta fält måste vara mindre än {{max}} bytes.",
             "pattern": "Detta fält måste följa mönstret {{pattern}}.",
             "number": "Detta fält måste vara ett tal.",
             "datetimelocal": "Detta fält måste vara ett datum och en tid."

--- a/languages/templates/src/main/webapp/i18n/tr/_global.json
+++ b/languages/templates/src/main/webapp/i18n/tr/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "E-posta adresi 50 karakterden fazla olamaz"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "Geri",
             "cancel": "İptal",
             "delete": "Sil",

--- a/languages/templates/src/main/webapp/i18n/tr/_global.json
+++ b/languages/templates/src/main/webapp/i18n/tr/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "Geri",
             "cancel": "İptal",
             "delete": "Sil",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/zh-cn/_global.json
+++ b/languages/templates/src/main/webapp/i18n/zh-cn/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "您的电子邮件长度不能超过50个字符"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "返回",
             "cancel": "取消",
             "delete": "删除",

--- a/languages/templates/src/main/webapp/i18n/zh-cn/_global.json
+++ b/languages/templates/src/main/webapp/i18n/zh-cn/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "返回",
             "cancel": "取消",
             "delete": "删除",
@@ -94,6 +95,8 @@
             "maxlength": "本字段最大长度为 {{max}} 个字符.",
             "min": "本字段不能小于 {{min}}.",
             "max": "本字段不能大于 {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "本字段必须符合模式 {{pattern}}.",
             "number": "本字段必须为数字.",
             "datetimelocal": "本字段必须为日期和时间."

--- a/languages/templates/src/main/webapp/i18n/zh-tw/_global.json
+++ b/languages/templates/src/main/webapp/i18n/zh-tw/_global.json
@@ -74,6 +74,7 @@
     },
     "entity": {
         "action": {
+            "addblob": "Add blob",
             "back": "返回",
             "cancel": "取消",
             "delete": "刪除",
@@ -94,6 +95,8 @@
             "maxlength": "This field cannot be longer than {{max}} characters.",
             "min": "This field should be more than {{min}}.",
             "max": "This field cannot be more than {{max}}.",
+            "minbytes": "This field should be more than {{min}} bytes.",
+            "maxbytes": "This field cannot be more than {{max}} bytes.",
             "pattern": "This field should follow pattern {{pattern}}.",
             "number": "This field should be a number.",
             "datetimelocal": "This field should be a date and time."

--- a/languages/templates/src/main/webapp/i18n/zh-tw/_global.json
+++ b/languages/templates/src/main/webapp/i18n/zh-tw/_global.json
@@ -67,7 +67,7 @@
                     "maxlength": "您的電子郵件長度不能超過50個字元"
                 }
             }
-        }, 
+        },
         "field": {
             "id" : "ID"
         }
@@ -75,6 +75,7 @@
     "entity": {
         "action": {
             "addblob": "Add blob",
+            "addimage": "Add image",
             "back": "返回",
             "cancel": "取消",
             "delete": "刪除",


### PR DESCRIPTION
- works with databaseType = sql and mongodb
- supports required, minbytes, maxbytes validation (both front-end angular validation and back-end java bean validation)
- uses REST CRUD as any other field type generated (data is passed in the json obejct representing the entity)
- uses [ng-file-upload](https://github.com/danialfarid/ng-file-upload) angular directive to upload blobs as files (drag and drop support)

Tested file sizes over 200MB, there seems to be some limit around 250MB (javascriot FileReader seems to fail). Maybe there should be maxbytes limit set by default. Is it possible to release this with a BETA tag anyway?