### PR TITLE
Add id dropdown to one-to-one-relationship

### DIFF
--- a/entity/index.js
+++ b/entity/index.js
@@ -4,6 +4,7 @@ var util = require('util'),
         path = require('path'),
         yeoman = require('yeoman-generator'),
         chalk = require('chalk'),
+        _ = require('underscore'),
         _s = require('underscore.string'),
         shelljs = require('shelljs'),
         html = require("html-wiring"),
@@ -101,6 +102,7 @@ var EntityGenerator = module.exports = function EntityGenerator(args, options, c
     this.fieldsContainBigDecimal = false;
     this.fieldsContainBlob = false;
     this.fieldsContainOwnerManyToMany = false;
+    this.fieldsContainOneToOne = false;
     this.fieldsContainOwnerOneToOne = false;
     this.fieldsContainOneToMany = false;
     this.relationshipId = 0;
@@ -749,7 +751,7 @@ EntityGenerator.prototype.askForRelationships = function askForRelationships() {
             when: function (response) {
                 return (response.relationshipAdd == true && (response.relationshipType == 'one-to-many' ||
                     (response.relationshipType == 'many-to-many' && response.ownerSide == false) ||
-                    (response.relationshipType == 'one-to-one' && response.ownerSide == false)));
+                    (response.relationshipType == 'one-to-one')));
             },
             type: 'input',
             name: 'otherEntityRelationshipName',
@@ -769,7 +771,7 @@ EntityGenerator.prototype.askForRelationships = function askForRelationships() {
         },
         {
             when: function (response) {
-                return (!(response.noOtherEntity == false || response.noOtherEntity2 == false) && response.relationshipAdd == true && (response.relationshipType == 'many-to-one' || (response.relationshipType == 'many-to-many' && response.ownerSide == true)));
+                return (!(response.noOtherEntity == false || response.noOtherEntity2 == false) && response.relationshipAdd == true && (response.relationshipType == 'many-to-one' || (response.relationshipType == 'many-to-many' && response.ownerSide == true) || (response.relationshipType == 'one-to-one' && response.ownerSide == true)));
             },
             type: 'input',
             name: 'otherEntityField',
@@ -798,6 +800,9 @@ EntityGenerator.prototype.askForRelationships = function askForRelationships() {
             }
             if (props.relationshipType == 'many-to-many' && props.ownerSide == true) {
                 this.fieldsContainOwnerManyToMany = true;
+            }
+            if (props.relationshipType == 'one-to-one') {
+                this.fieldsContainOneToOne = true;
             }
             if (props.relationshipType == 'one-to-one' && props.ownerSide == true) {
                 this.fieldsContainOwnerOneToOne = true;
@@ -907,6 +912,7 @@ EntityGenerator.prototype.files = function files() {
         this.data.fields = this.fields;
         this.data.fieldNamesUnderscored = this.fieldNamesUnderscored;
         this.data.fieldsContainOwnerManyToMany = this.fieldsContainOwnerManyToMany;
+        this.data.fieldsContainOneToOne = this.fieldsContainOneToOne;
         this.data.fieldsContainOwnerOneToOne = this.fieldsContainOwnerOneToOne;
         this.data.fieldsContainOneToMany = this.fieldsContainOneToMany;
         this.data.fieldsContainLocalDate = this.fieldsContainLocalDate;
@@ -937,6 +943,7 @@ EntityGenerator.prototype.files = function files() {
         }
         this.fieldNamesUnderscored = this.fileData.fieldNamesUnderscored;
         this.fieldsContainOwnerManyToMany = this.fileData.fieldsContainOwnerManyToMany;
+        this.fieldsContainOneToOne = this.fileData.fieldsContainOneToOne;
         this.fieldsContainOwnerOneToOne = this.fileData.fieldsContainOwnerOneToOne;
         this.fieldsContainOneToMany = this.fileData.fieldsContainOneToMany;
         this.fieldsContainLocalDate = this.fileData.fieldsContainLocalDate;
@@ -965,6 +972,11 @@ EntityGenerator.prototype.files = function files() {
             this.validation = false;
         }
     }
+
+    // Expose utility methods in templates
+    this.util = {};
+    this.util.contains = _.contains;
+
     this.entityClass = _s.capitalize(this.name);
     this.entityInstance = this.name.charAt(0).toLowerCase() + this.name.slice(1);
 

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -52,7 +52,8 @@
                 <tr>
                     <th translate="global.field.id">ID</th><% for (fieldId in fields) { %>
                     <th translate="<%=keyPrefix + fields[fieldId].fieldName %>"><%=fields[fieldId].fieldNameCapitalized%></th><% } %><% for (relationshipId in relationships) {
-                        if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
+                        if (relationships[relationshipId].relationshipType == 'many-to-one'
+                           || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) { %>
                     <th translate="<%= keyPrefix + relationships[relationshipId].relationshipName%>"><%=relationships[relationshipId].relationshipName%></th><% } } %>
                     <th></th>
                 </tr>
@@ -69,7 +70,8 @@
                         {{byteSize(<%= entityInstance %>.<%= fields[fieldId].fieldName %>)}}<% } %>
                     </td><% } else { %>
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% } %><% for (relationshipId in relationships) {
-                        if (relationships[relationshipId].relationshipType == 'many-to-one') {
+                        if (relationships[relationshipId].relationshipType == 'many-to-one'
+                           || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) {
                             var relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
                             if (dto == 'mapstruct') {
                                 relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;

--- a/entity/templates/src/main/webapp/app/_entity-detail.html
+++ b/entity/templates/src/main/webapp/app/_entity-detail.html
@@ -16,8 +16,8 @@
                 </td>
                 <td><% if (fields[fieldId].fieldIsEnum) {
                     var enumPrefix = angularAppName + '.'+ fields[fieldId].fieldType; %>
-                            <span class="input-sm form-control readonly" translate="<%=enumPrefix%>.SELECT"
-                                  translate-interpolation="messageformat" translate-values="{ VALUE: <%= entityInstance %>.<%=fields[fieldId].fieldName%> }"></span><%
+                    <span class="input-sm form-control readonly" translate="<%=enumPrefix%>.SELECT"
+                          translate-interpolation="messageformat" translate-values="{ VALUE: <%= entityInstance %>.<%=fields[fieldId].fieldName%> }"></span><%
                     } else if (fields[fieldId].fieldType == 'byte[]' && fields[fieldId].fieldTypeBlobContent == 'image') { %>
                     <img data-ng-src="{{'data:image/*;base64,' + <%=entityInstance %>.<%=fields[fieldId].fieldName%>}}" style="max-width: 100%;" ng-if="<%= entityInstance %>.<%= fields[fieldId].fieldName %>"/><%
                     } else { %>
@@ -25,13 +25,14 @@
                     } %>
                 </td>
             </tr><% } %><% for (relationshipId in relationships) {
-            if (relationships[relationshipId].relationshipType == 'many-to-one') {
-            var relationshipName = relationships[relationshipId].relationshipName;
-            var otherEntityName = relationships[relationshipId].otherEntityName;
-            var relationShipValue = entityInstance + "." + relationshipName + "." + relationships[relationshipId].otherEntityField;
-            if (dto == 'mapstruct') {
-            relationShipValue = entityInstance + "." + relationshipName + relationships[relationshipId].otherEntityFieldCapitalized;
-            }%>
+            if (relationships[relationshipId].relationshipType == 'many-to-one'
+                || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) {
+                var relationshipName = relationships[relationshipId].relationshipName;
+                var otherEntityName = relationships[relationshipId].otherEntityName;
+                var relationShipValue = entityInstance + "." + relationshipName + "." + relationships[relationshipId].otherEntityField;
+                if (dto == 'mapstruct') {
+                    relationShipValue = entityInstance + "." + relationshipName + relationships[relationshipId].otherEntityFieldCapitalized;
+                } %>
             <tr>
                 <td>
                     <span translate="<%= keyPrefix %>.<%= relationshipName %>"><%=relationshipName%></span>

--- a/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
@@ -4,8 +4,20 @@ angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogContro
     ['$scope', '$stateParams', '$modalInstance', 'entity', '<%= entityClass %>'<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, '<%= differentTypes[idx] %>'<% } } %>,
         function($scope, $stateParams, $modalInstance, entity, <%= entityClass %><% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, <%= differentTypes[idx] %><% } } %>) {
 
-        $scope.<%= entityInstance %> = entity;<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) { %>
-        $scope.<%= differentTypes[idx].toLowerCase() %>s = <%= differentTypes[idx] %>.query();<% } } %>
+        $scope.<%= entityInstance %> = entity;<%
+            var queries = [];
+            for (idx in relationships) {
+                var query;
+                if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide == true) {
+                    query = '$scope.' + relationships[idx].relationshipFieldName.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + ".query({filter: '" + relationships[idx].otherEntityRelationshipName.toLowerCase() + "-is-null'});";
+                } else {
+                    query = '$scope.' + relationships[idx].otherEntityNameCapitalized.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + '.query();';
+                }
+                if (!util.contains(queries, query)) {
+                    queries.push(query);
+                }
+            } %><% for (idx in queries) { %>
+        <%- queries[idx] %><% } %>
         $scope.load = function(id) {
             <%= entityClass %>.get({id : id}, function(result) {
                 $scope.<%= entityInstance %> = result;

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -106,11 +106,16 @@
     var relationshipName = relationships[relationshipId].relationshipName;
     var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
     var translationKey = keyPrefix + relationshipName;
-     if (relationships[relationshipId].relationshipType == 'many-to-one') {
-                        %>
+     if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
             <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>.id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
+            </select>
+        </div><% } else if (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true) {
+            %>
+        <div class="form-group">
+            <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>.id" ng-options="<%=relationshipFieldName %>.id as <%=relationshipFieldName %>.<%=relationships[relationshipId].otherEntityField %> for <%=relationshipFieldName %> in <%=relationshipFieldName.toLowerCase() %>s">
             </select>
         </div><% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) {
             %>

--- a/package.json
+++ b/package.json
@@ -28,16 +28,17 @@
     "test": "mocha --reporter spec"
   },
   "dependencies": {
-    "yo": "1.4.6",
-    "yeoman-generator": "0.20.1",
-    "mkdirp": "0.5.1",
-    "cheerio": "0.19.0",
-    "shelljs": "0.5.0",
     "chalk": "1.0.0",
-    "insight": "0.6.0",
-    "underscore.string": "3.0.3",
+    "cheerio": "0.19.0",
+    "ejs": "2.3.1",
     "html-wiring": "1.1.0",
-    "ejs": "2.3.1"
+    "insight": "0.6.0",
+    "mkdirp": "0.5.1",
+    "shelljs": "0.5.0",
+    "underscore": "1.8.3",
+    "underscore.string": "3.0.3",
+    "yeoman-generator": "0.20.1",
+    "yo": "1.4.6"
   },
   "devDependencies": {
     "grunt": "0.4.5",


### PR DESCRIPTION
- ask for other entity relationship name on owner side
- add underscore javascript library to generator
- sort packages in package.js in alphabetic order
- expose a new util object in templates (added contains method)
- add dropdown to select id on relationship owner entity in create/update dialog
- add presentation of relatinship id in all ohter html crud pages (on owner side)
- add filter parameter to findAll in REST query which returns only objects with no relationship
- query with filter parameter when getting the ids for one-to-one relationships in entity-dialog-controller
fix #1468