### PR TITLE
Fix languages template with Social authentication option

### DIFF
--- a/languages/index.js
+++ b/languages/index.js
@@ -16,6 +16,7 @@ var LanguagesGenerator = module.exports = function LanguagesGenerator(args, opti
     this.searchEngine = this.config.get('searchEngine');
     this.env.options.appPath = this.config.get('appPath') || 'src/main/webapp';
     this.enableTranslation = this.config.get('enableTranslation');
+    this.enableSocialSignIn = this.config.get('enableSocialSignIn');
 };
 
 util.inherits(LanguagesGenerator, yeoman.generators.Base);


### PR DESCRIPTION
When I tried to add new language in a project
```
$ yo jhipster:languages
Languages configuration is starting
? Please choose additional languages to install: Spanish
events.js:85
      throw er; // Unhandled 'error' event
            ^
ReferenceError: /home/david/Development/NodeJs/workspace/generator-jhipster-dalbelap/languages/templates/src/main/resources/i18n/_messages_es.properties:19
    17| email.reset.text1=Se ha solicitado el reinicio de contraseña para su cuenta de <%= baseName %>, por favor, haga clic en el enlace de abajo para reiniciarla:
    18| email.reset.text2=Saludos,
 >> 19| <%_ if (enableSocialSignIn) { _%>
    20| # Social validation e-mail
    21| email.social.registration.title=Activación de cuenta jhipster
    22| email.social.registration.greeting=Estimado {0}
``` 

I just added this line to LanguagesGenerator function in languages/index.js:
```
this.enableSocialSignIn = this.config.get('enableSocialSignIn');
```