### PR TITLE
fix error with float types and H2 database

### DIFF
--- a/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -11,7 +11,7 @@
     <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql"/>
     <property name="autoIncrement" value="false" dbms="oracle"/>
 
-    <property name="floatType" value="real" dbms="postgresql, h2"/>
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
     <property name="floatType" value="float" dbms="mysql, oracle"/>
 
     <!--


### PR DESCRIPTION
Liquibase creates "real" type as "float" and in H2 "FLOAT" is an alias for "DOUBLE". See https://github.com/liquibase/liquibase/pull/496
This makes the tests fail if an entity has a float field
This PR uses float4 which is correct for both H2 and postgres to represent floats
