### PR TITLE
Include JSONEditor script, needed for swagger-ui 2.1.4

### DIFF
--- a/generators/client/templates/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/src/main/webapp/swagger-ui/_index.html
@@ -19,6 +19,7 @@
     <script src='../bower_components/swagger-ui/dist/lib/backbone-min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/swagger-ui.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+    <script src='../bower_components/swagger-ui/dist/lib/jsoneditor.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/marked.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/swagger-oauth.js' type='text/javascript'></script>
 


### PR DESCRIPTION
I was just getting errors on the swagger page, in an app generated from latest master. It looks like swagger-ui version 2.1.4 (@jdubois updated recently) needs JSONEditor.

EDIT [this](https://github.com/jhipster/generator-jhipster/commit/72bfc62fb0c7eba178c19b4f9d56e6e6d43dccb3) is where it started.