### PR TITLE
Yeoman : fix deprecated warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,9 @@
     "shelljs": "0.5.3",
     "underscore.string": "3.2.2",
     "wordwrap": "1.0.0",
+    "yeoman-assert": "2.1.1",
     "yeoman-generator": "0.22.2",
+    "yeoman-test": "1.0.0",
     "yo": "1.6.0"
   },
   "devDependencies": {

--- a/script-base.js
+++ b/script-base.js
@@ -16,11 +16,11 @@ var MODULES_HOOK_FILE = '.jhipster/modules/jhi-hooks.json';
 module.exports = Generator;
 
 function Generator() {
-    yeoman.generators.NamedBase.apply(this, arguments);
+    yeoman.Base.apply(this, arguments);
     this.env.options.appPath = this.config.get('appPath') || 'src/main/webapp';
 }
 
-util.inherits(Generator, yeoman.generators.NamedBase);
+util.inherits(Generator, yeoman.Base);
 
 /**
  * A a new script to the application, in the index.html file.

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -2,8 +2,8 @@
 'use strict';
 
 var path = require('path');
-var assert = require('yeoman-generator').assert;
-var helpers = require('yeoman-generator').test;
+var assert = require('yeoman-assert');
+var helpers = require('yeoman-test');
 var os = require('os');
 
 describe('JHipster generator', function () {


### PR DESCRIPTION
Remove these warnings during `npm test` by adding 2 dependencies **yeoman-assert** and **yeoman-test** :
```
(!) yeoman.assert is deprecated. Instead `require('yeoman-assert')`. See https://github.com/yeoman/generator/issues/883
(!) yeoman.test is deprecated. Instead `require('yeoman-test')`.
```

It should remove the last warning about generators.Base (see https://github.com/jhipster/generator-jhipster/issues/2594) :
```
(!) require('yeoman-generator').generators.Base is deprecated. Use require('yeoman-generator').Base directly
```
