### PR TITLE
Configure a cassandra cluster in prod profile

### DIFF
--- a/app/templates/_docker-compose-prod.yml
+++ b/app/templates/_docker-compose-prod.yml
@@ -46,4 +46,11 @@
   - "7199:7199"
   - "9042:9042"
   - "9160:9160"
+
+<%=baseName%>-prod-cassandra-node:
+  image: cassandra:2.2.3
+  links:
+  - jhipster-prod-cassandra:seed
+  environment:
+  - CASSANDRA_SEEDS=seed
 <% } %>


### PR DESCRIPTION
In prod profile, a 2-node cluster will be spawned by docker-compose.
A simple ```docker-compose scale <your-app-name>-prod-cassandra-node=3``` for instance will spawn 3 more nodes that will add themselves to the ring.
By default only localhost is set as contact-points for the datastax driver. This is only needed at the driver startup. After that the driver will get the other nodes IPs and use them (meaning that even if the seed node fails, the app will continue to see the cluster).