### PR TITLE
id is being provided by default by the predicate

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/pagination-template.ejs
@@ -17,7 +17,7 @@
             <%= entityClass %>.query({
                 page: pagingParams.page - 1,
                 size: paginationConstants.itemsPerPage,
-                sort: [vm.predicate + ',' + (vm.reverse ? 'asc' : 'desc'), 'id']
+                sort: [vm.predicate + ',' + (vm.reverse ? 'asc' : 'desc')]
             }, onSuccess, onError);
         };
         vm.loadPage = function(page) {


### PR DESCRIPTION
This causes an error with some SQL implementations as Sprint data tries to sort twice by the same column