### PR TITLE
Read hikari conf from application.yml

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -57,6 +57,14 @@ spring:
         name:
         username: <% if (devDatabaseType == 'mysql') { %>root<% } else if (devDatabaseType == 'postgresql' || devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory' ) { %><%= baseName %><% } %>
         password:
+        <%_ if (devDatabaseType == 'mysql') { _%>
+        hikari:
+            data-source-properties:
+                cachePrepStmts: true
+                prepStmtCacheSize: 250
+                prepStmtCacheSqlLimit: 2048
+                useServerPrepStmts: true
+        <%_ } _%>
     <%_ if (devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory') { _%>
     h2:
         console:
@@ -142,13 +150,6 @@ server:
 # ===================================================================
 
 jhipster:
-    <%_ if (devDatabaseType == 'mysql') { _%>
-    datasource: # JHipster-specific configuration, in addition to the standard spring.datasource properties
-        cachePrepStmts: true
-        prepStmtCacheSize: 250
-        prepStmtCacheSqlLimit: 2048
-        useServerPrepStmts: true
-    <%_ } _%>
     <%_ if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast' || hibernateCache == 'ehcache') { _%>
     cache: # Hibernate 2nd level cache, used by CacheConfiguration
         timeToLiveSeconds: 3600

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -57,6 +57,14 @@ spring:
         username: <%= baseName %>
         <%_ } _%>
         password:
+        <%_ if (prodDatabaseType == 'mysql') { _%>
+        hikari:
+            data-source-properties:
+                cachePrepStmts: true
+                prepStmtCacheSize: 250
+                prepStmtCacheSqlLimit: 2048
+                useServerPrepStmts: true
+        <%_ } _%>
     jpa:
         <%_ if (prodDatabaseType == 'mysql') { _%>
         database-platform: org.hibernate.dialect.MySQLInnoDBDialect
@@ -137,13 +145,6 @@ jhipster:
         cache: # Used by the CachingHttpHeadersFilter
             timeToLiveInDays: 31
     <%_ if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast' || hibernateCache == 'ehcache') { _%>
-    <%_ if (devDatabaseType == 'mysql') { _%>
-    datasource: # JHipster-specific configuration, in addition to the standard spring.datasource properties
-        cachePrepStmts: true
-        prepStmtCacheSize: 250
-        prepStmtCacheSqlLimit: 2048
-        useServerPrepStmts: true
-    <%_ } _%>
     cache: # Hibernate 2nd level cache, used by CacheConfiguration
         timeToLiveSeconds: 3600
         <%_ if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast') { _%>


### PR DESCRIPTION
See #2769 

Note : it uses spring.datasource.hikari : this is not the current path for 1.3.2 but will be in 1.4.0
Now all Hikari configs are accessible by configuration. Eg :
```yaml
spring.datasource.hikari.connection-test-query: SELECT 1 FROM DUAL
```