### PR TITLE
rename SecurityUtils.getCurrentLoginId() to SecurityUtils.getCurrentUserId()

### DIFF
--- a/app/templates/src/main/java/package/security/_SecurityUtils.java
+++ b/app/templates/src/main/java/package/security/_SecurityUtils.java
@@ -58,7 +58,7 @@ public final class SecurityUtils {
      * 
      * @return the current user id
      */
-    public static <%= pkType %> getCurrentLoginId() {
+    public static <%= pkType %> getCurrentUserId() {
         return getCurrentUser().getId();
     }
 


### PR DESCRIPTION
Minor change to method name that makes more sense