### PR TITLE
Add datastax opscenter to dockerized cassandra

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -531,6 +531,8 @@ JhipsterGenerator.prototype.app = function app() {
     }
     if (this.devDatabaseType == "cassandra") {
         this.template('_Dockerfile_cassandra', 'Dockerfile', this, {});
+        this.template('docker/cassandra/_cassandra.sh', 'docker/cassandra/cassandra.sh', this, {});
+        this.template('docker/opscenter/_Dockerfile', 'docker/opscenter/Dockerfile', this, {});
     }
 
     switch (this.frontendBuilder) {

--- a/app/templates/_Dockerfile_cassandra
+++ b/app/templates/_Dockerfile_cassandra
@@ -1,6 +1,16 @@
 FROM cassandra:2.2.3
 MAINTAINER Pascal Grimaud <pascalgrimaud@gmail.com>
 
+# install datastax-agent
+RUN apt-get update && apt-get install -y curl sysstat
+RUN mkdir /opt/datastax-agent
+RUN curl -L http://downloads.datastax.com/community/datastax-agent-5.2.2.tar.gz | tar xz --strip-components=1 -C "/opt/datastax-agent"
+RUN echo "stomp_interface: opscenter" >> /opt/datastax-agent/conf/address.yaml
+
+# add datastax-agent wrapper entrypoint
+ADD docker/cassandra/cassandra.sh /cassandra.sh
+RUN chmod a+x /cassandra.sh
+
 # add script cql
 ADD src/main/resources/config/cql/create-keyspace.cql /create-keyspace.cql
 ADD src/main/resources/config/cql/create-tables.cql /create-tables.cql
@@ -14,3 +24,6 @@ RUN cat create-tables.cql >> create-keyspace-tables.cql
 RUN echo "#!/bin/bash" > /usr/local/bin/init
 RUN echo "cqlsh -f create-keyspace-tables.cql" >> /usr/local/bin/init
 RUN chmod 755 /usr/local/bin/init
+
+ENTRYPOINT ["/cassandra.sh"]
+CMD ["cassandra", "-f"]

--- a/app/templates/_docker-compose-prod.yml
+++ b/app/templates/_docker-compose-prod.yml
@@ -42,7 +42,7 @@
   - "8888:8888"
 
 jhipster-prod-cassandra:
-  container_name: <%=baseName%>-prod-cassandra
+  container_name: <%=baseName.toLowerCase()%>-prod-cassandra
   build: .
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-cassandra/:/var/lib/cassandra/data
@@ -55,7 +55,7 @@ jhipster-prod-cassandra:
   - "9042:9042"
   - "9160:9160"
 
-<%=baseName%>-prod-cassandra-node:
+<%=baseName.toLowerCase()%>-prod-cassandra-node:
   build: .
   links:
   - jhipster-prod-cassandra:seed

--- a/app/templates/_docker-compose-prod.yml
+++ b/app/templates/_docker-compose-prod.yml
@@ -35,11 +35,19 @@
   # - ~/volumes/jhipster/<%=baseName%>/prod-mongodb/:/data/db/
   ports:
   - "27017:27017"
-<% } if (prodDatabaseType == 'cassandra') { %>jhipster-prod-cassandra:
+<% } if (prodDatabaseType == 'cassandra') { %>jhipster-opscenter:
+  container_name: jhipster-opscenter
+  build: ./docker/opscenter
+  ports:
+  - "8888:8888"
+
+jhipster-prod-cassandra:
   container_name: <%=baseName%>-prod-cassandra
   build: .
   # volumes:
   # - ~/volumes/jhipster/<%=baseName%>/prod-cassandra/:/var/lib/cassandra/data
+  links:
+  - jhipster-opscenter:opscenter
   ports:
   - "7000:7000"
   - "7001:7001"
@@ -48,9 +56,10 @@
   - "9160:9160"
 
 <%=baseName%>-prod-cassandra-node:
-  image: cassandra:2.2.3
+  build: .
   links:
   - jhipster-prod-cassandra:seed
+  - jhipster-opscenter:opscenter
   environment:
   - CASSANDRA_SEEDS=seed
 <% } %>

--- a/app/templates/docker/cassandra/_cassandra.sh
+++ b/app/templates/docker/cassandra/_cassandra.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "${1:0:1}" = '-' ] || [ "$1" = 'cassandra' ]; then
+	/bin/bash -c 'sleep 30 ;/opt/datastax-agent/bin/datastax-agent' &
+fi
+
+/docker-entrypoint.sh "$@"

--- a/app/templates/docker/opscenter/_Dockerfile
+++ b/app/templates/docker/opscenter/_Dockerfile
@@ -1,0 +1,7 @@
+FROM python:2.7
+
+RUN mkdir /opt/opscenter && wget -O - http://downloads.datastax.com/community/opscenter-5.2.2.tar.gz | tar xzf - --strip-components=1 -C /opt/opscenter
+
+WORKDIR /opt/opscenter
+
+CMD bin/opscenter -f

--- a/travis/scripts/04-docker-compose.sh
+++ b/travis/scripts/04-docker-compose.sh
@@ -10,7 +10,7 @@ if [ -a docker-compose-prod.yml ]; then
   docker-compose -f docker-compose-prod.yml up -d
   if [ $JHIPSTER == "app-cassandra" ]; then
     sleep 30
-    docker exec -it sampleCassandra-prod-cassandra init
+    docker exec -it samplecassandra-prod-cassandra init
   else
     sleep 20
   fi


### PR DESCRIPTION
* Datastax Opscenter (community edition) is spawned by docker-compose and accessible at ```http://localhost:8888```
* The datastax-agent is installed and started on each node. The agent automatically connects to the opscenter container to send its metrics.

