### PR TITLE
Added support for max long valitation greater than Integer.MAX_VALUE

### DIFF
--- a/entity/templates/src/main/java/package/domain/field_validators.ejs
+++ b/entity/templates/src/main/java/package/domain/field_validators.ejs
@@ -6,6 +6,7 @@ var result = '';
 if (field.fieldValidate == true) {
 	var rules = field.fieldValidateRules;
 	var validators = [];
+  var MAX_VALUE = 2147483647;
 
     if (rules.indexOf('required') != -1) {
         validators.push('@NotNull');
@@ -32,7 +33,8 @@ if (field.fieldValidate == true) {
         validators.push('@Min(value = ' + field.fieldValidateRulesMin + ')');
     }
     if (rules.indexOf('max') != -1) {
-        validators.push('@Max(value = ' + field.fieldValidateRulesMax + ')');
+        var isLong = (field.fieldValidateRulesMax > MAX_VALUE) ? 'L' : '';
+        validators.push('@Max(value = ' + field.fieldValidateRulesMax + isLong + ')');
     }
     if (rules.indexOf('pattern') != -1) {
         validators.push('@Pattern(regexp = "' + field.fieldValidateRulesPatternJava  + '")');

--- a/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -24,6 +24,7 @@ public class <%= entityClass %>DTO implements Serializable {
     private UUID id;<% } %><% for (fieldId in fields) { %>
 <% if (fields[fieldId].fieldValidate == true) {
     var required = false;
+    var MAX_VALUE = 2147483647;
     if (fields[fieldId].fieldValidate == true && fields[fieldId].fieldValidateRules.indexOf('required') != -1) {
         required = true;
     }
@@ -36,7 +37,7 @@ public class <%= entityClass %>DTO implements Serializable {
     @Size(max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('minbytes') != -1 && fields[fieldId].fieldValidateRules.indexOf('maxbytes') != -1) { %>
     @Size(min = <%= fields[fieldId].fieldValidateRulesMinbytes %>, max = <%= fields[fieldId].fieldValidateRulesMaxbytes %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('min') != -1) { %>
     @Min(value = <%= fields[fieldId].fieldValidateRulesMin %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('max') != -1) { %>
-    @Max(value = <%= fields[fieldId].fieldValidateRulesMax %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
+    @Max(value = <%= fields[fieldId].fieldValidateRulesMax %><%= (fields[fieldId].fieldValidateRulesMax > MAX_VALUE) ? 'L' : '' %>)<% } %><% if (fields[fieldId].fieldValidateRules.indexOf('pattern') != -1) { %>
     @Pattern(regexp = "<%= fields[fieldId].fieldValidateRulesPatternJava %>")<% } } %><% if (fields[fieldId].fieldType == 'byte[]') { %>
     @Lob<% } %>
     private <%= fields[fieldId].fieldType %> <%= fields[fieldId].fieldName %>;<% } %><% for (relationshipId in relationships) {


### PR DESCRIPTION
Pull request according to the issue reported [2025](https://github.com/jhipster/generator-jhipster/issues/2025).

When it is created an entity numeric field as numeric, if validation maximum value is greater than Integer.MAX_VALUE(2147483647 in Java), the "Max" annotation must include a "L" at the end (as Long number).