### PR TITLE
docker-compose : use tags version instead of latest

### DIFF
--- a/app/templates/_Dockerfile_cassandra
+++ b/app/templates/_Dockerfile_cassandra
@@ -1,4 +1,4 @@
-FROM cassandra
+FROM cassandra:2.2.3
 MAINTAINER Pascal Grimaud <pascalgrimaud@gmail.com>
 
 # add script cql

--- a/app/templates/_docker-compose-prod.yml
+++ b/app/templates/_docker-compose-prod.yml
@@ -1,6 +1,6 @@
 <% if (searchEngine == 'elasticsearch') { %>jhipster-prod-elasticsearch:
   container_name: <%=baseName%>-prod-elasticsearch
-  image: elasticsearch
+  image: elasticsearch:1.7.3
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-elasticsearch/:/usr/share/elasticsearch/data/
   ports:
@@ -8,7 +8,7 @@
   - "9300:9300"
 <% } if (prodDatabaseType == 'mysql') { %>jhipster-prod-mysql:
   container_name: <%=baseName%>-prod-mysql
-  image: mysql
+  image: mysql:5.7.9
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-mysql/:/var/lib/mysql/
   environment:
@@ -17,10 +17,10 @@
   - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
   ports:
   - "3306:3306"
-  command: mysqld --lower_case_table_name=1
+  command: mysqld --lower_case_table_names=1
 <% } if (prodDatabaseType == 'postgresql') { %>jhipster-prod-postgresql:
   container_name: <%=baseName%>-prod-postgresql
-  image: postgres
+  image: postgres:9.4.5
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-postgresql/:/var/lib/postgresql/
   environment:
@@ -30,7 +30,7 @@
   - "5432:5432"
 <% } if (prodDatabaseType == 'mongodb') { %>jhipster-prod-mongodb:
   container_name: <%=baseName%>-prod-mongodb
-  image: mongo
+  image: mongo:3.0.7
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-mongodb/:/data/db/
   ports:

--- a/app/templates/_docker-compose.yml
+++ b/app/templates/_docker-compose.yml
@@ -1,6 +1,6 @@
 <% if (devDatabaseType == 'mysql') { %>jhipster-dev-mysql:
   container_name: <%=baseName%>-dev-mysql
-  image: mysql
+  image: mysql:5.7.9
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/dev-mysql/:/var/lib/mysql/
   environment:
@@ -9,10 +9,10 @@
   - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
   ports:
   - "3306:3306"
-  command: mysqld --lower_case_table_name=1
+  command: mysqld --lower_case_table_names=1
 <% } if (devDatabaseType == 'postgresql') { %>jhipster-dev-postgresql:
   container_name: <%=baseName%>-dev-postgresql
-  image: postgres
+  image: postgres:9.4.5
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/dev-postgresql/:/var/lib/postgresql/
   environment:
@@ -22,7 +22,7 @@
   - "5432:5432"
 <% } if (devDatabaseType == 'mongodb') { %>jhipster-dev-mongodb:
   container_name: <%=baseName%>-dev-mongodb
-  image: mongo
+  image: mongo:3.0.7
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/dev-mongodb/:/data/db/
   ports:


### PR DESCRIPTION
2 changes :
* use an official tags version, instead of the latest (to avoid a new update version of database/service which we didn't test)
* mysql : change the start cmd with lower_case_table_name (deprecated) to lower_case_table_names