### PR TITLE
return the correct date from the previousMonth function during January

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/admin/audits/_audits.controller.js
+++ b/app/templates/src/main/webapp/scripts/app/admin/audits/_audits.controller.js
@@ -22,7 +22,7 @@ angular.module('<%=angularAppName%>')
         $scope.previousMonth = function () {
             var fromDate = new Date();
             if (fromDate.getMonth() === 0) {
-                fromDate = new Date(fromDate.getFullYear() - 1, 0, fromDate.getDate());
+                fromDate = new Date(fromDate.getFullYear() - 1, 11, fromDate.getDate());
             } else {
                 fromDate = new Date(fromDate.getFullYear(), fromDate.getMonth() - 1, fromDate.getDate());
             }


### PR DESCRIPTION
Very small change, the Audits page currently fetches audits for the entire year.