### PR TITLE
added contextPath to baseUrl for links in emails to support applications not deployed in root context as well

### DIFF
--- a/app/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/app/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -68,7 +68,8 @@ public class AccountResource {
                     "://" +                                // "://"
                     request.getServerName() +              // "myhost"
                     ":" +                                  // ":"
-                    request.getServerPort();               // "80"
+                    request.getServerPort() +              // "80"
+                    request.getContextPath();              // "/myContextPath" or "" if deployed in root context
 
                     mailService.sendActivationEmail(user, baseUrl);
                     return new ResponseEntity<>(HttpStatus.CREATED);
@@ -198,7 +199,8 @@ public class AccountResource {
                     "://" +
                     request.getServerName() +
                     ":" +
-                    request.getServerPort();
+                    request.getServerPort() +
+                    request.getContextPath();
                 mailService.sendPasswordResetMail(user, baseUrl);
                 return new ResponseEntity<>("e-mail was sent", HttpStatus.OK);
             }).orElse(new ResponseEntity<>("e-mail address not registered", HttpStatus.BAD_REQUEST));


### PR DESCRIPTION
If the application is not deployed in the root context the baseUrl should link to:
http://myhost:80/myContextPath
instead of:
http://myhost:80