### PR TITLE
Use gulp-footer to insert semi-colons before concatenating scripts

### DIFF
--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -26,6 +26,7 @@
     "gulp-cssnano": "2.1.1",
     "gulp-eslint": "2.0.0",
     "gulp-flatten": "0.2.0",
+    "gulp-footer": "1.0.5",
     "gulp-htmlmin": "1.3.0",
     "gulp-imagemin": "2.4.0",
     "gulp-if": "2.0.0",

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -28,7 +28,8 @@ var gulp = require('gulp'),
     changed = require('gulp-changed'),
     handleErrors = require('./gulp/handleErrors'),
     util = require('./gulp/utils'),
-    gulpIf = require('gulp-if');
+    gulpIf = require('gulp-if'),
+    footer = require('gulp-footer');
 
 var config = {
     app: '<%= MAIN_SRC_DIR %>',
@@ -244,6 +245,7 @@ gulp.task('usemin', ['images', 'styles'], function () {
             js: [
                 sourcemaps.init,
                 ngAnnotate,
+                footer.bind(footer, ';'),
                 'concat',
                 uglify.bind(uglify, { mangle: false }),
                 rev,


### PR DESCRIPTION
As reported in [#3017](https://github.com/jhipster/generator-jhipster/issues/3017), the current master branch generates an app with broken production build. This is a quick-and-dirty workaround, the proper fix would probably be to prepend a `;` to all scripts which now follow the module pattern,

```js
;(function(){
    /* ... */
})();
```
