### PR TITLE
Entity relationship improvements

### DIFF
--- a/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
@@ -8,7 +8,7 @@ angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogContro
             var queries = [];
             for (idx in relationships) {
                 var query;
-                if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide == true) {
+                if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide == true && relationships[idx].otherEntityName != 'user') {
                     query = '$scope.' + relationships[idx].relationshipFieldName.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + ".query({filter: '" + relationships[idx].otherEntityRelationshipName.toLowerCase() + "-is-null'});"
                 + "\n        $q.all([$scope." + relationships[idx].otherEntityRelationshipName + ".$promise, $scope." + relationships[idx].relationshipFieldName.toLowerCase() + "s.$promise]).then(function() {"
                 + "\n            if (!$scope." + relationships[idx].otherEntityRelationshipName + "." + relationships[idx].relationshipFieldName + (dto == 'no' ? ".id" : "Id") + ") {"
@@ -17,7 +17,8 @@ angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogContro
                 + "\n            return " + relationships[idx].otherEntityNameCapitalized + ".get({id : $scope." + relationships[idx].otherEntityRelationshipName + "." + relationships[idx].relationshipFieldName + (dto == 'no' ? ".id" : "Id") + "}).$promise;"
                 + "\n        }).then(function(" + relationships[idx].relationshipFieldName + ") {"
                 + "\n            $scope." + relationships[idx].relationshipFieldName.toLowerCase() + "s.push(" + relationships[idx].relationshipFieldName + ");"
-                + "\n        });";                } else {
+                + "\n        });";
+                } else {
                     query = '$scope.' + relationships[idx].otherEntityNameCapitalized.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + '.query();';
                 }
                 if (!util.contains(queries, query)) {

--- a/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-dialog-controller.js
@@ -1,16 +1,23 @@
 'use strict';
 
 angular.module('<%=angularAppName%>').controller('<%= entityClass %>DialogController',
-    ['$scope', '$stateParams', '$modalInstance', 'entity', '<%= entityClass %>'<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, '<%= differentTypes[idx] %>'<% } } %>,
-        function($scope, $stateParams, $modalInstance, entity, <%= entityClass %><% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, <%= differentTypes[idx] %><% } } %>) {
+    ['$scope', '$stateParams', '$modalInstance'<% if (fieldsContainOwnerOneToOne) { %>, '$q'<% } %>, 'entity', '<%= entityClass %>'<% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, '<%= differentTypes[idx] %>'<% } } %>,
+        function($scope, $stateParams, $modalInstance<% if (fieldsContainOwnerOneToOne) { %>, $q<% } %>, entity, <%= entityClass %><% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, <%= differentTypes[idx] %><% } } %>) {
 
         $scope.<%= entityInstance %> = entity;<%
             var queries = [];
             for (idx in relationships) {
                 var query;
                 if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide == true) {
-                    query = '$scope.' + relationships[idx].relationshipFieldName.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + ".query({filter: '" + relationships[idx].otherEntityRelationshipName.toLowerCase() + "-is-null'});";
-                } else {
+                    query = '$scope.' + relationships[idx].relationshipFieldName.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + ".query({filter: '" + relationships[idx].otherEntityRelationshipName.toLowerCase() + "-is-null'});"
+                + "\n        $q.all([$scope." + relationships[idx].otherEntityRelationshipName + ".$promise, $scope." + relationships[idx].relationshipFieldName.toLowerCase() + "s.$promise]).then(function() {"
+                + "\n            if (!$scope." + relationships[idx].otherEntityRelationshipName + "." + relationships[idx].relationshipFieldName + (dto == 'no' ? ".id" : "Id") + ") {"
+                + "\n                return $q.reject();"
+                + "\n            }"
+                + "\n            return " + relationships[idx].otherEntityNameCapitalized + ".get({id : $scope." + relationships[idx].otherEntityRelationshipName + "." + relationships[idx].relationshipFieldName + (dto == 'no' ? ".id" : "Id") + "}).$promise;"
+                + "\n        }).then(function(" + relationships[idx].relationshipFieldName + ") {"
+                + "\n            $scope." + relationships[idx].relationshipFieldName.toLowerCase() + "s.push(" + relationships[idx].relationshipFieldName + ");"
+                + "\n        });";                } else {
                     query = '$scope.' + relationships[idx].otherEntityNameCapitalized.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + '.query();';
                 }
                 if (!util.contains(queries, query)) {

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -36,7 +36,7 @@
                var values = fields[fieldId].fieldValues.split(",");
                for (key in values) {
                  var value = values[key]; %>
-               <option value="<%= value %>" translate="<%=enumPrefix%>.<%=value%>"><%= value %></option><%
+                <option value="<%= value %>" translate="<%=enumPrefix%>.<%=value%>"><%= value %></option><%
                } %>
             </select><% } else { %><% if (fields[fieldId].fieldType == 'byte[]') { %>
             <div><% if (fields[fieldId].fieldTypeBlobContent == 'image') { %>
@@ -116,18 +116,26 @@
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
             <% if (dto == 'no') { %>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id"></select>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id">
+                <option value=""></option>
+            </select>
             <% } else { %>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s"></select>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=otherEntityName.toLowerCase() %>s">
+                <option value=""></option>
+            </select>
             <% } %>
         </div>
 <% } else if (relationshipType == 'one-to-one' && ownerSide == true) { -%>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
             <% if (dto == 'no') { %>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s track by <%=otherEntityName %>.id"></select>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s track by <%=otherEntityName %>.id">
+                <option value=""></option>
+            </select>
             <% } else { %>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s"></select>
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s">
+                <option value=""></option>
+            </select>
             <% } %>
         </div>
 <% } else if (relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) { -%>

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -112,7 +112,7 @@
     var otherEntityFieldCapitalized = relationships[relationshipId].otherEntityFieldCapitalized;
     var translationKey = keyPrefix + relationshipName; 
 -%>
-<% if (relationshipType == 'many-to-one') { -%>
+<% if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide == true && otherEntityName == 'user')) { -%>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
             <% if (dto == 'no') { %>

--- a/entity/templates/src/main/webapp/app/_entity-dialog.html
+++ b/entity/templates/src/main/webapp/app/_entity-dialog.html
@@ -129,11 +129,11 @@
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%=relationshipName %></label>
             <% if (dto == 'no') { %>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s track by <%=otherEntityName %>.id">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s | orderBy:'id' track by <%=otherEntityName %>.id">
                 <option value=""></option>
             </select>
             <% } else { %>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in <%=relationshipFieldName.toLowerCase() %>s | orderBy:'id'">
                 <option value=""></option>
             </select>
             <% } %>

--- a/entity/templates/src/main/webapp/i18n/_entity_ca.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ca.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_da.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_da.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_de.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_de.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_en.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_en.json
@@ -16,7 +16,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_es.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_es.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_fr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_fr.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_hu.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_hu.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_it.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_it.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_ja.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ja.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_kr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_kr.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_nl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_nl.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_pl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pl.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_ru.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ru.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_sv.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_sv.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_tr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_tr.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_zh-cn.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_zh-cn.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }

--- a/entity/templates/src/main/webapp/i18n/_entity_zh-tw.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_zh-tw.json
@@ -13,7 +13,7 @@
                 "title": "<%= entityClass %>"
             }<% for (fieldId in fields) { %>,
             "<%=fields[fieldId].fieldName%>": "<%=fields[fieldId].fieldNameCapitalized%>"<% } %><% for (relationshipId in relationships) { %>,
-            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipName %>"<% } %>
+            "<%=relationships[relationshipId].relationshipName%>": "<%= relationships[relationshipId].relationshipNameCapitalized %>"<% } %>
         }
     }
 }


### PR DESCRIPTION
Further entity improvments
- Add empty options to select inputs so that relationship can be resetted
- Add current value of relationship to select inputs of one to one relatinships (today the current value is displayed as a blank option which is confusing)
- Treat one to one relationships to the User object differently since it is not possible to modify the UserResource from the entity generator. Instead of showing user id's not in a relationship, show all user ids in the select input. The user will not be able to select user ids already used in a relationship since an sql exception will be thrown. A future improvement would be to make this error message more readable to the user. 
- Capitalize relationship field names in translations