### PR TITLE
Allow test continue if fail and generate the report

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -43,26 +43,24 @@ bootRun {
     addResources = false
 }
 
-
 test {
-    println 'Starting the Unit and Integration test'
     include '**/*UnitTest*'
     include '**/*IntTest*'
 
+    ignoreFailures true
     reports.html.enabled = false
 }
 
 task cucumberTest(type: Test) {
-    println 'Starting the Cucumber test'
     include '**/CucumberTest*'
 
+    ignoreFailures true
     reports.html.enabled = false
 }
 
 test.finalizedBy(cucumberTest)
 
 task testReport(type: TestReport) {
-    println 'Executing testReport'
     destinationDir = file("$buildDir/reports/tests")
     reportOn test
     reportOn cucumberTest


### PR DESCRIPTION
With gradle, when only one test fail, the report isn't generated.
Removing too the println to be less wordy