### PR TITLE
Fix protractor gulp task for new spec locations

### DIFF
--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -53,7 +53,7 @@ gulp.task('test', ['wiredep:test', 'ngconstant:dev'], function (done) {
 });
 <% if (testFrameworks.indexOf('protractor') > -1) { %>
 gulp.task('protractor', function () {
-    return gulp.src([config.test + 'e2e/*.js'])
+    return gulp.src([config.test + 'e2e/**/*.js'])
         .pipe(plumber({errorHandler: handleErrors}))
         .pipe(protractor({
             configFile: config.test + 'protractor.conf.js'


### PR DESCRIPTION
The locations of protractor spec files was changed recently, but the corresponding gulp task was not.