### PR TITLE
Fix cached usertoken

### DIFF
--- a/app/templates/src/main/java/package/repository/_UserRepository.java
+++ b/app/templates/src/main/java/package/repository/_UserRepository.java
@@ -3,7 +3,7 @@ package <%=packageName%>.repository;
 import com.datastax.driver.core.*;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;<% } %>
-import <%=packageName%>.domain.User;<% if (this.authenticationType == 'session') { %>
+import <%=packageName%>.domain.User;<% if (authenticationType == 'session') { %>
 import <%=packageName%>.domain.PersistentToken;<% } %>
 
 import java.time.ZonedDateTime;<% if (databaseType == 'sql') { %>
@@ -42,7 +42,7 @@ public interface UserRepository extends <% if (databaseType == 'sql') { %>JpaRep
 
     Optional<User> findOneByLogin(String login);
 
-    Optional<User> findOneById(<%= pkType %> userId);<% if (this.authenticationType == 'session') { %>
+    Optional<User> findOneById(<%= pkType %> userId);<% if (authenticationType == 'session') { %>
 
     Optional<User> findOneByPersistentTokens(PersistentToken token);<% } %>
 

--- a/app/templates/src/main/java/package/repository/_UserRepository.java
+++ b/app/templates/src/main/java/package/repository/_UserRepository.java
@@ -4,6 +4,7 @@ import com.datastax.driver.core.*;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;<% } %>
 import <%=packageName%>.domain.User;
+import <%=packageName%>.domain.PersistentToken;
 
 import java.time.ZonedDateTime;<% if (databaseType == 'sql') { %>
 import org.springframework.data.jpa.repository.JpaRepository;

--- a/app/templates/src/main/java/package/repository/_UserRepository.java
+++ b/app/templates/src/main/java/package/repository/_UserRepository.java
@@ -42,7 +42,7 @@ public interface UserRepository extends <% if (databaseType == 'sql') { %>JpaRep
 
     Optional<User> findOneByLogin(String login);
 
-    Optional<User> findOneById(<%= pkType %> userId);<% if (authenticationType == 'session') { %>
+    Optional<User> findOneById(<%= pkType %> userId);<% if (authenticationType == 'session' && databaseType == 'sql') { %>
 
     Optional<User> findOneByPersistentTokens(PersistentToken token);<% } %>
 

--- a/app/templates/src/main/java/package/repository/_UserRepository.java
+++ b/app/templates/src/main/java/package/repository/_UserRepository.java
@@ -42,6 +42,8 @@ public interface UserRepository extends <% if (databaseType == 'sql') { %>JpaRep
     Optional<User> findOneByLogin(String login);
 
     Optional<User> findOneById(<%= pkType %> userId);
+    
+    Optional<User> findOneByPersistentTokens(PersistentToken token);
 
     @Override
     void delete(User t);

--- a/app/templates/src/main/java/package/repository/_UserRepository.java
+++ b/app/templates/src/main/java/package/repository/_UserRepository.java
@@ -3,8 +3,8 @@ package <%=packageName%>.repository;
 import com.datastax.driver.core.*;
 import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;<% } %>
-import <%=packageName%>.domain.User;
-import <%=packageName%>.domain.PersistentToken;
+import <%=packageName%>.domain.User;<% if (this.authenticationType == 'session') { %>
+import <%=packageName%>.domain.PersistentToken;<% } %>
 
 import java.time.ZonedDateTime;<% if (databaseType == 'sql') { %>
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -42,9 +42,9 @@ public interface UserRepository extends <% if (databaseType == 'sql') { %>JpaRep
 
     Optional<User> findOneByLogin(String login);
 
-    Optional<User> findOneById(<%= pkType %> userId);
-    
-    Optional<User> findOneByPersistentTokens(PersistentToken token);
+    Optional<User> findOneById(<%= pkType %> userId);<% if (this.authenticationType == 'session') { %>
+
+    Optional<User> findOneByPersistentTokens(PersistentToken token);<% } %>
 
     @Override
     void delete(User t);

--- a/app/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/app/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -148,13 +148,14 @@ public class CustomPersistentRememberMeServices extends
         if (rememberMeCookie != null && rememberMeCookie.length() != 0) {
             try {
                 String[] cookieTokens = decodeCookie(rememberMeCookie);
-                PersistentToken token = getPersistentToken(cookieTokens);
-                
+                PersistentToken token = getPersistentToken(cookieTokens);<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+
                 // remove the token from the user, updating the user cache
                 userRepository.findOneByPersistentTokens(token).ifPresent(u -> {
                     u.getPersistentTokens().remove(token);
                     userRepository.save(u);
-                });
+                });<%}%>
+                persistentTokenRepository.delete(token);
             } catch (InvalidCookieException ice) {
                 log.info("Invalid cookie, no persistent token could be deleted");
             } catch (RememberMeAuthenticationException rmae) {

--- a/app/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/app/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -148,7 +148,7 @@ public class CustomPersistentRememberMeServices extends
         if (rememberMeCookie != null && rememberMeCookie.length() != 0) {
             try {
                 String[] cookieTokens = decodeCookie(rememberMeCookie);
-                PersistentToken token = getPersistentToken(cookieTokens);<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+                PersistentToken token = getPersistentToken(cookieTokens);<% if (databaseType == 'sql') { %>
 
                 // remove the token from the user, updating the user cache
                 userRepository.findOneByPersistentTokens(token).ifPresent(u -> {

--- a/app/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/app/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -149,7 +149,12 @@ public class CustomPersistentRememberMeServices extends
             try {
                 String[] cookieTokens = decodeCookie(rememberMeCookie);
                 PersistentToken token = getPersistentToken(cookieTokens);
-                persistentTokenRepository.delete(token);
+                
+                // remove the token from the user, updating the user cache
+                userRepository.findOneByPersistentTokens(token).ifPresent(u -> {
+                    u.getPersistentTokens().remove(token);
+                    userRepository.save(u);
+                });
             } catch (InvalidCookieException ice) {
                 log.info("Invalid cookie, no persistent token could be deleted");
             } catch (RememberMeAuthenticationException rmae) {


### PR DESCRIPTION
This change fixes a rare situation where when using a custom UserDetailsService, LoggingAspect will trigger errors in the second level cache when signing in a user that singed out before. 

The custom UserDetailsService uses UserService.getUserWithAuthoritiesByLogin to retrieve an existing user from the database. LoggingAspect tries to log the return value, which is a User object with a Set of PersistentToken entities. This (hibernate Persistent)Set still somehow includes a lazy loading link to the PersistentToken that was removed at sign out. Logging the set using toString triggers the retrieval of the token that is no longer available in the database, which results in a few lengthy stack traces in the error logging. The problem did not seem to extend passed the logging, i.e. the Set got 'fixed' later in the chain. This leads me to believe the order in which the LoggingAspect and transaction aspects are executed somehow got altered from the default in most other deployments, which is why this problem only showed in this case.

Also, it is my opinion that removing the token from the user and updating the user is a cleaner way of removing the token, since User is the owner of the token.

Please note that the changes to the UserRepository template are incomplete: The method findOneByPersistentTokens is missing for cassandra.