### PR TITLE
Fix pom.xml when generating application with --skipClient flag

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -941,8 +941,8 @@
                                     <action>
                                         <ignore/>
                                     </action>
-                                </pluginExecution>
-                            </pluginExecutions><% } %>
+                                </pluginExecution><% } %>
+                            </pluginExecutions>
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
@@ -980,8 +980,8 @@
                     <artifactId>spring-boot-starter-tomcat</artifactId>
                 </dependency>
             </dependencies>
-            <build><% if(!skipClient) {%>
-                <plugins>
+            <build>
+                <plugins><% if(!skipClient) {%>
                     <plugin>
                         <groupId>com.github.trecloux</groupId>
                         <artifactId>yeoman-maven-plugin</artifactId>


### PR DESCRIPTION
Linked to #2582, the `<% if(!skipClient) {%>` tag was also skipping `<plugins>` and `</pluginExecutions>` xml tags in the pom.xml file.