### PR TITLE
Upgrade image in docker-compose files

### DIFF
--- a/generators/server/templates/src/main/docker/_dev.yml
+++ b/generators/server/templates/src/main/docker/_dev.yml
@@ -1,7 +1,7 @@
 <%_ if (devDatabaseType == 'mysql') { _%>
 <%= baseName.toLowerCase() %>-dev-mysql:
   container_name: <%= baseName.toLowerCase() %>-dev-mysql
-  image: mysql:5.7.9
+  image: mysql:5.7.11
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/dev-mysql/:/var/lib/mysql/
   environment:
@@ -15,7 +15,7 @@
 <%_ if (devDatabaseType == 'postgresql') { _%>
 <%= baseName.toLowerCase() %>-dev-postgresql:
   container_name: <%= baseName.toLowerCase() %>-dev-postgresql
-  image: postgres:9.4.5
+  image: postgres:9.5.1
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/dev-postgresql/:/var/lib/postgresql/
   environment:
@@ -27,7 +27,7 @@
 <%_ if (devDatabaseType == 'mongodb') { _%>
 <%= baseName.toLowerCase() %>-dev-mongodb:
   container_name: <%= baseName.toLowerCase() %>-dev-mongodb
-  image: mongo:3.0.7
+  image: mongo:3.2.3
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/dev-mongodb/:/data/db/
   ports:

--- a/generators/server/templates/src/main/docker/_prod.yml
+++ b/generators/server/templates/src/main/docker/_prod.yml
@@ -1,7 +1,7 @@
 <%_ if (searchEngine == 'elasticsearch') { _%>
 <%= baseName.toLowerCase() %>-elasticsearch:
   container_name: <%= baseName.toLowerCase() %>-elasticsearch
-  image: elasticsearch:1.7.3
+  image: elasticsearch:1.7.5
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/elasticsearch/:/usr/share/elasticsearch/data/
   ports:
@@ -11,7 +11,7 @@
 <%_ if (prodDatabaseType == 'mysql') { _%>
 <%= baseName.toLowerCase() %>-mysql:
   container_name: <%= baseName.toLowerCase() %>-mysql
-  image: mysql:5.7.9
+  image: mysql:5.7.11
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/mysql/:/var/lib/mysql/
   environment:
@@ -25,7 +25,7 @@
 <%_ if (prodDatabaseType == 'postgresql') { _%>
 <%= baseName.toLowerCase() %>-postgresql:
   container_name: <%= baseName.toLowerCase() %>-postgresql
-  image: postgres:9.4.5
+  image: postgres:9.5.1
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/postgresql/:/var/lib/postgresql/
   environment:
@@ -36,7 +36,7 @@
 <%_ } _%>
 <%_ if (prodDatabaseType == 'mongodb') { _%><%= baseName.toLowerCase() %>-mongodb:
   container_name: <%= baseName.toLowerCase() %>-mongodb
-  image: mongo:3.0.7
+  image: mongo:3.2.3
   # volumes:
   #   - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/
   ports:

--- a/generators/server/templates/src/main/docker/cassandra/_Cassandra-Dev.Dockerfile
+++ b/generators/server/templates/src/main/docker/cassandra/_Cassandra-Dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM cassandra:2.2.3
+FROM cassandra:2.2.5
 
 # script to initialize the database
 ADD cassandra/scripts/init-dev.sh /usr/local/bin/init

--- a/generators/server/templates/src/main/docker/cassandra/_Cassandra-Prod.Dockerfile
+++ b/generators/server/templates/src/main/docker/cassandra/_Cassandra-Prod.Dockerfile
@@ -1,4 +1,4 @@
-FROM cassandra:2.2.3
+FROM cassandra:2.2.5
 
 # install datastax-agent
 RUN apt-get update && apt-get install -y curl sysstat


### PR DESCRIPTION
All new images have been tested manually by generating an appropriate JHipster app.
Upgrades :
- mysql from 5.7.9 to 5.7.11
- psql from 9.4.5 to 9.5.1
- mongo from 3.0.7 to 3.2.3
- cassandra from 2.2.3 to 2.2.5
- elasticsearch from 1.7.3 to 1.7.5

Notes:
- elasticsearch 2+ doesn't work
- cassandra 3+ doesn't work
