### PR TITLE
Add elasticsearch for docker-compose

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -498,7 +498,7 @@ JhipsterGenerator.prototype.app = function app() {
     if (this.devDatabaseType != "h2Memory" && this.devDatabaseType != "oracle") {
         this.template('_docker-compose.yml', 'docker-compose.yml', this, {});
     }
-    if (this.prodDatabaseType != "oracle") {
+    if (this.prodDatabaseType != "oracle" || this.searchEngine == "elasticsearch") {
         this.template('_docker-compose-prod.yml', 'docker-compose-prod.yml', this, {});
     }
     if (this.devDatabaseType == "cassandra") {

--- a/app/templates/_docker-compose-prod.yml
+++ b/app/templates/_docker-compose-prod.yml
@@ -1,6 +1,14 @@
-<% if (prodDatabaseType == 'mysql') { %>jhipster-prod-mysql:
+<% if (searchEngine == 'elasticsearch') { %>jhipster-prod-elasticsearch:
+  container_name: <%=baseName%>-prod-elasticsearch
+  image: elasticsearch
+  # volumes:
+  # - ~/volumes/jhipster/<%=baseName%>/prod-elasticsearch/:/usr/share/elasticsearch/data/
+  ports:
+  - "9200:9200"
+  - "9300:9300"
+<% } if (prodDatabaseType == 'mysql') { %>jhipster-prod-mysql:
   container_name: <%=baseName%>-prod-mysql
-  image : mysql
+  image: mysql
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-mysql/:/var/lib/mysql/
   environment:
@@ -12,7 +20,7 @@
   command: mysqld --lower_case_table_name=1
 <% } if (prodDatabaseType == 'postgresql') { %>jhipster-prod-postgresql:
   container_name: <%=baseName%>-prod-postgresql
-  image : postgres
+  image: postgres
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-postgresql/:/var/lib/postgresql/
   environment:

--- a/app/templates/_docker-compose.yml
+++ b/app/templates/_docker-compose.yml
@@ -1,6 +1,6 @@
 <% if (devDatabaseType == 'mysql') { %>jhipster-dev-mysql:
   container_name: <%=baseName%>-dev-mysql
-  image : mysql
+  image: mysql
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/dev-mysql/:/var/lib/mysql/
   environment:
@@ -12,7 +12,7 @@
   command: mysqld --lower_case_table_name=1
 <% } if (devDatabaseType == 'postgresql') { %>jhipster-dev-postgresql:
   container_name: <%=baseName%>-dev-postgresql
-  image : postgres
+  image: postgres
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/dev-postgresql/:/var/lib/postgresql/
   environment:


### PR DESCRIPTION
I added Elasticsearch for production profile, if search engine is Elasticsearch :
* MySQL : elasticsearch + mysql
* PostgreSQL : elasticsearch + psql
* Oracle : only elasticsearch, because there isn't official docker database 12c

@atomfrede : could you test this, if you have time ? Thanks in advance.
