### PR TITLE
improve first line of generated README.md

### DIFF
--- a/app/templates/_README.md
+++ b/app/templates/_README.md
@@ -1,6 +1,6 @@
 # Developing <%= baseName %>
 
-<%= baseName %> was generated using JHipster, you can find documentation and help at [JHipster][].
+This application was generated using JHipster, you can find documentation and help at [https://jhipster.gitub.io][].
 
 Before you can build this project, you must install and configure the following dependencies on your machine:
 


### PR DESCRIPTION
improve first line of generated README.md to not contain the name of the project and use "This application" instead. Also replaced duplicate references to the word "JHipster" to use a URL in the second instance

Fix #2188