### PR TITLE
only remove files once when updating jhipster

### DIFF
--- a/app/cleanup.js
+++ b/app/cleanup.js
@@ -1,0 +1,60 @@
+'use strict';
+
+module.exports = {
+    cleanupOldFiles: cleanupOldFiles
+};
+
+/**
+ * Removes files that where generated in previous JHipster versions and therefore needs to be removed
+ */
+function cleanupOldFiles(generator) {
+    if (generator.isJhipsterVersionLessThan('2.27.1')) {
+        generator.removefile(generator.JAVA_DIR + 'config/MailConfiguration.java');
+        generator.removefile(generator.JAVA_DIR + 'config/metrics/JavaMailHealthIndicator.java');
+        if (generator.databaseType == 'sql' || generator.databaseType == 'mongodb') {
+            generator.removefolder(generator.JAVA_DIR + 'config/metrics');
+        }
+
+        generator.removefile(generator.JAVA_DIR + 'security/_CustomUserDetails.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/CustomLocalDateSerializer.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/CustomDateTimeSerializer.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/CustomDateTimeDeserializer.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/CustomLocalDateDeserializer.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/DateToZonedDateTimeConverter.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/ZonedDateTimeToDateConverter.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/DateToLocalDateConverter.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/LocalDateToDateConverter.java');
+        generator.removefile(generator.JAVA_DIR + 'domain/util/ISO8601LocalDateDeserializer.java');
+        generator.removefolder(generator.JAVA_DIR + 'web/propertyeditors');
+
+        generator.removefile(generator.RESOURCE_DIR + 'logback.xml');
+
+        generator.removefile(generator.WEBAPP_DIR + 'scripts/app/account/logout/logout.js');
+        generator.removefile(generator.WEBAPP_DIR + 'scripts/app/account/logout/logout.controller.js');
+        generator.removefolder(generator.WEBAPP_DIR + 'scripts/app/account/logout');
+
+        generator.removefile(generator.TEST_DIR + 'config/MongoConfiguration.java');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/app/account/health/healthControllerSpec.js');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/app/account/login/loginControllerSpec.js');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/app/account/password/passwordControllerSpec.js');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/app/account/password/passwordDirectiveSpec.js');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/app/account/sessions/sessionsControllerSpec.js');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/app/account/settings/settingsControllerSpec.js');
+        generator.removefile(generator.TEST_JS_DIR + 'spec/components/auth/authServicesSpec.js');
+
+        generator.removefile('docker-compose.yml');
+        generator.removefile('docker-compose-prod.yml');
+        generator.removefile('Cassandra-Dev.Dockerfile');
+        generator.removefile('Cassandra-Prod.Dockerfile');
+        generator.removefolder('docker/');
+
+        generator.removefile('gatling.gradle');
+        generator.removefile('liquibase.gradle');
+        generator.removefile('mapstruct.gradle');
+        generator.removefile('profile_dev.gradle');
+        generator.removefile('profile_fast.gradle');
+        generator.removefile('profile_prod.gradle');
+        generator.removefile('sonar.gradle');
+        generator.removefile('yeoman.gradle');
+    }
+}

--- a/app/index.js
+++ b/app/index.js
@@ -1402,7 +1402,7 @@ module.exports = JhipsterGenerator.extend({
             var javaDir = this.javaDir;
             var testDir = this.testDir;
             // Remove old files, from previous JHipster versions
-            if (this.installedVersionIsLessThan('2.27.1', this.jhipsterVersion)) {
+            if (this.isVersionLessThan('2.27.1', this.jhipsterVersion)) {
                 this.removefile(javaDir + 'config/MailConfiguration.java');
                 this.removefile(javaDir + 'config/metrics/JavaMailHealthIndicator.java');
                 if (this.databaseType == 'sql' || this.databaseType == 'mongodb') {

--- a/app/index.js
+++ b/app/index.js
@@ -107,6 +107,7 @@ module.exports = JhipsterGenerator.extend({
 
         setupVars : function () {
             this.packagejs = packagejs;
+            this.jhipsterVersion = this.config.get('jhipsterVersion');
             this.baseName = this.config.get('baseName');
             this.rememberMeKey = this.config.get('rememberMeKey');
             this.testFrameworks = this.config.get('testFrameworks');
@@ -633,6 +634,7 @@ module.exports = JhipsterGenerator.extend({
         },
 
         saveConfig: function () {
+            this.config.set('jhipsterVersion', packagejs.version);
             this.config.set('baseName', this.baseName);
             this.config.set('packageName', this.packageName);
             this.config.set('packageFolder', this.packageFolder);
@@ -1400,53 +1402,55 @@ module.exports = JhipsterGenerator.extend({
             var javaDir = this.javaDir;
             var testDir = this.testDir;
             // Remove old files, from previous JHipster versions
-            this.removefile(javaDir + 'config/MailConfiguration.java');
-            this.removefile(javaDir + 'config/metrics/JavaMailHealthIndicator.java');
-            if (this.databaseType == 'sql' || this.databaseType == 'mongodb') {
-                this.removefolder(javaDir + 'config/metrics');
+            if (this.installedVersionIsLessThan('2.27.1', this.jhipsterVersion)) {
+                this.removefile(javaDir + 'config/MailConfiguration.java');
+                this.removefile(javaDir + 'config/metrics/JavaMailHealthIndicator.java');
+                if (this.databaseType == 'sql' || this.databaseType == 'mongodb') {
+                    this.removefolder(javaDir + 'config/metrics');
+                }
+
+                this.removefile(javaDir + 'security/_CustomUserDetails.java');
+                this.removefile(javaDir + 'domain/util/CustomLocalDateSerializer.java');
+                this.removefile(javaDir + 'domain/util/CustomDateTimeSerializer.java');
+                this.removefile(javaDir + 'domain/util/CustomDateTimeDeserializer.java');
+                this.removefile(javaDir + 'domain/util/CustomLocalDateDeserializer.java');
+                this.removefile(javaDir + 'domain/util/DateToZonedDateTimeConverter.java');
+                this.removefile(javaDir + 'domain/util/ZonedDateTimeToDateConverter.java');
+                this.removefile(javaDir + 'domain/util/DateToLocalDateConverter.java');
+                this.removefile(javaDir + 'domain/util/LocalDateToDateConverter.java');
+                this.removefile(javaDir + 'domain/util/ISO8601LocalDateDeserializer.java');
+                this.removefolder(javaDir + 'web/propertyeditors');
+
+                this.removefile(RESOURCE_DIR + 'logback.xml');
+
+                this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.js');
+                this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.controller.js');
+                this.removefolder(WEBAPP_DIR + 'scripts/app/account/logout');
+
+                this.removefile(testDir + 'config/MongoConfiguration.java');
+                this.removefile(TEST_JS_DIR + 'spec/app/account/health/healthControllerSpec.js');
+                this.removefile(TEST_JS_DIR + 'spec/app/account/login/loginControllerSpec.js');
+                this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordControllerSpec.js');
+                this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordDirectiveSpec.js');
+                this.removefile(TEST_JS_DIR + 'spec/app/account/sessions/sessionsControllerSpec.js');
+                this.removefile(TEST_JS_DIR + 'spec/app/account/settings/settingsControllerSpec.js');
+                this.removefile(TEST_JS_DIR + 'spec/components/auth/authServicesSpec.js');
+
+                this.removefile('docker-compose.yml');
+                this.removefile('docker-compose-prod.yml');
+                this.removefile('Cassandra-Dev.Dockerfile');
+                this.removefile('Cassandra-Prod.Dockerfile');
+                this.removefolder('docker/');
+
+                this.removefile('gatling.gradle');
+                this.removefile('liquibase.gradle');
+                this.removefile('mapstruct.gradle');
+                this.removefile('profile_dev.gradle');
+                this.removefile('profile_fast.gradle');
+                this.removefile('profile_prod.gradle');
+                this.removefile('sonar.gradle');
+                this.removefile('yeoman.gradle');
             }
-
-            this.removefile(javaDir + 'security/_CustomUserDetails.java');
-            this.removefile(javaDir + 'domain/util/CustomLocalDateSerializer.java');
-            this.removefile(javaDir + 'domain/util/CustomDateTimeSerializer.java');
-            this.removefile(javaDir + 'domain/util/CustomDateTimeDeserializer.java');
-            this.removefile(javaDir + 'domain/util/CustomLocalDateDeserializer.java');
-            this.removefile(javaDir + 'domain/util/DateToZonedDateTimeConverter.java');
-            this.removefile(javaDir + 'domain/util/ZonedDateTimeToDateConverter.java');
-            this.removefile(javaDir + 'domain/util/DateToLocalDateConverter.java');
-            this.removefile(javaDir + 'domain/util/LocalDateToDateConverter.java');
-            this.removefile(javaDir + 'domain/util/ISO8601LocalDateDeserializer.java');
-            this.removefolder(javaDir + 'web/propertyeditors');
-
-            this.removefile(RESOURCE_DIR + 'logback.xml');
-
-            this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.js');
-            this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.controller.js');
-            this.removefolder(WEBAPP_DIR + 'scripts/app/account/logout');
-
-            this.removefile(testDir + 'config/MongoConfiguration.java');
-            this.removefile(TEST_JS_DIR + 'spec/app/account/health/healthControllerSpec.js');
-            this.removefile(TEST_JS_DIR + 'spec/app/account/login/loginControllerSpec.js');
-            this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordControllerSpec.js');
-            this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordDirectiveSpec.js');
-            this.removefile(TEST_JS_DIR + 'spec/app/account/sessions/sessionsControllerSpec.js');
-            this.removefile(TEST_JS_DIR + 'spec/app/account/settings/settingsControllerSpec.js');
-            this.removefile(TEST_JS_DIR + 'spec/components/auth/authServicesSpec.js');
-
-            this.removefile('docker-compose.yml');
-            this.removefile('docker-compose-prod.yml');
-            this.removefile('Cassandra-Dev.Dockerfile');
-            this.removefile('Cassandra-Prod.Dockerfile');
-            this.removefolder('docker/');
-
-            this.removefile('gatling.gradle');
-            this.removefile('liquibase.gradle');
-            this.removefile('mapstruct.gradle');
-            this.removefile('profile_dev.gradle');
-            this.removefile('profile_fast.gradle');
-            this.removefile('profile_prod.gradle');
-            this.removefile('sonar.gradle');
-            this.removefile('yeoman.gradle');
         }
     },
 

--- a/app/index.js
+++ b/app/index.js
@@ -1,16 +1,17 @@
 'use strict';
 var util = require('util'),
-path = require('path'),
-generators = require('yeoman-generator'),
-chalk = require('chalk'),
-_ = require('underscore.string'),
-shelljs = require('shelljs'),
-scriptBase = require('../script-base'),
-packagejs = require(__dirname + '/../package.json'),
-crypto = require("crypto"),
-mkdirp = require('mkdirp'),
-html = require("html-wiring"),
-ejs = require('ejs');
+    path = require('path'),
+    generators = require('yeoman-generator'),
+    chalk = require('chalk'),
+    _ = require('underscore.string'),
+    shelljs = require('shelljs'),
+    scriptBase = require('../script-base'),
+    cleanup = require('../app/cleanup'),
+    packagejs = require(__dirname + '/../package.json'),
+    crypto = require("crypto"),
+    mkdirp = require('mkdirp'),
+    html = require("html-wiring"),
+    ejs = require('ejs');
 
 var JhipsterGenerator = generators.Base.extend({});
 
@@ -1397,60 +1398,8 @@ module.exports = JhipsterGenerator.extend({
 
         },
 
-        removeOlderVersionFiles: function () {
-            var packageFolder = this.packageFolder;
-            var javaDir = this.javaDir;
-            var testDir = this.testDir;
-            // Remove old files, from previous JHipster versions
-            if (this.isVersionLessThan('2.27.1', this.jhipsterVersion)) {
-                this.removefile(javaDir + 'config/MailConfiguration.java');
-                this.removefile(javaDir + 'config/metrics/JavaMailHealthIndicator.java');
-                if (this.databaseType == 'sql' || this.databaseType == 'mongodb') {
-                    this.removefolder(javaDir + 'config/metrics');
-                }
-
-                this.removefile(javaDir + 'security/_CustomUserDetails.java');
-                this.removefile(javaDir + 'domain/util/CustomLocalDateSerializer.java');
-                this.removefile(javaDir + 'domain/util/CustomDateTimeSerializer.java');
-                this.removefile(javaDir + 'domain/util/CustomDateTimeDeserializer.java');
-                this.removefile(javaDir + 'domain/util/CustomLocalDateDeserializer.java');
-                this.removefile(javaDir + 'domain/util/DateToZonedDateTimeConverter.java');
-                this.removefile(javaDir + 'domain/util/ZonedDateTimeToDateConverter.java');
-                this.removefile(javaDir + 'domain/util/DateToLocalDateConverter.java');
-                this.removefile(javaDir + 'domain/util/LocalDateToDateConverter.java');
-                this.removefile(javaDir + 'domain/util/ISO8601LocalDateDeserializer.java');
-                this.removefolder(javaDir + 'web/propertyeditors');
-
-                this.removefile(RESOURCE_DIR + 'logback.xml');
-
-                this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.js');
-                this.removefile(WEBAPP_DIR + 'scripts/app/account/logout/logout.controller.js');
-                this.removefolder(WEBAPP_DIR + 'scripts/app/account/logout');
-
-                this.removefile(testDir + 'config/MongoConfiguration.java');
-                this.removefile(TEST_JS_DIR + 'spec/app/account/health/healthControllerSpec.js');
-                this.removefile(TEST_JS_DIR + 'spec/app/account/login/loginControllerSpec.js');
-                this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordControllerSpec.js');
-                this.removefile(TEST_JS_DIR + 'spec/app/account/password/passwordDirectiveSpec.js');
-                this.removefile(TEST_JS_DIR + 'spec/app/account/sessions/sessionsControllerSpec.js');
-                this.removefile(TEST_JS_DIR + 'spec/app/account/settings/settingsControllerSpec.js');
-                this.removefile(TEST_JS_DIR + 'spec/components/auth/authServicesSpec.js');
-
-                this.removefile('docker-compose.yml');
-                this.removefile('docker-compose-prod.yml');
-                this.removefile('Cassandra-Dev.Dockerfile');
-                this.removefile('Cassandra-Prod.Dockerfile');
-                this.removefolder('docker/');
-
-                this.removefile('gatling.gradle');
-                this.removefile('liquibase.gradle');
-                this.removefile('mapstruct.gradle');
-                this.removefile('profile_dev.gradle');
-                this.removefile('profile_fast.gradle');
-                this.removefile('profile_prod.gradle');
-                this.removefile('sonar.gradle');
-                this.removefile('yeoman.gradle');
-            }
+        cleanup: function () {
+            cleanup.cleanupOldFiles(this);
         }
     },
 

--- a/package.json
+++ b/package.json
@@ -39,7 +39,8 @@
     "underscore.string": "3.2.2",
     "wordwrap": "1.0.0",
     "yeoman-generator": "0.22.2",
-    "yo": "1.6.0"
+    "yo": "1.6.0",
+    "semver": "5.1.0"
   },
   "devDependencies": {
     "fs-extra": "0.26.4",

--- a/script-base.js
+++ b/script-base.js
@@ -9,7 +9,8 @@ var path = require('path'),
     Insight = require('insight'),
     fs = require('fs'),
     shelljs = require('shelljs'),
-    ejs = require('ejs');
+    ejs = require('ejs'),
+    semver = require('semver');
 
 const MODULES_HOOK_FILE = '.jhipster/modules/jhi-hooks.json';
 
@@ -1134,4 +1135,11 @@ Generator.prototype.removefolder = function(folder) {
         this.log('Removing the folder - ' + folder)
         shelljs.rm("-rf", folder);
     }
+}
+
+Generator.prototype.installedVersionIsLessThan = function(version, installedJhipsterVersion) {
+    if (!installedJhipsterVersion) {
+        return true;
+    }
+    return semver.lt(installedJhipsterVersion, version);
 }

--- a/script-base.js
+++ b/script-base.js
@@ -1137,9 +1137,10 @@ Generator.prototype.removefolder = function(folder) {
     }
 }
 
-Generator.prototype.isVersionLessThan = function(version, installedJhipsterVersion) {
-    if (!installedJhipsterVersion) {
+Generator.prototype.isJhipsterVersionLessThan = function(version) {
+    var jhipsterVersion = this.config.get('jhipsterVersion');
+    if (!jhipsterVersion) {
         return true;
     }
-    return semver.lt(installedJhipsterVersion, version);
+    return semver.lt(jhipsterVersion, version);
 }

--- a/script-base.js
+++ b/script-base.js
@@ -1137,7 +1137,7 @@ Generator.prototype.removefolder = function(folder) {
     }
 }
 
-Generator.prototype.installedVersionIsLessThan = function(version, installedJhipsterVersion) {
+Generator.prototype.isVersionLessThan = function(version, installedJhipsterVersion) {
     if (!installedJhipsterVersion) {
         return true;
     }


### PR DESCRIPTION
When we rename/remove generated files we have to programatically remove them in app/index.js.
This list of files are becoming very large and if the user would want to have a file called something that is in our remove list the file will get removed every time the user updates jhipster.

To avoid this we could make the generator only remove the files once by giving the remove a version. Thereby the remove will only take place if the current installed version is less than the remove version which is the version when the remove got added.