### PR TITLE
avoid to show doNotMatch error with other result messages

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/account/password/_password.controller.js
+++ b/app/templates/src/main/webapp/scripts/app/account/password/_password.controller.js
@@ -11,6 +11,8 @@ angular.module('<%=angularAppName%>')
         $scope.doNotMatch = null;
         $scope.changePassword = function () {
             if ($scope.password !== $scope.confirmPassword) {
+                $scope.error = null;
+                $scope.success = null;
                 $scope.doNotMatch = 'ERROR';
             } else {
                 $scope.doNotMatch = null;

--- a/app/templates/src/test/javascript/spec/app/account/password/_password.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/password/_password.controller.spec.js
@@ -34,6 +34,8 @@ describe('Controllers Tests ', function() {
             $scope.changePassword();
             //THEN
             expect($scope.doNotMatch).toBe('ERROR');
+            expect($scope.error).toBeNull();
+            expect($scope.success).toBeNull();
         });
         it('should call Auth.changePassword when passwords match', function() {
             //GIVEN
@@ -58,6 +60,7 @@ describe('Controllers Tests ', function() {
             $scope.$apply($scope.changePassword);
 
             //THEN
+            expect($scope.doNotMatch).toBeNull();
             expect($scope.error).toBeNull();
             expect($scope.success).toBe('OK');
         });
@@ -72,6 +75,7 @@ describe('Controllers Tests ', function() {
             $scope.$apply($scope.changePassword);
 
             //THEN
+            expect($scope.doNotMatch).toBeNull();
             expect($scope.success).toBeNull();
             expect($scope.error).toBe('ERROR');
         });


### PR DESCRIPTION
If you submit non matching form after you changed the password successfully; you would get error error message and success message at the same time.  Other messages should be set to `null`, so does `$scope.doNotMatch`.

![screenshot from 2015-12-04 14-47-48](https://cloud.githubusercontent.com/assets/1939193/11626319/1b1a05e6-9ce2-11e5-965e-bfca2fc9e3c3.png)

*The changes were tested.*