### PR TITLE
Add static swagger docs

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -478,6 +478,7 @@ JhipsterGenerator.prototype.app = function app() {
     var packageFolder = this.packageName.replace(/\./g, '/');
     var javaDir = 'src/main/java/' + packageFolder + '/';
     var resourceDir = 'src/main/resources/';
+    var docsDir = 'src/docs/asciidoc/';
     var webappDir = 'src/main/webapp/';
     var interpolateRegex = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
 
@@ -521,6 +522,7 @@ JhipsterGenerator.prototype.app = function app() {
             this.template('_profile_fast.gradle', 'profile_fast.gradle', this, { 'interpolate': interpolateRegex });
             this.template('_mapstruct.gradle', 'mapstruct.gradle', this, { 'interpolate': interpolateRegex });
             this.template('_gatling.gradle', 'gatling.gradle', this, {});
+            this.template('_asciidoc.gradle', 'asciidoc.gradle', this, {});
           if (this.databaseType == "sql") {
             this.template('_liquibase.gradle', 'liquibase.gradle', this, {});
           }
@@ -771,6 +773,10 @@ JhipsterGenerator.prototype.app = function app() {
         this.template('src/main/java/package/web/websocket/dto/_ActivityDTO.java', javaDir + 'web/websocket/dto/ActivityDTO.java', this, {});
     }
 
+    // Create docs index file
+    mkdirp(docsDir);
+    this.copy('src/docs/asciidoc/index.adoc', docsDir + 'index.adoc');
+
     // Create Test Java files
     var testDir = 'src/test/java/' + packageFolder + '/';
     var testResourceDir = 'src/test/resources/';
@@ -788,6 +794,7 @@ JhipsterGenerator.prototype.app = function app() {
         this.template('src/test/java/package/service/_UserServiceTest.java', testDir + 'service/UserServiceTest.java', this, {});
     }
     this.template('src/test/java/package/web/rest/_AccountResourceTest.java', testDir + 'web/rest/AccountResourceTest.java', this, {});
+    this.template('src/test/java/package/web/rest/_Swagger2MarkupTest.java', testDir + 'web/rest/Swagger2MarkupTest.java', this, {});
     this.template('src/test/java/package/web/rest/_TestUtil.java', testDir + 'web/rest/TestUtil.java', this, {});
     this.template('src/test/java/package/web/rest/_UserResourceTest.java', testDir + 'web/rest/UserResourceTest.java', this, {});
 
@@ -826,7 +833,7 @@ JhipsterGenerator.prototype.app = function app() {
     }else{
         this.template(resourceDir + '/i18n/_messages_en.properties', resourceDir + 'i18n/messages_en.properties', this, {});
     }
-    
+
     // Angular JS views
 
     this.template(webappDir + '/scripts/app/_app.js', webappDir + 'scripts/app/app.js', this, {});

--- a/app/templates/_asciidoc.gradle
+++ b/app/templates/_asciidoc.gradle
@@ -1,0 +1,23 @@
+apply plugin: 'org.asciidoctor.convert'
+
+ext {
+    generatedAsciidoc = file("${buildDir}/docs/asciidoc/generated")
+}
+
+asciidoctor {
+    dependsOn test
+    sources {
+        include 'index.adoc'
+    }
+    backends = ['html5', 'pdf']
+    attributes = [
+        doctype: 'book',
+        toc: 'left',
+        toclevels: '2',
+        numbered: '',
+        sectlinks: '',
+        sectanchors: '',
+        hardbreaks: '',
+        generated: generatedAsciidoc
+    ]
+}

--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -4,11 +4,12 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath('org.springframework.boot:spring-boot-gradle-plugin:1.2.5.RELEASE')
-        classpath('com.moowork.gradle:gradle-node-plugin:0.10')<% if(frontendBuilder == 'grunt') {%>
-        classpath('com.moowork.gradle:gradle-grunt-plugin:0.10')<% }  if(frontendBuilder == 'gulp') {%>
-  	    classpath('com.moowork.gradle:gradle-gulp-plugin:0.10')
-        <% } %>
+        classpath 'org.springframework.boot:spring-boot-gradle-plugin:1.2.5.RELEASE'
+        classpath 'com.moowork.gradle:gradle-node-plugin:0.10'<% if(frontendBuilder == 'grunt') {%>
+        classpath 'com.moowork.gradle:gradle-grunt-plugin:0.10'<% }  if(frontendBuilder == 'gulp') {%>
+  	    classpath 'com.moowork.gradle:gradle-gulp-plugin:0.10'<% } %>
+        classpath 'org.asciidoctor:asciidoctor-gradle-plugin:1.5.2'
+        classpath 'org.asciidoctor:asciidoctorj-pdf:1.5.0-alpha.8'
     }
 }
 
@@ -32,7 +33,7 @@ bootRun {
 }
 
 apply from: 'yeoman.gradle'
-
+apply from: 'asciidoc.gradle'
 <% if (databaseType == 'sql') { %>
 apply from: 'liquibase.gradle'<% } %>
 apply from: 'gatling.gradle'
@@ -167,6 +168,7 @@ dependencies {
     testCompile group: 'cz.jirutka.spring', name: 'embedmongo-spring', version: embedmongo_spring_version<% } %>
     testCompile group: 'org.hamcrest', name: 'hamcrest-library'
     testCompile group: 'io.gatling.highcharts', name: 'gatling-charts-highcharts', version: gatling_version
+    testCompile group: 'io.springfox', name:'springfox-staticdocs', version: springfox_version
     <% if (devDatabaseType != 'h2Memory') { %>
     testCompile group: 'com.h2database', name: 'h2'<% } %><% if (devDatabaseType == 'oracle' || prodDatabaseType == 'oracle') { %>
     runtime files('lib/oracle/ojdbc/<% if (javaVersion == '7') { %>6/ojdbc-6<% }else { %>7/ojdbc-7<% } %>.jar')

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -165,6 +165,12 @@
         </dependency>
         <dependency>
             <groupId>io.springfox</groupId>
+            <artifactId>springfox-staticdocs</artifactId>
+            <version>${springfox.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
             <artifactId>springfox-swagger-ui</artifactId>
             <version>${springfox.version}</version>
         </dependency>
@@ -241,6 +247,12 @@
             <groupId>io.gatling.highcharts</groupId>
             <artifactId>gatling-charts-highcharts</artifactId>
             <version>${gatling.version}</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-staticdocs</artifactId>
+            <version>${springfox.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -640,6 +652,56 @@
                 <groupId>org.codehaus.mojo</groupId>
                 <artifactId>sonar-maven-plugin</artifactId>
                 <version>${sonar-maven-plugin.version}</version>
+            </plugin>
+            <plugin>
+                <groupId>org.asciidoctor</groupId>
+                <artifactId>asciidoctor-maven-plugin</artifactId>
+                <version>1.5.2</version>
+                <!-- Since each execution can only handle one backend, run
+                     separate executions for each desired output type -->
+                <executions>
+                    <execution>
+                        <id>output-html</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>html5</backend>
+                            <outputDirectory>${project.build.directory}/docs/html</outputDirectory>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>output-pdf</id>
+                        <phase>test</phase>
+                        <goals>
+                            <goal>process-asciidoc</goal>
+                        </goals>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <outputDirectory>${project.build.directory}/docs/pdf</outputDirectory>
+                        </configuration>
+                    </execution>
+                </executions>
+                <!-- Include Asciidoctor PDF for pdf generation -->
+                <dependencies>
+                    <dependency>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctorj-pdf</artifactId>
+                        <version>1.5.0-alpha.8</version>
+                    </dependency>
+                </dependencies>
+                <!-- Configure generic document generation settings -->
+                <configuration>
+                    <sourceDirectory>src/docs/asciidoc</sourceDirectory>
+                    <sourceDocumentName>index.adoc</sourceDocumentName>
+                    <attributes>
+                        <doctype>book</doctype>
+                        <toc>left</toc>
+                        <toclevels>2</toclevels>
+                        <generated>${project.build.directory}/docs/asciidoc/generated</generated>
+                    </attributes>
+                </configuration>
             </plugin>
             <plugin>
                 <groupId>org.bsc.maven</groupId>

--- a/app/templates/src/docs/asciidoc/index.adoc
+++ b/app/templates/src/docs/asciidoc/index.adoc
@@ -1,0 +1,3 @@
+include::{generated}/overview.adoc[]
+include::{generated}/paths.adoc[]
+include::{generated}/definitions.adoc[]

--- a/app/templates/src/test/java/package/web/rest/_Swagger2MarkupTest.java
+++ b/app/templates/src/test/java/package/web/rest/_Swagger2MarkupTest.java
@@ -1,0 +1,66 @@
+package <%=packageName%>.web.rest;
+
+import <%=packageName%>.Application;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+import springfox.documentation.staticdocs.Swagger2MarkupResultHandler;
+
+import javax.inject.Inject;
+import java.io.File;
+import java.io.IOException;
+
+import static org.springframework.http.MediaType.APPLICATION_JSON;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@WebAppConfiguration
+@IntegrationTest
+public class Swagger2MarkupTest {
+
+    private static final String API_URI = "/v2/api-docs";
+
+    @Inject
+    private WebApplicationContext context;
+
+    private MockMvc mockMvc;
+
+    private File projectDir;
+
+    @Before
+    public void setup() throws IOException {
+        this.mockMvc = MockMvcBuilders.webAppContextSetup(this.context).build();
+
+        ClassPathResource pathfileRes = new ClassPathResource("config/application.yml");
+        projectDir = pathfileRes.getFile().getParentFile().getParentFile().getParentFile().getParentFile();
+    }
+
+    @Test
+    public void convertSwaggerToAsciiDoc() throws Exception {
+        Swagger2MarkupResultHandler.Builder builder = Swagger2MarkupResultHandler
+            .outputDirectory(outputDirForFormat("asciidoc"));
+        mockMvc.perform(get(API_URI).accept(APPLICATION_JSON))
+            .andDo(builder.build())
+            .andExpect(status().isOk());
+
+    }
+
+
+
+    private String outputDirForFormat(String format) throws IOException {
+        <% if (buildTool == 'gradle') { %>
+        return new File(projectDir, "docs/" + format + "/generated").getAbsolutePath();<% } %><% if (buildTool == 'maven') { %>
+        return new File(projectDir, "target/docs/" + format + "/generated").getAbsolutePath();<% }%>
+
+    }
+}


### PR DESCRIPTION
Generated static api docs are located in: `target/docs` for maven and `build/asciidoc` for gradle. Will provide another PR for the jhipster website.

Close #1715 