### PR TITLE
Upgrade proxy-middleware to 0.13.1 for passing csrf cookie correctly.

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -50,7 +50,7 @@
     "gulp-jshint": "1.9.0",
     "gulp-browserify": "0.5.1",<% if (useCompass) { %>
     "gulp-compass": "2.0.3",<% } %>
-    "proxy-middleware": "0.9.0",
+    "proxy-middleware": "0.13.1",
     "run-sequence": "1.1.0",<% } %>
     "event-stream": "3.3.1",
     "jshint-stylish": "1.0.1",


### PR DESCRIPTION
Upgrade proxy-middleware to 0.13.1 for passing csrf cookie correctly.

Fixes #1454