### PR TITLE
Travis : add protractor tests to 1 project

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ env:
   - JHIPSTER_MVN_DEP=1
   - RUNTASK=1
   - GRUNT=1
+  - PROTRACTOR=0
   - JHIPSTER_TRAVIS=$TRAVIS_BUILD_DIR/travis
   - JHIPSTER_INSTALL=$JHIPSTER_TRAVIS/install
   - JHIPSTER_SAMPLES=$JHIPSTER_TRAVIS/samples
@@ -22,7 +23,7 @@ env:
   - PROFILE=dev  JHIPSTER=app-cassandra
   - PROFILE=dev  JHIPSTER=app-default
   - PROFILE=dev  JHIPSTER=app-mongodb
-  - PROFILE=dev  JHIPSTER=app-websocket
+  - PROFILE=dev  JHIPSTER=app-websocket PROTRACTOR=1
   - PROFILE=dev  JHIPSTER=app-noi18n
   - PROFILE=dev  JHIPSTER=app-oauth2
   - PROFILE=prod JHIPSTER=app-mysql

--- a/.travis.yml
+++ b/.travis.yml
@@ -42,6 +42,8 @@ script:
   - $JHIPSTER_SCRIPTS/02-generate-entities.sh
   - $JHIPSTER_SCRIPTS/03-tests.sh
   - $JHIPSTER_SCRIPTS/04-docker-compose.sh
+  - export DISPLAY=:99.0
+  - sh -e /etc/init.d/xvfb start
   - $JHIPSTER_SCRIPTS/05-run.sh
 # notifications:
 #   webhooks:

--- a/app/templates/src/test/javascript/_protractor.conf.js
+++ b/app/templates/src/test/javascript/_protractor.conf.js
@@ -16,6 +16,8 @@ exports.config = {
         'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG']
     },
 
+    directConnect: true,
+
     baseUrl: 'http://localhost:8080/',
 
     framework: 'jasmine2',

--- a/travis/samples/app-websocket/.jhipster/BankAccount.json
+++ b/travis/samples/app-websocket/.jhipster/BankAccount.json
@@ -82,5 +82,6 @@
     ],
     "changelogDate": "20150805124838",
     "dto": "yes",
+    "service": "no",
     "pagination": "no"
 }

--- a/travis/samples/app-websocket/.jhipster/Label.json
+++ b/travis/samples/app-websocket/.jhipster/Label.json
@@ -23,5 +23,6 @@
     ],
     "changelogDate": "20150805124936",
     "dto": "no",
+    "service": "no",
     "pagination": "no"
 }

--- a/travis/samples/app-websocket/.jhipster/Operation.json
+++ b/travis/samples/app-websocket/.jhipster/Operation.json
@@ -41,5 +41,6 @@
     ],
     "changelogDate": "20150805125054",
     "dto": "no",
+    "service": "no",
     "pagination": "infinite-scroll"
 }

--- a/travis/samples/app-websocket/.yo-rc.json
+++ b/travis/samples/app-websocket/.yo-rc.json
@@ -17,7 +17,7 @@
     "enableTranslation": true,
     "rememberMeKey": "9e08e1e17590675533a598f0dca7b75fb11d234a",
     "testFrameworks": [
-      "gatling"
+      "protractor"
     ]
   }
 }

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -5,11 +5,6 @@ set -ev
 #--------------------------------------------------
 cd $HOME/$JHIPSTER
 if [ $RUNTASK == 1 ]; then
-  if [ $PROTRACTOR == 1 ]; then
-    export DISPLAY=:99.0
-    /etc/init.d/xvfb start
-  fi
-  
   if [ $JHIPSTER != "app-gradle" ]; then
     mvn -P$PROFILE &
     if [ $PROFILE == "dev" ]; then

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -5,6 +5,11 @@ set -ev
 #--------------------------------------------------
 cd $HOME/$JHIPSTER
 if [ $RUNTASK == 1 ]; then
+  if [ $PROTRACTOR == 1 ]; then
+    export DISPLAY=:99.0
+    /etc/init.d/xvfb start
+  fi
+  
   if [ $JHIPSTER != "app-gradle" ]; then
     mvn -P$PROFILE &
     if [ $PROFILE == "dev" ]; then
@@ -20,4 +25,8 @@ if [ $RUNTASK == 1 ]; then
     # curl --retry 10 --retry-delay 5 -I http://localhost:8080/ | grep "HTTP/1.1 200 OK"
     # fuser -k 8080/tcp ; sleep 10
   fi
+fi
+
+if [ $PROTRACTOR == 1 ]; then
+  grunt itest
 fi


### PR DESCRIPTION
Add protractor tests to sample/app-websocket ; I think 1 project is enough.
I did the same thing : https://github.com/mraible/21-points/pull/17

I don't know if Travis will return error if one test failed => so I will monitor :eyes: the Travis builds logs, when someone PR 
