### PR TITLE
Browser sync proxy sets X-Forwarded-Host header

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -110,7 +110,12 @@ module.exports = function (grunt) {
             },
             options: {
                 watchTask: true,
-                proxy: "localhost:8080"
+                proxy: {
+                    target: "localhost:8080",
+                    proxyOptions: {
+                        xfwd: true
+                    }
+                }
             }
         },
         clean: {

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -157,6 +157,7 @@ gulp.task('serve', function() {
                         res.end();
                     }
                 });
+                req.headers['X-Forwarded-Host'] = req.headers.host;
 
                 next();
             }

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -157,7 +157,6 @@ gulp.task('serve', function() {
                         res.end();
                     }
                 });
-                req.headers['X-Forwarded-Host'] = req.headers.host;
 
                 next();
             }
@@ -166,6 +165,7 @@ gulp.task('serve', function() {
             proxyRoutes.map(function (r) {
                 var options = url.parse(baseUri + r);
                 options.route = r;
+                options.preserveHost = true;
                 return proxy(options);
             }));
 


### PR DESCRIPTION
The X-Forwarded-Host header is used by springfox to fill the host field in swagger spec.
With this PR, swagger now works in browser-sync