### PR TITLE
Align artifact version to mvn build

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -48,7 +48,7 @@ if (project.hasProperty('prod')) {
 }
 
 group = '<%= packageName %>'
-version = '0.1-SNAPSHOT'
+version = '0.0.1-SNAPSHOT'
 
 description = ''
 


### PR DESCRIPTION
Maven uses 0.0.1-SNAPSHOT as artifact version, gradle now too (before it was 0.1-SNAPSHOT).