### PR TITLE
add missing hibernate envers dependency

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -377,6 +377,10 @@
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.hibernate</groupId>
+            <artifactId>hibernate-envers</artifactId>
+        </dependency>
         <%_ if (databaseType == 'sql') { _%>
         <dependency>
             <groupId>org.hibernate</groupId>


### PR DESCRIPTION
This dependency disappeared recently from _pom.xml

Fix #3010 

