### PR TITLE
Entity relationship bugfixes and refactoring

### DIFF
--- a/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
+++ b/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
@@ -24,8 +24,9 @@ for (relationshipId in relationships) {
 for (relationshipId in relationships) {
         if (relationships[relationshipId].relationshipType == 'many-to-one' || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) { %>
     @Mapping(source = "<%= relationships[relationshipId].relationshipName %>Id", target = "<%= relationships[relationshipId].relationshipName %>")<% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == false) { %>
-    @Mapping(target = "<%= relationships[relationshipId].relationshipName %>s", ignore = true)<% } else if (relationships[relationshipId].relationshipType == 'one-to-many'  || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == false)) { %>
-    @Mapping(target = "<%= relationships[relationshipId].relationshipName %>s", ignore = true)<% } } %>
+    @Mapping(target = "<%= relationships[relationshipId].relationshipName %>s", ignore = true)<% } else if (relationships[relationshipId].relationshipType == 'one-to-many') { %>
+    @Mapping(target = "<%= relationships[relationshipId].relationshipName %>s", ignore = true)<% } else if (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == false) { %>
+    @Mapping(target = "<%= relationships[relationshipId].relationshipName %>", ignore = true)<% } } %>
     <%= entityClass %> <%= entityInstance %>DTOTo<%= entityClass %>(<%= entityClass %>DTO <%= entityInstance %>DTO);<%
 
 for (relationshipId in relationships) {

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -72,11 +72,18 @@
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one'
                            || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) {
-                            var relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
-                            if (dto == 'mapstruct') {
-                                relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
-                            }%>
-                    <td>{{<%= relationshipNgModel %>}}</td><% } } %>
+                            var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
+                            var otherEntityName = relationships[relationshipId].otherEntityName;
+                            var otherEntityField = relationships[relationshipId].otherEntityField;
+                            var otherEntityFieldCapitalized = relationships[relationshipId].otherEntityFieldCapitalized; 
+                        %>
+                    <td>
+<% if (dto == 'no') { -%>
+                        <a ui-sref="<%= otherEntityName %>.detail({id:<%= entityInstance + "." + relationshipFieldName + ".id" %>})">{{<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}}</a>
+<% } else { -%>
+                        <a ui-sref="<%= otherEntityName %>.detail({id:<%= entityInstance + "." + relationshipFieldName + "Id" %>})">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
+<% } -%>
+                    </td><% } } %>
                     <td>
                         <button type="submit"
                                 ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})"

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -72,11 +72,11 @@
                     <td>{{<%=entityInstance %>.<%=fields[fieldId].fieldName%>}}</td><% } %><% } %><% for (relationshipId in relationships) {
                         if (relationships[relationshipId].relationshipType == 'many-to-one'
                            || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) {
-                            var relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
+                            var relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
                             if (dto == 'mapstruct') {
-                                relationShipValue = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
+                                relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
                             }%>
-                    <td>{{<%=relationShipValue %>}}</td><% } } %>
+                    <td>{{<%= relationshipNgModel %>}}</td><% } } %>
                     <td>
                         <button type="submit"
                                 ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})"

--- a/entity/templates/src/main/webapp/app/_entity-detail.html
+++ b/entity/templates/src/main/webapp/app/_entity-detail.html
@@ -50,7 +50,7 @@
     </div>
 
     <button type="submit"
-            ui-sref="<%= entityInstance %>"
+            onclick="window.history.back()"
             class="btn btn-info">
         <span class="glyphicon glyphicon-arrow-left"></span>&nbsp;<span translate="entity.action.back"> Back</span>
     </button>

--- a/entity/templates/src/main/webapp/app/_entity-detail.html
+++ b/entity/templates/src/main/webapp/app/_entity-detail.html
@@ -29,16 +29,16 @@
                 || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) {
                 var relationshipName = relationships[relationshipId].relationshipName;
                 var otherEntityName = relationships[relationshipId].otherEntityName;
-                var relationShipValue = entityInstance + "." + relationshipName + "." + relationships[relationshipId].otherEntityField;
+                var relationshipNgModel = entityInstance + "." + relationshipName + "." + relationships[relationshipId].otherEntityField;
                 if (dto == 'mapstruct') {
-                    relationShipValue = entityInstance + "." + relationshipName + relationships[relationshipId].otherEntityFieldCapitalized;
+                    relationshipNgModel = entityInstance + "." + relationshipName + relationships[relationshipId].otherEntityFieldCapitalized;
                 } %>
             <tr>
                 <td>
                     <span translate="<%= keyPrefix %>.<%= relationshipName %>"><%=relationshipName%></span>
                 </td>
                 <td>
-                    <span class="form-control-static">{{<%= relationShipValue%>}}</span>
+                    <span class="form-control-static">{{<%= relationshipNgModel %>}}</span>
                 </td>
             </tr><% } } %>
             </tbody>

--- a/entity/templates/src/main/webapp/app/_entity-detail.html
+++ b/entity/templates/src/main/webapp/app/_entity-detail.html
@@ -28,17 +28,21 @@
             if (relationships[relationshipId].relationshipType == 'many-to-one'
                 || (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true)) {
                 var relationshipName = relationships[relationshipId].relationshipName;
+                var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
                 var otherEntityName = relationships[relationshipId].otherEntityName;
-                var relationshipNgModel = entityInstance + "." + relationshipName + "." + relationships[relationshipId].otherEntityField;
-                if (dto == 'mapstruct') {
-                    relationshipNgModel = entityInstance + "." + relationshipName + relationships[relationshipId].otherEntityFieldCapitalized;
-                } %>
+                var otherEntityField = relationships[relationshipId].otherEntityField;
+                var otherEntityFieldCapitalized = relationships[relationshipId].otherEntityFieldCapitalized;
+                %>
             <tr>
                 <td>
                     <span translate="<%= keyPrefix %>.<%= relationshipName %>"><%=relationshipName%></span>
                 </td>
                 <td>
-                    <span class="form-control-static">{{<%= relationshipNgModel %>}}</span>
+<% if (dto == 'no') { -%>
+                    <a class="form-control-static" ui-sref="<%= otherEntityName %>.detail({id:<%= entityInstance + "." + relationshipFieldName + ".id" %>})">{{<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}}</a>
+<% } else { -%>
+                    <a class="form-control-static" ui-sref="<%= otherEntityName %>.detail({id:<%= entityInstance + "." + relationshipFieldName + "Id" %>})">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
+<% } -%>
                 </td>
             </tr><% } } %>
             </tbody>

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -108,22 +108,22 @@
     var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
     var translationKey = keyPrefix + relationshipName;
      if (relationships[relationshipId].relationshipType == 'many-to-one') { 
-        var relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
+        var relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
         if (dto == 'mapstruct') {
-            relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
+            relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
         } %>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationNgModel %>" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationshipNgModel %>" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
             </select>
         </div><% } else if (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true) {
-        var relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
+        var relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
         if (dto == 'mapstruct') {
-            relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
+            relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
         } %>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationNgModel %>" ng-options="<%=relationshipFieldName %>.id as <%=relationshipFieldName %>.<%=relationships[relationshipId].otherEntityField %> for <%=relationshipFieldName %> in <%=relationshipFieldName.toLowerCase() %>s">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationshipNgModel %>" ng-options="<%=relationshipFieldName %>.id as <%=relationshipFieldName %>.<%=relationships[relationshipId].otherEntityField %> for <%=relationshipFieldName %> in <%=relationshipFieldName.toLowerCase() %>s">
             </select>
         </div><% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) {
             %>

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -103,35 +103,40 @@
             </div><% } %>
         </div><% } %>
 <% for (relationshipId in relationships) {
+    var relationshipType = relationships[relationshipId].relationshipType;
+    var ownerSide = relationships[relationshipId].ownerSide;
     var otherEntityName = relationships[relationshipId].otherEntityName;
     var relationshipName = relationships[relationshipId].relationshipName;
     var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
-    var translationKey = keyPrefix + relationshipName;
-     if (relationships[relationshipId].relationshipType == 'many-to-one') { 
-        var relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
-        if (dto == 'mapstruct') {
-            relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
-        } %>
+    var otherEntityField = relationships[relationshipId].otherEntityField;
+    var otherEntityFieldCapitalized = relationships[relationshipId].otherEntityFieldCapitalized;
+    var translationKey = keyPrefix + relationshipName; 
+-%>
+<% if (relationshipType == 'many-to-one') { -%>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationshipNgModel %>" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
-            </select>
-        </div><% } else if (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true) {
-        var relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
-        if (dto == 'mapstruct') {
-            relationshipNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
-        } %>
+            <% if (dto == 'no') { %>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id"></select>
+            <% } else { %>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s"></select>
+            <% } %>
+        </div>
+<% } else if (relationshipType == 'one-to-one' && ownerSide == true) { -%>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationshipNgModel %>" ng-options="<%=relationshipFieldName %>.id as <%=relationshipFieldName %>.<%=relationships[relationshipId].otherEntityField %> for <%=relationshipFieldName %> in <%=relationshipFieldName.toLowerCase() %>s">
-            </select>
-        </div><% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) {
-            %>
+            <% if (dto == 'no') { %>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s track by <%=otherEntityName %>.id"></select>
+            <% } else { %>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s"></select>
+            <% } %>
+        </div>
+<% } else if (relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) { -%>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>s" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id">
-            </select>
-        </div><% } } %>
+            <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>s" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id"></select>
+        </div>
+<% } -%>
+<% } -%>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-default" data-dismiss="modal" ng-click="clear()">

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -107,16 +107,23 @@
     var relationshipName = relationships[relationshipId].relationshipName;
     var relationshipFieldName = relationships[relationshipId].relationshipFieldName;
     var translationKey = keyPrefix + relationshipName;
-     if (relationships[relationshipId].relationshipType == 'many-to-one') { %>
+     if (relationships[relationshipId].relationshipType == 'many-to-one') { 
+        var relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
+        if (dto == 'mapstruct') {
+            relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
+        } %>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>.id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationNgModel %>" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=relationships[relationshipId].otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
             </select>
         </div><% } else if (relationships[relationshipId].relationshipType == 'one-to-one' && relationships[relationshipId].ownerSide == true) {
-            %>
+        var relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + "." + relationships[relationshipId].otherEntityField;
+        if (dto == 'mapstruct') {
+            relationNgModel = entityInstance + "." + relationships[relationshipId].relationshipFieldName + relationships[relationshipId].otherEntityFieldCapitalized;
+        } %>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%=entityInstance %>.<%=relationshipFieldName %>.id" ng-options="<%=relationshipFieldName %>.id as <%=relationshipFieldName %>.<%=relationships[relationshipId].otherEntityField %> for <%=relationshipFieldName %> in <%=relationshipFieldName.toLowerCase() %>s">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= relationNgModel %>" ng-options="<%=relationshipFieldName %>.id as <%=relationshipFieldName %>.<%=relationships[relationshipId].otherEntityField %> for <%=relationshipFieldName %> in <%=relationshipFieldName.toLowerCase() %>s">
             </select>
         </div><% } else if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) {
             %>


### PR DESCRIPTION
This is the renamed version of #1851 and it contains a bit more.

Lots of entity relationship generator bugfixes when using dto and otherEntityField option. It also makes the ids (or otherEntityField texts) clickable

It is fully tested with and without dto option and with or without otherEntityField option with all relationship types.

the following setup of entities (in jdl) where used for testing
```
entity MultiRelationalEntity{
}
entity OneToOneEntity{
}
entity OneToManyEntity{
}
entity ManyToManyEntity{
}
relationship ManyToOne{
  MultiRelationalEntity{oneToMany} to OneToManyEntity{multiRelational}
}
relationship OneToOne{
  MultiRelationalEntity{oneToOne} to OneToOneEntity{multiRelational}
}
relationship ManyToMany{
  MultiRelationalEntity{manyToMany} to ManyToManyEntity{multiRelational}
}



entity MultiRelationalDisplayFieldEntity{
}
entity OneToOneDisplayFieldEntity{
  displayField String
}
entity OneToManyDisplayFieldEntity{
  displayField String
}
entity ManyToManyDisplayFieldEntity{
  displayField String
}
relationship ManyToOne{
  MultiRelationalDisplayFieldEntity{oneToMany(displayField)} to OneToManyDisplayFieldEntity{multiRelational}
}
relationship OneToOne{
  MultiRelationalDisplayFieldEntity{oneToOne(displayField)} to OneToOneDisplayFieldEntity{multiRelational}
}
relationship ManyToMany{
  MultiRelationalDisplayFieldEntity{manyToMany(displayField)} to ManyToManyDisplayFieldEntity{multiRelational}
}
```