### PR TITLE
Aggregate microservices swagger docs on the gateway

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -780,10 +780,9 @@ module.exports = JhipsterServerGenerator.extend({
 
             if (this.applicationType != 'gateway') return;
 
-
             this.template('src/main/java/package/web/rest/dto/_RouteDTO.java', javaDir + 'web/rest/dto/RouteDTO.java', this, {});
             this.template('src/main/java/package/web/rest/_GatewayResource.java', javaDir + 'web/rest/GatewayResource.java', this, {});
-
+            this.template('src/main/java/package/web/rest/_GatewaySwaggerApiResource.java', javaDir + 'web/rest/GatewaySwaggerApiResource.java', this, {});
         },
 
         writeServerJavaAppFiles: function () {

--- a/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
@@ -52,6 +52,9 @@ public class SwaggerConfiguration {
 
         Docket docket = new Docket(DocumentationType.SWAGGER_2)
             .apiInfo(apiInfo)
+            <%_ if (applicationType == 'microservice') { _%>
+            .pathMapping("/<%= baseName.toLowerCase() %>")
+            <%_ } _%>
             .forCodeGeneration(true)
             .genericModelSubstitutes(ResponseEntity.class)
             .ignoredParameterTypes(Pageable.class)

--- a/generators/server/templates/src/main/java/package/web/rest/_GatewaySwaggerApiResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_GatewaySwaggerApiResource.java
@@ -1,0 +1,65 @@
+package <%=packageName%>.web.rest;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+import org.springframework.cloud.netflix.zuul.filters.ProxyRouteLocator;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.bind.annotation.RestController;
+import springfox.documentation.swagger.web.SwaggerResource;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * REST controller for retrieving all registered microservices Swagger resources.
+ */
+@RestController
+public class GatewaySwaggerApiResource {
+
+    private final Logger log = LoggerFactory.getLogger(GatewaySwaggerApiResource.class);
+
+    @Inject
+    private ProxyRouteLocator routeLocator;
+
+    @Inject
+    private DiscoveryClient discoveryClient;
+
+    /**
+     * GET  /swagger-resources -> get the currently registered microservices swagger resources
+     * (Override the Springfox provided /swagger-resources endpoint)
+     */
+    @RequestMapping(value = "/swagger-resources",
+        method = RequestMethod.GET,
+        produces = MediaType.APPLICATION_JSON_VALUE)
+    @ResponseBody
+    ResponseEntity<List<SwaggerResource>> swaggerResources() {
+        List<SwaggerResource> resources = new ArrayList<>();
+
+        //Add the default swagger resource that correspond to the gateway's own swagger doc
+        resources.add(swaggerResource("default", "/v2/api-docs", "2.0"));
+
+        //Add the registered microservices swagger docs as additional swagger resources
+        Map<String, String> routes = routeLocator.getRoutes();
+        routes.forEach((path, serviceId) -> {
+            resources.add(swaggerResource(serviceId, path.replace("**","v2/api-docs"), "2.0"));
+        });
+        return new ResponseEntity<>(resources, HttpStatus.OK);
+    }
+
+    private SwaggerResource swaggerResource(String name, String location, String version) {
+        SwaggerResource swaggerResource = new SwaggerResource();
+        swaggerResource.setName(name);
+        swaggerResource.setLocation(location);
+        swaggerResource.setSwaggerVersion(version);
+        return swaggerResource;
+    }
+}


### PR DESCRIPTION
This is fully functional and allows viewing and "trying out" the microservices API on the gateway's Swagger-UI.
![multi_swagger](https://cloud.githubusercontent.com/assets/513471/12944612/81583e70-cfe8-11e5-844a-8aa032d3b105.png)
To pass the JWT access authorization, the backend microservices app must be configured to have the same jwtsecret property as the gateway but this is already documented in the [registry's Readme](https://github.com/jhipster/jhipster-registry).