### PR TITLE
When --skip-server flag is set, gulp should not parse pom.xml for version

### DIFF
--- a/generators/client/templates/gulp/utils.js
+++ b/generators/client/templates/gulp/utils.js
@@ -26,10 +26,16 @@ function parseVersion() {
         }
     });
     return version;
-};<% } else { %>
+}
+<% } else if (buildTool == 'gradle') { %>
 // Returns the second occurrence of the version number from `build.gradle` file
 function parseVersion() {
     var versionRegex = /^version\s*=\s*[',"]([^',"]*)[',"]/gm; // Match and group the version number
     var buildGradle = fs.readFileSync('build.gradle', 'utf8');
     return versionRegex.exec(buildGradle)[1];
+}
+<% } else { %>
+// Returns a static version number when server is skipped
+function parseVersion() {
+    return '0.0.1-SNAPSHOT';
 };<% } %>


### PR DESCRIPTION
When --skip-server flag is set, gulp should not parse pom.xml or build.gradle to extract project version as these files don't exist.
In this case, the version is direcly set in gulp/utils.js

Fix #2810