### PR TITLE
Pull .content from threadDump for metrics modal

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/admin/metrics/_metrics.controller.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/metrics/_metrics.controller.js
@@ -49,7 +49,7 @@ angular.module('<%=angularAppName%>')
                     size: 'lg',
                     resolve: {
                         threadDump: function() {
-                            return data;
+                            return data.content;
                         }
 
                     }


### PR DESCRIPTION
The Metrics modal requires the thread dump content as an array, but
/dump returns { content: [], ...}.  Updated the metrics.controller.js
to return response.data.content when resolving the threadDump.

I thought about putting the .content into the MonitoringService
but doing that would restrict other client code from using any of the
other information in the /dump response.

Addresses jhipster/generator-jhipster#2342