### PR TITLE
Add swagger doc annotations from javadoc

### DIFF
--- a/entity/index.js
+++ b/entity/index.js
@@ -890,21 +890,30 @@ EntityGenerator.prototype.files = function files() {
     // Expose utility methods in templates
     this.util = {};
     this.util.contains = _.contains;
-    var wordwrap = function(text, width){
+    var wordwrap = function(text, width, seperator, keepLF){
         var wrappedText = '';
         var rows = text.split('\n');
         for (var i = 0; i < rows.length; i++) {
             var row = rows[i];
-            wrappedText = wrappedText + '\n' + _s.wrap(row, { width: width });
+            if(keepLF == true && i != 0) {
+                wrappedText = wrappedText + '\\n';
+            }
+            wrappedText = wrappedText + seperator + _s.wrap(row, { width: width , seperator : seperator, preserveSpaces: keepLF });
         }
         return wrappedText;
     }
     var wordwrapWidth = 80;
     this.util.formatAsClassJavadoc = function (text) {
-        return '/**' + wordwrap(text, wordwrapWidth - 4).replace(/\n/g, '\n * ') + '\n */';
+        return '/**' + wordwrap(text, wordwrapWidth - 4, '\n * ', false) + '\n */';
     };
     this.util.formatAsFieldJavadoc = function (text) {
-        return '    /**' + wordwrap(text, wordwrapWidth - 8).replace(/\n/g, '\n     * ') + '\n     */';
+        return '    /**' + wordwrap(text, wordwrapWidth - 8, '\n     * ', false) + '\n     */';
+    };
+    this.util.formatAsApiModel = function (text) {
+        return wordwrap(text.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"'), wordwrapWidth - 9, '"\n    + "', true)
+    };
+    this.util.formatAsApiModelProperty = function (text) {
+        return wordwrap(text.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"'), wordwrapWidth - 13, '"\n        + "', true)
     };
 
     if (this.useConfigurationFile == false) { // store informations in a file for further use.

--- a/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/entity/templates/src/main/java/package/domain/_Entity.java
@@ -1,6 +1,20 @@
 package <%=packageName%>.domain;
 <% if (databaseType == 'cassandra') { %>
-import com.datastax.driver.mapping.annotations.*;<% } %><%
+import com.datastax.driver.mapping.annotations.*;<% } %><% if (typeof javadoc != 'undefined') { -%>
+import io.swagger.annotations.ApiModel;<% } %><%
+var importApiModelProperty = false;
+for (relationshipId in relationships) {
+    if (typeof relationships[relationshipId].javadoc != 'undefined') {
+        importApiModelProperty = true;
+    }
+}
+for (fieldId in fields) {
+    if (typeof fields[fieldId].javadoc != 'undefined') {
+        importApiModelProperty = true;
+    }
+}
+if (importApiModelProperty) { %>
+import io.swagger.annotations.ApiModelProperty;<% } %><%
 var importJsonignore = false;
 for (relationshipId in relationships) {
     if (relationships[relationshipId].relationshipType == 'one-to-many') {
@@ -48,6 +62,7 @@ import <%=packageName%>.domain.enumeration.<%= element %>;<% }); %>
  */
 <% } else { -%>
 <%- util.formatAsClassJavadoc(javadoc) %>
+@ApiModel(description = "<%- util.formatAsApiModel(javadoc) %>")
 <% } -%>
 <% if (databaseType == 'sql') { -%>
 @Entity
@@ -68,7 +83,8 @@ public class <%= entityClass %> implements Serializable {
 
 <%_ for (fieldId in fields) {
     if (typeof fields[fieldId].javadoc != 'undefined') { _%>
-<%- util.formatAsFieldJavadoc(fields[fieldId].javadoc) -%>
+<%- util.formatAsFieldJavadoc(fields[fieldId].javadoc) %>
+    @ApiModelProperty(value = "<%- util.formatAsApiModelProperty(fields[fieldId].javadoc) %>")
     <%_ }
     var required = false;
     if (fields[fieldId].fieldValidate == true) {
@@ -115,7 +131,8 @@ public class <%= entityClass %> implements Serializable {
             mappedBy = otherEntityRelationshipName.charAt(0).toLowerCase() + otherEntityRelationshipName.slice(1)
         }
         if (typeof relationships[relationshipId].javadoc != 'undefined') { _%>
-<%- util.formatAsFieldJavadoc(relationships[relationshipId].javadoc) -%>
+<%- util.formatAsFieldJavadoc(relationships[relationshipId].javadoc) %>
+    @ApiModelProperty(value = "<%- util.formatAsApiModelProperty(relationships[relationshipId].javadoc) %>")
     <%_ }
         if (relationships[relationshipId].relationshipType == 'one-to-many') {
     _%>


### PR DESCRIPTION
This adds swagger annotations in the generated entities based on the "javadoc" field of the entity json file.
The doc is then accessible in swagger-ui and used when generating clients with swagger-codegen