### PR TITLE
add entity update feature

### DIFF
--- a/entity/index.js
+++ b/entity/index.js
@@ -34,7 +34,7 @@ var enums = [];
 var existingEnum = false;
 
 var fieldNamesUnderscored = ['id'];
-var fieldNameChoices = [], relNameChoices = [];
+var fieldNameChoices = [], relNameChoices = []; // this variable will hold field and relationship names for question options during update
 var databaseType;
 var prodDatabaseType;
 const INTERPOLATE_REGEX = /<%=([\s\S]+?)%>/g; // so that thymeleaf tags in templates do not get mistreated as _ templates

--- a/entity/index.js
+++ b/entity/index.js
@@ -957,9 +957,11 @@ module.exports = EntityGenerator.extend({
 
     prompting: {
         /* pre entity hook needs to be written here */
+        /* ask question to user if s/he wants to update entity */
         askForUpdate: function () {
             // ask only if running an existing entity without arg option --force
             var isForce = this.options['force'];
+            this.updateEntity == 'rewrite'; // default if skipping questions by --force
             if (isForce || !this.useConfigurationFile) {
                 return;
             }
@@ -1311,7 +1313,7 @@ module.exports = EntityGenerator.extend({
 
         writeEntityJson: function () {
             if (this.useConfigurationFile && this.updateEntity == 'rewrite') {
-                return;
+                return; //do not update if regenerating entity
             }
              // store informations in a file for further use.
             if (!this.useConfigurationFile && (this.databaseType == "sql" || this.databaseType == "cassandra")) {
@@ -1493,7 +1495,7 @@ module.exports = EntityGenerator.extend({
         },
 
         insight: function() {
-
+            // track insights
             var insight = this.insight();
 
             insight.track('generator', 'entity');
@@ -1654,7 +1656,7 @@ module.exports = EntityGenerator.extend({
             try {
                 var modules = this.getModuleHooks();
                 if (modules.length > 0) {
-                    this.log('\n' + chalk.bold.green('Running post run module hooks\n'));
+                    this.log('\n' + chalk.bold.green('\nRunning post run module hooks\n'));
                     // form the data to be passed to modules
                     var entityConfig = {
                         jhipsterConfigDirectory: this.jhipsterConfigDirectory,

--- a/entity/index.js
+++ b/entity/index.js
@@ -1656,7 +1656,7 @@ module.exports = EntityGenerator.extend({
             try {
                 var modules = this.getModuleHooks();
                 if (modules.length > 0) {
-                    this.log('\n' + chalk.bold.green('\nRunning post run module hooks\n'));
+                    this.log('\n' + chalk.bold.green('Running post run module hooks\n'));
                     // form the data to be passed to modules
                     var entityConfig = {
                         jhipsterConfigDirectory: this.jhipsterConfigDirectory,

--- a/entity/index.js
+++ b/entity/index.js
@@ -123,7 +123,8 @@ module.exports = EntityGenerator.extend({
 
         setupVars: function() {
             // Specific Entity sub-generator variables
-            if (this.useConfigurationFile == false) {
+            if (!this.useConfigurationFile) {
+                //no file present, new entity creation
                 this.log(chalk.red('\nThe entity ' + this.name + ' is being created.\n'));
                 this.fieldId = 0;
                 this.fields = [];
@@ -134,6 +135,7 @@ module.exports = EntityGenerator.extend({
                 this.dto = 'no';
                 this.service = 'no';
             } else {
+                //existing entity reading values from file
                 this.log(chalk.red('\nThe entity ' + this.name + ' is being updated.\n'));
                 this.fieldId = this.fileData.fields? this.fileData.fields.length : 0;
                 this.relationshipId = this.fileData.relationships? this.fileData.relationships.length : 0;
@@ -156,6 +158,9 @@ module.exports = EntityGenerator.extend({
     },
 
     /* private Helper methods */
+    /**
+     * ask question for a field creation
+     */
     _askForField : function(cb){
         this.fieldId++;
         this.log(chalk.green('\nGenerating field #' + this.fieldId + '\n'));
@@ -690,7 +695,9 @@ module.exports = EntityGenerator.extend({
             }
         }.bind(this));
     },
-
+    /**
+     * ask question for field deletion
+     */
     _askForFieldsToRemove : function(cb){
         var prompts = [
             {
@@ -732,7 +739,9 @@ module.exports = EntityGenerator.extend({
 
         }.bind(this));
     },
-
+    /**
+     * ask question for a relationship creation
+     */
     _askForRelationship: function(cb){
         var packageFolder = this.packageFolder;
         var name = this.name;
@@ -899,7 +908,9 @@ module.exports = EntityGenerator.extend({
             }
         }.bind(this));
     },
-
+    /**
+     * ask question for relationship deletion
+     */
     _askForRelationsToRemove : function(cb){
         var prompts = [
             {

--- a/entity/index.js
+++ b/entity/index.js
@@ -900,6 +900,48 @@ module.exports = EntityGenerator.extend({
         }.bind(this));
     },
 
+    _askForRelationsToRemove : function(cb){
+        var prompts = [
+            {
+                type: 'checkbox',
+                name: 'relsToRemove',
+                message: 'Please choose the relationships you want to remove',
+                choices: relNameChoices,
+                default: 'none'
+            },
+            {
+                when: function(response) {
+                    return response.relsToRemove != 'none';
+                },
+                type: 'confirm',
+                name: 'confirmRemove',
+                message: 'Are you sure to remove these relationships?',
+                default: true
+            }
+        ];
+        this.prompt(prompts, function(props) {
+            if (props.confirmRemove) {
+                this.log(chalk.red('\nRemoving relationships: ' + props.relsToRemove + '\n'));
+                var i;
+                for (i = this.relationships.length - 1; i >= 0; i -= 1) {
+                    var rel = this.relationships[i];
+                    if(props.relsToRemove.filter(function (val) {
+                        return val == rel.relationshipName + ':' + rel.relationshipType;
+                    }).length > 0){
+                        this.relationships.splice(i, 1);
+                    }
+                }
+                //reset filed IDs
+                for (i = 0; i < this.relationships.length; i++) {
+                    this.relationships[i].relationshipId = i;
+                }
+                this.relationshipId = this.relationships.length;
+            }
+            cb();
+
+        }.bind(this));
+    },
+
     /* end of Helper methods */
 
     prompting: {

--- a/entity/index.js
+++ b/entity/index.js
@@ -986,6 +986,9 @@ module.exports = EntityGenerator.extend({
                 }
                 cb();
 
+            }.bind(this));
+        },
+
         askForFields: function() {
             // don't prompt if data is imported from a file
             if (this.useConfigurationFile && this.updateEntity != 'add') {
@@ -1296,7 +1299,7 @@ module.exports = EntityGenerator.extend({
         },
 
         writeEntityJson: function () {
-            if (this.useConfigurationFile) {
+            if (this.useConfigurationFile && this.updateEntity == 'rewrite') {
                 return;
             }
              // store informations in a file for further use.

--- a/entity/index.js
+++ b/entity/index.js
@@ -722,7 +722,7 @@ module.exports = EntityGenerator.extend({
                         this.fields.splice(i, 1);
                     }
                 }
-                //reset filed IDs
+                //reset field IDs
                 for (i = 0; i < this.fields.length; i++) {
                     this.fields[i].fieldId = i;
                 }
@@ -931,7 +931,7 @@ module.exports = EntityGenerator.extend({
                         this.relationships.splice(i, 1);
                     }
                 }
-                //reset filed IDs
+                //reset relationship IDs
                 for (i = 0; i < this.relationships.length; i++) {
                     this.relationships[i].relationshipId = i;
                 }

--- a/entity/index.js
+++ b/entity/index.js
@@ -981,6 +981,20 @@ module.exports = EntityGenerator.extend({
             this._askForRelationship(cb);
         },
 
+        askForRelationsToRemove: function() {
+            // prompt only if data is imported from a file
+            if (!this.useConfigurationFile || this.updateEntity != 'remove') {
+                return;
+            }
+            if (this.databaseType == 'mongodb' || this.databaseType == 'cassandra') {
+                return;
+            }
+
+            var cb = this.async();
+
+            this._askForRelationsToRemove(cb);
+        },
+
         askForDTO: function() {
             // don't prompt if data is imported from a file
             if (this.useConfigurationFile) {

--- a/entity/index.js
+++ b/entity/index.js
@@ -957,6 +957,16 @@ module.exports = EntityGenerator.extend({
             this._askForField(cb);
         },
 
+        askForFieldsToRemove: function() {
+            // prompt only if data is imported from a file
+            if (!this.useConfigurationFile || this.updateEntity != 'remove') {
+                return;
+            }
+            var cb = this.async();
+
+            this._askForFieldsToRemove(cb);
+        },
+
         askForRelationships: function() {
             // don't prompt if data is imported from a file
             if (this.useConfigurationFile && this.updateEntity != 'add') {

--- a/entity/index.js
+++ b/entity/index.js
@@ -946,6 +946,45 @@ module.exports = EntityGenerator.extend({
 
     prompting: {
         /* pre entity hook needs to be written here */
+        askForUpdate: function () {
+            // ask only if running an existing entity without arg option --force
+            var isForce = this.options['force'];
+            if (isForce || !this.useConfigurationFile) {
+                return;
+            }
+            var cb = this.async();
+            var prompts = [
+                {
+                    type: 'list',
+                    name: 'updateEntity',
+                    message: 'Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwritten',
+                    choices: [
+                        {
+                            value: 'rewrite',
+                            name: 'Yes, re generate the entity'
+                        },
+                        {
+                            value: 'add',
+                            name: '[BETA] Yes, add more fields and relationships'
+                        },
+                        {
+                            value: 'remove',
+                            name: '[BETA] Yes, remove fields and relationships'
+                        },
+                        {
+                            value: 'none',
+                            name: 'No, exit'
+                        },
+                    ],
+                    default: 0
+                }
+            ];
+            this.prompt(prompts, function(props) {
+                this.updateEntity = props.updateEntity;
+                if(this.updateEntity == 'none'){
+                    this.env.error(chalk.green('Aborting entity update, no changes were made.'));
+                }
+                cb();
 
         askForFields: function() {
             // don't prompt if data is imported from a file


### PR DESCRIPTION
This is somewhat inline with what @jdubois suggested in #2668 

When running `yo jhipster:entity` on an existing entity the below options are given

- If the user did a `yo jhipster:entity Foo --force` entity is regenerated directly (like we already do)
- Otherwise a new question is asked `Do you want to update the entity? This will replace the existing files for this entity, all your custom code will be overwriiten` this will have options 
    * Yes, re generate the entity
    * [BETA] Yes, add more fields and relationships
    * [BETA] Yes, remove fields and relationships
    * No, exit
- If Add is selected, use the current options for creating an attribute/relation
- If Remove is selected, give choice to select attributes/relations and remove the selected attribute/relation, this will reset the `fieldId` and `relationshipId` of existing items

fix #2668 
