### PR TITLE
Prevent promise calls from stacking after unsubscription

### DIFF
--- a/app/templates/src/main/webapp/scripts/components/tracker/_tracker.service.js
+++ b/app/templates/src/main/webapp/scripts/components/tracker/_tracker.service.js
@@ -48,6 +48,7 @@ angular.module('<%=angularAppName%>')
                 if (subscriber != null) {
                     subscriber.unsubscribe();
                 }
+                listener = $q.defer();
             },
             receive: function() {
                 return listener.promise;


### PR DESCRIPTION
showActivity() function in TrackerController gets called multiple times when User Tracker page is revisited. This is cause the Tracker listener promise does is not reseted on unsubscribe.

Please note that the User Tracker page seems to work anyway though showActivity() gets called multiple times. So the fix is not visual.