### PR TITLE
Upgrade springfox to 2.3.1 and enhance swagger-ui

### DIFF
--- a/generators/client/templates/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/src/main/webapp/swagger-ui/_index.html
@@ -28,90 +28,155 @@
     <!-- <script src='lang/en.js' type='text/javascript'></script> -->
 
     <script type="text/javascript">
-        $(function () {
-            var url = "../../v2/api-docs";
-
-            // Pre load translate...
-            if(window.SwaggerTranslator) {
-                window.SwaggerTranslator.translate();
-            }
-            window.swaggerUi = new SwaggerUi({
-                url: url,
-                dom_id: "swagger-ui-container",
-                supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
-                onComplete: function(swaggerApi, swaggerUi){
-                    if(typeof initOAuth == "function") {
-                        initOAuth({
-                            clientId: "your-client-id",
-                            clientSecret: "your-client-secret",
-                            realm: "your-realms",
-                            appName: "your-app-name",
-                            scopeSeparator: ","
-                        });
-                    }
-
-                    if(window.SwaggerTranslator) {
-                        window.SwaggerTranslator.translate();
-                    }
-
-                    $('pre code').each(function(i, e) {
-                        hljs.highlightBlock(e)
+        $(function() {
+            var springfox = {
+                "baseUrl": function() {
+                    var urlMatches = /(.*)\/swagger-ui\/index.html.*/.exec(window.location.href);
+                    return urlMatches[1];
+                },
+                "securityConfig": function(cb) {
+                    $.getJSON(this.baseUrl() + "/configuration/security", function(data) {
+                        cb(data);
                     });
                 },
-                onFailure: function(data) {
-                    log("Unable to Load SwaggerUI");
-                },
-                docExpansion: "none",
-                apisSorter: "alpha",
-                showRequestHeaders: false
+                "uiConfig": function(cb) {
+                    $.getJSON(this.baseUrl() + "/configuration/ui", function(data) {
+                        cb(data);
+                    });
+                }
+            };
+            window.springfox = springfox;
+            window.oAuthRedirectUrl = springfox.baseUrl() + '../bower_components/swagger-ui/dist/o2c.html'
+
+            window.springfox.uiConfig(function(data) {
+                window.swaggerUi = new SwaggerUi({
+                    dom_id: "swagger-ui-container",
+                    validatorUrl: data.validatorUrl,
+                    supportedSubmitMethods: ['get', 'post', 'put', 'delete', 'patch'],
+                    onComplete: function(swaggerApi, swaggerUi) {
+                        initializeSpringfox();
+                        if (window.SwaggerTranslator) {
+                            window.SwaggerTranslator.translate();
+                        }
+                        $('pre code').each(function(i, e) {
+                            hljs.highlightBlock(e)
+                        });
+                    },
+                    onFailure: function(data) {
+                        log("Unable to Load SwaggerUI");
+                    },
+                    docExpansion: "none",
+                    apisSorter: "alpha",
+                    showRequestHeaders: false
+                });
+
+                initializeBaseUrl();
+
+                $('#select_baseUrl').change(function() {
+                    window.swaggerUi.headerView.trigger('update-swagger-ui', {
+                        url: $('#select_baseUrl').val()
+                    });
+                    addApiKeyAuthorization();
+                });
+
+                function addApiKeyAuthorization(){
+                <% if (authenticationType == 'session') { %>
+                    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-CSRF-TOKEN", getCSRF(), "header");
+                    window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
+                <% } %>
+                <% if (authenticationType == 'oauth2') { %>
+                    var authToken = JSON.parse(localStorage.getItem("ls.token")).access_token;
+                    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization",
+                            "Bearer " + authToken, "header");
+                    window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
+                <% } %>
+                <% if (authenticationType == 'xauth') { %>
+                    var authToken = JSON.parse(localStorage.getItem("ls.token")).token;
+                    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-Auth-Token", authToken, "header");
+                    window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
+                <% } %>
+                }
+
+                function getCSRF() {
+                    var name = "CSRF-TOKEN=";
+                    var ca = document.cookie.split(';');
+                    for(var i=0; i<ca.length; i++) {
+                        var c = ca[i];
+                        while (c.charAt(0)==' ') c = c.substring(1);
+                        if (c.indexOf(name) != -1) return c.substring(name.length,c.length);
+                    }
+                    return "";
+                }
+
+                function log() {
+                    if ('console' in window) {
+                        console.log.apply(console, arguments);
+                    }
+                }
+
+                function oAuthIsDefined(security) {
+                    return security.clientId
+                    && security.clientSecret
+                    && security.appName
+                    && security.realm;
+                }
+
+                function initializeSpringfox() {
+                    var security = {};
+                    window.springfox.securityConfig(function(data) {
+                        security = data;
+                        if (typeof initOAuth == "function" && oAuthIsDefined(security)) {
+                            initOAuth(security);
+                        }
+                    });
+                }
             });
 
-            function addApiKeyAuthorization(){
-            <% if (authenticationType == 'session') { %>
-                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-CSRF-TOKEN", getCSRF(), "header");
-                window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-            <% } %>
-            <% if (authenticationType == 'oauth2') { %>
-                var authToken = JSON.parse(localStorage.getItem("ls.token")).access_token;
-                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization",
-                        "Bearer " + authToken, "header");
-                window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-            <% } %>
-            <% if (authenticationType == 'xauth') { %>
-                var authToken = JSON.parse(localStorage.getItem("ls.token")).token;
-                var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-Auth-Token", authToken, "header");
-                window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-            <% } %>
-            }
-
-            function getCSRF() {
-                var name = "CSRF-TOKEN=";
-                var ca = document.cookie.split(';');
-                for(var i=0; i<ca.length; i++) {
-                    var c = ca[i];
-                    while (c.charAt(0)==' ') c = c.substring(1);
-                    if (c.indexOf(name) != -1) return c.substring(name.length,c.length);
+            function maybePrefix(location, withRelativePath) {
+                var pat = /^https?:\/\//i;
+                if (pat.test(location)) {
+                    return location;
                 }
-                return "";
+                return withRelativePath + location;
             }
 
-            window.swaggerUi.load();
+            function initializeBaseUrl() {
+                var relativeLocation = springfox.baseUrl();
 
-            addApiKeyAuthorization();
+                $('#input_baseUrl').hide();
 
-            function log() {
-                if ('console' in window) {
-                    console.log.apply(console, arguments);
-                }
+                $.getJSON(relativeLocation + "/swagger-resources", function(data) {
+
+                    var $urlDropdown = $('#select_baseUrl');
+                    $urlDropdown.empty();
+                    $.each(data, function(i, resource) {
+                        var option = $('<option></option>')
+                        .attr("value", maybePrefix(resource.location, relativeLocation))
+                        .text(resource.name + " (" + resource.location + ")");
+                        $urlDropdown.append(option);
+                    });
+                    $urlDropdown.change();
+                });
+
             }
+
         });
     </script>
 </head>
+
 
 <body class="swagger-section">
 <div id='header'>
     <div class="swagger-ui-wrap">
         <a id="logo" href="http://swagger.io">swagger</a>
+
+        <form id='api_selector'>
+            <div class='input'>
+                <select id="select_baseUrl" name="select_baseUrl"/>
+            </div>
+            <div class='input'><input placeholder="http://example.com/api" id="input_baseUrl" name="baseUrl" type="text"/>
+            </div>
+        </form>
     </div>
 </div>
 

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -29,7 +29,7 @@ metrics_spring_version=3.1.2<% if (devDatabaseType == 'postgresql' || prodDataba
 postgresql_version=9.4-1203-jdbc42<% } %><% if (authenticationType == 'oauth2') { %>
 spring_security_oauth2_version=2.0.8.RELEASE<% } %>
 spring_security_version=4.0.2.RELEASE
-springfox_version=2.0.3
+springfox_version=2.3.1
 spring_boot_version=1.3.2.RELEASE
 <%_ if (applicationType == 'microservice' || applicationType == 'gateway') { _%>
 spring_cloud_version=1.1.0.M4

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -89,7 +89,7 @@
         <%_ if (authenticationType == 'oauth2') { _%>
         <spring-security-oauth2.version>2.0.8.RELEASE</spring-security-oauth2.version>
         <%_ } _%>
-        <springfox.version>2.0.3</springfox.version>
+        <springfox.version>2.3.1</springfox.version>
         <%_ if (enableSocialSignIn) { _%>
         <!-- Spring social -->
         <httpclient.version>4.5.1</httpclient.version>


### PR DESCRIPTION
Adds auth headers (such as CSRF,OAuth, ...) to springfox swagger-ui index.html (not using the webjar)
THis way we get all features from springfox such as support for multiple dockets.