### PR TITLE
Sass-bootstrap: move output to vendor.css

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -1018,10 +1018,12 @@ module.exports = JhipsterGenerator.extend({
             // normal CSS or SCSS?
             if (this.useSass) {
                 this.template(WEBAPP_DIR + 'scss/main.scss', WEBAPP_DIR + 'scss/main.scss');
+                this.template(WEBAPP_DIR + 'scss/vendor.scss', WEBAPP_DIR + 'scss/vendor.scss');
             }
             // this css file will be overwritten by the sass generated css if sass is enabled
             // but this will avoid errors when running app without running sass task first
             this.template(WEBAPP_DIR + 'content/css/main.css', WEBAPP_DIR + 'content/css/main.css');
+            this.template(WEBAPP_DIR + 'content/css/vendor.css', WEBAPP_DIR + 'content/css/vendor.css');
 
             // HTML5 BoilerPlate
             this.copy(WEBAPP_DIR + 'favicon.ico', WEBAPP_DIR + 'favicon.ico');

--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -66,7 +66,7 @@ module.exports = function (grunt) {
         },
         wiredep: {
             app: {<% if (useSass) { %>
-                src: ['src/main/webapp/index.html', 'src/main/webapp/scss/main.scss'],
+                src: ['src/main/webapp/index.html', 'src/main/webapp/scss/*.scss'],
                 exclude: [
                     /angular-i18n/, // localizations are loaded dynamically
                     'bower_components/bootstrap/' // Exclude Bootstrap LESS as we use bootstrap-sass
@@ -184,7 +184,7 @@ module.exports = function (grunt) {
                     html: {
                         steps: {
                             js: ['concat', 'uglifyjs'],
-                            css: ['cssmin', useminAutoprefixer] // Let cssmin concat files so it corrects relative paths to fonts and images
+                            css: ['concat', 'cssmin', useminAutoprefixer] // Let cssmin concat files so it corrects relative paths to fonts and images
                         },
                             post: {}
                         }

--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -200,7 +200,7 @@ gulp.task('wiredep:app', function () {
         }))
         .pipe(gulp.dest('src/main/webapp'));
 
-    return <% if (useSass) { %>es.merge(s, gulp.src(yeoman.scss + 'main.scss')
+    return <% if (useSass) { %>es.merge(s, gulp.src(yeoman.scss + '*.scss')
         .pipe(wiredep({
             exclude: [
                 /angular-i18n/,  // localizations are loaded dynamically

--- a/app/templates/src/main/webapp/_index.html
+++ b/app/templates/src/main/webapp/_index.html
@@ -13,6 +13,7 @@
     <!-- build:css content/css/vendor.css -->
     <!-- bower:css -->
     <!-- endbower -->
+    <link rel="stylesheet" href="content/css/vendor.css">
     <!-- endbuild -->
     <!-- build:css content/css/main.css -->
     <link rel="stylesheet" href="content/css/main.css">

--- a/app/templates/src/main/webapp/content/css/vendor.css
+++ b/app/templates/src/main/webapp/content/css/vendor.css
@@ -1,0 +1,2 @@
+/* Empty placeholder, will be replaced by the 'sass' task. */
+

--- a/app/templates/src/main/webapp/scss/main.scss
+++ b/app/templates/src/main/webapp/scss/main.scss
@@ -1,8 +1,3 @@
-$icon-font-path: "../../bower_components/bootstrap-sass/assets/fonts/bootstrap/";
-
-// bower:scss
-// endbower
-
 body {
     background: #fafafa;
     font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;

--- a/app/templates/src/main/webapp/scss/vendor.scss
+++ b/app/templates/src/main/webapp/scss/vendor.scss
@@ -1,0 +1,6 @@
+$icon-font-path: "../../bower_components/bootstrap-sass/assets/fonts/bootstrap/"; 
+
+/* The following will be replaced by sass bower components */ 
+// bower:scss 
+// endbower
+


### PR DESCRIPTION
I figured the bootstrap style sheets should be a part of vendor.css, in stead of app.css. We're not supposed to edit the contents of `bower_components`, and so we don't expect the output of bootstrap-sass to change as often as our own styles, and therefore would prefer this to be in vendor.css to facilitate browser caches.