### PR TITLE
Added rule to only permit users with ADMIN authority to access /api/users

### DIFF
--- a/app/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/app/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -135,6 +135,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
             .antMatchers("/api/account/reset_password/finish").permitAll()
             .antMatchers("/api/logs/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/api/audits/**").hasAuthority(AuthoritiesConstants.ADMIN)
+            .antMatchers("/api/users/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/api/**").authenticated()<% if (websocket == 'spring-websocket') { %>
             .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/websocket/**").permitAll()<% } %>


### PR DESCRIPTION
A user with role USER (not ADMIN), can access the route of /api/users/** that gives us the list of users with all their information. I think that should be restricted only for those with a role of ADMIN. 