### PR TITLE
add skip bower option

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -53,7 +53,7 @@ module.exports = JhipsterGenerator.extend({
             type: Boolean,
             defaults: false
         });
-        // This method adds support for a `--with-entities` flag
+        // This adds support for a `--with-entities` flag
         this.option('with-entities', {
             desc: 'Regenerate the existing entities if any',
             type: Boolean,

--- a/app/index.js
+++ b/app/index.js
@@ -29,23 +29,29 @@ const INTERPOLATE_REGEX = /<%=([\s\S]+?)%>/g; // so that tags in templates do no
 module.exports = JhipsterGenerator.extend({
     constructor: function() {
         generators.Base.apply(this, arguments);
-        // This method adds support for a `--skip-client` flag
+        // This adds support for a `--skip-client` flag
         this.option('skip-client', {
             desc: 'Skip the client side app generation',
             type: Boolean,
             defaults: false
         });
-        // This method adds support for a `--client-build` flag
+        // This adds support for a `--client-build` flag
         this.option('client-build', {
             desc: 'Specify the client side build to use when skipping client side generation, has no effect otherwise',
             type: String,
             defaults: 'none'
         });
-        // This method adds support for a `--[no-]i18n` flag
+        // This adds support for a `--[no-]i18n` flag
         this.option('i18n', {
             desc: 'Disable or enable i18n when skipping client side generation, has no effect otherwise',
             type: Boolean,
             defaults: true
+        });
+        // This adds support for a `--skip-bower` flag
+        this.option('skip-bower', {
+            desc: 'Disable bower hookd from the Maven/Gradle build',
+            type: Boolean,
+            defaults: false
         });
         // This method adds support for a `--with-entities` flag
         this.option('with-entities', {
@@ -57,6 +63,7 @@ module.exports = JhipsterGenerator.extend({
         this.skipClient = this.options['skip-client'] || skipClient;
         this.clientBuild = this.options['client-build'];
         this.i18n = this.options['i18n'];
+        this.skipBower = this.options['skip-bower'];
         this.withEntities = this.options['with-entities'];
 
     },

--- a/app/templates/gradle/_profile_prod.gradle
+++ b/app/templates/gradle/_profile_prod.gradle
@@ -47,14 +47,14 @@ task gruntTest(type: Exec) {
   }
 
 }
-gruntBuild.dependsOn 'npmInstall'
-gruntBuild.dependsOn 'bower'
+gruntBuild.dependsOn 'npmInstall'<% if(!skipBower) {%>
+gruntBuild.dependsOn 'bower'<% } %>
 processResources.dependsOn gruntBuild
 test.dependsOn gruntTest
 bootRun.dependsOn gruntTest
 <% }  if(frontendBuilder == 'gulp') {%>
-gulp_build.dependsOn 'npmInstall'
-gulp_build.dependsOn 'bower'
+gulp_build.dependsOn 'npmInstall'<% if(!skipBower) {%>
+gulp_build.dependsOn 'bower'<% } %>
 processResources.dependsOn gulp_build
 test.dependsOn gulp_test
 bootRun.dependsOn gulp_test

--- a/app/templates/gradle/_yeoman.gradle
+++ b/app/templates/gradle/_yeoman.gradle
@@ -2,7 +2,7 @@ import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'com.moowork.node'<% if(frontendBuilder == 'grunt') {%>
 apply plugin: 'com.moowork.grunt'<% } if(frontendBuilder == 'gulp') {%>
 apply plugin: 'com.moowork.gulp'<% } %>
-<% if(!skipClient) {%>
+<% if(!skipBower) {%>
 task bower(type: Exec) {
     if (Os.isFamily(Os.FAMILY_WINDOWS)) {
         commandLine 'cmd', '/c', 'bower', 'install'


### PR DESCRIPTION
adds a flag to skip bower, useful when a client does not need bower, like for eg, React does things with npm instead of bower