### PR TITLE
add needles to gradle build file

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -14,6 +14,7 @@ buildscript {
         classpath group: 'com.moowork.gradle', name: 'gradle-node-plugin', version: '0.11'<% if(frontendBuilder == 'grunt') {%>
         classpath group: 'com.moowork.gradle', name: 'gradle-grunt-plugin', version: '0.11'<% }  if(frontendBuilder == 'gulp') {%>
   	    classpath group: 'com.moowork.gradle', name: 'gradle-gulp-plugin', version: '0.11'<% } %>
+        //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }
 
@@ -59,6 +60,7 @@ apply from: 'liquibase.gradle'<% } %>
 <% if (testFrameworks.indexOf('gatling') != -1) { %>
 apply from: 'gatling.gradle'<% } %>
 apply from: 'mapstruct.gradle'
+//jhipster-needle-gradle-apply-from - JHipster will add additional gradle scripts to be applied here
 
 if (project.hasProperty('prod')) {
     apply from: 'profile_prod.gradle'
@@ -199,6 +201,7 @@ dependencies {
     runtime files('lib/oracle/ojdbc/7/ojdbc-7.jar')
     runtime fileTree(dir: 'lib', include: '*.jar')<% } %>
     optional group: 'org.springframework.boot', name:'spring-boot-configuration-processor', version: spring_boot_version
+    //jhipster-needle-gradle-dependency - JHipster will add additional dependencies here
 }
 
 compileJava.dependsOn(processResources)

--- a/modules/index.js
+++ b/modules/index.js
@@ -81,6 +81,7 @@ ModulesGenerator.prototype.configurer = function configurer() {
 
     this.jhipsterVar['baseName'] = this.baseName;
     this.jhipsterVar['packageName'] = this.packageName;
+    this.jhipsterVar['packageFolder'] = this.packageFolder;
     this.jhipsterVar['angularAppName'] = this.angularAppName;
     this.jhipsterVar['javaDir'] = this.javaDir;
     this.jhipsterVar['resourceDir'] = this.resourceDir;

--- a/modules/index.js
+++ b/modules/index.js
@@ -86,6 +86,10 @@ ModulesGenerator.prototype.configurer = function configurer() {
     this.jhipsterVar['resourceDir'] = this.resourceDir;
     this.jhipsterVar['webappDir'] = this.webappDir;
 
+    this.jhipsterFunc['addGradlePlugin'] = this.addGradlePlugin;
+    this.jhipsterFunc['addGradleDependency'] = this.addGradleDependency;
+    this.jhipsterFunc['applyFromGradleScript'] = this.applyFromGradleScript;
+
     this.jhipsterFunc['addJavaScriptToIndex'] = this.addJavaScriptToIndex;
     this.jhipsterFunc['addMessageformatLocaleToIndex'] = this.addMessageformatLocaleToIndex;
     this.jhipsterFunc['addElementToMenu'] = this.addElementToMenu;

--- a/script-base.js
+++ b/script-base.js
@@ -171,7 +171,7 @@ Generator.prototype.addChangelogToLiquibase = function (changelogName) {
  *
  * @param {group} plugin GroupId
  * @param {name} plugin name
- * @param {version} plugin version
+ * @param {version} explicit plugin version number
  */
 Generator.prototype.addGradlePlugin = function (group, name, version) {
     try {
@@ -180,7 +180,7 @@ Generator.prototype.addGradlePlugin = function (group, name, version) {
             file: fullPath,
             needle: 'jhipster-needle-gradle-buildscript-dependency',
             splicable: [
-                    'classpath group: \'' + group + ', name: \'' + name + ', version: \'' + version
+                    'classpath group: \'' + group + ', name: \'' + name + ', version: \'' + version + '\''
             ]
         });
     } catch (e) {
@@ -194,7 +194,7 @@ Generator.prototype.addGradlePlugin = function (group, name, version) {
  * @param {scope} scope of the new dependency, e.g. compile
  * @param {group} maven GroupId
  * @param {name} maven ArtifactId
- * @param {version} Version
+ * @param {version} explicit version number
  */
 Generator.prototype.addGradleDependency = function (scope, group, name, version) {
     try {
@@ -203,7 +203,7 @@ Generator.prototype.addGradleDependency = function (scope, group, name, version)
             file: fullPath,
             needle: 'jhipster-needle-gradle-dependency',
             splicable: [
-                    scope + ' group: \'' + group + ', name: \'' + name + ', version: \'' + version
+                    scope + ' group: \'' + group + ', name: \'' + name + ', version: \'' + version + '\''
             ]
         });
     } catch (e) {
@@ -223,7 +223,7 @@ Generator.prototype.applyFromGradleScript = function (name) {
             file: fullPath,
             needle: 'jhipster-needle-gradle-apply-from',
             splicable: [
-                    'apply from: ' + name
+                    'apply from: \'' + name + '.gradle\''
             ]
         });
     } catch (e) {

--- a/script-base.js
+++ b/script-base.js
@@ -167,6 +167,71 @@ Generator.prototype.addChangelogToLiquibase = function (changelogName) {
 };
 
 /**
+ * A new gradle plugin
+ *
+ * @param {group} plugin GroupId
+ * @param {name} plugin name
+ * @param {version} plugin version
+ */
+Generator.prototype.addGradlePlugin = function (group, name, version) {
+    try {
+        var fullPath = 'build.gradle';
+        jhipsterUtils.rewriteFile({
+            file: fullPath,
+            needle: 'jhipster-needle-gradle-buildscript-dependency',
+            splicable: [
+                    'classpath group: \'' + group + ', name: \'' + name + ', version: \'' + version
+            ]
+        });
+    } catch (e) {
+        console.log('\nUnable to find '.yellow + fullPath + '. Reference to '.yellow + 'classpath: ' + group + ':' + name + ':' + version + 'not added.\n'.yellow);
+    }
+};
+
+/**
+ * A new dependency to build.gradle file
+ *
+ * @param {scope} scope of the new dependency, e.g. compile
+ * @param {group} maven GroupId
+ * @param {name} maven ArtifactId
+ * @param {version} Version
+ */
+Generator.prototype.addGradleDependency = function (scope, group, name, version) {
+    try {
+        var fullPath = 'build.gradle';
+        jhipsterUtils.rewriteFile({
+            file: fullPath,
+            needle: 'jhipster-needle-gradle-dependency',
+            splicable: [
+                    scope + ' group: \'' + group + ', name: \'' + name + ', version: \'' + version
+            ]
+        });
+    } catch (e) {
+        console.log('\nUnable to find '.yellow + fullPath + '. Reference to '.yellow + group + ':' + name + ':' + version + 'not added.\n'.yellow);
+    }
+};
+
+/**
+ * Apply from an external gradle build script
+ *
+ * @param {name} name of the file to apply from, must be 'fileName.gradle'
+ */
+Generator.prototype.applyFromGradleScript = function (name) {
+    try {
+        var fullPath = 'build.gradle';
+        jhipsterUtils.rewriteFile({
+            file: fullPath,
+            needle: 'jhipster-needle-gradle-apply-from',
+            splicable: [
+                    'apply from: ' + name
+            ]
+        });
+    } catch (e) {
+        console.log('\nUnable to find '.yellow + fullPath + '. Reference to '.yellow + name + 'not added.\n'.yellow);
+    }
+};
+
+/**
  * Generate a date to be used by Liquibase changelogs.
  */
 Generator.prototype.dateFormatForLiquibase = function () {


### PR DESCRIPTION
add some needles in gradle build file for my [swagger2markup](https://github.com/atomfrede/generator-jhipster-swagger2markup) generator. With the new needles you can

* add additional build script plugins
* apply from an external gradle script
* add a new dependency