### PR TITLE
More RESTful access to AuditEvents

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -802,6 +802,7 @@ JhipsterGenerator.prototype.app = function app() {
         this.template('src/test/java/package/service/_UserServiceTest.java', testDir + 'service/UserServiceTest.java', this, {});
     }
     this.template('src/test/java/package/web/rest/_AccountResourceTest.java', testDir + 'web/rest/AccountResourceTest.java', this, {});
+    this.template('src/test/java/package/web/rest/_AuditResourceTest.java', testDir + 'web/rest/AuditResourceTest.java', this, {});
     this.template('src/test/java/package/web/rest/_TestUtil.java', testDir + 'web/rest/TestUtil.java', this, {});
     this.template('src/test/java/package/web/rest/_UserResourceTest.java', testDir + 'web/rest/UserResourceTest.java', this, {});
 

--- a/app/templates/src/main/java/package/config/audit/_AuditEventConverter.java
+++ b/app/templates/src/main/java/package/config/audit/_AuditEventConverter.java
@@ -12,6 +12,7 @@ public class AuditEventConverter {
 
     /**
      * Convert a list of PersistentAuditEvent to a list of AuditEvent
+     *
      * @param persistentAuditEvents the list to convert
      * @return the converted list.
      */
@@ -23,12 +24,21 @@ public class AuditEventConverter {
         List<AuditEvent> auditEvents = new ArrayList<>();
 
         for (PersistentAuditEvent persistentAuditEvent : persistentAuditEvents) {
-            AuditEvent auditEvent = new AuditEvent(persistentAuditEvent.getAuditEventDate().toDate(), persistentAuditEvent.getPrincipal(),
-                    persistentAuditEvent.getAuditEventType(), convertDataToObjects(persistentAuditEvent.getData()));
-            auditEvents.add(auditEvent);
+            auditEvents.add(convertToAuditEvent(persistentAuditEvent));
         }
 
         return auditEvents;
+    }
+
+    /**
+     * Convert a PersistentAuditEvent to an AuditEvent
+     *
+     * @param persistentAuditEvent the event to convert
+     * @return the converted list.
+     */
+    public AuditEvent convertToAuditEvent(PersistentAuditEvent persistentAuditEvent) {
+        return new AuditEvent(persistentAuditEvent.getAuditEventDate().toDate(), persistentAuditEvent.getPrincipal(),
+                persistentAuditEvent.getAuditEventType(), convertDataToObjects(persistentAuditEvent.getData()));
     }
 
     /**

--- a/app/templates/src/main/java/package/repository/_PersistenceAuditEventRepository.java
+++ b/app/templates/src/main/java/package/repository/_PersistenceAuditEventRepository.java
@@ -12,7 +12,7 @@ import java.util.List;
  */<% } %><% if (databaseType == 'mongodb') { %>/**
  * Spring Data MongoDB repository for the PersistentAuditEvent entity.
  */<% } %>
-public interface PersistenceAuditEventRepository extends <% if (databaseType == 'sql') { %>JpaRepository<% } %><% if (databaseType == 'mongodb') { %>MongoRepository<% } %><PersistentAuditEvent, String> {
+public interface PersistenceAuditEventRepository extends <% if (databaseType == 'sql') { %>JpaRepository<PersistentAuditEvent, Long><% } %><% if (databaseType == 'mongodb') { %>MongoRepository<PersistentAuditEvent, String><% } %> {
 
     List<PersistentAuditEvent> findByPrincipal(String principal);
 

--- a/app/templates/src/main/java/package/web/rest/_AuditResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AuditResource.java
@@ -8,37 +8,56 @@ import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.WebDataBinder;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 
 import javax.inject.Inject;
 import java.util.List;
+import javax.annotation.security.RolesAllowed;
 
 /**
  * REST controller for getting the audit events.
  */
 @RestController
-@RequestMapping("/api")
+@RequestMapping(value = "/api/audits", produces = MediaType.APPLICATION_JSON_VALUE)
 public class AuditResource {
 
-    @Inject
     private AuditEventService auditEventService;
+
+    @Inject
+    public AuditResource(AuditEventService auditEventService) {
+        this.auditEventService = auditEventService;
+    }
 
     @InitBinder
     public void initBinder(WebDataBinder binder) {
         binder.registerCustomEditor(LocalDateTime.class, new LocaleDateTimeEditor("yyyy-MM-dd", false));
     }
 
-    @RequestMapping(value = "/audits/all",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<AuditEvent> findAll() {
+    @RequestMapping(method = RequestMethod.GET)
+    public List<AuditEvent> getAll() {
         return auditEventService.findAll();
     }
 
-    @RequestMapping(value = "/audits/byDates",
-            method = RequestMethod.GET,
-            produces = MediaType.APPLICATION_JSON_VALUE)
-    public List<AuditEvent> findByDates(@RequestParam(value = "fromDate") LocalDateTime fromDate,
-                                    @RequestParam(value = "toDate") LocalDateTime toDate) {
+    @RequestMapping(method = RequestMethod.GET,
+            params = {"fromDate", "toDate"})
+    public List<AuditEvent> getByDates(@RequestParam(value = "fromDate") LocalDateTime fromDate,
+                                       @RequestParam(value = "toDate") LocalDateTime toDate) {
         return auditEventService.findByDates(fromDate, toDate);
     }
+
+    @RequestMapping(value = "/{id:.+}",
+            method = RequestMethod.GET)
+    public ResponseEntity<AuditEvent> get(@PathVariable <% if (databaseType == 'sql') { %>Long <% } %><% if (databaseType == 'mongodb') { %>String <% } %>id) {
+        <% if (javaVersion == '7') { %>AuditEvent event = auditEventService.find(id);
+        if(event != null){
+            return new ResponseEntity<AuditEvent>(event, HttpStatus.OK);
+        }else{
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }<% } %>
+        <% if (javaVersion == '8') { %>return auditEventService.find(id)
+                .map((entity) -> new ResponseEntity<>(entity, HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));<% } else { %><% } %>
+    }
 }
+

--- a/app/templates/src/main/webapp/scripts/components/admin/_audits.service.js
+++ b/app/templates/src/main/webapp/scripts/components/admin/_audits.service.js
@@ -4,7 +4,7 @@ angular.module('<%=angularAppName%>')
     .factory('AuditsService', function ($http) {
         return {
             findAll: function () {
-                return $http.get('api/audits/all').then(function (response) {
+                return $http.get('api/audits/').then(function (response) {
                     return response.data;
                 });
             },
@@ -17,7 +17,7 @@ angular.module('<%=angularAppName%>')
                     return dateToFormat;
                 };
 
-                return $http.get('api/audits/byDates', {params: {fromDate: formatDate(fromDate), toDate: formatDate(toDate)}}).then(function (response) {
+                return $http.get('api/audits/', {params: {fromDate: formatDate(fromDate), toDate: formatDate(toDate)}}).then(function (response) {
                     return response.data;
                 });
             }

--- a/app/templates/src/test/java/package/web/rest/_AuditResourceTest.java
+++ b/app/templates/src/test/java/package/web/rest/_AuditResourceTest.java
@@ -1,0 +1,108 @@
+package <%=packageName%>.web.rest;
+
+import <%=packageName%>.Application;<% if (databaseType == 'mongodb') { %>
+import <%=packageName%>.config.MongoConfiguration;
+import org.springframework.context.annotation.Import;<% } %>
+import <%=packageName%>.config.audit.AuditEventConverter;
+import <%=packageName%>.domain.PersistentAuditEvent;
+import <%=packageName%>.repository.PersistenceAuditEventRepository;
+import <%=packageName%>.service.AuditEventService;
+import org.joda.time.LocalDateTime;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.MockitoAnnotations;<% if (databaseType == 'sql') { %>
+import org.springframework.transaction.annotation.Transactional;<% } %>
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import javax.inject.Inject;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+/**
+ * Test class for the AuditResource REST controller.
+ *
+ */
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = Application.class)
+@WebAppConfiguration
+@IntegrationTest<% if (databaseType == 'mongodb') { %>
+@Import(MongoConfiguration.class)<% } %><% if (databaseType == 'sql') { %>
+@Transactional<% } %>
+public class AuditResourceTest {
+
+    private static final String SAMPLE_PRINCIPAL = "SAMPLE_PRINCIPAL";
+    private static final String SAMPLE_TYPE = "SAMPLE_TYPE";
+    private static final LocalDateTime SAMPLE_TIMESTAMP = LocalDateTime.parse("2015-08-04T10:11:30");
+
+    @Inject
+    private PersistenceAuditEventRepository auditEventRepository;
+
+    @Inject
+    private AuditEventConverter auditEventConverter;
+
+    private PersistentAuditEvent auditEvent;
+
+    private MockMvc restAuditMockMvc;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+        AuditEventService auditEventService =
+                new AuditEventService(auditEventRepository, auditEventConverter);
+        AuditResource auditResource = new AuditResource(auditEventService);
+        this.restAuditMockMvc = MockMvcBuilders.standaloneSetup(auditResource).build();
+    }
+
+    @Before
+    public void initTest() {
+        auditEventRepository.deleteAll();
+        auditEvent = new PersistentAuditEvent();
+        auditEvent.setAuditEventType(SAMPLE_TYPE);
+        auditEvent.setPrincipal(SAMPLE_PRINCIPAL);
+        auditEvent.setAuditEventDate(SAMPLE_TIMESTAMP);
+    }
+
+
+    @Test
+    public void getAllAudits() throws Exception {
+        // Initialize the database
+        auditEventRepository.save(auditEvent);
+
+        // Get all the audits
+        restAuditMockMvc.perform(get("/api/audits"))
+                .andExpect(status().isOk())
+                // .andDo(print())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.[*].principal").value(hasItem(SAMPLE_PRINCIPAL)));
+    }
+
+    @Test
+    public void getAudit() throws Exception {
+        // Initialize the database
+        auditEventRepository.save(auditEvent);
+
+        // Get the audit
+        restAuditMockMvc.perform(get("/api/audits/{id}", auditEvent.getId()))
+                .andExpect(status().isOk())
+                .andExpect(content().contentType(MediaType.APPLICATION_JSON))
+                .andExpect(jsonPath("$.principal").value(SAMPLE_PRINCIPAL));
+    }
+
+    @Test
+    public void getNonExistingAudit() throws Exception {
+        // Get the audit
+        restAuditMockMvc.perform(get("/api/audits/{id}", Long.MAX_VALUE))
+                .andExpect(status().isNotFound());
+    }
+
+}

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -142,6 +142,7 @@ describe('JHipster generator ', function () {
             'src/test/java/com/mycompany/myapp/security/SecurityUtilsTest.java',
             'src/test/java/com/mycompany/myapp/service/UserServiceTest.java',
             'src/test/java/com/mycompany/myapp/web/rest/AccountResourceTest.java',
+            'src/test/java/com/mycompany/myapp/web/rest/AuditResourceTest.java',
             'src/test/java/com/mycompany/myapp/web/rest/TestUtil.java',
             'src/test/java/com/mycompany/myapp/web/rest/UserResourceTest.java',
             'src/test/resources/config/application.yml',


### PR DESCRIPTION
change URL mappings to /api/audits and handle methods dispatching based on parameters
add tests for AuditResource
fix bug where PersistenceAuditEventRepository has String as ID type for SQL databases (schema declares autoincremented bigint)
add alternative Optional-based service API if Java 8 is used
resolve https://github.com/jhipster/generator-jhipster/issues/1899