### PR TITLE
only use @Transactional with sql and @Lob without mongodb

### DIFF
--- a/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -9,7 +9,7 @@ import java.util.Date;<% } %><% if (relationships.length > 0) { %>
 import java.util.HashSet;
 import java.util.Set;<% } %>
 import java.util.Objects;<% if (databaseType == 'cassandra') { %>
-import java.util.UUID;<% } %><% if (fieldsContainBlob == true) { %>
+import java.util.UUID;<% } %><% if (fieldsContainBlob == true && databaseType != 'mongodb') { %>
 import javax.persistence.Lob;<% } %>
 <% for (idx in fields) { if (fields[idx].fieldIsEnum == true) { %>
 import <%=packageName%>.domain.enumeration.<%= fields[idx].fieldType %>;<% } } %>
@@ -52,7 +52,7 @@ public class <%= entityClass %>DTO implements Serializable {
     @Size(min = <%= fieldValidateRulesMinbytes %>, max = <%= fieldValidateRulesMaxbytes %>)<% } %><% if (fieldValidateRules.indexOf('min') != -1) { %>
     @Min(value = <%= fieldValidateRulesMin %>)<% } %><% if (fieldValidateRules.indexOf('max') != -1) { %>
     @Max(value = <%= fieldValidateRulesMax %><%= (fieldValidateRulesMax > MAX_VALUE) ? 'L' : '' %>)<% } %><% if (fieldValidateRules.indexOf('pattern') != -1) { %>
-    @Pattern(regexp = "<%= fieldValidateRulesPatternJava %>")<% } } %><% if (fieldType == 'byte[]') { %>
+    @Pattern(regexp = "<%= fieldValidateRulesPatternJava %>")<% } } %><% if (fieldType == 'byte[]' && databaseType != 'mongodb') { %>
     @Lob<% } %>
     <%_ if (fieldTypeBlobContent != 'text') { _%>
     private <%= fieldType %> <%= fieldName %>;

--- a/generators/server/templates/src/test/java/package/web/rest/_AccountResourceIntTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_AccountResourceIntTest.java
@@ -24,8 +24,8 @@ import org.springframework.test.util.ReflectionTestUtils;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 
-import javax.inject.Inject;
-import javax.transaction.Transactional;
+import javax.inject.Inject;<% if (databaseType == 'sql') { %>
+import javax.transaction.Transactional;<% } %>
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -143,8 +143,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
                 .andExpect(status().isInternalServerError());
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterValid() throws Exception {
         UserDTO u = new UserDTO(
             "joe",                  // login
@@ -167,8 +167,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         assertThat(user.isPresent()).isTrue();
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterInvalidLogin() throws Exception {
         UserDTO u = new UserDTO(
             "funky-log!n",          // login <-- invalid
@@ -191,8 +191,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         assertThat(user.isPresent()).isFalse();
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterInvalidEmail() throws Exception {
         UserDTO u = new UserDTO(
             "bob",              // login
@@ -215,8 +215,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         assertThat(user.isPresent()).isFalse();
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterEmailEmpty() throws Exception {
         UserDTO u = new UserDTO(
             "bob",              // login
@@ -239,8 +239,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         assertThat(user.isPresent()).isFalse();
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterDuplicateLogin() throws Exception {
         // Good
         UserDTO u = new UserDTO(
@@ -276,8 +276,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         assertThat(userDup.isPresent()).isFalse();
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterDuplicateEmail() throws Exception {
         // Good
         UserDTO u = new UserDTO(
@@ -313,8 +313,8 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         assertThat(userDup.isPresent()).isFalse();
     }
 
-    @Test
-    @Transactional
+    @Test<% if (databaseType == 'sql') { %>
+    @Transactional<% } %>
     public void testRegisterAdminIsIgnored() throws Exception {
         UserDTO u = new UserDTO(
             "badguy",               // login


### PR DESCRIPTION
The Tranactional annotation is normally only used with SQL (based off of _UserService.java) so removing that should allow AccountResourceIntTest to compile and run for mongo and cassandra.

Removing the Lob annotation for Mongo allows Mongo projects with entities containing blobs to compile/upload files and images.

Fix #3010 
