### PR TITLE
Fix base name for social email translation

### DIFF
--- a/app/templates/src/main/resources/i18n/_messages_en.properties
+++ b/app/templates/src/main/resources/i18n/_messages_en.properties
@@ -16,6 +16,7 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
 email.social.registration.title=<%= baseName %> account activation

--- a/app/templates/src/main/resources/i18n/_messages_fr.properties
+++ b/app/templates/src/main/resources/i18n/_messages_fr.properties
@@ -16,6 +16,7 @@ email.reset.title=<%= baseName %> Réinitialisation de mot de passe
 email.reset.greeting=Cher {0}
 email.reset.text1=Un nouveau mot de passe pour votre compte <%= baseName %> a été demandé, veuillez cliquer sur le lien ci-dessous pour le réinitialiser:
 email.reset.text2=Cordialement,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
 email.social.registration.title=Activation de votre compte <%= baseName %>

--- a/languages/templates/src/main/resources/i18n/_messages_ca.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_ca.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_da.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_da.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_de.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_de.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> Passwort zurücksetzen
 email.reset.greeting=Liebe(r) {0}
 email.reset.text1=Für ihren <%= baseName %> Account wurde ein Passwordreset angefordert, bitte klicke Sie auf den Link unten, um das Passwort zurückzusetzen:
 email.reset.text2=Grüße,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_es.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_es.properties
@@ -16,10 +16,11 @@ email.reset.title=Reinicio de contraseña de <%= baseName %>
 email.reset.greeting=Estimado {0}
 email.reset.text1=Se ha solicitado el reinicio de contraseña para su cuenta de <%= baseName %>, por favor, haga clic en el enlace de abajo para reiniciarla:
 email.reset.text2=Saludos,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=Activación de cuenta jhipster
+email.social.registration.title=Activación de cuenta <%= baseName %>
 email.social.registration.greeting=Estimado {0}
-email.social.registration.text1=Tu cuenta de jhipster ha sido creada con una conexión {0}.
+email.social.registration.text1=Tu cuenta de <%= baseName %> ha sido creada con una conexión {0}.
 email.social.registration.text2=Saludos,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_gl.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_gl.properties
@@ -16,10 +16,11 @@ email.reset.title=Reinicio de contrasinal de <%= baseName %>
 email.reset.greeting=Estimado {0}
 email.reset.text1=Solicitouse o reinicio de contrasinal para a súa conta de <%= baseName %>, por favor faga clic na ligazón de abaixo para reiniciala:
 email.reset.text2=Saúdos,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=Activación da conta jhipster
+email.social.registration.title=Activación da conta <%= baseName %>
 email.social.registration.greeting=Estimado {0}
-email.social.registration.text1=A súa conta de jhipster foi creada cunha conexión {0}.
+email.social.registration.text1=A súa conta de <%= baseName %> foi creada cunha conexión {0}.
 email.social.registration.text2=Saúdos,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_hu.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_hu.properties
@@ -16,6 +16,7 @@ email.reset.title=<%= baseName %> jelszó visszaállítás
 email.reset.greeting=Tisztelt {0}
 email.reset.text1=Az Ön <%= baseName %> fiókjához jelszó-visszaállítót kértek, kérjük kattintson az alábbi linkre, hogy a jelszavát visszaállíthassa :
 email.reset.text2=Üdvözlettel,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
 email.social.registration.title=<%= baseName %> hozzáférés aktíválása

--- a/languages/templates/src/main/resources/i18n/_messages_it.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_it.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> reimpostazione della password
 email.reset.greeting=Caro {0}
 email.reset.text1=Per il vostro <%= baseName %> account, è stato richiesta una reimpostazione della password , cliccate sul seguente URL per ripristinarlo:
 email.reset.text2=Saluti,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_ja.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_ja.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_ko.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_ko.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> \ube44\ubc00\ubc88\ud638 \ubcc0\uacbd
 email.reset.greeting={0}\ub2d8 \uc548\ub155\ud558\uc138\uc694
 email.reset.text1=<%= baseName %> \uacc4\uc815 \ube44\ubc00\ubc88\ud638 \ubcc0\uacbd \uc694\uccad\uc744 \ud558\uc168\uc2b5\ub2c8\ub2e4. \uc544\ub798 URL\uc744 \ud074\ub9ad\ud574 \ube44\ubc00\ubc88\ud638\ub97c \ubcc0\uacbd\ud574 \uc8fc\uc138\uc694:
 email.reset.text2=\uac10\uc0ac\ud569\ub2c8\ub2e4.
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_nl.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_nl.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> wachtwoord reset
 email.reset.greeting=Beste {0}
 email.reset.text1=Voor uw <%= baseName %> account werd een wachtwoord reset gevraagd, gelieve op de onderstaande URL te klikken om te resetten:
 email.reset.text2=Met vriendelijke groeten,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_pl.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_pl.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_pt_br.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_pt_br.properties
@@ -16,10 +16,11 @@ email.reset.title=A Senha da aplicação <%= baseName %> foi reiniciada
 email.reset.greeting=Caro {0}
 email.reset.text1=Foi solicitado o reinicio de senha da sua conta <%= baseName %>. Por favor clique na url abaixo para alterá-la:
 email.reset.text2=Prezado,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_pt_pt.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_pt_pt.properties
@@ -16,10 +16,11 @@ email.reset.title=A palavra-passe da aplicação <%= baseName %> foi reiniciada
 email.reset.greeting=Caro {0}
 email.reset.text1=Foi solicitada a recuperação da palavra-passe da sua conta <%= baseName %>. Por favor clique na ligação abaixo para alterá-la:
 email.reset.text2=Atenciosamente,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=ativação de conta
+email.social.registration.title=<%= baseName %> ativação de conta
 email.social.registration.greeting=Caro {0}
-email.social.registration.text1=A sua conta foi criada com ligação a {0}.
+email.social.registration.text1=A sua <%= baseName %> conta foi criada com ligação a {0}.
 email.social.registration.text2=Atenciosamente,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_ro.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_ro.properties
@@ -16,10 +16,11 @@ email.reset.title=Resetare parolă pentru <%= baseName %>
 email.reset.greeting=Draga {0}
 email.reset.text1=A fost cerută o resetare de parolă pentru contul dumneavoastră <%= baseName %>, va rugam să accesați pagina de mai jos:
 email.reset.text2=Cu stimă,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_ru.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_ru.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_sv.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_sv.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> återställning av lösenord
 email.reset.greeting=Käre {0}
 email.reset.text1=Du har begärt att få återställa ditt lösenord för ditt <%= baseName %> konto, klicka på länken nedanför för att återställa det:
 email.reset.text2=Vänliga hälsningar,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_tr.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_tr.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> \u015Fifre s\u0131f\u0131rlama
 email.reset.greeting=De\u011Ferli {0}
 email.reset.text1=<%= baseName %> hesab\u0131n\u0131z i\u00E7in \u015Fifre \u015F\u0131f\u0131rlama talebi al\u0131nd\u0131, l\u00FCtfen \u015Fifrenizi s\u0131f\u0131rlamak i\u00E7in a\u015Fa\u011F\u0131daki ba\u011Flant\u0131ya t\u0131klay\u0131n:
 email.reset.text2=Sayg\u0131lar\u0131m\u0131zla,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster hesap aktifle\u015Ftirme
+email.social.registration.title=<%= baseName %> hesap aktifle\u015Ftirme
 email.social.registration.greeting=De\u011Ferli {0}
-email.social.registration.text1=JHipster hesab\u0131n\u0131z {0} ba\u011Flant\u0131s\u0131 ile olu\u015Fturuldu.
+email.social.registration.text1=<%= baseName %> hesab\u0131n\u0131z {0} ba\u011Flant\u0131s\u0131 ile olu\u015Fturuldu.
 email.social.registration.text2=Sayg\u0131lar\u0131m\u0131zla,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_zh_cn.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_zh_cn.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>

--- a/languages/templates/src/main/resources/i18n/_messages_zh_tw.properties
+++ b/languages/templates/src/main/resources/i18n/_messages_zh_tw.properties
@@ -16,10 +16,11 @@ email.reset.title=<%= baseName %> password reset
 email.reset.greeting=Dear {0}
 email.reset.text1=For your <%= baseName %> account a password reset was requested, please click on the URL below to reset it:
 email.reset.text2=Regards,
+
 <%_ if (enableSocialSignIn) { _%>
 # Social validation e-mail
-email.social.registration.title=jhipster account activation
+email.social.registration.title=<%= baseName %> account activation
 email.social.registration.greeting=Dear {0}
-email.social.registration.text1=Your jhipster account has been created with a {0} connection.
+email.social.registration.text1=Your <%= baseName %> account has been created with a {0} connection.
 email.social.registration.text2=Regards,
 <%_ } _%>


### PR DESCRIPTION
Like @deepu105 says, change jhipster by baseName and add new line above social translate block.