### PR TITLE
Add documentation about (Yeoman/EJS) templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -172,11 +172,11 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 The template engine used by yeoman is [EJS](http://ejs.co/), its syntax is fairly simple.
 For simple code (few lines), logic can be embedded in the main file but if logic becomes more complex it's better to externalise the JS fragment to a sub template included by the first one and located in same folder.
 
-Sub templates should be named with the `ejs` extension because it's the default one, it enables editors to apply correct syntax hilighting and it enables us to use a very concise syntax:
+Sub templates should be named with the `ejs` extension because it's the default one, it enables editors to apply correct syntax highlighting and it enables us to use a very concise syntax:
 
     <%- include field_validators -%>
 
-[_Entity.java](https://github.com/gmarziou/generator-jhipster/blob/validators/entity/templates/src/main/java/package/domain/_Entity.java) includes [field_validators.ejs](https://github.com/gmarziou/generator-jhipster/blob/validators/entity/templates/src/main/java/package/domain/field_validators.ejs)
+This staement means that [_Entity.java](entity/templates/src/main/java/package/domain/_Entity.java) template includes [field_validators.ejs](entity/templates/src/main/java/package/domain/field_validators.ejs) sub template.
 
 Sub templates can be unit tested.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,4 +1,4 @@
-#Contributing to JHipster
+# Contributing to JHipster
 
 Are you ready to contribute to JHipster? We'd love to have you on board, and we will help you as much as we can. Here are the guidelines we'd like you to follow so that we can be of more help:
 
@@ -166,6 +166,19 @@ To ensure consistency throughout the source code, keep these rules in mind as yo
 * All files must follow the [.editorconfig file](http://editorconfig.org/) located at the root of the JHipster generator project. Please note that generated projects use the same .editorconfig file, so that both the generator and the generated projects share the same configuration.
 * Java files **must be** formatted using [Intellij IDEA's code style](http://confluence.jetbrains.com/display/IntelliJIDEA/Code+Style+and+Formatting). Please note that JHipster commiters have a free Intellij IDEA Ultimate Edition for developing the project.
 * JavaScript files **must follow** [Google's JavaScript Style Guide](https://google-styleguide.googlecode.com/svn/trunk/javascriptguide.xml).
+
+## <a name="templates"></a> Template Guidelines
+
+The template engine used by yeoman is [EJS](http://ejs.co/), its syntax is fairly simple.
+For simple code (few lines), logic can be embedded in the main file but if logic becomes more complex it's better to externalise the JS fragment to a sub template included by the first one and located in same folder.
+
+Sub templates should be named with the `ejs` extension because it's the default one, it enables editors to apply correct syntax hilighting and it enables us to use a very concise syntax:
+
+    <%- include field_validators -%>
+
+[_Entity.java](https://github.com/gmarziou/generator-jhipster/blob/validators/entity/templates/src/main/java/package/domain/_Entity.java) includes [field_validators.ejs](https://github.com/gmarziou/generator-jhipster/blob/validators/entity/templates/src/main/java/package/domain/field_validators.ejs)
+
+Sub templates can be unit tested.
 
 ## <a name="commit"></a> Git Commit Guidelines
 


### PR DESCRIPTION
Add documentation about (Yeoman/EJS) templates to 'Contributing guidelines'.

Fixes #1749