### PR TITLE
Use a fixed datetime format

### DIFF
--- a/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -56,7 +56,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @IntegrationTest
 public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra') { %>extends AbstractCassandraTest <% } %>{<% if (fieldsContainZonedDateTime == true) { %>
 
-    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.of("Z"));<% } %>
+    private static final DateTimeFormatter dateTimeFormatter = DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.of("Z"));<% } %>
 <% for (fieldId in fields) {
     var defaultValueName = 'DEFAULT_' + fields[fieldId].fieldNameUnderscored.toUpperCase();
     var updatedValueName = 'UPDATED_' + fields[fieldId].fieldNameUnderscored.toUpperCase();

--- a/generators/server/templates/src/main/java/package/domain/util/_JSR310DateTimeSerializer.java
+++ b/generators/server/templates/src/main/java/package/domain/util/_JSR310DateTimeSerializer.java
@@ -12,7 +12,7 @@ import com.fasterxml.jackson.databind.SerializerProvider;
 public final class JSR310DateTimeSerializer extends JsonSerializer<TemporalAccessor> {
 
     private static final DateTimeFormatter ISOFormatter =
-        DateTimeFormatter.ISO_OFFSET_DATE_TIME.withZone(ZoneId.of("Z"));
+        DateTimeFormatter.ofPattern("yyyy-MM-dd'T'HH:mm:ss.SSS'Z'").withZone(ZoneId.of("Z"));
 
     public static final JSR310DateTimeSerializer INSTANCE = new JSR310DateTimeSerializer();
 


### PR DESCRIPTION
Fix #2689 

The format is ```yyyy-MM-dd'T'HH:mm:ss.SSSZ``` which should be supported by most clients and is the official ES5 one.