### PR TITLE
Fixed translations not being loaded when the user refreshes the docs …

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/admin/docs/_docs.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/docs/_docs.js
@@ -14,6 +14,11 @@ angular.module('<%=angularAppName%>')
                     'content@': {
                         templateUrl: 'scripts/app/admin/docs/docs.html'
                     }
+                },
+                resolve: {
+                    translatePartialLoader: ['$translate', function ($translate) {
+                        return $translate.refresh();
+                    }]
                 }
             });
     });


### PR DESCRIPTION
I'm new to JHipster, so I said to try and fix a minor issue. Whenever I refreshed the docs page, the translations were lost. I saw that docs.js was missing the resolve translations part, so I added it.
I searched and didn't find anything about this bug so I did this PR.