### PR TITLE
Specify Cloud Foundry buildpack

### DIFF
--- a/cloudfoundry/templates/_manifest.yml
+++ b/cloudfoundry/templates/_manifest.yml
@@ -1,6 +1,7 @@
 ---
 path: .
 instances: 1
+buildpack: https://github.com/cloudfoundry/java-buildpack
 services:
 - <%= cloudfoundryDeployedName %>
 applications:


### PR DESCRIPTION
Setting a specific buildpack will make sure the behaviour of the application is consistent on all Cloud Foundry providers. Bluemix uses a different default buildpack that doesn't use Java 8 by default, so currently Java 8 apps fail.