### PR TITLE
Update _initial_schema.xml (oauth_access_token table definition)

### DIFF
--- a/app/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
+++ b/app/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
@@ -210,7 +210,9 @@
         <createTable tableName="oauth_access_token">
             <column name="token_id" type="varchar(255)"/>
             <column name="token" type="BLOB"/>
-            <column name="authentication_id" type="varchar(255)"/>
+            <column name="authentication_id" type="varchar(255)">
+                 <constraints nullable="false" primaryKey="true"/>
+            </column>
             <column name="user_name" type="varchar(255)"/>
             <column name="client_id" type="varchar(255)"/>
             <column name="authentication" type="BLOB"/>


### PR DESCRIPTION
The oauth_access_token table definition is incorrect 
I ran into this issue (double authentication_id in oauth_access_token) : https://github.com/spring-projects/spring-security-oauth/issues/463
changed the oauth_access_token table model to avoid it