### PR TITLE
Open authenticate url to all

### DIFF
--- a/app/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/app/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -132,6 +132,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
             .antMatchers("/api/register").permitAll()
             .antMatchers("/api/activate").permitAll()
             .antMatchers("/api/authenticate").permitAll()
+            .antMatchers("/api/account").permitAll()
             .antMatchers("/api/account/reset_password/init").permitAll()
             .antMatchers("/api/account/reset_password/finish").permitAll()
             .antMatchers("/api/logs/**").hasAuthority(AuthoritiesConstants.ADMIN)

--- a/app/templates/src/main/java/package/service/_UserService.java
+++ b/app/templates/src/main/java/package/service/_UserService.java
@@ -197,7 +197,7 @@ public class UserService {
 <% if (databaseType == 'sql') { %>
     @Transactional(readOnly = true)<% } %>
     public User getUserWithAuthorities() {
-        User user = userRepository.findOneByLogin(SecurityUtils.getCurrentUser().getUsername()).get();
+        User user = userRepository.findOneByLogin(SecurityUtils.getCurrentUserLogin()).get();
         user.getAuthorities().size(); // eagerly load the association
         return user;
     }<% if ((databaseType == 'sql' || databaseType == 'mongodb') && authenticationType == 'session') { %>

--- a/app/templates/src/main/webapp/scripts/components/auth/_principal.service.js
+++ b/app/templates/src/main/webapp/scripts/components/auth/_principal.service.js
@@ -58,10 +58,16 @@ angular.module('<%=angularAppName%>')
                 // retrieve the identity data from the server, update the identity object, and then resolve.
                 Account.get().$promise
                     .then(function (account) {
-                        _identity = account.data;
-                        _authenticated = true;
-                        deferred.resolve(_identity);<% if (websocket == 'spring-websocket') { %>
-                        Tracker.connect();<% } %>
+                        if(account.data.login === "anonymousUser"){
+                            _identity = null;
+                            _authenticated = false;
+                            deferred.resolve(_identity);
+                        }else {
+                            _identity = account.data;
+                            _authenticated = true;
+                            deferred.resolve(_identity);<% if (websocket == 'spring-websocket') { %>
+                            Tracker.connect();<% } %>
+                         }
                     })
                     .catch(function() {
                         _identity = null;


### PR DESCRIPTION
In order to avoid the 401 (User Not Authorized Error) we need to open the access to /api/account. As we check /api/account all the time I think the access should be open.

In order to avoid the NPE  we need to fix the UserService.

Changed the principal.service.js so that JS considers the anonymousUser as a non-login.
