### PR TITLE
Remove watcher from $rootScope upon $scope destroy

### DIFF
--- a/entity/index.js
+++ b/entity/index.js
@@ -1266,6 +1266,8 @@ EntityGenerator.prototype.files = function files() {
 
     this.template('src/main/webapp/app/_entity-detail-controller.js',
         'src/main/webapp/scripts/app/entities/' +    this.entityInstance + '/' + this.entityInstance + '-detail.controller' + '.js', this, {});
+    this.template('src/test/javascript/spec/app/_entity-detail-controller.spec.js',
+        'src/test/javascript/spec/app/entities/' +    this.entityInstance + '/' + this.entityInstance + '-detail.controller.spec.js', this, {});
     this.addAppScriptToIndex(this.entityInstance + '/' + this.entityInstance + '-detail.controller' + '.js');
 
     this.template('src/main/webapp/components/_entity-service.js',

--- a/entity/templates/src/main/webapp/app/_entity-detail-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-detail-controller.js
@@ -8,9 +8,11 @@ angular.module('<%=angularAppName%>')
                 $scope.<%= entityInstance %> = result;
             });
         };
-        $rootScope.$on('<%=angularAppName%>:<%= entityInstance %>Update', function(event, result) {
+        var unsubscribe = $rootScope.$on('<%=angularAppName%>:<%= entityInstance %>Update', function(event, result) {
             $scope.<%= entityInstance %> = result;
         });
+        $scope.$on('$destroy', unsubscribe);
+
         <%_ if (fieldsContainBlob) { _%>
 
         $scope.byteSize = function (base64String) {

--- a/entity/templates/src/test/javascript/spec/app/_entity-detail-controller.spec.js
+++ b/entity/templates/src/test/javascript/spec/app/_entity-detail-controller.spec.js
@@ -1,0 +1,35 @@
+'use strict';
+
+describe('<%= entityClass %> Detail Controller', function() {
+  var scope, rootScope, entity, createController;
+
+  beforeEach(module('<%=angularAppName%>'));
+  beforeEach(inject(function($rootScope, $controller) {
+    rootScope = $rootScope;
+    scope = rootScope.$new();
+    entity = jasmine.createSpyObj('entity', ['unused']);
+
+    createController = function() {
+      return $controller("<%= entityClass %>DetailController", {
+        '$scope': scope,
+        '$rootScope': rootScope,
+        'entity': null<% for (idx in differentTypes) { %>,
+        '<%= differentTypes[idx] %>' : null<% } %>
+      });
+    };
+  }));
+
+
+  describe('Root Scope Listening', function() {
+    it('Unregisters root scope listener upon scope destruction',
+      function() {
+        var eventType = '<%=angularAppName%>:<%= entityInstance %>Update';
+
+        createController();
+        expect(rootScope.$$listenerCount[eventType]).toEqual(1);
+
+        scope.$destroy();
+        expect(rootScope.$$listenerCount[eventType]).toBeUndefined();
+      });
+  });
+});


### PR DESCRIPTION
Watchers on root scope should be cleaned up or it can lead to memory leaks.  Attach a listener to the scope, so that when it's destroyed ($scope.$on('$destroy'...) call the unsubcribe method returned from the $rootScope.$on(...) call