### PR TITLE
Add service layer option for entity sub gen

### DIFF
--- a/entity/index.js
+++ b/entity/index.js
@@ -54,6 +54,7 @@ var EntityGenerator = module.exports = function EntityGenerator(args, options, c
     }
     this.angularAppName = _s.camelize(_s.slugify(this.baseName)) + 'App';
     this.jhipsterConfigDirectory = '.jhipster';
+    this.name = this.name.replace('.json','');
     this.filename = this.jhipsterConfigDirectory + '/' + _s.capitalize(this.name) + '.json';
     if (shelljs.test('-f', this.filename)) {
         console.log(chalk.green('Found the ' + this.filename + ' configuration file, automatically generating the entity'));
@@ -1283,17 +1284,13 @@ EntityGenerator.prototype.files = function files() {
     this.template('src/main/java/package/web/rest/_EntityResource.java',
         'src/main/java/' + this.packageFolder + '/web/rest/' +    this.entityClass + 'Resource.java', this, {});
     if (this.service == 'serviceImpl') {
-        this.entityHasService = true;
         this.template('src/main/java/package/service/_EntityService.java',
             'src/main/java/' + this.packageFolder + '/service/' +    this.entityClass + 'Service.java', this, {});
         this.template('src/main/java/package/service/impl/_EntityServiceImpl.java',
             'src/main/java/' + this.packageFolder + '/service/impl/' +    this.entityClass + 'ServiceImpl.java', this, {});
     } else if(this.service == 'serviceClass') {
-        this.entityHasService = true;
         this.template('src/main/java/package/service/impl/_EntityServiceImpl.java',
             'src/main/java/' + this.packageFolder + '/service/' +    this.entityClass + 'Service.java', this, {});
-    } else {
-        this.entityHasService = false;
     }
     if (this.dto == 'mapstruct') {
         this.template('src/main/java/package/web/rest/dto/_EntityDTO.java',

--- a/entity/index.js
+++ b/entity/index.js
@@ -825,7 +825,7 @@ EntityGenerator.prototype.askForService = function askForService() {
             choices: [
                 {
                     value: 'no',
-                    name: 'No, implement it in the http resource class'
+                    name: 'No, the REST controller should use the repository directly'
                 },
                 {
                     value: 'serviceClass',

--- a/entity/templates/src/main/java/package/common/delete_template.ejs
+++ b/entity/templates/src/main/java/package/common/delete_template.ejs
@@ -1,0 +1,5 @@
+<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+        <%= entityInstance %>Repository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
+        <%= entityInstance %>Repository.delete(UUID.fromString(id));<% } %><% if (searchEngine == 'elasticsearch') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+        <%= entityInstance %>SearchRepository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
+        <%= entityInstance %>SearchRepository.delete(UUID.fromString(id));<% } %><% } %>

--- a/entity/templates/src/main/java/package/common/delete_template.ejs
+++ b/entity/templates/src/main/java/package/common/delete_template.ejs
@@ -1,8 +1,8 @@
 <% if (!viaService) {
-    if (databaseType == 'sql' || databaseType == 'mongodb') { -%>
+    if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>Repository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
         <%= entityInstance %>Repository.delete(UUID.fromString(id));<% } %><% if (searchEngine == 'elasticsearch') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>SearchRepository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
         <%= entityInstance %>SearchRepository.delete(UUID.fromString(id));<% } %><% }
-} else { -%>
-        <%= entityInstance %>Service.delete(id);<% } -%>
+} else { %>
+        <%= entityInstance %>Service.delete(id);<% } %>

--- a/entity/templates/src/main/java/package/common/delete_template.ejs
+++ b/entity/templates/src/main/java/package/common/delete_template.ejs
@@ -1,9 +1,8 @@
 <% if (!viaService) {
-    if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+    if (databaseType == 'sql' || databaseType == 'mongodb') { -%>
         <%= entityInstance %>Repository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
         <%= entityInstance %>Repository.delete(UUID.fromString(id));<% } %><% if (searchEngine == 'elasticsearch') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>SearchRepository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
         <%= entityInstance %>SearchRepository.delete(UUID.fromString(id));<% } %><% }
-} else {%>
-        <%= entityInstance %>Service.delete(id);
-<% } %>
+} else { -%>
+        <%= entityInstance %>Service.delete(id);<% } -%>

--- a/entity/templates/src/main/java/package/common/delete_template.ejs
+++ b/entity/templates/src/main/java/package/common/delete_template.ejs
@@ -1,5 +1,9 @@
-<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+<% if (!viaService) {
+    if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>Repository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
         <%= entityInstance %>Repository.delete(UUID.fromString(id));<% } %><% if (searchEngine == 'elasticsearch') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>SearchRepository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
-        <%= entityInstance %>SearchRepository.delete(UUID.fromString(id));<% } %><% } %>
+        <%= entityInstance %>SearchRepository.delete(UUID.fromString(id));<% } %><% }
+} else {%>
+        <%= entityInstance %>Service.delete(id);
+<% } %>

--- a/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
@@ -4,7 +4,7 @@ var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + '
 for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
         if ("<%= relationships[idx].relationshipName.toLowerCase() %>-is-null".equals(filter)) {
             log.debug("REST request to get all <%= entityClass %>s where <%= relationships[idx].relationshipName %> is null");<% if (viaService) { %>
-            return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %><%= entityInstance %>Service.findAll()<% } if (pagination != 'no') { %>,
+            return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %><%= entityInstance %>Service.findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull()<% } if (pagination != 'no') { %>,
                     HttpStatus.OK)<% } %>;<% } else { %>
             return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %>StreamSupport
                 .stream(<%= entityInstance %>Repository.findAll().spliterator(), false)

--- a/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
@@ -4,7 +4,7 @@ var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + '
 for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
         if ("<%= relationships[idx].relationshipName.toLowerCase() %>-is-null".equals(filter)) {
             log.debug("REST request to get all <%= entityClass %>s where <%= relationships[idx].relationshipName %> is null");<% if (viaService) { %>
-            return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %><%= entityInstance %>Service.findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull()<% } if (pagination != 'no') { %>,
+            return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %><%= entityInstance %>Service.findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull()<% if (pagination != 'no') { %>,
                     HttpStatus.OK)<% } %>;<% } else { %>
             return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %>StreamSupport
                 .stream(<%= entityInstance %>Repository.findAll().spliterator(), false)

--- a/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
@@ -1,0 +1,15 @@
+<%
+var mapper = entityInstance  + 'Mapper';
+var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
+var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
+        if ("<%= relationships[idx].relationshipName.toLowerCase() %>-is-null".equals(filter)) {
+            log.debug("REST request to get all <%= entityClass %>s where <%= relationships[idx].relationshipName %> is null");
+            return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %>StreamSupport
+                .stream(<%= entityInstance %>Repository.findAll().spliterator(), false)
+                .filter(<%= entityInstance %> -> <%= entityInstance %>.get<%= relationships[idx].relationshipNameCapitalized %>() == null)<% if (dto == 'mapstruct') { %>
+                .map(<%= mapper %>::<%= entityToDto %>)<% } if (pagination != 'no') { %>
+                .collect(Collectors.toList()), HttpStatus.OK);<% } else { if (dto == 'mapstruct') { %>
+                .collect(Collectors.toCollection(LinkedList::new));<% } else { %>
+                .collect(Collectors.toList());<% }} %>
+        }<% } } -%>

--- a/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
@@ -1,15 +1,16 @@
 <%
 var mapper = entityInstance  + 'Mapper';
-var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
-var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
 for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
         if ("<%= relationships[idx].relationshipName.toLowerCase() %>-is-null".equals(filter)) {
-            log.debug("REST request to get all <%= entityClass %>s where <%= relationships[idx].relationshipName %> is null");
+            log.debug("REST request to get all <%= entityClass %>s where <%= relationships[idx].relationshipName %> is null");<% if (viaService) { %>
+            return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %><%= entityInstance %>Service.findAll()<% } if (pagination != 'no') { %>,
+                    HttpStatus.OK)<% } %>;<% } else { %>
             return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %>StreamSupport
                 .stream(<%= entityInstance %>Repository.findAll().spliterator(), false)
                 .filter(<%= entityInstance %> -> <%= entityInstance %>.get<%= relationships[idx].relationshipNameCapitalized %>() == null)<% if (dto == 'mapstruct') { %>
-                .map(<%= mapper %>::<%= entityToDto %>)<% } if (pagination != 'no') { %>
+                .map(<%= entityToDtoReference %>)<% } if (pagination != 'no') { %>
                 .collect(Collectors.toList()), HttpStatus.OK);<% } else { if (dto == 'mapstruct') { %>
                 .collect(Collectors.toCollection(LinkedList::new));<% } else { %>
-                .collect(Collectors.toList());<% }} %>
+                .collect(Collectors.toList());<% }} %><% } %>
         }<% } } -%>

--- a/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_stream_template.ejs
@@ -1,7 +1,7 @@
 <%
 var mapper = entityInstance  + 'Mapper';
 var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
-for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
+for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { %>
         if ("<%= relationships[idx].relationshipName.toLowerCase() %>-is-null".equals(filter)) {
             log.debug("REST request to get all <%= entityClass %>s where <%= relationships[idx].relationshipName %> is null");<% if (viaService) { %>
             return <% if (pagination != 'no') { %>new ResponseEntity<>(<% } %><%= entityInstance %>Service.findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull()<% if (pagination != 'no') { %>,
@@ -13,4 +13,4 @@ for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-
                 .collect(Collectors.toList()), HttpStatus.OK);<% } else { if (dto == 'mapstruct') { %>
                 .collect(Collectors.toCollection(LinkedList::new));<% } else { %>
                 .collect(Collectors.toList());<% }} %><% } %>
-        }<% } } -%>
+        }<% } } %>

--- a/entity/templates/src/main/java/package/common/get_all_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_template.ejs
@@ -1,0 +1,21 @@
+    <%_
+    var mapper = entityInstance  + 'Mapper';
+    var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
+    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+    if (dto == 'mapstruct') { _%>
+    @Transactional(readOnly = true)<% } if (pagination == 'no') { -%>
+    public List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> getAll<%= entityClass %>s(<% if (fieldsContainNoOwnerOneToOne == true) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template'); -%>
+        log.debug("REST request to get all <%= entityClass %>s");
+        return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
+            .map(<%= mapper %>::<%= entityToDto %>)
+            .collect(Collectors.toCollection(LinkedList::new))<% } %>;
+            <%_ } if (pagination != 'no') { _%>
+    public ResponseEntity<List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>>> getAll<%= entityClass %>s(Pageable pageable<% if (fieldsContainNoOwnerOneToOne == true) { %>, @RequestParam(required = false) String filter<% } %>)
+        throws URISyntaxException {<%- include('get_all_stream_template'); -%>
+        Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityInstance %>s");
+        return new ResponseEntity<>(page.getContent()<% if (dto == 'mapstruct') { %>.stream()
+            .map(<%= mapper %>::<%= entityToDto %>)
+            .collect(Collectors.toCollection(LinkedList::new))<% } %>, headers, HttpStatus.OK);
+    <%_ } _%>
+    }

--- a/entity/templates/src/main/java/package/common/get_all_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_template.ejs
@@ -3,18 +3,18 @@
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
     var mapper = entityInstance  + 'Mapper';
     var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
-    if (dto == 'mapstruct') { -%>
-    @Transactional(readOnly = true)<% } if (pagination == 'no') { -%>
+    if (dto == 'mapstruct') { %>
+    @Transactional(readOnly = true)<% } if (pagination == 'no') { %>
     public List<<%= instanceType %>> getAll<%= entityClass %>s(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get all <%= entityClass %>s");<% if (viaService) { %>
         return <%= entityInstance %>Service.findAll();<% } else { %>
         return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
             .map(<%= entityToDtoReference %>)
             .collect(Collectors.toCollection(LinkedList::new))<% } %>;<% } %>
-            <%_ } if (pagination != 'no') { _%>
+            <% } if (pagination != 'no') { %>
     public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClass %>s(Pageable pageable<% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %>)
         throws URISyntaxException {<%- include('get_all_stream_template', {viaService: viaService}); -%>
-        log.debug("REST request to get all <%= entityClass %>s");<% if (viaService) { %>
+        log.debug("REST request to get a page of <%= entityClass %>s");<% if (viaService) { %>
         Page<<%= entityClass %>> page = <%= entityInstance %>Service.findAll(pageable); <% } else { %>
         Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(pageable); <% } %>
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityInstance %>s");

--- a/entity/templates/src/main/java/package/common/get_all_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_template.ejs
@@ -1,21 +1,25 @@
     <%_
+    var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
     var mapper = entityInstance  + 'Mapper';
-    var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
-    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
     if (dto == 'mapstruct') { _%>
     @Transactional(readOnly = true)<% } if (pagination == 'no') { -%>
-    public List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> getAll<%= entityClass %>s(<% if (fieldsContainNoOwnerOneToOne == true) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template'); -%>
-        log.debug("REST request to get all <%= entityClass %>s");
+    public List<<%= instanceType %>> getAll<%= entityClass %>s(<% if (fieldsContainNoOwnerOneToOne == true) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+        log.debug("REST request to get all <%= entityClass %>s");<% if (viaService) { %>
+        return <%= entityInstance %>Service.findAll();<% } else { %>
         return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
-            .map(<%= mapper %>::<%= entityToDto %>)
-            .collect(Collectors.toCollection(LinkedList::new))<% } %>;
+            .map(<%= entityToDtoReference %>)
+            .collect(Collectors.toCollection(LinkedList::new))<% } %>;<% } %>
             <%_ } if (pagination != 'no') { _%>
-    public ResponseEntity<List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>>> getAll<%= entityClass %>s(Pageable pageable<% if (fieldsContainNoOwnerOneToOne == true) { %>, @RequestParam(required = false) String filter<% } %>)
-        throws URISyntaxException {<%- include('get_all_stream_template'); -%>
-        Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(pageable);
+    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClass %>s(Pageable pageable<% if (fieldsContainNoOwnerOneToOne == true) { %>, @RequestParam(required = false) String filter<% } %>)
+        throws URISyntaxException {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+        log.debug("REST request to get all <%= entityClass %>s");<% if (viaService) { %>
+        Page<<%= entityClass %>> page = <%= entityInstance %>Service.findAll(pageable); <% } else { %>
+        Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(pageable); <% } %>
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityInstance %>s");
         return new ResponseEntity<>(page.getContent()<% if (dto == 'mapstruct') { %>.stream()
-            .map(<%= mapper %>::<%= entityToDto %>)
+            .map(<%= entityToDtoReference %>)
             .collect(Collectors.toCollection(LinkedList::new))<% } %>, headers, HttpStatus.OK);
     <%_ } _%>
     }

--- a/entity/templates/src/main/java/package/common/get_all_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_template.ejs
@@ -3,16 +3,16 @@
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
     var mapper = entityInstance  + 'Mapper';
     var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
-    if (dto == 'mapstruct') { _%>
+    if (dto == 'mapstruct') { -%>
     @Transactional(readOnly = true)<% } if (pagination == 'no') { -%>
-    public List<<%= instanceType %>> getAll<%= entityClass %>s(<% if (fieldsContainNoOwnerOneToOne == true) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+    public List<<%= instanceType %>> getAll<%= entityClass %>s(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get all <%= entityClass %>s");<% if (viaService) { %>
         return <%= entityInstance %>Service.findAll();<% } else { %>
-        return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
+        return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
             .map(<%= entityToDtoReference %>)
             .collect(Collectors.toCollection(LinkedList::new))<% } %>;<% } %>
             <%_ } if (pagination != 'no') { _%>
-    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClass %>s(Pageable pageable<% if (fieldsContainNoOwnerOneToOne == true) { %>, @RequestParam(required = false) String filter<% } %>)
+    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClass %>s(Pageable pageable<% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %>)
         throws URISyntaxException {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get all <%= entityClass %>s");<% if (viaService) { %>
         Page<<%= entityClass %>> page = <%= entityInstance %>Service.findAll(pageable); <% } else { %>
@@ -21,5 +21,5 @@
         return new ResponseEntity<>(page.getContent()<% if (dto == 'mapstruct') { %>.stream()
             .map(<%= entityToDtoReference %>)
             .collect(Collectors.toCollection(LinkedList::new))<% } %>, headers, HttpStatus.OK);
-    <%_ } _%>
+    <% } -%>
     }

--- a/entity/templates/src/main/java/package/common/get_all_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_all_template.ejs
@@ -22,4 +22,4 @@
             .map(<%= entityToDtoReference %>)
             .collect(Collectors.toCollection(LinkedList::new))<% } %>, headers, HttpStatus.OK);
     <% } -%>
-    }
+}

--- a/entity/templates/src/main/java/package/common/get_filtered_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_filtered_template.ejs
@@ -1,4 +1,5 @@
 <%
+var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
 var mapper = entityInstance  + 'Mapper';
 var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
 for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>

--- a/entity/templates/src/main/java/package/common/get_filtered_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_filtered_template.ejs
@@ -1,0 +1,19 @@
+<%
+var mapper = entityInstance  + 'Mapper';
+var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
+for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
+    /**
+     *  get all the <%= entityInstance %>s where <%= relationships[idx].relationshipNameCapitalized %> is null.
+     *  @return the list of entities
+     */<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = true) <% } %>
+    public List<<%= instanceType %>> findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull() {
+        log.debug("Request to get all <%= entityInstance %>s where <%= relationships[idx].relationshipNameCapitalized %> is null");
+        return StreamSupport
+            .stream(<%= entityInstance %>Repository.findAll().spliterator(), false)
+            .filter(<%= entityInstance %> -> <%= entityInstance %>.get<%= relationships[idx].relationshipNameCapitalized %>() == null)<% if (dto == 'mapstruct') { %>
+            .map(<%= entityToDtoReference %>)
+            .collect(Collectors.toCollection(LinkedList::new));<% } else { %>
+            .collect(Collectors.toList());<% } %>
+    }
+    <% } } -%>

--- a/entity/templates/src/main/java/package/common/get_filtered_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_filtered_template.ejs
@@ -3,6 +3,7 @@ var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
 var mapper = entityInstance  + 'Mapper';
 var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
 for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { %>
+
     /**
      *  get all the <%= entityInstance %>s where <%= relationships[idx].relationshipNameCapitalized %> is null.
      *  @return the list of entities

--- a/entity/templates/src/main/java/package/common/get_filtered_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_filtered_template.ejs
@@ -2,7 +2,7 @@
 var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
 var mapper = entityInstance  + 'Mapper';
 var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
-for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
+for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { %>
     /**
      *  get all the <%= entityInstance %>s where <%= relationships[idx].relationshipNameCapitalized %> is null.
      *  @return the list of entities
@@ -17,4 +17,4 @@ for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-
             .collect(Collectors.toCollection(LinkedList::new));<% } else { %>
             .collect(Collectors.toList());<% } %>
     }
-<% } } -%>
+<% } } %>

--- a/entity/templates/src/main/java/package/common/get_filtered_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_filtered_template.ejs
@@ -16,4 +16,4 @@ for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-
             .collect(Collectors.toCollection(LinkedList::new));<% } else { %>
             .collect(Collectors.toList());<% } %>
     }
-    <% } } -%>
+<% } } -%>

--- a/entity/templates/src/main/java/package/common/get_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_template.ejs
@@ -1,11 +1,9 @@
-<% if (!viaService) {
-    var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+<%  var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
     var mapper = entityInstance  + 'Mapper';
     var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+    if (!viaService) {
 -%>
-        <%= entityClass %> <%= entityInstance %> = <% if (databaseType == 'sql' || databaseType == 'mongodb') { %><%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id))<% } %><% if (databaseType == 'cassandra') { %><%= entityInstance %>Repository.findOne(UUID.fromString(id)))<% } %>;<%_ if (dto == 'mapstruct') { _%>
-        <%= instanceType %> <%= instanceName %> = <%= entityToDto %>(<%= entityInstance %>);<%_ } _%>
-<% } else {
-        <%= instanceType %> <%= instanceName %> = <%= entityInstance %>Service.findOne(id);
-<% } -%>
+        <%= entityClass %> <%= entityInstance %> = <% if (databaseType == 'sql' || databaseType == 'mongodb') { %><%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id)<% } %><% if (databaseType == 'cassandra') { %><%= entityInstance %>Repository.findOne(UUID.fromString(id))<% } %>;<% if (dto == 'mapstruct') { %>
+        <%= instanceType %> <%= instanceName %> = <%= entityToDto %>(<%= entityInstance %>);<% } } else { %>
+        <%= instanceType %> <%= instanceName %> = <%= entityInstance %>Service.findOne(id);<% } -%>

--- a/entity/templates/src/main/java/package/common/get_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_template.ejs
@@ -3,7 +3,7 @@
     var mapper = entityInstance  + 'Mapper';
     var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
     if (!viaService) {
--%>
+%>
         <%= entityClass %> <%= entityInstance %> = <% if (databaseType == 'sql' || databaseType == 'mongodb') { %><%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id)<% } %><% if (databaseType == 'cassandra') { %><%= entityInstance %>Repository.findOne(UUID.fromString(id))<% } %>;<% if (dto == 'mapstruct') { %>
         <%= instanceType %> <%= instanceName %> = <%= entityToDto %>(<%= entityInstance %>);<% } } else { %>
-        <%= instanceType %> <%= instanceName %> = <%= entityInstance %>Service.findOne(id);<% } -%>
+        <%= instanceType %> <%= instanceName %> = <%= entityInstance %>Service.findOne(id);<% } %>

--- a/entity/templates/src/main/java/package/common/get_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_template.ejs
@@ -1,7 +1,11 @@
-<%_ var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
-var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
-var mapper = entityInstance  + 'Mapper';
-var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+<% if (!viaService) {
+    var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
+    var mapper = entityInstance  + 'Mapper';
+    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
 -%>
         <%= entityClass %> <%= entityInstance %> = <% if (databaseType == 'sql' || databaseType == 'mongodb') { %><%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id))<% } %><% if (databaseType == 'cassandra') { %><%= entityInstance %>Repository.findOne(UUID.fromString(id)))<% } %>;<%_ if (dto == 'mapstruct') { _%>
         <%= instanceType %> <%= instanceName %> = <%= entityToDto %>(<%= entityInstance %>);<%_ } _%>
+<% } else {
+        <%= instanceType %> <%= instanceName %> = <%= entityInstance %>Service.findOne(id);
+<% } -%>

--- a/entity/templates/src/main/java/package/common/get_template.ejs
+++ b/entity/templates/src/main/java/package/common/get_template.ejs
@@ -1,0 +1,7 @@
+<%_ var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
+var mapper = entityInstance  + 'Mapper';
+var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+-%>
+        <%= entityClass %> <%= entityInstance %> = <% if (databaseType == 'sql' || databaseType == 'mongodb') { %><%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findOneWithEagerRelationships<% } else { %>findOne<% } %>(id))<% } %><% if (databaseType == 'cassandra') { %><%= entityInstance %>Repository.findOne(UUID.fromString(id)))<% } %>;<%_ if (dto == 'mapstruct') { _%>
+        <%= instanceType %> <%= instanceName %> = <%= entityToDto %>(<%= entityInstance %>);<%_ } _%>

--- a/entity/templates/src/main/java/package/common/inject_template.ejs
+++ b/entity/templates/src/main/java/package/common/inject_template.ejs
@@ -1,0 +1,10 @@
+
+    @Inject
+    private <%= entityClass %>Repository <%= entityInstance %>Repository;
+    <%_ if (dto == 'mapstruct') { _%>
+    @Inject
+    private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
+    <%_ } if (searchEngine == 'elasticsearch') { _%>
+    @Inject
+    private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;
+    <%_ } _%>

--- a/entity/templates/src/main/java/package/common/inject_template.ejs
+++ b/entity/templates/src/main/java/package/common/inject_template.ejs
@@ -1,18 +1,18 @@
-<%_ if (!viaService) { _%>
+<% if (!viaService) { -%>
     @Inject
     private <%= entityClass %>Repository <%= entityInstance %>Repository;
-    <%_ if (dto == 'mapstruct') { _%>
+    <% if (dto == 'mapstruct') { -%>
     @Inject
     private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
-    <%_ } if (searchEngine == 'elasticsearch') { _%>
+    <% } if (searchEngine == 'elasticsearch') { -%>
     @Inject
     private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;
-    <%_ }
-  } else {_%>
+    <% }
+  } else { -%>
     @Inject
     private <%= entityClass %>Service <%= entityInstance %>Service;
-    <%_ if (dto == 'mapstruct') { _%>
+    <% if (dto == 'mapstruct') { -%>
     @Inject
     private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
-    <%_ } _%>
-<%_ } _%>
+    <% } -%>
+<% } -%>

--- a/entity/templates/src/main/java/package/common/inject_template.ejs
+++ b/entity/templates/src/main/java/package/common/inject_template.ejs
@@ -1,18 +1,18 @@
 <% if (!viaService) { %>
     @Inject
     private <%= entityClass %>Repository <%= entityInstance %>Repository;
-    <% if (dto == 'mapstruct') { -%>
+    <% if (dto == 'mapstruct') { %>
     @Inject
     private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
-    <% } if (searchEngine == 'elasticsearch') { -%>
+    <% } if (searchEngine == 'elasticsearch') { %>
     @Inject
     private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;
     <% }
   } else { %>
     @Inject
     private <%= entityClass %>Service <%= entityInstance %>Service;
-    <% if (dto == 'mapstruct') { -%>
+    <% if (dto == 'mapstruct') { %>
     @Inject
     private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
     <% } -%>
-<% } -%>
+<% } %>

--- a/entity/templates/src/main/java/package/common/inject_template.ejs
+++ b/entity/templates/src/main/java/package/common/inject_template.ejs
@@ -1,4 +1,4 @@
-<% if (!viaService) { -%>
+<% if (!viaService) { %>
     @Inject
     private <%= entityClass %>Repository <%= entityInstance %>Repository;
     <% if (dto == 'mapstruct') { -%>
@@ -8,7 +8,7 @@
     @Inject
     private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;
     <% }
-  } else { -%>
+  } else { %>
     @Inject
     private <%= entityClass %>Service <%= entityInstance %>Service;
     <% if (dto == 'mapstruct') { -%>

--- a/entity/templates/src/main/java/package/common/inject_template.ejs
+++ b/entity/templates/src/main/java/package/common/inject_template.ejs
@@ -1,4 +1,4 @@
-
+<%_ if (!viaService) { _%>
     @Inject
     private <%= entityClass %>Repository <%= entityInstance %>Repository;
     <%_ if (dto == 'mapstruct') { _%>
@@ -7,4 +7,12 @@
     <%_ } if (searchEngine == 'elasticsearch') { _%>
     @Inject
     private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;
+    <%_ }
+  } else {_%>
+    @Inject
+    private <%= entityClass %>Service <%= entityInstance %>Service;
+    <%_ if (dto == 'mapstruct') { _%>
+    @Inject
+    private <%= entityClass %>Mapper <%= entityInstance %>Mapper;
     <%_ } _%>
+<%_ } _%>

--- a/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/entity/templates/src/main/java/package/common/save_template.ejs
@@ -6,17 +6,11 @@ var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
 var resultEntity;
 if (!viaService) {
     if (dto == 'mapstruct') {
-        resultEntity = entityInstance; _%>
+        resultEntity = entityInstance; -%>
         <%= entityClass %> <%= entityInstance %> = <%= dtoToEntity %>(<%= instanceName %>);
         <%= entityInstance %> = <%= entityInstance %>Repository.save(<%= entityInstance %>);
-        <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);
-    <%_ } else {
-    resultEntity = 'result'; _%>
-        <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);
-    <%_ }
-    if (searchEngine == 'elasticsearch') { _%>
-        <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);
-    <%_ }
-} else {_%>
-    <%= entityClass %> result = <%= entityInstance %>Service.save(<%= entityInstance %>);
-<%_ } _%>
+        <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);<% } else {
+    resultEntity = 'result'; -%>
+        <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine == 'elasticsearch') { %>
+        <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% }} else {-%>
+        <%= instanceType %> result = <%= entityInstance %>Service.save(<%= entityInstance %>);<% } -%>

--- a/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/entity/templates/src/main/java/package/common/save_template.ejs
@@ -13,4 +13,4 @@ if (!viaService) {
     resultEntity = 'result'; -%>
         <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine == 'elasticsearch') { %>
         <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% }} else {-%>
-        <%= instanceType %> result = <%= entityInstance %>Service.save(<%= entityInstance %>);<% } -%>
+        <%= instanceType %> result = <%= entityInstance %>Service.save(<%= instanceName %>);<% } -%>

--- a/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/entity/templates/src/main/java/package/common/save_template.ejs
@@ -1,0 +1,18 @@
+<%_ var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
+var mapper = entityInstance  + 'Mapper';
+var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
+var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+var resultEntity;
+if (dto == 'mapstruct') {
+    resultEntity = entityInstance; _%>
+        <%= entityClass %> <%= entityInstance %> = <%= dtoToEntity %>(<%= instanceName %>);
+        <%= entityInstance %> = <%= entityInstance %>Repository.save(<%= entityInstance %>);
+        <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);
+<%_ } else {
+    resultEntity = 'result'; _%>
+        <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);
+<%_ }
+if (searchEngine == 'elasticsearch') { _%>
+        <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);
+<%_ } _%>

--- a/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/entity/templates/src/main/java/package/common/save_template.ejs
@@ -6,11 +6,11 @@ var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
 var resultEntity;
 if (!viaService) {
     if (dto == 'mapstruct') {
-        resultEntity = entityInstance; -%>
+        resultEntity = entityInstance; %>
         <%= entityClass %> <%= entityInstance %> = <%= dtoToEntity %>(<%= instanceName %>);
         <%= entityInstance %> = <%= entityInstance %>Repository.save(<%= entityInstance %>);
         <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);<% } else {
-    resultEntity = 'result'; -%>
+    resultEntity = 'result'; %>
         <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine == 'elasticsearch') { %>
         <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% }} else {-%>
-        <%= instanceType %> result = <%= entityInstance %>Service.save(<%= instanceName %>);<% } -%>
+        <%= instanceType %> result = <%= entityInstance %>Service.save(<%= instanceName %>);<% } %>

--- a/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/entity/templates/src/main/java/package/common/save_template.ejs
@@ -12,5 +12,5 @@ if (!viaService) {
         <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);<% } else {
     resultEntity = 'result'; %>
         <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine == 'elasticsearch') { %>
-        <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% }} else {-%>
+        <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% }} else { %>
         <%= instanceType %> result = <%= entityInstance %>Service.save(<%= instanceName %>);<% } %>

--- a/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/entity/templates/src/main/java/package/common/save_template.ejs
@@ -4,15 +4,19 @@ var mapper = entityInstance  + 'Mapper';
 var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
 var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
 var resultEntity;
-if (dto == 'mapstruct') {
-    resultEntity = entityInstance; _%>
+if (!viaService) {
+    if (dto == 'mapstruct') {
+        resultEntity = entityInstance; _%>
         <%= entityClass %> <%= entityInstance %> = <%= dtoToEntity %>(<%= instanceName %>);
         <%= entityInstance %> = <%= entityInstance %>Repository.save(<%= entityInstance %>);
         <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);
-<%_ } else {
+    <%_ } else {
     resultEntity = 'result'; _%>
         <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);
-<%_ }
-if (searchEngine == 'elasticsearch') { _%>
+    <%_ }
+    if (searchEngine == 'elasticsearch') { _%>
         <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);
+    <%_ }
+} else {_%>
+    <%= entityClass %> result = <%= entityInstance %>Service.save(<%= entityInstance %>);
 <%_ } _%>

--- a/entity/templates/src/main/java/package/common/search_template.ejs
+++ b/entity/templates/src/main/java/package/common/search_template.ejs
@@ -1,6 +1,9 @@
-<% var mapper = entityInstance  + 'Mapper';
-var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO'; %>
+<% if (!viaService) {
+    var mapper = entityInstance  + 'Mapper';
+    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; %>
         return StreamSupport
             .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto == 'mapstruct') { %>
-            .map(<%= mapper %>::<%= entityToDto %>)<% } %>
-            .collect(Collectors.toList());
+            .map(<%= entityToDtoReference %>)<% } %>
+            .collect(Collectors.toList());<% } else { -%>
+        return <%= entityInstance %>Service.search(query);
+<% } -%>

--- a/entity/templates/src/main/java/package/common/search_template.ejs
+++ b/entity/templates/src/main/java/package/common/search_template.ejs
@@ -1,10 +1,10 @@
 <% if (!viaService) {
     var mapper = entityInstance  + 'Mapper';
-    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; -%>
+    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; %>
         log.debug("REST request to search <%= entityClass %>s for query {}", query);
         return StreamSupport
             .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto == 'mapstruct') { %>
             .map(<%= entityToDtoReference %>)<% } %>
-            .collect(Collectors.toList());<% } else { -%>
+            .collect(Collectors.toList());<% } else { %>
         log.debug("Request to search <%= entityClass %>s for query {}", query);
-        return <%= entityInstance %>Service.search(query);<% } -%>
+        return <%= entityInstance %>Service.search(query);<% } %>

--- a/entity/templates/src/main/java/package/common/search_template.ejs
+++ b/entity/templates/src/main/java/package/common/search_template.ejs
@@ -1,9 +1,10 @@
 <% if (!viaService) {
     var mapper = entityInstance  + 'Mapper';
-    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; %>
+    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; -%>
+        log.debug("REST request to search <%= entityClass %>s for query {}", query);
         return StreamSupport
             .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto == 'mapstruct') { %>
             .map(<%= entityToDtoReference %>)<% } %>
             .collect(Collectors.toList());<% } else { -%>
-        return <%= entityInstance %>Service.search(query);
-<% } -%>
+        log.debug("Request to search <%= entityClass %>s for query {}", query);
+        return <%= entityInstance %>Service.search(query);<% } -%>

--- a/entity/templates/src/main/java/package/common/search_template.ejs
+++ b/entity/templates/src/main/java/package/common/search_template.ejs
@@ -1,0 +1,6 @@
+<% var mapper = entityInstance  + 'Mapper';
+var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO'; %>
+        return StreamSupport
+            .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto == 'mapstruct') { %>
+            .map(<%= mapper %>::<%= entityToDto %>)<% } %>
+            .collect(Collectors.toList());

--- a/entity/templates/src/main/java/package/repository/_EntityRepository.java
+++ b/entity/templates/src/main/java/package/repository/_EntityRepository.java
@@ -25,7 +25,7 @@ import java.util.UUID;<% } %>
  */<% } %><% if (databaseType=='cassandra') { %>/**
  * Cassandra repository for the <%= entityClass %> entity.
  */<% } %><% if (databaseType=='sql' || databaseType=='mongodb') { %>
-public interface <%=entityClass%>Repository extends <% if (databaseType=='sql') { %>JpaRepository<% } %><% if (databaseType=='mongodb') { %>MongoRepository<% } %><<%=entityClass%>,<% if (databaseType=='sql') {%>Long<%}%><% if (databaseType=='mongodb') { %>String<%}%>> {<% for (relationshipId in relationships) { %><% if (relationships[relationshipId].relationshipType == 'many-to-one' && relationships[relationshipId].otherEntityName == 'user') { %>
+public interface <%=entityClass%>Repository extends <% if (databaseType=='sql') { %>JpaRepository<% } %><% if (databaseType=='mongodb') { %>MongoRepository<% } %><<%=entityClass%>,<%= pkType %>> {<% for (relationshipId in relationships) { %><% if (relationships[relationshipId].relationshipType == 'many-to-one' && relationships[relationshipId].otherEntityName == 'user') { %>
 
     @Query("select <%= entityInstance %> from <%= entityClass %> <%= entityInstance %> where <%= entityInstance %>.<%= relationships[relationshipId].relationshipFieldName %>.login = ?#{principal.username}")
     List<<%= entityClass %>> findBy<%= relationships[relationshipId].relationshipNameCapitalized %>IsCurrentUser();<% } } %>

--- a/entity/templates/src/main/java/package/service/_EntityService.java
+++ b/entity/templates/src/main/java/package/service/_EntityService.java
@@ -1,0 +1,60 @@
+package <%=packageName%>.service;
+<%  var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
+    var mapper = entityInstance  + 'Mapper';
+    var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
+    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; %>
+import <%=packageName%>.domain.<%= entityClass %>;<% } if (dto == 'mapstruct') { %>
+import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;<% } %><% if (pagination != 'no') { %>
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;<% } %>
+<% if (dto == 'mapstruct') { %>
+import java.util.LinkedList;<% } %>
+import java.util.List;
+
+/**
+ * Service Interface for managing <%= entityClass %>.
+ */
+public Interface <%= entityClass %>Service {
+
+    /**
+     * Save a <%= entityInstance %>.
+     * @param input the <%= instanceType %>
+     * @return the persisted entity
+     */
+    public <%= instanceType %> save<%= entityClass %>(<%= instanceType %> <%= instanceName %>);
+
+    /**
+     *  get all the <%= entityInstance %>s.
+     *  @return the list of entities
+     */
+    public <% if (pagination != 'no') { %>Page<<%= entityClass %>% } else { %>List<<%= instanceType %><% } %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>);
+<% for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
+    /**
+     *  get all the <%= entityInstance %>s where <%= relationships[idx].relationshipNameCapitalized %> is null.
+     *  @return the list of entities
+     */
+    public List<<%= instanceType %>> findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull();
+<% } } -%>
+
+    /**
+     *  get the "id" <%= entityInstance %>.
+     *  @param input id
+     *  @return the entity
+     */
+    public <%= instanceType %> findOne(<%= pkType %> id);
+
+    /**
+     *  delete the "id" <%= entityInstance %>.
+     *  @param input id
+     */
+    public void delete(<%= pkType %> id);<% if (searchEngine == 'elasticsearch') { %>
+
+    /**
+     * search for the <%= entityInstance %> corresponding
+     * to the query.
+     * @param input query
+     */
+    public List<<%= instanceType %>> search(String query);<% } %>
+}

--- a/entity/templates/src/main/java/package/service/_EntityService.java
+++ b/entity/templates/src/main/java/package/service/_EntityService.java
@@ -1,12 +1,8 @@
 package <%=packageName%>.service;
 <%  var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
-    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
-    var mapper = entityInstance  + 'Mapper';
-    var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
-    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
-    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; %>
-import <%=packageName%>.domain.<%= entityClass %>;<% } if (dto == 'mapstruct') { %>
-import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;<% } %><% if (pagination != 'no') { %>
+    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance; %>
+import <%=packageName%>.domain.<%= entityClass %>;<% if (dto == 'mapstruct') { %>
+import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;<% } if (pagination != 'no') { %>
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;<% } %>
 <% if (dto == 'mapstruct') { %>
@@ -29,7 +25,7 @@ public Interface <%= entityClass %>Service {
      *  get all the <%= entityInstance %>s.
      *  @return the list of entities
      */
-    public <% if (pagination != 'no') { %>Page<<%= entityClass %>% } else { %>List<<%= instanceType %><% } %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>);
+    public <% if (pagination != 'no') { %>Page<<%= entityClass %><% } else { %>List<<%= instanceType %><% } %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>);
 <% for (idx in relationships) { if (relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide != true) { -%>
     /**
      *  get all the <%= entityInstance %>s where <%= relationships[idx].relationshipNameCapitalized %> is null.

--- a/entity/templates/src/main/java/package/service/_EntityService.java
+++ b/entity/templates/src/main/java/package/service/_EntityService.java
@@ -12,14 +12,14 @@ import java.util.List;
 /**
  * Service Interface for managing <%= entityClass %>.
  */
-public Interface <%= entityClass %>Service {
+public interface <%= entityClass %>Service {
 
     /**
      * Save a <%= entityInstance %>.
      * @param input the <%= instanceType %>
      * @return the persisted entity
      */
-    public <%= instanceType %> save<%= entityClass %>(<%= instanceType %> <%= instanceName %>);
+    public <%= instanceType %> save(<%= instanceType %> <%= instanceName %>);
 
     /**
      *  get all the <%= entityInstance %>s.

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -66,7 +66,7 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
     }
 <%- include('../../common/get_filtered_template'); -%>
     /**
-     *  get the "id" <%= entityInstance %>.
+     *  get one <%= entityInstance %> by id.
      *  @return the entity
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true) <% } %>
@@ -76,7 +76,7 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
     }
 
     /**
-     *  delete the "id" <%= entityInstance %>.
+     *  delete the  <%= entityInstance %> by id.
      */
     public void delete(<%= pkType %> id) {
         log.debug("Request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template', {viaService: viaService}); -%>

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -56,12 +56,16 @@ public class <%= serviceClassName %> {
      *  @return the list of entities
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true) <% } %>
-    public <% if (pagination != 'no') { %>Page<% } else { %>List<% } %><<%= instanceType %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>) {
-        log.debug("Request to get all <%= entityClass %>s");
-        //TODO
-        return <%= instanceName %>;
+    public <% if (pagination != 'no') { %>Page<<%= entityClass %>% } else { %>List<<%= instanceType %><% } %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>) {
+        log.debug("Request to get all <%= entityClass %>s");<% if (pagination == 'no') { %>
+        List<<%= instanceType %>> result = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
+            .map(<%= entityToDtoReference %>)
+            .collect(Collectors.toCollection(LinkedList::new))<% } %>;<% } else { %>
+        Page<<%= entityClass %>> result = <%= entityInstance %>Repository.findAll(pageable); <% } %>
+        return result;
     }
 
+<%- include('../../common/get_filtered_template'); -%>
 
     /**
      *  get the "id" <%= entityInstance %>.

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -36,17 +36,16 @@ import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
 /**
  * Service Implementation for managing <%= entityClass %>.
  */
-@Service
+@Service<% if (databaseType == 'sql') { %>
+@Transactional<% } %>
 public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implements <%= entityClass %>Service<% } %>{
 
     private final Logger log = LoggerFactory.getLogger(<%= serviceClassName %>.class);
     <%- include('../../common/inject_template', {viaService: viaService}); -%>
     /**
      * Save a <%= entityInstance %>.
-     * @param input the <%= instanceType %>
      * @return the persisted entity
-     */<% if (databaseType == 'sql') { %>
-    @Transactional(readOnly = false) <% } %>
+     */
     public <%= instanceType %> save(<%= instanceType %> <%= instanceName %>) {
         log.debug("Request to save <%= entityClass %> : {}", <%= instanceName %>);<%- include('../../common/save_template', {viaService: viaService}); -%>
         return result;
@@ -67,10 +66,8 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
     }
 
 <%- include('../../common/get_filtered_template'); -%>
-
     /**
      *  get the "id" <%= entityInstance %>.
-     *  @param input id
      *  @return the entity
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true) <% } %>
@@ -81,9 +78,7 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
 
     /**
      *  delete the "id" <%= entityInstance %>.
-     *  @param input id
-     */<% if (databaseType == 'sql') { %>
-    @Transactional(readOnly = false) <% } %>
+     */
     public void delete(<%= pkType %> id) {
         log.debug("Request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template', {viaService: viaService}); -%>
     }<% if (searchEngine == 'elasticsearch') { %>
@@ -91,8 +86,8 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
     /**
      * search for the <%= entityInstance %> corresponding
      * to the query.
-     * @param input query
-     */
+     */<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = true) <% } %>
     public List<<%= instanceType %>> search(String query) {
         <%- include('../../common/search_template', {viaService: viaService}); -%>
     }<% } %>

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -1,5 +1,5 @@
-package <%=packageName%>.<%=servicePackage%>;
-<%  var serviceClassName = TODO;
+package <%=packageName%>.service<% if (service == 'serviceImpl') { %>.impl<% } %>;
+<%  var serviceClassName = service == 'serviceImpl' ? <%= entityClass %>+ 'serviceImpl' : <%= entityClass %>+ 'service';
     var viaService = false;
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
@@ -11,13 +11,13 @@ package <%=packageName%>.<%=servicePackage%>;
     var searchRepository = entityInstance  + 'SearchRepository'; %>
 import <%=packageName%>.domain.<%= entityClass %>;
 import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine == 'elasticsearch') { %>
-import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } if (dto == 'mapstruct') { %>
 import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;
 import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;<% } %>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;<% if (pagination != 'no') { %>
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;<% } if (dto == 'mapstruct') { %>
+import org.springframework.data.domain.Pageable;<% } if (databaseType == 'sql') { %>
 import org.springframework.transaction.annotation.Transactional;<% } %>
 import org.springframework.stereotype.Service;
 
@@ -73,7 +73,7 @@ public class <%= serviceClassName %> {
      *  @return the entity
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true) <% } %>
-    public <%= instanceType %> findOne(<% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+    public <%= instanceType %> findOne(<%= pkType %> id) {
         log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template'); -%>
         return <%= instanceName %>;
     }
@@ -83,7 +83,7 @@ public class <%= serviceClassName %> {
      *  @param input id
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = false) <% } %>
-    public void delete(<% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+    public void delete(<%= pkType %> id) {
         log.debug("Request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template'); -%>
     }<% if (searchEngine == 'elasticsearch') { %>
 

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -1,0 +1,94 @@
+package <%=packageName%>.<%=servicePackage%>;
+<%  var serviceClassName = TODO;
+    var viaService = false;
+    var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
+    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
+    var mapper = entityInstance  + 'Mapper';
+    var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
+    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
+    var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
+    var repository = entityInstance  + 'Repository';
+    var searchRepository = entityInstance  + 'SearchRepository'; %>
+import <%=packageName%>.domain.<%= entityClass %>;
+import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine == 'elasticsearch') { %>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %>
+import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;
+import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;<% } %>
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;<% if (pagination != 'no') { %>
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;<% } if (dto == 'mapstruct') { %>
+import org.springframework.transaction.annotation.Transactional;<% } %>
+import org.springframework.stereotype.Service;
+
+import javax.inject.Inject;<% if (dto == 'mapstruct') { %>
+import java.util.LinkedList;<% } %>
+import java.util.List;
+import java.util.Optional;<% if (databaseType == 'cassandra') { %>
+import java.util.UUID;<% } %><% if (searchEngine == 'elasticsearch' || dto == 'mapstruct' || fieldsContainNoOwnerOneToOne == true) { %>
+import java.util.stream.Collectors;<% } %><% if (searchEngine == 'elasticsearch' || fieldsContainNoOwnerOneToOne == true) { %>
+import java.util.stream.StreamSupport;<% } %><% if (searchEngine == 'elasticsearch') { %>
+
+import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
+
+/**
+ * Service Implementation for managing <%= entityClass %>.
+ */
+@Service
+public class <%= serviceClassName %> {
+
+    private final Logger log = LoggerFactory.getLogger(<%= serviceClassName %>.class);
+    <%- include('../../common/inject_template', {viaService: viaService}); -%>
+    /**
+     * Save a <%= entityInstance %>.
+     * @param input the <%= instanceType %>
+     * @return the persisted entity
+     */<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = false) <% } %>
+    public <%= instanceType %> save<%= entityClass %>(<%= instanceType %> <%= instanceName %>) {
+        log.debug("Request to save <%= entityClass %> : {}", <%= instanceName %>);
+        <%- include('../../common/save_template', {viaService: viaService}); -%>
+        return result;
+    }
+
+    /**
+     *  get all the <%= entityInstance %>s.
+     *  @return the list of entities
+     */<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = true) <% } %>
+    public <% if (pagination != 'no') { %>Page<% } else { %>List<% } %><<%= instanceType %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>) {
+        log.debug("Request to get all <%= entityClass %>s");
+        //TODO
+        return <%= instanceName %>;
+    }
+
+
+    /**
+     *  get the "id" <%= entityInstance %>.
+     *  @param input id
+     *  @return the entity
+     */<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = true) <% } %>
+    public <%= instanceType %> findOne(<% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+        log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template'); -%>
+        return <%= instanceName %>;
+    }
+
+    /**
+     *  delete the "id" <%= entityInstance %>.
+     *  @param input id
+     */<% if (databaseType == 'sql') { %>
+    @Transactional(readOnly = false) <% } %>
+    public void delete(<% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+        log.debug("Request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template'); -%>
+    }<% if (searchEngine == 'elasticsearch') { %>
+
+    /**
+     * search for the <%= entityInstance %> corresponding
+     * to the query.
+     * @param input query
+     */
+    public List<<%= instanceType %>> search(String query) {
+        <%- include('../../common/search_template'); -%>
+    }<% } %>
+}

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -8,7 +8,9 @@ package <%=packageName%>.service<% if (service == 'serviceImpl') { %>.impl<% } %
     var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
     var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO';
     var repository = entityInstance  + 'Repository';
-    var searchRepository = entityInstance  + 'SearchRepository'; %>
+    var searchRepository = entityInstance  + 'SearchRepository';
+    if (service == 'serviceImpl') { %>
+import <%=packageName%>.service.<%= entityClass %>Service;<% } %>
 import <%=packageName%>.domain.<%= entityClass %>;
 import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine == 'elasticsearch') { %>
 import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } if (dto == 'mapstruct') { %>
@@ -45,7 +47,7 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
      * @return the persisted entity
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = false) <% } %>
-    public <%= instanceType %> save<%= entityClass %>(<%= instanceType %> <%= instanceName %>) {
+    public <%= instanceType %> save(<%= instanceType %> <%= instanceName %>) {
         log.debug("Request to save <%= entityClass %> : {}", <%= instanceName %>);<%- include('../../common/save_template', {viaService: viaService}); -%>
         return result;
     }

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -64,7 +64,6 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
         Page<<%= entityClass %>> result = <%= entityInstance %>Repository.findAll(pageable); <% } %>
         return result;
     }
-
 <%- include('../../common/get_filtered_template'); -%>
     /**
      *  get the "id" <%= entityInstance %>.

--- a/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -1,5 +1,5 @@
 package <%=packageName%>.service<% if (service == 'serviceImpl') { %>.impl<% } %>;
-<%  var serviceClassName = service == 'serviceImpl' ? <%= entityClass %>+ 'serviceImpl' : <%= entityClass %>+ 'service';
+<%  var serviceClassName = service == 'serviceImpl' ? entityClass + 'ServiceImpl' : entityClass + 'Service';
     var viaService = false;
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
@@ -35,7 +35,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
  * Service Implementation for managing <%= entityClass %>.
  */
 @Service
-public class <%= serviceClassName %> {
+public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implements <%= entityClass %>Service<% } %>{
 
     private final Logger log = LoggerFactory.getLogger(<%= serviceClassName %>.class);
     <%- include('../../common/inject_template', {viaService: viaService}); -%>
@@ -46,8 +46,7 @@ public class <%= serviceClassName %> {
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = false) <% } %>
     public <%= instanceType %> save<%= entityClass %>(<%= instanceType %> <%= instanceName %>) {
-        log.debug("Request to save <%= entityClass %> : {}", <%= instanceName %>);
-        <%- include('../../common/save_template', {viaService: viaService}); -%>
+        log.debug("Request to save <%= entityClass %> : {}", <%= instanceName %>);<%- include('../../common/save_template', {viaService: viaService}); -%>
         return result;
     }
 
@@ -56,7 +55,7 @@ public class <%= serviceClassName %> {
      *  @return the list of entities
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true) <% } %>
-    public <% if (pagination != 'no') { %>Page<<%= entityClass %>% } else { %>List<<%= instanceType %><% } %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>) {
+    public <% if (pagination != 'no') { %>Page<<%= entityClass %><% } else { %>List<<%= instanceType %><% } %>> findAll(<% if (pagination != 'no') { %>Pageable pageable<% } %>) {
         log.debug("Request to get all <%= entityClass %>s");<% if (pagination == 'no') { %>
         List<<%= instanceType %>> result = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany == true) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto == 'mapstruct') { %>.stream()
             .map(<%= entityToDtoReference %>)
@@ -74,7 +73,7 @@ public class <%= serviceClassName %> {
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true) <% } %>
     public <%= instanceType %> findOne(<%= pkType %> id) {
-        log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template'); -%>
+        log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {viaService: viaService}); -%>
         return <%= instanceName %>;
     }
 
@@ -84,7 +83,7 @@ public class <%= serviceClassName %> {
      */<% if (databaseType == 'sql') { %>
     @Transactional(readOnly = false) <% } %>
     public void delete(<%= pkType %> id) {
-        log.debug("Request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template'); -%>
+        log.debug("Request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template', {viaService: viaService}); -%>
     }<% if (searchEngine == 'elasticsearch') { %>
 
     /**
@@ -93,6 +92,6 @@ public class <%= serviceClassName %> {
      * @param input query
      */
     public List<<%= instanceType %>> search(String query) {
-        <%- include('../../common/search_template'); -%>
+        <%- include('../../common/search_template', {viaService: viaService}); -%>
     }<% } %>
 }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -40,12 +40,11 @@ import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
 public class <%= entityClass %>Resource {
 
     private final Logger log = LoggerFactory.getLogger(<%= entityClass %>Resource.class);
-    <% var viaService = entityHasService; %>
-    <%- include('../../common/inject_template', {viaService: viaService}); -%>
-    <%_
+    <% var viaService = service != 'no'; -%>
+    <%- include('../../common/inject_template', {viaService: viaService}); -%><%
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
-    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
-    _%>
+    var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance; -%>
+
     /**
      * POST  /<%= entityInstance %>s -> Create a new <%= entityInstance %>.
      */
@@ -124,7 +123,6 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public List<<%= instanceType %>> search<%= entityClass %>s(@PathVariable String query) {
-        <%- include('../../common/search_template', {viaService: viaService}); -%>
+    public List<<%= instanceType %>> search<%= entityClass %>s(@PathVariable String query) {<%- include('../../common/search_template', {viaService: viaService}); -%>
     }<% } %>
 }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -95,7 +95,7 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public ResponseEntity<<%= instanceType %>> get<%= entityClass %>(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+    public ResponseEntity<<%= instanceType %>> get<%= entityClass %>(@PathVariable <%= pkType %> id) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {viaService: viaService}); -%>
         return Optional.ofNullable(<%= instanceName %>)
             .map(<%= instanceType %> -> new ResponseEntity<>(
@@ -111,7 +111,7 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.DELETE,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public ResponseEntity<Void> delete<%= entityClass %>(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+    public ResponseEntity<Void> delete<%= entityClass %>(@PathVariable <%= pkType %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template', {viaService: viaService}); -%>
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert("<%= entityInstance %>", id.toString())).build();
     }<% if (searchEngine == 'elasticsearch') { %>

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -98,8 +98,8 @@ public class <%= entityClass %>Resource {
     public ResponseEntity<<%= instanceType %>> get<%= entityClass %>(@PathVariable <%= pkType %> id) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {viaService: viaService}); -%>
         return Optional.ofNullable(<%= instanceName %>)
-            .map(<%= instanceName %> -> new ResponseEntity<>(
-                <%= instanceName %>,
+            .map(result -> new ResponseEntity<>(
+                result,
                 HttpStatus.OK))
             .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -41,11 +41,10 @@ import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
 public class <%= entityClass %>Resource {
 
     private final Logger log = LoggerFactory.getLogger(<%= entityClass %>Resource.class);
-    <% var viaService = service != 'no'; -%>
-    <%- include('../../common/inject_template', {viaService: viaService}); -%><%
+    <% var viaService = service != 'no';
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance; -%>
-
+    <%- include('../../common/inject_template', {viaService: viaService}); -%>
     /**
      * POST  /<%= entityInstance %>s -> Create a new <%= entityInstance %>.
      */
@@ -87,6 +86,7 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed<%- include('../../common/get_all_template', {viaService: viaService}); -%>
+    
     /**
      * GET  /<%= entityInstance %>s/:id -> get the "id" <%= entityInstance %>.
      */

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -98,8 +98,8 @@ public class <%= entityClass %>Resource {
     public ResponseEntity<<%= instanceType %>> get<%= entityClass %>(@PathVariable <%= pkType %> id) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {viaService: viaService}); -%>
         return Optional.ofNullable(<%= instanceName %>)
-            .map(<%= instanceType %> -> new ResponseEntity<>(
-                <%= instanceType %>,
+            .map(<%= instanceName %> -> new ResponseEntity<>(
+                <%= instanceName %>,
                 HttpStatus.OK))
             .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
     }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -40,13 +40,11 @@ import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
 public class <%= entityClass %>Resource {
 
     private final Logger log = LoggerFactory.getLogger(<%= entityClass %>Resource.class);
-    <%- include('../../common/inject_template'); -%>
+    <% var viaService = entityHasService; %>
+    <%- include('../../common/inject_template', {viaService: viaService}); -%>
     <%_
     var instanceType = (dto == 'mapstruct') ? entityClass + 'DTO' : entityClass;
     var instanceName = (dto == 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
-    var mapper = entityInstance  + 'Mapper';
-    var dtoToEntity = mapper + '.'+ entityInstance +'DTOTo' + entityClass;
-    var entityToDto = mapper + '.'+ entityInstance +'To' + entityClass + 'DTO';
     _%>
     /**
      * POST  /<%= entityInstance %>s -> Create a new <%= entityInstance %>.
@@ -59,7 +57,7 @@ public class <%= entityClass %>Resource {
         log.debug("REST request to save <%= entityClass %> : {}", <%= instanceName %>);
         if (<%= instanceName %>.getId() != null) {
             return ResponseEntity.badRequest().header("Failure", "A new <%= entityInstance %> cannot already have an ID").body(null);
-        }<%- include('../../common/save_template'); -%>
+        }<%- include('../../common/save_template', {viaService: viaService}); -%>
         return ResponseEntity.created(new URI("/api/<%= entityInstance %>s/" + result.getId()))
             .headers(HeaderUtil.createEntityCreationAlert("<%= entityInstance %>", result.getId().toString()))
             .body(result);
@@ -76,7 +74,7 @@ public class <%= entityClass %>Resource {
         log.debug("REST request to update <%= entityClass %> : {}", <%= instanceName %>);
         if (<%= instanceName %>.getId() == null) {
             return create<%= entityClass %>(<%= instanceName %>);
-        }<%- include('../../common/save_template'); -%>
+        }<%- include('../../common/save_template', {viaService: viaService}); -%>
         return ResponseEntity.ok()
             .headers(HeaderUtil.createEntityUpdateAlert("<%= entityInstance %>", <%= instanceName %>.getId().toString()))
             .body(result);
@@ -88,7 +86,7 @@ public class <%= entityClass %>Resource {
     @RequestMapping(value = "/<%= entityInstance %>s",
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
-    @Timed<%- include('../../common/get_all_template'); -%>
+    @Timed<%- include('../../common/get_all_template', {viaService: viaService}); -%>
 
     /**
      * GET  /<%= entityInstance %>s/:id -> get the "id" <%= entityInstance %>.
@@ -97,8 +95,8 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public ResponseEntity<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> get<%= entityClass %>(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
-        log.debug("REST request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template'); -%>
+    public ResponseEntity<<%= instanceType %>> get<%= entityClass %>(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
+        log.debug("REST request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {viaService: viaService}); -%>
         return Optional.ofNullable(<%= instanceName %>)
             .map(<%= instanceType %> -> new ResponseEntity<>(
                 <%= instanceType %>,
@@ -114,7 +112,7 @@ public class <%= entityClass %>Resource {
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
     public ResponseEntity<Void> delete<%= entityClass %>(@PathVariable <% if (databaseType == 'sql') { %>Long<% } %><% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } %> id) {
-        log.debug("REST request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template'); -%>
+        log.debug("REST request to delete <%= entityClass %> : {}", id);<%- include('../../common/delete_template', {viaService: viaService}); -%>
         return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert("<%= entityInstance %>", id.toString())).build();
     }<% if (searchEngine == 'elasticsearch') { %>
 
@@ -126,7 +124,7 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed
-    public List<<%= entityClass %><% if (dto == 'mapstruct') { %>DTO<% } %>> search<%= entityClass %>s(@PathVariable String query) {
-        <%- include('../../common/search_template'); -%>
+    public List<<%= instanceType %>> search<%= entityClass %>s(@PathVariable String query) {
+        <%- include('../../common/search_template', {viaService: viaService}); -%>
     }<% } %>
 }

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -1,9 +1,10 @@
 package <%=packageName%>.web.rest;
 
 import com.codahale.metrics.annotation.Timed;
-import <%=packageName%>.domain.<%= entityClass %>;
+import <%=packageName%>.domain.<%= entityClass %>;<% if (service != 'no') { %>
+import <%=packageName%>.service.<%= entityClass %>Service;<% } else { %>
 import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine == 'elasticsearch') { %>
-import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% }} %>
 import <%=packageName%>.web.rest.util.HeaderUtil;<% if (pagination != 'no') { %>
 import <%=packageName%>.web.rest.util.PaginationUtil;<% } %><% if (dto == 'mapstruct') { %>
 import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;

--- a/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -87,7 +87,6 @@ public class <%= entityClass %>Resource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     @Timed<%- include('../../common/get_all_template', {viaService: viaService}); -%>
-
     /**
      * GET  /<%= entityInstance %>s/:id -> get the "id" <%= entityInstance %>.
      */

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -151,7 +151,7 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
     private static final String <%=updatedValueName %>_CONTENT_TYPE = "image/png";<% } else if (isEnum) { %>
 
 
-private static final <%=fieldType %> <%=defaultValueName %> = <%=fieldType %>.<%=enumValue1 %>;
+    private static final <%=fieldType %> <%=defaultValueName %> = <%=fieldType %>.<%=enumValue1 %>;
     private static final <%=fieldType %> <%=updatedValueName %> = <%=fieldType %>.<%=enumValue2 %>;<% } } %>
 
     @Inject

--- a/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -3,8 +3,9 @@ package <%=packageName%>.web.rest;
 import <%=packageName%>.AbstractCassandraTest;<% } %>
 import <%=packageName%>.Application;
 import <%=packageName%>.domain.<%= entityClass %>;
-import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine == 'elasticsearch') { %>
-import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %><% if (dto == 'mapstruct') { %>
+import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (service != 'no') { %>
+import <%=packageName%>.service.<%= entityClass %>Service;<% } else { if (searchEngine == 'elasticsearch') { %>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% }} if (dto == 'mapstruct') { %>
 import <%=packageName%>.web.rest.dto.<%= entityClass %>DTO;
 import <%=packageName%>.web.rest.mapper.<%= entityClass %>Mapper;<% } %>
 
@@ -158,10 +159,13 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
     private <%= entityClass %>Repository <%= entityInstance %>Repository;<% if (dto == 'mapstruct') { %>
 
     @Inject
-    private <%= entityClass %>Mapper <%= entityInstance %>Mapper;<% } %><% if (searchEngine == 'elasticsearch') { %>
+    private <%= entityClass %>Mapper <%= entityInstance %>Mapper;<% } if (service != 'no') { %>
 
     @Inject
-    private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;<% } %>
+    private <%= entityClass %>Service <%= entityInstance %>Service;<% } else { if (searchEngine == 'elasticsearch') { %>
+
+    @Inject
+    private <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;<% }} %>
 
     @Inject
     private MappingJackson2HttpMessageConverter jacksonMessageConverter;
@@ -176,10 +180,11 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
     @PostConstruct
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource();
-        ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Repository", <%= entityInstance %>Repository);<% if (dto == 'mapstruct') { %>
-        ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Mapper", <%= entityInstance %>Mapper);<% } %><% if (searchEngine == 'elasticsearch') { %>
+        <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource();<% if (service != 'no') { %>
+        ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Service", <%= entityInstance %>Service);<% } else { if (searchEngine == 'elasticsearch') { %>
         ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>SearchRepository", <%= entityInstance %>SearchRepository);<% } %>
+        ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Repository", <%= entityInstance %>Repository);<% } if (dto == 'mapstruct') { %>
+        ReflectionTestUtils.setField(<%= entityInstance %>Resource, "<%= entityInstance %>Mapper", <%= entityInstance %>Mapper);<% } %>
         this.rest<%= entityClass %>MockMvc = MockMvcBuilders.standaloneSetup(<%= entityInstance %>Resource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
             .setMessageConverters(jacksonMessageConverter).build();


### PR DESCRIPTION
Option to choose service layer with or without interface/impl
Most of the code in `_entityResource.java` has been moved into `common/*.ejs` files and is resusedin service as well, so there is very little duplication of code also is much easier to maintain (as per https://github.com/jhipster/generator-jhipster/issues/1749)
works with DTO and non DTO options
works with and without pagination (findAll will fail in casandra it was already as such)
