### PR TITLE
fix jQuery error when predicate has a period in it

### DIFF
--- a/generators/client/templates/src/main/webapp/app/components/util/_sort.directive.js
+++ b/generators/client/templates/src/main/webapp/app/components/util/_sort.directive.js
@@ -37,7 +37,7 @@ angular.module('<%=angularAppName%>')
                     thisIcon.removeClass(remove);
                     thisIcon.addClass(add);
                 };
-                this.applyClass($element.find('th[jh-sort-by=' + $scope.predicate + ']'));
+                this.applyClass($element.find('th[jh-sort-by=\'' + $scope.predicate + '\']'));
             }]
         };
     }).directive('jhSortBy', function () {


### PR DESCRIPTION
fix jQuery error when predicate has a period in it by surrounding it with quotes

fix #2928