### PR TITLE
username should have same size as user.login

### DIFF
--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
@@ -227,7 +227,7 @@
             <column name="token_id" type="varchar(255)"/>
             <column name="token" type="BLOB"/>
             <column name="authentication_id" type="varchar(255)"/>
-            <column name="user_name" type="varchar(255)"/>
+            <column name="user_name" type="varchar(50)"/>
             <column name="client_id" type="varchar(255)"/>
         </createTable>
 
@@ -243,7 +243,7 @@
             <column name="authentication_id" type="varchar(255)">
                  <constraints nullable="false" primaryKey="true"/>
             </column>
-            <column name="user_name" type="varchar(255)"/>
+            <column name="user_name" type="varchar(50)"/>
             <column name="client_id" type="varchar(255)"/>
             <column name="authentication" type="BLOB"/>
             <column name="refresh_token" type="varchar(255)"/>


### PR DESCRIPTION
FOREIGN keys might fail on strict dbms servers setup because of the different sizes.