### PR TITLE
fix user management server-side validation

### DIFF
--- a/app/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/app/templates/src/main/java/package/web/rest/_UserResource.java
@@ -131,8 +131,12 @@ public class UserResource {
     public ResponseEntity<ManagedUserDTO> updateUser(@RequestBody ManagedUserDTO managedUserDTO) throws URISyntaxException {
         log.debug("REST request to update User : {}", managedUserDTO);
         Optional<User> existingUser = userRepository.findOneByEmail(managedUserDTO.getEmail());
-        if (existingUser.isPresent() && (!existingUser.get().getLogin().equalsIgnoreCase(managedUserDTO.getLogin()))) {
+        if (existingUser.isPresent() && (!existingUser.get().getId().equals(managedUserDTO.getId()))) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("user-management", "emailexists", "Email already in use")).body(null);
+        }
+        existingUser = userRepository.findOneByLogin(managedUserDTO.getLogin());
+        if (existingUser.isPresent() && (!existingUser.get().getId().equals(managedUserDTO.getId()))) {
+        	  return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("user-management", "userexists", "Login name already used")).body(null);
         }
         return userRepository
             .findOneById(managedUserDTO.getId())


### PR DESCRIPTION
This PR fixes the following in Administration -> User management:

When changing the login to a login that is already in use the error message is:
E-mail is already in use!

When changing the login to a login that is already in use and also the email to the email of the login already in use (e.g. user to admin and user@localhost to admin@localhost), a ConstraintViolationException is thrown.