### PR TITLE
browsersync ignores changes on angular templates

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -96,7 +96,7 @@ module.exports = function (grunt) {
                         'src/main/webapp/**/*.html',
                         'src/main/webapp/**/*.json',
                         'src/main/webapp/assets/styles/**/*.css',
-                        'src/main/webapp/scripts/**/*.js',
+                        'src/main/webapp/scripts/**/*.{js,html}',
                         'src/main/webapp/assets/images/**/*.{png,jpg,jpeg,gif,webp,svg}',
                         'tmp/**/*.{css,js}'
                     ]


### PR DESCRIPTION
The longer "src/main/webapp/scripts/**/*.js" path seems to override the shorter "src/main/webapp/**/*.html" path, so changes in html-templates didn't get picked up by browsersync.