### PR TITLE
Style sort icons to make them less visually intrusive in entity table

### DIFF
--- a/generators/client/templates/src/main/webapp/content/css/main.css
+++ b/generators/client/templates/src/main/webapp/content/css/main.css
@@ -278,6 +278,17 @@ Social Buttons
 .jh-table > tbody > tr > td {
     vertical-align: middle;
 }
+
+/* less visible sort icons */
+.glyphicon-sort, .glyphicon-sort-by-attributes, .glyphicon-sort-by-attributes-alt {
+    color: #bbb;
+}
+
+/* full visible sort icons and pointer when mouse is over them */
+.glyphicon-sort:hover, .glyphicon-sort-by-attributes:hover, .glyphicon-sort-by-attributes-alt:hover {
+    color: #000;
+    cursor: pointer;
+}
 /* end of entity tables helpers */
 
 /* ui bootstrap tweaks */

--- a/generators/client/templates/src/main/webapp/content/css/main.css
+++ b/generators/client/templates/src/main/webapp/content/css/main.css
@@ -279,14 +279,14 @@ Social Buttons
     vertical-align: middle;
 }
 
-/* less visible sort icons */
-.glyphicon-sort, .glyphicon-sort-by-attributes, .glyphicon-sort-by-attributes-alt {
-    color: #bbb;
+/* less visible sorting icons */
+.jh-table > thead > tr > th > .glyphicon-sort, .glyphicon-sort-by-attributes, .glyphicon-sort-by-attributes-alt {
+    opacity: 0.5;
 }
 
-/* full visible sort icons and pointer when mouse is over them */
-.glyphicon-sort:hover, .glyphicon-sort-by-attributes:hover, .glyphicon-sort-by-attributes-alt:hover {
-    color: #000;
+/* full visible sorting icons and pointer when mouse is over them */
+.jh-table > thead > tr > th > .glyphicon-sort:hover, .glyphicon-sort-by-attributes:hover, .glyphicon-sort-by-attributes-alt:hover {
+    opacity: 1;
     cursor: pointer;
 }
 /* end of entity tables helpers */

--- a/generators/client/templates/src/main/webapp/scss/main.scss
+++ b/generators/client/templates/src/main/webapp/scss/main.scss
@@ -268,6 +268,17 @@ ul#strength {
 .jh-table > tbody > tr > td {
     vertical-align: middle;
 }
+
+/* less visible sorting icons */
+.jh-table > thead > tr > th > .glyphicon-sort, .glyphicon-sort-by-attributes, .glyphicon-sort-by-attributes-alt {
+    opacity: 0.5;
+}
+
+/* full visible sorting icons and pointer when mouse is over them */
+.jh-table > thead > tr > th > .glyphicon-sort:hover, .glyphicon-sort-by-attributes:hover, .glyphicon-sort-by-attributes-alt:hover {
+    opacity: 1;
+    cursor: pointer;
+}
 /* end of entity tables helpers */
 
 /* ui bootstrap tweaks */


### PR DESCRIPTION
Make sort icons less visually intrusive in entity table by using lighter grey and switching back to black with a pointer when mouse is over.

Here is a screenshot below though the mouse pointer is wrong due to the capture tool, it should be the usual hand.

![sort_icons](https://cloud.githubusercontent.com/assets/361007/13219445/55e7cc10-d970-11e5-9a20-f0bf3379ba67.png)
