### PR TITLE
Separate user management server code 

### DIFF
--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
@@ -110,7 +110,7 @@
                                  constraintName="fk_user_persistent_token"
                                  referencedColumnNames="id"
                                  referencedTableName="jhi_user"/><% } %>
-
+        <% if (!skipUserManagement) { %>
         <loadData encoding="UTF-8"
                   file="config/liquibase/users.csv"
                   separator=";"
@@ -129,7 +129,7 @@
                   file="config/liquibase/users_authorities.csv"
                   separator=";"
                   tableName="jhi_user_authority"/>
-
+        <% } %>
         <createTable tableName="jhi_persistent_audit_event">
             <column name="event_id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
@@ -19,6 +19,7 @@
         The initial schema has the '00000000000001' id, so that it is over-written if we re-generate it.
     -->
     <changeSet id="00000000000001" author="jhipster">
+        <% if (!skipUserManagement) { %>
         <createTable tableName="jhi_user">
             <column name="id" type="bigint" autoIncrement="${autoIncrement}">
                 <constraints primaryKey="true" nullable="false"/>
@@ -110,7 +111,6 @@
                                  constraintName="fk_user_persistent_token"
                                  referencedColumnNames="id"
                                  referencedTableName="jhi_user"/><% } %>
-        <% if (!skipUserManagement) { %>
         <loadData encoding="UTF-8"
                   file="config/liquibase/users.csv"
                   separator=";"

--- a/generators/server/templates/src/main/resources/config/mongeez/master.xml
+++ b/generators/server/templates/src/main/resources/config/mongeez/master.xml
@@ -1,5 +1,7 @@
 <changeFiles>
+    <%_ if (!skipUserManagement) { _%>
     <file path="authorities.xml"/>
     <file path="users.xml"/>
     <file path="social_user_connections.xml"/>
+    <%_ } _%>
 </changeFiles>


### PR DESCRIPTION
Related to #2811

Allow not generating server code that concerns user management with the --skip-server-management flag.
Include some tweaks to liquibase and mongeez database changelogs to pass the tests when user management has been removed.