### PR TITLE
Fix #2607 by using relative URL to swagger spec file

### DIFF
--- a/app/templates/src/main/webapp/swagger-ui/_index.html
+++ b/app/templates/src/main/webapp/swagger-ui/_index.html
@@ -29,7 +29,7 @@
 
     <script type="text/javascript">
         $(function () {
-            var url = "/v2/api-docs";
+            var url = "../../v2/api-docs";
 
             // Pre load translate...
             if(window.SwaggerTranslator) {


### PR DESCRIPTION
The swagger*:index*;html was loading spec file by using absolute URL: /v2/api-docs, this did not work when app used a context path.
Now we use a relative URL.

Fix #2607