### PR TITLE
Protractor tests can failed Travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ env:
     - JHIPSTER_SAMPLES=$JHIPSTER_TRAVIS/samples
     - JHIPSTER_SCRIPTS=$JHIPSTER_TRAVIS/scripts
   matrix:
-    - JHIPSTER=app-default-from-scratch JHIPSTER_NODE_CACHE=0
-    - JHIPSTER=app-gradle RUN_APP=0
-    - JHIPSTER=app-cassandra
-    - JHIPSTER=app-microservice
-    - JHIPSTER=app-gateway
-    - JHIPSTER=app-hazelcast-cucumber
-    - JHIPSTER=app-mongodb
-    - JHIPSTER=app-oauth2
-    - JHIPSTER=app-jwt
-    - JHIPSTER=app-mysql PROFILE=prod
-    - JHIPSTER=app-psql-es-noi18n PROFILE=prod
+    # - JHIPSTER=app-default-from-scratch JHIPSTER_NODE_CACHE=0
+    # - JHIPSTER=app-gradle RUN_APP=0
+    # - JHIPSTER=app-cassandra
+    # - JHIPSTER=app-microservice
+    # - JHIPSTER=app-gateway
+    # - JHIPSTER=app-hazelcast-cucumber
+    # - JHIPSTER=app-mongodb
+    # - JHIPSTER=app-oauth2
+    # - JHIPSTER=app-jwt
+    # - JHIPSTER=app-mysql PROFILE=prod
+    # - JHIPSTER=app-psql-es-noi18n PROFILE=prod
     - JHIPSTER=app-social-websocket PROTRACTOR=1
 
 before_install:

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,17 +18,17 @@ env:
     - JHIPSTER_SAMPLES=$JHIPSTER_TRAVIS/samples
     - JHIPSTER_SCRIPTS=$JHIPSTER_TRAVIS/scripts
   matrix:
-    # - JHIPSTER=app-default-from-scratch JHIPSTER_NODE_CACHE=0
-    # - JHIPSTER=app-gradle RUN_APP=0
-    # - JHIPSTER=app-cassandra
-    # - JHIPSTER=app-microservice
-    # - JHIPSTER=app-gateway
-    # - JHIPSTER=app-hazelcast-cucumber
-    # - JHIPSTER=app-mongodb
-    # - JHIPSTER=app-oauth2
-    # - JHIPSTER=app-jwt
-    # - JHIPSTER=app-mysql PROFILE=prod
-    # - JHIPSTER=app-psql-es-noi18n PROFILE=prod
+    - JHIPSTER=app-default-from-scratch JHIPSTER_NODE_CACHE=0
+    - JHIPSTER=app-gradle RUN_APP=0
+    - JHIPSTER=app-cassandra
+    - JHIPSTER=app-microservice
+    - JHIPSTER=app-gateway
+    - JHIPSTER=app-hazelcast-cucumber
+    - JHIPSTER=app-mongodb
+    - JHIPSTER=app-oauth2
+    - JHIPSTER=app-jwt
+    - JHIPSTER=app-mysql PROFILE=prod PROTRACTOR=1
+    - JHIPSTER=app-psql-es-noi18n PROFILE=prod
     - JHIPSTER=app-social-websocket PROTRACTOR=1
 
 before_install:

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -56,7 +56,7 @@ gulp.task('test', ['wiredep:test', 'ngconstant:dev'], function (done) {
 
 <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
 gulp.task('protractor', function () {
-    gulp.src([config.test + 'e2e/!**!/!*.js'])
+    gulp.src([config.test + 'e2e/**/*.js'])
         .pipe(protractor({
             configFile: config.test + 'protractor.conf.js'
         }))

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -60,19 +60,7 @@ gulp.task('protractor', function () {
         .pipe(plumber({errorHandler: handleErrors}))
         .pipe(protractor({
             configFile: config.test + 'protractor.conf.js'
-    }));
-});
-
-gulp.task('protractor-travis', function () {
-    gulp.src([config.test + 'e2e/**/*.js'])
-        .pipe(protractor({
-            configFile: config.test + 'protractor.conf.js'
         }))
-        .on('end', function() {
-            console.log('E2E Testing complete');
-            // exit with success.
-            process.exit(0);
-        })
         .on('error', function(err) {
             console.log('E2E Tests failed');
             process.exit(1);
@@ -341,6 +329,5 @@ gulp.task('eslint-and-fix', function () {
 
 <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
 gulp.task('itest', ['protractor']);
-gulp.task('itest-travis', ['protractor-travis']);
 <%_ } _%>
 gulp.task('default', ['serve']);

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -53,14 +53,24 @@ gulp.task('test', ['wiredep:test', 'ngconstant:dev'], function (done) {
         singleRun: true
     }, done).start();
 });
-<% if (testFrameworks.indexOf('protractor') > -1) { %>
+
+<%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
 gulp.task('protractor', function () {
-    return gulp.src([config.test + 'e2e/**/*.js'])
-        .pipe(plumber({errorHandler: handleErrors}))
+    gulp.src([config.test + 'e2e/!**!/!*.js'])
         .pipe(protractor({
             configFile: config.test + 'protractor.conf.js'
-        }));
-});<% } %>
+        }))
+        .on('end', function() {
+            console.log('E2E Testing complete');
+            // exit with success.
+            process.exit(0);
+        })
+        .on('error', function(err) {
+            console.log('E2E Tests failed');
+            process.exit(1);
+        });
+});
+<%_ } _%>
 
 gulp.task('copy', function () {
     return es.merge( <% if(enableTranslation) { %> // copy i18n folders only if translation is enabled

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -56,6 +56,14 @@ gulp.task('test', ['wiredep:test', 'ngconstant:dev'], function (done) {
 
 <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
 gulp.task('protractor', function () {
+    return gulp.src([config.test + 'e2e/**/*.js'])
+        .pipe(plumber({errorHandler: handleErrors}))
+        .pipe(protractor({
+            configFile: config.test + 'protractor.conf.js'
+    }));
+});
+
+gulp.task('protractor-travis', function () {
     gulp.src([config.test + 'e2e/**/*.js'])
         .pipe(protractor({
             configFile: config.test + 'protractor.conf.js'
@@ -331,8 +339,8 @@ gulp.task('eslint-and-fix', function () {
         .pipe(gulpIf(util.isLintFixed, gulp.dest(config.app + 'app')));
 });
 
-
-<% if (testFrameworks.indexOf('protractor') > -1) { %>
+<%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
 gulp.task('itest', ['protractor']);
-<% } %>
+gulp.task('itest-travis', ['protractor-travis']);
+<%_ } _%>
 gulp.task('default', ['serve']);

--- a/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
+++ b/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
@@ -37,7 +37,7 @@ describe('administration', function () {
 
     it('should load health', function () {
         element(by.css('[ui-sref="health"]')).click();
-        expect(element.all(by.css('h2')).first().getText()).toMatch(/Wrong Health Checks/);
+        expect(element.all(by.css('h2')).first().getText()).toMatch(/Health Checks/);
     });
 
     it('should load configuration', function () {
@@ -53,11 +53,6 @@ describe('administration', function () {
     it('should load logs', function () {
         element(by.css('[ui-sref="logs"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Logs/);
-    });
-
-    it('should load api docs', function () {
-        element(by.css('[ui-sref="docs"]')).click();
-        expect(element.all(by.css('iframe')).isDisplayed()).toBeTruthy();
     });
 
     afterAll(function () {

--- a/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
+++ b/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
@@ -37,7 +37,7 @@ describe('administration', function () {
 
     it('should load health', function () {
         element(by.css('[ui-sref="health"]')).click();
-        expect(element.all(by.css('h2')).first().getText()).toMatch(/Health Checks/);
+        expect(element.all(by.css('h2')).first().getText()).toMatch(/Wrong Health Checks/);
     });
 
     it('should load configuration', function () {

--- a/travis/samples/app-mysql/.yo-rc.json
+++ b/travis/samples/app-mysql/.yo-rc.json
@@ -20,7 +20,8 @@
     "enableSocialSignIn": false,
     "rememberMeKey": "338224d584859bd80d093bc4346526637190816b",
     "testFrameworks": [
-      "gatling"
+      "gatling",
+      "protractor"
     ]
   }
 }

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -24,6 +24,6 @@ if [ "$RUN_APP" == 1 ]; then
   # Launch protractor tests
   #-------------------------------------------------------------------------------
   if [ "$PROTRACTOR" == 1 ]; then
-    gulp itest-travis --no-notification
+    gulp itest --no-notification
   fi
 fi

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -24,6 +24,6 @@ if [ "$RUN_APP" == 1 ]; then
   # Launch protractor tests
   #-------------------------------------------------------------------------------
   if [ "$PROTRACTOR" == 1 ]; then
-    gulp itest --no-notification
+    gulp itest-travis --no-notification
   fi
 fi


### PR DESCRIPTION
I add 2 news tasks in gulpfile.js : itest-travis and protractor-travis

So when the protractor tests failed, it should return 1 to travis build, so it should failed now...
I add protractor tests to MySQL sample in production profile.
So I had to remove the test on "api docs" because it doesn't exist in prod profile