### PR TITLE
Do not fetch entity when prompting to delete it

### DIFF
--- a/entity/templates/src/main/webapp/app/_entity-delete-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-delete-dialog-controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('<%=angularAppName%>')
-	.controller('<%= entityClass %>DeleteController', function($scope, $uibModalInstance, $stateParams, <%= entityClass %>) {
+	.controller('<%= entityClass %>DeleteController', function($scope, $uibModalInstance, entity, <%= entityClass %>) {
 
-        $scope.<%= entityInstance %> = {id:$stateParams.id};
+        $scope.<%= entityInstance %> = entity;
         $scope.clear = function() {
             $uibModalInstance.dismiss('cancel');
         };

--- a/entity/templates/src/main/webapp/app/_entity-delete-dialog-controller.js
+++ b/entity/templates/src/main/webapp/app/_entity-delete-dialog-controller.js
@@ -1,9 +1,9 @@
 'use strict';
 
 angular.module('<%=angularAppName%>')
-	.controller('<%= entityClass %>DeleteController', function($scope, $uibModalInstance, entity, <%= entityClass %>) {
+	.controller('<%= entityClass %>DeleteController', function($scope, $uibModalInstance, $stateParams, <%= entityClass %>) {
 
-        $scope.<%= entityInstance %> = entity;
+        $scope.<%= entityInstance %> = {id:$stateParams.id};
         $scope.clear = function() {
             $uibModalInstance.dismiss('cancel');
         };

--- a/entity/templates/src/main/webapp/app/_entity.js
+++ b/entity/templates/src/main/webapp/app/_entity.js
@@ -121,12 +121,7 @@ angular.module('<%=angularAppName%>')
                     $uibModal.open({
                         templateUrl: 'scripts/app/entities/<%= entityInstance %>/<%= entityInstance %>-delete-dialog.html',
                         controller: '<%= entityClass %>DeleteController',
-                        size: 'md',
-                        resolve: {
-                            entity: ['<%= entityClass %>', function(<%= entityClass %>) {
-                                return <%= entityClass %>.get({id : $stateParams.id});
-                            }]
-                        }
+                        size: 'md'
                     }).result.then(function(result) {
                         $state.go('<%= entityInstance %>', null, { reload: true });
                     }, function() {

--- a/entity/templates/src/main/webapp/app/_entity.js
+++ b/entity/templates/src/main/webapp/app/_entity.js
@@ -117,11 +117,19 @@ angular.module('<%=angularAppName%>')
                 data: {
                     authorities: ['ROLE_USER'],
                 },
+                params: {
+                    entity: null
+                },
                 onEnter: ['$stateParams', '$state', '$uibModal', function($stateParams, $state, $uibModal) {
                     $uibModal.open({
                         templateUrl: 'scripts/app/entities/<%= entityInstance %>/<%= entityInstance %>-delete-dialog.html',
                         controller: '<%= entityClass %>DeleteController',
-                        size: 'md'
+                        size: 'md',
+                        resolve: {
+                            entity: function () {
+                                return $stateParams.entity;
+                            }
+                        }
                     }).result.then(function(result) {
                         $state.go('<%= entityInstance %>', null, { reload: true });
                     }, function() {


### PR DESCRIPTION
The entity's delete button does not function while an entity is loading in the modal's resolve function.  Once the entity is loaded, its ID is used to populate the form's ng-submit.

If you are fetching an entity by ID, it will have the same ID when it is received.  Instead of waiting for the entity to load in order to delete it, it is more efficient to delete the entity based on the ID from the stateParams.