### PR TITLE
Tasks that executes with the ExceptionHandlingAsyncTaskExecutor are not being wrapped - fixed #2714

### DIFF
--- a/app/templates/src/main/java/package/async/_ExceptionHandlingAsyncTaskExecutor.java
+++ b/app/templates/src/main/java/package/async/_ExceptionHandlingAsyncTaskExecutor.java
@@ -22,7 +22,7 @@ public class ExceptionHandlingAsyncTaskExecutor implements AsyncTaskExecutor,
 
     @Override
     public void execute(Runnable task) {
-        executor.execute(task);
+        executor.execute(createWrappedRunnable(task));
     }
 
     @Override


### PR DESCRIPTION


<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/jhipster/generator-jhipster/2715)
<!-- Reviewable:end -->
