### PR TITLE
Set executable war to true by default

### DIFF
--- a/app/templates/_pom.xml
+++ b/app/templates/_pom.xml
@@ -1003,8 +1003,7 @@
                         <groupId>org.springframework.boot</groupId>
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
-                            <!-- this is set to false because of https://github.com/jhipster/generator-jhipster/issues/2225 -->
-                            <executable>false</executable>
+                            <executable>true</executable>
                             <arguments>
                                 <argument>--spring.profiles.active=prod</argument>
                             </arguments>


### PR DESCRIPTION
See #2225 

The issue with Cloud Foundry deployment should be fixed with cf CLI  v6.14.1
I don't have a CF account so I cannot test. Can somebody confim that it works ?