### PR TITLE
#2001 Used short code `cf -v` to determine whether cf CLI tools are installed ...

### DIFF
--- a/cloudfoundry/index.js
+++ b/cloudfoundry/index.js
@@ -81,7 +81,7 @@ CloudFoundryGenerator.prototype.checkInstallation = function checkInstallation()
     if(this.abort) return;
     var done = this.async();
 
-    exec('cf --version', function (err) {
+    exec('cf -v', function (err) {
         if (err) {
             this.log.error('cloudfoundry\'s cf command line interface is not available. ' +
             'You can install it via https://github.com/cloudfoundry/cli/releases');


### PR DESCRIPTION
… properly. Fixes issues with current cf version 6.12.3.

See issue #2001.