### PR TITLE
Remove translation from projects without translation enabled

### DIFF
--- a/app/templates/src/main/webapp/scripts/app/account/password/_password.directive.js
+++ b/app/templates/src/main/webapp/scripts/app/account/password/_password.directive.js
@@ -7,7 +7,7 @@ angular.module('<%=angularAppName%>')
             replace: true,
             restrict: 'E',
             template: '<div id="strength">' +
-                '<small translate="global.messages.validate.newpassword.strength">Password strength:</small>' +
+                '<small<% if(enableTranslation){ %> translate="global.messages.validate.newpassword.strength"<% } %>>Password strength:</small>' +
                 '<ul id="strengthBar">' +
                 '<li class="point"></li><li class="point"></li><li class="point"></li><li class="point"></li><li class="point"></li>' +
                 '</ul>' +

--- a/app/templates/src/main/webapp/scripts/app/account/password/_password.directive.js
+++ b/app/templates/src/main/webapp/scripts/app/account/password/_password.directive.js
@@ -7,7 +7,7 @@ angular.module('<%=angularAppName%>')
             replace: true,
             restrict: 'E',
             template: '<div id="strength">' +
-                '<small<% if(enableTranslation){ %> translate="global.messages.validate.newpassword.strength"<% } %>>Password strength:</small>' +
+                '<small<% if (enableTranslation) { %> translate="global.messages.validate.newpassword.strength"<% } %>>Password strength:</small>' +
                 '<ul id="strengthBar">' +
                 '<li class="point"></li><li class="point"></li><li class="point"></li><li class="point"></li><li class="point"></li>' +
                 '</ul>' +

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -17,7 +17,7 @@
             <div class="col-xs-8 no-padding-right">
                 <form name="searchForm" class="form-inline">
                     <div class="input-group pull-right" >
-                        <input type="text" class="form-control" ng-model="searchQuery" id="searchQuery" placeholder="<% if(enableTranslation){ %>{{ '<%= keyPrefix %>home.search' | translate }}<%}else{ %>Query<% } %>">
+                        <input type="text" class="form-control" ng-model="searchQuery" id="searchQuery" placeholder="<% if (enableTranslation) { %>{{ '<%= keyPrefix %>home.search' | translate }}<% } else { %>Query<% } %>">
                         <span  class="input-group-btn width-min" >
                             <button class="btn btn-info" ng-click="search()">
                                 <span class="glyphicon glyphicon-search"></span>

--- a/entity/templates/src/main/webapp/app/_entities.html
+++ b/entity/templates/src/main/webapp/app/_entities.html
@@ -17,7 +17,7 @@
             <div class="col-xs-8 no-padding-right">
                 <form name="searchForm" class="form-inline">
                     <div class="input-group pull-right" >
-                        <input type="text" class="form-control" ng-model="searchQuery" id="searchQuery" placeholder="{{ '<%= keyPrefix %>home.search' | translate }}">
+                        <input type="text" class="form-control" ng-model="searchQuery" id="searchQuery" placeholder="<% if(enableTranslation){ %>{{ '<%= keyPrefix %>home.search' | translate }}<%}else{ %>Query<% } %>">
                         <span  class="input-group-btn width-min" >
                             <button class="btn btn-info" ng-click="search()">
                                 <span class="glyphicon glyphicon-search"></span>


### PR DESCRIPTION
Remove the translate filter from the entity listings page (breaks the JS currently) and remove the translation from the password directive, for projects without translation enabled.

Fix #2698
