### PR TITLE
rename app state site to app

### DIFF
--- a/generators/client/templates/src/main/webapp/app/_app.state.js
+++ b/generators/client/templates/src/main/webapp/app/_app.state.js
@@ -3,7 +3,7 @@
 angular.module('<%=angularAppName%>')
     .config(function ($stateProvider) {
         $stateProvider
-            .state('site', {
+            .state('app', {
                 abstract: true,
                 views: {
                     'navbar@': {

--- a/generators/client/templates/src/main/webapp/app/account/_account.state.js
+++ b/generators/client/templates/src/main/webapp/app/account/_account.state.js
@@ -5,6 +5,6 @@ angular.module('<%=angularAppName%>')
         $stateProvider
             .state('account', {
                 abstract: true,
-                parent: 'site'
+                parent: 'app'
             });
     });

--- a/generators/client/templates/src/main/webapp/app/admin/_admin.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/_admin.state.js
@@ -5,6 +5,6 @@ angular.module('<%=angularAppName%>')
         $stateProvider
             .state('admin', {
                 abstract: true,
-                parent: 'site'
+                parent: 'app'
             });
     });

--- a/generators/client/templates/src/main/webapp/app/entities/_entity.state.js
+++ b/generators/client/templates/src/main/webapp/app/entities/_entity.state.js
@@ -5,6 +5,6 @@ angular.module('<%=angularAppName%>')
         $stateProvider
             .state('entity', {
                 abstract: true,
-                parent: 'site'
+                parent: 'app'
             });
     });

--- a/generators/client/templates/src/main/webapp/app/home/_home.state.js
+++ b/generators/client/templates/src/main/webapp/app/home/_home.state.js
@@ -4,7 +4,7 @@ angular.module('<%=angularAppName%>')
     .config(function ($stateProvider) {
         $stateProvider
             .state('home', {
-                parent: 'site',
+                parent: 'app',
                 url: '/',
                 data: {
                     authorities: []

--- a/generators/client/templates/src/main/webapp/app/layouts/error/_error.state.js
+++ b/generators/client/templates/src/main/webapp/app/layouts/error/_error.state.js
@@ -4,7 +4,7 @@ angular.module('<%=angularAppName%>')
     .config(function ($stateProvider) {
         $stateProvider
             .state('error', {
-                parent: 'site',
+                parent: 'app',
                 url: '/error',
                 data: {
                     authorities: [],
@@ -23,7 +23,7 @@ angular.module('<%=angularAppName%>')
                 }
             })
             .state('accessdenied', {
-                parent: 'site',
+                parent: 'app',
                 url: '/accessdenied',
                 data: {
                     authorities: []


### PR DESCRIPTION
I think it would make sense to rename the app main ui-router state to `app` from `site` just for consistency