### PR TITLE
Add user mapper

### DIFF
--- a/generators/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
@@ -10,7 +10,7 @@ import java.util.List;
  * Mapper for the entity <%= entityClass %> and its DTO <%= entityClass %>DTO.
  */
 @Mapper(componentModel = "spring", uses = {<% for (relationshipId in relationships) {
-    if (relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) { %><%= relationships[relationshipId].otherEntityNameCapitalized %>Mapper.class, <% } } %>})
+    if ((relationships[relationshipId].relationshipType == 'many-to-many' && relationships[relationshipId].ownerSide == true) || relationships[relationshipId].otherEntityNameCapitalized == 'User') { %><%= relationships[relationshipId].otherEntityNameCapitalized %>Mapper.class, <% } } %>})
 public interface <%= entityClass %>Mapper {
 <%
 // entity -> DTO mapping
@@ -40,7 +40,8 @@ for (relationshipId in relationships) {
 
     List<<%= entityClass %>> <%= entityInstance %>DTOsTo<%= entityClassPlural %>(List<<%= entityClass %>DTO> <%= entityInstance %>DTOs);<%
 
-var existingMappings = [];
+// the user mapping is imported in the @Mapper annotation
+var existingMappings = ['user'];
 for (relationshipId in relationships) {
     var relationshipType = relationships[relationshipId].relationshipType;
     var otherEntityName = relationships[relationshipId].otherEntityName;

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -922,13 +922,14 @@ module.exports = JhipsterServerGenerator.extend({
             this.template('src/main/java/package/web/filter/_CachingHttpHeadersFilter.java', javaDir + 'web/filter/CachingHttpHeadersFilter.java', this, {});
             this.template('src/main/java/package/web/filter/_StaticResourcesProductionFilter.java', javaDir + 'web/filter/StaticResourcesProductionFilter.java', this, {});
 
+            this.template('src/main/java/package/web/rest/mapper/_UserMapper.java', javaDir + 'web/rest/mapper/UserMapper.java', this, {});
             this.template('src/main/java/package/web/rest/dto/_package-info.java', javaDir + 'web/rest/dto/package-info.java', this, {});
             this.template('src/main/java/package/web/rest/dto/_LoggerDTO.java', javaDir + 'web/rest/dto/LoggerDTO.java', this, {});
             this.template('src/main/java/package/web/rest/dto/_UserDTO.java', javaDir + 'web/rest/dto/UserDTO.java', this, {});
             this.template('src/main/java/package/web/rest/dto/_ManagedUserDTO.java', javaDir + 'web/rest/dto/ManagedUserDTO.java', this, {});
-            this.template('src/main/java/package/web/rest/util/_HeaderUtil.java', javaDir + 'web/rest/util/HeaderUtil.java', this, {});
             this.template('src/main/java/package/web/rest/dto/_KeyAndPasswordDTO.java', javaDir + 'web/rest/dto/KeyAndPasswordDTO.java', this, {});
 
+            this.template('src/main/java/package/web/rest/util/_HeaderUtil.java', javaDir + 'web/rest/util/HeaderUtil.java', this, {});
             this.template('src/main/java/package/web/rest/util/_PaginationUtil.java', javaDir + 'web/rest/util/PaginationUtil.java', this, {});
             this.template('src/main/java/package/web/rest/_package-info.java', javaDir + 'web/rest/package-info.java', this, {});
             this.template('src/main/java/package/web/rest/_AccountResource.java', javaDir + 'web/rest/AccountResource.java', this, {});

--- a/generators/server/templates/src/main/java/package/web/rest/mapper/_UserMapper.java
+++ b/generators/server/templates/src/main/java/package/web/rest/mapper/_UserMapper.java
@@ -1,0 +1,52 @@
+package <%=packageName%>.web.rest.mapper;
+
+import <%=packageName%>.domain.Authority;
+import <%=packageName%>.domain.User;
+import <%=packageName%>.web.rest.dto.UserDTO;
+import org.mapstruct.Mapper;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Mapper for the entity User and its DTO UserDTO.
+ */
+@Mapper(componentModel = "spring", uses = {})
+public interface UserMapper {
+
+    UserDTO userToUserDTO(User user);
+
+    List<UserDTO> usersToUserDTOs(List<User> users);
+
+    User userDTOToUser(UserDTO userDTO);
+
+    List<User> userDTOsToUsers(List<UserDTO> userDTOs);
+
+    default User userFromId(Long id) {
+        if (id == null) {
+            return null;
+        }
+        User user = new User();
+        user.setId(id);
+        return user;
+    }
+
+    default Set<String> stringsFromAuthorities(Set<Authority> authorities) {
+        Set<String> auths = new HashSet<>();
+        for(Authority auth : authorities){
+            auths.add(auth.getName());
+        }
+        return auths;
+    }
+
+    default Set<Authority> authoritiesFromStrings(Set<String> strings) {
+        Set<Authority> auths = new HashSet<>();
+        for(String auth : strings){
+            Authority a = new Authority();
+            a.setName(auth);
+            auths.add(a);
+        }
+        return auths;
+    }
+}

--- a/generators/server/templates/src/main/java/package/web/rest/mapper/_UserMapper.java
+++ b/generators/server/templates/src/main/java/package/web/rest/mapper/_UserMapper.java
@@ -1,6 +1,7 @@
 package <%=packageName%>.web.rest.mapper;
 
-import <%=packageName%>.domain.Authority;
+<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+import <%=packageName%>.domain.Authority;<% } %>
 import <%=packageName%>.domain.User;
 import <%=packageName%>.web.rest.dto.UserDTO;
 import org.mapstruct.Mapper;
@@ -23,7 +24,7 @@ public interface UserMapper {
 
     List<User> userDTOsToUsers(List<UserDTO> userDTOs);
 
-    default User userFromId(Long id) {
+    default User userFromId(<% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } else { %>Long<% } %> id) {
         if (id == null) {
             return null;
         }
@@ -31,7 +32,7 @@ public interface UserMapper {
         user.setId(id);
         return user;
     }
-
+<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
     default Set<String> stringsFromAuthorities(Set<Authority> authorities) {
         Set<String> auths = new HashSet<>();
         for(Authority auth : authorities){
@@ -48,5 +49,5 @@ public interface UserMapper {
             auths.add(a);
         }
         return auths;
-    }
+    }<% } %>
 }

--- a/travis/samples/app-default-from-scratch/.jhipster/RelationshipTestMapstructEntity.json
+++ b/travis/samples/app-default-from-scratch/.jhipster/RelationshipTestMapstructEntity.json
@@ -32,6 +32,14 @@
         },
         {
             "relationshipId": 5,
+            "relationshipName": "userManyToManyEntity",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "login",
+            "ownerSide": true
+        },
+        {
+            "relationshipId": 6,
             "relationshipName": "userOneToOneEntity",
             "otherEntityName": "user",
             "relationshipType": "one-to-one",

--- a/travis/samples/app-mysql/.jhipster/RelationshipTestMapstructEntity.json
+++ b/travis/samples/app-mysql/.jhipster/RelationshipTestMapstructEntity.json
@@ -32,6 +32,14 @@
         },
         {
             "relationshipId": 5,
+            "relationshipName": "userManyToManyEntity",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "login",
+            "ownerSide": true
+        },
+        {
+            "relationshipId": 6,
             "relationshipName": "userOneToOneEntity",
             "otherEntityName": "user",
             "relationshipType": "one-to-one",

--- a/travis/samples/app-psql-es-noi18n/.jhipster/RelationshipTestMapstructEntity.json
+++ b/travis/samples/app-psql-es-noi18n/.jhipster/RelationshipTestMapstructEntity.json
@@ -32,6 +32,14 @@
         },
         {
             "relationshipId": 5,
+            "relationshipName": "userManyToManyEntity",
+            "otherEntityName": "user",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "login",
+            "ownerSide": true
+        },
+        {
+            "relationshipId": 6,
             "relationshipName": "userOneToOneEntity",
             "otherEntityName": "user",
             "relationshipType": "one-to-one",


### PR DESCRIPTION
I added UserMapper to the generated project.  This Mapper should probably be used elsewhere in the code but for now this pull should fix the two issues related to MapStruct (#2867 and #2006).  I added the Travis tests back as requested in the issue.

The biggest difference is when an entity has a relationship with User, it uses the userFromId method in UserMapper instead of declaring it in each entity.

There might be a better way to go from Sets of Authorities to Sets of Strings  and back in the UserMapper, please advise. 