### PR TITLE
Revert jdbc clientdetails

### DIFF
--- a/app/templates/src/main/java/package/config/_OAuth2ServerConfiguration.java
+++ b/app/templates/src/main/java/package/config/_OAuth2ServerConfiguration.java
@@ -126,7 +126,7 @@ public class OAuth2ServerConfiguration {
         @Override
         public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
             clients
-                <% if (databaseType == 'sql') { %>.jdbc(dataSource)<% } else { %>.inMemory()<% } %>
+                .inMemory()
                 .withClient(jHipsterProperties.getSecurity().getAuthentication().getOauth().getClientid())
                 .scopes("read", "write")
                 .authorities(AuthoritiesConstants.ADMIN, AuthoritiesConstants.USER)


### PR DESCRIPTION
Let's remove the usage of the database for storing the client details so that everybody can login again.
A correct implementation of multi-client app oauth can be discussed later.

Fix #2069