### PR TITLE
URI encode username and password before posting during login

### DIFF
--- a/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.oauth2.service.js
+++ b/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.oauth2.service.js
@@ -4,8 +4,8 @@ angular.module('<%=angularAppName%>')
     .factory('AuthServerProvider', function loginService($http, localStorageService, Base64) {
         return {
             login: function(credentials) {
-                var data = "username=" + credentials.username + "&password="
-                    + credentials.password + "&grant_type=password&scope=read%20write&" +
+                var data = "username=" +  encodeURIComponent(credentials.username) + "&password="
+                    + encodeURIComponent(credentials.password) + "&grant_type=password&scope=read%20write&" +
                     "client_secret=mySecretOAuthSecret&client_id=<%= baseName%>app";
                 return $http.post('oauth/token', data, {
                     headers: {

--- a/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.xauth.service.js
+++ b/app/templates/src/main/webapp/scripts/components/auth/provider/_auth.xauth.service.js
@@ -4,8 +4,8 @@ angular.module('<%=angularAppName%>')
     .factory('AuthServerProvider', function loginService($http, localStorageService, Base64) {
         return {
             login: function(credentials) {
-                var data = "username=" + credentials.username + "&password="
-                    + credentials.password;
+                var data = "username=" +  encodeURIComponent(credentials.username) + "&password="
+                    + encodeURIComponent(credentials.password);
                 return $http.post('api/authenticate', data, {
                     headers: {
                         "Content-Type": "application/x-www-form-urlencoded",


### PR DESCRIPTION
Originally found using oauth.  I compared oauth and xauth to session
and saw that _auth.session.service.js was already using the 
encodeURIComponent function, so I made the fix for both oauth and xauth

Fix #1834