### PR TITLE
Gradle packaging : remove tomcat-embed libs in war.original

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -31,6 +31,10 @@ bootRepackage {
    mainClass = '<%= packageName %>.Application'
 }
 
+war {
+    rootSpec.exclude("**/tomcat-*.jar")
+}
+
 springBoot {
     mainClass = '<%= packageName %>.Application'
     executable = true


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/2561
- app.war is inchanged
- app.war.original => doesn't contain tomcat-embed libs anymore

Same code for maven :
https://github.com/jhipster/generator-jhipster/blob/3becfa8c7e1fea1700eb6eec6395e435470c6c27/app/templates/_pom.xml#L706-L708

@atomfrede can you merge it, if it's correct for you ?