### PR TITLE
Fix Elasticsearch default port in profile production

### DIFF
--- a/app/templates/src/main/resources/config/_application-prod.yml
+++ b/app/templates/src/main/resources/config/_application-prod.yml
@@ -96,7 +96,7 @@ spring:
     data:
         elasticsearch:
             cluster-name:
-            cluster-nodes: localhost:9200
+            cluster-nodes: localhost:9300
     <%_ } _%>
     thymeleaf:
         cache: true

--- a/app/templates/src/main/resources/config/_application-prod.yml
+++ b/app/templates/src/main/resources/config/_application-prod.yml
@@ -34,7 +34,7 @@ spring:
         <%_ } else if (prodDatabaseType == 'oracle') { _%>
         url: jdbc:oracle:thin:@localhost:1521:<%= baseName %>
         <%_ } _%>
-        databaseName: <% if (prodDatabaseType == 'postgresql') { %><%= baseName %><% } %>
+        name: <% if (prodDatabaseType == 'postgresql') { %><%= baseName %><% } %>
         <%_ if (prodDatabaseType == 'mysql') { _%>
         username: root
         <%_ } else if (prodDatabaseType == 'postgresql') { _%>


### PR DESCRIPTION
I'm testing elasticsearch and I got the same problem #1660

In development profile, no error because it's an embedded Elasticsearch

In production profile, I got this error when starting the app :
```
[INFO] com.mycompany.myapp.config.ThymeleafConfiguration - loading non-reloadable mail messages resources
[ERROR] org.springframework.data.elasticsearch.repository.support.AbstractElasticsearchRepository - failed to load elasticsearch nodes : org.elasticsearch.client.transport.NoNodeAvailableException: None of the configured nodes are available: []
[INFO] com.mycompany.myapp.Application - Started Application in 24.697 seconds (JVM running for 25.311)
```

The elasticsearch logs :
```
[2015-10-03 19:29:33,589][WARN ][http.netty               ] [Spike] Caught exception while handling client http traffic, closing connection [id: 0x0f6c5855, /127.0.0.1:35353 => /127.0.0.1:9200]
java.lang.IllegalArgumentException: empty text
	at org.elasticsearch.common.netty.handler.codec.http.HttpVersion.<init>(HttpVersion.java:89)
	at org.elasticsearch.common.netty.handler.codec.http.HttpVersion.valueOf(HttpVersion.java:62)
	at org.elasticsearch.common.netty.handler.codec.http.HttpRequestDecoder.createMessage(HttpRequestDecoder.java:75)
	at org.elasticsearch.common.netty.handler.codec.http.HttpMessageDecoder.decode(HttpMessageDecoder.java:191)
```

In the `application-prod.yml` file, if I change : `cluster-nodes: localhost:9200` to `cluster-nodes: localhost:9300`, it seems to work.
App logs, no error :
```
[INFO] com.mycompany.myapp.config.ThymeleafConfiguration - loading non-reloadable mail messages resources
[INFO] com.mycompany.myapp.Application - Started Application in 18.54 seconds (JVM running for 19.119)
```

Elasticsearch logs :
```
[2015-10-03 19:45:08,013][INFO ][cluster.metadata         ] [Thunderclap] [user] creating index, cause [api], templates [], shards [5]/[1], mappings []
[2015-10-03 19:45:08,340][INFO ][cluster.metadata         ] [Thunderclap] [user] create_mapping [user]
```

Am I correct ?
