### PR TITLE
Ensures the pom.xml file has a defined project version or an inherited parent version

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -8,7 +8,13 @@ var parseVersionFromPomXml = function() {
     var version;
     var pomXml = fs.readFileSync('pom.xml', "utf8");
     parseString(pomXml, function (err, result){
-        version = result.project.version[0];
+        if (result.project.version && result.project.version[0]) {
+            version = result.project.version[0];
+        } else if (result.project.parent && result.project.parent[0] && result.project.parent[0].version && result.project.parent[0].version[0]) {
+            version = result.project.parent[0].version[0]
+        } else {
+            throw new Error('pom.xml is malformed. No version is defined');
+        }
     });
     return version;
 };<% } else { %>

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -49,7 +49,13 @@ var parseVersionFromPomXml = function() {
     var version;
     var pomXml = fs.readFileSync('pom.xml', 'utf8');
     parseString(pomXml, function (err, result) {
-        version = result.project.version[0];
+        if (result.project.version && result.project.version[0]) {
+            version = result.project.version[0];
+        } else if (result.project.parent && result.project.parent[0] && result.project.parent[0].version && result.project.parent[0].version[0]) {
+            version = result.project.parent[0].version[0]
+        } else {
+            throw new Error('pom.xml is malformed. No version is defined');
+        }
     });
     return version;
 };<% } else { %>


### PR DESCRIPTION
I made this pull request because after generating my project, I actually had to use a company specific parent and not the default one. The project used it's inherited versionand no project version was defined. I could not execute any Grunt task.

I actually spent an entire day figuring this outbecause the error I had with our without --stack was of no help at all : 
TypeError: Cannot read property '0' of undefined
Warning: Task "default" not found. Use --force to continue.

This pull request is made to ensure that the pom.xml file has a defined project version or an inherited parent version.
The updated template code throws an exception otherwise to indicate the source of the error.