### PR TITLE
change equals method in entity template

### DIFF
--- a/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/entity/templates/src/main/java/package/domain/_Entity.java
@@ -224,6 +224,9 @@ public class <%= entityClass %> implements Serializable {
             return false;
         }
         <%= entityClass %> <%= entityInstance %> = (<%= entityClass %>) o;
+        if(<%= entityInstance %>.id == null || id == null) {
+            return false;
+        }
         return Objects.equals(id, <%= entityInstance %>.id);
     }
 


### PR DESCRIPTION
Add multiple entities with id null in a collection with cascade
persistence lead to persist only one entity, because they are
equals. Without business key, entites with null primary key
should be never equals with anything.

Fix #2543