### PR TITLE
docker-compose file : registry

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -605,6 +605,9 @@ module.exports = JhipsterServerGenerator.extend({
                 this.template(DOCKER_DIR + 'cassandra/scripts/_cassandra.sh', DOCKER_DIR + 'cassandra/scripts/cassandra.sh', this, {});
                 this.template(DOCKER_DIR + 'opscenter/_Dockerfile', DOCKER_DIR + 'opscenter/Dockerfile', this, {});
             }
+            if (this.applicationType == 'microservice' || this.applicationType == 'gateway') {
+                this.template(DOCKER_DIR + '_registry.yml', DOCKER_DIR + 'registry.yml', this, {});
+            }
         },
 
         writeServerBuildFiles: function () {

--- a/generators/server/templates/src/main/docker/_registry.yml
+++ b/generators/server/templates/src/main/docker/_registry.yml
@@ -1,0 +1,5 @@
+jhipster-registry:
+  container_name: jhipster-registry
+  image: jhipster/jhipster-registry
+  ports:
+    - "8761:8761"

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -316,7 +316,8 @@ const expectedFiles = {
         'src/main/webapp/app/admin/gateway/gateway.controller.js',
         'src/main/webapp/app/admin/gateway/gateway.js',
         'src/main/webapp/app/admin/gateway/gateway.html',
-        'src/main/webapp/app/admin/gateway/gateway.routes.service.js'
+        'src/main/webapp/app/admin/gateway/gateway.routes.service.js',
+        'src/main/docker/registry.yml'
     ]
 };
 

--- a/travis/scripts/03-docker-compose.sh
+++ b/travis/scripts/03-docker-compose.sh
@@ -15,5 +15,10 @@ elif [[ ($JHIPSTER == 'app-mysql') || ($JHIPSTER == 'app-psql-es') ]]; then
   if [ -a src/main/docker/prod.yml ]; then
     docker-compose -f src/main/docker/prod.yml up -d
   fi
+elif [[ ($JHIPSTER == 'app-gateway') || ($JHIPSTER == 'app-microservice') ]]; then
+  if [ -a src/main/docker/registry.yml ]; then
+    docker-compose -f src/main/docker/registry.yml up -d
+    sleep 15
+  fi
 fi
 docker ps -a


### PR DESCRIPTION
new docker-compose file : registry.yml
It uses the official [jhipster/jhipster-registry](https://hub.docker.com/r/jhipster/jhipster-registry) image

To start the registry :
```
docker-compose -f src/main/docker/registry.yml up -d
```

Travis build should not display stacktrace anymore (for gateway and microservice build)