### PR TITLE
remove annoying google translation popup question

### DIFF
--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -5,6 +5,9 @@
         <meta http-equiv="X-UA-Compatible" content="IE=edge">
         <title><%= baseName %></title>
         <meta name="description" content="">
+        <%_ if(enableTranslation) { _%>
+        <meta name="google" value="notranslate">
+        <%_ } _%>
         <meta name="viewport" content="width=device-width">
         <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->
         <!-- build:css assets/styles/vendor.css -->


### PR DESCRIPTION
Not sure this is wanted since it does not follow 
```
Policy 1: technologies used by JHipster have their default configuration used as much as possible
```
but it really annoys me that google chrome tries to translate the webpage when in fact there is already a translate mechanism in angular. 

Please feel free to close this if this is not wanted.

