### PR TITLE
Introduced API media type versioning through angular-vendor-media-type

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -605,6 +605,8 @@ JhipsterGenerator.prototype.app = function app() {
     if (this.databaseType == 'sql' || this.databaseType == 'mongodb') {
         this.template('src/main/java/package/config/_DatabaseConfiguration.java', javaDir + 'config/DatabaseConfiguration.java', this, {});
     }
+    this.template('src/main/java/package/config/_ApplicationMediaType.java', javaDir + 'config/ApplicationMediaType.java', this, {});
+    this.template('src/main/java/package/config/_ContentNegotiationConfiguration.java', javaDir + 'config/ContentNegotiationConfiguration.java', this, {});
     this.template('src/main/java/package/config/_JacksonConfiguration.java', javaDir + 'config/JacksonConfiguration.java', this, {});
     this.template('src/main/java/package/config/_LocaleConfiguration.java', javaDir + 'config/LocaleConfiguration.java', this, {});
     this.template('src/main/java/package/config/_LoggingAspectConfiguration.java', javaDir + 'config/LoggingAspectConfiguration.java', this, {});

--- a/app/index.js
+++ b/app/index.js
@@ -51,7 +51,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
 
     console.log('\nWelcome to the JHipster Generator v' + packagejs.version + '\n');
     var insight = this.insight();
-    var questions = 15; // making questions a variable to avoid updating each question by hand when adding additional options
+    var questions = 16; // making questions a variable to avoid updating each question by hand when adding additional options
 
     var prompts = [
         {
@@ -358,6 +358,12 @@ JhipsterGenerator.prototype.askFor = function askFor() {
             name: 'enableTranslation',
             message: '(15/' + questions + ') Would you like to enable translation support with Angular Translate?',
             default: true
+        },
+        {
+            type: 'confirm',
+            name: 'versionApi',
+            message: '(16/' + questions + ') Would you like to enable API media type versioning?',
+            default: false
         }
     ];
 
@@ -387,6 +393,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
     this.frontendBuilder = this.config.get('frontendBuilder');
     this.rememberMeKey = this.config.get('rememberMeKey');
     this.enableTranslation = this.config.get('enableTranslation'); // this is enabled by default to avoid conflicts for existing applications
+    this.versionApi = this.config.get('versionApi');
     this.packagejs = packagejs;
 
     if (this.baseName != null &&
@@ -414,6 +421,11 @@ JhipsterGenerator.prototype.askFor = function askFor() {
             this.enableTranslation = true;
         }
 
+        // disables the API versioning by default
+        if (this.versionApi == null) {
+            this.versionApi = false;
+        }
+
         console.log(chalk.green('This is an existing project, using the configuration from your .yo-rc.json file \n' +
             'to re-generate the project...\n'));
 
@@ -438,6 +450,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
             this.frontendBuilder = props.frontendBuilder;
             this.javaVersion = props.javaVersion;
             this.enableTranslation = props.enableTranslation;
+            this.versionApi = props.versionApi;
             this.rememberMeKey = crypto.randomBytes(20).toString('hex');
 
             if (this.databaseType == 'mongodb') {

--- a/app/templates/_bower.json
+++ b/app/templates/_bower.json
@@ -27,7 +27,8 @@
         "angular-cache-buster": "0.4.3",
         "ngInfiniteScroll": "1.2.0",
         "ng-file-upload": "5.0.9",
-        "swagger-ui": "2.1.1"
+        "swagger-ui": "2.1.1",
+        "angular-vendor-media-type": "2.0.2"
     },
     "devDependencies": {
         "angular-mocks": "1.4.4",

--- a/app/templates/src/main/java/package/config/_ApplicationMediaType.java
+++ b/app/templates/src/main/java/package/config/_ApplicationMediaType.java
@@ -5,13 +5,21 @@ import org.springframework.http.MediaType;
 /**
  * Defines application specific MIME types.
  */
-public interface ApplicationMediaType {
+public final class ApplicationMediaType {
 
-    MediaType APPLICATION_JSON_V1 = new MediaType("application", "vnd.<%=baseName%>.v1+json");
+    public static final MediaType APPLICATION_JSON;
 
-    String APPLICATION_JSON_V1_VALUE = "application/vnd.<%=baseName%>.v1+json";
+    public static final String APPLICATION_JSON_VALUE = <% if(versionApi) { %>"application/vnd.<%=baseName%>.v1+json"<% } else { %>MediaType.APPLICATION_JSON_VALUE<% } %>;
 
-    MediaType TEXT_PLAIN_V1 = new MediaType("text", "vnd.<%=baseName%>.v1+plain");
+    public static final MediaType TEXT_PLAIN;
 
-    String TEXT_PLAIN_V1_VALUE = "text/vnd.<%=baseName%>.v1+plain";
+    public static final String TEXT_PLAIN_VALUE = <% if(versionApi) { %>"text/vnd.<%=baseName%>.v1+plain"<% } else { %>MediaType.TEXT_PLAIN_VALUE<% } %>;
+
+    static {
+        APPLICATION_JSON = MediaType.parseMediaType(APPLICATION_JSON_VALUE);
+        TEXT_PLAIN = MediaType.parseMediaType(TEXT_PLAIN_VALUE);
+    }
+
+    private ApplicationMediaType() {
+    }
 }

--- a/app/templates/src/main/java/package/config/_ApplicationMediaType.java
+++ b/app/templates/src/main/java/package/config/_ApplicationMediaType.java
@@ -1,0 +1,17 @@
+package <%=packageName%>.config;
+
+import org.springframework.http.MediaType;
+
+/**
+ * Defines application specific MIME types.
+ */
+public interface ApplicationMediaType {
+
+    MediaType APPLICATION_JSON_V1 = new MediaType("application", "vnd.<%=baseName%>.v1+json");
+
+    String APPLICATION_JSON_V1_VALUE = "application/vnd.<%=baseName%>.v1+json";
+
+    MediaType TEXT_PLAIN_V1 = new MediaType("text", "vnd.<%=baseName%>.v1+plain");
+
+    String TEXT_PLAIN_V1_VALUE = "text/vnd.<%=baseName%>.v1+plain";
+}

--- a/app/templates/src/main/java/package/config/_ContentNegotiationConfiguration.java
+++ b/app/templates/src/main/java/package/config/_ContentNegotiationConfiguration.java
@@ -1,0 +1,17 @@
+package <%=packageName%>.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.ContentNegotiationConfigurer;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurerAdapter;
+
+/**
+ * Configures the REST endpoints content negotation and supported media types.
+ */
+@Configuration
+public class ContentNegotiationConfiguration extends WebMvcConfigurerAdapter {
+
+    @Override
+    public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
+        configurer.defaultContentType(ApplicationMediaType.APPLICATION_JSON_V1);
+    }
+}

--- a/app/templates/src/main/java/package/config/_ContentNegotiationConfiguration.java
+++ b/app/templates/src/main/java/package/config/_ContentNegotiationConfiguration.java
@@ -12,6 +12,6 @@ public class ContentNegotiationConfiguration extends WebMvcConfigurerAdapter {
 
     @Override
     public void configureContentNegotiation(ContentNegotiationConfigurer configurer) {
-        configurer.defaultContentType(ApplicationMediaType.APPLICATION_JSON_V1);
+        configurer.defaultContentType(ApplicationMediaType.APPLICATION_JSON);
     }
 }

--- a/app/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -11,11 +11,11 @@ import <%=packageName%>.service.MailService;
 import <%=packageName%>.service.UserService;
 import <%=packageName%>.web.rest.dto.KeyAndPasswordDTO;
 import <%=packageName%>.web.rest.dto.UserDTO;
+import <%=packageName%>.config.ApplicationMediaType;
 import org.apache.commons.lang.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
@@ -53,7 +53,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/register",
             method = RequestMethod.POST,
-            produces = MediaType.TEXT_PLAIN_VALUE)
+            produces = ApplicationMediaType.TEXT_PLAIN_V1_VALUE)
     @Timed
     public ResponseEntity<?> registerAccount(@Valid @RequestBody UserDTO userDTO, HttpServletRequest request) {<% if (javaVersion == '8') { %>
         return userRepository.findOneByLogin(userDTO.getLogin())
@@ -76,10 +76,10 @@ public class AccountResource {
         );<% } else { %>
         User user = userRepository.findOneByLogin(userDTO.getLogin());
         if (user != null) {
-            return ResponseEntity.badRequest().contentType(MediaType.TEXT_PLAIN).body("login already in use");
+            return ResponseEntity.badRequest().contentType(ApplicationMediaType.TEXT_PLAIN_V1).body("login already in use");
         } else {
             if (userRepository.findOneByEmail(userDTO.getEmail()) != null) {
-                return ResponseEntity.badRequest().contentType(MediaType.TEXT_PLAIN).body("e-mail address already in use");
+                return ResponseEntity.badRequest().contentType(ApplicationMediaType.TEXT_PLAIN_V1).body("e-mail address already in use");
             }
             user = userService.createUserInformation(userDTO.getLogin(), userDTO.getPassword(),
             userDTO.getFirstName(), userDTO.getLastName(), userDTO.getEmail().toLowerCase(),
@@ -100,7 +100,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/activate",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<String> activateAccount(@RequestParam(value = "key") String key) {<% if (javaVersion == '8') { %>
         return Optional.ofNullable(userService.activateRegistration(key))
@@ -118,7 +118,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/authenticate",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public String isAuthenticated(HttpServletRequest request) {
         log.debug("REST request to check if the current user is authenticated");
@@ -130,7 +130,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<UserDTO> getAccount() {<% if (javaVersion == '8') { %>
         return Optional.ofNullable(userService.getUserWithAuthorities())
@@ -176,7 +176,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account",
             method = RequestMethod.POST,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<String> saveAccount(@RequestBody UserDTO userDTO) {<% if (javaVersion == '8') { %>
         return userRepository
@@ -202,7 +202,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account/change_password",
             method = RequestMethod.POST,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<?> changePassword(@RequestBody String password) {
         if (!checkPasswordLength(password)) {
@@ -217,7 +217,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account/sessions",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<List<PersistentToken>> getCurrentSessions() {<% if (javaVersion == '8') { %>
         return userRepository.findOneByLogin(SecurityUtils.getCurrentLogin())
@@ -268,7 +268,7 @@ public class AccountResource {
 
     @RequestMapping(value = "/account/reset_password/init",
         method = RequestMethod.POST,
-        produces = MediaType.TEXT_PLAIN_VALUE)
+        produces = ApplicationMediaType.TEXT_PLAIN_V1_VALUE)
     @Timed
     public ResponseEntity<?> requestPasswordReset(@RequestBody String mail, HttpServletRequest request) {
         <% if (javaVersion == '8') { %>
@@ -279,8 +279,8 @@ public class AccountResource {
                     request.getServerName() +
                     ":" +
                     request.getServerPort();
-            mailService.sendPasswordResetMail(user, baseUrl);
-            return new ResponseEntity<>("e-mail was sent", HttpStatus.OK);
+                mailService.sendPasswordResetMail(user, baseUrl);
+                return new ResponseEntity<>("e-mail was sent", HttpStatus.OK);
             }).orElse(new ResponseEntity<>("e-mail address not registered", HttpStatus.BAD_REQUEST));
         <% } else {%>
         User user = userService.requestPasswordReset(mail);
@@ -301,7 +301,7 @@ public class AccountResource {
 
     @RequestMapping(value = "/account/reset_password/finish",
         method = RequestMethod.POST,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<String> finishPasswordReset(@RequestBody KeyAndPasswordDTO keyAndPassword) {
         if (!checkPasswordLength(keyAndPassword.getNewPassword())) {

--- a/app/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -53,7 +53,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/register",
             method = RequestMethod.POST,
-            produces = ApplicationMediaType.TEXT_PLAIN_V1_VALUE)
+            produces = ApplicationMediaType.TEXT_PLAIN_VALUE)
     @Timed
     public ResponseEntity<?> registerAccount(@Valid @RequestBody UserDTO userDTO, HttpServletRequest request) {<% if (javaVersion == '8') { %>
         return userRepository.findOneByLogin(userDTO.getLogin())
@@ -76,10 +76,10 @@ public class AccountResource {
         );<% } else { %>
         User user = userRepository.findOneByLogin(userDTO.getLogin());
         if (user != null) {
-            return ResponseEntity.badRequest().contentType(ApplicationMediaType.TEXT_PLAIN_V1).body("login already in use");
+            return ResponseEntity.badRequest().contentType(ApplicationMediaType.TEXT_PLAIN).body("login already in use");
         } else {
             if (userRepository.findOneByEmail(userDTO.getEmail()) != null) {
-                return ResponseEntity.badRequest().contentType(ApplicationMediaType.TEXT_PLAIN_V1).body("e-mail address already in use");
+                return ResponseEntity.badRequest().contentType(ApplicationMediaType.TEXT_PLAIN).body("e-mail address already in use");
             }
             user = userService.createUserInformation(userDTO.getLogin(), userDTO.getPassword(),
             userDTO.getFirstName(), userDTO.getLastName(), userDTO.getEmail().toLowerCase(),
@@ -100,7 +100,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/activate",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<String> activateAccount(@RequestParam(value = "key") String key) {<% if (javaVersion == '8') { %>
         return Optional.ofNullable(userService.activateRegistration(key))
@@ -118,7 +118,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/authenticate",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public String isAuthenticated(HttpServletRequest request) {
         log.debug("REST request to check if the current user is authenticated");
@@ -130,7 +130,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<UserDTO> getAccount() {<% if (javaVersion == '8') { %>
         return Optional.ofNullable(userService.getUserWithAuthorities())
@@ -176,7 +176,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account",
             method = RequestMethod.POST,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<String> saveAccount(@RequestBody UserDTO userDTO) {<% if (javaVersion == '8') { %>
         return userRepository
@@ -202,7 +202,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account/change_password",
             method = RequestMethod.POST,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<?> changePassword(@RequestBody String password) {
         if (!checkPasswordLength(password)) {
@@ -217,7 +217,7 @@ public class AccountResource {
      */
     @RequestMapping(value = "/account/sessions",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<List<PersistentToken>> getCurrentSessions() {<% if (javaVersion == '8') { %>
         return userRepository.findOneByLogin(SecurityUtils.getCurrentLogin())
@@ -268,7 +268,7 @@ public class AccountResource {
 
     @RequestMapping(value = "/account/reset_password/init",
         method = RequestMethod.POST,
-        produces = ApplicationMediaType.TEXT_PLAIN_V1_VALUE)
+        produces = ApplicationMediaType.TEXT_PLAIN_VALUE)
     @Timed
     public ResponseEntity<?> requestPasswordReset(@RequestBody String mail, HttpServletRequest request) {
         <% if (javaVersion == '8') { %>
@@ -301,7 +301,7 @@ public class AccountResource {
 
     @RequestMapping(value = "/account/reset_password/finish",
         method = RequestMethod.POST,
-        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<String> finishPasswordReset(@RequestBody KeyAndPasswordDTO keyAndPassword) {
         if (!checkPasswordLength(keyAndPassword.getNewPassword())) {

--- a/app/templates/src/main/java/package/web/rest/_AuditResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AuditResource.java
@@ -3,9 +3,9 @@ package <%=packageName%>.web.rest;
 import <%=packageName%>.security.AuthoritiesConstants;
 import <%=packageName%>.service.AuditEventService;
 import <%=packageName%>.web.propertyeditors.LocaleDateTimeEditor;
+import <%=packageName%>.config.ApplicationMediaType;
 import org.joda.time.LocalDateTime;
 import org.springframework.boot.actuate.audit.AuditEvent;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
 
@@ -29,14 +29,14 @@ public class AuditResource {
 
     @RequestMapping(value = "/audits/all",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     public List<AuditEvent> findAll() {
         return auditEventService.findAll();
     }
 
     @RequestMapping(value = "/audits/byDates",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     public List<AuditEvent> findByDates(@RequestParam(value = "fromDate") LocalDateTime fromDate,
                                     @RequestParam(value = "toDate") LocalDateTime toDate) {
         return auditEventService.findByDates(fromDate, toDate);

--- a/app/templates/src/main/java/package/web/rest/_AuditResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AuditResource.java
@@ -29,14 +29,14 @@ public class AuditResource {
 
     @RequestMapping(value = "/audits/all",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     public List<AuditEvent> findAll() {
         return auditEventService.findAll();
     }
 
     @RequestMapping(value = "/audits/byDates",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     public List<AuditEvent> findByDates(@RequestParam(value = "fromDate") LocalDateTime fromDate,
                                     @RequestParam(value = "toDate") LocalDateTime toDate) {
         return auditEventService.findByDates(fromDate, toDate);

--- a/app/templates/src/main/java/package/web/rest/_LogsResource.java
+++ b/app/templates/src/main/java/package/web/rest/_LogsResource.java
@@ -4,9 +4,9 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
 import com.codahale.metrics.annotation.Timed;
 import <%=packageName%>.web.rest.dto.LoggerDTO;
+import <%=packageName%>.config.ApplicationMediaType;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.*;
 <% if (javaVersion != '8') { %>
 import java.util.ArrayList;<% } %>
@@ -22,7 +22,7 @@ public class LogsResource {
 
     @RequestMapping(value = "/logs",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public List<LoggerDTO> getList() {
         LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();<% if (javaVersion == '8') { %>

--- a/app/templates/src/main/java/package/web/rest/_LogsResource.java
+++ b/app/templates/src/main/java/package/web/rest/_LogsResource.java
@@ -22,7 +22,7 @@ public class LogsResource {
 
     @RequestMapping(value = "/logs",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public List<LoggerDTO> getList() {
         LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();<% if (javaVersion == '8') { %>

--- a/app/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/app/templates/src/main/java/package/web/rest/_UserResource.java
@@ -43,7 +43,7 @@ public class UserResource {
      */
     @RequestMapping(value = "/users",
         method = RequestMethod.GET,
-        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public List<User> getAll() {
         log.debug("REST request to get all Users");
@@ -55,7 +55,7 @@ public class UserResource {
      */
     @RequestMapping(value = "/users/{login}",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed<% if (javaVersion == '8') { %>
     ResponseEntity<User> getUser(@PathVariable String login) {
         log.debug("REST request to get User : {}", login);
@@ -78,7 +78,7 @@ public class UserResource {
      */
     @RequestMapping(value = "/_search/users/{query}",
         method = RequestMethod.GET,
-        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public List<User> search(@PathVariable String query) {
         return StreamSupport

--- a/app/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/app/templates/src/main/java/package/web/rest/_UserResource.java
@@ -5,11 +5,11 @@ import <%=packageName%>.domain.User;
 import <%=packageName%>.repository.UserRepository;<% if (searchEngine == 'elasticsearch') { %>
 import <%=packageName%>.repository.search.UserSearchRepository;<% } %>
 import <%=packageName%>.security.AuthoritiesConstants;
+import <%=packageName%>.config.ApplicationMediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;<% if (javaVersion == '8') { %>
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;<% } %>
-import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
@@ -43,7 +43,7 @@ public class UserResource {
      */
     @RequestMapping(value = "/users",
         method = RequestMethod.GET,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public List<User> getAll() {
         log.debug("REST request to get all Users");
@@ -55,7 +55,7 @@ public class UserResource {
      */
     @RequestMapping(value = "/users/{login}",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed<% if (javaVersion == '8') { %>
     ResponseEntity<User> getUser(@PathVariable String login) {
         log.debug("REST request to get User : {}", login);
@@ -78,7 +78,7 @@ public class UserResource {
      */
     @RequestMapping(value = "/_search/users/{query}",
         method = RequestMethod.GET,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public List<User> search(@PathVariable String query) {
         return StreamSupport

--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -2,7 +2,7 @@
 
 angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTranslation) { %>'tmh.dynamicLocale', 'pascalprecht.translate', <% } %>
                'ui.bootstrap', // for modal dialogs
-    'ngResource', 'ui.router', 'ngCookies', 'ngCacheBuster', 'ngFileUpload', 'infinite-scroll'])
+    'ngResource', 'ui.router', 'ngCookies', 'ngCacheBuster', 'ngFileUpload', 'infinite-scroll', 'ngVendorMediaType'])
 
     .run(function ($rootScope, $location, $window, $http, $state, <% if (enableTranslation) { %>$translate, Language,<% } %> Auth, Principal, ENV, VERSION) {
         $rootScope.ENV = ENV;
@@ -49,7 +49,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
             }
         };
     })
-    .config(function ($stateProvider, $urlRouterProvider, $httpProvider, $locationProvider, <% if (enableTranslation) { %>$translateProvider, tmhDynamicLocaleProvider,<% } %> httpRequestInterceptorCacheBusterProvider) {
+    .config(function ($stateProvider, $urlRouterProvider, $httpProvider, $locationProvider, <% if (enableTranslation) { %>$translateProvider, tmhDynamicLocaleProvider,<% } %> httpRequestInterceptorCacheBusterProvider, httpRequestInterceptorVendorMediaTypeProvider) {
 <% if (authenticationType == 'session') { %>
         //enable CSRF
         $httpProvider.defaults.xsrfCookieName = 'CSRF-TOKEN';
@@ -57,6 +57,16 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
 <% } %>
         //Cache everything except rest api requests
         httpRequestInterceptorCacheBusterProvider.setMatchlist([/.*api.*/, /.*protected.*/], true);
+
+        //Configures application specific versioned media types
+        httpRequestInterceptorVendorMediaTypeProvider
+            .matchingRequests([/.*api.*/])
+            .matchingMediaTypes(['text/plain', 'application/json'])
+            .withVendor({
+                name: 'vnd',
+                application: '<%=baseName%>',
+                version: '1'
+            });
 
         $urlRouterProvider.otherwise('/');
         $stateProvider.state('site', {

--- a/app/templates/src/main/webapp/scripts/app/_app.js
+++ b/app/templates/src/main/webapp/scripts/app/_app.js
@@ -49,7 +49,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
             }
         };
     })
-    .config(function ($stateProvider, $urlRouterProvider, $httpProvider, $locationProvider, <% if (enableTranslation) { %>$translateProvider, tmhDynamicLocaleProvider,<% } %> httpRequestInterceptorCacheBusterProvider, httpRequestInterceptorVendorMediaTypeProvider) {
+    .config(function ($stateProvider, $urlRouterProvider, $httpProvider, $locationProvider, <% if (enableTranslation) { %>$translateProvider, tmhDynamicLocaleProvider,<% } %> httpRequestInterceptorCacheBusterProvider <% if (versionApi) { %>, httpRequestInterceptorVendorMediaTypeProvider <% } %>) {
 <% if (authenticationType == 'session') { %>
         //enable CSRF
         $httpProvider.defaults.xsrfCookieName = 'CSRF-TOKEN';
@@ -58,6 +58,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
         //Cache everything except rest api requests
         httpRequestInterceptorCacheBusterProvider.setMatchlist([/.*api.*/, /.*protected.*/], true);
 
+<% if (versionApi) { %>
         //Configures application specific versioned media types
         httpRequestInterceptorVendorMediaTypeProvider
             .matchingRequests([/.*api.*/])
@@ -67,7 +68,7 @@ angular.module('<%=angularAppName%>', ['LocalStorageModule', <% if (enableTransl
                 application: '<%=baseName%>',
                 version: '1'
             });
-
+<% } %>
         $urlRouterProvider.otherwise('/');
         $stateProvider.state('site', {
             'abstract': true,

--- a/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
@@ -11,6 +11,7 @@ import <%=packageName%>.security.AuthoritiesConstants;
 import <%=packageName%>.service.MailService;
 import <%=packageName%>.service.UserService;
 import <%=packageName%>.web.rest.dto.UserDTO;
+import <%=packageName%>.config.ApplicationMediaType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,8 +19,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;<% if (databaseType == 'mongodb') { %>
-import org.springframework.context.annotation.Import;<% } %>
-import org.springframework.http.MediaType;<% if (javaVersion == '7') { %>
+import org.springframework.context.annotation.Import;<% } %> <% if (javaVersion == '7') { %>
 import org.springframework.mock.web.MockHttpServletRequest;<% } %>
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -97,7 +97,7 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
     @Test
     public void testNonAuthenticatedUser() throws Exception {
         restUserMockMvc.perform(get("/api/authenticate")
-                .accept(MediaType.APPLICATION_JSON))
+                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(status().isOk())
                 .andExpect(content().string(""));
     }
@@ -113,7 +113,7 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
                         return request;
                     }<% } %>
                 })
-                .accept(MediaType.APPLICATION_JSON))
+                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(status().isOk())
                 .andExpect(content().string("test"));
     }
@@ -136,9 +136,9 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
         when(mockUserService.getUserWithAuthorities()).thenReturn(user);
 
         restUserMockMvc.perform(get("/api/account")
-                .accept(MediaType.APPLICATION_JSON))
+                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(jsonPath("$.login").value("test"))
                 .andExpect(jsonPath("$.firstName").value("john"))
                 .andExpect(jsonPath("$.lastName").value("doe"))
@@ -151,7 +151,7 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
         when(mockUserService.getUserWithAuthorities()).thenReturn(null);
 
         restUserMockMvc.perform(get("/api/account")
-                .accept(MediaType.APPLICATION_JSON))
+                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(status().isInternalServerError());
     }
 

--- a/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_AccountResourceTest.java
@@ -97,7 +97,7 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
     @Test
     public void testNonAuthenticatedUser() throws Exception {
         restUserMockMvc.perform(get("/api/authenticate")
-                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
+                .accept(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string(""));
     }
@@ -113,7 +113,7 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
                         return request;
                     }<% } %>
                 })
-                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
+                .accept(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
                 .andExpect(content().string("test"));
     }
@@ -136,9 +136,9 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
         when(mockUserService.getUserWithAuthorities()).thenReturn(user);
 
         restUserMockMvc.perform(get("/api/account")
-                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
+                .accept(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))
+                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.login").value("test"))
                 .andExpect(jsonPath("$.firstName").value("john"))
                 .andExpect(jsonPath("$.lastName").value("doe"))
@@ -151,7 +151,7 @@ public class AccountResourceTest <% if (databaseType == 'cassandra') { %>extends
         when(mockUserService.getUserWithAuthorities()).thenReturn(null);
 
         restUserMockMvc.perform(get("/api/account")
-                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
+                .accept(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(status().isInternalServerError());
     }
 

--- a/app/templates/src/test/java/package/web/rest/_TestUtil.java
+++ b/app/templates/src/test/java/package/web/rest/_TestUtil.java
@@ -21,8 +21,8 @@ public class TestUtil {
 
     /** MediaType for JSON UTF8 */
     public static final MediaType APPLICATION_JSON_UTF8 = new MediaType(
-            ApplicationMediaType.APPLICATION_JSON_V1.getType(),
-            ApplicationMediaType.APPLICATION_JSON_V1.getSubtype(), Charset.forName("utf8"));
+            ApplicationMediaType.APPLICATION_JSON.getType(),
+            ApplicationMediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
 
     /**
      * Convert an object to JSON byte array.

--- a/app/templates/src/test/java/package/web/rest/_TestUtil.java
+++ b/app/templates/src/test/java/package/web/rest/_TestUtil.java
@@ -10,6 +10,7 @@ import org.springframework.http.MediaType;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.joda.JodaModule;
+import <%=packageName%>.config.ApplicationMediaType;
 import <%=packageName%>.domain.util.CustomDateTimeSerializer;
 import <%=packageName%>.domain.util.CustomLocalDateSerializer;
 
@@ -20,8 +21,8 @@ public class TestUtil {
 
     /** MediaType for JSON UTF8 */
     public static final MediaType APPLICATION_JSON_UTF8 = new MediaType(
-            MediaType.APPLICATION_JSON.getType(),
-            MediaType.APPLICATION_JSON.getSubtype(), Charset.forName("utf8"));
+            ApplicationMediaType.APPLICATION_JSON_V1.getType(),
+            ApplicationMediaType.APPLICATION_JSON_V1.getSubtype(), Charset.forName("utf8"));
 
     /**
      * Convert an object to JSON byte array.

--- a/app/templates/src/test/java/package/web/rest/_UserResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_UserResourceTest.java
@@ -4,13 +4,13 @@ import <%=packageName%>.AbstractCassandraTest;<% } %>
 import <%=packageName%>.Application;<% if (databaseType == 'mongodb') { %>
 import <%=packageName%>.config.MongoConfiguration;<% } %>
 import <%=packageName%>.repository.UserRepository;
+import <%=packageName%>.config.ApplicationMediaType;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;<% if (databaseType == 'mongodb') { %>
 import org.springframework.context.annotation.Import;<% } %>
-import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.util.ReflectionTestUtils;
@@ -49,16 +49,16 @@ public class UserResourceTest <% if (databaseType == 'cassandra') { %>extends Ab
     @Test
     public void testGetExistingUser() throws Exception {
         restUserMockMvc.perform(get("/api/users/admin")
-                .accept(MediaType.APPLICATION_JSON))
+                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType("application/json"))
+                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(jsonPath("$.lastName").value("Administrator"));
     }
 
     @Test
     public void testGetUnknownUser() throws Exception {
         restUserMockMvc.perform(get("/api/users/unknown")
-                .accept(MediaType.APPLICATION_JSON))
+                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
                 .andExpect(status().isNotFound());
     }
 }

--- a/app/templates/src/test/java/package/web/rest/_UserResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_UserResourceTest.java
@@ -49,16 +49,16 @@ public class UserResourceTest <% if (databaseType == 'cassandra') { %>extends Ab
     @Test
     public void testGetExistingUser() throws Exception {
         restUserMockMvc.perform(get("/api/users/admin")
-                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
+                .accept(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))
+                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(jsonPath("$.lastName").value("Administrator"));
     }
 
     @Test
     public void testGetUnknownUser() throws Exception {
         restUserMockMvc.perform(get("/api/users/unknown")
-                .accept(ApplicationMediaType.APPLICATION_JSON_V1))
+                .accept(ApplicationMediaType.APPLICATION_JSON))
                 .andExpect(status().isNotFound());
     }
 }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -56,7 +56,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
             method = RequestMethod.POST,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed<%
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
@@ -82,7 +82,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
         method = RequestMethod.PUT,
-        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<<%= instanceType %>> update(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) throws URISyntaxException {
         log.debug("REST request to update <%= entityClass %> : {}", <%= instanceName %>);
@@ -102,7 +102,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed<% if (dto == 'mapstruct') { %>
     @Transactional(readOnly = true)<% } %><% if (pagination == 'no') { %>
     public List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> getAll(<% if (fieldsContainNoOwnerOneToOne == true) { %>@RequestParam(required = false) String filter<% } %>) {<% for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { %>
@@ -158,7 +158,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s/{id}",
             method = RequestMethod.GET,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> get(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id<% if (javaVersion == '7') { %>, HttpServletResponse response<% } %>) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<% if (javaVersion == '8') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
@@ -181,7 +181,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s/{id}",
             method = RequestMethod.DELETE,
-            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<Void> delete(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
@@ -198,7 +198,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/_search/<%= entityInstance %>s/{query}",
         method = RequestMethod.GET,
-        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_VALUE)
     @Timed
     public List<<%= entityClass %>> search(@PathVariable String query) {
         return StreamSupport

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -8,12 +8,12 @@ import <%=packageName%>.web.rest.util.HeaderUtil;<% if (pagination != 'no') { %>
 import <%=packageName%>.web.rest.util.PaginationUtil;<% } %><% if (dto == 'mapstruct') { %>
 import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;
 import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;<% } %>
+import <%=packageName%>.config.ApplicationMediaType;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;<% if (pagination != 'no') { %>
 import org.springframework.data.domain.Page;<% } %>
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;<% if (dto == 'mapstruct') { %>
 import org.springframework.transaction.annotation.Transactional;<% } %>
 import org.springframework.web.bind.annotation.*;
@@ -56,7 +56,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
             method = RequestMethod.POST,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed<%
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
@@ -82,7 +82,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
         method = RequestMethod.PUT,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<<%= instanceType %>> update(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) throws URISyntaxException {
         log.debug("REST request to update <%= entityClass %> : {}", <%= instanceName %>);
@@ -102,7 +102,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed<% if (dto == 'mapstruct') { %>
     @Transactional(readOnly = true)<% } %><% if (pagination == 'no') { %>
     public List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> getAll(<% if (fieldsContainNoOwnerOneToOne == true) { %>@RequestParam(required = false) String filter<% } %>) {<% for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { %>
@@ -158,7 +158,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s/{id}",
             method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> get(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id<% if (javaVersion == '7') { %>, HttpServletResponse response<% } %>) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<% if (javaVersion == '8') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
@@ -181,7 +181,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/<%= entityInstance %>s/{id}",
             method = RequestMethod.DELETE,
-            produces = MediaType.APPLICATION_JSON_VALUE)
+            produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public ResponseEntity<Void> delete(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
@@ -198,7 +198,7 @@ public class <%= entityClass %>Resource {
      */
     @RequestMapping(value = "/_search/<%= entityInstance %>s/{query}",
         method = RequestMethod.GET,
-        produces = MediaType.APPLICATION_JSON_VALUE)
+        produces = ApplicationMediaType.APPLICATION_JSON_V1_VALUE)
     @Timed
     public List<<%= entityClass %>> search(@PathVariable String query) {
         return StreamSupport

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -7,6 +7,7 @@ import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEng
 import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %><% if (dto == 'mapstruct') { %>
 import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;
 import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;<% } %>
+import <%=packageName%>.config.ApplicationMediaType;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -15,7 +16,6 @@ import static org.hamcrest.Matchers.hasItem;
 import org.mockito.MockitoAnnotations;
 import org.springframework.boot.test.IntegrationTest;
 import org.springframework.boot.test.SpringApplicationConfiguration;
-import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 import org.springframework.test.context.web.WebAppConfiguration;
@@ -225,7 +225,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
         // Get all the <%= entityInstance %>s
         rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
+                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))<% if (databaseType == 'sql') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().intValue())))<% } %><% if (databaseType == 'mongodb') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId())))<% } %><% if (databaseType == 'cassandra') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().toString())))<% } %><% for (fieldId in fields) {%>
@@ -241,7 +241,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
         // Get the <%= entityInstance %>
         rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s/{id}", <%= entityInstance %>.getId()))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(MediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
+            .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))<% if (databaseType == 'sql') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'mongodb') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId()))<% } %><% if (databaseType == 'cassandra') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().toString()))<% } %><% for (fieldId in fields) {%>

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceTest.java
@@ -225,7 +225,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
         // Get all the <%= entityInstance %>s
         rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s"))
                 .andExpect(status().isOk())
-                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))<% if (databaseType == 'sql') { %>
+                .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().intValue())))<% } %><% if (databaseType == 'mongodb') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId())))<% } %><% if (databaseType == 'cassandra') { %>
                 .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().toString())))<% } %><% for (fieldId in fields) {%>
@@ -241,7 +241,7 @@ public class <%= entityClass %>ResourceTest <% if (databaseType == 'cassandra') 
         // Get the <%= entityInstance %>
         rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityInstance %>s/{id}", <%= entityInstance %>.getId()))
             .andExpect(status().isOk())
-            .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON_V1))<% if (databaseType == 'sql') { %>
+            .andExpect(content().contentType(ApplicationMediaType.APPLICATION_JSON))<% if (databaseType == 'sql') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().intValue()))<% } %><% if (databaseType == 'mongodb') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId()))<% } %><% if (databaseType == 'cassandra') { %>
             .andExpect(jsonPath("$.id").value(<%= entityInstance %>.getId().toString()))<% } %><% for (fieldId in fields) {%>

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -27,7 +27,8 @@ describe('JHipster generator ', function () {
                 "frontendBuilder": "grunt",
                 "javaVersion": "8",
                 "rememberMeKey": "5c37379956bd1242f5636c8cb322c2966ad81277",
-                "searchEngine": "no"
+                "searchEngine": "no",
+                "versionApi": false
             })
         .on('end', done);
     });
@@ -305,7 +306,8 @@ describe('JHipster generator ', function () {
                 "frontendBuilder": "grunt",
                 "javaVersion": "8",
                 "rememberMeKey": "5c37379956bd1242f5636c8cb322c2966ad81277",
-                "searchEngine": "no"
+                "searchEngine": "no",
+                "versionApi": false
             })
         .on('end', done);
     });
@@ -339,7 +341,9 @@ describe('JHipster generator ', function () {
                 "frontendBuilder": "grunt",
                 "javaVersion": "8",
                 "rememberMeKey": "5c37379956bd1242f5636c8cb322c2966ad81277",
-                "searchEngine": "no" })
+                "searchEngine": "no",
+                "versionApi": false
+            })
       .on('end', done);
   });
 
@@ -372,7 +376,9 @@ describe('JHipster generator ', function () {
                 "frontendBuilder": "grunt",
                 "javaVersion": "8",
                 "rememberMeKey": "5c37379956bd1242f5636c8cb322c2966ad81277",
-                "searchEngine": "no" })
+                "searchEngine": "no",
+                "versionApi": false
+            })
       .on('end', done);
   });
 
@@ -404,7 +410,9 @@ describe('JHipster generator ', function () {
                 "frontendBuilder": "grunt",
                 "javaVersion": "8",
                 "rememberMeKey": "5c37379956bd1242f5636c8cb322c2966ad81277",
-                "searchEngine": "no" })
+                "searchEngine": "no",
+                "versionApi": false
+            })
       .on('end', done);
   });
 
@@ -437,7 +445,9 @@ describe('JHipster generator ', function () {
                 "frontendBuilder": "grunt",
                 "javaVersion": "8",
                 "rememberMeKey": "5c37379956bd1242f5636c8cb322c2966ad81277",
-                "searchEngine": "no" })
+                "searchEngine": "no",
+                "versionApi": false
+            })
       .on('end', done);
   });
 


### PR DESCRIPTION
I've introduced support in both frontend and backend for versioned vendor specific media types:

Examples:
text/plain -> text/vnd.jhipster.v1+plain
application/json -> application/vnd.jhipster.v1+json

Spring does not require any specific handling in other to introduce this change. 
On the angular side I had added angular-vendor- media-type extension and customized it so that the generator would populate the base name into it.

I would like to introduce this change and also open the discusion on potential improvments.

References:
http://www.baeldung.com/rest-versioning
http://restcookbook.com/Basics/versioning/
http://pivotallabs.com/api-versioning/
https://www.npmjs.com/package/angular-vendor-media-type