### PR TITLE
specify heroku app name to heroku:deploy jar command

### DIFF
--- a/heroku/index.js
+++ b/heroku/index.js
@@ -190,7 +190,7 @@ HerokuGenerator.prototype.productionDeploy = function productionDeploy() {
         var done = this.async();
         this.log(chalk.bold('\nBuilding and deploying application'));
 
-        var herokuDeployCommand = 'mvn package -Pprod -DskipTests=true && heroku deploy:jar --jar target/*.war';
+        var herokuDeployCommand = 'mvn package -Pprod -DskipTests=true && heroku deploy:jar --jar target/*.war --app ' + this.herokuDeployedName;
         if (this.buildTool == 'gradle') {
             herokuDeployCommand = './gradlew -Pprod bootRepackage -x test && heroku deploy:jar --jar build/libs/*.war'
         }


### PR DESCRIPTION
Similar to my prior pull request https://github.com/jhipster/generator-jhipster/pull/1311, the --app parameter should also now be passed along with the heroku deploy:jar command to prevent errors if there's multiple heroku apps in the same folder.

