### PR TITLE
Fix password strength indicator style 

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/account/password/_password.directive.js
+++ b/app/templates/src/main/webapp/scripts/app/account/password/_password.directive.js
@@ -71,9 +71,9 @@ angular.module('<%=angularAppName%>')
                         var c = strength.getColor(strength.mesureStrength(password));
                         iElement.removeClass('ng-hide');
                         iElement.find('ul').children('li')
-                            .css({ 'background': '#DDD' })
+                            .css({ 'background-color': '#DDD' })
                             .slice(0, c.idx)
-                            .css({ 'background': c.col });
+                            .css({ 'background-color': c.col });
                     }
                 });
             }


### PR DESCRIPTION
Replace 'backroung' with 'background-color' CSS key in password.directive.js to match jasmine tests in password.directive.spec.js