### PR TITLE
Fixed Improve entity list UI (#2552)

### DIFF
--- a/app/templates/src/main/scss/main.scss
+++ b/app/templates/src/main/scss/main.scss
@@ -233,4 +233,46 @@ ul#strength {
 /* end of Social Button */
 <%_ } _%>
 
+/* entity tables helpers */
+
+/* Remove Bootstrap padding from the element
+   http://stackoverflow.com/questions/19562903/remove-padding-from-columns-in-bootstrap-3 */
+@mixin no-padding($side) {
+    @if $side == 'all' {
+        .no-padding {
+            padding: 0 !important;
+        }
+    } @else {
+        .no-padding-#{$side} {
+            padding-#{$side}: 0 !important;
+        }
+    }
+}
+@include no-padding("left");
+@include no-padding("right");
+@include no-padding("top");
+@include no-padding("bottom");
+@include no-padding("all");
+
+/* bootstrap 3 input-group 100% width
+   http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
+.width-min { width: 1% !important; }
+
+/* Makes toolbar not wrap on smaller screens
+   http://www.sketchingwithcss.com/samplechapter/cheatsheet.html#right */
+.flex-btn-group-container {
+   display: -webkit-flex;
+   display: flex;
+   -webkit-flex-direction: row;
+   flex-direction: row;
+   -webkit-justify-content: flex-end;
+   justify-content: flex-end;
+}  
+
+/* Align text in td verifically (top aligned by Bootstrap) */
+.jh-table > tbody > tr > td {
+    vertical-align: middle;
+}
+/* end of entity tables helpers */
+
 /* jhipster-needle-scss-add-main JHipster will add new css style */

--- a/app/templates/src/main/webapp/assets/styles/main.css
+++ b/app/templates/src/main/webapp/assets/styles/main.css
@@ -243,4 +243,37 @@ Social Buttons
 }
 <%_ } _%>
 
+/* entity tables helpers */
+
+/* Remove Bootstrap padding from the element
+   http://stackoverflow.com/questions/19562903/remove-padding-from-columns-in-bootstrap-3 */
+.no-padding-left { padding-left: 0 !important; }
+.no-padding-right { padding-right: 0 !important; }
+.no-padding-top { padding-top: 0 !important; }
+.no-padding-bottom { padding-bottom: 0 !important; }
+.no-padding { padding: 0 !important; }
+
+/* bootstrap 3 input-group 100% width
+   http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
+.width-min { width: 1% !important; }
+
+/* Makes toolbar not wrap on smaller screens
+ http://www.sketchingwithcss.com/samplechapter/cheatsheet.html#right */
+.flex-btn-group-container {
+   display: -webkit-flex;
+   display: flex;
+   -webkit-flex-direction: row;
+   flex-direction: row;
+   -webkit-justify-content: flex-end;
+   justify-content: flex-end;
+}
+
+/* Align text in td verifically (top aligned by Bootstrap) */
+.jh-table > tbody > tr > td {
+    vertical-align: middle;
+}
+/* end of entity tables helpers */
+
+/* jhipster-needle-scss-add-main JHipster will add new css style */
+
 /* jhipster-needle-css-add-main JHipster will add new css style */

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -2,29 +2,36 @@
 <%_ var keyPrefix = angularAppName + '.'+ entityInstance + '.'; _%>
     <h2 translate="<%= keyPrefix %>home.title"><%= entityClass %>s</h2>
     <jh-alert></jh-alert>
-    <div class="container">
+    <div class="container-fluid">
         <div class="row">
-            <div class="col-md-4">
-                <button class="btn btn-primary" ui-sref="<%= entityInstance %>.new">
-                    <span class="glyphicon glyphicon-flash"></span> <span translate="<%= keyPrefix %>home.createLabel">Create a new <%= entityClass %></span>
+            <div class="col-xs-4 no-padding-left">
+                <button class="btn btn-primary" ui-sref="<%= entityInstance %>.new" >
+                    <span class="glyphicon glyphicon-plus"></span>
+                    <span 
+                        <%_ if (searchEngine == 'elasticsearch') { _%>class="hidden-xs" <%_ } _%>
+                        translate="<%= keyPrefix %>home.createLabel">Create new <%= entityClass %>
+                    </span>
                 </button>
             </div>
             <%_ if (searchEngine == 'elasticsearch') { _%>
-            <div class="col-md-8">
+            <div class="col-xs-8 no-padding-right">
                 <form name="searchForm" class="form-inline">
-                    <div class="form-group">
-                        <input type="text" class="form-control" ng-model="searchQuery" id="searchQuery" placeholder="query">
+                    <div class="input-group pull-right" >
+                        <input type="text" class="form-control" ng-model="searchQuery" id="searchQuery" placeholder="{{ '<%= keyPrefix %>home.search' | translate }}">
+                        <span  class="input-group-btn width-min" >
+                            <button class="btn btn-info" ng-click="search()">
+                                <span class="glyphicon glyphicon-search"></span>
+                            </button>
+                        </span>
                     </div>
-                    <button class="btn btn-info" ng-click="search()"><span class="glyphicon glyphicon-search"></span> <span>Search a <%= entityClass %></span>
-                    </button>
                 </form>
             </div>
             <%_ } _%>
         </div>
     </div>
-
+    <br/>
     <div class="table-responsive">
-        <table class="table table-striped">
+        <table class="jh-table table table-striped">
             <thead>
                 <tr<% if (pagination != 'no') { %> jh-sort="predicate" ascending="reverse" callback="<%=pagination != 'infinite-scroll' ? 'loadAll' : 'reset'%>()"<% } %>>
                     <th<% if (pagination != 'no') { %> jh-sort-by="id"<% } %>><span translate="global.field.id">ID</span><% if (pagination != 'no') { %> <span class="glyphicon glyphicon-sort"></span><% } %></th>
@@ -101,22 +108,27 @@
                     </td>
                         <%_ } _%>
                     <%_ } _%>
-                    <td>
-                        <button type="submit"
-                                ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})"
-                                class="btn btn-info btn-sm">
-                            <span class="glyphicon glyphicon-eye-open"></span>&nbsp;<span translate="entity.action.view"> View</span>
-                        </button>
-                        <button type="submit"
-                                ui-sref="<%= entityInstance %>.edit({id:<%=entityInstance %>.id})"
-                                class="btn btn-primary btn-sm">
-                            <span class="glyphicon glyphicon-pencil"></span>&nbsp;<span translate="entity.action.edit"> Edit</span>
-                        </button>
-                        <button type="submit"
-                                ui-sref="<%= entityInstance %>.delete({id:<%=entityInstance %>.id})"
-                                class="btn btn-danger btn-sm">
-                            <span class="glyphicon glyphicon-remove-circle"></span>&nbsp;<span translate="entity.action.delete"> Delete</span>
-                        </button>
+                    <td class="text-right">
+                        <div class="btn-group flex-btn-group-container">
+                            <button type="submit"
+                                    ui-sref="<%= entityInstance %>.detail({id:<%= entityInstance %>.id})"
+                                    class="btn btn-info btn-sm"> 
+                                <span class="glyphicon glyphicon-eye-open"></span>
+                                <span class="hidden-xs hidden-sm" translate="entity.action.view"></span>
+                            </button>
+                            <button type="submit"
+                                    ui-sref="<%= entityInstance %>.edit({id:<%=entityInstance %>.id})"
+                                    class="btn btn-primary btn-sm">
+                                <span class="glyphicon glyphicon-pencil"></span>
+                                <span class="hidden-xs hidden-sm" translate="entity.action.edit"></span>
+                            </button>
+                            <button type="submit"
+                                    ui-sref="<%= entityInstance %>.delete({id:<%=entityInstance %>.id})"
+                                    class="btn btn-danger btn-sm">                                    
+                                <span class="glyphicon glyphicon-remove-circle"></span>
+                                <span class="hidden-xs hidden-sm" translate="entity.action.delete"></span>
+                            </button>
+                        </div>
                     </td>
                 </tr>
             </tbody>

--- a/entity/templates/src/main/webapp/i18n/_entity_ca.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ca.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "A new <%= entityClass %> is created with identifier {{ param }}",
             "updated": "A <%= entityClass %> is updated with identifier {{ param }}",

--- a/entity/templates/src/main/webapp/i18n/_entity_da.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_da.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_de.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_de.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_en.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_en.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "A new <%= entityClass %> is created with identifier {{ param }}",
             "updated": "A <%= entityClass %> is updated with identifier {{ param }}",

--- a/entity/templates/src/main/webapp/i18n/_entity_es.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_es.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Crear nuevo <%= entityClass %>",
-                "createOrEditLabel": "Crear o editar <%= entityClass %>"
+                "createOrEditLabel": "Crear o editar <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "Un nuevo <%= entityClass %> ha sido creado con el identificador {{ param }}",
             "updated": "Un <%= entityClass %> ha sido actualizado con el identificador {{ param }}",

--- a/entity/templates/src/main/webapp/i18n/_entity_fr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_fr.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Créer un nouveau <%= entityClass %>",
-                "createOrEditLabel": "Créer ou éditer un <%= entityClass %>"
+                "createOrEditLabel": "Créer ou éditer un <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "Un nouveau <%= entityClass %> a été créé avec l'identifiant {{ param }}",
             "updated": "Le <%= entityClass %> avec l'identifiant {{ param }} a été mis à jour",

--- a/entity/templates/src/main/webapp/i18n/_entity_gl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_gl.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Crear novo <%= entityClass %>",
-                "createOrEditLabel": "Crear ou editar <%= entityClass %>"
+                "createOrEditLabel": "Crear ou editar <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "Un novo <%= entityClass %> foi creado co identificador {{ param }}",
             "updated": "Un <%= entityClass %> foi actualizado co identificador {{ param }}",

--- a/entity/templates/src/main/webapp/i18n/_entity_hu.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_hu.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Egy új <%= entityClass %> létrehozása",
-                "createOrEditLabel": "Hozzon létre, vagy módosítson <%= entityClass %>t"
+                "createOrEditLabel": "Hozzon létre, vagy módosítson <%= entityClass %>t",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Biztos benne, hogy törölni szeretné az <%= entityClass %>t {{ id }} azonosítóval?"

--- a/entity/templates/src/main/webapp/i18n/_entity_it.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_it.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_ja.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ja.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "<%= entityClass %> を追加",
-                "createOrEditLabel": "<%= entityClass %>を追加または編集"
+                "createOrEditLabel": "<%= entityClass %>を追加または編集",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "<%= entityClass %> {{ id }}を削除してもよろしいですか？"

--- a/entity/templates/src/main/webapp/i18n/_entity_kr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_kr.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_nl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_nl.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Maak een nieuwe <%= entityClass %>",
-                "createOrEditLabel": "Maak of wijzig een <%= entityClass %>"
+                "createOrEditLabel": "Maak of wijzig een <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Bent u zeker dat u <%= entityClass %> {{ id }} wilt verwijderen?"

--- a/entity/templates/src/main/webapp/i18n/_entity_pl.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pl.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>",
                 "createLabel": "Dodaj <%= entityClass %>",
-                "createOrEditLabel": "Dodaj lub edytuj: <%= entityClass %>"
+                "createOrEditLabel": "Dodaj lub edytuj: <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Czy na pewno chcesz usunąć <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_pt-pt.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_pt-pt.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Criar um(a) novo(a) <%= entityClass %>",
-                "createOrEditLabel": "Criar ou editar um(a) <%= entityClass %>"
+                "createOrEditLabel": "Criar ou editar um(a) <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Tem a certeza que pretende eliminar o(a) <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_ro.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ro.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Crează o nouă <%= entityClass %>",
-                "createOrEditLabel": "Crează sau editează o <%= entityClass %>"
+                "createOrEditLabel": "Crează sau editează o <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "O nouă <%= entityClass %> este creată cu identificatorul {{ param }}",
             "updated": "O <%= entityClass %> este editată cu identificatorul {{ param }}",

--- a/entity/templates/src/main/webapp/i18n/_entity_ru.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ru.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_sv.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_sv.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Skapa en ny <%= entityClass %>",
-                "createOrEditLabel": "Skapa eller ändra en <%= entityClass %>"
+                "createOrEditLabel": "Skapa eller ändra en <%= entityClass %>",
+                "search": "Sök efter <%= entityClass %>"
             },
             "delete": {
                 "question": "Är du säker på att du vill ta bort <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_ta.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_ta.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "<%= entityClass %>-ஐ உருவாக்கு",
-                "createOrEditLabel": "<%= entityClass %> -ஐ மாற்று (அ) உருவாக்கு"
+                "createOrEditLabel": "<%= entityClass %> -ஐ மாற்று (அ) உருவாக்கு",
+                "search": "Search for <%= entityClass %>"
             },
             "created": "<%= entityClass %> புதிதாக உருவாக்கப்பட்டது, அடையாளம் {{ param }}",
             "updated": "<%= entityClass %> மாற்றப்பட்டது, அடையாளம்  {{ param }}",

--- a/entity/templates/src/main/webapp/i18n/_entity_tr.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_tr.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_zh-cn.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_zh-cn.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"

--- a/entity/templates/src/main/webapp/i18n/_entity_zh-tw.json
+++ b/entity/templates/src/main/webapp/i18n/_entity_zh-tw.json
@@ -4,7 +4,8 @@
             "home": {
                 "title": "<%= entityClass %>s",
                 "createLabel": "Create a new <%= entityClass %>",
-                "createOrEditLabel": "Create or edit a <%= entityClass %>"
+                "createOrEditLabel": "Create or edit a <%= entityClass %>",
+                "search": "Search for <%= entityClass %>"
             },
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClass %> {{ id }}?"


### PR DESCRIPTION
"Create new <Entity>"button is left aligned (padding removed)
Search bar is now an input group (input followed by search icon) and left-aligned.
Search bar text "Search a <Entity>" is now in a tooltip.
The text "Search a <Entity>" was not localized, added english.
When shrinking the window (and search is enabled), the text "Create new
button" is removed  on smaller screen sizes and only the icon is visible, text is available as a tooltip.
The "View", "Edit", and "Delete" buttons are now inside button group.

Fix #2552