### PR TITLE
Needles maven : dependency and plugin

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -1010,7 +1010,6 @@
                             </arguments>
                         </configuration>
                     </plugin>
-
                 </plugins>
             </build>
             <properties>

--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -589,6 +589,7 @@
             <scope>test</scope>
         </dependency>
         <%_ } _%>
+        <!-- jhipster-needle-maven-add-dependency -->
     </dependencies>
     <build>
         <defaultGoal>spring-boot:run</defaultGoal>
@@ -825,6 +826,7 @@
                     </arguments>
                 </configuration>
             </plugin>
+            <!-- jhipster-needle-maven-add-plugin -->
         </plugins>
         <pluginManagement>
             <plugins>
@@ -1008,6 +1010,7 @@
                             </arguments>
                         </configuration>
                     </plugin>
+
                 </plugins>
             </build>
             <properties>

--- a/modules/index.js
+++ b/modules/index.js
@@ -87,6 +87,8 @@ ModulesGenerator.prototype.configurer = function configurer() {
     this.jhipsterVar['resourceDir'] = this.resourceDir;
     this.jhipsterVar['webappDir'] = this.webappDir;
 
+    this.jhipsterFunc['addMavenDependency'] = this.addMavenDependency;
+    this.jhipsterFunc['addMavenPlugin'] = this.addMavenPlugin;
     this.jhipsterFunc['addGradlePlugin'] = this.addGradlePlugin;
     this.jhipsterFunc['addGradleDependency'] = this.addGradleDependency;
     this.jhipsterFunc['applyFromGradleScript'] = this.applyFromGradleScript;

--- a/script-base.js
+++ b/script-base.js
@@ -167,6 +167,72 @@ Generator.prototype.addChangelogToLiquibase = function (changelogName) {
 };
 
 /**
+ * Add a new Maven dependency.
+ *
+ * @param {groupId} dependency groupId
+ * @param {artifactId} dependency artifactId
+ * @param {version} explicit dependency version number
+ * @param {other} explicit other thing: scope, exclusions...
+ */
+Generator.prototype.addMavenDependency = function (groupId, artifactId, version, other) {
+    try {
+        var fullPath = 'pom.xml';
+        var dependency = '<dependency>\n' +
+            '            <groupId>' + groupId + '</groupId>\n' +
+            '            <artifactId>' + artifactId + '</artifactId>\n';
+        if (version) {
+            dependency += '            <version>' + version + '</version>\n';
+        }
+        if (other) {
+            dependency += other + '\n';
+        }
+        dependency += '        </dependency>';
+        jhipsterUtils.rewriteFile({
+            file: fullPath,
+            needle: 'jhipster-needle-maven-add-dependency',
+            splicable: [
+                dependency
+            ]
+        });
+    } catch (e) {
+        console.log('\nUnable to find '.yellow + fullPath + '. Reference to '.yellow + 'maven dependency (groupId: ' + groupId + ', artifactId:' + artifactId + ', version:' + version + ')' +' not added.\n'.yellow);
+    }
+};
+
+/**
+ * Add a new Maven plugin.
+ *
+ * @param {groupId} plugin groupId
+ * @param {artifactId} plugin artifactId
+ * @param {version} explicit plugin version number
+ * @param {other} explicit other thing: executions, configuration...
+ */
+Generator.prototype.addMavenPlugin = function (groupId, artifactId, version, other) {
+    try {
+        var fullPath = 'pom.xml';
+        var plugin =  '<plugin>\n' +
+            '                <groupId>' + groupId + '</groupId>\n' +
+            '                <artifactId>' + artifactId + '</artifactId>\n';
+        if (version) {
+            plugin += '                <version>' + version + '</version>\n';
+        }
+        if (other) {
+            plugin += other + '\n';
+        }
+        plugin += '            </plugin>';
+        jhipsterUtils.rewriteFile({
+            file: fullPath,
+            needle: 'jhipster-needle-maven-add-plugin',
+            splicable: [
+                plugin
+            ]
+        });
+    } catch (e) {
+        console.log('\nUnable to find '.yellow + fullPath + '. Reference to '.yellow + 'maven plugin (groupId: ' + groupId + ', artifactId:' + artifactId + ', version:' + version + ')' +' not added.\n'.yellow);
+    }
+};
+
+/**
  * A new Gradle plugin.
  *
  * @param {group} plugin GroupId


### PR DESCRIPTION
Add 2 needles for maven, needed by [generator-jhipster-swagger2markup](https://github.com/atomfrede/generator-jhipster-swagger2markup) and [generator-jhipster-docker](https://github.com/pascalgrimaud/generator-jhipster-docker)
* add dependency
* add plugin

As discussed in dev mailing list, this solution has an issue if something is changed when upgrading.
We have to find a solution to do something like bower