### PR TITLE
Configure jackson to serialize joda date types globally

### DIFF
--- a/app/templates/src/main/java/package/config/_JacksonConfiguration.java
+++ b/app/templates/src/main/java/package/config/_JacksonConfiguration.java
@@ -1,13 +1,15 @@
 package <%=packageName%>.config;
 
-import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer;
-import com.fasterxml.jackson.datatype.joda.ser.JacksonJodaFormat;
 import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.format.datetime.joda.DateTimeFormatterFactory;
+
+import <%=packageName%>.domain.util.CustomDateTimeDeserializer;
+import <%=packageName%>.domain.util.CustomDateTimeSerializer;
+import <%=packageName%>.domain.util.CustomLocalDateSerializer;
+import <%=packageName%>.domain.util.ISO8601LocalDateDeserializer;
+import com.fasterxml.jackson.datatype.joda.JodaModule;
 
 @Configuration
 public class JacksonConfiguration {
@@ -15,11 +17,10 @@ public class JacksonConfiguration {
     @Bean
     public JodaModule jacksonJodaModule() {
         JodaModule module = new JodaModule();
-        DateTimeFormatterFactory formatterFactory = new DateTimeFormatterFactory();
-        formatterFactory.setIso(DateTimeFormat.ISO.DATE);
-        module.addSerializer(DateTime.class, new DateTimeSerializer(
-                new JacksonJodaFormat(formatterFactory.createDateTimeFormatter()
-                        .withZoneUTC())));
+        module.addSerializer(DateTime.class, new CustomDateTimeSerializer());
+        module.addDeserializer(DateTime.class, new CustomDateTimeDeserializer());
+        module.addSerializer(LocalDate.class, new CustomLocalDateSerializer());
+        module.addDeserializer(LocalDate.class, new ISO8601LocalDateDeserializer());
         return module;
     }
 }

--- a/app/templates/src/test/java/package/web/rest/_TestUtil.java
+++ b/app/templates/src/test/java/package/web/rest/_TestUtil.java
@@ -1,17 +1,17 @@
 package <%=packageName%>.web.rest;
 
+import java.io.IOException;
+import java.nio.charset.Charset;
+
+import org.joda.time.DateTime;
+import org.joda.time.LocalDate;
+import org.springframework.http.MediaType;
+
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
-import com.fasterxml.jackson.datatype.joda.ser.DateTimeSerializer;
-import com.fasterxml.jackson.datatype.joda.ser.JacksonJodaFormat;
-import org.joda.time.DateTime;
-import org.springframework.format.annotation.DateTimeFormat;
-import org.springframework.format.datetime.joda.DateTimeFormatterFactory;
-import org.springframework.http.MediaType;
-
-import java.io.IOException;
-import java.nio.charset.Charset;
+import <%=packageName%>.domain.util.CustomDateTimeSerializer;
+import <%=packageName%>.domain.util.CustomLocalDateSerializer;
 
 /**
  * Utility class for testing REST controllers.
@@ -36,11 +36,8 @@ public class TestUtil {
         ObjectMapper mapper = new ObjectMapper();
         mapper.setSerializationInclusion(JsonInclude.Include.NON_NULL);
         JodaModule module = new JodaModule();
-        DateTimeFormatterFactory formatterFactory = new DateTimeFormatterFactory();
-        formatterFactory.setIso(DateTimeFormat.ISO.DATE);
-        module.addSerializer(DateTime.class, new DateTimeSerializer(
-            new JacksonJodaFormat(formatterFactory.createDateTimeFormatter()
-                .withZoneUTC())));
+        module.addSerializer(DateTime.class, new CustomDateTimeSerializer());
+        module.addSerializer(LocalDate.class, new CustomLocalDateSerializer());
         mapper.registerModule(module);
         return mapper.writeValueAsBytes(object);
     }

--- a/entity/index.js
+++ b/entity/index.js
@@ -389,6 +389,7 @@ EntityGenerator.prototype.askForFields = function askForFields() {
                     response.fieldValidate == true &&
                     (response.fieldType == 'LocalDate' ||
                     response.fieldType == 'DateTime' ||
+                    response.fieldType == 'Date' ||
                     response.fieldType == 'UUID' ||
                     response.fieldType == 'TimeUUID' ||
                     response.fieldIsEnum == true);
@@ -1124,3 +1125,4 @@ EntityGenerator.prototype.copyEnumI18n = function(language, enumInfo) {
         // do nothing
     }
 };
+

--- a/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -1,11 +1,5 @@
 package <%=packageName%>.web.rest.dto;
-<% if (fieldsContainCustomTime == true) { %>
-import com.fasterxml.jackson.databind.annotation.JsonDeserialize;
-import com.fasterxml.jackson.databind.annotation.JsonSerialize;<% } %><% if (fieldsContainLocalDate == true) { %>
-import <%=packageName%>.domain.util.CustomLocalDateSerializer;
-import <%=packageName%>.domain.util.ISO8601LocalDateDeserializer;<% } %><% if (fieldsContainDateTime == true) { %>
-import <%=packageName%>.domain.util.CustomDateTimeDeserializer;
-import <%=packageName%>.domain.util.CustomDateTimeSerializer;<% } %><% if (fieldsContainLocalDate == true) { %>
+<% if (fieldsContainLocalDate == true) { %>
 import org.joda.time.LocalDate;<% } %><% if (fieldsContainDateTime == true) { %>
 import org.joda.time.DateTime;<% } %><% if (validation) { %>
 import javax.validation.constraints.*;<% } %>
@@ -42,12 +36,8 @@ public class <%= entityClass %>DTO implements Serializable {
     @Size(min = <%= fields[fieldId].fieldValidateRulesMinbytes %>, max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
     @Min(value = <%= fields[fieldId].fieldValidateRulesMin %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
     @Max(value = <%= fields[fieldId].fieldValidateRulesMax %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
-    @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPattern %>")<% } } %><% if (fields[fieldId].fieldType == 'DateTime') { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
+    @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPattern %>")<% } } %><% if (fields[fieldId].fieldType == 'byte[]') { %>
     @Lob<% } %>
-    @JsonSerialize(using = CustomDateTimeSerializer.class)
-    @JsonDeserialize(using = CustomDateTimeDeserializer.class)<% } else if (fields[fieldId].fieldType == 'LocalDate') { %>
-    @JsonSerialize(using = CustomLocalDateSerializer.class)
-    @JsonDeserialize(using = ISO8601LocalDateDeserializer.class)<% } %>
     private <%= fields[fieldId].fieldType %> <%= fields[fieldId].fieldName %>;<% } %><% for (relationshipId in relationships) {
     otherEntityRelationshipName = relationships[relationshipId].otherEntityRelationshipName;%><% if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) { %>
     private Set<<%= relationships[relationshipId].otherEntityNameCapitalized %>DTO> <%= relationships[relationshipId].relationshipFieldName %>s = new HashSet<>();<% } else if (relationships[relationshipId].relationshipType == 'many-to-one') { %>

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -15,6 +15,7 @@ import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
 import org.springframework.http.MediaType;
+import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -132,6 +133,9 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
     @Inject
     private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;<% } %>
 
+    @Inject
+    private MappingJackson2HttpMessageConverter jacksonMessageConverter;
+
     private MockMvc rest<%= entityClass %>MockMvc;
 
     private <%= entityClass %> <%= entityInstance %>;
@@ -143,7 +147,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
         ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Repository", <%= entityInstance %>Repository);<% if (dto == 'mapstruct') { %>
         ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Mapper", <%= entityInstance %>Mapper);<% } %><% if (searchEngine == 'elasticsearch') { %>
         ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>SearchRepository", <%= entityInstance %>SearchRepository);<% } %>
-        this.rest<%= entityClass %>MockMvc = MockMvcBuilders.standaloneSetup(<%= entityInstance %>Resource).build();
+        this.rest<%= entityClass %>MockMvc = MockMvcBuilders.standaloneSetup(<%= entityInstance %>Resource).setMessageConverters(jacksonMessageConverter).build();
     }
 
     @Before
@@ -275,3 +279,4 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
         assertThat(<%= entityInstance %>s).hasSize(databaseSizeBeforeDelete - 1);
     }
 }
+


### PR DESCRIPTION
With this PR, there is no more annotations in the domain file for the json ser/deser on joda types as it is configured globally on the mapper.
