### PR TITLE
Configuring heroku database when using postgres

### DIFF
--- a/generators/heroku/templates/src/main/java/package/config/_HerokuDatabaseConfiguration.java
+++ b/generators/heroku/templates/src/main/java/package/config/_HerokuDatabaseConfiguration.java
@@ -23,15 +23,16 @@ public class HerokuDatabaseConfiguration {
 
         String herokuUrl = System.getenv("JDBC_DATABASE_URL");
         if (herokuUrl != null) {
-	    HikariConfig config = new HikariConfig();
+	        HikariConfig config = new HikariConfig();
 
-	    //MySQL optimizations, see https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
-	    if ("com.mysql.jdbc.jdbc2.optional.MysqlDataSource".equals(dataSourceProperties.getDriverClassName())) {
+	        <%_ if (prodDatabaseType == 'mysql') { _%>
+            //MySQL optimizations, see https://github.com/brettwooldridge/HikariCP/wiki/MySQL-Configuration
+    	    if ("com.mysql.jdbc.jdbc2.optional.MysqlDataSource".equals(dataSourceProperties.getDriverClassName())) {
                 config.addDataSourceProperty("cachePrepStmts", jHipsterProperties.getDatasource().isCachePrepStmts());
                 config.addDataSourceProperty("prepStmtCacheSize", jHipsterProperties.getDatasource().getPrepStmtCacheSize());
                 config.addDataSourceProperty("prepStmtCacheSqlLimit", jHipsterProperties.getDatasource().getPrepStmtCacheSqlLimit());
             }
-
+            <%_ } _%>
             config.setDataSourceClassName(dataSourceProperties.getDriverClassName());
             config.addDataSourceProperty("url", herokuUrl);
             return new HikariDataSource(config);

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -17,7 +17,7 @@ jjwt_version=0.6.0<% } %>
 geronimo_javamail_1_4_mail_version=1.8.4<% if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast') { %>
 hazelcast_version=3.5.4<% } %>
 hibernate_entitymanager_version=4.3.11.Final
-HikariCP_version=2.4.1<% if (databaseType == 'sql') { %>
+HikariCP_version=2.4.3<% if (databaseType == 'sql') { %>
 liquibase_slf4j_version=1.2.1
 liquibase_core_version=3.4.2
 liquibase_hibernate4_version=3.5<% } %><% if (databaseType == 'mongodb') { %>

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -48,6 +48,9 @@ spring:
         username: <%= baseName %>
         <%_ } _%>
         password:
+        <%_ if (prodDatabaseType == 'postgresql') { _%>
+        driver-class-name: org.postgresql.ds.PGSimpleDataSource
+        <%_ } _%>
         <%_ if (prodDatabaseType == 'mysql') { _%>
         hikari:
             data-source-properties:


### PR DESCRIPTION
Fix #2876 

If not set spring.datasource.driver-class-name, in heroku give the error:
```
ClassCastException: Cannot cast org.postgresql.Driver to javax.sql.DataSource
2016-02-14T19:36:17.056837+00:00 app[web.1]: 	at com.zaxxer.hikari.pool.PoolElf.initializeDataSource(PoolElf.java:153) ~[HikariCP-2.4.1.jar!/:na]
2016-02-14T19:36:17.056837+00:00 app[web.1]: 	at com.zaxxer.hikari.util.UtilityElf.createInstance(UtilityElf.java:79) ~[HikariCP-2.4.1.jar!/:na]
2016-02-14T19:36:17.056835+00:00 app[web.1]: 	... 38 common frames omitted
2016-02-14T19:36:17.056836+00:00 app[web.1]: Caused by: java.lang.RuntimeException: java.lang.ClassCastException: Cannot cast org.postgresql.Driver to javax.sql.DataSource
2016-02-14T19:36:17.056838+00:00 app[web.1]: 	at com.zaxxer.hikari.pool.HikariPool.<init>(HikariPool.java:113) ~[HikariCP-2.4.1.jar!/:na]
2016-02-14T19:36:17.056839+00:00 app[web.1]: 	at com.zaxxer.hikari.HikariDataSource.<init>(HikariDataSource.java:73) ~[HikariCP-2.4.1.jar!/:na]

```