### PR TITLE
Fix elastic search serialization of jsr310 types

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -725,6 +725,7 @@ JhipsterGenerator.prototype.app = function app() {
     }
 
     if (this.searchEngine == 'elasticsearch') {
+        this.template('src/main/java/package/config/_ElasticSearchConfiguration.java', javaDir + 'config/ElasticSearchConfiguration.java', this, {});
         this.template('src/main/java/package/repository/search/_package-info.java', javaDir + 'repository/search/package-info.java', this, {});
         this.template('src/main/java/package/repository/search/_UserSearchRepository.java', javaDir + 'repository/search/UserSearchRepository.java', this, {});
     }

--- a/app/templates/src/main/java/package/config/_ElasticSearchConfiguration.java
+++ b/app/templates/src/main/java/package/config/_ElasticSearchConfiguration.java
@@ -1,0 +1,44 @@
+package <%=packageName%>.config;
+
+import java.io.IOException;
+
+import org.elasticsearch.client.Client;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.elasticsearch.core.ElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.EntityMapper;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+@Configuration
+@AutoConfigureAfter(value = { JacksonConfiguration.class })
+public class ElasticSearchConfiguration {
+
+    @Bean
+    public ElasticsearchTemplate elasticsearchTemplate(Client client, ObjectMapper objectMapper) {
+        return new ElasticsearchTemplate(client, new CustomEntityMapper(objectMapper) );
+    }
+
+    public class CustomEntityMapper implements EntityMapper {
+
+        private ObjectMapper objectMapper;
+
+        public CustomEntityMapper(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        }
+
+        @Override
+        public String mapToString(Object object) throws IOException {
+            return objectMapper.writeValueAsString(object);
+        }
+
+        @Override
+        public <T> T mapToObject(String source, Class<T> clazz) throws IOException {
+            return objectMapper.readValue(source, clazz);
+        }
+    }
+}


### PR DESCRIPTION
By default, elasticsearch uses its own ObjectMapper and not the one created by spring-boot

Fix #2241