### PR TITLE
use longblob in entity liquibase changelogs when using mysql

### DIFF
--- a/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -50,7 +50,11 @@
             } else if (fieldType == 'ZonedDateTime') {
                 columnType="timestamp";
             } else if (fieldType == 'byte[]' && fieldTypeBlobContent != 'text') {
-                columnType="blob";
+                if (prodDatabaseType === 'mysql') {
+                    columnType="longblob";
+                } else {
+                    columnType="blob";
+                }
             } else if (fieldTypeBlobContent == 'text') {
                 columnType="clob";
             } else if (fieldType == 'Boolean') {


### PR DESCRIPTION
This increases the max blob size for MySQL from 64 KB to 4 GB.  

Fix #2934