### PR TITLE
adds JWT Token for websockets

### DIFF
--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -2,7 +2,7 @@
 /* globals window, SockJS, Stomp */
 
 angular.module('<%=angularAppName%>')
-    .factory('Tracker', function ($rootScope, $cookies, $http, $q) {
+    .factory('Tracker', function ($rootScope, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();
@@ -24,7 +24,11 @@ angular.module('<%=angularAppName%>')
                 /* globals localStorage */
                 /*jshint camelcase: false */
                 var authToken = JSON.parse(localStorage.getItem('jhi-authenticationToken')).access_token;
-                url += '?access_token=' + authToken;<% } %>
+                url += '?access_token=' + authToken;<% } %><% if (authenticationType == 'jwt') { %>
+                var authToken = AuthServerProvider.getToken();
+                if(authToken){
+                    url += '?access_token=' + authToken;
+                }<% } %>
                 var socket = new SockJS(url);
                 stompClient = Stomp.over(socket);
                 var headers = {};<% if (authenticationType == 'session') { %>

--- a/generators/server/templates/src/main/java/package/config/_WebsocketSecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_WebsocketSecurityConfiguration.java
@@ -1,8 +1,6 @@
 package <%=packageName%>.config;
 
-<%_ if (authenticationType == 'session' || authenticationType == 'oauth2') { _%>
 import <%=packageName%>.security.AuthoritiesConstants;
-<%_ } _%>
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.SimpMessageType;
 import org.springframework.security.config.annotation.web.messaging.MessageSecurityMetadataSourceRegistry;
@@ -17,9 +15,7 @@ public class WebsocketSecurityConfiguration extends AbstractSecurityWebSocketMes
             // message types other than MESSAGE and SUBSCRIBE
             .nullDestMatcher().authenticated()
             // matches any destination that starts with /rooms/
-            <%_ if (authenticationType == 'session' || authenticationType == 'oauth2') { // ignoring authentiation check for authenticationType == 'jwt' since it does not work, see issue #2129 _%>
             .simpDestMatchers("/topic/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
-            <%_ } _%>
             .simpDestMatchers("/topic/**").authenticated()
             // (i.e. cannot send messages directly to /topic/, /queue/)
             // (i.e. cannot subscribe to /topic/messages/* to get messages sent to

--- a/generators/server/templates/src/main/java/package/security/jwt/_JWTConfigurer.java
+++ b/generators/server/templates/src/main/java/package/security/jwt/_JWTConfigurer.java
@@ -8,6 +8,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 public class JWTConfigurer extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
 
     public final static String AUTHORIZATION_HEADER = "Authorization";
+    <% if (websocket == 'spring-websocket') { %>public final static String AUTHORIZATION_TOKEN = "access_token";<% } %>
 
     private TokenProvider tokenProvider;
 

--- a/generators/server/templates/src/main/java/package/security/jwt/_JWTFilter.java
+++ b/generators/server/templates/src/main/java/package/security/jwt/_JWTFilter.java
@@ -33,9 +33,8 @@ public class JWTFilter extends GenericFilterBean {
         throws IOException, ServletException {
         try {
             HttpServletRequest httpServletRequest = (HttpServletRequest) servletRequest;
-            String bearerToken = httpServletRequest.getHeader(JWTConfigurer.AUTHORIZATION_HEADER);
-            if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
-                String jwt = bearerToken.substring(7, bearerToken.length());
+            String jwt = resolveToken(httpServletRequest);
+            if (StringUtils.hasText(jwt)) {
                 if (this.tokenProvider.validateToken(jwt)) {
                     Authentication authentication = this.tokenProvider.getAuthentication(jwt);
                     SecurityContextHolder.getContext().setAuthentication(authentication);
@@ -46,5 +45,19 @@ public class JWTFilter extends GenericFilterBean {
             log.info("Security exception for user {} - {}", eje.getClaims().getSubject(), eje.getMessage());
             ((HttpServletResponse) servletResponse).setStatus(HttpServletResponse.SC_UNAUTHORIZED);
         }
+    }
+
+    private String resolveToken(HttpServletRequest request){
+        String bearerToken = request.getHeader(JWTConfigurer.AUTHORIZATION_HEADER);
+        if(StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")){
+            String jwt = bearerToken.substring(7, bearerToken.length());
+            return jwt;
+        }
+        <% if (websocket == 'spring-websocket') { %>
+        String jwt = request.getParameter(JWTConfigurer.AUTHORIZATION_TOKEN);
+        if(StringUtils.hasText(jwt)) {
+            return jwt;
+        }<% } %>
+        return null;
     }
 }


### PR DESCRIPTION
Similar to oauth, this fix adds the current JWT token as a query param for the tracker (websocket) url. The query param is checked in the JWTFilter, if there is no JWT token in the header. This allows to authenticate the user during a STOMP connect frame.