### PR TITLE
Change default mongo port for unit tests

### DIFF
--- a/app/templates/src/test/resources/config/_application.yml
+++ b/app/templates/src/test/resources/config/_application.yml
@@ -10,12 +10,6 @@
 # http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
 # ===================================================================
 
-
-
-# ===================================================================
-# JHipster specific properties
-# ===================================================================
-
 spring:
     <%_ if (databaseType == 'sql') { _%>
     datasource:
@@ -42,7 +36,7 @@ spring:
     data:
         mongodb:
             host: localhost
-            port: 27017
+            port: 27117
             database: <%= baseName %>
     <%_ } _%>
     <%_ if (databaseType == 'cassandra') { _%>


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/2218 to launch tests when a mongodb instance is running

Add +100 to port, like Cassandra port for unit tests
