### PR TITLE
Put a username for H2 database

### DIFF
--- a/app/templates/src/main/resources/config/_application-dev.yml
+++ b/app/templates/src/main/resources/config/_application-dev.yml
@@ -41,7 +41,7 @@ spring:
         url: jdbc:h2:mem:<%= lowercaseBaseName %>;DB_CLOSE_DELAY=-1
         <%_ } _%>
         name:
-        username: <% if (devDatabaseType == 'mysql') { %>root<% } else if (devDatabaseType == 'postgresql') { %><%= baseName %><% } %>
+        username: <% if (devDatabaseType == 'mysql') { %>root<% } else if (devDatabaseType == 'postgresql' || devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory' ) { %><%= baseName %><% } %>
         password:
     <%_ if (devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory') { _%>
     h2:

--- a/app/templates/src/main/resources/h2.server.properties
+++ b/app/templates/src/main/resources/h2.server.properties
@@ -1,9 +1,9 @@
 #H2 Server Properties
 <%_ if (devDatabaseType == 'h2Memory') { _%>
-0=JHipster H2 (Memory)|org.h2.Driver|jdbc\:h2\:mem\:<%= lowercaseBaseName %>|
+0=JHipster H2 (Memory)|org.h2.Driver|jdbc\:h2\:mem\:<%= lowercaseBaseName %>|<%= baseName %>
 <%_ } _%>
 <%_ if (devDatabaseType == 'h2Disk') { _%>
-0=JHipster H2 (Disk)|org.h2.Driver|jdbc\:h2\:file\:./target/h2db/db/<%= lowercaseBaseName %>|
+0=JHipster H2 (Disk)|org.h2.Driver|jdbc\:h2\:file\:./target/h2db/db/<%= lowercaseBaseName %>|<%= baseName %>
 <%_ } _%>
 webAllowOthers=true
 webPort=8082


### PR DESCRIPTION
With the current setting, as there is no username, the h2-console will put "admin:admin" as default username/password instead of keeping the fields empty so you have to manually empty the fields. This PR sets a username so the user can directly connect to the database when he opens the console. This is a major improvement for productivity :smile: 
