### PR TITLE
Generate docker-compose

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -508,6 +508,9 @@ JhipsterGenerator.prototype.app = function app() {
     if (this.devDatabaseType != "h2Memory" && this.devDatabaseType != "oracle") {
         this.template('_docker-compose.yml', 'docker-compose.yml', this, {});
     }
+    if (this.prodDatabaseType != "oracle") {
+        this.template('_docker-compose-prod.yml', 'docker-compose-prod.yml', this, {});
+    }
     if (this.devDatabaseType == "cassandra") {
         this.template('_Dockerfile_cassandra', 'Dockerfile', this, {});
     }

--- a/app/index.js
+++ b/app/index.js
@@ -504,6 +504,14 @@ JhipsterGenerator.prototype.app = function app() {
     this.copy('gitignore', '.gitignore');
     this.copy('gitattributes', '.gitattributes');
 
+    // Create docker-compose file
+    if (this.devDatabaseType != "h2Memory" && this.devDatabaseType != "oracle") {
+        this.template('_docker-compose.yml', 'docker-compose.yml', this, {});
+    }
+    if (this.devDatabaseType == "cassandra") {
+        this.template('_Dockerfile_cassandra', 'Dockerfile', this, {});
+    }
+
     switch (this.frontendBuilder) {
         case 'gulp':
             this.template('gulpfile.js', 'gulpfile.js', this, {});

--- a/app/templates/_Dockerfile_cassandra
+++ b/app/templates/_Dockerfile_cassandra
@@ -1,0 +1,16 @@
+FROM cassandra
+MAINTAINER Pascal Grimaud <pascalgrimaud@gmail.com>
+
+# add script cql
+ADD src/main/resources/config/cql/create-keyspace.cql /create-keyspace.cql
+ADD src/main/resources/config/cql/create-tables.cql /create-tables.cql
+
+# concat 2 scripts to 1
+RUN cat create-keyspace.cql > create-keyspace-tables.cql
+RUN echo "USE <%=baseName%>;" >> create-keyspace-tables.cql
+RUN cat create-tables.cql >> create-keyspace-tables.cql
+
+# init, for easier docker exec
+RUN echo "#!/bin/bash" > /usr/local/bin/init
+RUN echo "cqlsh -f create-keyspace-tables.cql" >> /usr/local/bin/init
+RUN chmod 755 /usr/local/bin/init

--- a/app/templates/_docker-compose-prod.yml
+++ b/app/templates/_docker-compose-prod.yml
@@ -1,0 +1,41 @@
+<% if (prodDatabaseType == 'mysql') { %>jhipster-prod-mysql:
+  container_name: <%=baseName%>-prod-mysql
+  image : mysql
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/prod-mysql/:/var/lib/mysql/
+  environment:
+  - MYSQL_USER=root
+  - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+  - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
+  ports:
+  - "3306:3306"
+  command: mysqld --lower_case_table_name=1
+<% } if (prodDatabaseType == 'postgresql') { %>jhipster-prod-postgresql:
+  container_name: <%=baseName%>-prod-postgresql
+  image : postgres
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/prod-postgresql/:/var/lib/postgresql/
+  environment:
+  - POSTGRES_USER=<%=baseName%>
+  - POSTGRES_PASSWORD=
+  ports:
+  - "5432:5432"
+<% } if (prodDatabaseType == 'mongodb') { %>jhipster-prod-mongodb:
+  container_name: <%=baseName%>-prod-mongodb
+  image: mongo
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/prod-mongodb/:/data/db/
+  ports:
+  - "27017:27017"
+<% } if (prodDatabaseType == 'cassandra') { %>jhipster-prod-cassandra:
+  container_name: <%=baseName%>-prod-cassandra
+  build: .
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/prod-cassandra/:/var/lib/cassandra/data
+  ports:
+  - "7000:7000"
+  - "7001:7001"
+  - "7199:7199"
+  - "9042:9042"
+  - "9160:9160"
+<% } %>

--- a/app/templates/_docker-compose.yml
+++ b/app/templates/_docker-compose.yml
@@ -1,37 +1,37 @@
-<% if (devDatabaseType == 'mysql') { %>jhipster-mysql:
-  container_name: jhipster-<%=baseName%>-mysql
+<% if (devDatabaseType == 'mysql') { %>jhipster-dev-mysql:
+  container_name: <%=baseName%>-dev-mysql
   image : mysql
   # volumes:
-  # - ~/volumes/jhipster/<%=baseName%>/mysql/:/var/lib/mysql/
+  # - ~/volumes/jhipster/<%=baseName%>/dev-mysql/:/var/lib/mysql/
   environment:
   - MYSQL_USER=root
   - MYSQL_ALLOW_EMPTY_PASSWORD=yes
-  - MYSQL_DATABASE=<%=baseName%>
+  - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
   ports:
   - "3306:3306"
   command: mysqld --lower_case_table_name=1
-<% } if (devDatabaseType == 'postgresql') { %>jhipster-postgresql:
-  container_name: jhipster-<%=baseName%>-postgresql
+<% } if (devDatabaseType == 'postgresql') { %>jhipster-dev-postgresql:
+  container_name: <%=baseName%>-dev-postgresql
   image : postgres
   # volumes:
-  # - ~/volumes/jhipster/<%=baseName%>/postgresql/:/var/lib/postgresql/
+  # - ~/volumes/jhipster/<%=baseName%>/dev-postgresql/:/var/lib/postgresql/
   environment:
   - POSTGRES_USER=<%=baseName%>
   - POSTGRES_PASSWORD=
   ports:
   - "5432:5432"
-<% } if (devDatabaseType == 'mongodb') { %>jhipster-mongodb:
-  container_name: jhipster-<%=baseName%>-mongodb
+<% } if (devDatabaseType == 'mongodb') { %>jhipster-dev-mongodb:
+  container_name: <%=baseName%>-dev-mongodb
   image: mongo
   # volumes:
-  # - ~/volumes/jhipster/<%=baseName%>/mongodb/:/data/db/
+  # - ~/volumes/jhipster/<%=baseName%>/dev-mongodb/:/data/db/
   ports:
   - "27017:27017"
-<% } if (devDatabaseType == 'cassandra') { %>jhipster-cassandra:
-  container_name: jhipster-<%=baseName%>-cassandra
+<% } if (devDatabaseType == 'cassandra') { %>jhipster-dev-cassandra:
+  container_name: <%=baseName%>-dev-cassandra
   build: .
   # volumes:
-  # - ~/volumes/jhipster/<%=baseName%>/cassandra/:/var/lib/cassandra/data
+  # - ~/volumes/jhipster/<%=baseName%>/dev-cassandra/:/var/lib/cassandra/data
   ports:
   - "7000:7000"
   - "7001:7001"

--- a/app/templates/_docker-compose.yml
+++ b/app/templates/_docker-compose.yml
@@ -1,0 +1,41 @@
+<% if (devDatabaseType == 'mysql') { %>jhipster-mysql:
+  container_name: jhipster-<%=baseName%>-mysql
+  image : mysql
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/mysql/:/var/lib/mysql/
+  environment:
+  - MYSQL_USER=root
+  - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+  - MYSQL_DATABASE=<%=baseName%>
+  ports:
+  - "3306:3306"
+  command: mysqld --lower_case_table_name=1
+<% } if (devDatabaseType == 'postgresql') { %>jhipster-postgresql:
+  container_name: jhipster-<%=baseName%>-postgresql
+  image : postgres
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/postgresql/:/var/lib/postgresql/
+  environment:
+  - POSTGRES_USER=<%=baseName%>
+  - POSTGRES_PASSWORD=
+  ports:
+  - "5432:5432"
+<% } if (devDatabaseType == 'mongodb') { %>jhipster-mongodb:
+  container_name: jhipster-<%=baseName%>-mongodb
+  image: mongo
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/mongodb/:/data/db/
+  ports:
+  - "27017:27017"
+<% } if (devDatabaseType == 'cassandra') { %>jhipster-cassandra:
+  container_name: jhipster-<%=baseName%>-cassandra
+  build: .
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/cassandra/:/var/lib/cassandra/data
+  ports:
+  - "7000:7000"
+  - "7001:7001"
+  - "7199:7199"
+  - "9042:9042"
+  - "9160:9160"
+<% } %>


### PR DESCRIPTION
Hello,

**Description** :
As discussed in #1674 (which is closed), I want to propose this.
This is a first pull request about docker-compose, to know if I'm in correct way.

The main goal is to provided the other services **for the developer to start faster** !
After generating a new JHipster project, you'll have a new `docker-compose.yml` file in the folder project.
You can simply ignore this file or... if you like Docker, you can start the service needed by your project.

For example, you decided to build a new project with MySQL in DEV (instead of H2)
```
yo jhipster
docker-compose up -d
mvn spring-boot:run
```

You don't have to install or configure a new database.
At the moment, it works with MySQL, PostgreSQL, MongoDB, Cassandra.

With Cassandra, you have to build the image, inject the cql files and execute the cql :
```
yo jhipster
docker-compose build
docker-compose up -d
docker exec -it <name or id of the container> init
mvn spring-boot:run
```

**Prerequisite** :
- have docker & docker-compose installed

**Improvements** :
- improve the cassandra : I don't like my solution
  - Maybe rework the entrypoint.sh ?
  - Provide a jhipster/cassandra in docker-hub ?
- add elasticsearch
- add hazelcast
- add oracle
- work on volumes, because it's different with Mac / Windows. At the moment, the volume is commented in docker-compose.yml file
- add different docker-compose with different profile

**Tests** :
I tested the generator with linuxmint and ubuntu, I don't have OSX or Windows, sorry...
Probably on Mac or Windows, you have to edit your application-dev.xml after `docker-compose up` ?

I hope it will help the project.
Thanks @jdubois and all contributors for making JHipster a so cool project.
