### PR TITLE
Whitelist OPTIONS requests

### DIFF
--- a/app/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/app/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -5,7 +5,8 @@ import <%=packageName%>.web.filter.CsrfCookieGeneratorFilter;<% } %><% if (authe
 import <%=packageName%>.security.xauth.*;<% } %>
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;<% if (authenticationType == 'session') { %>
-import org.springframework.core.env.Environment;<% } %><% if (authenticationType == 'oauth2' || authenticationType == 'xauth') { %>
+import org.springframework.core.env.Environment;<% } %>
+import org.springframework.http.HttpMethod;<% if (authenticationType == 'oauth2' || authenticationType == 'xauth') { %>
 import org.springframework.security.authentication.AuthenticationManager;<% } %>
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
@@ -72,6 +73,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
     @Override
     public void configure(WebSecurity web) throws Exception {
         web.ignoring()
+            .antMatchers(HttpMethod.OPTIONS, "/**")
             .antMatchers("/scripts/**/*.{js,html}")
             .antMatchers("/bower_components/**")
             .antMatchers("/i18n/**")


### PR DESCRIPTION
This has already been done for OAuth. This PR is to bring it to session auth

OPTIONS are only used for CORS preflight requests and because as per the spec, the browser shall not include auth cookies in preflight requests, we need to whitelist them for cross-domain situations