### PR TITLE
Support 3-legged oauth2 flows (authorization_code and implicit)

### DIFF
--- a/app/templates/src/main/java/package/config/_OAuth2ServerConfiguration.java
+++ b/app/templates/src/main/java/package/config/_OAuth2ServerConfiguration.java
@@ -126,7 +126,7 @@ public class OAuth2ServerConfiguration {
         @Override
         public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
             clients
-                .inMemory()
+                <% if (databaseType == 'sql') { %>.jdbc(dataSource)<% } else { %>.inMemory()<% } %>
                 .withClient(jHipsterProperties.getSecurity().getAuthentication().getOauth().getClientid())
                 .scopes("read", "write")
                 .authorities(AuthoritiesConstants.ADMIN, AuthoritiesConstants.USER)

--- a/app/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/app/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -5,30 +5,22 @@ import <%=packageName%>.web.filter.CsrfCookieGeneratorFilter;<% } %><% if (authe
 import <%=packageName%>.security.xauth.*;<% } %>
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;<% if (authenticationType == 'session') { %>
-import org.springframework.core.env.Environment;<% } %><% if (authenticationType == 'oauth2') { %>
-import org.springframework.security.access.expression.method.MethodSecurityExpressionHandler;<% } %>
-
-import org.springframework.data.repository.query.spi.EvaluationContextExtension;
-import org.springframework.data.repository.query.spi.EvaluationContextExtensionSupport;
-import org.springframework.security.access.expression.SecurityExpressionRoot;<% if (authenticationType == 'oauth2' || authenticationType == 'xauth') { %>
+import org.springframework.core.env.Environment;<% } %><% if (authenticationType == 'oauth2' || authenticationType == 'xauth') { %>
 import org.springframework.security.authentication.AuthenticationManager;<% } %>
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
-import org.springframework.security.config.annotation.method.configuration.GlobalMethodSecurityConfiguration;<% if (authenticationType == 'session' || authenticationType == 'xauth') { %>
-import org.springframework.security.config.annotation.web.builders.HttpSecurity;<% } %>
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.builders.WebSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;<% if (authenticationType == 'xauth') { %>
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;<% if (authenticationType == 'xauth' || authenticationType == 'oauth2') { %>
 import org.springframework.security.config.http.SessionCreationPolicy;<% } %>
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.data.repository.query.SecurityEvaluationContextExtension;
 <% if (authenticationType == 'session') { %>
 import org.springframework.security.web.authentication.RememberMeServices;
-import org.springframework.security.web.csrf.CsrfFilter;<% } %><% if (authenticationType == 'oauth2') { %>
-import org.springframework.security.oauth2.provider.expression.OAuth2MethodSecurityExpressionHandler;<% } %>
+import org.springframework.security.web.csrf.CsrfFilter;<% } %>
 
 import javax.inject.Inject;
 
@@ -160,6 +152,20 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
             .apply(securityConfigurerAdapter());<% } %>
 
     }<% } %><% if (authenticationType == 'oauth2') { %>
+
+    @Override
+    public void configure(HttpSecurity http) throws Exception {
+        http
+            .httpBasic().realmName("<%= baseName %>")
+            .and()
+                .sessionManagement()
+                .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and()
+                .requestMatchers().antMatchers("/oauth/authorize")
+            .and()
+                .authorizeRequests()
+                .antMatchers("/oauth/authorize").authenticated();
+    }
 
     @Override
     @Bean

--- a/app/templates/src/main/java/package/domain/_OAuth2AuthenticationAccessToken.java
+++ b/app/templates/src/main/java/package/domain/_OAuth2AuthenticationAccessToken.java
@@ -38,7 +38,9 @@ public class OAuth2AuthenticationAccessToken implements Serializable {
         this.userName = authentication.getName();
         this.clientId = authentication.getOAuth2Request().getClientId();
         this.authentication = authentication;
-        this.refreshToken = oAuth2AccessToken.getRefreshToken().getValue();
+        if(oAuth2AccessToken.getRefreshToken() != null) {
+            this.refreshToken = oAuth2AccessToken.getRefreshToken().getValue();
+        }
     }
 
     public String getTokenId() {


### PR DESCRIPTION
This brings basic support for 3-legged oauth support to open your API to the world

There is still a lot of room for improvement:
- the approval page is spring security's default one which is quite ugly
- the /oauth/authorize endpoint is secured with stateless basic auth. It would be better to use the jhipster's login form but this one should redirect back to the authorize page after login which is currently not the case.
- springfox could be used to document the authorization (securityDefinitions) but then it doesn't work anymore with password oauth. I guess this is because when there is securityDefinitions the auth bearer that we pass from angular is overridden.
- for SQL databases, you can configure as many client apps as you want by adding rows in the oauth_client_details table. Unfortunately there is currentlly no equivalent for Mongo so you have only the main app registered.