### PR TITLE
Fix a typo in gradle spring cloud dependency name

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -171,7 +171,7 @@ dependencies {
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-zuul', version: spring_cloud_version
     <%_ } _%>
     <%_ if (applicationType == 'microservice' || applicationType == 'gateway') { _%>
-    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-starter', version: spring_cloud_version
+    compile group: 'org.springframework.cloud', name: 'spring-cloud-starter', version: spring_cloud_version
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-ribbon', version: spring_cloud_version
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-eureka', version: spring_cloud_version
     compile group: 'org.springframework.cloud', name: 'spring-cloud-starter-hystrix', version: spring_cloud_version


### PR DESCRIPTION
The gradle build is broken for microservices. I think we should add a Travis build for a microservice app and microservice gateway with gradle and maven. @jdubois Can I can do it by myself ?