### PR TITLE
Improve the gulp experience so it's like grunt.

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -163,7 +163,7 @@ gulp.task('serve', function() {
             }));
 
         browserSync({
-            open: false,
+            open: true,
             port: yeoman.port,
             server: {
                 baseDir: yeoman.app,
@@ -171,7 +171,7 @@ gulp.task('serve', function() {
             }
         });
 
-        gulp.run('watch');
+        gulp.start('watch');
     });
 });
 


### PR DESCRIPTION
- Open a browser window automatically when you type 'gulp'.
- Change from gulp.run to gulp.start since run is deprecated.

http://stackoverflow.com/questions/21905875/gulp-run-is-deprecated-how-do-i-compose-tasks