### PR TITLE
Use dedicated object mapper for elasticsearch

### DIFF
--- a/app/templates/src/main/java/package/config/_ElasticSearchConfiguration.java
+++ b/app/templates/src/main/java/package/config/_ElasticSearchConfiguration.java
@@ -17,8 +17,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 public class ElasticSearchConfiguration {
 
     @Bean
-    public ElasticsearchTemplate elasticsearchTemplate(Client client, ObjectMapper objectMapper) {
-        return new ElasticsearchTemplate(client, new CustomEntityMapper(objectMapper) );
+    public ElasticsearchTemplate elasticsearchTemplate(Client client, Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder) {
+        return new ElasticsearchTemplate(client, new CustomEntityMapper(jackson2ObjectMapperBuilder.createXmlMapper(false).build()));
     }
 
     public class CustomEntityMapper implements EntityMapper {


### PR DESCRIPTION
Since elastic search has it owns settings for json serialization, it is preferable to use a dedicated object mapper