### PR TITLE
fix jasmine test heirarchy

### DIFF
--- a/app/templates/src/test/javascript/spec/app/account/activate/_activate.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/activate/_activate.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Controllers Tests ', function() {
+describe('Controller Tests', function() {
 
     beforeEach(mockApiAccountCall);
     beforeEach(mockI18nCalls);

--- a/app/templates/src/test/javascript/spec/app/account/login/_login.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/login/_login.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Controllers Tests ', function () {
+describe('Controller Tests', function () {
 
     beforeEach(module('<%= angularAppName %>'));
 

--- a/app/templates/src/test/javascript/spec/app/account/password/_password.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/password/_password.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Controllers Tests ', function() {
+describe('Controller Tests', function() {
     beforeEach(mockApiAccountCall);
     beforeEach(mockI18nCalls);
 

--- a/app/templates/src/test/javascript/spec/app/account/password/_password.directive.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/password/_password.directive.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Directive Tests ', function () {
+describe('Directive Tests', function () {
     beforeEach(mockApiAccountCall);
     <%_ if (enableTranslation) { _%>
     beforeEach(mockI18nCalls);

--- a/app/templates/src/test/javascript/spec/app/account/register/_register.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/register/_register.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Controllers Tests ', function() {
+describe('Controller Tests', function() {
 
     beforeEach(mockApiAccountCall);
     beforeEach(mockI18nCalls);

--- a/app/templates/src/test/javascript/spec/app/account/settings/_settings.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/account/settings/_settings.controller.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Controllers Tests ', function() {
+describe('Controller Tests', function() {
 
     beforeEach(mockApiAccountCall);
     beforeEach(mockI18nCalls);

--- a/app/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
+++ b/app/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
@@ -1,5 +1,6 @@
 'use strict';
-describe('Controllers Tests ', function () {
+
+describe('Controller Tests', function () {
 
     describe('HealthController', function () {
         var $scope; // actual implementations

--- a/app/templates/src/test/javascript/spec/components/auth/_auth.services.spec.js
+++ b/app/templates/src/test/javascript/spec/components/auth/_auth.services.spec.js
@@ -1,6 +1,6 @@
 'use strict';
 
-describe('Services Tests ', function () {
+describe('Service Tests', function () {
     <%_ if (authenticationType == 'session') { _%>
     beforeEach(mockApiAccountCall);
     <%_ } _%>

--- a/entity/templates/src/test/javascript/spec/app/_entity-detail-controller.spec.js
+++ b/entity/templates/src/test/javascript/spec/app/_entity-detail-controller.spec.js
@@ -1,38 +1,42 @@
 'use strict';
 
-describe('<%= entityClass %> Detail Controller', function() {
-    var $scope, $rootScope;
-    var MockEntity<% for (idx in differentTypes) { %>, Mock<%= differentTypes[idx] %><%}%>;
-    var createController;
+describe('Controller Tests', function() {
 
-    beforeEach(inject(function($injector) {
-        $rootScope = $injector.get('$rootScope');
-        $scope = $rootScope.$new();
-        MockEntity = jasmine.createSpy('MockEntity');
-        <% for (idx in differentTypes) { %>Mock<%= differentTypes[idx] %> = jasmine.createSpy('Mock<%= differentTypes[idx] %>');
-        <%}%>
+    describe('<%= entityClass %> Detail Controller', function() {
+        var $scope, $rootScope;
+        var MockEntity<% for (idx in differentTypes) { %>, Mock<%= differentTypes[idx] %><%}%>;
+        var createController;
 
-        var locals = {
-            '$scope': $scope,
-            '$rootScope': $rootScope,
-            'entity': MockEntity <% for (idx in differentTypes) { %>,
-            '<%= differentTypes[idx] %>': Mock<%= differentTypes[idx] %><% } %>
-        };
-        createController = function() {
-            $injector.get('$controller')("<%= entityClass %>DetailController", locals);
-        };
-    }));
+        beforeEach(inject(function($injector) {
+            $rootScope = $injector.get('$rootScope');
+            $scope = $rootScope.$new();
+            MockEntity = jasmine.createSpy('MockEntity');
+            <% for (idx in differentTypes) { %>Mock<%= differentTypes[idx] %> = jasmine.createSpy('Mock<%= differentTypes[idx] %>');
+            <%}%>
+
+            var locals = {
+                '$scope': $scope,
+                '$rootScope': $rootScope,
+                'entity': MockEntity <% for (idx in differentTypes) { %>,
+                '<%= differentTypes[idx] %>': Mock<%= differentTypes[idx] %><% } %>
+            };
+            createController = function() {
+                $injector.get('$controller')("<%= entityClass %>DetailController", locals);
+            };
+        }));
 
 
-    describe('Root Scope Listening', function() {
-        it('Unregisters root scope listener upon scope destruction', function() {
-            var eventType = '<%=angularAppName%>:<%= entityInstance %>Update';
+        describe('Root Scope Listening', function() {
+            it('Unregisters root scope listener upon scope destruction', function() {
+                var eventType = '<%=angularAppName%>:<%= entityInstance %>Update';
 
-            createController();
-            expect($rootScope.$$listenerCount[eventType]).toEqual(1);
+                createController();
+                expect($rootScope.$$listenerCount[eventType]).toEqual(1);
 
-            $scope.$destroy();
-            expect($rootScope.$$listenerCount[eventType]).toBeUndefined();
+                $scope.$destroy();
+                expect($rootScope.$$listenerCount[eventType]).toBeUndefined();
+            });
         });
     });
+
 });


### PR DESCRIPTION
fix jasmine test heirarchy by fixing test names and moving entity
controller tests under `Controller Tests`

fix #2493