### PR TITLE
Add unique constraint on relationship column in one to one owner entity

### DIFF
--- a/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -41,8 +41,11 @@
                 <constraints nullable="false" />
             </column><% } %><%
 
-            } %><% for (relationshipId in relationships) { %><% if ((relationships[relationshipId].relationshipType == 'many-to-one') || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) { %>
-            <column name="<%=relationships[relationshipId].relationshipName.toLowerCase() %>_id" type="bigint"/><% } } %>
+            } %><% for (relationshipId in relationships) { %><% if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
+            <column name="<%=relationships[relationshipId].relationshipName.toLowerCase() %>_id" type="bigint"/><% } else if (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true) %>
+            <column name="<%=relationships[relationshipId].relationshipName.toLowerCase() %>_id" type="bigint">
+                <constraints unique="true"/>
+            </column><% } %>
         </createTable><% for (fieldId in fields) {
             if (fields[fieldId].fieldType == 'DateTime') { %>
         <dropDefaultValue tableName="<%= name.toUpperCase() %>" columnName="<%=fields[fieldId].fieldNameUnderscored %>" columnDataType="datetime"/>


### PR DESCRIPTION
It should not be possible to insert multiple rows with the same foreign key in the one to one relationship database table.

If this is done by accident the crud interface fails with the following exception
```org.hibernate.HibernateException: More than one row with the given identifier was found: ```