### PR TITLE
Fix jhiAlert and jhiAlertErrors components

### DIFF
--- a/generators/client/templates/src/main/webapp/app/components/alert/_alert-error.directive.js
+++ b/generators/client/templates/src/main/webapp/app/components/alert/_alert-error.directive.js
@@ -1,23 +1,18 @@
 (function() {
     'use strict';
 
+    var jhiAlertError = {
+        template: '<div class="alerts" ng-cloak="">' +
+                        '<div ng-repeat="alert in $ctrl.alerts" ng-class="[alert.position, {\'toast\': alert.toast}]">' +
+                            '<uib-alert ng-cloak="" type="{{alert.type}}" close="alert.close($ctrl.alerts)"><pre>{{ alert.msg }}</pre></uib-alert>' +
+                        '</div>' +
+                  '</div>',
+        controller: jhiAlertErrorController
+    };
+    
     angular
         .module('<%=angularAppName%>')
         .component('jhiAlertError', jhiAlertError);
-
-    function jhiAlertError () {
-        var component = {
-            template: '<div class="alerts" ng-cloak="">' +
-                            '<div ng-repeat="alert in vm.alerts" ng-class="[alert.position, {\'toast\': alert.toast}]">' +
-                                '<uib-alert ng-cloak="" type="{{alert.type}}" close="alert.close(vm.alerts)"><pre>{{ alert.msg }}</pre></uib-alert>' +
-                            '</div>' +
-                      '</div>',
-            controller: jhiAlertErrorController,
-            controllerAs: 'vm'
-        };
-
-        return component;
-    }
 
     jhiAlertErrorController.$inject = ['$scope', 'AlertService', '$rootScope'<% if (enableTranslation) { %>, '$translate'<% } %>];
 

--- a/generators/client/templates/src/main/webapp/app/components/alert/_alert.directive.js
+++ b/generators/client/templates/src/main/webapp/app/components/alert/_alert.directive.js
@@ -4,7 +4,7 @@
     var jhiAlert = {
         template: '<div class="alerts" ng-cloak="">' +
                         '<div ng-repeat="alert in $ctrl.alerts" ng-class="[alert.position, {\'toast\': alert.toast}]">' +
-                            '<uib-alert ng-cloak="" type="{{alert.type}}" close="alert.close()"><pre>{{ alert.msg }}</pre></uib-alert>' +
+                            '<uib-alert ng-cloak="" type="{{alert.type}}" close="alert.close($ctrl.alerts)"><pre>{{ alert.msg }}</pre></uib-alert>' +
                         '</div>' +
                   '</div>',
         controller: jhiAlertController

--- a/generators/client/templates/src/main/webapp/app/components/alert/_alert.directive.js
+++ b/generators/client/templates/src/main/webapp/app/components/alert/_alert.directive.js
@@ -1,23 +1,18 @@
 (function() {
     'use strict';
 
+    var jhiAlert = {
+        template: '<div class="alerts" ng-cloak="">' +
+                        '<div ng-repeat="alert in $ctrl.alerts" ng-class="[alert.position, {\'toast\': alert.toast}]">' +
+                            '<uib-alert ng-cloak="" type="{{alert.type}}" close="alert.close()"><pre>{{ alert.msg }}</pre></uib-alert>' +
+                        '</div>' +
+                  '</div>',
+        controller: jhiAlertController
+    };
+
     angular
         .module('<%=angularAppName%>')
         .component('jhiAlert', jhiAlert);
-
-    function jhiAlert () {
-        var component = {
-            template: '<div class="alerts" ng-cloak="">' +
-                            '<div ng-repeat="alert in vm.alerts" ng-class="[alert.position, {\'toast\': alert.toast}]">' +
-                                '<uib-alert ng-cloak="" type="{{alert.type}}" close="alert.close()"><pre>{{ alert.msg }}</pre></uib-alert>' +
-                            '</div>' +
-                      '</div>',
-            controller: jhiAlertController,
-            controllerAs: 'vm'
-        };
-
-        return component;
-    }
 
     jhiAlertController.$inject = ['$scope', 'AlertService'];
 

--- a/generators/client/templates/src/main/webapp/app/components/alert/_alert.service.js
+++ b/generators/client/templates/src/main/webapp/app/components/alert/_alert.service.js
@@ -9,7 +9,7 @@
         this.toast = false;
         /*jshint validthis: true */
         this.$get = getService;
-        
+
         this.showAsToast = function(isToast) {
             this.toast = isToast;
         };
@@ -102,7 +102,7 @@
                     position: alertOptions.position ? alertOptions.position : 'top right',
                     scoped: alertOptions.scoped,
                     close: function (alerts) {
-                        return exports.closeAlert(this.id, alerts);
+                        return closeAlert(this.id, alerts);
                     }
                 };
                 if(!alert.scoped) {
@@ -128,7 +128,7 @@
 
             function closeAlert(id, extAlerts) {
                 var thisAlerts = extAlerts ? extAlerts : alerts;
-                return this.closeAlertByIndex(thisAlerts.map(function(e) { return e.id; }).indexOf(id), thisAlerts);
+                return closeAlertByIndex(thisAlerts.map(function(e) { return e.id; }).indexOf(id), thisAlerts);
             }
 
             function closeAlertByIndex(index, thisAlerts) {


### PR DESCRIPTION
While working on #3043 I realized that I've refactored wrongly the alert and alert-error directives into components. 
In directives, second parameter in `.directive('jhiAlertError', jhiAlertError)` was a function, in components it has to be a variable. So I fixed it and turned functions into variables. 

I followed [this issue](https://github.com/johnpapa/angular-styleguide/issues/662) to stay consistent with Johnpapa's style.