### PR TITLE
Corrrection embedmongo_spring version

### DIFF
--- a/app/templates/_gradle.properties
+++ b/app/templates/_gradle.properties
@@ -20,7 +20,7 @@ HikariCP_version=2.4.1<% if (databaseType == 'sql') { %>
 liquibase_slf4j_version=1.2.1
 liquibase_core_version=3.4.1
 liquibase_hibernate4_version=3.5<% } %><% if (databaseType == 'mongodb') { %>
-embedmongo_spring_version=1.50.0
+embedmongo_spring_version=1.3.1
 mongeez_version=0.9.4<% } %>
 hibernate_validator_version=5.2.1.Final<% if (databaseType == 'cassandra') { %>
 lz4_version=1.3.0<% } %>


### PR DESCRIPTION
Replacing the embedmongo-spring version 1.50 by version 1.3.1, because the version 1.50 doesn't exist