### PR TITLE
Update gitignore

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -11,6 +11,11 @@
 /node_modules/**
 
 ######################
+# Bower
+######################
+/src/main/webapp/bower_components/
+
+######################
 # SASS
 ######################
 .sass-cache/**


### PR DESCRIPTION
Including bower_components into .gitignore to escape committing all bower dependencies once project is generated and setup