### PR TITLE
remove recommended for maven

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -322,7 +322,7 @@ JhipsterGenerator.prototype.askFor = function askFor() {
             choices: [
                 {
                     value: 'maven',
-                    name: 'Maven (recommended)'
+                    name: 'Maven'
                 },
                 {
                     value: 'gradle',


### PR DESCRIPTION
make maven and gradle equally supported options
by removing the recommended label for maven
will update the documentation site as well

fix #1942