### PR TITLE
Travis : split grunt lib and gulp lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,14 @@ env:
   global:
   - JHIPSTER_MVN_DEP=1
   - RUNTASK=1
+  - GRUNT=1
   - JHIPSTER_TRAVIS=$TRAVIS_BUILD_DIR/travis
   - JHIPSTER_INSTALL=$JHIPSTER_TRAVIS/install
   - JHIPSTER_SAMPLES=$JHIPSTER_TRAVIS/samples
   - JHIPSTER_SCRIPTS=$JHIPSTER_TRAVIS/scripts
   matrix:
   - PROFILE=dev  JHIPSTER=app-gradle    RUNTASK=0
-  - PROFILE=dev  JHIPSTER=app-gulp
+  - PROFILE=dev  JHIPSTER=app-gulp      GRUNT=0
   - PROFILE=dev  JHIPSTER=app-cassandra
   - PROFILE=dev  JHIPSTER=app-default
   - PROFILE=dev  JHIPSTER=app-mongodb

--- a/travis/scripts/01-generate-project.sh
+++ b/travis/scripts/01-generate-project.sh
@@ -5,6 +5,11 @@ set -ev
 #--------------------------------------------------
 mv -f $JHIPSTER_SAMPLES/$JHIPSTER $HOME/
 cd $HOME/$JHIPSTER
+if [ $GRUNT == 1 ]; then
+    rm -Rf $HOME/$JHIPSTER/node_modules/gulp*
+else
+    rm -Rf $HOME/$JHIPSTER/node_modules/grunt*
+fi
 npm link generator-jhipster
 yo jhipster --force --no-insight
 ls -al $HOME/$JHIPSTER


### PR DESCRIPTION
When upgrading lib, there can be conflict between grunt lib and gulp lib.
So split grunt lib and gulp lib (delete the useless lib) before generating project
