### PR TITLE
Generate JS source maps for JS in prod (gulp)

### DIFF
--- a/app/templates/_package.json
+++ b/app/templates/_package.json
@@ -59,6 +59,7 @@
     "jasmine-reporters": "^2.0.6",
     "protractor-jasmine2-screenshot-reporter": "0.1.7",<% } %>
     "gulp-rev": "6.0.1",
+    "gulp-sourcemaps": "^1.6.0",
     "gulp-jshint": "1.12.0",
     "gulp-browserify": "0.5.1",<% if (useSass) { %>
     "gulp-sass": "2.1.0",<% } %>

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -24,7 +24,8 @@ var gulp = require('gulp'),
     wiredep = require('wiredep').stream,
     fs = require('fs'),
     runSequence = require('run-sequence'),
-    browserSync = require('browser-sync');
+    browserSync = require('browser-sync'),
+    sourcemaps = require('gulp-sourcemaps');
 
 var karmaServer = require('karma').Server;
 
@@ -248,10 +249,12 @@ gulp.task('usemin', ['images', 'styles'], function() {
                 htmlmin.bind(htmlmin, {collapseWhitespace: true})
             ],
             js: [
+                sourcemaps.init,
                 ngAnnotate,
-                uglify,
                 'concat',
-                rev
+                uglify.bind(uglify, { mangle: false }),
+                rev,
+                sourcemaps.write.bind(sourcemaps.write, '.')
             ]
         })).
         pipe(gulp.dest(yeoman.dist));


### PR DESCRIPTION
* Added gulp-sourcemaps to the build flow
* JS sourcemaps are now generated and debugging production builds work
* Uglify doesn't mangle variable names any more so we are able to check variables content while debugging (but the output JS file is a little bigger)
* Now uglifying AFTER concatenating files to let uglify fully optimize the output