### PR TITLE
add entity update feature

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -16,13 +16,13 @@ var JhipsterGenerator = generators.Base.extend({});
 
 util.inherits(JhipsterGenerator, scriptBase);
 
-var questions = 15; // making questions a variable to avoid updating each question by hand when adding additional options
-var resourceDir = 'src/main/resources/';
-var webappDir = 'src/main/webapp/';
-var testJsDir = 'src/test/javascript/';
-var testResourceDir = 'src/test/resources/';
-var dockerDir = 'src/main/docker/';
-var interpolateRegex = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
+const questions = 15; // making questions a variable to avoid updating each question by hand when adding additional options
+const resourceDir = 'src/main/resources/';
+const webappDir = 'src/main/webapp/';
+const testJsDir = 'src/test/javascript/';
+const testResourceDir = 'src/test/resources/';
+const dockerDir = 'src/main/docker/';
+const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
 
 module.exports = JhipsterGenerator.extend({
     constructor: function() {

--- a/app/index.js
+++ b/app/index.js
@@ -16,8 +16,8 @@ var JhipsterGenerator = generators.Base.extend({});
 
 util.inherits(JhipsterGenerator, scriptBase);
 
-const questions = 15; // making questions a variable to avoid updating each question by hand when adding additional options
-const resourceDir = 'src/main/resources/';
+const QUESTIONS = 15; // making questions a variable to avoid updating each question by hand when adding additional options
+const RESOURCE_DIR = 'src/main/resources/';
 const webappDir = 'src/main/webapp/';
 const testJsDir = 'src/test/javascript/';
 const testResourceDir = 'src/test/resources/';
@@ -191,7 +191,7 @@ module.exports = JhipsterGenerator.extend({
                     if (/^([a-zA-Z0-9_]*)$/.test(input)) return true;
                     return 'Your application name cannot contain special characters or a blank space, using the default name instead';
                 },
-                message: '(1/' + questions + ') What is the base name of your application?',
+                message: '(1/' + QUESTIONS + ') What is the base name of your application?',
                 default: defaultAppBaseName
             }, function (prompt) {
                 this.baseName = prompt.baseName;
@@ -214,14 +214,14 @@ module.exports = JhipsterGenerator.extend({
                         if (/^([a-z_]{1}[a-z0-9_]*(\.[a-z_]{1}[a-z0-9_]*)*)$/.test(input)) return true;
                         return 'The package name you have provided is not a valid Java package name.';
                     },
-                    message: '(2/' + questions + ') What is your default Java package name?',
+                    message: '(2/' + QUESTIONS + ') What is your default Java package name?',
                     default: 'com.mycompany.myapp',
                     store: true
                 },
                 {
                     type: 'list',
                     name: 'authenticationType',
-                    message: '(3/' + questions + ') Which *type* of authentication would you like to use?',
+                    message: '(3/' + QUESTIONS + ') Which *type* of authentication would you like to use?',
                     choices: [
                         {
                             value: 'session',
@@ -248,7 +248,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'databaseType',
-                    message: '(4/' + questions + ') Which *type* of database would you like to use?',
+                    message: '(4/' + QUESTIONS + ') Which *type* of database would you like to use?',
                     choices: [
                         {
                             value: 'sql',
@@ -267,7 +267,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'databaseType',
-                    message: '(4/' + questions + ') Which *type* of database would you like to use?',
+                    message: '(4/' + QUESTIONS + ') Which *type* of database would you like to use?',
                     choices: [
                         {
                             value: 'sql',
@@ -290,7 +290,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'prodDatabaseType',
-                    message: '(5/' + questions + ') Which *production* database would you like to use?',
+                    message: '(5/' + QUESTIONS + ') Which *production* database would you like to use?',
                     choices: [
                         {
                             value: 'mysql',
@@ -313,7 +313,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'devDatabaseType',
-                    message: '(6/' + questions + ') Which *development* database would you like to use?',
+                    message: '(6/' + QUESTIONS + ') Which *development* database would you like to use?',
                     choices: [
                         {
                             value: 'h2Disk',
@@ -336,7 +336,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'devDatabaseType',
-                    message: '(6/' + questions + ') Which *development* database would you like to use?',
+                    message: '(6/' + QUESTIONS + ') Which *development* database would you like to use?',
                     choices: [
                         {
                             value: 'h2Disk',
@@ -359,7 +359,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'devDatabaseType',
-                    message: '(6/' + questions + ') Which *development* database would you like to use?',
+                    message: '(6/' + QUESTIONS + ') Which *development* database would you like to use?',
                     choices: [
                         {
                             value: 'h2Disk',
@@ -382,7 +382,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'hibernateCache',
-                    message: '(7/' + questions + ') Do you want to use Hibernate 2nd level cache?',
+                    message: '(7/' + QUESTIONS + ') Do you want to use Hibernate 2nd level cache?',
                     choices: [
                         {
                             value: 'no',
@@ -405,7 +405,7 @@ module.exports = JhipsterGenerator.extend({
                     },
                     type: 'list',
                     name: 'searchEngine',
-                    message: '(8/' + questions + ') Do you want to use a search engine in your application?',
+                    message: '(8/' + QUESTIONS + ') Do you want to use a search engine in your application?',
                     choices: [
                         {
                             value: 'no',
@@ -421,7 +421,7 @@ module.exports = JhipsterGenerator.extend({
                 {
                     type: 'list',
                     name: 'clusteredHttpSession',
-                    message: '(9/' + questions + ') Do you want to use clustered HTTP sessions?',
+                    message: '(9/' + QUESTIONS + ') Do you want to use clustered HTTP sessions?',
                     choices: [
                         {
                             value: 'no',
@@ -437,7 +437,7 @@ module.exports = JhipsterGenerator.extend({
                 {
                     type: 'list',
                     name: 'websocket',
-                    message: '(10/' + questions + ') Do you want to use WebSockets?',
+                    message: '(10/' + QUESTIONS + ') Do you want to use WebSockets?',
                     choices: [
                         {
                             value: 'no',
@@ -453,7 +453,7 @@ module.exports = JhipsterGenerator.extend({
                 {
                     type: 'list',
                     name: 'buildTool',
-                    message: '(11/' + questions + ') Would you like to use Maven or Gradle for building the backend?',
+                    message: '(11/' + QUESTIONS + ') Would you like to use Maven or Gradle for building the backend?',
                     choices: [
                         {
                             value: 'maven',
@@ -527,19 +527,19 @@ module.exports = JhipsterGenerator.extend({
                             name: 'Gulp.js'
                         }
                     ],
-                    message: '(12/' + questions + ') Would you like to use Grunt or Gulp.js for building the frontend?',
+                    message: '(12/' + QUESTIONS + ') Would you like to use Grunt or Gulp.js for building the frontend?',
                     default: 'grunt'
                 },
                 {
                     type: 'confirm',
                     name: 'useSass',
-                    message: '(13/' + questions + ') Would you like to use the LibSass stylesheet preprocessor for your CSS?',
+                    message: '(13/' + QUESTIONS + ') Would you like to use the LibSass stylesheet preprocessor for your CSS?',
                     default: false
                 },
                 {
                     type: 'confirm',
                     name: 'enableTranslation',
-                    message: '(14/' + questions + ') Would you like to enable translation support with Angular Translate?',
+                    message: '(14/' + QUESTIONS + ') Would you like to enable translation support with Angular Translate?',
                     default: true
                 }
             ];
@@ -572,7 +572,7 @@ module.exports = JhipsterGenerator.extend({
             this.prompt({
                 type: 'checkbox',
                 name: 'testFrameworks',
-                message: '(15/' + questions + ') Which testing frameworks would you like to use?',
+                message: '(15/' + QUESTIONS + ') Which testing frameworks would you like to use?',
                 choices: choices,
                 default: [ 'gatling' ]
             }, function (prompt) {
@@ -721,53 +721,53 @@ module.exports = JhipsterGenerator.extend({
             }
 
             // Create Java resource files
-            mkdirp(resourceDir);
-            this.copy(resourceDir + '/banner.txt', resourceDir + '/banner.txt');
+            mkdirp(RESOURCE_DIR);
+            this.copy(RESOURCE_DIR + '/banner.txt', RESOURCE_DIR + '/banner.txt');
 
             if (this.hibernateCache == "ehcache") {
-                this.template(resourceDir + '_ehcache.xml', resourceDir + 'ehcache.xml', this, {});
+                this.template(RESOURCE_DIR + '_ehcache.xml', RESOURCE_DIR + 'ehcache.xml', this, {});
             }
             if (this.devDatabaseType == "h2Disk" || this.devDatabaseType == "h2Memory") {
-                this.copy(resourceDir + 'h2.server.properties', resourceDir + '.h2.server.properties');
+                this.copy(RESOURCE_DIR + 'h2.server.properties', RESOURCE_DIR + '.h2.server.properties');
             }
 
             // Thymeleaf templates
-            this.copy(resourceDir + '/templates/error.html', resourceDir + 'templates/error.html');
+            this.copy(RESOURCE_DIR + '/templates/error.html', RESOURCE_DIR + 'templates/error.html');
 
-            this.template(resourceDir + '_logback-spring.xml', resourceDir + 'logback-spring.xml', this, {'interpolate': interpolateRegex});
+            this.template(RESOURCE_DIR + '_logback-spring.xml', RESOURCE_DIR + 'logback-spring.xml', this, {'interpolate': interpolateRegex});
 
-            this.template(resourceDir + '/config/_application.yml', resourceDir + 'config/application.yml', this, {});
-            this.template(resourceDir + '/config/_application-dev.yml', resourceDir + 'config/application-dev.yml', this, {});
-            this.template(resourceDir + '/config/_application-prod.yml', resourceDir + 'config/application-prod.yml', this, {});
+            this.template(RESOURCE_DIR + '/config/_application.yml', RESOURCE_DIR + 'config/application.yml', this, {});
+            this.template(RESOURCE_DIR + '/config/_application-dev.yml', RESOURCE_DIR + 'config/application-dev.yml', this, {});
+            this.template(RESOURCE_DIR + '/config/_application-prod.yml', RESOURCE_DIR + 'config/application-prod.yml', this, {});
 
             if (this.databaseType == "sql") {
-                this.template(resourceDir + '/config/liquibase/changelog/_initial_schema.xml', resourceDir + 'config/liquibase/changelog/00000000000000_initial_schema.xml', this, {'interpolate': interpolateRegex});
-                this.copy(resourceDir + '/config/liquibase/master.xml', resourceDir + 'config/liquibase/master.xml');
-                this.copy(resourceDir + '/config/liquibase/users.csv', resourceDir + 'config/liquibase/users.csv');
-                this.copy(resourceDir + '/config/liquibase/authorities.csv', resourceDir + 'config/liquibase/authorities.csv');
-                this.copy(resourceDir + '/config/liquibase/users_authorities.csv', resourceDir + 'config/liquibase/users_authorities.csv');
+                this.template(RESOURCE_DIR + '/config/liquibase/changelog/_initial_schema.xml', RESOURCE_DIR + 'config/liquibase/changelog/00000000000000_initial_schema.xml', this, {'interpolate': interpolateRegex});
+                this.copy(RESOURCE_DIR + '/config/liquibase/master.xml', RESOURCE_DIR + 'config/liquibase/master.xml');
+                this.copy(RESOURCE_DIR + '/config/liquibase/users.csv', RESOURCE_DIR + 'config/liquibase/users.csv');
+                this.copy(RESOURCE_DIR + '/config/liquibase/authorities.csv', RESOURCE_DIR + 'config/liquibase/authorities.csv');
+                this.copy(RESOURCE_DIR + '/config/liquibase/users_authorities.csv', RESOURCE_DIR + 'config/liquibase/users_authorities.csv');
             }
 
             if (this.databaseType == "mongodb") {
-                this.copy(resourceDir + '/config/mongeez/authorities.xml', resourceDir + 'config/mongeez/authorities.xml');
-                this.copy(resourceDir + '/config/mongeez/master.xml', resourceDir + 'config/mongeez/master.xml');
-                this.copy(resourceDir + '/config/mongeez/users.xml', resourceDir + 'config/mongeez/users.xml');
-                this.copy(resourceDir + '/config/mongeez/social_user_connections.xml', resourceDir + 'config/mongeez/social_user_connections.xml');
+                this.copy(RESOURCE_DIR + '/config/mongeez/authorities.xml', RESOURCE_DIR + 'config/mongeez/authorities.xml');
+                this.copy(RESOURCE_DIR + '/config/mongeez/master.xml', RESOURCE_DIR + 'config/mongeez/master.xml');
+                this.copy(RESOURCE_DIR + '/config/mongeez/users.xml', RESOURCE_DIR + 'config/mongeez/users.xml');
+                this.copy(RESOURCE_DIR + '/config/mongeez/social_user_connections.xml', RESOURCE_DIR + 'config/mongeez/social_user_connections.xml');
             }
 
             if (this.databaseType == "cassandra") {
-                this.template(resourceDir + '/config/cql/_create-keyspace-prod.cql', resourceDir + 'config/cql/create-keyspace-prod.cql', this, {});
-                this.template(resourceDir + '/config/cql/_create-keyspace.cql', resourceDir + 'config/cql/create-keyspace.cql', this, {});
-                this.template(resourceDir + '/config/cql/_drop-keyspace.cql', resourceDir + 'config/cql/drop-keyspace.cql', this, {});
-                this.copy(resourceDir + '/config/cql/create-tables.cql', resourceDir + 'config/cql/create-tables.cql');
+                this.template(RESOURCE_DIR + '/config/cql/_create-keyspace-prod.cql', RESOURCE_DIR + 'config/cql/create-keyspace-prod.cql', this, {});
+                this.template(RESOURCE_DIR + '/config/cql/_create-keyspace.cql', RESOURCE_DIR + 'config/cql/create-keyspace.cql', this, {});
+                this.template(RESOURCE_DIR + '/config/cql/_drop-keyspace.cql', RESOURCE_DIR + 'config/cql/drop-keyspace.cql', this, {});
+                this.copy(RESOURCE_DIR + '/config/cql/create-tables.cql', RESOURCE_DIR + 'config/cql/create-tables.cql');
             }
 
             // Create mail templates
-            this.copy(resourceDir + '/mails/activationEmail.html', resourceDir + 'mails/activationEmail.html');
-            this.copy(resourceDir + '/mails/creationEmail.html', resourceDir + 'mails/creationEmail.html');
-            this.copy(resourceDir + '/mails/passwordResetEmail.html', resourceDir + 'mails/passwordResetEmail.html');
+            this.copy(RESOURCE_DIR + '/mails/activationEmail.html', RESOURCE_DIR + 'mails/activationEmail.html');
+            this.copy(RESOURCE_DIR + '/mails/creationEmail.html', RESOURCE_DIR + 'mails/creationEmail.html');
+            this.copy(RESOURCE_DIR + '/mails/passwordResetEmail.html', RESOURCE_DIR + 'mails/passwordResetEmail.html');
             if (this.enableSocialSignIn) {
-                this.copy(resourceDir + '/mails/socialRegistrationValidationEmail.html', resourceDir + 'mails/socialRegistrationValidationEmail.html');
+                this.copy(RESOURCE_DIR + '/mails/socialRegistrationValidationEmail.html', RESOURCE_DIR + 'mails/socialRegistrationValidationEmail.html');
             }
 
             // Create Java files
@@ -1020,10 +1020,10 @@ module.exports = JhipsterGenerator.extend({
 
             // install all files related to i18n if translation is enabled
             if (this.enableTranslation) {
-                this.installI18nFilesByLanguage(this, webappDir, resourceDir, 'en');
-                this.installI18nFilesByLanguage(this, webappDir, resourceDir, 'fr');
+                this.installI18nFilesByLanguage(this, webappDir, RESOURCE_DIR, 'en');
+                this.installI18nFilesByLanguage(this, webappDir, RESOURCE_DIR, 'fr');
             } else {
-                this.template(resourceDir + '/i18n/_messages_en.properties', resourceDir + 'i18n/messages_en.properties', this, {});
+                this.template(RESOURCE_DIR + '/i18n/_messages_en.properties', RESOURCE_DIR + 'i18n/messages_en.properties', this, {});
             }
 
             // Swagger-ui for Jhipster
@@ -1419,7 +1419,7 @@ module.exports = JhipsterGenerator.extend({
             this.removefile(javaDir + 'domain/util/ISO8601LocalDateDeserializer.java');
             this.removefolder(javaDir + 'web/propertyeditors');
 
-            this.removefile(resourceDir + 'logback.xml');
+            this.removefile(RESOURCE_DIR + 'logback.xml');
 
             this.removefile(webappDir + 'scripts/app/account/logout/logout.js');
             this.removefile(webappDir + 'scripts/app/account/logout/logout.controller.js');

--- a/app/index.js
+++ b/app/index.js
@@ -19,9 +19,9 @@ util.inherits(JhipsterGenerator, scriptBase);
 const QUESTIONS = 15; // making questions a variable to avoid updating each question by hand when adding additional options
 const RESOURCE_DIR = 'src/main/resources/';
 const WEBAPP_DIR = 'src/main/webapp/';
-const testJsDir = 'src/test/javascript/';
-const testResourceDir = 'src/test/resources/';
-const dockerDir = 'src/main/docker/';
+const TEST_JS_DIR = 'src/test/javascript/';
+const TEST_RES_DIR = 'src/test/resources/';
+const DOCKER_DIR = 'src/main/docker/';
 const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
 
 module.exports = JhipsterGenerator.extend({
@@ -672,21 +672,21 @@ module.exports = JhipsterGenerator.extend({
             var javaDir = this.javaDir;
 
             // Create docker-compose file
-            this.template(dockerDir + '_sonar.yml', dockerDir + 'sonar.yml', this, {});
+            this.template(DOCKER_DIR + '_sonar.yml', DOCKER_DIR + 'sonar.yml', this, {});
             if (this.devDatabaseType != "h2Disk" && this.devDatabaseType != "h2Memory" && this.devDatabaseType != "oracle") {
-                this.template(dockerDir + '_dev.yml', dockerDir + 'dev.yml', this, {});
+                this.template(DOCKER_DIR + '_dev.yml', DOCKER_DIR + 'dev.yml', this, {});
             }
             if (this.prodDatabaseType != "oracle" || this.searchEngine == "elasticsearch") {
-                this.template(dockerDir + '_prod.yml', dockerDir + 'prod.yml', this, {});
+                this.template(DOCKER_DIR + '_prod.yml', DOCKER_DIR + 'prod.yml', this, {});
             }
             if (this.devDatabaseType == "cassandra") {
-                this.template(dockerDir + 'cassandra/_Cassandra-Dev.Dockerfile', dockerDir + 'cassandra/Cassandra-Dev.Dockerfile', this, {});
-                this.template(dockerDir + 'cassandra/_Cassandra-Prod.Dockerfile', dockerDir + 'cassandra/Cassandra-Prod.Dockerfile', this, {});
-                this.template(dockerDir + 'cassandra/scripts/_init-dev.sh', dockerDir + 'cassandra/scripts/init-dev.sh', this, {});
-                this.template(dockerDir + 'cassandra/scripts/_init-prod.sh', dockerDir + 'cassandra/scripts/init-prod.sh', this, {});
-                this.template(dockerDir + 'cassandra/scripts/_entities.sh', dockerDir + 'cassandra/scripts/entities.sh', this, {});
-                this.template(dockerDir + 'cassandra/scripts/_cassandra.sh', dockerDir + 'cassandra/scripts/cassandra.sh', this, {});
-                this.template(dockerDir + 'opscenter/_Dockerfile', dockerDir + 'opscenter/Dockerfile', this, {});
+                this.template(DOCKER_DIR + 'cassandra/_Cassandra-Dev.Dockerfile', DOCKER_DIR + 'cassandra/Cassandra-Dev.Dockerfile', this, {});
+                this.template(DOCKER_DIR + 'cassandra/_Cassandra-Prod.Dockerfile', DOCKER_DIR + 'cassandra/Cassandra-Prod.Dockerfile', this, {});
+                this.template(DOCKER_DIR + 'cassandra/scripts/_init-dev.sh', DOCKER_DIR + 'cassandra/scripts/init-dev.sh', this, {});
+                this.template(DOCKER_DIR + 'cassandra/scripts/_init-prod.sh', DOCKER_DIR + 'cassandra/scripts/init-prod.sh', this, {});
+                this.template(DOCKER_DIR + 'cassandra/scripts/_entities.sh', DOCKER_DIR + 'cassandra/scripts/entities.sh', this, {});
+                this.template(DOCKER_DIR + 'cassandra/scripts/_cassandra.sh', DOCKER_DIR + 'cassandra/scripts/cassandra.sh', this, {});
+                this.template(DOCKER_DIR + 'opscenter/_Dockerfile', DOCKER_DIR + 'opscenter/Dockerfile', this, {});
             }
 
             switch (this.buildTool) {
@@ -1332,11 +1332,11 @@ module.exports = JhipsterGenerator.extend({
             this.template('src/test/java/package/web/rest/_TestUtil.java', testDir + 'web/rest/TestUtil.java', this, {});
             this.template('src/test/java/package/web/rest/_UserResourceIntTest.java', testDir + 'web/rest/UserResourceIntTest.java', this, {});
 
-            this.template(testResourceDir + 'config/_application.yml', testResourceDir + 'config/application.yml', this, {});
-            this.template(testResourceDir + '_logback-test.xml', testResourceDir + 'logback-test.xml', this, {});
+            this.template(TEST_RES_DIR + 'config/_application.yml', TEST_RES_DIR + 'config/application.yml', this, {});
+            this.template(TEST_RES_DIR + '_logback-test.xml', TEST_RES_DIR + 'logback-test.xml', this, {});
 
             if (this.hibernateCache == "ehcache") {
-                this.template(testResourceDir + '_ehcache.xml', testResourceDir + 'ehcache.xml', this, {});
+                this.template(TEST_RES_DIR + '_ehcache.xml', TEST_RES_DIR + 'ehcache.xml', this, {});
             }
 
             if (this.enableSocialSignIn) {
@@ -1391,7 +1391,7 @@ module.exports = JhipsterGenerator.extend({
                 testTemplates.push('_protractor.conf.js')
             }
             testTemplates.map(function(testTemplatePath) {
-                this.template(testJsDir + testTemplatePath, testJsDir + testTemplatePath.replace(/_/,''), this, {});
+                this.template(TEST_JS_DIR + testTemplatePath, TEST_JS_DIR + testTemplatePath.replace(/_/,''), this, {});
             }.bind(this));
 
         },
@@ -1426,13 +1426,13 @@ module.exports = JhipsterGenerator.extend({
             this.removefolder(WEBAPP_DIR + 'scripts/app/account/logout');
 
             this.removefile(testDir + 'config/MongoConfiguration.java');
-            this.removefile(testJsDir + 'spec/app/account/health/healthControllerSpec.js');
-            this.removefile(testJsDir + 'spec/app/account/login/loginControllerSpec.js');
-            this.removefile(testJsDir + 'spec/app/account/password/passwordControllerSpec.js');
-            this.removefile(testJsDir + 'spec/app/account/password/passwordDirectiveSpec.js');
-            this.removefile(testJsDir + 'spec/app/account/sessions/sessionsControllerSpec.js');
-            this.removefile(testJsDir + 'spec/app/account/settings/settingsControllerSpec.js');
-            this.removefile(testJsDir + 'spec/components/auth/authServicesSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/app/account/health/healthControllerSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/app/account/login/loginControllerSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordControllerSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordDirectiveSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/app/account/sessions/sessionsControllerSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/app/account/settings/settingsControllerSpec.js');
+            this.removefile(TEST_JS_DIR + 'spec/components/auth/authServicesSpec.js');
 
             this.removefile('docker-compose.yml');
             this.removefile('docker-compose-prod.yml');

--- a/app/index.js
+++ b/app/index.js
@@ -22,7 +22,7 @@ const WEBAPP_DIR = 'src/main/webapp/';
 const TEST_JS_DIR = 'src/test/javascript/';
 const TEST_RES_DIR = 'src/test/resources/';
 const DOCKER_DIR = 'src/main/docker/';
-const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
+const INTERPOLATE_REGEX = /<%=([\s\S]+?)%>/g; // so that tags in templates do not get mistreated as _ templates
 
 module.exports = JhipsterGenerator.extend({
     constructor: function() {
@@ -696,10 +696,10 @@ module.exports = JhipsterGenerator.extend({
                     this.template('_gradle.properties', 'gradle.properties', this, {});
                     this.template('gradle/_yeoman.gradle', 'gradle/yeoman.gradle', this, {});
                     this.template('gradle/_sonar.gradle', 'gradle/sonar.gradle', this, {});
-                    this.template('gradle/_profile_dev.gradle', 'gradle/profile_dev.gradle', this, {'interpolate': interpolateRegex});
-                    this.template('gradle/_profile_prod.gradle', 'gradle/profile_prod.gradle', this, {'interpolate': interpolateRegex});
-                    this.template('gradle/_profile_fast.gradle', 'gradle/profile_fast.gradle', this, {'interpolate': interpolateRegex});
-                    this.template('gradle/_mapstruct.gradle', 'gradle/mapstruct.gradle', this, {'interpolate': interpolateRegex});
+                    this.template('gradle/_profile_dev.gradle', 'gradle/profile_dev.gradle', this, {'interpolate': INTERPOLATE_REGEX});
+                    this.template('gradle/_profile_prod.gradle', 'gradle/profile_prod.gradle', this, {'interpolate': INTERPOLATE_REGEX});
+                    this.template('gradle/_profile_fast.gradle', 'gradle/profile_fast.gradle', this, {'interpolate': INTERPOLATE_REGEX});
+                    this.template('gradle/_mapstruct.gradle', 'gradle/mapstruct.gradle', this, {'interpolate': INTERPOLATE_REGEX});
                     if (this.testFrameworks.indexOf('gatling') != -1) {
                         this.template('gradle/_gatling.gradle', 'gradle/gatling.gradle', this, {});
                     }
@@ -717,7 +717,7 @@ module.exports = JhipsterGenerator.extend({
                     this.copy('mvnw.cmd', 'mvnw.cmd');
                     this.copy('.mvn/wrapper/maven-wrapper.jar', '.mvn/wrapper/maven-wrapper.jar');
                     this.copy('.mvn/wrapper/maven-wrapper.properties', '.mvn/wrapper/maven-wrapper.properties');
-                    this.template('_pom.xml', 'pom.xml', null, {'interpolate': interpolateRegex});
+                    this.template('_pom.xml', 'pom.xml', null, {'interpolate': INTERPOLATE_REGEX});
             }
 
             // Create Java resource files
@@ -734,14 +734,14 @@ module.exports = JhipsterGenerator.extend({
             // Thymeleaf templates
             this.copy(RESOURCE_DIR + '/templates/error.html', RESOURCE_DIR + 'templates/error.html');
 
-            this.template(RESOURCE_DIR + '_logback-spring.xml', RESOURCE_DIR + 'logback-spring.xml', this, {'interpolate': interpolateRegex});
+            this.template(RESOURCE_DIR + '_logback-spring.xml', RESOURCE_DIR + 'logback-spring.xml', this, {'interpolate': INTERPOLATE_REGEX});
 
             this.template(RESOURCE_DIR + '/config/_application.yml', RESOURCE_DIR + 'config/application.yml', this, {});
             this.template(RESOURCE_DIR + '/config/_application-dev.yml', RESOURCE_DIR + 'config/application-dev.yml', this, {});
             this.template(RESOURCE_DIR + '/config/_application-prod.yml', RESOURCE_DIR + 'config/application-prod.yml', this, {});
 
             if (this.databaseType == "sql") {
-                this.template(RESOURCE_DIR + '/config/liquibase/changelog/_initial_schema.xml', RESOURCE_DIR + 'config/liquibase/changelog/00000000000000_initial_schema.xml', this, {'interpolate': interpolateRegex});
+                this.template(RESOURCE_DIR + '/config/liquibase/changelog/_initial_schema.xml', RESOURCE_DIR + 'config/liquibase/changelog/00000000000000_initial_schema.xml', this, {'interpolate': INTERPOLATE_REGEX});
                 this.copy(RESOURCE_DIR + '/config/liquibase/master.xml', RESOURCE_DIR + 'config/liquibase/master.xml');
                 this.copy(RESOURCE_DIR + '/config/liquibase/users.csv', RESOURCE_DIR + 'config/liquibase/users.csv');
                 this.copy(RESOURCE_DIR + '/config/liquibase/authorities.csv', RESOURCE_DIR + 'config/liquibase/authorities.csv');

--- a/app/index.js
+++ b/app/index.js
@@ -18,7 +18,7 @@ util.inherits(JhipsterGenerator, scriptBase);
 
 const QUESTIONS = 15; // making questions a variable to avoid updating each question by hand when adding additional options
 const RESOURCE_DIR = 'src/main/resources/';
-const webappDir = 'src/main/webapp/';
+const WEBAPP_DIR = 'src/main/webapp/';
 const testJsDir = 'src/test/javascript/';
 const testResourceDir = 'src/test/resources/';
 const dockerDir = 'src/main/docker/';
@@ -1002,7 +1002,7 @@ module.exports = JhipsterGenerator.extend({
             }
 
             // Create Webapp
-            mkdirp(webappDir);
+            mkdirp(WEBAPP_DIR);
 
             // normal CSS or SCSS?
             if (this.useSass) {
@@ -1013,172 +1013,172 @@ module.exports = JhipsterGenerator.extend({
             this.template('src/main/webapp/assets/styles/main.css', 'src/main/webapp/assets/styles/main.css');
 
             // HTML5 BoilerPlate
-            this.copy(webappDir + 'favicon.ico', webappDir + 'favicon.ico');
-            this.copy(webappDir + 'robots.txt', webappDir + 'robots.txt');
-            this.copy(webappDir + 'htaccess.txt', webappDir + '.htaccess');
-            this.copy(webappDir + '404.html', webappDir + '404.html');
+            this.copy(WEBAPP_DIR + 'favicon.ico', WEBAPP_DIR + 'favicon.ico');
+            this.copy(WEBAPP_DIR + 'robots.txt', WEBAPP_DIR + 'robots.txt');
+            this.copy(WEBAPP_DIR + 'htaccess.txt', WEBAPP_DIR + '.htaccess');
+            this.copy(WEBAPP_DIR + '404.html', WEBAPP_DIR + '404.html');
 
             // install all files related to i18n if translation is enabled
             if (this.enableTranslation) {
-                this.installI18nFilesByLanguage(this, webappDir, RESOURCE_DIR, 'en');
-                this.installI18nFilesByLanguage(this, webappDir, RESOURCE_DIR, 'fr');
+                this.installI18nFilesByLanguage(this, WEBAPP_DIR, RESOURCE_DIR, 'en');
+                this.installI18nFilesByLanguage(this, WEBAPP_DIR, RESOURCE_DIR, 'fr');
             } else {
                 this.template(RESOURCE_DIR + '/i18n/_messages_en.properties', RESOURCE_DIR + 'i18n/messages_en.properties', this, {});
             }
 
             // Swagger-ui for Jhipster
-            this.template(webappDir + '/swagger-ui/_index.html', webappDir + 'swagger-ui/index.html', this, {});
-            this.copy(webappDir + '/swagger-ui/images/throbber.gif', webappDir + 'swagger-ui/images/throbber.gif');
+            this.template(WEBAPP_DIR + '/swagger-ui/_index.html', WEBAPP_DIR + 'swagger-ui/index.html', this, {});
+            this.copy(WEBAPP_DIR + '/swagger-ui/images/throbber.gif', WEBAPP_DIR + 'swagger-ui/images/throbber.gif');
 
             // Angular JS views
 
-            this.template(webappDir + '/scripts/app/_app.js', webappDir + 'scripts/app/app.js', this, {});
-            this.template(webappDir + '/scripts/app/_app.constants.js', webappDir + 'scripts/app/app.constants.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/_app.js', WEBAPP_DIR + 'scripts/app/app.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/_app.constants.js', WEBAPP_DIR + 'scripts/app/app.constants.js', this, {});
 
             // Client Components
-            this.template(webappDir + '/scripts/components/admin/_audits.service.js', webappDir + 'scripts/components/admin/audits.service.js', this, {});
-            this.template(webappDir + '/scripts/components/admin/_configuration.service.js', webappDir + 'scripts/components/admin/configuration.service.js', this, {});
-            this.template(webappDir + '/scripts/components/admin/_logs.service.js', webappDir + 'scripts/components/admin/logs.service.js', this, {});
-            this.template(webappDir + '/scripts/components/admin/_monitoring.service.js', webappDir + 'scripts/components/admin/monitoring.service.js', this, {});
-            this.template(webappDir + '/scripts/components/auth/_auth.service.js', webappDir + 'scripts/components/auth/auth.service.js', this, {});
-            this.template(webappDir + '/scripts/components/auth/_principal.service.js', webappDir + 'scripts/components/auth/principal.service.js', this, {});
-            this.template(webappDir + '/scripts/components/auth/_authority.directive.js', webappDir + 'scripts/components/auth/authority.directive.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/admin/_audits.service.js', WEBAPP_DIR + 'scripts/components/admin/audits.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/admin/_configuration.service.js', WEBAPP_DIR + 'scripts/components/admin/configuration.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/admin/_logs.service.js', WEBAPP_DIR + 'scripts/components/admin/logs.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/admin/_monitoring.service.js', WEBAPP_DIR + 'scripts/components/admin/monitoring.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/_auth.service.js', WEBAPP_DIR + 'scripts/components/auth/auth.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/_principal.service.js', WEBAPP_DIR + 'scripts/components/auth/principal.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/_authority.directive.js', WEBAPP_DIR + 'scripts/components/auth/authority.directive.js', this, {});
             if (this.authenticationType == 'oauth2') {
-                this.template(webappDir + '/scripts/components/auth/provider/_auth.oauth2.service.js', webappDir + 'scripts/components/auth/provider/auth.oauth2.service.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/auth/provider/_auth.oauth2.service.js', WEBAPP_DIR + 'scripts/components/auth/provider/auth.oauth2.service.js', this, {});
             } else if (this.authenticationType == 'xauth') {
-                this.template(webappDir + '/scripts/components/auth/provider/_auth.xauth.service.js', webappDir + 'scripts/components/auth/provider/auth.xauth.service.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/auth/provider/_auth.xauth.service.js', WEBAPP_DIR + 'scripts/components/auth/provider/auth.xauth.service.js', this, {});
             } else {
-                this.template(webappDir + '/scripts/components/auth/provider/_auth.session.service.js', webappDir + 'scripts/components/auth/provider/auth.session.service.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/auth/provider/_auth.session.service.js', WEBAPP_DIR + 'scripts/components/auth/provider/auth.session.service.js', this, {});
             }
-            this.template(webappDir + '/scripts/components/auth/services/_account.service.js', webappDir + 'scripts/components/auth/services/account.service.js', this, {});
-            this.template(webappDir + '/scripts/components/auth/services/_activate.service.js', webappDir + 'scripts/components/auth/services/activate.service.js', this, {});
-            this.template(webappDir + '/scripts/components/auth/services/_password.service.js', webappDir + 'scripts/components/auth/services/password.service.js', this, {});
-            this.template(webappDir + '/scripts/components/auth/services/_register.service.js', webappDir + 'scripts/components/auth/services/register.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/services/_account.service.js', WEBAPP_DIR + 'scripts/components/auth/services/account.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/services/_activate.service.js', WEBAPP_DIR + 'scripts/components/auth/services/activate.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/services/_password.service.js', WEBAPP_DIR + 'scripts/components/auth/services/password.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/auth/services/_register.service.js', WEBAPP_DIR + 'scripts/components/auth/services/register.service.js', this, {});
             if (this.authenticationType == 'session') {
-                this.template(webappDir + '/scripts/components/auth/services/_sessions.service.js', webappDir + 'scripts/components/auth/services/sessions.service.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/auth/services/_sessions.service.js', WEBAPP_DIR + 'scripts/components/auth/services/sessions.service.js', this, {});
             }
-            this.template(webappDir + '/scripts/components/form/_form.directive.js', webappDir + 'scripts/components/form/form.directive.js', this, {});
-            this.template(webappDir + '/scripts/components/form/_maxbytes.directive.js', webappDir + 'scripts/components/form/maxbytes.directive.js', this, {});
-            this.template(webappDir + '/scripts/components/form/_minbytes.directive.js', webappDir + 'scripts/components/form/minbytes.directive.js', this, {});
-            this.template(webappDir + '/scripts/components/form/_uib-pager.config.js', webappDir + 'scripts/components/form/uib-pager.config.js', this, {});
-            this.template(webappDir + '/scripts/components/form/_uib-pagination.config.js', webappDir + 'scripts/components/form/uib-pagination.config.js', this, {});
-            this.template(webappDir + '/scripts/components/form/_pagination.constants.js', webappDir + 'scripts/components/form/pagination.constants.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/form/_form.directive.js', WEBAPP_DIR + 'scripts/components/form/form.directive.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/form/_maxbytes.directive.js', WEBAPP_DIR + 'scripts/components/form/maxbytes.directive.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/form/_minbytes.directive.js', WEBAPP_DIR + 'scripts/components/form/minbytes.directive.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/form/_uib-pager.config.js', WEBAPP_DIR + 'scripts/components/form/uib-pager.config.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/form/_uib-pagination.config.js', WEBAPP_DIR + 'scripts/components/form/uib-pagination.config.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/form/_pagination.constants.js', WEBAPP_DIR + 'scripts/components/form/pagination.constants.js', this, {});
             if (this.enableTranslation) {
-                this.template(webappDir + '/scripts/components/language/_language.controller.js', webappDir + 'scripts/components/language/language.controller.js', this, {});
-                this.template(webappDir + '/scripts/components/language/_language.service.js', webappDir + 'scripts/components/language/language.service.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/language/_language.controller.js', WEBAPP_DIR + 'scripts/components/language/language.controller.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/language/_language.service.js', WEBAPP_DIR + 'scripts/components/language/language.service.js', this, {});
             }
-            this.template(webappDir + '/scripts/components/navbar/_navbar.directive.js', webappDir + 'scripts/components/navbar/navbar.directive.js', this, {});
-            this.copyHtml(webappDir + '/scripts/components/navbar/navbar.html', webappDir + 'scripts/components/navbar/navbar.html');
-            this.template(webappDir + '/scripts/components/navbar/_navbar.controller.js', webappDir + 'scripts/components/navbar/navbar.controller.js', this, {});
-            this.template(webappDir + '/scripts/components/user/_user.service.js', webappDir + 'scripts/components/user/user.service.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_base64.service.js', webappDir + 'scripts/components/util/base64.service.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_capitalize.filter.js', webappDir + 'scripts/components/util/capitalize.filter.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_parse-links.service.js', webappDir + 'scripts/components/util/parse-links.service.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_truncate.filter.js', webappDir + 'scripts/components/util/truncate.filter.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_date-util.service.js', webappDir + 'scripts/components/util/date-util.service.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_data-util.service.js', webappDir + 'scripts/components/util/data-util.service.js', this, {});
-            this.template(webappDir + '/scripts/components/util/_sort.directive.js', webappDir + 'scripts/components/util/sort.directive.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/navbar/_navbar.directive.js', WEBAPP_DIR + 'scripts/components/navbar/navbar.directive.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/components/navbar/navbar.html', WEBAPP_DIR + 'scripts/components/navbar/navbar.html');
+            this.template(WEBAPP_DIR + '/scripts/components/navbar/_navbar.controller.js', WEBAPP_DIR + 'scripts/components/navbar/navbar.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/user/_user.service.js', WEBAPP_DIR + 'scripts/components/user/user.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_base64.service.js', WEBAPP_DIR + 'scripts/components/util/base64.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_capitalize.filter.js', WEBAPP_DIR + 'scripts/components/util/capitalize.filter.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_parse-links.service.js', WEBAPP_DIR + 'scripts/components/util/parse-links.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_truncate.filter.js', WEBAPP_DIR + 'scripts/components/util/truncate.filter.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_date-util.service.js', WEBAPP_DIR + 'scripts/components/util/date-util.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_data-util.service.js', WEBAPP_DIR + 'scripts/components/util/data-util.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/util/_sort.directive.js', WEBAPP_DIR + 'scripts/components/util/sort.directive.js', this, {});
 
             // Client App
-            this.template(webappDir + '/scripts/app/account/_account.js', webappDir + 'scripts/app/account/account.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/account/activate/activate.html', webappDir + 'scripts/app/account/activate/activate.html');
-            this.copyJs(webappDir + '/scripts/app/account/activate/_activate.js', webappDir + 'scripts/app/account/activate/activate.js', this, {});
-            this.template(webappDir + '/scripts/app/account/activate/_activate.controller.js', webappDir + 'scripts/app/account/activate/activate.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/account/login/login.html', webappDir + 'scripts/app/account/login/login.html');
-            this.copyJs(webappDir + '/scripts/app/account/login/_login.js', webappDir + 'scripts/app/account/login/login.js', this, {});
-            this.template(webappDir + '/scripts/app/account/login/_login.controller.js', webappDir + 'scripts/app/account/login/login.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/account/password/password.html', webappDir + 'scripts/app/account/password/password.html');
-            this.copyJs(webappDir + '/scripts/app/account/password/_password.js', webappDir + 'scripts/app/account/password/password.js', this, {});
-            this.template(webappDir + '/scripts/app/account/password/_password.controller.js', webappDir + 'scripts/app/account/password/password.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/account/password/_password.directive.js', webappDir + 'scripts/app/account/password/password.directive.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/account/register/register.html', webappDir + 'scripts/app/account/register/register.html');
-            this.copyJs(webappDir + '/scripts/app/account/register/_register.js', webappDir + 'scripts/app/account/register/register.js', this, {});
-            this.template(webappDir + '/scripts/app/account/register/_register.controller.js', webappDir + 'scripts/app/account/register/register.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/account/reset/request/reset.request.html', webappDir + 'scripts/app/account/reset/request/reset.request.html');
-            this.copyJs(webappDir + '/scripts/app/account/reset/request/_reset.request.js', webappDir + 'scripts/app/account/reset/request/reset.request.js', this, {});
-            this.template(webappDir + '/scripts/app/account/reset/request/_reset.request.controller.js', webappDir + 'scripts/app/account/reset/request/reset.request.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/account/reset/finish/reset.finish.html', webappDir + 'scripts/app/account/reset/finish/reset.finish.html');
-            this.copyJs(webappDir + '/scripts/app/account/reset/finish/_reset.finish.js', webappDir + 'scripts/app/account/reset/finish/reset.finish.js', this, {});
-            this.template(webappDir + '/scripts/app/account/reset/finish/_reset.finish.controller.js', webappDir + 'scripts/app/account/reset/finish/reset.finish.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/_account.js', WEBAPP_DIR + 'scripts/app/account/account.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/activate/activate.html', WEBAPP_DIR + 'scripts/app/account/activate/activate.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/activate/_activate.js', WEBAPP_DIR + 'scripts/app/account/activate/activate.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/activate/_activate.controller.js', WEBAPP_DIR + 'scripts/app/account/activate/activate.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/login/login.html', WEBAPP_DIR + 'scripts/app/account/login/login.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/login/_login.js', WEBAPP_DIR + 'scripts/app/account/login/login.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/login/_login.controller.js', WEBAPP_DIR + 'scripts/app/account/login/login.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/password/password.html', WEBAPP_DIR + 'scripts/app/account/password/password.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/password/_password.js', WEBAPP_DIR + 'scripts/app/account/password/password.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/password/_password.controller.js', WEBAPP_DIR + 'scripts/app/account/password/password.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/password/_password.directive.js', WEBAPP_DIR + 'scripts/app/account/password/password.directive.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/register/register.html', WEBAPP_DIR + 'scripts/app/account/register/register.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/register/_register.js', WEBAPP_DIR + 'scripts/app/account/register/register.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/register/_register.controller.js', WEBAPP_DIR + 'scripts/app/account/register/register.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/reset/request/reset.request.html', WEBAPP_DIR + 'scripts/app/account/reset/request/reset.request.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/reset/request/_reset.request.js', WEBAPP_DIR + 'scripts/app/account/reset/request/reset.request.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/reset/request/_reset.request.controller.js', WEBAPP_DIR + 'scripts/app/account/reset/request/reset.request.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/reset/finish/reset.finish.html', WEBAPP_DIR + 'scripts/app/account/reset/finish/reset.finish.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/reset/finish/_reset.finish.js', WEBAPP_DIR + 'scripts/app/account/reset/finish/reset.finish.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/reset/finish/_reset.finish.controller.js', WEBAPP_DIR + 'scripts/app/account/reset/finish/reset.finish.controller.js', this, {});
             if (this.authenticationType == 'session') {
-                this.copyHtml(webappDir + '/scripts/app/account/sessions/sessions.html', webappDir + 'scripts/app/account/sessions/sessions.html');
-                this.copyJs(webappDir + '/scripts/app/account/sessions/_sessions.js', webappDir + 'scripts/app/account/sessions/sessions.js', this, {});
-                this.template(webappDir + '/scripts/app/account/sessions/_sessions.controller.js', webappDir + 'scripts/app/account/sessions/sessions.controller.js', this, {});
+                this.copyHtml(WEBAPP_DIR + '/scripts/app/account/sessions/sessions.html', WEBAPP_DIR + 'scripts/app/account/sessions/sessions.html');
+                this.copyJs(WEBAPP_DIR + '/scripts/app/account/sessions/_sessions.js', WEBAPP_DIR + 'scripts/app/account/sessions/sessions.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/app/account/sessions/_sessions.controller.js', WEBAPP_DIR + 'scripts/app/account/sessions/sessions.controller.js', this, {});
             }
-            this.copyHtml(webappDir + '/scripts/app/account/settings/settings.html', webappDir + 'scripts/app/account/settings/settings.html');
-            this.copyJs(webappDir + '/scripts/app/account/settings/_settings.js', webappDir + 'scripts/app/account/settings/settings.js', this, {});
-            this.template(webappDir + '/scripts/app/account/settings/_settings.controller.js', webappDir + 'scripts/app/account/settings/settings.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/_admin.js', webappDir + 'scripts/app/admin/admin.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/admin/audits/audits.html', webappDir + 'scripts/app/admin/audits/audits.html');
-            this.copyJs(webappDir + '/scripts/app/admin/audits/_audits.js', webappDir + 'scripts/app/admin/audits/audits.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/audits/_audits.controller.js', webappDir + 'scripts/app/admin/audits/audits.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/admin/configuration/configuration.html', webappDir + 'scripts/app/admin/configuration/configuration.html');
-            this.copyJs(webappDir + '/scripts/app/admin/configuration/_configuration.js', webappDir + 'scripts/app/admin/configuration/configuration.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/configuration/_configuration.controller.js', webappDir + 'scripts/app/admin/configuration/configuration.controller.js', this, {});
-            this.copy(webappDir + '/scripts/app/admin/docs/docs.html', webappDir + 'scripts/app/admin/docs/docs.html');
-            this.copyJs(webappDir + '/scripts/app/admin/docs/_docs.js', webappDir + 'scripts/app/admin/docs/docs.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/admin/health/health.html', webappDir + 'scripts/app/admin/health/health.html');
-            this.copyHtml(webappDir + '/scripts/app/admin/health/_health.modal.html', webappDir + 'scripts/app/admin/health/health.modal.html');
-            this.copyJs(webappDir + '/scripts/app/admin/health/_health.js', webappDir + 'scripts/app/admin/health/health.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/health/_health.controller.js', webappDir + 'scripts/app/admin/health/health.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/health/_health.modal.controller.js', webappDir + 'scripts/app/admin/health/health.modal.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/admin/logs/logs.html', webappDir + 'scripts/app/admin/logs/logs.html');
-            this.copyJs(webappDir + '/scripts/app/admin/logs/_logs.js', webappDir + 'scripts/app/admin/logs/logs.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/logs/_logs.controller.js', webappDir + 'scripts/app/admin/logs/logs.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/admin/metrics/_metrics.html', webappDir + 'scripts/app/admin/metrics/metrics.html', this, {}, true);
-            this.copyHtml(webappDir + '/scripts/app/admin/metrics/_metrics.modal.html', webappDir + 'scripts/app/admin/metrics/metrics.modal.html', this, {}, true);
-            this.copyJs(webappDir + '/scripts/app/admin/metrics/_metrics.js', webappDir + 'scripts/app/admin/metrics/metrics.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/metrics/_metrics.controller.js', webappDir + 'scripts/app/admin/metrics/metrics.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/metrics/_metrics.modal.controller.js', webappDir + 'scripts/app/admin/metrics/metrics.modal.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/account/settings/settings.html', WEBAPP_DIR + 'scripts/app/account/settings/settings.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/account/settings/_settings.js', WEBAPP_DIR + 'scripts/app/account/settings/settings.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/account/settings/_settings.controller.js', WEBAPP_DIR + 'scripts/app/account/settings/settings.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/_admin.js', WEBAPP_DIR + 'scripts/app/admin/admin.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/audits/audits.html', WEBAPP_DIR + 'scripts/app/admin/audits/audits.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/audits/_audits.js', WEBAPP_DIR + 'scripts/app/admin/audits/audits.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/audits/_audits.controller.js', WEBAPP_DIR + 'scripts/app/admin/audits/audits.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/configuration/configuration.html', WEBAPP_DIR + 'scripts/app/admin/configuration/configuration.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/configuration/_configuration.js', WEBAPP_DIR + 'scripts/app/admin/configuration/configuration.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/configuration/_configuration.controller.js', WEBAPP_DIR + 'scripts/app/admin/configuration/configuration.controller.js', this, {});
+            this.copy(WEBAPP_DIR + '/scripts/app/admin/docs/docs.html', WEBAPP_DIR + 'scripts/app/admin/docs/docs.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/docs/_docs.js', WEBAPP_DIR + 'scripts/app/admin/docs/docs.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/health/health.html', WEBAPP_DIR + 'scripts/app/admin/health/health.html');
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/health/_health.modal.html', WEBAPP_DIR + 'scripts/app/admin/health/health.modal.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/health/_health.js', WEBAPP_DIR + 'scripts/app/admin/health/health.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/health/_health.controller.js', WEBAPP_DIR + 'scripts/app/admin/health/health.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/health/_health.modal.controller.js', WEBAPP_DIR + 'scripts/app/admin/health/health.modal.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/logs/logs.html', WEBAPP_DIR + 'scripts/app/admin/logs/logs.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/logs/_logs.js', WEBAPP_DIR + 'scripts/app/admin/logs/logs.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/logs/_logs.controller.js', WEBAPP_DIR + 'scripts/app/admin/logs/logs.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/metrics/_metrics.html', WEBAPP_DIR + 'scripts/app/admin/metrics/metrics.html', this, {}, true);
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/metrics/_metrics.modal.html', WEBAPP_DIR + 'scripts/app/admin/metrics/metrics.modal.html', this, {}, true);
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/metrics/_metrics.js', WEBAPP_DIR + 'scripts/app/admin/metrics/metrics.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/metrics/_metrics.controller.js', WEBAPP_DIR + 'scripts/app/admin/metrics/metrics.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/metrics/_metrics.modal.controller.js', WEBAPP_DIR + 'scripts/app/admin/metrics/metrics.modal.controller.js', this, {});
             if (this.websocket == 'spring-websocket') {
-                this.copyHtml(webappDir + '/scripts/app/admin/tracker/tracker.html', webappDir + 'scripts/app/admin/tracker/tracker.html');
-                this.copyJs(webappDir + '/scripts/app/admin/tracker/_tracker.js', webappDir + 'scripts/app/admin/tracker/tracker.js', this, {});
-                this.template(webappDir + '/scripts/app/admin/tracker/_tracker.controller.js', webappDir + 'scripts/app/admin/tracker/tracker.controller.js', this, {});
-                this.template(webappDir + '/scripts/components/tracker/_tracker.service.js', webappDir + '/scripts/components/tracker/tracker.service.js', this, {});
+                this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/tracker/tracker.html', WEBAPP_DIR + 'scripts/app/admin/tracker/tracker.html');
+                this.copyJs(WEBAPP_DIR + '/scripts/app/admin/tracker/_tracker.js', WEBAPP_DIR + 'scripts/app/admin/tracker/tracker.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/app/admin/tracker/_tracker.controller.js', WEBAPP_DIR + 'scripts/app/admin/tracker/tracker.controller.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/components/tracker/_tracker.service.js', WEBAPP_DIR + '/scripts/components/tracker/tracker.service.js', this, {});
             }
-            this.copyHtml(webappDir + '/scripts/app/admin/user-management/user-management.html', webappDir + 'scripts/app/admin/user-management/user-management.html');
-            this.copyHtml(webappDir + '/scripts/app/admin/user-management/_user-management-detail.html', webappDir + 'scripts/app/admin/user-management/user-management-detail.html');
-            this.copyHtml(webappDir + '/scripts/app/admin/user-management/_user-management-dialog.html', webappDir + 'scripts/app/admin/user-management/user-management-dialog.html');
-            this.copyHtml(webappDir + '/scripts/app/admin/user-management/_user-management-delete-dialog.html', webappDir + 'scripts/app/admin/user-management/user-management-delete-dialog.html');
-            this.copyJs(webappDir + '/scripts/app/admin/user-management/_user-management.js', webappDir + 'scripts/app/admin/user-management/user-management.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/user-management/_user-management.controller.js', webappDir + 'scripts/app/admin/user-management/user-management.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/user-management/_user-management-detail.controller.js', webappDir + 'scripts/app/admin/user-management/user-management-detail.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/user-management/_user-management-dialog.controller.js', webappDir + 'scripts/app/admin/user-management/user-management-dialog.controller.js', this, {});
-            this.template(webappDir + '/scripts/app/admin/user-management/_user-management-delete-dialog.controller.js', webappDir + 'scripts/app/admin/user-management/user-management-delete-dialog.controller.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/error/error.html', webappDir + 'scripts/app/error/error.html');
-            this.copyHtml(webappDir + '/scripts/app/error/accessdenied.html', webappDir + 'scripts/app/error/accessdenied.html');
-            this.copyJs(webappDir + '/scripts/app/entities/_entity.js', webappDir + 'scripts/app/entities/entity.js', this, {});
-            this.copyJs(webappDir + '/scripts/app/error/_error.js', webappDir + 'scripts/app/error/error.js', this, {});
-            this.copyHtml(webappDir + '/scripts/app/main/main.html', webappDir + 'scripts/app/main/main.html');
-            this.copyJs(webappDir + '/scripts/app/main/_main.js', webappDir + 'scripts/app/main/main.js', this, {});
-            this.template(webappDir + '/scripts/app/main/_main.controller.js', webappDir + 'scripts/app/main/main.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/user-management/user-management.html', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management.html');
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management-detail.html', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management-detail.html');
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management-dialog.html', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management-dialog.html');
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management-delete-dialog.html', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management-delete-dialog.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management.js', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management.controller.js', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management-detail.controller.js', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management-detail.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management-dialog.controller.js', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management-dialog.controller.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/admin/user-management/_user-management-delete-dialog.controller.js', WEBAPP_DIR + 'scripts/app/admin/user-management/user-management-delete-dialog.controller.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/error/error.html', WEBAPP_DIR + 'scripts/app/error/error.html');
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/error/accessdenied.html', WEBAPP_DIR + 'scripts/app/error/accessdenied.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/entities/_entity.js', WEBAPP_DIR + 'scripts/app/entities/entity.js', this, {});
+            this.copyJs(WEBAPP_DIR + '/scripts/app/error/_error.js', WEBAPP_DIR + 'scripts/app/error/error.js', this, {});
+            this.copyHtml(WEBAPP_DIR + '/scripts/app/main/main.html', WEBAPP_DIR + 'scripts/app/main/main.html');
+            this.copyJs(WEBAPP_DIR + '/scripts/app/main/_main.js', WEBAPP_DIR + 'scripts/app/main/main.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/app/main/_main.controller.js', WEBAPP_DIR + 'scripts/app/main/main.controller.js', this, {});
 
             // Social
             if (this.enableSocialSignIn) {
-                this.copyHtml(webappDir + '/scripts/app/account/social/directive/_social.html', webappDir + 'scripts/app/account/social/directive/social.html');
-                this.template(webappDir + '/scripts/app/account/social/directive/_social.directive.js', webappDir + 'scripts/app/account/social/directive/social.directive.js', this, {});
-                this.copyHtml(webappDir + '/scripts/app/account/social/_social-register.html', webappDir + 'scripts/app/account/social/social-register.html');
-                this.template(webappDir + '/scripts/app/account/social/_social-register.controller.js', webappDir + 'scripts/app/account/social/social-register.controller.js', this, {});
-                this.template(webappDir + '/scripts/app/account/social/_social.service.js', webappDir + 'scripts/app/account/social/social.service.js', this, {});
-                this.copyJs(webappDir + '/scripts/app/account/social/_social-register.js', webappDir + 'scripts/app/account/social/social-register.js', this, {});
+                this.copyHtml(WEBAPP_DIR + '/scripts/app/account/social/directive/_social.html', WEBAPP_DIR + 'scripts/app/account/social/directive/social.html');
+                this.template(WEBAPP_DIR + '/scripts/app/account/social/directive/_social.directive.js', WEBAPP_DIR + 'scripts/app/account/social/directive/social.directive.js', this, {});
+                this.copyHtml(WEBAPP_DIR + '/scripts/app/account/social/_social-register.html', WEBAPP_DIR + 'scripts/app/account/social/social-register.html');
+                this.template(WEBAPP_DIR + '/scripts/app/account/social/_social-register.controller.js', WEBAPP_DIR + 'scripts/app/account/social/social-register.controller.js', this, {});
+                this.template(WEBAPP_DIR + '/scripts/app/account/social/_social.service.js', WEBAPP_DIR + 'scripts/app/account/social/social.service.js', this, {});
+                this.copyJs(WEBAPP_DIR + '/scripts/app/account/social/_social-register.js', WEBAPP_DIR + 'scripts/app/account/social/social-register.js', this, {});
             }
 
             // interceptor code
-            this.template(webappDir + '/scripts/components/interceptor/_auth.interceptor.js', webappDir + 'scripts/components/interceptor/auth.interceptor.js', this, {});
-            this.template(webappDir + '/scripts/components/interceptor/_errorhandler.interceptor.js', webappDir + 'scripts/components/interceptor/errorhandler.interceptor.js', this, {});
-            this.template(webappDir + '/scripts/components/interceptor/_notification.interceptor.js', webappDir + 'scripts/components/interceptor/notification.interceptor.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/interceptor/_auth.interceptor.js', WEBAPP_DIR + 'scripts/components/interceptor/auth.interceptor.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/interceptor/_errorhandler.interceptor.js', WEBAPP_DIR + 'scripts/components/interceptor/errorhandler.interceptor.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/interceptor/_notification.interceptor.js', WEBAPP_DIR + 'scripts/components/interceptor/notification.interceptor.js', this, {});
 
             //alert service code
-            this.template(webappDir + '/scripts/components/alert/_alert.service.js', webappDir + 'scripts/components/alert/alert.service.js', this, {});
-            this.template(webappDir + '/scripts/components/alert/_alert.directive.js', webappDir + 'scripts/components/alert/alert.directive.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/alert/_alert.service.js', WEBAPP_DIR + 'scripts/components/alert/alert.service.js', this, {});
+            this.template(WEBAPP_DIR + '/scripts/components/alert/_alert.directive.js', WEBAPP_DIR + 'scripts/components/alert/alert.directive.js', this, {});
 
             // CSS
-            this.copy(webappDir + 'assets/styles/documentation.css', webappDir + 'assets/styles/documentation.css');
+            this.copy(WEBAPP_DIR + 'assets/styles/documentation.css', WEBAPP_DIR + 'assets/styles/documentation.css');
 
             // Images
-            this.copy(webappDir + 'assets/images/development_ribbon.png', webappDir + 'assets/images/development_ribbon.png');
-            this.copy(webappDir + 'assets/images/hipster.png', webappDir + 'assets/images/hipster.png');
-            this.copy(webappDir + 'assets/images/hipster2x.png', webappDir + 'assets/images/hipster2x.png');
+            this.copy(WEBAPP_DIR + 'assets/images/development_ribbon.png', WEBAPP_DIR + 'assets/images/development_ribbon.png');
+            this.copy(WEBAPP_DIR + 'assets/images/hipster.png', WEBAPP_DIR + 'assets/images/hipster.png');
+            this.copy(WEBAPP_DIR + 'assets/images/hipster2x.png', WEBAPP_DIR + 'assets/images/hipster2x.png');
 
         },
 
@@ -1187,7 +1187,7 @@ module.exports = JhipsterGenerator.extend({
                 return;
             }
             // Index page
-            var indexFile = html.readFileAsString(path.join(this.sourceRoot(), webappDir + '_index.html'));
+            var indexFile = html.readFileAsString(path.join(this.sourceRoot(), WEBAPP_DIR + '_index.html'));
             var engine = ejs.render;
             indexFile = engine(indexFile, this, {});
 
@@ -1306,7 +1306,7 @@ module.exports = JhipsterGenerator.extend({
             }
 
             indexFile = html.appendScripts(indexFile, 'scripts/app.js', appScripts, {}, ['.tmp', 'src/main/webapp']);
-            this.write(webappDir + 'index.html', indexFile);
+            this.write(WEBAPP_DIR + 'index.html', indexFile);
 
         },
 
@@ -1421,9 +1421,9 @@ module.exports = JhipsterGenerator.extend({
 
             this.removefile(RESOURCE_DIR + 'logback.xml');
 
-            this.removefile(webappDir + 'scripts/app/account/logout/logout.js');
-            this.removefile(webappDir + 'scripts/app/account/logout/logout.controller.js');
-            this.removefolder(webappDir + 'scripts/app/account/logout');
+            this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.js');
+            this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.controller.js');
+            this.removefolder(WEBAPP_DIR + 'scripts/app/account/logout');
 
             this.removefile(testDir + 'config/MongoConfiguration.java');
             this.removefile(testJsDir + 'spec/app/account/health/healthControllerSpec.js');

--- a/entity/index.js
+++ b/entity/index.js
@@ -33,7 +33,7 @@ var enums = [];
 var existingEnum = false;
 
 var fieldNamesUnderscored = ['id'];
-var fieldNameChoices = [{name:'id', value: 'ID'}];
+var fieldNameChoices = [];
 var databaseType;
 var prodDatabaseType;
 const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates
@@ -686,7 +686,6 @@ module.exports = EntityGenerator.extend({
     },
 
     _askForFieldsToRemove : function(cb){
-        this.fieldId++;
         var prompts = [
             {
                 type: 'checkbox',
@@ -701,7 +700,7 @@ module.exports = EntityGenerator.extend({
                 },
                 type: 'confirm',
                 name: 'confirmRemove',
-                message: 'Are you sure to remove fields ' + response.fieldsToRemove,
+                message: 'Are you sure to remove these fields?',
                 default: true
             }
         ];
@@ -717,6 +716,11 @@ module.exports = EntityGenerator.extend({
                         this.fields.splice(i, 1);
                     }
                 }
+                //reset filed IDs
+                for (i = 0; i < this.fields.length; i++) {
+                    this.fields[i].fieldId = i;
+                }
+                this.fieldId = this.fileData.fields.length;
             }
             cb();
 

--- a/entity/index.js
+++ b/entity/index.js
@@ -36,8 +36,8 @@ var fieldNamesUnderscored = ['id'];
 var fieldNameChoices = [], relNameChoices = [];
 var databaseType;
 var prodDatabaseType;
-const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates
-const resourceDir = 'src/main/resources/';
+const INTERPOLATE_REGEX = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates
+const RESOURCE_DIR = 'src/main/resources/';
 
 var EntityGenerator = generators.Base.extend({});
 
@@ -1557,16 +1557,16 @@ module.exports = EntityGenerator.extend({
 
         writeDbFiles: function() {
             if (this.databaseType == "sql") {
-                this.template(resourceDir + '/config/liquibase/changelog/_added_entity.xml',
-                resourceDir + 'config/liquibase/changelog/' + this.changelogDate + '_added_entity_' + this.entityClass + '.xml', this, {
-                    'interpolate': interpolateRegex
+                this.template(RESOURCE_DIR + '/config/liquibase/changelog/_added_entity.xml',
+                RESOURCE_DIR + 'config/liquibase/changelog/' + this.changelogDate + '_added_entity_' + this.entityClass + '.xml', this, {
+                    'interpolate': INTERPOLATE_REGEX
                 });
 
                 this.addChangelogToLiquibase(this.changelogDate + '_added_entity_' + this.entityClass);
             }
             if (this.databaseType == "cassandra") {
-                this.template(resourceDir + '/config/cql/_added_entity.cql',
-                resourceDir + 'config/cql/' + this.changelogDate + '_added_entity_' + this.entityClass + '.cql', this, {});
+                this.template(RESOURCE_DIR + '/config/cql/_added_entity.cql',
+                RESOURCE_DIR + 'config/cql/' + this.changelogDate + '_added_entity_' + this.entityClass + '.cql', this, {});
             }
         },
 

--- a/entity/index.js
+++ b/entity/index.js
@@ -955,7 +955,7 @@ module.exports = EntityGenerator.extend({
                 {
                     type: 'list',
                     name: 'updateEntity',
-                    message: 'Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwriiten',
+                    message: 'Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwritten',
                     choices: [
                         {
                             value: 'rewrite',

--- a/entity/index.js
+++ b/entity/index.js
@@ -1296,6 +1296,26 @@ module.exports = EntityGenerator.extend({
 
         },
 
+        writeEntityJson: function () {
+            if (this.useConfigurationFile && this.updateEntity == 'rewrite') {
+                return;
+            }
+             // store informations in a file for further use.
+            if (!this.useConfigurationFile && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
+                this.changelogDate = this.dateFormatForLiquibase();
+            }
+            this.data = {};
+            this.data.relationships = this.relationships;
+            this.data.fields = this.fields;
+            this.data.changelogDate = this.changelogDate;
+            this.data.dto = this.dto;
+            this.data.service = this.service;
+            if (databaseType == 'sql' || databaseType == 'mongodb') {
+                this.data.pagination = this.pagination;
+            }
+            this.fs.writeJSON(this.filename, this.data, null, 4);
+        },
+
         LoadInMemoryData: function() {
 
             // Load in-memory data for fields
@@ -1473,25 +1493,6 @@ module.exports = EntityGenerator.extend({
     },
 
     writing : {
-        writeEntityJson: function () {
-            if (this.useConfigurationFile && this.updateEntity == 'rewrite') {
-                return;
-            }
-             // store informations in a file for further use.
-            if (!this.useConfigurationFile && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
-                this.changelogDate = this.dateFormatForLiquibase();
-            }
-            this.data = {};
-            this.data.relationships = this.relationships;
-            this.data.fields = this.fields;
-            this.data.changelogDate = this.changelogDate;
-            this.data.dto = this.dto;
-            this.data.service = this.service;
-            if (databaseType == 'sql' || databaseType == 'mongodb') {
-                this.data.pagination = this.pagination;
-            }
-            this.fs.writeJSON(this.filename, this.data, null, 4);
-        },
 
         writeEnumFiles: function() {
 

--- a/entity/index.js
+++ b/entity/index.js
@@ -143,11 +143,11 @@ module.exports = EntityGenerator.extend({
                 this.service = this.fileData.service;
                 this.pagination = this.fileData.pagination;
                 this.javadoc = this.fileData.javadoc;
-                this.fields.forEach(function (field) {
+                this.fields && this.fields.forEach(function (field) {
                     fieldNamesUnderscored.push(_s.underscored(field.fieldName));
                     fieldNameChoices.push({name: field.fieldName, value: field.fieldName});
                 }, this);
-                this.relationships.forEach(function (rel) {
+                this.relationships && this.relationships.forEach(function (rel) {
                     relNameChoices.push({name: rel.relationshipName + ':' + rel.relationshipType, value: rel.relationshipName + ':' + rel.relationshipType});
                 }, this);
             }

--- a/entity/index.js
+++ b/entity/index.js
@@ -33,7 +33,7 @@ var enums = [];
 var existingEnum = false;
 
 var fieldNamesUnderscored = ['id'];
-var fieldNameChoices = [];
+var fieldNameChoices = [], relNameChoices = [];
 var databaseType;
 var prodDatabaseType;
 const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates
@@ -145,6 +145,9 @@ module.exports = EntityGenerator.extend({
                 this.fields.forEach(function (field) {
                     fieldNamesUnderscored.push(_s.underscored(field.fieldName));
                     fieldNameChoices.push({name: field.fieldName, value: field.fieldName});
+                }, this);
+                this.relationships.forEach(function (rel) {
+                    relNameChoices.push({name: rel.fieldName + ':' + rel.relationshipType, value: field.fieldName + ':' + rel.relationshipType});
                 }, this);
             }
         }
@@ -720,7 +723,7 @@ module.exports = EntityGenerator.extend({
                 for (i = 0; i < this.fields.length; i++) {
                     this.fields[i].fieldId = i;
                 }
-                this.fieldId = this.fileData.fields.length;
+                this.fieldId = this.fields.length;
             }
             cb();
 
@@ -897,38 +900,38 @@ module.exports = EntityGenerator.extend({
         var prompts = [
             {
                 type: 'checkbox',
-                name: 'fieldsToRemove',
-                message: 'Please choose the fields you want to remove',
-                choices: fieldNameChoices,
+                name: 'relsToRemove',
+                message: 'Please choose the relationships you want to remove',
+                choices: relNameChoices,
                 default: 'none'
             },
             {
                 when: function(response) {
-                    return response.fieldsToRemove != 'none';
+                    return response.relsToRemove != 'none';
                 },
                 type: 'confirm',
                 name: 'confirmRemove',
-                message: 'Are you sure to remove these fields?',
+                message: 'Are you sure to remove these relationships?',
                 default: true
             }
         ];
         this.prompt(prompts, function(props) {
             if (props.confirmRemove) {
-                this.log(chalk.red('Removing fields: ' + props.fieldsToRemove));
+                this.log(chalk.red('Removing relationships: ' + props.relsToRemove));
                 var i;
-                for (i = this.fields.length - 1; i >= 0; i -= 1) {
-                    var field = this.fields[i];
-                    if(props.fieldsToRemove.filter(function (val) {
-                        return val == field.fieldName;
+                for (i = this.relationships.length - 1; i >= 0; i -= 1) {
+                    var rel = this.relationships[i];
+                    if(props.relsToRemove.filter(function (val) {
+                        return val == rel.relationshipName + ':' + rel.relationshipType;
                     }).length > 0){
-                        this.fields.splice(i, 1);
+                        this.relationships.splice(i, 1);
                     }
                 }
                 //reset filed IDs
-                for (i = 0; i < this.fields.length; i++) {
-                    this.fields[i].fieldId = i;
+                for (i = 0; i < this.relationships.length; i++) {
+                    this.relationships[i].relationshipId = i;
                 }
-                this.fieldId = this.fileData.fields.length;
+                this.relationshipId = this.relationships.length;
             }
             cb();
 

--- a/entity/index.js
+++ b/entity/index.js
@@ -81,11 +81,11 @@ module.exports = EntityGenerator.extend({
 
             this.filename = this.jhipsterConfigDirectory + '/' + _s.capitalize(this.name) + '.json';
             if (shelljs.test('-f', this.filename)) {
-                this.log(chalk.green('Found the ' + this.filename + ' configuration file, entity can be automatically generated!'));
+                this.log(chalk.green('\nFound the ' + this.filename + ' configuration file, entity can be automatically generated!\n'));
                 try {
                     this.fileData = this.fs.readJSON(this.filename);
                 } catch (err) {
-                    this.log(chalk.red('The configuration file could not be read!'));
+                    this.log(chalk.red('\nThe configuration file could not be read!\n'));
                     return;
                 }
                 this.useConfigurationFile = true;
@@ -121,9 +121,9 @@ module.exports = EntityGenerator.extend({
         },
 
         setupVars: function() {
-            this.log(chalk.red('The entity ' + this.name + ' is being created.'));
             // Specific Entity sub-generator variables
             if (this.useConfigurationFile == false) {
+                this.log(chalk.red('\nThe entity ' + this.name + ' is being created.\n'));
                 this.fieldId = 0;
                 this.fields = [];
                 this.relationshipId = 0;
@@ -133,6 +133,7 @@ module.exports = EntityGenerator.extend({
                 this.dto = 'no';
                 this.service = 'no';
             } else {
+                this.log(chalk.red('\nThe entity ' + this.name + ' is being updated.\n'));
                 this.fieldId = this.fileData.fields? this.fileData.fields.length : 0;
                 this.relationshipId = this.fileData.relationships? this.fileData.relationships.length : 0;
                 this.relationships = this.fileData.relationships;
@@ -147,7 +148,7 @@ module.exports = EntityGenerator.extend({
                     fieldNameChoices.push({name: field.fieldName, value: field.fieldName});
                 }, this);
                 this.relationships.forEach(function (rel) {
-                    relNameChoices.push({name: rel.fieldName + ':' + rel.relationshipType, value: field.fieldName + ':' + rel.relationshipType});
+                    relNameChoices.push({name: rel.relationshipName + ':' + rel.relationshipType, value: rel.relationshipName + ':' + rel.relationshipType});
                 }, this);
             }
         }
@@ -155,7 +156,7 @@ module.exports = EntityGenerator.extend({
     /* private Helper methods */
     _askForField : function(cb){
         this.fieldId++;
-        this.log(chalk.green('Generating field #' + this.fieldId));
+        this.log(chalk.green('\nGenerating field #' + this.fieldId + '\n'));
         var prompts = [
             {
                 type: 'confirm',
@@ -648,7 +649,7 @@ module.exports = EntityGenerator.extend({
                 fieldNamesUnderscored.push(_s.underscored(props.fieldName));
                 this.fields.push(field);
             }
-            this.log(chalk.red('=================' + _s.capitalize(this.name) + '================='));
+            this.log(chalk.red('\n=================' + _s.capitalize(this.name) + '================='));
             this.fields.forEach(function(field) {
                 var validationDetails = '';
                 var fieldValidate = _.isArray(field.fieldValidateRules) && field.fieldValidateRules.length >= 1;
@@ -709,7 +710,7 @@ module.exports = EntityGenerator.extend({
         ];
         this.prompt(prompts, function(props) {
             if (props.confirmRemove) {
-                this.log(chalk.red('Removing fields: ' + props.fieldsToRemove));
+                this.log(chalk.red('\nRemoving fields: ' + props.fieldsToRemove + '\n'));
                 var i;
                 for (i = this.fields.length - 1; i >= 0; i -= 1) {
                     var field = this.fields[i];
@@ -734,7 +735,7 @@ module.exports = EntityGenerator.extend({
         var packageFolder = this.packageFolder;
         var name = this.name;
         this.relationshipId++;
-        this.log(chalk.green('Generating relationships with other entities'));
+        this.log(chalk.green('\nGenerating relationships with other entities\n'));
         var prompts = [
             {
                 type: 'confirm',
@@ -864,7 +865,7 @@ module.exports = EntityGenerator.extend({
         ];
         this.prompt(prompts, function(props) {
             if (props.noOtherEntity == false || props.noOtherEntity2 == false) {
-                this.log(chalk.red('Generation aborted, as requested by the user.'));
+                this.log(chalk.red('\nGeneration aborted, as requested by the user.\n'));
                 return;
             }
             if (props.relationshipAdd) {
@@ -880,7 +881,7 @@ module.exports = EntityGenerator.extend({
                 fieldNamesUnderscored.push(_s.underscored(props.relationshipName));
                 this.relationships.push(relationship);
             }
-            this.log(chalk.red('===========' + _s.capitalize(this.name) + '=============='));
+            this.log(chalk.red('\n===========' + _s.capitalize(this.name) + '=============='));
             this.fields.forEach(function(field) {
                 this.log(chalk.red(field.fieldName + ' (' + field.fieldType + (field.fieldTypeBlobContent ? ' ' + field.fieldTypeBlobContent : '') + ')'));
             }, this);
@@ -891,12 +892,13 @@ module.exports = EntityGenerator.extend({
             if (props.relationshipAdd) {
                 this._askForRelationship(cb);
             } else {
+                this.log('\n')
                 cb();
             }
         }.bind(this));
     },
 
-    askForRelationsToRemove : function(cb){
+    _askForRelationsToRemove : function(cb){
         var prompts = [
             {
                 type: 'checkbox',
@@ -917,7 +919,7 @@ module.exports = EntityGenerator.extend({
         ];
         this.prompt(prompts, function(props) {
             if (props.confirmRemove) {
-                this.log(chalk.red('Removing relationships: ' + props.relsToRemove));
+                this.log(chalk.red('\nRemoving relationships: ' + props.relsToRemove + '\n'));
                 var i;
                 for (i = this.relationships.length - 1; i >= 0; i -= 1) {
                     var rel = this.relationships[i];
@@ -1134,7 +1136,7 @@ module.exports = EntityGenerator.extend({
             ];
             this.prompt(prompts, function(props) {
                 this.pagination = props.pagination;
-                this.log(chalk.green('Everything is configured, generating the entity...'));
+                this.log(chalk.green('\nEverything is configured, generating the entity...\n'));
                 cb();
             }.bind(this));
         }
@@ -1476,7 +1478,7 @@ module.exports = EntityGenerator.extend({
                 return;
             }
              // store informations in a file for further use.
-            if (this.useConfigurationFile && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
+            if (!this.useConfigurationFile && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
                 this.changelogDate = this.dateFormatForLiquibase();
             }
             this.data = {};

--- a/entity/index.js
+++ b/entity/index.js
@@ -685,6 +685,43 @@ module.exports = EntityGenerator.extend({
         }.bind(this));
     },
 
+    _askForFieldsToRemove : function(cb){
+        this.fieldId++;
+        var prompts = [
+            {
+                type: 'checkbox',
+                name: 'fieldsToRemove',
+                message: 'Please choose the fields you want to remove',
+                choices: fieldNameChoices,
+                default: 'none'
+            },
+            {
+                when: function(response) {
+                    return response.fieldsToRemove != 'none';
+                },
+                type: 'confirm',
+                name: 'confirmRemove',
+                message: 'Are you sure to remove fields ' + response.fieldsToRemove,
+                default: true
+            }
+        ];
+        this.prompt(prompts, function(props) {
+            if (props.confirmRemove) {
+                this.log(chalk.red('Removing fields: ' + props.fieldsToRemove));
+                var i;
+                for (i = this.fields.length - 1; i >= 0; i -= 1) {
+                    var field = this.fields[i];
+                    if(props.fieldsToRemove.filter(function (val) {
+                        return val == field.fieldName;
+                    }).length > 0){
+                        this.fields.splice(i, 1);
+                    }
+                }
+            }
+            cb();
+
+        }.bind(this));
+    },
 
     _askForRelationship: function(cb){
         var packageFolder = this.packageFolder;
@@ -909,6 +946,15 @@ module.exports = EntityGenerator.extend({
             this._askForField(cb);
         },
 
+        askForFieldsToRemove: function() {
+            // prompt only if data is imported from a file
+            if (!this.useConfigurationFile || this.updateEntity != 'remove') {
+                return;
+            }
+            var cb = this.async();
+
+            this._askForFieldsToRemove(cb);
+        },
 
         askForRelationships: function() {
             // don't prompt if data is imported from a file
@@ -922,6 +968,16 @@ module.exports = EntityGenerator.extend({
             var cb = this.async();
 
             this._askForRelationship(cb);
+        },
+
+        askForRelationsToRemove: function() {
+            // prompt only if data is imported from a file
+            if (!this.useConfigurationFile || this.updateEntity != 'remove') {
+                return;
+            }
+            var cb = this.async();
+
+            this._askForField(cb);
         },
 
         askForDTO: function() {

--- a/entity/index.js
+++ b/entity/index.js
@@ -7,26 +7,25 @@ chalk = require('chalk'),
 _ = require('lodash'),
 _s = require('underscore.string'),
 shelljs = require('shelljs'),
-html = require("html-wiring"),
 scriptBase = require('../script-base');
 
-var reservedWords_Java = ["ABSTRACT", "CONTINUE", "FOR", "NEW", "SWITCH", "ASSERT", "DEFAULT", "GOTO", "PACKAGE", "SYNCHRONIZED", "BOOLEAN", "DO", "IF", "PRIVATE", "THIS", "BREAK", "DOUBLE", "IMPLEMENTS", "PROTECTED", "THROW", "BYTE", "ELSE", "IMPORT", "PUBLIC", "THROWS", "CASE", "ENUM", "INSTANCEOF", "RETURN", "TRANSIENT", "CATCH", "EXTENDS", "INT", "SHORT", "TRY", "CHAR", "FINAL", "INTERFACE", "STATIC", "VOID", "CLASS", "FINALLY", "LONG", "STRICTFP", "VOLATILE", "CONST", "FLOAT", "NATIVE", "SUPER", "WHILE"];
+const RESERVED_WORDS_JAVA = ["ABSTRACT", "CONTINUE", "FOR", "NEW", "SWITCH", "ASSERT", "DEFAULT", "GOTO", "PACKAGE", "SYNCHRONIZED", "BOOLEAN", "DO", "IF", "PRIVATE", "THIS", "BREAK", "DOUBLE", "IMPLEMENTS", "PROTECTED", "THROW", "BYTE", "ELSE", "IMPORT", "PUBLIC", "THROWS", "CASE", "ENUM", "INSTANCEOF", "RETURN", "TRANSIENT", "CATCH", "EXTENDS", "INT", "SHORT", "TRY", "CHAR", "FINAL", "INTERFACE", "STATIC", "VOID", "CLASS", "FINALLY", "LONG", "STRICTFP", "VOLATILE", "CONST", "FLOAT", "NATIVE", "SUPER", "WHILE"];
 
 // The JHipster reserved keywords are only for the entity names.
 // They are used to generate AngularJS routes, so we cannot create an entity using one of the JHipster default routes.
-var reservedWords_JHipster = ["ADMIN", "ACCOUNT", "LOGIN", "LOGOUT", "ACTIVATE", "SETTINGS", "PASSWORD", "SESSIONS", "METRICS", "HEALTH", "CONFIGURATION", "AUDITS", "LOGS", "REGISTER", "RESET", "TEST", "LOAD"];
+const RESERVED_WORDS_JHIPSTER = ["ADMIN", "ACCOUNT", "LOGIN", "LOGOUT", "ACTIVATE", "SETTINGS", "PASSWORD", "SESSIONS", "METRICS", "HEALTH", "CONFIGURATION", "AUDITS", "LOGS", "REGISTER", "RESET", "TEST", "LOAD"];
 
-var reservedWords_MySQL = ["ACCESSIBLE", "ADD", "ALL", "ALTER", "ANALYZE", "AND", "AS", "ASC", "ASENSITIVE", "BEFORE", "BETWEEN", "BIGINT", "BINARY", "BLOB", "BOTH", "BY", "CALL", "CASCADE", "CASE", "CHANGE", "CHAR", "CHARACTER", "CHECK", "COLLATE", "COLUMN", "CONDITION", "CONSTRAINT", "CONTINUE", "CONVERT", "CREATE", "CROSS", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR", "DATABASE", "DATABASES", "DAY_HOUR", "DAY_MICROSECOND", "DAY_MINUTE", "DAY_SECOND", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DELAYED", "DELETE", "DESC", "DESCRIBE", "DETERMINISTIC", "DISTINCT", "DISTINCTROW", "DIV", "DOUBLE", "DROP", "DUAL", "EACH", "ELSE", "ELSEIF", "ENCLOSED", "ESCAPED", "EXISTS", "EXIT", "EXPLAIN", "FALSE", "FETCH", "FLOAT", "FLOAT4", "FLOAT8", "FOR", "FORCE", "FOREIGN", "FROM", "FULLTEXT", "GRANT", "GROUP", "HAVING", "HIGH_PRIORITY", "HOUR_MICROSECOND", "HOUR_MINUTE", "HOUR_SECOND", "IF", "IGNORE", "IN", "INDEX", "INFILE", "INNER", "INOUT", "INSENSITIVE", "INSERT", "INT", "INT1", "INT2", "INT3", "INT4", "INT8", "INTEGER", "INTERVAL", "INTO", "IS", "ITERATE", "JOIN", "KEY", "KEYS", "KILL", "LEADING", "LEAVE", "LEFT", "LIKE", "LIMIT", "LINEAR", "LINES", "LOAD", "LOCALTIME", "LOCALTIMESTAMP", "LOCK", "LONG", "LONGBLOB", "LONGTEXT", "LOOP", "LOW_PRIORITY", "MASTER_SSL_VERIFY_SERVER_CERT", "MATCH", "MAXVALUE", "MEDIUMBLOB", "MEDIUMINT", "MEDIUMTEXT", "MIDDLEINT", "MINUTE_MICROSECOND", "MINUTE_SECOND", "MOD", "MODIFIES", "NATURAL", "NOT", "NO_WRITE_TO_BINLOG", "NULL", "NUMERIC", "ON", "OPTIMIZE", "OPTION", "OPTIONALLY", "OR", "ORDER", "OUT", "OUTER", "OUTFILE", "PRECISION", "PRIMARY", "PROCEDURE", "PURGE", "RANGE", "READ", "READS", "READ_WRITE", "REAL", "REFERENCES", "REGEXP", "RELEASE", "RENAME", "REPEAT", "REPLACE", "REQUIRE", "RESIGNAL", "RESTRICT", "RETURN", "REVOKE", "RIGHT", "RLIKE", "SCHEMA", "SCHEMAS", "SECOND_MICROSECOND", "SELECT", "SENSITIVE", "SEPARATOR", "SET", "SHOW", "SIGNAL", "SMALLINT", "SPATIAL", "SPECIFIC", "SQL", "SQLEXCEPTION", "SQLSTATE", "SQLWARNING", "SQL_BIG_RESULT", "SQL_CALC_FOUND_ROWS", "SQL_SMALL_RESULT", "SSL", "STARTING", "STRAIGHT_JOIN", "TABLE", "TERMINATED", "THEN", "TINYBLOB", "TINYINT", "TINYTEXT", "TO", "TRAILING", "TRIGGER", "TRUE", "UNDO", "UNION", "UNIQUE", "UNLOCK", "UNSIGNED", "UPDATE", "USAGE", "USE", "USING", "UTC_DATE", "UTC_TIME", "UTC_TIMESTAMP", "VALUES", "VARBINARY", "VARCHAR", "VARCHARACTER", "VARYING", "WHEN", "WHERE", "WHILE", "WITH", "WRITE", "XOR", "YEAR_MONTH", "ZEROFILL", "GENERAL", "IGNORE_SERVER_IDS", "MASTER_HEARTBEAT_PERIOD", "MAXVALUE", "RESIGNAL", "SIGNAL", "SLOW"];
+const RESERVED_WORDS_MYSQL = ["ACCESSIBLE", "ADD", "ALL", "ALTER", "ANALYZE", "AND", "AS", "ASC", "ASENSITIVE", "BEFORE", "BETWEEN", "BIGINT", "BINARY", "BLOB", "BOTH", "BY", "CALL", "CASCADE", "CASE", "CHANGE", "CHAR", "CHARACTER", "CHECK", "COLLATE", "COLUMN", "CONDITION", "CONSTRAINT", "CONTINUE", "CONVERT", "CREATE", "CROSS", "CURRENT_DATE", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "CURSOR", "DATABASE", "DATABASES", "DAY_HOUR", "DAY_MICROSECOND", "DAY_MINUTE", "DAY_SECOND", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DELAYED", "DELETE", "DESC", "DESCRIBE", "DETERMINISTIC", "DISTINCT", "DISTINCTROW", "DIV", "DOUBLE", "DROP", "DUAL", "EACH", "ELSE", "ELSEIF", "ENCLOSED", "ESCAPED", "EXISTS", "EXIT", "EXPLAIN", "FALSE", "FETCH", "FLOAT", "FLOAT4", "FLOAT8", "FOR", "FORCE", "FOREIGN", "FROM", "FULLTEXT", "GRANT", "GROUP", "HAVING", "HIGH_PRIORITY", "HOUR_MICROSECOND", "HOUR_MINUTE", "HOUR_SECOND", "IF", "IGNORE", "IN", "INDEX", "INFILE", "INNER", "INOUT", "INSENSITIVE", "INSERT", "INT", "INT1", "INT2", "INT3", "INT4", "INT8", "INTEGER", "INTERVAL", "INTO", "IS", "ITERATE", "JOIN", "KEY", "KEYS", "KILL", "LEADING", "LEAVE", "LEFT", "LIKE", "LIMIT", "LINEAR", "LINES", "LOAD", "LOCALTIME", "LOCALTIMESTAMP", "LOCK", "LONG", "LONGBLOB", "LONGTEXT", "LOOP", "LOW_PRIORITY", "MASTER_SSL_VERIFY_SERVER_CERT", "MATCH", "MAXVALUE", "MEDIUMBLOB", "MEDIUMINT", "MEDIUMTEXT", "MIDDLEINT", "MINUTE_MICROSECOND", "MINUTE_SECOND", "MOD", "MODIFIES", "NATURAL", "NOT", "NO_WRITE_TO_BINLOG", "NULL", "NUMERIC", "ON", "OPTIMIZE", "OPTION", "OPTIONALLY", "OR", "ORDER", "OUT", "OUTER", "OUTFILE", "PRECISION", "PRIMARY", "PROCEDURE", "PURGE", "RANGE", "READ", "READS", "READ_WRITE", "REAL", "REFERENCES", "REGEXP", "RELEASE", "RENAME", "REPEAT", "REPLACE", "REQUIRE", "RESIGNAL", "RESTRICT", "RETURN", "REVOKE", "RIGHT", "RLIKE", "SCHEMA", "SCHEMAS", "SECOND_MICROSECOND", "SELECT", "SENSITIVE", "SEPARATOR", "SET", "SHOW", "SIGNAL", "SMALLINT", "SPATIAL", "SPECIFIC", "SQL", "SQLEXCEPTION", "SQLSTATE", "SQLWARNING", "SQL_BIG_RESULT", "SQL_CALC_FOUND_ROWS", "SQL_SMALL_RESULT", "SSL", "STARTING", "STRAIGHT_JOIN", "TABLE", "TERMINATED", "THEN", "TINYBLOB", "TINYINT", "TINYTEXT", "TO", "TRAILING", "TRIGGER", "TRUE", "UNDO", "UNION", "UNIQUE", "UNLOCK", "UNSIGNED", "UPDATE", "USAGE", "USE", "USING", "UTC_DATE", "UTC_TIME", "UTC_TIMESTAMP", "VALUES", "VARBINARY", "VARCHAR", "VARCHARACTER", "VARYING", "WHEN", "WHERE", "WHILE", "WITH", "WRITE", "XOR", "YEAR_MONTH", "ZEROFILL", "GENERAL", "IGNORE_SERVER_IDS", "MASTER_HEARTBEAT_PERIOD", "MAXVALUE", "RESIGNAL", "SIGNAL", "SLOW"];
 
-var reservedWords_Postgresql = ["ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC", "ASYMMETRIC", "AUTHORIZATION", "BINARY", "BOTH", "CASE", "CAST", "CHECK", "COLLATE", "COLLATION", "COLUMN", "CONCURRENTLY", "CONSTRAINT", "CREATE", "CROSS", "CURRENT_CATALOG", "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_SCHEMA", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "DEFAULT", "DEFERRABLE", "DESC", "DISTINCT", "DO", "ELSE", "END", "EXCEPT", "FALSE", "FETCH", "FOR", "FOREIGN", "FROM", "FULL", "GRANT", "GROUP", "HAVING", "ILIKE", "IN", "INITIALLY", "INNER", "INTERSECT", "INTO", "IS", "ISNULL", "JOIN", "LATERAL", "LEADING", "LEFT", "LIKE", "LIMIT", "LOCALTIME", "LOCALTIMESTAMP", "NATURAL", "NOT", "NOTNULL", "NULL", "OFFSET", "ON", "ONLY", "OR", "ORDER", "OUTER", "OVERLAPS", "PLACING", "PRIMARY", "REFERENCES", "RETURNING", "RIGHT", "SELECT", "SESSION_USER", "SIMILAR", "SOME", "SYMMETRIC", "TABLE", "THEN", "TO", "TRAILING", "TRUE", "UNION", "UNIQUE", "USER", "USING", "VARIADIC", "VERBOSE", "WHEN", "WHERE", "WINDOW", "WITH"];
+const RESERVED_WORDS_POSGRES = ["ALL", "ANALYSE", "ANALYZE", "AND", "ANY", "ARRAY", "AS", "ASC", "ASYMMETRIC", "AUTHORIZATION", "BINARY", "BOTH", "CASE", "CAST", "CHECK", "COLLATE", "COLLATION", "COLUMN", "CONCURRENTLY", "CONSTRAINT", "CREATE", "CROSS", "CURRENT_CATALOG", "CURRENT_DATE", "CURRENT_ROLE", "CURRENT_SCHEMA", "CURRENT_TIME", "CURRENT_TIMESTAMP", "CURRENT_USER", "DEFAULT", "DEFERRABLE", "DESC", "DISTINCT", "DO", "ELSE", "END", "EXCEPT", "FALSE", "FETCH", "FOR", "FOREIGN", "FROM", "FULL", "GRANT", "GROUP", "HAVING", "ILIKE", "IN", "INITIALLY", "INNER", "INTERSECT", "INTO", "IS", "ISNULL", "JOIN", "LATERAL", "LEADING", "LEFT", "LIKE", "LIMIT", "LOCALTIME", "LOCALTIMESTAMP", "NATURAL", "NOT", "NOTNULL", "NULL", "OFFSET", "ON", "ONLY", "OR", "ORDER", "OUTER", "OVERLAPS", "PLACING", "PRIMARY", "REFERENCES", "RETURNING", "RIGHT", "SELECT", "SESSION_USER", "SIMILAR", "SOME", "SYMMETRIC", "TABLE", "THEN", "TO", "TRAILING", "TRUE", "UNION", "UNIQUE", "USER", "USING", "VARIADIC", "VERBOSE", "WHEN", "WHERE", "WINDOW", "WITH"];
 
-var reservedWords_Cassandra = ["ADD", "ALL", "ALTER", "AND", "ANY", "APPLY", "AS", "ASC", "ASCII", "AUTHORIZE", "BATCH", "BEGIN", "BIGINT", "BLOB", "BOOLEAN", "BY", "CLUSTERING", "COLUMNFAMILY", "COMPACT", "CONSISTENCY", "COUNT", "COUNTER", "CREATE", "DECIMAL", "DELETE", "DESC", "DOUBLE", "DROP", "EACH_QUORUM", "FLOAT", "FROM", "GRANT", "IN", "INDEX", "CUSTOM", "INSERT", "INT", "INTO", "KEY", "KEYSPACE", "LEVEL", "LIMIT", "LOCAL_ONE", "LOCAL_QUORUM", "MODIFY", "NORECURSIVE", "NOSUPERUSER", "OF", "ON", "ONE", "ORDER", "PASSWORD", "PERMISSION", "PERMISSIONS", "PRIMARY", "QUORUM", "REVOKE", "SCHEMA", "SELECT", "SET", "STORAGE", "SUPERUSER", "TABLE", "TEXT", "TIMESTAMP", "TIMEUUID", "THREE", "TOKEN", "TRUNCATE", "TTL", "TWO", "TYPE", "UPDATE", "USE", "USER", "USERS", "USING", "UUID", "VALUES", "VARCHAR", "VARINT", "WHERE", "WITH", "WRITETIME", "DISTINCT", "BYTE", "SMALLINT", "COMPLEX", "ENUM", "DATE", "INTERVAL", "MACADDR", "BITSTRING"];
+const RESERVED_WORDS_CASSANDRA = ["ADD", "ALL", "ALTER", "AND", "ANY", "APPLY", "AS", "ASC", "ASCII", "AUTHORIZE", "BATCH", "BEGIN", "BIGINT", "BLOB", "BOOLEAN", "BY", "CLUSTERING", "COLUMNFAMILY", "COMPACT", "CONSISTENCY", "COUNT", "COUNTER", "CREATE", "DECIMAL", "DELETE", "DESC", "DOUBLE", "DROP", "EACH_QUORUM", "FLOAT", "FROM", "GRANT", "IN", "INDEX", "CUSTOM", "INSERT", "INT", "INTO", "KEY", "KEYSPACE", "LEVEL", "LIMIT", "LOCAL_ONE", "LOCAL_QUORUM", "MODIFY", "NORECURSIVE", "NOSUPERUSER", "OF", "ON", "ONE", "ORDER", "PASSWORD", "PERMISSION", "PERMISSIONS", "PRIMARY", "QUORUM", "REVOKE", "SCHEMA", "SELECT", "SET", "STORAGE", "SUPERUSER", "TABLE", "TEXT", "TIMESTAMP", "TIMEUUID", "THREE", "TOKEN", "TRUNCATE", "TTL", "TWO", "TYPE", "UPDATE", "USE", "USER", "USERS", "USING", "UUID", "VALUES", "VARCHAR", "VARINT", "WHERE", "WITH", "WRITETIME", "DISTINCT", "BYTE", "SMALLINT", "COMPLEX", "ENUM", "DATE", "INTERVAL", "MACADDR", "BITSTRING"];
 
-var reservedWords_Oracle = ["ACCESS", "ACCOUNT", "ACTIVATE", "ADD", "ADMIN", "ADVISE", "AFTER", "ALL", "ALL_ROWS", "ALLOCATE", "ALTER", "ANALYZE", "AND", "ANY", "ARCHIVE", "ARCHIVELOG", "ARRAY", "AS", "ASC", "AT", "AUDIT", "AUTHENTICATED", "AUTHORIZATION", "AUTOEXTEND", "AUTOMATIC", "BACKUP", "BECOME", "BEFORE", "BEGIN", "BETWEEN", "BFILE", "BITMAP", "BLOB", "BLOCK", "BODY", "BY", "CACHE", "CACHE_INSTANCES", "CANCEL", "CASCADE", "CAST", "CFILE", "CHAINED", "CHANGE", "CHAR", "CHAR_CS", "CHARACTER", "CHECK", "CHECKPOINT", "CHOOSE", "CHUNK", "CLEAR", "CLOB", "CLONE", "CLOSE", "CLOSE_CACHED_OPEN_CURSORS", "CLUSTER", "COALESCE", "COLUMN", "COLUMNS", "COMMENT", "COMMIT", "COMMITTED", "COMPATIBILITY", "COMPILE", "COMPLETE", "COMPOSITE_LIMIT", "COMPRESS", "COMPUTE", "CONNECT", "CONNECT_TIME", "CONSTRAINT", "CONSTRAINTS", "CONTENTS", "CONTINUE", "CONTROLFILE", "CONVERT", "COST", "CPU_PER_CALL", "CPU_PER_SESSION", "CREATE", "CURRENT", "CURRENT_SCHEMA", "CURREN_USER", "CURSOR", "CYCLE", " ", "DANGLING", "DATABASE", "DATAFILE", "DATAFILES", "DATAOBJNO", "DATE", "DBA", "DBHIGH", "DBLOW", "DBMAC", "DEALLOCATE", "DEBUG", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DEFERRABLE", "DEFERRED", "DEGREE", "DELETE", "DEREF", "DESC", "DIRECTORY", "DISABLE", "DISCONNECT", "DISMOUNT", "DISTINCT", "DISTRIBUTED", "DML", "DOUBLE", "DROP", "DUMP", "EACH", "ELSE", "ENABLE", "END", "ENFORCE", "ENTRY", "ESCAPE", "EXCEPT", "EXCEPTIONS", "EXCHANGE", "EXCLUDING", "EXCLUSIVE", "EXECUTE", "EXISTS", "EXPIRE", "EXPLAIN", "EXTENT", "EXTENTS", "EXTERNALLY", "FAILED_LOGIN_ATTEMPTS", "FALSE", "FAST", "FILE", "FIRST_ROWS", "FLAGGER", "FLOAT", "FLOB", "FLUSH", "FOR", "FORCE", "FOREIGN", "FREELIST", "FREELISTS", "FROM", "FULL", "FUNCTION", "GLOBAL", "GLOBALLY", "GLOBAL_NAME", "GRANT", "GROUP", "GROUPS", "HASH", "HASHKEYS", "HAVING", "HEADER", "HEAP", "IDENTIFIED", "IDGENERATORS", "IDLE_TIME", "IF", "IMMEDIATE", "IN", "INCLUDING", "INCREMENT", "INDEX", "INDEXED", "INDEXES", "INDICATOR", "IND_PARTITION", "INITIAL", "INITIALLY", "INITRANS", "INSERT", "INSTANCE", "INSTANCES", "INSTEAD", "INT", "INTEGER", "INTERMEDIATE", "INTERSECT", "INTO", "IS", "ISOLATION", "ISOLATION_LEVEL", "KEEP", "KEY", "KILL", "LABEL", "LAYER", "LESS", "LEVEL", "LIBRARY", "LIKE", "LIMIT", "LINK", "LIST", "LOB", "LOCAL", "LOCK", "LOCKED", "LOG", "LOGFILE", "LOGGING", "LOGICAL_READS_PER_CALL", "LOGICAL_READS_PER_SESSION", "LONG", "MANAGE", "MASTER", "MAX", "MAXARCHLOGS", "MAXDATAFILES", "MAXEXTENTS", "MAXINSTANCES", "MAXLOGFILES", "MAXLOGHISTORY", "MAXLOGMEMBERS", "MAXSIZE", "MAXTRANS", "MAXVALUE", "MIN", "MEMBER", "MINIMUM", "MINEXTENTS", "MINUS", "MINVALUE", "MLSLABEL", "MLS_LABEL_FORMAT", "MODE", "MODIFY", "MOUNT", "MOVE", "MTS_DISPATCHERS", "MULTISET", "NATIONAL", "NCHAR", "NCHAR_CS", "NCLOB", "NEEDED", "NESTED", "NETWORK", "NEW", "NEXT", "NOARCHIVELOG", "NOAUDIT", "NOCACHE", "NOCOMPRESS", "NOCYCLE", "NOFORCE", "NOLOGGING", "NOMAXVALUE", "NOMINVALUE", "NONE", "NOORDER", "NOOVERRIDE", "NOPARALLEL", "NOPARALLEL", "NOREVERSE", "NORMAL", "NOSORT", "NOT", "NOTHING", "NOWAIT", "NULL", "NUMBER", "NUMERIC", "NVARCHAR2", "OBJECT", "OBJNO", "OBJNO_REUSE", "OF", "OFF", "OFFLINE", "OID", "OIDINDEX", "OLD", "ON", "ONLINE", "ONLY", "OPCODE", "OPEN", "OPTIMAL", "OPTIMIZER_GOAL", "OPTION", "OR", "ORDER", "ORGANIZATION", "OSLABEL", "OVERFLOW", "OWN", "PACKAGE", "PARALLEL", "PARTITION", "PASSWORD", "PASSWORD_GRACE_TIME", "PASSWORD_LIFE_TIME", "PASSWORD_LOCK_TIME", "PASSWORD_REUSE_MAX", "PASSWORD_REUSE_TIME", "PASSWORD_VERIFY_FUNCTION", "PCTFREE", "PCTINCREASE", "PCTTHRESHOLD", "PCTUSED", "PCTVERSION", "PERCENT", "PERMANENT", "PLAN", "PLSQL_DEBUG", "POST_TRANSACTION", "PRECISION", "PRESERVE", "PRIMARY", "PRIOR", "PRIVATE", "PRIVATE_SGA", "PRIVILEGE", "PRIVILEGES", "PROCEDURE", "PROFILE", "PUBLIC", "PURGE", "QUEUE", "QUOTA", "RANGE", "RAW", "RBA", "READ", "READUP", "REAL", "REBUILD", "RECOVER", "RECOVERABLE", "RECOVERY", "REF", "REFERENCES", "REFERENCING", "REFRESH", "RENAME", "REPLACE", "RESET", "RESETLOGS", "RESIZE", "RESOURCE", "RESTRICTED", "RETURN", "RETURNING", "REUSE", "REVERSE", "REVOKE", "ROLE", "ROLES", "ROLLBACK", "ROW", "ROWID", "ROWNUM", "ROWS", "RULE", "SAMPLE", "SAVEPOINT", "SB4", "SCAN_INSTANCES", "SCHEMA", "SCN", "SCOPE", "SD_ALL", "SD_INHIBIT", "SD_SHOW", "SEGMENT", "SEG_BLOCK", "SEG_FILE", "SELECT", "SEQUENCE", "SERIALIZABLE", "SESSION", "SESSION_CACHED_CURSORS", "SESSIONS_PER_USER", "SET", "SHARE", "SHARED", "SHARED_POOL", "SHRINK", "SIZE", "SKIP", "SKIP_UNUSABLE_INDEXES", "SMALLINT", "SNAPSHOT", "SOME", "SORT", "SPECIFICATION", "SPLIT", "SQL_TRACE", "STANDBY", "START", "STATEMENT_ID", "STATISTICS", "STOP", "STORAGE", "STORE", "STRUCTURE", "SUCCESSFUL", "SWITCH", "SYS_OP_ENFORCE_NOT_NULL$", "SYS_OP_NTCIMG$", "SYNONYM", "SYSDATE", "SYSDBA", "SYSOPER", "SYSTEM", "TABLE", "TABLES", "TABLESPACE", "TABLESPACE_NO", "TABNO", "TEMPORARY", "THAN", "THE", "THEN", "THREAD", "TIMESTAMP", "TIME", "TO", "TOPLEVEL", "TRACE", "TRACING", "TRANSACTION", "TRANSITIONAL", "TRIGGER", "TRIGGERS", "TRUE", "TRUNCATE", "TX", "TYPE", "UB2", "UBA", "UID", "UNARCHIVED", "UNDO", "UNION", "UNIQUE", "UNLIMITED", "UNLOCK", "UNRECOVERABLE", "UNTIL", "UNUSABLE", "UNUSED", "UPDATABLE", "UPDATE", "USAGE", "USE", "USER", "USING", "VALIDATE", "VALIDATION", "VALUE", "VALUES", "VARCHAR", "VARCHAR2", "VARYING", "VIEW", "WHEN", "WHENEVER", "WHERE", "WITH", "WITHOUT", "WORK", "WRITE", "WRITEDOWN", "WRITEUP", "XID", "YEAR", "ZONE"];
+const RESERVED_WORDS_ORACLE = ["ACCESS", "ACCOUNT", "ACTIVATE", "ADD", "ADMIN", "ADVISE", "AFTER", "ALL", "ALL_ROWS", "ALLOCATE", "ALTER", "ANALYZE", "AND", "ANY", "ARCHIVE", "ARCHIVELOG", "ARRAY", "AS", "ASC", "AT", "AUDIT", "AUTHENTICATED", "AUTHORIZATION", "AUTOEXTEND", "AUTOMATIC", "BACKUP", "BECOME", "BEFORE", "BEGIN", "BETWEEN", "BFILE", "BITMAP", "BLOB", "BLOCK", "BODY", "BY", "CACHE", "CACHE_INSTANCES", "CANCEL", "CASCADE", "CAST", "CFILE", "CHAINED", "CHANGE", "CHAR", "CHAR_CS", "CHARACTER", "CHECK", "CHECKPOINT", "CHOOSE", "CHUNK", "CLEAR", "CLOB", "CLONE", "CLOSE", "CLOSE_CACHED_OPEN_CURSORS", "CLUSTER", "COALESCE", "COLUMN", "COLUMNS", "COMMENT", "COMMIT", "COMMITTED", "COMPATIBILITY", "COMPILE", "COMPLETE", "COMPOSITE_LIMIT", "COMPRESS", "COMPUTE", "CONNECT", "CONNECT_TIME", "CONSTRAINT", "CONSTRAINTS", "CONTENTS", "CONTINUE", "CONTROLFILE", "CONVERT", "COST", "CPU_PER_CALL", "CPU_PER_SESSION", "CREATE", "CURRENT", "CURRENT_SCHEMA", "CURREN_USER", "CURSOR", "CYCLE", " ", "DANGLING", "DATABASE", "DATAFILE", "DATAFILES", "DATAOBJNO", "DATE", "DBA", "DBHIGH", "DBLOW", "DBMAC", "DEALLOCATE", "DEBUG", "DEC", "DECIMAL", "DECLARE", "DEFAULT", "DEFERRABLE", "DEFERRED", "DEGREE", "DELETE", "DEREF", "DESC", "DIRECTORY", "DISABLE", "DISCONNECT", "DISMOUNT", "DISTINCT", "DISTRIBUTED", "DML", "DOUBLE", "DROP", "DUMP", "EACH", "ELSE", "ENABLE", "END", "ENFORCE", "ENTRY", "ESCAPE", "EXCEPT", "EXCEPTIONS", "EXCHANGE", "EXCLUDING", "EXCLUSIVE", "EXECUTE", "EXISTS", "EXPIRE", "EXPLAIN", "EXTENT", "EXTENTS", "EXTERNALLY", "FAILED_LOGIN_ATTEMPTS", "FALSE", "FAST", "FILE", "FIRST_ROWS", "FLAGGER", "FLOAT", "FLOB", "FLUSH", "FOR", "FORCE", "FOREIGN", "FREELIST", "FREELISTS", "FROM", "FULL", "FUNCTION", "GLOBAL", "GLOBALLY", "GLOBAL_NAME", "GRANT", "GROUP", "GROUPS", "HASH", "HASHKEYS", "HAVING", "HEADER", "HEAP", "IDENTIFIED", "IDGENERATORS", "IDLE_TIME", "IF", "IMMEDIATE", "IN", "INCLUDING", "INCREMENT", "INDEX", "INDEXED", "INDEXES", "INDICATOR", "IND_PARTITION", "INITIAL", "INITIALLY", "INITRANS", "INSERT", "INSTANCE", "INSTANCES", "INSTEAD", "INT", "INTEGER", "INTERMEDIATE", "INTERSECT", "INTO", "IS", "ISOLATION", "ISOLATION_LEVEL", "KEEP", "KEY", "KILL", "LABEL", "LAYER", "LESS", "LEVEL", "LIBRARY", "LIKE", "LIMIT", "LINK", "LIST", "LOB", "LOCAL", "LOCK", "LOCKED", "LOG", "LOGFILE", "LOGGING", "LOGICAL_READS_PER_CALL", "LOGICAL_READS_PER_SESSION", "LONG", "MANAGE", "MASTER", "MAX", "MAXARCHLOGS", "MAXDATAFILES", "MAXEXTENTS", "MAXINSTANCES", "MAXLOGFILES", "MAXLOGHISTORY", "MAXLOGMEMBERS", "MAXSIZE", "MAXTRANS", "MAXVALUE", "MIN", "MEMBER", "MINIMUM", "MINEXTENTS", "MINUS", "MINVALUE", "MLSLABEL", "MLS_LABEL_FORMAT", "MODE", "MODIFY", "MOUNT", "MOVE", "MTS_DISPATCHERS", "MULTISET", "NATIONAL", "NCHAR", "NCHAR_CS", "NCLOB", "NEEDED", "NESTED", "NETWORK", "NEW", "NEXT", "NOARCHIVELOG", "NOAUDIT", "NOCACHE", "NOCOMPRESS", "NOCYCLE", "NOFORCE", "NOLOGGING", "NOMAXVALUE", "NOMINVALUE", "NONE", "NOORDER", "NOOVERRIDE", "NOPARALLEL", "NOPARALLEL", "NOREVERSE", "NORMAL", "NOSORT", "NOT", "NOTHING", "NOWAIT", "NULL", "NUMBER", "NUMERIC", "NVARCHAR2", "OBJECT", "OBJNO", "OBJNO_REUSE", "OF", "OFF", "OFFLINE", "OID", "OIDINDEX", "OLD", "ON", "ONLINE", "ONLY", "OPCODE", "OPEN", "OPTIMAL", "OPTIMIZER_GOAL", "OPTION", "OR", "ORDER", "ORGANIZATION", "OSLABEL", "OVERFLOW", "OWN", "PACKAGE", "PARALLEL", "PARTITION", "PASSWORD", "PASSWORD_GRACE_TIME", "PASSWORD_LIFE_TIME", "PASSWORD_LOCK_TIME", "PASSWORD_REUSE_MAX", "PASSWORD_REUSE_TIME", "PASSWORD_VERIFY_FUNCTION", "PCTFREE", "PCTINCREASE", "PCTTHRESHOLD", "PCTUSED", "PCTVERSION", "PERCENT", "PERMANENT", "PLAN", "PLSQL_DEBUG", "POST_TRANSACTION", "PRECISION", "PRESERVE", "PRIMARY", "PRIOR", "PRIVATE", "PRIVATE_SGA", "PRIVILEGE", "PRIVILEGES", "PROCEDURE", "PROFILE", "PUBLIC", "PURGE", "QUEUE", "QUOTA", "RANGE", "RAW", "RBA", "READ", "READUP", "REAL", "REBUILD", "RECOVER", "RECOVERABLE", "RECOVERY", "REF", "REFERENCES", "REFERENCING", "REFRESH", "RENAME", "REPLACE", "RESET", "RESETLOGS", "RESIZE", "RESOURCE", "RESTRICTED", "RETURN", "RETURNING", "REUSE", "REVERSE", "REVOKE", "ROLE", "ROLES", "ROLLBACK", "ROW", "ROWID", "ROWNUM", "ROWS", "RULE", "SAMPLE", "SAVEPOINT", "SB4", "SCAN_INSTANCES", "SCHEMA", "SCN", "SCOPE", "SD_ALL", "SD_INHIBIT", "SD_SHOW", "SEGMENT", "SEG_BLOCK", "SEG_FILE", "SELECT", "SEQUENCE", "SERIALIZABLE", "SESSION", "SESSION_CACHED_CURSORS", "SESSIONS_PER_USER", "SET", "SHARE", "SHARED", "SHARED_POOL", "SHRINK", "SIZE", "SKIP", "SKIP_UNUSABLE_INDEXES", "SMALLINT", "SNAPSHOT", "SOME", "SORT", "SPECIFICATION", "SPLIT", "SQL_TRACE", "STANDBY", "START", "STATEMENT_ID", "STATISTICS", "STOP", "STORAGE", "STORE", "STRUCTURE", "SUCCESSFUL", "SWITCH", "SYS_OP_ENFORCE_NOT_NULL$", "SYS_OP_NTCIMG$", "SYNONYM", "SYSDATE", "SYSDBA", "SYSOPER", "SYSTEM", "TABLE", "TABLES", "TABLESPACE", "TABLESPACE_NO", "TABNO", "TEMPORARY", "THAN", "THE", "THEN", "THREAD", "TIMESTAMP", "TIME", "TO", "TOPLEVEL", "TRACE", "TRACING", "TRANSACTION", "TRANSITIONAL", "TRIGGER", "TRIGGERS", "TRUE", "TRUNCATE", "TX", "TYPE", "UB2", "UBA", "UID", "UNARCHIVED", "UNDO", "UNION", "UNIQUE", "UNLIMITED", "UNLOCK", "UNRECOVERABLE", "UNTIL", "UNUSABLE", "UNUSED", "UPDATABLE", "UPDATE", "USAGE", "USE", "USER", "USING", "VALIDATE", "VALIDATION", "VALUE", "VALUES", "VARCHAR", "VARCHAR2", "VARYING", "VIEW", "WHEN", "WHENEVER", "WHERE", "WITH", "WITHOUT", "WORK", "WRITE", "WRITEDOWN", "WRITEUP", "XID", "YEAR", "ZONE"];
 
-var reservedWords_Mongo = ["DOCUMENT"];
+const RESERVED_WORDS_MONGO = ["DOCUMENT"];
 
-var supportedValidationRules = ['required', 'max', 'min', 'maxlength', 'minlength', 'maxbytes', 'minbytes', 'pattern'];
+const SUPPORTED_VALIDATION_RULES = ['required', 'max', 'min', 'maxlength', 'minlength', 'maxbytes', 'minbytes', 'pattern'];
 
 // enum-specific vars
 var enums = [];
@@ -34,10 +33,11 @@ var enums = [];
 var existingEnum = false;
 
 var fieldNamesUnderscored = ['id'];
+var fieldNameChoices = [{name:'id', value: 'ID'}];
 var databaseType;
 var prodDatabaseType;
-var interpolateRegex = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates
-var resourceDir = 'src/main/resources/';
+const interpolateRegex = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates
+const resourceDir = 'src/main/resources/';
 
 var EntityGenerator = generators.Base.extend({});
 
@@ -81,9 +81,9 @@ module.exports = EntityGenerator.extend({
 
             this.filename = this.jhipsterConfigDirectory + '/' + _s.capitalize(this.name) + '.json';
             if (shelljs.test('-f', this.filename)) {
-                this.log(chalk.green('Found the ' + this.filename + ' configuration file, automatically generating the entity'));
+                this.log(chalk.green('Found the ' + this.filename + ' configuration file, entity can be automatically generated!'));
                 try {
-                    this.fileData = JSON.parse(html.readFileAsString(this.filename))
+                    this.fileData = this.fs.readJSON(this.filename);
                 } catch (err) {
                     this.log(chalk.red('The configuration file could not be read!'));
                     return;
@@ -101,21 +101,21 @@ module.exports = EntityGenerator.extend({
                 this.env.error(chalk.red('The entity name cannot be empty'));
             } else if (this.name.indexOf("Detail", this.name.length - "Detail".length) !== -1) {
                 this.env.error(chalk.red('The entity name cannot end with \'Detail\''));
-            } else if (reservedWords_Java.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (RESERVED_WORDS_JAVA.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a Java reserved keyword'));
-            } else if (reservedWords_JHipster.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (RESERVED_WORDS_JHIPSTER.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a JHipster reserved keyword'));
-            } else if (prodDatabaseType == 'mysql' && reservedWords_MySQL.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (prodDatabaseType == 'mysql' && RESERVED_WORDS_MYSQL.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a MySQL reserved keyword'));
-            } else if (prodDatabaseType == 'postgresql' && reservedWords_Postgresql.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (prodDatabaseType == 'postgresql' && RESERVED_WORDS_POSGRES.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a PostgreSQL reserved keyword'));
-            } else if (prodDatabaseType == 'cassandra' && reservedWords_Cassandra.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (prodDatabaseType == 'cassandra' && RESERVED_WORDS_CASSANDRA.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a Cassandra reserved keyword'));
-            } else if (prodDatabaseType == 'oracle' && reservedWords_Oracle.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (prodDatabaseType == 'oracle' && RESERVED_WORDS_ORACLE.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a Oracle reserved keyword'));
             } else if (prodDatabaseType == 'oracle' && _s.underscored(this.name).length > 26) {
                 this.env.error(chalk.red('The entity name is too long for Oracle, try a shorter name'));
-            } else if (prodDatabaseType == 'mongodb' && reservedWords_Mongo.indexOf(this.name.toUpperCase()) != -1) {
+            } else if (prodDatabaseType == 'mongodb' && RESERVED_WORDS_MONGO.indexOf(this.name.toUpperCase()) != -1) {
                 this.env.error(chalk.red('The entity name cannot contain a MongoDB reserved keyword'));
             }
         },
@@ -123,741 +123,810 @@ module.exports = EntityGenerator.extend({
         setupVars: function() {
             this.log(chalk.red('The entity ' + this.name + ' is being created.'));
             // Specific Entity sub-generator variables
-            this.fieldId = 0;
-            this.fields = [];
-            this.relationshipId = 0;
-            this.relationships = [];
-            this.pagination = 'no';
-            this.validation = false;
-            this.dto = 'no';
-            this.service = 'no';
+            if (this.useConfigurationFile == false) {
+                this.fieldId = 0;
+                this.fields = [];
+                this.relationshipId = 0;
+                this.relationships = [];
+                this.pagination = 'no';
+                this.validation = false;
+                this.dto = 'no';
+                this.service = 'no';
+            } else {
+                this.fieldId = this.fileData.fields? this.fileData.fields.length : 0;
+                this.relationshipId = this.fileData.relationships? this.fileData.relationships.length : 0;
+                this.relationships = this.fileData.relationships;
+                this.fields = this.fileData.fields;
+                this.changelogDate = this.fileData.changelogDate;
+                this.dto = this.fileData.dto;
+                this.service = this.fileData.service;
+                this.pagination = this.fileData.pagination;
+                this.javadoc = this.fileData.javadoc;
+                this.fields.forEach(function (field) {
+                    fieldNamesUnderscored.push(_s.underscored(field.fieldName));
+                    fieldNameChoices.push({name: field.fieldName, value: field.fieldName});
+                }, this);
+            }
         }
     },
+    /* private Helper methods */
+    _askForField : function(cb){
+        this.fieldId++;
+        this.log(chalk.green('Generating field #' + this.fieldId));
+        var prompts = [
+            {
+                type: 'confirm',
+                name: 'fieldAdd',
+                message: 'Do you want to add a field to your entity?',
+                default: true
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true;
+                },
+                type: 'input',
+                name: 'fieldName',
+                validate: function(input) {
+                    if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
+                        return 'Your field name cannot contain special characters';
+                    } else if (input == '') {
+                        return 'Your field name cannot be empty';
+                    } else if (input.charAt(0) == input.charAt(0).toUpperCase()) {
+                        return 'Your field name cannot start with a upper case letter';
+                    } else if (input == 'id' || fieldNamesUnderscored.indexOf(_s.underscored(input)) != -1) {
+                        return 'Your field name cannot use an already existing field name';
+                    } else if (RESERVED_WORDS_JAVA.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your field name cannot contain a Java reserved keyword';
+                    } else if (prodDatabaseType == 'mysql' && RESERVED_WORDS_MYSQL.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your field name cannot contain a MySQL reserved keyword';
+                    } else if (prodDatabaseType == 'postgresql' && RESERVED_WORDS_POSGRES.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your field name cannot contain a PostgreSQL reserved keyword';
+                    } else if (prodDatabaseType == 'cassandra' && RESERVED_WORDS_CASSANDRA.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your field name cannot contain a Cassandra reserved keyword';
+                    } else if (prodDatabaseType == 'oracle' && RESERVED_WORDS_ORACLE.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your field name cannot contain a Oracle reserved keyword';
+                    } else if (prodDatabaseType == 'oracle' && input.length > 30) {
+                        return 'The field name cannot be of more than 30 characters';
+                    } else if (prodDatabaseType == 'mongodb' && RESERVED_WORDS_MONGO.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your field name cannot contain a MongoDB reserved keyword';
+                    }
+                    return true;
+                },
+                message: 'What is the name of your field?'
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true && (databaseType == 'sql' || databaseType == 'mongodb');
+                },
+                type: 'list',
+                name: 'fieldType',
+                message: 'What is the type of your field?',
+                choices: [
+                    {
+                        value: 'String',
+                        name: 'String'
+                    },
+                    {
+                        value: 'Integer',
+                        name: 'Integer'
+                    },
+                    {
+                        value: 'Long',
+                        name: 'Long'
+                    },
+                    {
+                        value: 'Float',
+                        name: 'Float'
+                    },
+                    {
+                        value: 'Double',
+                        name: 'Double'
+                    },
+                    {
+                        value: 'BigDecimal',
+                        name: 'BigDecimal'
+                    },
+                    {
+                        value: 'LocalDate',
+                        name: 'LocalDate'
+                    },
+                    {
+                        value: 'ZonedDateTime',
+                        name: 'ZonedDateTime'
+                    },
+                    {
+                        value: 'Boolean',
+                        name: 'Boolean'
+                    },
+                    {
+                        value: 'enum',
+                        name: 'Enumeration (Java enum type)'
+                    },
+                    {
+                        value: 'byte[]',
+                        name: '[BETA] Blob'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    if (response.fieldType == 'enum') {
+                        response.fieldIsEnum = true;
+                        return true;
+                    } else {
+                        response.fieldIsEnum = false;
+                        return false;
+                    }
+                },
+                type: 'input',
+                name: 'fieldType',
+                validate: function(input) {
+                    if (input == '') {
+                        return 'Your class name cannot be empty.';
+                    }
+                    if (enums.indexOf(input) != -1) {
+                        existingEnum = true;
+                    } else {
+                        enums.push(input);
+                    }
+                    return true;
+                },
+                message: 'What is the class name of your enumeration?'
+            },
+            {
+                when: function(response) {
+                    return response.fieldIsEnum;
+                },
+                type: 'input',
+                name: 'fieldValues',
+                validate: function(input) {
+                    if (input == '' && existingEnum) {
+                        existingEnum = false;
+                        return true;
+                    }
+                    if (input == '') {
+                        return 'You must specify values for your enumeration';
+                    }
+                    if (!/^[A-Za-z0-9_,\s]*$/.test(input)) {
+                        return 'Enum values cannot contain special characters (allowed characters: A-Z, a-z, 0-9 and _)';
+                    }
+                    var enums = input.replace(/\s/g, '').split(',');
+                    if (_.uniq(enums).length !== enums.length) {
+                        return 'Enum values cannot contain duplicates (typed values: ' + input + ')';
+                    }
+                    for (var i = 0; i < enums.length; i++) {
+                        if (/^[0-9].*/.test(enums[i])) {
+                            return 'Enum value "' + enums[i] + '" cannot start with a number';
+                        }
+                        if (enums[i] == '') {
+                            return 'Enum value cannot be empty (did you accidently type "," twice in a row?)';
+                        }
+                    }
+
+                    return true;
+                },
+                message: function(answers) {
+                    if (!existingEnum) {
+                        return 'What are the values of your enumeration (separated by comma)?';
+                    }
+                    return 'What are the new values of your enumeration (separated by comma)?\nThe new values will replace the old ones.\nNothing will be done if there are no new values.';
+                }
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true && databaseType == 'cassandra';
+                },
+                type: 'list',
+                name: 'fieldType',
+                message: 'What is the type of your field?',
+                choices: [
+                    {
+                        value: 'UUID',
+                        name: 'UUID'
+                    },
+                    {
+                        value: 'String',
+                        name: 'String'
+                    },
+                    {
+                        value: 'Integer',
+                        name: 'Integer'
+                    },
+                    {
+                        value: 'Long',
+                        name: 'Long'
+                    },
+                    {
+                        value: 'Float',
+                        name: 'Float'
+                    },
+                    {
+                        value: 'Double',
+                        name: 'Double'
+                    },
+                    {
+                        value: 'BigDecimal',
+                        name: 'BigDecimal'
+                    },
+                    {
+                        value: 'Date',
+                        name: 'Date'
+                    },
+                    {
+                        value: 'Boolean',
+                        name: 'Boolean'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldType == 'byte[]';
+                },
+                type: 'list',
+                name: 'fieldTypeBlobContent',
+                message: 'What is the content of the Blob field?',
+                choices: [
+                    {
+                        value: 'image',
+                        name: 'An image'
+                    },
+                    {
+                        value: 'any',
+                        name: 'A binary file'
+                    },
+                    {
+                        value: 'text',
+                        name: 'A CLOB (Text field)'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true;
+                },
+                type: 'confirm',
+                name: 'fieldValidate',
+                message: 'Do you want to add validation rules to your field?',
+                default: false
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldType == 'String';
+                },
+                type: 'checkbox',
+                name: 'fieldValidateRules',
+                message: 'Which validation rules do you want to add?',
+                choices: [
+                    {
+                        name: 'Required',
+                        value: 'required'
+                    },
+                    {
+                        name: 'Minimum length',
+                        value: 'minlength'
+                    },
+                    {
+                        name: 'Maximum length',
+                        value: 'maxlength'
+                    },
+                    {
+                        name: 'Regular expression pattern',
+                        value: 'pattern'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    (response.fieldType == 'Integer' ||
+                    response.fieldType == 'Long' ||
+                    response.fieldType == 'Float' ||
+                    response.fieldType == 'Double' ||
+                    response.fieldType == 'BigDecimal' ||
+                    response.fieldTypeBlobContent == 'text');
+                },
+                type: 'checkbox',
+                name: 'fieldValidateRules',
+                message: 'Which validation rules do you want to add?',
+                choices: [
+                    {
+                        name: 'Required',
+                        value: 'required'
+                    },
+                    {
+                        name: 'Minimum',
+                        value: 'min'
+                    },
+                    {
+                        name: 'Maximum',
+                        value: 'max'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldType == 'byte[]' &&
+                    response.fieldTypeBlobContent != 'text';
+                },
+                type: 'checkbox',
+                name: 'fieldValidateRules',
+                message: 'Which validation rules do you want to add?',
+                choices: [
+                    {
+                        name: 'Required',
+                        value: 'required'
+                    },
+                    {
+                        name: 'Minimum byte size',
+                        value: 'minbytes'
+                    },
+                    {
+                        name: 'Maximum byte size',
+                        value: 'maxbytes'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    (response.fieldType == 'LocalDate' ||
+                    response.fieldType == 'ZonedDateTime' ||
+                    response.fieldType == 'UUID' ||
+                    response.fieldType == 'Date' ||
+                    response.fieldType == 'Boolean' ||
+                    response.fieldTypeBlobContent == 'text' ||
+                    response.fieldIsEnum == true);
+                },
+                type: 'checkbox',
+                name: 'fieldValidateRules',
+                message: 'Which validation rules do you want to add?',
+                choices: [
+                    {
+                        name: 'Required',
+                        value: 'required'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('minlength') != -1;
+                },
+                type: 'input',
+                name: 'fieldValidateRulesMinlength',
+                validate: function(input) {
+                    if (/^([0-9]*)$/.test(input)) return true;
+                    return 'Minimum length must be a number';
+                },
+                message: 'What is the minimum length of your field?',
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('maxlength') != -1;
+                },
+                type: 'input',
+                name: 'fieldValidateRulesMaxlength',
+                validate: function(input) {
+                    if (/^([0-9]*)$/.test(input)) return true;
+                    return 'Maximum length must be a number';
+                },
+                message: 'What is the maximum length of your field?',
+                default: 20
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('pattern') != -1;
+                },
+                type: 'input',
+                name: 'fieldValidateRulesPattern',
+                message: 'What is the regular expression pattern you want to apply on your field?',
+                default: '^[a-zA-Z0-9]*$'
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('min') != -1 &&
+                    (response.fieldType == 'Integer' ||
+                    response.fieldType == 'Long' ||
+                    response.fieldType == 'Float' ||
+                    response.fieldType == 'Double' ||
+                    response.fieldTypeBlobContent == 'text' ||
+                    response.fieldType == 'BigDecimal');
+                },
+                type: 'input',
+                name: 'fieldValidateRulesMin',
+                message: 'What is the minimum of your field?',
+                validate: function(input) {
+                    if (/^([0-9]*)$/.test(input)) return true;
+                    return 'Minimum must be a number';
+                },
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('max') != -1 &&
+                    (response.fieldType == 'Integer' ||
+                    response.fieldType == 'Long' ||
+                    response.fieldType == 'Float' ||
+                    response.fieldType == 'Double' ||
+                    response.fieldTypeBlobContent == 'text' ||
+                    response.fieldType == 'BigDecimal');
+                },
+                type: 'input',
+                name: 'fieldValidateRulesMax',
+                message: 'What is the maximum of your field?',
+                validate: function(input) {
+                    if (/^([0-9]*)$/.test(input)) return true;
+                    return 'Maximum must be a number';
+                },
+                default: 100
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('minbytes') != -1 &&
+                    response.fieldType == 'byte[]' &&
+                    response.fieldTypeBlobContent != 'text';
+                },
+                type: 'input',
+                name: 'fieldValidateRulesMinbytes',
+                message: 'What is the minimum byte size of your field?',
+                validate: function(input) {
+                    if (/^([0-9]*)$/.test(input)) return true;
+                    return 'Minimum byte size must be a number';
+                },
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return response.fieldAdd == true &&
+                    response.fieldValidate == true &&
+                    response.fieldValidateRules.indexOf('maxbytes') != -1 &&
+                    response.fieldType == 'byte[]' &&
+                    response.fieldTypeBlobContent != 'text';
+                },
+                type: 'input',
+                name: 'fieldValidateRulesMaxbytes',
+                message: 'What is the maximum byte size of your field?',
+                validate: function(input) {
+                    if (/^([0-9]*)$/.test(input)) return true;
+                    return 'Maximum byte size must be a number';
+                },
+                default: 5000000
+            }
+        ];
+        this.prompt(prompts, function(props) {
+            if (props.fieldAdd) {
+                if (props.fieldIsEnum) {
+                    props.fieldType = _s.capitalize(props.fieldType);
+                }
+
+                var field = {
+                    fieldId: this.fieldId,
+                    fieldName: props.fieldName,
+                    fieldType: props.fieldType,
+                    fieldTypeBlobContent: props.fieldTypeBlobContent,
+                    fieldValues: props.fieldValues,
+                    fieldValidateRules: props.fieldValidateRules,
+                    fieldValidateRulesMinlength: props.fieldValidateRulesMinlength,
+                    fieldValidateRulesMaxlength: props.fieldValidateRulesMaxlength,
+                    fieldValidateRulesPattern: props.fieldValidateRulesPattern,
+                    fieldValidateRulesPatternJava: props.fieldValidateRulesPattern ? props.fieldValidateRulesPattern.replace(/\\/g, '\\\\') : props.fieldValidateRulesPattern,
+                    fieldValidateRulesMin: props.fieldValidateRulesMin,
+                    fieldValidateRulesMax: props.fieldValidateRulesMax,
+                    fieldValidateRulesMinbytes: props.fieldValidateRulesMinbytes,
+                    fieldValidateRulesMaxbytes: props.fieldValidateRulesMaxbytes
+                };
+
+                fieldNamesUnderscored.push(_s.underscored(props.fieldName));
+                this.fields.push(field);
+            }
+            this.log(chalk.red('=================' + _s.capitalize(this.name) + '================='));
+            this.fields.forEach(function(field) {
+                var validationDetails = '';
+                var fieldValidate = _.isArray(field.fieldValidateRules) && field.fieldValidateRules.length >= 1;
+                if (fieldValidate == true) {
+                    if (field.fieldValidateRules.indexOf('required') != -1) {
+                        validationDetails = 'required ';
+                    }
+                    if (field.fieldValidateRules.indexOf('minlength') != -1) {
+                        validationDetails += 'minlength=\'' + field.fieldValidateRulesMinlength + '\' ';
+                    }
+                    if (field.fieldValidateRules.indexOf('maxlength') != -1) {
+                        validationDetails += 'maxlength=\'' + field.fieldValidateRulesMaxlength + '\' ';
+                    }
+                    if (field.fieldValidateRules.indexOf('pattern') != -1) {
+                        validationDetails += 'pattern=\'' + field.fieldValidateRulesPattern + '\' ';
+                    }
+                    if (field.fieldValidateRules.indexOf('min') != -1) {
+                        validationDetails += 'min=\'' + field.fieldValidateRulesMin + '\' ';
+                    }
+                    if (field.fieldValidateRules.indexOf('max') != -1) {
+                        validationDetails += 'max=\'' + field.fieldValidateRulesMax + '\' ';
+                    }
+                    if (field.fieldValidateRules.indexOf('minbytes') != -1) {
+                        validationDetails += 'minbytes=\'' + field.fieldValidateRulesMinbytes + '\' ';
+                    }
+                    if (field.fieldValidateRules.indexOf('maxbytes') != -1) {
+                        validationDetails += 'maxbytes=\'' + field.fieldValidateRulesMaxbytes + '\' ';
+                    }
+                }
+                this.log(chalk.red(field.fieldName) + chalk.white(' (' + field.fieldType + (field.fieldTypeBlobContent ? ' ' + field.fieldTypeBlobContent : '') + ') ') + chalk.cyan(validationDetails));
+            }, this);
+            if (props.fieldAdd) {
+                this._askForField(cb);
+            } else {
+                cb();
+            }
+        }.bind(this));
+    },
+
+
+    _askForRelationship: function(cb){
+        var packageFolder = this.packageFolder;
+        var name = this.name;
+        this.relationshipId++;
+        this.log(chalk.green('Generating relationships with other entities'));
+        var prompts = [
+            {
+                type: 'confirm',
+                name: 'relationshipAdd',
+                message: 'Do you want to add a relationship to another entity?',
+                default: true
+            },
+            {
+                when: function(response) {
+                    return response.relationshipAdd == true;
+                },
+                type: 'input',
+                name: 'otherEntityName',
+                validate: function(input) {
+                    if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
+                        return 'Your other entity name cannot contain special characters';
+                    } else if (input == '') {
+                        return 'Your other entity name cannot be empty';
+                    } else if (RESERVED_WORDS_JAVA.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your other entity name cannot contain a Java reserved keyword';
+                    }
+                    return true;
+                },
+                message: 'What is the name of the other entity?'
+            },
+            {
+                when: function(response) {
+                    return response.relationshipAdd == true;
+                },
+                type: 'input',
+                name: 'relationshipName',
+                validate: function(input) {
+                    if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
+                        return 'Your relationship cannot contain special characters';
+                    } else if (input == '') {
+                        return 'Your relationship cannot be empty';
+                    } else if (input == 'id' || fieldNamesUnderscored.indexOf(_s.underscored(input)) != -1) {
+                        return 'Your relationship cannot use an already existing field name';
+                    } else if (RESERVED_WORDS_JAVA.indexOf(input.toUpperCase()) != -1) {
+                        return 'Your relationship cannot contain a Java reserved keyword';
+                    }
+                    return true;
+                },
+                message: 'What is the name of the relationship?',
+                default: function(response) {
+                    return _s.decapitalize(response.otherEntityName);
+                }
+            },
+            {
+                when: function(response) {
+                    return response.relationshipAdd == true;
+                },
+                type: 'list',
+                name: 'relationshipType',
+                message: 'What is the type of the relationship?',
+                choices: [
+                    {
+                        value: 'one-to-many',
+                        name: 'one-to-many'
+                    },
+                    {
+                        value: 'many-to-one',
+                        name: 'many-to-one'
+                    },
+                    {
+                        value: 'many-to-many',
+                        name: 'many-to-many'
+                    },
+                    {
+                        value: 'one-to-one',
+                        name: 'one-to-one'
+                    }
+                ],
+                default: 0
+            },
+            {
+                when: function(response) {
+                    return (response.relationshipAdd == true && response.relationshipType == 'many-to-one' && !shelljs.test('-f', 'src/main/java/' + packageFolder + '/domain/' + _s.capitalize(response.otherEntityName) + '.java'))
+                },
+                type: 'confirm',
+                name: 'noOtherEntity',
+                message: 'WARNING! You are trying to generate a many-to-one relationship on an entity that does not exist. This will probably fail, as you will need to create a foreign key on a table that does not exist. We advise you to create the other side of this relationship first (do the one-to-many before the many-to-one relationship). Are you sure you want to continue?',
+                default: false
+            },
+            {
+                when: function(response) {
+                    return (response.relationshipAdd == true && (response.relationshipType == 'many-to-many' || response.relationshipType == 'one-to-one'));
+                },
+                type: 'confirm',
+                name: 'ownerSide',
+                message: 'Is this entity the owner of the relationship?',
+                default: false
+            },
+            {
+                when: function(response) {
+                    return (response.relationshipAdd == true && (response.relationshipType == 'one-to-many' ||
+                    (response.relationshipType == 'many-to-many' && response.ownerSide == false) ||
+                    (response.relationshipType == 'one-to-one' && response.otherEntityName.toLowerCase() != "user")));
+                },
+                type: 'input',
+                name: 'otherEntityRelationshipName',
+                message: 'What is the name of this relationship in the other entity?',
+                default: function(response) {
+                    return _s.decapitalize(name);
+                }
+            },
+            {
+                when: function(response) {
+                    return (response.relationshipAdd == true && response.ownerSide == true && !shelljs.test('-f', 'src/main/java/' + packageFolder + '/domain/' + _s.capitalize(response.otherEntityName) + '.java'))
+                },
+                type: 'confirm',
+                name: 'noOtherEntity2',
+                message: 'WARNING! You have selected that this entity is the owner of a relationship on another entity, that does not exist yet. This will probably fail, as you will need to create a foreign key on a table that does not exist. We advise you to create the other side of this relationship first (do the non-owning side before the owning side). Are you sure you want to continue?',
+                default: false
+            },
+            {
+                when: function(response) {
+                    return (!(response.noOtherEntity == false || response.noOtherEntity2 == false) && response.relationshipAdd == true && (response.relationshipType == 'many-to-one' || (response.relationshipType == 'many-to-many' && response.ownerSide == true) || (response.relationshipType == 'one-to-one' && response.ownerSide == true)));
+                },
+                type: 'input',
+                name: 'otherEntityField',
+                message: function(response) {
+                    return 'When you display this relationship with AngularJS, which field from \'' + response.otherEntityName + '\' do you want to use?'
+                },
+                default: 'id'
+            }
+        ];
+        this.prompt(prompts, function(props) {
+            if (props.noOtherEntity == false || props.noOtherEntity2 == false) {
+                this.log(chalk.red('Generation aborted, as requested by the user.'));
+                return;
+            }
+            if (props.relationshipAdd) {
+                var relationship = {
+                    relationshipId: this.relationshipId,
+                    relationshipName: props.relationshipName,
+                    otherEntityName: _s.decapitalize(props.otherEntityName),
+                    relationshipType: props.relationshipType,
+                    otherEntityField: props.otherEntityField,
+                    ownerSide: props.ownerSide,
+                    otherEntityRelationshipName: props.otherEntityRelationshipName
+                }
+                fieldNamesUnderscored.push(_s.underscored(props.relationshipName));
+                this.relationships.push(relationship);
+            }
+            this.log(chalk.red('===========' + _s.capitalize(this.name) + '=============='));
+            this.fields.forEach(function(field) {
+                this.log(chalk.red(field.fieldName + ' (' + field.fieldType + (field.fieldTypeBlobContent ? ' ' + field.fieldTypeBlobContent : '') + ')'));
+            }, this);
+            this.log(chalk.red('-------------------'));
+            this.relationships.forEach(function(relationship) {
+                this.log(chalk.red(relationship.relationshipName + ' - ' + relationship.otherEntityName + ' (' + relationship.relationshipType + ')'));
+            }, this);
+            if (props.relationshipAdd) {
+                this._askForRelationship(cb);
+            } else {
+                cb();
+            }
+        }.bind(this));
+    },
+
+    /* end of Helper methods */
+
     prompting: {
         /* pre entity hook needs to be written here */
-        askForFields: function() {
-            // don't prompt if data are imported from a file
-            if (this.useConfigurationFile == true) {
+        askForUpdate: function () {
+            // ask only if running an existing entity without arg option --force
+            var isForce = this.options['force'];
+            if (isForce || !this.useConfigurationFile) {
                 return;
             }
             var cb = this.async();
-            function _askForField(_this){
-                _this.fieldId++;
-                _this.log(chalk.green('Generating field #' + _this.fieldId));
-                var prompts = [
-                    {
-                        type: 'confirm',
-                        name: 'fieldAdd',
-                        message: 'Do you want to add a field to your entity?',
-                        default: true
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true;
+            var prompts = [
+                {
+                    type: 'list',
+                    name: 'updateEntity',
+                    message: 'Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwriiten',
+                    choices: [
+                        {
+                            value: 'rewrite',
+                            name: 'Yes, re generate the entity'
                         },
-                        type: 'input',
-                        name: 'fieldName',
-                        validate: function(input) {
-                            if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
-                                return 'Your field name cannot contain special characters';
-                            } else if (input == '') {
-                                return 'Your field name cannot be empty';
-                            } else if (input.charAt(0) == input.charAt(0).toUpperCase()) {
-                                return 'Your field name cannot start with a upper case letter';
-                            } else if (input == 'id' || fieldNamesUnderscored.indexOf(_s.underscored(input)) != -1) {
-                                return 'Your field name cannot use an already existing field name';
-                            } else if (reservedWords_Java.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your field name cannot contain a Java reserved keyword';
-                            } else if (prodDatabaseType == 'mysql' && reservedWords_MySQL.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your field name cannot contain a MySQL reserved keyword';
-                            } else if (prodDatabaseType == 'postgresql' && reservedWords_Postgresql.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your field name cannot contain a PostgreSQL reserved keyword';
-                            } else if (prodDatabaseType == 'cassandra' && reservedWords_Cassandra.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your field name cannot contain a Cassandra reserved keyword';
-                            } else if (prodDatabaseType == 'oracle' && reservedWords_Oracle.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your field name cannot contain a Oracle reserved keyword';
-                            } else if (prodDatabaseType == 'oracle' && input.length > 30) {
-                                return 'The field name cannot be of more than 30 characters';
-                            } else if (prodDatabaseType == 'mongodb' && reservedWords_Mongo.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your field name cannot contain a MongoDB reserved keyword';
-                            }
-                            return true;
+                        {
+                            value: 'add',
+                            name: '[BETA] Yes, add more fields and relationships'
                         },
-                        message: 'What is the name of your field?'
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true && (databaseType == 'sql' || databaseType == 'mongodb');
+                        {
+                            value: 'remove',
+                            name: '[BETA] Yes, remove fields and relationships'
                         },
-                        type: 'list',
-                        name: 'fieldType',
-                        message: 'What is the type of your field?',
-                        choices: [
-                            {
-                                value: 'String',
-                                name: 'String'
-                            },
-                            {
-                                value: 'Integer',
-                                name: 'Integer'
-                            },
-                            {
-                                value: 'Long',
-                                name: 'Long'
-                            },
-                            {
-                                value: 'Float',
-                                name: 'Float'
-                            },
-                            {
-                                value: 'Double',
-                                name: 'Double'
-                            },
-                            {
-                                value: 'BigDecimal',
-                                name: 'BigDecimal'
-                            },
-                            {
-                                value: 'LocalDate',
-                                name: 'LocalDate'
-                            },
-                            {
-                                value: 'ZonedDateTime',
-                                name: 'ZonedDateTime'
-                            },
-                            {
-                                value: 'Boolean',
-                                name: 'Boolean'
-                            },
-                            {
-                                value: 'enum',
-                                name: 'Enumeration (Java enum type)'
-                            },
-                            {
-                                value: 'byte[]',
-                                name: '[BETA] Blob'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            if (response.fieldType == 'enum') {
-                                response.fieldIsEnum = true;
-                                return true;
-                            } else {
-                                response.fieldIsEnum = false;
-                                return false;
-                            }
+                        {
+                            value: 'none',
+                            name: 'No, exit'
                         },
-                        type: 'input',
-                        name: 'fieldType',
-                        validate: function(input) {
-                            if (input == '') {
-                                return 'Your class name cannot be empty.';
-                            }
-                            if (enums.indexOf(input) != -1) {
-                                existingEnum = true;
-                            } else {
-                                enums.push(input);
-                            }
-                            return true;
-                        },
-                        message: 'What is the class name of your enumeration?'
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldIsEnum;
-                        },
-                        type: 'input',
-                        name: 'fieldValues',
-                        validate: function(input) {
-                            if (input == '' && existingEnum) {
-                                existingEnum = false;
-                                return true;
-                            }
-                            if (input == '') {
-                                return 'You must specify values for your enumeration';
-                            }
-                            if (!/^[A-Za-z0-9_,\s]*$/.test(input)) {
-                                return 'Enum values cannot contain special characters (allowed characters: A-Z, a-z, 0-9 and _)';
-                            }
-                            var enums = input.replace(/\s/g, '').split(',');
-                            if (_.uniq(enums).length !== enums.length) {
-                                return 'Enum values cannot contain duplicates (typed values: ' + input + ')';
-                            }
-                            for (var i = 0; i < enums.length; i++) {
-                                if (/^[0-9].*/.test(enums[i])) {
-                                    return 'Enum value "' + enums[i] + '" cannot start with a number';
-                                }
-                                if (enums[i] == '') {
-                                    return 'Enum value cannot be empty (did you accidently type "," twice in a row?)';
-                                }
-                            }
+                    ],
+                    default: 0
+                }
+            ];
+            this.prompt(prompts, function(props) {
+                this.updateEntity = props.updateEntity;
+                if(this.updateEntity == 'none'){
+                    this.env.error(chalk.green('Aborting entity update, no changes were made.'));
+                }
+                cb();
 
-                            return true;
-                        },
-                        message: function(answers) {
-                            if (!existingEnum) {
-                                return 'What are the values of your enumeration (separated by comma)?';
-                            }
-                            return 'What are the new values of your enumeration (separated by comma)?\nThe new values will replace the old ones.\nNothing will be done if there are no new values.';
-                        }
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true && databaseType == 'cassandra';
-                        },
-                        type: 'list',
-                        name: 'fieldType',
-                        message: 'What is the type of your field?',
-                        choices: [
-                            {
-                                value: 'UUID',
-                                name: 'UUID'
-                            },
-                            {
-                                value: 'String',
-                                name: 'String'
-                            },
-                            {
-                                value: 'Integer',
-                                name: 'Integer'
-                            },
-                            {
-                                value: 'Long',
-                                name: 'Long'
-                            },
-                            {
-                                value: 'Float',
-                                name: 'Float'
-                            },
-                            {
-                                value: 'Double',
-                                name: 'Double'
-                            },
-                            {
-                                value: 'BigDecimal',
-                                name: 'BigDecimal'
-                            },
-                            {
-                                value: 'Date',
-                                name: 'Date'
-                            },
-                            {
-                                value: 'Boolean',
-                                name: 'Boolean'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldType == 'byte[]';
-                        },
-                        type: 'list',
-                        name: 'fieldTypeBlobContent',
-                        message: 'What is the content of the Blob field?',
-                        choices: [
-                            {
-                                value: 'image',
-                                name: 'An image'
-                            },
-                            {
-                                value: 'any',
-                                name: 'A binary file'
-                            },
-                            {
-                                value: 'text',
-                                name: 'A CLOB (Text field)'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true;
-                        },
-                        type: 'confirm',
-                        name: 'fieldValidate',
-                        message: 'Do you want to add validation rules to your field?',
-                        default: false
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldType == 'String';
-                        },
-                        type: 'checkbox',
-                        name: 'fieldValidateRules',
-                        message: 'Which validation rules do you want to add?',
-                        choices: [
-                            {
-                                name: 'Required',
-                                value: 'required'
-                            },
-                            {
-                                name: 'Minimum length',
-                                value: 'minlength'
-                            },
-                            {
-                                name: 'Maximum length',
-                                value: 'maxlength'
-                            },
-                            {
-                                name: 'Regular expression pattern',
-                                value: 'pattern'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            (response.fieldType == 'Integer' ||
-                            response.fieldType == 'Long' ||
-                            response.fieldType == 'Float' ||
-                            response.fieldType == 'Double' ||
-                            response.fieldType == 'BigDecimal' ||
-                            response.fieldTypeBlobContent == 'text');
-                        },
-                        type: 'checkbox',
-                        name: 'fieldValidateRules',
-                        message: 'Which validation rules do you want to add?',
-                        choices: [
-                            {
-                                name: 'Required',
-                                value: 'required'
-                            },
-                            {
-                                name: 'Minimum',
-                                value: 'min'
-                            },
-                            {
-                                name: 'Maximum',
-                                value: 'max'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldType == 'byte[]' &&
-                            response.fieldTypeBlobContent != 'text';
-                        },
-                        type: 'checkbox',
-                        name: 'fieldValidateRules',
-                        message: 'Which validation rules do you want to add?',
-                        choices: [
-                            {
-                                name: 'Required',
-                                value: 'required'
-                            },
-                            {
-                                name: 'Minimum byte size',
-                                value: 'minbytes'
-                            },
-                            {
-                                name: 'Maximum byte size',
-                                value: 'maxbytes'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            (response.fieldType == 'LocalDate' ||
-                            response.fieldType == 'ZonedDateTime' ||
-                            response.fieldType == 'UUID' ||
-                            response.fieldType == 'Date' ||
-                            response.fieldType == 'Boolean' ||
-                            response.fieldTypeBlobContent == 'text' ||
-                            response.fieldIsEnum == true);
-                        },
-                        type: 'checkbox',
-                        name: 'fieldValidateRules',
-                        message: 'Which validation rules do you want to add?',
-                        choices: [
-                            {
-                                name: 'Required',
-                                value: 'required'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('minlength') != -1;
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesMinlength',
-                        validate: function(input) {
-                            if (/^([0-9]*)$/.test(input)) return true;
-                            return 'Minimum length must be a number';
-                        },
-                        message: 'What is the minimum length of your field?',
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('maxlength') != -1;
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesMaxlength',
-                        validate: function(input) {
-                            if (/^([0-9]*)$/.test(input)) return true;
-                            return 'Maximum length must be a number';
-                        },
-                        message: 'What is the maximum length of your field?',
-                        default: 20
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('pattern') != -1;
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesPattern',
-                        message: 'What is the regular expression pattern you want to apply on your field?',
-                        default: '^[a-zA-Z0-9]*$'
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('min') != -1 &&
-                            (response.fieldType == 'Integer' ||
-                            response.fieldType == 'Long' ||
-                            response.fieldType == 'Float' ||
-                            response.fieldType == 'Double' ||
-                            response.fieldTypeBlobContent == 'text' ||
-                            response.fieldType == 'BigDecimal');
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesMin',
-                        message: 'What is the minimum of your field?',
-                        validate: function(input) {
-                            if (/^([0-9]*)$/.test(input)) return true;
-                            return 'Minimum must be a number';
-                        },
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('max') != -1 &&
-                            (response.fieldType == 'Integer' ||
-                            response.fieldType == 'Long' ||
-                            response.fieldType == 'Float' ||
-                            response.fieldType == 'Double' ||
-                            response.fieldTypeBlobContent == 'text' ||
-                            response.fieldType == 'BigDecimal');
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesMax',
-                        message: 'What is the maximum of your field?',
-                        validate: function(input) {
-                            if (/^([0-9]*)$/.test(input)) return true;
-                            return 'Maximum must be a number';
-                        },
-                        default: 100
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('minbytes') != -1 &&
-                            response.fieldType == 'byte[]' &&
-                            response.fieldTypeBlobContent != 'text';
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesMinbytes',
-                        message: 'What is the minimum byte size of your field?',
-                        validate: function(input) {
-                            if (/^([0-9]*)$/.test(input)) return true;
-                            return 'Minimum byte size must be a number';
-                        },
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return response.fieldAdd == true &&
-                            response.fieldValidate == true &&
-                            response.fieldValidateRules.indexOf('maxbytes') != -1 &&
-                            response.fieldType == 'byte[]' &&
-                            response.fieldTypeBlobContent != 'text';
-                        },
-                        type: 'input',
-                        name: 'fieldValidateRulesMaxbytes',
-                        message: 'What is the maximum byte size of your field?',
-                        validate: function(input) {
-                            if (/^([0-9]*)$/.test(input)) return true;
-                            return 'Maximum byte size must be a number';
-                        },
-                        default: 5000000
-                    }
-                ];
-                _this.prompt(prompts, function(props) {
-                    if (props.fieldAdd) {
-                        if (props.fieldIsEnum) {
-                            props.fieldType = _s.capitalize(props.fieldType);
-                        }
-
-                        var field = {
-                            fieldId: this.fieldId,
-                            fieldName: props.fieldName,
-                            fieldType: props.fieldType,
-                            fieldTypeBlobContent: props.fieldTypeBlobContent,
-                            fieldValues: props.fieldValues,
-                            fieldValidateRules: props.fieldValidateRules,
-                            fieldValidateRulesMinlength: props.fieldValidateRulesMinlength,
-                            fieldValidateRulesMaxlength: props.fieldValidateRulesMaxlength,
-                            fieldValidateRulesPattern: props.fieldValidateRulesPattern,
-                            fieldValidateRulesPatternJava: props.fieldValidateRulesPattern ? props.fieldValidateRulesPattern.replace(/\\/g, '\\\\') : props.fieldValidateRulesPattern,
-                            fieldValidateRulesMin: props.fieldValidateRulesMin,
-                            fieldValidateRulesMax: props.fieldValidateRulesMax,
-                            fieldValidateRulesMinbytes: props.fieldValidateRulesMinbytes,
-                            fieldValidateRulesMaxbytes: props.fieldValidateRulesMaxbytes
-                        };
-
-                        fieldNamesUnderscored.push(_s.underscored(props.fieldName));
-                        this.fields.push(field);
-                    }
-                    _this.log(chalk.red('=================' + _s.capitalize(_this.name) + '================='));
-                    _this.fields.forEach(function(field) {
-                        var validationDetails = '';
-                        var fieldValidate = _.isArray(field.fieldValidateRules) && field.fieldValidateRules.length >= 1;
-                        if (fieldValidate == true) {
-                            if (field.fieldValidateRules.indexOf('required') != -1) {
-                                validationDetails = 'required ';
-                            }
-                            if (field.fieldValidateRules.indexOf('minlength') != -1) {
-                                validationDetails += 'minlength=\'' + field.fieldValidateRulesMinlength + '\' ';
-                            }
-                            if (field.fieldValidateRules.indexOf('maxlength') != -1) {
-                                validationDetails += 'maxlength=\'' + field.fieldValidateRulesMaxlength + '\' ';
-                            }
-                            if (field.fieldValidateRules.indexOf('pattern') != -1) {
-                                validationDetails += 'pattern=\'' + field.fieldValidateRulesPattern + '\' ';
-                            }
-                            if (field.fieldValidateRules.indexOf('min') != -1) {
-                                validationDetails += 'min=\'' + field.fieldValidateRulesMin + '\' ';
-                            }
-                            if (field.fieldValidateRules.indexOf('max') != -1) {
-                                validationDetails += 'max=\'' + field.fieldValidateRulesMax + '\' ';
-                            }
-                            if (field.fieldValidateRules.indexOf('minbytes') != -1) {
-                                validationDetails += 'minbytes=\'' + field.fieldValidateRulesMinbytes + '\' ';
-                            }
-                            if (field.fieldValidateRules.indexOf('maxbytes') != -1) {
-                                validationDetails += 'maxbytes=\'' + field.fieldValidateRulesMaxbytes + '\' ';
-                            }
-                        }
-                        this.log(chalk.red(field.fieldName) + chalk.white(' (' + field.fieldType + (field.fieldTypeBlobContent ? ' ' + field.fieldTypeBlobContent : '') + ') ') + chalk.cyan(validationDetails));
-                    }, _this);
-                    if (props.fieldAdd) {
-                        _askForField(_this);
-                    } else {
-                        cb();
-                    }
-                }.bind(_this));
-            }
-            _askForField(this);
+            }.bind(this));
         },
 
+        askForFields: function() {
+            // don't prompt if data is imported from a file
+            if (this.useConfigurationFile && this.updateEntity != 'add') {
+                return;
+            }
+            var cb = this.async();
+
+            this._askForField(cb);
+        },
+
+
         askForRelationships: function() {
-            // don't prompt if data are imported from a file
-            if (this.useConfigurationFile == true) {
+            // don't prompt if data is imported from a file
+            if (this.useConfigurationFile && this.updateEntity != 'add') {
                 return;
             }
             if (this.databaseType == 'mongodb' || this.databaseType == 'cassandra') {
                 return;
             }
-            var packageFolder = this.packageFolder;
-            var name = this.name;
+
             var cb = this.async();
-            function _askForRelationship(_this){
-                _this.relationshipId++;
-                _this.log(chalk.green('Generating relationships with other entities'));
-                var prompts = [
-                    {
-                        type: 'confirm',
-                        name: 'relationshipAdd',
-                        message: 'Do you want to add a relationship to another entity?',
-                        default: true
-                    },
-                    {
-                        when: function(response) {
-                            return response.relationshipAdd == true;
-                        },
-                        type: 'input',
-                        name: 'otherEntityName',
-                        validate: function(input) {
-                            if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
-                                return 'Your other entity name cannot contain special characters';
-                            } else if (input == '') {
-                                return 'Your other entity name cannot be empty';
-                            } else if (reservedWords_Java.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your other entity name cannot contain a Java reserved keyword';
-                            }
-                            return true;
-                        },
-                        message: 'What is the name of the other entity?'
-                    },
-                    {
-                        when: function(response) {
-                            return response.relationshipAdd == true;
-                        },
-                        type: 'input',
-                        name: 'relationshipName',
-                        validate: function(input) {
-                            if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
-                                return 'Your relationship cannot contain special characters';
-                            } else if (input == '') {
-                                return 'Your relationship cannot be empty';
-                            } else if (input == 'id' || fieldNamesUnderscored.indexOf(_s.underscored(input)) != -1) {
-                                return 'Your relationship cannot use an already existing field name';
-                            } else if (reservedWords_Java.indexOf(input.toUpperCase()) != -1) {
-                                return 'Your relationship cannot contain a Java reserved keyword';
-                            }
-                            return true;
-                        },
-                        message: 'What is the name of the relationship?',
-                        default: function(response) {
-                            return _s.decapitalize(response.otherEntityName);
-                        }
-                    },
-                    {
-                        when: function(response) {
-                            return response.relationshipAdd == true;
-                        },
-                        type: 'list',
-                        name: 'relationshipType',
-                        message: 'What is the type of the relationship?',
-                        choices: [
-                            {
-                                value: 'one-to-many',
-                                name: 'one-to-many'
-                            },
-                            {
-                                value: 'many-to-one',
-                                name: 'many-to-one'
-                            },
-                            {
-                                value: 'many-to-many',
-                                name: 'many-to-many'
-                            },
-                            {
-                                value: 'one-to-one',
-                                name: 'one-to-one'
-                            }
-                        ],
-                        default: 0
-                    },
-                    {
-                        when: function(response) {
-                            return (response.relationshipAdd == true && response.relationshipType == 'many-to-one' && !shelljs.test('-f', 'src/main/java/' + packageFolder + '/domain/' + _s.capitalize(response.otherEntityName) + '.java'))
-                        },
-                        type: 'confirm',
-                        name: 'noOtherEntity',
-                        message: 'WARNING! You are trying to generate a many-to-one relationship on an entity that does not exist. This will probably fail, as you will need to create a foreign key on a table that does not exist. We advise you to create the other side of this relationship first (do the one-to-many before the many-to-one relationship). Are you sure you want to continue?',
-                        default: false
-                    },
-                    {
-                        when: function(response) {
-                            return (response.relationshipAdd == true && (response.relationshipType == 'many-to-many' || response.relationshipType == 'one-to-one'));
-                        },
-                        type: 'confirm',
-                        name: 'ownerSide',
-                        message: 'Is this entity the owner of the relationship?',
-                        default: false
-                    },
-                    {
-                        when: function(response) {
-                            return (response.relationshipAdd == true && (response.relationshipType == 'one-to-many' ||
-                            (response.relationshipType == 'many-to-many' && response.ownerSide == false) ||
-                            (response.relationshipType == 'one-to-one' && response.otherEntityName.toLowerCase() != "user")));
-                        },
-                        type: 'input',
-                        name: 'otherEntityRelationshipName',
-                        message: 'What is the name of this relationship in the other entity?',
-                        default: function(response) {
-                            return _s.decapitalize(name);
-                        }
-                    },
-                    {
-                        when: function(response) {
-                            return (response.relationshipAdd == true && response.ownerSide == true && !shelljs.test('-f', 'src/main/java/' + packageFolder + '/domain/' + _s.capitalize(response.otherEntityName) + '.java'))
-                        },
-                        type: 'confirm',
-                        name: 'noOtherEntity2',
-                        message: 'WARNING! You have selected that this entity is the owner of a relationship on another entity, that does not exist yet. This will probably fail, as you will need to create a foreign key on a table that does not exist. We advise you to create the other side of this relationship first (do the non-owning side before the owning side). Are you sure you want to continue?',
-                        default: false
-                    },
-                    {
-                        when: function(response) {
-                            return (!(response.noOtherEntity == false || response.noOtherEntity2 == false) && response.relationshipAdd == true && (response.relationshipType == 'many-to-one' || (response.relationshipType == 'many-to-many' && response.ownerSide == true) || (response.relationshipType == 'one-to-one' && response.ownerSide == true)));
-                        },
-                        type: 'input',
-                        name: 'otherEntityField',
-                        message: function(response) {
-                            return 'When you display this relationship with AngularJS, which field from \'' + response.otherEntityName + '\' do you want to use?'
-                        },
-                        default: 'id'
-                    }
-                ];
-                _this.prompt(prompts, function(props) {
-                    if (props.noOtherEntity == false || props.noOtherEntity2 == false) {
-                        _this.log(chalk.red('Generation aborted, as requested by the user.'));
-                        return;
-                    }
-                    if (props.relationshipAdd) {
-                        var relationship = {
-                            relationshipId: _this.relationshipId,
-                            relationshipName: props.relationshipName,
-                            otherEntityName: _s.decapitalize(props.otherEntityName),
-                            relationshipType: props.relationshipType,
-                            otherEntityField: props.otherEntityField,
-                            ownerSide: props.ownerSide,
-                            otherEntityRelationshipName: props.otherEntityRelationshipName
-                        }
-                        fieldNamesUnderscored.push(_s.underscored(props.relationshipName));
-                        _this.relationships.push(relationship);
-                    }
-                    _this.log(chalk.red('===========' + _s.capitalize(_this.name) + '=============='));
-                    _this.fields.forEach(function(field) {
-                        this.log(chalk.red(field.fieldName + ' (' + field.fieldType + (field.fieldTypeBlobContent ? ' ' + field.fieldTypeBlobContent : '') + ')'));
-                    }, _this);
-                    _this.log(chalk.red('-------------------'));
-                    _this.relationships.forEach(function(relationship) {
-                        this.log(chalk.red(relationship.relationshipName + ' - ' + relationship.otherEntityName + ' (' + relationship.relationshipType + ')'));
-                    }, _this);
-                    if (props.relationshipAdd) {
-                        _askForRelationship(_this);
-                    } else {
-                        cb();
-                    }
-                }.bind(_this));
-            }
-            _askForRelationship(this);
+
+            this._askForRelationship(cb);
         },
 
         askForDTO: function() {
-            // don't prompt if data are imported from a file
-            if (this.useConfigurationFile == true) {
+            // don't prompt if data is imported from a file
+            if (this.useConfigurationFile) {
                 return;
             }
             var cb = this.async();
@@ -887,7 +956,7 @@ module.exports = EntityGenerator.extend({
 
         askForService: function() {
             // don't prompt if data are imported from a file
-            if (this.useConfigurationFile == true) {
+            if (this.useConfigurationFile) {
                 return;
             }
             var cb = this.async();
@@ -921,7 +990,7 @@ module.exports = EntityGenerator.extend({
 
         askForPagination: function() {
             // don't prompt if data are imported from a file
-            if (this.useConfigurationFile == true) {
+            if (this.useConfigurationFile) {
                 return;
             }
             if (this.databaseType == 'cassandra') {
@@ -998,142 +1067,122 @@ module.exports = EntityGenerator.extend({
             };
         },
 
-        validate: function() {
+        validateFile: function() {
 
-            if (this.useConfigurationFile == false) { // store informations in a file for further use.
-                if (this.databaseType == "sql" || this.databaseType == "cassandra") {
-                    this.changelogDate = this.dateFormatForLiquibase();
-                }
-                this.data = {};
-                this.data.relationships = this.relationships;
-                this.data.fields = this.fields;
-                this.data.changelogDate = this.changelogDate;
-                this.data.dto = this.dto;
-                this.data.service = this.service;
-                if (databaseType == 'sql' || databaseType == 'mongodb') {
-                    this.data.pagination = this.pagination;
-                }
-                this.write(this.filename, JSON.stringify(this.data, null, 4));
-            } else {
-                this.relationships = this.fileData.relationships;
-                this.fields = this.fileData.fields;
-                this.changelogDate = this.fileData.changelogDate;
-                this.dto = this.fileData.dto;
-                this.service = this.fileData.service;
-                this.pagination = this.fileData.pagination;
-                this.javadoc = this.fileData.javadoc;
-
-                // Validate entity json field content
-                for (var idx in this.fields) {
-                    var field = this.fields[idx];
-                    if (_.isUndefined(field.fieldId)) {
-                        this.env.error(chalk.red('ERROR fieldId is missing in .jhipster/' + this.name + '.json for field ' + JSON.stringify(field, null, 4)));
-                    }
-
-                    if (_.isUndefined(field.fieldName)) {
-                        this.env.error(chalk.red('ERROR fieldName is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                    }
-
-                    if (_.isUndefined(field.fieldType)) {
-                        this.env.error(chalk.red('ERROR fieldType is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                    }
-
-                    if (!_.isUndefined(field.fieldValidateRules)) {
-                        if (!_.isArray(field.fieldValidateRules)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRules is not an array in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        for (var idxRules in field.fieldValidateRules) {
-                            var fieldValidateRule = field.fieldValidateRules[idxRules];
-                            if (!_.contains(supportedValidationRules, fieldValidateRule)) {
-                                this.env.error(chalk.red('ERROR fieldValidateRules contains unknown validation rule ' + fieldValidateRule + ' in .jhipster/' + this.name + '.json for field with id ' + field.fieldId + ' [supported validation rules ' + supportedValidationRules + ']'));
-                            }
-                        }
-                        if (_.contains(field.fieldValidateRules, 'max') && _.isUndefined(field.fieldValidateRulesMax)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesMax is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        if (_.contains(field.fieldValidateRules, 'min') && _.isUndefined(field.fieldValidateRulesMin)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesMin is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        if (_.contains(field.fieldValidateRules, 'maxlength') && _.isUndefined(field.fieldValidateRulesMaxlength)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesMaxlength is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        if (_.contains(field.fieldValidateRules, 'minlength') && _.isUndefined(field.fieldValidateRulesMinlength)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesMinlength is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        if (_.contains(field.fieldValidateRules, 'maxbytes') && _.isUndefined(field.fieldValidateRulesMaxbytes)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesMaxbytes is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        if (_.contains(field.fieldValidateRules, 'minbytes') && _.isUndefined(field.fieldValidateRulesMinbytes)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesMinbytes is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                        if (_.contains(field.fieldValidateRules, 'pattern') && _.isUndefined(field.fieldValidateRulesPattern)) {
-                            this.env.error(chalk.red('ERROR fieldValidateRulesPattern is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
-                        }
-                    }
+            if (!this.useConfigurationFile) {
+                return;
+            }
+            // Validate entity json field content
+            for (var idx in this.fields) {
+                var field = this.fields[idx];
+                if (_.isUndefined(field.fieldId)) {
+                    this.env.error(chalk.red('ERROR fieldId is missing in .jhipster/' + this.name + '.json for field ' + JSON.stringify(field, null, 4)));
                 }
 
-                // Validate entity json relationship content
-                for (var idx in this.relationships) {
-                    var relationship = this.relationships[idx];
-                    if (_.isUndefined(relationship.relationshipId)) {
-                        this.env.error(chalk.red('ERROR relationshipId is missing in .jhipster/' + this.name + '.json for relationship ' + JSON.stringify(relationship, null, 4)));
-                    }
-
-                    if (_.isUndefined(relationship.relationshipName)) {
-                        relationship.relationshipName = relationship.otherEntityName;
-                        this.log(chalk.yellow('WARNING relationshipName is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId + ', using ' + relationship.otherEntityName + ' as fallback'));
-                    }
-
-                    if (_.isUndefined(relationship.otherEntityName)) {
-                        this.env.error(chalk.red('ERROR otherEntityName is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId));
-                    }
-
-                    if (_.isUndefined(relationship.otherEntityRelationshipName)
-                    && (relationship.relationshipType == 'one-to-many' || (relationship.relationshipType == 'many-to-many' && relationship.ownerSide == false) || (relationship.relationshipType == 'one-to-one'))) {
-                        relationship.otherEntityRelationshipName = _s.decapitalize(this.name);
-                        this.log(chalk.yellow('WARNING otherEntityRelationshipName is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId + ', using ' + _s.decapitalize(this.name) + ' as fallback'));
-                    }
-
-                    if (_.isUndefined(relationship.otherEntityField)
-                    && (relationship.relationshipType == 'many-to-one' || (relationship.relationshipType == 'many-to-many' && relationship.ownerSide == true) || (relationship.relationshipType == 'one-to-one' && relationship.ownerSide == true))) {
-                        this.log(chalk.yellow('WARNING otherEntityField is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId + ', using id as fallback'));
-                        relationship.otherEntityField = 'id';
-                    }
-
-                    if (_.isUndefined(relationship.relationshipType)) {
-                        this.env.error(chalk.red('ERROR relationshipType is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId));
-                    }
-
-                    if (_.isUndefined(relationship.ownerSide)
-                    && (relationship.relationshipType == 'one-to-one' || relationship.relationshipType == 'many-to-many')) {
-                        this.env.error(chalk.red('ERROR ownerSide is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId));
-                    }
+                if (_.isUndefined(field.fieldName)) {
+                    this.env.error(chalk.red('ERROR fieldName is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
                 }
 
-                // Validate root entity json content
-                if (_.isUndefined(this.changelogDate)
-                && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
-                    var currentDate = this.dateFormatForLiquibase();
-                    this.log(chalk.yellow('WARNING changelogDate is missing in .jhipster/' + this.name + '.json, using ' + currentDate + ' as fallback'));
-                    this.changelogDate = currentDate;
+                if (_.isUndefined(field.fieldType)) {
+                    this.env.error(chalk.red('ERROR fieldType is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
                 }
-                if (_.isUndefined(this.dto)) {
-                    this.log(chalk.yellow('WARNING dto is missing in .jhipster/' + this.name + '.json, using no as fallback'));
-                    this.dto = 'no';
-                }
-                if (_.isUndefined(this.service)) {
-                    this.log(chalk.yellow('WARNING service is missing in .jhipster/' + this.name + '.json, using no as fallback'));
-                    this.service = 'no';
-                }
-                if (_.isUndefined(this.pagination)) {
-                    if (databaseType == 'sql' || databaseType == 'mongodb') {
-                        this.log(chalk.yellow('WARNING pagination is missing in .jhipster/' + this.name + '.json, using no as fallback'));
-                        this.pagination = 'no';
-                    } else {
-                        this.pagination = 'no';
+
+                if (!_.isUndefined(field.fieldValidateRules)) {
+                    if (!_.isArray(field.fieldValidateRules)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRules is not an array in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    for (var idxRules in field.fieldValidateRules) {
+                        var fieldValidateRule = field.fieldValidateRules[idxRules];
+                        if (!_.contains(SUPPORTED_VALIDATION_RULES, fieldValidateRule)) {
+                            this.env.error(chalk.red('ERROR fieldValidateRules contains unknown validation rule ' + fieldValidateRule + ' in .jhipster/' + this.name + '.json for field with id ' + field.fieldId + ' [supported validation rules ' + SUPPORTED_VALIDATION_RULES + ']'));
+                        }
+                    }
+                    if (_.contains(field.fieldValidateRules, 'max') && _.isUndefined(field.fieldValidateRulesMax)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesMax is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    if (_.contains(field.fieldValidateRules, 'min') && _.isUndefined(field.fieldValidateRulesMin)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesMin is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    if (_.contains(field.fieldValidateRules, 'maxlength') && _.isUndefined(field.fieldValidateRulesMaxlength)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesMaxlength is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    if (_.contains(field.fieldValidateRules, 'minlength') && _.isUndefined(field.fieldValidateRulesMinlength)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesMinlength is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    if (_.contains(field.fieldValidateRules, 'maxbytes') && _.isUndefined(field.fieldValidateRulesMaxbytes)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesMaxbytes is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    if (_.contains(field.fieldValidateRules, 'minbytes') && _.isUndefined(field.fieldValidateRulesMinbytes)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesMinbytes is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
+                    }
+                    if (_.contains(field.fieldValidateRules, 'pattern') && _.isUndefined(field.fieldValidateRulesPattern)) {
+                        this.env.error(chalk.red('ERROR fieldValidateRulesPattern is missing in .jhipster/' + this.name + '.json for field with id ' + field.fieldId));
                     }
                 }
             }
+
+            // Validate entity json relationship content
+            for (var idx in this.relationships) {
+                var relationship = this.relationships[idx];
+                if (_.isUndefined(relationship.relationshipId)) {
+                    this.env.error(chalk.red('ERROR relationshipId is missing in .jhipster/' + this.name + '.json for relationship ' + JSON.stringify(relationship, null, 4)));
+                }
+
+                if (_.isUndefined(relationship.relationshipName)) {
+                    relationship.relationshipName = relationship.otherEntityName;
+                    this.log(chalk.yellow('WARNING relationshipName is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId + ', using ' + relationship.otherEntityName + ' as fallback'));
+                }
+
+                if (_.isUndefined(relationship.otherEntityName)) {
+                    this.env.error(chalk.red('ERROR otherEntityName is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId));
+                }
+
+                if (_.isUndefined(relationship.otherEntityRelationshipName)
+                && (relationship.relationshipType == 'one-to-many' || (relationship.relationshipType == 'many-to-many' && relationship.ownerSide == false) || (relationship.relationshipType == 'one-to-one'))) {
+                    relationship.otherEntityRelationshipName = _s.decapitalize(this.name);
+                    this.log(chalk.yellow('WARNING otherEntityRelationshipName is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId + ', using ' + _s.decapitalize(this.name) + ' as fallback'));
+                }
+
+                if (_.isUndefined(relationship.otherEntityField)
+                && (relationship.relationshipType == 'many-to-one' || (relationship.relationshipType == 'many-to-many' && relationship.ownerSide == true) || (relationship.relationshipType == 'one-to-one' && relationship.ownerSide == true))) {
+                    this.log(chalk.yellow('WARNING otherEntityField is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId + ', using id as fallback'));
+                    relationship.otherEntityField = 'id';
+                }
+
+                if (_.isUndefined(relationship.relationshipType)) {
+                    this.env.error(chalk.red('ERROR relationshipType is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId));
+                }
+
+                if (_.isUndefined(relationship.ownerSide)
+                && (relationship.relationshipType == 'one-to-one' || relationship.relationshipType == 'many-to-many')) {
+                    this.env.error(chalk.red('ERROR ownerSide is missing in .jhipster/' + this.name + '.json for relationship with id ' + relationship.relationshipId));
+                }
+            }
+
+            // Validate root entity json content
+            if (_.isUndefined(this.changelogDate)
+            && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
+                var currentDate = this.dateFormatForLiquibase();
+                this.log(chalk.yellow('WARNING changelogDate is missing in .jhipster/' + this.name + '.json, using ' + currentDate + ' as fallback'));
+                this.changelogDate = currentDate;
+            }
+            if (_.isUndefined(this.dto)) {
+                this.log(chalk.yellow('WARNING dto is missing in .jhipster/' + this.name + '.json, using no as fallback'));
+                this.dto = 'no';
+            }
+            if (_.isUndefined(this.service)) {
+                this.log(chalk.yellow('WARNING service is missing in .jhipster/' + this.name + '.json, using no as fallback'));
+                this.service = 'no';
+            }
+            if (_.isUndefined(this.pagination)) {
+                if (databaseType == 'sql' || databaseType == 'mongodb') {
+                    this.log(chalk.yellow('WARNING pagination is missing in .jhipster/' + this.name + '.json, using no as fallback'));
+                    this.pagination = 'no';
+                } else {
+                    this.pagination = 'no';
+                }
+            }
+
         },
 
         LoadInMemoryData: function() {
@@ -1313,6 +1362,26 @@ module.exports = EntityGenerator.extend({
     },
 
     writing : {
+        writeEntityJson: function () {
+            if (this.useConfigurationFile && this.updateEntity == 'rewrite') {
+                return;
+            }
+             // store informations in a file for further use.
+            if (this.useConfigurationFile && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
+                this.changelogDate = this.dateFormatForLiquibase();
+            }
+            this.data = {};
+            this.data.relationships = this.relationships;
+            this.data.fields = this.fields;
+            this.data.changelogDate = this.changelogDate;
+            this.data.dto = this.dto;
+            this.data.service = this.service;
+            if (databaseType == 'sql' || databaseType == 'mongodb') {
+                this.data.pagination = this.pagination;
+            }
+            this.fs.writeJSON(this.filename, this.data, null, 4);
+        },
+
         writeEnumFiles: function() {
 
             for (var fieldIdx in this.fields) {


### PR DESCRIPTION
This is somewhat inline with what @jdubois suggested in #2668 

When running `yo jhipster:entity` on an existing entity the below options are given

- If the user did a `yo jhipster:entity Foo --force` entity is regenerated directly (like we already do)
- Otherwise a new question is asked `Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwriiten` this will have options 
    * Yes, re generate the entity
    * [BETA] Yes, add more fields and relationships
    * [BETA] Yes, remove fields and relationships
    * No, exit
- If Add is selected, use the current options for creating an attribute/relation
- If Remove is selected, give choice to select attributes/relations and remove the selected attribute/relation, this will reset the `fieldId` and `relationshipId` of existing items

Additionally have moved helper methods outside prompt methods for better readability and reuse
have also renamed the naming style for all constants used in entity and main generators

fix #2668 
