### PR TITLE
Renaming clashing services and controllers

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -105,6 +105,7 @@ module.exports = JhipsterClientGenerator.extend({
         this.searchEngine = this.options['search-engine'];
         this.hibernateCache = this.options['hb-cache'];
         this.jhiPrefix = this.options['jhi-prefix'];
+        this.jhiPrefixCapitalized = _.capitalize(this.jhiPrefix);
         this.testFrameworks = [];
         this.options['protractor'] &&  this.testFrameworks.push('protractor');
         var lastQuestion = configOptions.lastQuestion;

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -87,6 +87,13 @@ module.exports = JhipsterClientGenerator.extend({
             type: String
         });
 
+        // This adds support for a `--jhi-prefix` flag
+        this.option('jhi-prefix', {
+            desc: 'Add prefix before services, controllers and states name',
+            type: String,
+            defaults: 'jhi'
+        });
+
         this.skipServer = configOptions.skipServer || this.config.get('skipServer');
         this.skipUserManagement = configOptions.skipUserManagement ||  this.config.get('skipUserManagement');
         this.authenticationType = this.options['auth'];
@@ -97,6 +104,7 @@ module.exports = JhipsterClientGenerator.extend({
         this.enableSocialSignIn = this.options['social'];
         this.searchEngine = this.options['search-engine'];
         this.hibernateCache = this.options['hb-cache'];
+        this.jhiPrefix = this.options['jhi-prefix'];
         this.testFrameworks = [];
         this.options['protractor'] &&  this.testFrameworks.push('protractor');
         var lastQuestion = configOptions.lastQuestion;

--- a/generators/client/templates/src/main/webapp/app/account/settings/_settings.controller.js
+++ b/generators/client/templates/src/main/webapp/app/account/settings/_settings.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('SettingsController', SettingsController);
 
-    SettingsController.$inject = ['Principal', 'Auth'<% if (enableTranslation){ %>, 'JhiLanguageService', '$translate'<% } %>];
+    SettingsController.$inject = ['Principal', 'Auth'<% if (enableTranslation){ %>, '<%=jhiPrefix%>LanguageService', '$translate'<% } %>];
 
-    function SettingsController (Principal, Auth<% if (enableTranslation){ %>, JhiLanguageService, $translate<% } %>) {
+    function SettingsController (Principal, Auth<% if (enableTranslation){ %>, <%=jhiPrefix%>LanguageService, $translate<% } %>) {
         var vm = this;
 
         vm.error = null;
@@ -40,7 +40,7 @@
                 Principal.identity(true).then(function(account) {
                     vm.settingsAccount = copyAccount(account);
                 });<% if (enableTranslation){ %>
-                JhiLanguageService.getCurrent().then(function(current) {
+                <%=jhiPrefix%>LanguageService.getCurrent().then(function(current) {
                     if (vm.settingsAccount.langKey !== current) {
                         $translate.use(vm.settingsAccount.langKey);
                     }

--- a/generators/client/templates/src/main/webapp/app/account/settings/_settings.controller.js
+++ b/generators/client/templates/src/main/webapp/app/account/settings/_settings.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('SettingsController', SettingsController);
 
-    SettingsController.$inject = ['Principal', 'Auth'<% if (enableTranslation){ %>, 'Language', '$translate'<% } %>];
+    SettingsController.$inject = ['Principal', 'Auth'<% if (enableTranslation){ %>, 'JhiLanguageService', '$translate'<% } %>];
 
-    function SettingsController (Principal, Auth<% if (enableTranslation){ %>, Language, $translate<% } %>) {
+    function SettingsController (Principal, Auth<% if (enableTranslation){ %>, JhiLanguageService, $translate<% } %>) {
         var vm = this;
 
         vm.error = null;
@@ -40,7 +40,7 @@
                 Principal.identity(true).then(function(account) {
                     vm.settingsAccount = copyAccount(account);
                 });<% if (enableTranslation){ %>
-                Language.getCurrent().then(function(current) {
+                JhiLanguageService.getCurrent().then(function(current) {
                     if (vm.settingsAccount.langKey !== current) {
                         $translate.use(vm.settingsAccount.langKey);
                     }

--- a/generators/client/templates/src/main/webapp/app/account/settings/_settings.controller.js
+++ b/generators/client/templates/src/main/webapp/app/account/settings/_settings.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('SettingsController', SettingsController);
 
-    SettingsController.$inject = ['Principal', 'Auth'<% if (enableTranslation){ %>, '<%=jhiPrefix%>LanguageService', '$translate'<% } %>];
+    SettingsController.$inject = ['Principal', 'Auth'<% if (enableTranslation){ %>, '<%=jhiPrefixCapitalized%>LanguageService', '$translate'<% } %>];
 
-    function SettingsController (Principal, Auth<% if (enableTranslation){ %>, <%=jhiPrefix%>LanguageService, $translate<% } %>) {
+    function SettingsController (Principal, Auth<% if (enableTranslation){ %>, <%=jhiPrefixCapitalized%>LanguageService, $translate<% } %>) {
         var vm = this;
 
         vm.error = null;
@@ -40,7 +40,7 @@
                 Principal.identity(true).then(function(account) {
                     vm.settingsAccount = copyAccount(account);
                 });<% if (enableTranslation){ %>
-                <%=jhiPrefix%>LanguageService.getCurrent().then(function(current) {
+                <%=jhiPrefixCapitalized%>LanguageService.getCurrent().then(function(current) {
                     if (vm.settingsAccount.langKey !== current) {
                         $translate.use(vm.settingsAccount.langKey);
                     }

--- a/generators/client/templates/src/main/webapp/app/account/settings/settings.html
+++ b/generators/client/templates/src/main/webapp/app/account/settings/settings.html
@@ -80,7 +80,7 @@
                 </div><% if (enableTranslation){ %>
                 <div class="form-group">
                     <label for="langKey" translate="settings.form.language">Language</label>
-                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="LanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
+                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="JhiLanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
                 </div><% } %>
 
                 <button type="submit" ng-disabled="form.$invalid" class="btn btn-primary" translate="settings.form.button">Save</button>

--- a/generators/client/templates/src/main/webapp/app/account/settings/settings.html
+++ b/generators/client/templates/src/main/webapp/app/account/settings/settings.html
@@ -80,7 +80,7 @@
                 </div><% if (enableTranslation){ %>
                 <div class="form-group">
                     <label for="langKey" translate="settings.form.language">Language</label>
-                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="LanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
+                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="<%=jhiPrefix%>LanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
                 </div><% } %>
 
                 <button type="submit" ng-disabled="form.$invalid" class="btn btn-primary" translate="settings.form.button">Save</button>

--- a/generators/client/templates/src/main/webapp/app/account/settings/settings.html
+++ b/generators/client/templates/src/main/webapp/app/account/settings/settings.html
@@ -80,7 +80,7 @@
                 </div><% if (enableTranslation){ %>
                 <div class="form-group">
                     <label for="langKey" translate="settings.form.language">Language</label>
-                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="JhiLanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
+                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="LanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
                 </div><% } %>
 
                 <button type="submit" ng-disabled="form.$invalid" class="btn btn-primary" translate="settings.form.button">Save</button>

--- a/generators/client/templates/src/main/webapp/app/account/settings/settings.html
+++ b/generators/client/templates/src/main/webapp/app/account/settings/settings.html
@@ -80,7 +80,7 @@
                 </div><% if (enableTranslation){ %>
                 <div class="form-group">
                     <label for="langKey" translate="settings.form.language">Language</label>
-                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="<%=jhiPrefix%>LanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
+                    <select id="langKey" name="langKey" class="form-control" ng-model="vm.settingsAccount.langKey" ng-controller="<%=jhiPrefixCapitalized%>LanguageController as languageVm" ng-options="code as (code | findLanguageFromKey) for code in languageVm.languages"></select>
                 </div><% } %>
 
                 <button type="submit" ng-disabled="form.$invalid" class="btn btn-primary" translate="settings.form.button">Save</button>

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
@@ -3,20 +3,20 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('<%=jhiPrefix%>ConfigurationController', <%=jhiPrefix%>ConfigurationController);
+        .controller('<%=jhiPrefixCapitalized%>ConfigurationController', <%=jhiPrefixCapitalized%>ConfigurationController);
 
-    <%=jhiPrefix%>ConfigurationController.$inject = ['$filter','<%=jhiPrefix%>ConfigurationService'];
+    <%=jhiPrefixCapitalized%>ConfigurationController.$inject = ['$filter','<%=jhiPrefixCapitalized%>ConfigurationService'];
 
-    function <%=jhiPrefix%>ConfigurationController (filter,<%=jhiPrefix%>ConfigurationService) {
+    function <%=jhiPrefixCapitalized%>ConfigurationController (filter,<%=jhiPrefixCapitalized%>ConfigurationService) {
         var vm = this;
 
         vm.allConfiguration = null;
         vm.configuration = null;
 
-        <%=jhiPrefix%>ConfigurationService.get().then(function(configuration) {
+        <%=jhiPrefixCapitalized%>ConfigurationService.get().then(function(configuration) {
             vm.configuration = configuration;
         });
-        <%=jhiPrefix%>ConfigurationService.getEnv().then(function (configuration) {
+        <%=jhiPrefixCapitalized%>ConfigurationService.getEnv().then(function (configuration) {
             vm.allConfiguration = configuration;
         });
     }

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('JhiConfigurationController', JhiConfigurationController);
+        .controller('ConfigurationController', ConfigurationController);
 
-    JhiConfigurationController.$inject = ['$filter','JhiConfigurationService'];
+    ConfigurationController.$inject = ['$filter','JhiConfigurationService'];
 
-    function JhiConfigurationController (filter,JhiConfigurationService) {
+    function ConfigurationController (filter,JhiConfigurationService) {
         var vm = this;
 
         vm.allConfiguration = null;

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
@@ -5,18 +5,18 @@
         .module('<%=angularAppName%>')
         .controller('ConfigurationController', ConfigurationController);
 
-    ConfigurationController.$inject = ['$filter','ConfigurationService'];
+    ConfigurationController.$inject = ['$filter','JhiConfigurationService'];
 
-    function ConfigurationController (filter,ConfigurationService) {
+    function ConfigurationController (filter,JhiConfigurationService) {
         var vm = this;
 
         vm.allConfiguration = null;
         vm.configuration = null;
 
-        ConfigurationService.get().then(function(configuration) {
+        JhiConfigurationService.get().then(function(configuration) {
             vm.configuration = configuration;
         });
-        ConfigurationService.getEnv().then(function (configuration) {
+        JhiConfigurationService.getEnv().then(function (configuration) {
             vm.allConfiguration = configuration;
         });
     }

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
@@ -3,20 +3,20 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('ConfigurationController', ConfigurationController);
+        .controller('<%=jhiPrefix%>ConfigurationController', <%=jhiPrefix%>ConfigurationController);
 
-    ConfigurationController.$inject = ['$filter','JhiConfigurationService'];
+    <%=jhiPrefix%>ConfigurationController.$inject = ['$filter','<%=jhiPrefix%>ConfigurationService'];
 
-    function ConfigurationController (filter,JhiConfigurationService) {
+    function <%=jhiPrefix%>ConfigurationController (filter,<%=jhiPrefix%>ConfigurationService) {
         var vm = this;
 
         vm.allConfiguration = null;
         vm.configuration = null;
 
-        JhiConfigurationService.get().then(function(configuration) {
+        <%=jhiPrefix%>ConfigurationService.get().then(function(configuration) {
             vm.configuration = configuration;
         });
-        JhiConfigurationService.getEnv().then(function (configuration) {
+        <%=jhiPrefix%>ConfigurationService.getEnv().then(function (configuration) {
             vm.allConfiguration = configuration;
         });
     }

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('ConfigurationController', ConfigurationController);
+        .controller('JhiConfigurationController', JhiConfigurationController);
 
-    ConfigurationController.$inject = ['$filter','JhiConfigurationService'];
+    JhiConfigurationController.$inject = ['$filter','JhiConfigurationService'];
 
-    function ConfigurationController (filter,JhiConfigurationService) {
+    function JhiConfigurationController (filter,JhiConfigurationService) {
         var vm = this;
 
         vm.allConfiguration = null;

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('ConfigurationService', ConfigurationService);
+        .factory('JhiConfigurationService', JhiConfigurationService);
 
-    ConfigurationService.$inject = ['$filter', '$http'];
+    JhiConfigurationService.$inject = ['$filter', '$http'];
 
-    function ConfigurationService ($filter, $http) {
+    function JhiConfigurationService ($filter, $http) {
         var service = {
             get: get,
             getEnv: getEnv

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('<%=jhiPrefix%>ConfigurationService', <%=jhiPrefix%>ConfigurationService);
+        .factory('<%=jhiPrefixCapitalized%>ConfigurationService', <%=jhiPrefixCapitalized%>ConfigurationService);
 
-    <%=jhiPrefix%>ConfigurationService.$inject = ['$filter', '$http'];
+    <%=jhiPrefixCapitalized%>ConfigurationService.$inject = ['$filter', '$http'];
 
-    function <%=jhiPrefix%>ConfigurationService ($filter, $http) {
+    function <%=jhiPrefixCapitalized%>ConfigurationService ($filter, $http) {
         var service = {
             get: get,
             getEnv: getEnv

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('JhiConfigurationService', JhiConfigurationService);
+        .factory('<%=jhiPrefix%>ConfigurationService', <%=jhiPrefix%>ConfigurationService);
 
-    JhiConfigurationService.$inject = ['$filter', '$http'];
+    <%=jhiPrefix%>ConfigurationService.$inject = ['$filter', '$http'];
 
-    function JhiConfigurationService ($filter, $http) {
+    function <%=jhiPrefix%>ConfigurationService ($filter, $http) {
         var service = {
             get: get,
             getEnv: getEnv

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/configuration/configuration.html',
-                    controller: 'ConfigurationController',
+                    controller: 'JhiConfigurationController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/configuration/configuration.html',
-                    controller: 'JhiConfigurationController',
+                    controller: 'ConfigurationController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('<%=jhiPrefix%>configuration', {
+        $stateProvider.state('<%=jhiPrefix%>-configuration', {
             parent: 'admin',
             url: '/configuration',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/configuration/configuration.html',
-                    controller: '<%=jhiPrefix%>ConfigurationController',
+                    controller: '<%=jhiPrefixCapitalized%>ConfigurationController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/configuration/_configuration.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('configuration', {
+        $stateProvider.state('<%=jhiPrefix%>configuration', {
             parent: 'admin',
             url: '/configuration',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/configuration/configuration.html',
-                    controller: 'ConfigurationController',
+                    controller: '<%=jhiPrefix%>ConfigurationController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('HealthController', HealthController);
+        .controller('JhiHealthController', JhiHealthController);
 
-    HealthController.$inject = ['JhiHealthService', '$uibModal'];
+    JhiHealthController.$inject = ['JhiHealthService', '$uibModal'];
 
-    function HealthController (JhiHealthService, $uibModal) {
+    function JhiHealthController (JhiHealthService, $uibModal) {
         var vm = this;
 
         vm.addHealthObject = addHealthObject;
@@ -135,7 +135,7 @@
         function showHealth (health) {
             $uibModal.open({
                 templateUrl: 'app/admin/health/health.modal.html',
-                controller: 'HealthModalController',
+                controller: 'JhiHealthModalController',
                 controllerAs: 'vm',
                 size: 'lg',
                 resolve: {

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('HealthController', HealthController);
+        .controller('HealthCheckController', HealthCheckController);
 
-    HealthController.$inject = ['JhiHealthService', '$uibModal'];
+    HealthCheckController.$inject = ['JhiHealthService', '$uibModal'];
 
-    function HealthController (JhiHealthService, $uibModal) {
+    function HealthCheckController (JhiHealthService, $uibModal) {
         var vm = this;
 
         vm.addHealthObject = addHealthObject;

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('<%=jhiPrefix%>HealthCheckController', <%=jhiPrefix%>HealthCheckController);
+        .controller('<%=jhiPrefixCapitalized%>HealthCheckController', <%=jhiPrefixCapitalized%>HealthCheckController);
 
-    <%=jhiPrefix%>HealthCheckController.$inject = ['<%=jhiPrefix%>HealthService', '$uibModal'];
+    <%=jhiPrefixCapitalized%>HealthCheckController.$inject = ['<%=jhiPrefixCapitalized%>HealthService', '$uibModal'];
 
-    function <%=jhiPrefix%>HealthCheckController (<%=jhiPrefix%>HealthService, $uibModal) {
+    function <%=jhiPrefixCapitalized%>HealthCheckController (<%=jhiPrefixCapitalized%>HealthService, $uibModal) {
         var vm = this;
 
         vm.addHealthObject = addHealthObject;
@@ -123,7 +123,7 @@
 
         function refresh () {
             vm.updatingHealth = true;
-            <%=jhiPrefix%>HealthService.checkHealth().then(function (response) {
+            <%=jhiPrefixCapitalized%>HealthService.checkHealth().then(function (response) {
                 vm.healthData = vm.transformHealthData(response);
                 vm.updatingHealth = false;
             }, function (response) {

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('HealthController', HealthController);
 
-    HealthController.$inject = ['HealthService', '$uibModal'];
+    HealthController.$inject = ['JhiHealthService', '$uibModal'];
 
-    function HealthController (HealthService, $uibModal) {
+    function HealthController (JhiHealthService, $uibModal) {
         var vm = this;
 
         vm.addHealthObject = addHealthObject;
@@ -123,7 +123,7 @@
 
         function refresh () {
             vm.updatingHealth = true;
-            HealthService.checkHealth().then(function (response) {
+            JhiHealthService.checkHealth().then(function (response) {
                 vm.healthData = vm.transformHealthData(response);
                 vm.updatingHealth = false;
             }, function (response) {

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('JhiHealthController', JhiHealthController);
+        .controller('HealthController', HealthController);
 
-    JhiHealthController.$inject = ['JhiHealthService', '$uibModal'];
+    HealthController.$inject = ['JhiHealthService', '$uibModal'];
 
-    function JhiHealthController (JhiHealthService, $uibModal) {
+    function HealthController (JhiHealthService, $uibModal) {
         var vm = this;
 
         vm.addHealthObject = addHealthObject;
@@ -135,7 +135,7 @@
         function showHealth (health) {
             $uibModal.open({
                 templateUrl: 'app/admin/health/health.modal.html',
-                controller: 'JhiHealthModalController',
+                controller: 'HealthModalController',
                 controllerAs: 'vm',
                 size: 'lg',
                 resolve: {

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('HealthCheckController', HealthCheckController);
+        .controller('<%=jhiPrefix%>HealthCheckController', <%=jhiPrefix%>HealthCheckController);
 
-    HealthCheckController.$inject = ['JhiHealthService', '$uibModal'];
+    <%=jhiPrefix%>HealthCheckController.$inject = ['<%=jhiPrefix%>HealthService', '$uibModal'];
 
-    function HealthCheckController (JhiHealthService, $uibModal) {
+    function <%=jhiPrefix%>HealthCheckController (<%=jhiPrefix%>HealthService, $uibModal) {
         var vm = this;
 
         vm.addHealthObject = addHealthObject;
@@ -123,7 +123,7 @@
 
         function refresh () {
             vm.updatingHealth = true;
-            JhiHealthService.checkHealth().then(function (response) {
+            <%=jhiPrefix%>HealthService.checkHealth().then(function (response) {
                 vm.healthData = vm.transformHealthData(response);
                 vm.updatingHealth = false;
             }, function (response) {

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.modal.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.modal.controller.js
@@ -2,11 +2,11 @@
     'use strict';
 
     angular.module('<%=angularAppName%>')
-        .controller('JhiHealthModalController', JhiHealthModalController);
+        .controller('HealthModalController', HealthModalController);
 
-    JhiHealthModalController.$inject = ['$uibModalInstance', 'currentHealth', 'baseName', 'subSystemName'];
+    HealthModalController.$inject = ['$uibModalInstance', 'currentHealth', 'baseName', 'subSystemName'];
 
-    function JhiHealthModalController ($uibModalInstance, currentHealth, baseName, subSystemName) {
+    function HealthModalController ($uibModalInstance, currentHealth, baseName, subSystemName) {
         var vm = this;
 
         vm.cancel = cancel;

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.modal.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.modal.controller.js
@@ -2,11 +2,11 @@
     'use strict';
 
     angular.module('<%=angularAppName%>')
-        .controller('HealthModalController', HealthModalController);
+        .controller('JhiHealthModalController', JhiHealthModalController);
 
-    HealthModalController.$inject = ['$uibModalInstance', 'currentHealth', 'baseName', 'subSystemName'];
+    JhiHealthModalController.$inject = ['$uibModalInstance', 'currentHealth', 'baseName', 'subSystemName'];
 
-    function HealthModalController ($uibModalInstance, currentHealth, baseName, subSystemName) {
+    function JhiHealthModalController ($uibModalInstance, currentHealth, baseName, subSystemName) {
         var vm = this;
 
         vm.cancel = cancel;

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('<%=jhiPrefix%>HealthService', <%=jhiPrefix%>HealthService);
+        .factory('<%=jhiPrefixCapitalized%>HealthService', <%=jhiPrefixCapitalized%>HealthService);
 
-    <%=jhiPrefix%>HealthService.$inject = ['$rootScope', '$http'];
+    <%=jhiPrefixCapitalized%>HealthService.$inject = ['$rootScope', '$http'];
 
-    function <%=jhiPrefix%>HealthService ($rootScope, $http) {
+    function <%=jhiPrefixCapitalized%>HealthService ($rootScope, $http) {
         var service = {
             checkHealth: checkHealth
         };

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('JhiHealthService', JhiHealthService);
+        .factory('<%=jhiPrefix%>HealthService', <%=jhiPrefix%>HealthService);
 
-    JhiHealthService.$inject = ['$rootScope', '$http'];
+    <%=jhiPrefix%>HealthService.$inject = ['$rootScope', '$http'];
 
-    function JhiHealthService ($rootScope, $http) {
+    function <%=jhiPrefix%>HealthService ($rootScope, $http) {
         var service = {
             checkHealth: checkHealth
         };

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('HealthService', HealthService);
-        
-    HealthService.$inject = ['$rootScope', '$http'];
+        .factory('JhiHealthService', JhiHealthService);
 
-    function HealthService ($rootScope, $http) {
+    JhiHealthService.$inject = ['$rootScope', '$http'];
+
+    function JhiHealthService ($rootScope, $http) {
         var service = {
             checkHealth: checkHealth
         };

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('health', {
+        $stateProvider.state('<%=jhiPrefix%>health', {
             parent: 'admin',
             url: '/health',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/health/health.html',
-                    controller: 'HealthCheckController',
+                    controller: '<%=jhiPrefix%>HealthCheckController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/health/health.html',
-                    controller: 'HealthController',
+                    controller: 'JhiHealthController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('<%=jhiPrefix%>health', {
+        $stateProvider.state('<%=jhiPrefix%>-health', {
             parent: 'admin',
             url: '/health',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/health/health.html',
-                    controller: '<%=jhiPrefix%>HealthCheckController',
+                    controller: '<%=jhiPrefixCapitalized%>HealthCheckController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/health/health.html',
-                    controller: 'JhiHealthController',
+                    controller: 'HealthController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/health/_health.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/health/health.html',
-                    controller: 'HealthController',
+                    controller: 'HealthCheckController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('MetricsMonitoringController', MetricsMonitoringController);
+        .controller('<%=jhiPrefix%>MetricsMonitoringController', <%=jhiPrefix%>MetricsMonitoringController);
 
-    MetricsMonitoringController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
+    <%=jhiPrefix%>MetricsMonitoringController.$inject = ['$scope','<%=jhiPrefix%>MetricsService', '$uibModal'];
 
-    function MetricsMonitoringController ($scope, JhiMetricsService, $uibModal) {
+    function <%=jhiPrefix%>MetricsMonitoringController ($scope, <%=jhiPrefix%>MetricsService, $uibModal) {
         var vm = this;
 
         vm.cachesStats = {};
@@ -43,7 +43,7 @@
 
         function refresh () {
             vm.updatingMetrics = true;
-            JhiMetricsService.getMetrics().then(function (promise) {
+            <%=jhiPrefix%>MetricsService.getMetrics().then(function (promise) {
                 vm.metrics = promise;
                 vm.updatingMetrics = false;
             }, function (promise) {
@@ -53,10 +53,10 @@
         }
 
         function refreshThreadDumpData () {
-            JhiMetricsService.threadDump().then(function(data) {
+            <%=jhiPrefix%>MetricsService.threadDump().then(function(data) {
                 $uibModal.open({
                     templateUrl: 'app/admin/metrics/metrics.modal.html',
-                    controller: 'MetricsModalController',
+                    controller: '<%=jhiPrefix%>MetricsMonitoringModalController',
                     controllerAs: 'vm',
                     size: 'lg',
                     resolve: {

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('MetricsController', MetricsController);
 
-    MetricsController.$inject = ['$scope','MetricsService', '$uibModal'];
+    MetricsController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
 
-    function MetricsController ($scope, MetricsService, $uibModal) {
+    function MetricsController ($scope, JhiMetricsService, $uibModal) {
         var vm = this;
 
         vm.cachesStats = {};
@@ -43,7 +43,7 @@
 
         function refresh () {
             vm.updatingMetrics = true;
-            MetricsService.getMetrics().then(function (promise) {
+            JhiMetricsService.getMetrics().then(function (promise) {
                 vm.metrics = promise;
                 vm.updatingMetrics = false;
             }, function (promise) {
@@ -53,7 +53,7 @@
         }
 
         function refreshThreadDumpData () {
-            MetricsService.threadDump().then(function(data) {
+            JhiMetricsService.threadDump().then(function(data) {
                 $uibModal.open({
                     templateUrl: 'app/admin/metrics/metrics.modal.html',
                     controller: 'MetricsModalController',

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('JhiMetricsController', JhiMetricsController);
+        .controller('MetricsController', MetricsController);
 
-    JhiMetricsController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
+    MetricsController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
 
-    function JhiMetricsController ($scope, JhiMetricsService, $uibModal) {
+    function MetricsController ($scope, JhiMetricsService, $uibModal) {
         var vm = this;
 
         vm.cachesStats = {};
@@ -56,7 +56,7 @@
             JhiMetricsService.threadDump().then(function(data) {
                 $uibModal.open({
                     templateUrl: 'app/admin/metrics/metrics.modal.html',
-                    controller: 'JhiMetricsModalController',
+                    controller: 'MetricsModalController',
                     controllerAs: 'vm',
                     size: 'lg',
                     resolve: {

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('MetricsController', MetricsController);
+        .controller('MetricsMonitoringController', MetricsMonitoringController);
 
-    MetricsController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
+    MetricsMonitoringController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
 
-    function MetricsController ($scope, JhiMetricsService, $uibModal) {
+    function MetricsMonitoringController ($scope, JhiMetricsService, $uibModal) {
         var vm = this;
 
         vm.cachesStats = {};

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('<%=jhiPrefix%>MetricsMonitoringController', <%=jhiPrefix%>MetricsMonitoringController);
+        .controller('<%=jhiPrefixCapitalized%>MetricsMonitoringController', <%=jhiPrefixCapitalized%>MetricsMonitoringController);
 
-    <%=jhiPrefix%>MetricsMonitoringController.$inject = ['$scope','<%=jhiPrefix%>MetricsService', '$uibModal'];
+    <%=jhiPrefixCapitalized%>MetricsMonitoringController.$inject = ['$scope','<%=jhiPrefixCapitalized%>MetricsService', '$uibModal'];
 
-    function <%=jhiPrefix%>MetricsMonitoringController ($scope, <%=jhiPrefix%>MetricsService, $uibModal) {
+    function <%=jhiPrefixCapitalized%>MetricsMonitoringController ($scope, <%=jhiPrefixCapitalized%>MetricsService, $uibModal) {
         var vm = this;
 
         vm.cachesStats = {};
@@ -43,7 +43,7 @@
 
         function refresh () {
             vm.updatingMetrics = true;
-            <%=jhiPrefix%>MetricsService.getMetrics().then(function (promise) {
+            <%=jhiPrefixCapitalized%>MetricsService.getMetrics().then(function (promise) {
                 vm.metrics = promise;
                 vm.updatingMetrics = false;
             }, function (promise) {
@@ -53,10 +53,10 @@
         }
 
         function refreshThreadDumpData () {
-            <%=jhiPrefix%>MetricsService.threadDump().then(function(data) {
+            <%=jhiPrefixCapitalized%>MetricsService.threadDump().then(function(data) {
                 $uibModal.open({
                     templateUrl: 'app/admin/metrics/metrics.modal.html',
-                    controller: '<%=jhiPrefix%>MetricsMonitoringModalController',
+                    controller: '<%=jhiPrefixCapitalized%>MetricsMonitoringModalController',
                     controllerAs: 'vm',
                     size: 'lg',
                     resolve: {

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('MetricsController', MetricsController);
+        .controller('JhiMetricsController', JhiMetricsController);
 
-    MetricsController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
+    JhiMetricsController.$inject = ['$scope','JhiMetricsService', '$uibModal'];
 
-    function MetricsController ($scope, JhiMetricsService, $uibModal) {
+    function JhiMetricsController ($scope, JhiMetricsService, $uibModal) {
         var vm = this;
 
         vm.cachesStats = {};
@@ -56,7 +56,7 @@
             JhiMetricsService.threadDump().then(function(data) {
                 $uibModal.open({
                     templateUrl: 'app/admin/metrics/metrics.modal.html',
-                    controller: 'MetricsModalController',
+                    controller: 'JhiMetricsModalController',
                     controllerAs: 'vm',
                     size: 'lg',
                     resolve: {

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('JhiMetricsModalController', JhiMetricsModalController);
+        .controller('MetricsModalController', MetricsModalController);
 
-    JhiMetricsModalController.$inject = ['$uibModalInstance', 'threadDump'];
+    MetricsModalController.$inject = ['$uibModalInstance', 'threadDump'];
 
-    function JhiMetricsModalController ($uibModalInstance, threadDump) {
+    function MetricsModalController ($uibModalInstance, threadDump) {
         var vm = this;
 
         vm.cancel = cancel;

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('<%=jhiPrefix%>MetricsMonitoringModalController', <%=jhiPrefix%>MetricsMonitoringModalController);
+        .controller('<%=jhiPrefixCapitalized%>MetricsMonitoringModalController', <%=jhiPrefixCapitalized%>MetricsMonitoringModalController);
 
-    <%=jhiPrefix%>MetricsMonitoringModalController.$inject = ['$uibModalInstance', 'threadDump'];
+    <%=jhiPrefixCapitalized%>MetricsMonitoringModalController.$inject = ['$uibModalInstance', 'threadDump'];
 
-    function <%=jhiPrefix%>MetricsMonitoringModalController ($uibModalInstance, threadDump) {
+    function <%=jhiPrefixCapitalized%>MetricsMonitoringModalController ($uibModalInstance, threadDump) {
         var vm = this;
 
         vm.cancel = cancel;

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('MetricsModalController', MetricsModalController);
+        .controller('JhiMetricsModalController', JhiMetricsModalController);
 
-    MetricsModalController.$inject = ['$uibModalInstance', 'threadDump'];
+    JhiMetricsModalController.$inject = ['$uibModalInstance', 'threadDump'];
 
-    function MetricsModalController ($uibModalInstance, threadDump) {
+    function JhiMetricsModalController ($uibModalInstance, threadDump) {
         var vm = this;
 
         vm.cancel = cancel;

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.modal.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('MetricsModalController', MetricsModalController);
+        .controller('<%=jhiPrefix%>MetricsMonitoringModalController', <%=jhiPrefix%>MetricsMonitoringModalController);
 
-    MetricsModalController.$inject = ['$uibModalInstance', 'threadDump'];
+    <%=jhiPrefix%>MetricsMonitoringModalController.$inject = ['$uibModalInstance', 'threadDump'];
 
-    function MetricsModalController ($uibModalInstance, threadDump) {
+    function <%=jhiPrefix%>MetricsMonitoringModalController ($uibModalInstance, threadDump) {
         var vm = this;
 
         vm.cancel = cancel;

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('JhiMetricsService', JhiMetricsService);
+        .factory('<%=jhiPrefix%>MetricsService', <%=jhiPrefix%>MetricsService);
 
-    JhiMetricsService.$inject = ['$rootScope', '$http'];
+    <%=jhiPrefix%>MetricsService.$inject = ['$rootScope', '$http'];
 
-    function JhiMetricsService ($rootScope, $http) {
+    function <%=jhiPrefix%>MetricsService ($rootScope, $http) {
         var service = {
             getMetrics: getMetrics,
             threadDump: threadDump

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('MetricsService', MetricsService);
+        .factory('JhiMetricsService', JhiMetricsService);
 
-    MetricsService.$inject = ['$rootScope', '$http'];
+    JhiMetricsService.$inject = ['$rootScope', '$http'];
 
-    function MetricsService ($rootScope, $http) {
+    function JhiMetricsService ($rootScope, $http) {
         var service = {
             getMetrics: getMetrics,
             threadDump: threadDump

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('<%=jhiPrefix%>MetricsService', <%=jhiPrefix%>MetricsService);
+        .factory('<%=jhiPrefixCapitalized%>MetricsService', <%=jhiPrefixCapitalized%>MetricsService);
 
-    <%=jhiPrefix%>MetricsService.$inject = ['$rootScope', '$http'];
+    <%=jhiPrefixCapitalized%>MetricsService.$inject = ['$rootScope', '$http'];
 
-    function <%=jhiPrefix%>MetricsService ($rootScope, $http) {
+    function <%=jhiPrefixCapitalized%>MetricsService ($rootScope, $http) {
         var service = {
             getMetrics: getMetrics,
             threadDump: threadDump

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('<%=jhiPrefix%>metrics', {
+        $stateProvider.state('<%=jhiPrefix%>-metrics', {
             parent: 'admin',
             url: '/metrics',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/metrics/metrics.html',
-                    controller: '<%=jhiPrefix%>MetricsMonitoringController',
+                    controller: '<%=jhiPrefixCapitalized%>MetricsMonitoringController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/metrics/metrics.html',
-                    controller: 'MetricsController',
+                    controller: 'MetricsMonitoringController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('metrics', {
+        $stateProvider.state('<%=jhiPrefix%>metrics', {
             parent: 'admin',
             url: '/metrics',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/metrics/metrics.html',
-                    controller: 'MetricsMonitoringController',
+                    controller: '<%=jhiPrefix%>MetricsMonitoringController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/metrics/metrics.html',
-                    controller: 'JhiMetricsController',
+                    controller: 'MetricsController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/metrics/_metrics.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/metrics/metrics.html',
-                    controller: 'MetricsController',
+                    controller: 'JhiMetricsController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
@@ -3,17 +3,17 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('<%=jhiPrefix%>TrackerController', <%=jhiPrefix%>TrackerController);
+        .controller('<%=jhiPrefixCapitalized%>TrackerController', <%=jhiPrefixCapitalized%>TrackerController);
 
-    <%=jhiPrefix%>TrackerController.$inject = ['$cookies', '$http', '<%=jhiPrefix%>TrackerService'];
+    <%=jhiPrefixCapitalized%>TrackerController.$inject = ['$cookies', '$http', '<%=jhiPrefixCapitalized%>TrackerService'];
 
-    function <%=jhiPrefix%>TrackerController ($cookies, $http, <%=jhiPrefix%>TrackerService) {
+    function <%=jhiPrefixCapitalized%>TrackerController ($cookies, $http, <%=jhiPrefixCapitalized%>TrackerService) {
         // This controller uses a Websocket connection to receive user activities in real-time.
         var vm = this;
 
         vm.activities = [];
 
-        <%=jhiPrefix%>TrackerService.receive().then(null, null, function(activity) {
+        <%=jhiPrefixCapitalized%>TrackerService.receive().then(null, null, function(activity) {
             showActivity(activity);
         });
 

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('TrackerController', TrackerController);
+        .controller('JhiTrackerController', JhiTrackerController);
 
-    TrackerController.$inject = ['$cookies', '$http', 'JhiTrackerService'];
+    JhiTrackerController.$inject = ['$cookies', '$http', 'JhiTrackerService'];
 
-    function TrackerController ($cookies, $http, JhiTrackerService) {
+    function JhiTrackerController ($cookies, $http, JhiTrackerService) {
         // This controller uses a Websocket connection to receive user activities in real-time.
         var vm = this;
 

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('JhiTrackerController', JhiTrackerController);
+        .controller('TrackerController', TrackerController);
 
-    JhiTrackerController.$inject = ['$cookies', '$http', 'JhiTrackerService'];
+    TrackerController.$inject = ['$cookies', '$http', 'JhiTrackerService'];
 
-    function JhiTrackerController ($cookies, $http, JhiTrackerService) {
+    function TrackerController ($cookies, $http, JhiTrackerService) {
         // This controller uses a Websocket connection to receive user activities in real-time.
         var vm = this;
 

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
@@ -5,15 +5,15 @@
         .module('<%=angularAppName%>')
         .controller('TrackerController', TrackerController);
 
-    TrackerController.$inject = ['$cookies', '$http', 'Tracker'];
+    TrackerController.$inject = ['$cookies', '$http', 'JhiTrackerService'];
 
-    function TrackerController ($cookies, $http, Tracker) {
+    function TrackerController ($cookies, $http, JhiTrackerService) {
         // This controller uses a Websocket connection to receive user activities in real-time.
         var vm = this;
 
         vm.activities = [];
 
-        Tracker.receive().then(null, null, function(activity) {
+        JhiTrackerService.receive().then(null, null, function(activity) {
             showActivity(activity);
         });
 

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.controller.js
@@ -3,17 +3,17 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('TrackerController', TrackerController);
+        .controller('<%=jhiPrefix%>TrackerController', <%=jhiPrefix%>TrackerController);
 
-    TrackerController.$inject = ['$cookies', '$http', 'JhiTrackerService'];
+    <%=jhiPrefix%>TrackerController.$inject = ['$cookies', '$http', '<%=jhiPrefix%>TrackerService'];
 
-    function TrackerController ($cookies, $http, JhiTrackerService) {
+    function <%=jhiPrefix%>TrackerController ($cookies, $http, <%=jhiPrefix%>TrackerService) {
         // This controller uses a Websocket connection to receive user activities in real-time.
         var vm = this;
 
         vm.activities = [];
 
-        JhiTrackerService.receive().then(null, null, function(activity) {
+        <%=jhiPrefix%>TrackerService.receive().then(null, null, function(activity) {
             showActivity(activity);
         });
 

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -4,11 +4,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('<%=jhiPrefix%>TrackerService', <%=jhiPrefix%>TrackerService);
+        .factory('<%=jhiPrefixCapitalized%>TrackerService', <%=jhiPrefixCapitalized%>TrackerService);
 
-    <%=jhiPrefix%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%>];
+    <%=jhiPrefixCapitalized%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%>];
 
-    function <%=jhiPrefix%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
+    function <%=jhiPrefixCapitalized%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -4,11 +4,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('Tracker', Tracker);
+        .factory('JhiTrackerService', JhiTrackerService);
 
-    Tracker.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%>];
+    JhiTrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%>];
 
-    function Tracker ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
+    function JhiTrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -4,11 +4,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('JhiTrackerService', JhiTrackerService);
+        .factory('<%=jhiPrefix%>TrackerService', <%=jhiPrefix%>TrackerService);
 
-    JhiTrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%>];
+    <%=jhiPrefix%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%>];
 
-    function JhiTrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
+    function <%=jhiPrefix%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%>) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/tracker/tracker.html',
-                    controller: 'JhiTrackerController',
+                    controller: 'TrackerController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('<%=jhiPrefix%>tracker', {
+        $stateProvider.state('<%=jhiPrefix%>-tracker', {
             parent: 'admin',
             url: '/tracker',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/tracker/tracker.html',
-                    controller: '<%=jhiPrefix%>TrackerController',
+                    controller: '<%=jhiPrefixCapitalized%>TrackerController',
                     controllerAs: 'vm'
                 }
             },
@@ -28,11 +28,11 @@
                     return $translate.refresh();
                 }]
             },
-            onEnter: function(<%=jhiPrefix%>TrackerService) {
-                <%=jhiPrefix%>TrackerService.subscribe();
+            onEnter: function(<%=jhiPrefixCapitalized%>TrackerService) {
+                <%=jhiPrefixCapitalized%>TrackerService.subscribe();
             },
-            onExit: function(<%=jhiPrefix%>TrackerService) {
-                <%=jhiPrefix%>TrackerService.unsubscribe();
+            onExit: function(<%=jhiPrefixCapitalized%>TrackerService) {
+                <%=jhiPrefixCapitalized%>TrackerService.unsubscribe();
             }
         });
     }

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/tracker/tracker.html',
-                    controller: 'TrackerController',
+                    controller: 'JhiTrackerController',
                     controllerAs: 'vm'
                 }
             },

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
@@ -8,7 +8,7 @@
     stateConfig.$inject = ['$stateProvider'];
 
     function stateConfig($stateProvider) {
-        $stateProvider.state('tracker', {
+        $stateProvider.state('<%=jhiPrefix%>tracker', {
             parent: 'admin',
             url: '/tracker',
             data: {
@@ -18,7 +18,7 @@
             views: {
                 'content@': {
                     templateUrl: 'app/admin/tracker/tracker.html',
-                    controller: 'TrackerController',
+                    controller: '<%=jhiPrefix%>TrackerController',
                     controllerAs: 'vm'
                 }
             },
@@ -28,11 +28,11 @@
                     return $translate.refresh();
                 }]
             },
-            onEnter: function(JhiTrackerService) {
-                JhiTrackerService.subscribe();
+            onEnter: function(<%=jhiPrefix%>TrackerService) {
+                <%=jhiPrefix%>TrackerService.subscribe();
             },
-            onExit: function(JhiTrackerService) {
-                JhiTrackerService.unsubscribe();
+            onExit: function(<%=jhiPrefix%>TrackerService) {
+                <%=jhiPrefix%>TrackerService.unsubscribe();
             }
         });
     }

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.state.js
@@ -28,11 +28,11 @@
                     return $translate.refresh();
                 }]
             },
-            onEnter: function(Tracker) {
-                Tracker.subscribe();
+            onEnter: function(JhiTrackerService) {
+                JhiTrackerService.subscribe();
             },
-            onExit: function(Tracker) {
-                Tracker.unsubscribe();
+            onExit: function(JhiTrackerService) {
+                JhiTrackerService.unsubscribe();
             }
         });
     }

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('UserManagementDialogController',UserManagementDialogController);
 
-    UserManagementDialogController.$inject = ['$stateParams', '$uibModalInstance', 'entity', 'User'<% if (enableTranslation) { %>, 'Language'<% } %>];
+    UserManagementDialogController.$inject = ['$stateParams', '$uibModalInstance', 'entity', 'User'<% if (enableTranslation) { %>, 'JhiLanguageService'<% } %>];
 
-    function UserManagementDialogController ($stateParams, $uibModalInstance, entity, User<% if (enableTranslation) { %>, Language<% } %>) {
+    function UserManagementDialogController ($stateParams, $uibModalInstance, entity, User<% if (enableTranslation) { %>, JhiLanguageService<% } %>) {
         var vm = this;
 
         vm.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
@@ -18,7 +18,7 @@
 
 
         <%_ if (enableTranslation) { _%>
-        Language.getAll().then(function (languages) {
+        JhiLanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });
         <%_ } _%>

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('UserManagementDialogController',UserManagementDialogController);
 
-    UserManagementDialogController.$inject = ['$stateParams', '$uibModalInstance', 'entity', 'User'<% if (enableTranslation) { %>, 'JhiLanguageService'<% } %>];
+    UserManagementDialogController.$inject = ['$stateParams', '$uibModalInstance', 'entity', 'User'<% if (enableTranslation) { %>, '<%=jhiPrefix%>LanguageService'<% } %>];
 
-    function UserManagementDialogController ($stateParams, $uibModalInstance, entity, User<% if (enableTranslation) { %>, JhiLanguageService<% } %>) {
+    function UserManagementDialogController ($stateParams, $uibModalInstance, entity, User<% if (enableTranslation) { %>, <%=jhiPrefix%>LanguageService<% } %>) {
         var vm = this;
 
         vm.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
@@ -18,7 +18,7 @@
 
 
         <%_ if (enableTranslation) { _%>
-        JhiLanguageService.getAll().then(function (languages) {
+        <%=jhiPrefix%>LanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });
         <%_ } _%>

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('UserManagementDialogController',UserManagementDialogController);
 
-    UserManagementDialogController.$inject = ['$stateParams', '$uibModalInstance', 'entity', 'User'<% if (enableTranslation) { %>, '<%=jhiPrefix%>LanguageService'<% } %>];
+    UserManagementDialogController.$inject = ['$stateParams', '$uibModalInstance', 'entity', 'User'<% if (enableTranslation) { %>, '<%=jhiPrefixCapitalized%>LanguageService'<% } %>];
 
-    function UserManagementDialogController ($stateParams, $uibModalInstance, entity, User<% if (enableTranslation) { %>, <%=jhiPrefix%>LanguageService<% } %>) {
+    function UserManagementDialogController ($stateParams, $uibModalInstance, entity, User<% if (enableTranslation) { %>, <%=jhiPrefixCapitalized%>LanguageService<% } %>) {
         var vm = this;
 
         vm.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
@@ -18,7 +18,7 @@
 
 
         <%_ if (enableTranslation) { _%>
-        <%=jhiPrefix%>LanguageService.getAll().then(function (languages) {
+        <%=jhiPrefixCapitalized%>LanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });
         <%_ } _%>

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('UserManagementController', UserManagementController);
 
-    UserManagementController.$inject = ['Principal', 'User', 'ParseLinks', 'paginationConstants'<% if (enableTranslation) { %>, 'JhiLanguageService'<% } %>];
+    UserManagementController.$inject = ['Principal', 'User', 'ParseLinks', 'paginationConstants'<% if (enableTranslation) { %>, '<%=jhiPrefix%>LanguageService'<% } %>];
 
-    function UserManagementController(Principal, User, ParseLinks, paginationConstants<% if (enableTranslation) { %>, JhiLanguageService<% } %>) {
+    function UserManagementController(Principal, User, ParseLinks, paginationConstants<% if (enableTranslation) { %>, <%=jhiPrefix%>LanguageService<% } %>) {
         var vm = this;
 
         vm.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
@@ -26,7 +26,7 @@
         vm.loadAll();
 
         <% if (enableTranslation) { %>
-        JhiLanguageService.getAll().then(function (languages) {
+        <%=jhiPrefix%>LanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });<% } %>
 

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('UserManagementController', UserManagementController);
 
-    UserManagementController.$inject = ['Principal', 'User', 'ParseLinks', 'paginationConstants'<% if (enableTranslation) { %>, '<%=jhiPrefix%>LanguageService'<% } %>];
+    UserManagementController.$inject = ['Principal', 'User', 'ParseLinks', 'paginationConstants'<% if (enableTranslation) { %>, '<%=jhiPrefixCapitalized%>LanguageService'<% } %>];
 
-    function UserManagementController(Principal, User, ParseLinks, paginationConstants<% if (enableTranslation) { %>, <%=jhiPrefix%>LanguageService<% } %>) {
+    function UserManagementController(Principal, User, ParseLinks, paginationConstants<% if (enableTranslation) { %>, <%=jhiPrefixCapitalized%>LanguageService<% } %>) {
         var vm = this;
 
         vm.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
@@ -26,7 +26,7 @@
         vm.loadAll();
 
         <% if (enableTranslation) { %>
-        <%=jhiPrefix%>LanguageService.getAll().then(function (languages) {
+        <%=jhiPrefixCapitalized%>LanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });<% } %>
 

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.controller.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('UserManagementController', UserManagementController);
 
-    UserManagementController.$inject = ['Principal', 'User', 'ParseLinks', 'paginationConstants'<% if (enableTranslation) { %>, 'Language'<% } %>];
+    UserManagementController.$inject = ['Principal', 'User', 'ParseLinks', 'paginationConstants'<% if (enableTranslation) { %>, 'JhiLanguageService'<% } %>];
 
-    function UserManagementController(Principal, User, ParseLinks, paginationConstants<% if (enableTranslation) { %>, Language<% } %>) {
+    function UserManagementController(Principal, User, ParseLinks, paginationConstants<% if (enableTranslation) { %>, JhiLanguageService<% } %>) {
         var vm = this;
 
         vm.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
@@ -26,7 +26,7 @@
         vm.loadAll();
 
         <% if (enableTranslation) { %>
-        Language.getAll().then(function (languages) {
+        JhiLanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });<% } %>
 

--- a/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
@@ -5,10 +5,10 @@
         .module('<%=angularAppName%>')
         .factory('stateHandler', stateHandler);
 
-    stateHandler.$inject = ['$rootScope', '$state', <% if (enableTranslation) { %>'$translate', 'Language', 'translationHandler',<% } else { %> '$window', <% } %>
+    stateHandler.$inject = ['$rootScope', '$state', <% if (enableTranslation) { %>'$translate', 'JhiLanguageService', 'translationHandler',<% } else { %> '$window', <% } %>
         'Auth', 'Principal', 'ENV', 'VERSION'];
 
-    function stateHandler($rootScope, $state, <% if (enableTranslation) { %>$translate, Language, translationHandler,<% } else { %> $window, <% } %>
+    function stateHandler($rootScope, $state, <% if (enableTranslation) { %>$translate, JhiLanguageService, translationHandler,<% } else { %> $window, <% } %>
         Auth, Principal, ENV, VERSION) {
         return {
             initialize: initialize
@@ -29,7 +29,7 @@
 
                 <% if (enableTranslation) { %>
                 // Update the language
-                Language.getCurrent().then(function (language) {
+                JhiLanguageService.getCurrent().then(function (language) {
                     $translate.use(language);
                 });
                 <% } %>

--- a/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
@@ -5,10 +5,10 @@
         .module('<%=angularAppName%>')
         .factory('stateHandler', stateHandler);
 
-    stateHandler.$inject = ['$rootScope', '$state', <% if (enableTranslation) { %>'$translate', '<%=jhiPrefix%>LanguageService', 'translationHandler',<% } else { %> '$window', <% } %>
+    stateHandler.$inject = ['$rootScope', '$state', <% if (enableTranslation) { %>'$translate', '<%=jhiPrefixCapitalized%>LanguageService', 'translationHandler',<% } else { %> '$window', <% } %>
         'Auth', 'Principal', 'ENV', 'VERSION'];
 
-    function stateHandler($rootScope, $state, <% if (enableTranslation) { %>$translate, <%=jhiPrefix%>LanguageService, translationHandler,<% } else { %> $window, <% } %>
+    function stateHandler($rootScope, $state, <% if (enableTranslation) { %>$translate, <%=jhiPrefixCapitalized%>LanguageService, translationHandler,<% } else { %> $window, <% } %>
         Auth, Principal, ENV, VERSION) {
         return {
             initialize: initialize
@@ -29,7 +29,7 @@
 
                 <% if (enableTranslation) { %>
                 // Update the language
-                <%=jhiPrefix%>LanguageService.getCurrent().then(function (language) {
+                <%=jhiPrefixCapitalized%>LanguageService.getCurrent().then(function (language) {
                     $translate.use(language);
                 });
                 <% } %>

--- a/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
@@ -5,10 +5,10 @@
         .module('<%=angularAppName%>')
         .factory('stateHandler', stateHandler);
 
-    stateHandler.$inject = ['$rootScope', '$state', <% if (enableTranslation) { %>'$translate', 'JhiLanguageService', 'translationHandler',<% } else { %> '$window', <% } %>
+    stateHandler.$inject = ['$rootScope', '$state', <% if (enableTranslation) { %>'$translate', '<%=jhiPrefix%>LanguageService', 'translationHandler',<% } else { %> '$window', <% } %>
         'Auth', 'Principal', 'ENV', 'VERSION'];
 
-    function stateHandler($rootScope, $state, <% if (enableTranslation) { %>$translate, JhiLanguageService, translationHandler,<% } else { %> $window, <% } %>
+    function stateHandler($rootScope, $state, <% if (enableTranslation) { %>$translate, <%=jhiPrefix%>LanguageService, translationHandler,<% } else { %> $window, <% } %>
         Auth, Principal, ENV, VERSION) {
         return {
             initialize: initialize
@@ -29,7 +29,7 @@
 
                 <% if (enableTranslation) { %>
                 // Update the language
-                JhiLanguageService.getCurrent().then(function (language) {
+                <%=jhiPrefix%>LanguageService.getCurrent().then(function (language) {
                     $translate.use(language);
                 });
                 <% } %>

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('JhiLanguageController', JhiLanguageController);
+        .controller('LanguageController', LanguageController);
 
-    JhiLanguageController.$inject = ['$translate', 'JhiLanguageService', 'tmhDynamicLocale'];
+    LanguageController.$inject = ['$translate', 'JhiLanguageService', 'tmhDynamicLocale'];
 
-    function JhiLanguageController ($translate, JhiLanguageService, tmhDynamicLocale) {
+    function LanguageController ($translate, JhiLanguageService, tmhDynamicLocale) {
         var vm = this;
 
         vm.changeLanguage = changeLanguage;

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('LanguageController', LanguageController);
+        .controller('JhiLanguageController', JhiLanguageController);
 
-    LanguageController.$inject = ['$translate', 'JhiLanguageService', 'tmhDynamicLocale'];
+    JhiLanguageController.$inject = ['$translate', 'JhiLanguageService', 'tmhDynamicLocale'];
 
-    function LanguageController ($translate, JhiLanguageService, tmhDynamicLocale) {
+    function JhiLanguageController ($translate, JhiLanguageService, tmhDynamicLocale) {
         var vm = this;
 
         vm.changeLanguage = changeLanguage;

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
@@ -5,15 +5,15 @@
         .module('<%=angularAppName%>')
         .controller('LanguageController', LanguageController);
 
-    LanguageController.$inject = ['$translate', 'Language', 'tmhDynamicLocale'];
+    LanguageController.$inject = ['$translate', 'JhiLanguageService', 'tmhDynamicLocale'];
 
-    function LanguageController ($translate, Language, tmhDynamicLocale) {
+    function LanguageController ($translate, JhiLanguageService, tmhDynamicLocale) {
         var vm = this;
 
         vm.changeLanguage = changeLanguage;
         vm.languages = null;
 
-        Language.getAll().then(function (languages) {
+        JhiLanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });
 

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
@@ -3,17 +3,17 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('<%=jhiPrefix%>LanguageController', <%=jhiPrefix%>LanguageController);
+        .controller('<%=jhiPrefixCapitalized%>LanguageController', <%=jhiPrefixCapitalized%>LanguageController);
 
-    <%=jhiPrefix%>LanguageController.$inject = ['$translate', '<%=jhiPrefix%>LanguageService', 'tmhDynamicLocale'];
+    <%=jhiPrefixCapitalized%>LanguageController.$inject = ['$translate', '<%=jhiPrefixCapitalized%>LanguageService', 'tmhDynamicLocale'];
 
-    function <%=jhiPrefix%>LanguageController ($translate, <%=jhiPrefix%>LanguageService, tmhDynamicLocale) {
+    function <%=jhiPrefixCapitalized%>LanguageController ($translate, <%=jhiPrefixCapitalized%>LanguageService, tmhDynamicLocale) {
         var vm = this;
 
         vm.changeLanguage = changeLanguage;
         vm.languages = null;
 
-        <%=jhiPrefix%>LanguageService.getAll().then(function (languages) {
+        <%=jhiPrefixCapitalized%>LanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });
 

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.controller.js
@@ -3,17 +3,17 @@
 
     angular
         .module('<%=angularAppName%>')
-        .controller('LanguageController', LanguageController);
+        .controller('<%=jhiPrefix%>LanguageController', <%=jhiPrefix%>LanguageController);
 
-    LanguageController.$inject = ['$translate', 'JhiLanguageService', 'tmhDynamicLocale'];
+    <%=jhiPrefix%>LanguageController.$inject = ['$translate', '<%=jhiPrefix%>LanguageService', 'tmhDynamicLocale'];
 
-    function LanguageController ($translate, JhiLanguageService, tmhDynamicLocale) {
+    function <%=jhiPrefix%>LanguageController ($translate, <%=jhiPrefix%>LanguageService, tmhDynamicLocale) {
         var vm = this;
 
         vm.changeLanguage = changeLanguage;
         vm.languages = null;
 
-        JhiLanguageService.getAll().then(function (languages) {
+        <%=jhiPrefix%>LanguageService.getAll().then(function (languages) {
             vm.languages = languages;
         });
 

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('<%=jhiPrefix%>LanguageService', <%=jhiPrefix%>LanguageService);
+        .factory('<%=jhiPrefixCapitalized%>LanguageService', <%=jhiPrefixCapitalized%>LanguageService);
 
-    <%=jhiPrefix%>LanguageService.$inject = ['$q', '$http', '$translate', 'LANGUAGES'];
+    <%=jhiPrefixCapitalized%>LanguageService.$inject = ['$q', '$http', '$translate', 'LANGUAGES'];
 
-    function <%=jhiPrefix%>LanguageService ($q, $http, $translate, LANGUAGES) {
+    function <%=jhiPrefixCapitalized%>LanguageService ($q, $http, $translate, LANGUAGES) {
         var service = {
             getAll: getAll,
             getCurrent: getCurrent

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('Language', Language);
+        .factory('JhiLanguageService', JhiLanguageService);
 
-    Language.$inject = ['$q', '$http', '$translate', 'LANGUAGES'];
+    JhiLanguageService.$inject = ['$q', '$http', '$translate', 'LANGUAGES'];
 
-    function Language ($q, $http, $translate, LANGUAGES) {
+    function JhiLanguageService ($q, $http, $translate, LANGUAGES) {
         var service = {
             getAll: getAll,
             getCurrent: getCurrent

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('JhiLanguageService', JhiLanguageService);
+        .factory('<%=jhiPrefix%>LanguageService', <%=jhiPrefix%>LanguageService);
 
-    JhiLanguageService.$inject = ['$q', '$http', '$translate', 'LANGUAGES'];
+    <%=jhiPrefix%>LanguageService.$inject = ['$q', '$http', '$translate', 'LANGUAGES'];
 
-    function JhiLanguageService ($q, $http, $translate, LANGUAGES) {
+    function <%=jhiPrefix%>LanguageService ($q, $http, $translate, LANGUAGES) {
         var service = {
             getAll: getAll,
             getCurrent: getCurrent

--- a/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
+++ b/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
@@ -78,7 +78,7 @@
                         <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>tracker" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-eye-open"></span>
                                 &nbsp;<span translate="global.menu.admin.tracker">User tracker</span></a></li>
                         <%_ } _%>
-                        <li ui-sref-active="active"><a ui-sref="metrics" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-dashboard"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>metrics" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-dashboard"></span>
                             &#xA0;<span translate="global.menu.admin.metrics">Metrics</span></a></li>
                         <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>health" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-heart"></span>
                             &#xA0;<span translate="global.menu.admin.health">Health</span></a></li>

--- a/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
+++ b/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
@@ -75,14 +75,14 @@
                         <li ui-sref-active="active"><a ui-sref="user-management" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-user"></span>
                             &#xA0;<span translate="global.menu.admin.userManagement">User management</span></a></li>
                         <%_ if (websocket == 'spring-websocket') { _%>
-                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>tracker" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-eye-open"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>-tracker" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-eye-open"></span>
                                 &nbsp;<span translate="global.menu.admin.tracker">User tracker</span></a></li>
                         <%_ } _%>
-                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>metrics" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-dashboard"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>-metrics" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-dashboard"></span>
                             &#xA0;<span translate="global.menu.admin.metrics">Metrics</span></a></li>
-                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>health" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-heart"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>-health" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-heart"></span>
                             &#xA0;<span translate="global.menu.admin.health">Health</span></a></li>
-                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>configuration" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-list-alt"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>-configuration" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-list-alt"></span>
                             &#xA0;<span translate="global.menu.admin.configuration">Configuration</span></a></li>
                         <li ui-sref-active="active"><a ui-sref="audits" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-bell"></span>
                             &#xA0;<span translate="global.menu.admin.audits">Audits</span></a></li>
@@ -98,7 +98,7 @@
                     </ul>
                 </li>
                 <%_ if (enableTranslation){ _%>
-                <li ui-sref-active="active" class="dropdown pointer" ng-controller="<%=jhiPrefix%>LanguageController as languageVm">
+                <li ui-sref-active="active" class="dropdown pointer" ng-controller="<%=jhiPrefixCapitalized%>LanguageController as languageVm">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="" ng-if="languageVm.languages.length > 1">
                         <span>
                             <span class="glyphicon glyphicon-flag"></span>

--- a/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
+++ b/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
@@ -75,14 +75,14 @@
                         <li ui-sref-active="active"><a ui-sref="user-management" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-user"></span>
                             &#xA0;<span translate="global.menu.admin.userManagement">User management</span></a></li>
                         <%_ if (websocket == 'spring-websocket') { _%>
-                        <li ui-sref-active="active"><a ui-sref="tracker" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-eye-open"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>tracker" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-eye-open"></span>
                                 &nbsp;<span translate="global.menu.admin.tracker">User tracker</span></a></li>
                         <%_ } _%>
                         <li ui-sref-active="active"><a ui-sref="metrics" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-dashboard"></span>
                             &#xA0;<span translate="global.menu.admin.metrics">Metrics</span></a></li>
-                        <li ui-sref-active="active"><a ui-sref="health" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-heart"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>health" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-heart"></span>
                             &#xA0;<span translate="global.menu.admin.health">Health</span></a></li>
-                        <li ui-sref-active="active"><a ui-sref="configuration" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-list-alt"></span>
+                        <li ui-sref-active="active"><a ui-sref="<%=jhiPrefix%>configuration" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-list-alt"></span>
                             &#xA0;<span translate="global.menu.admin.configuration">Configuration</span></a></li>
                         <li ui-sref-active="active"><a ui-sref="audits" data-toggle="collapse" data-target=".navbar-collapse.in"><span class="glyphicon glyphicon-bell"></span>
                             &#xA0;<span translate="global.menu.admin.audits">Audits</span></a></li>

--- a/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
+++ b/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
@@ -98,7 +98,7 @@
                     </ul>
                 </li>
                 <%_ if (enableTranslation){ _%>
-                <li ui-sref-active="active" class="dropdown pointer" ng-controller="LanguageController as languageVm">
+                <li ui-sref-active="active" class="dropdown pointer" ng-controller="JhiLanguageController as languageVm">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="" ng-if="languageVm.languages.length > 1">
                         <span>
                             <span class="glyphicon glyphicon-flag"></span>

--- a/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
+++ b/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
@@ -98,7 +98,7 @@
                     </ul>
                 </li>
                 <%_ if (enableTranslation){ _%>
-                <li ui-sref-active="active" class="dropdown pointer" ng-controller="JhiLanguageController as languageVm">
+                <li ui-sref-active="active" class="dropdown pointer" ng-controller="LanguageController as languageVm">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="" ng-if="languageVm.languages.length > 1">
                         <span>
                             <span class="glyphicon glyphicon-flag"></span>

--- a/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
+++ b/generators/client/templates/src/main/webapp/app/layouts/navbar/navbar.html
@@ -98,7 +98,7 @@
                     </ul>
                 </li>
                 <%_ if (enableTranslation){ _%>
-                <li ui-sref-active="active" class="dropdown pointer" ng-controller="LanguageController as languageVm">
+                <li ui-sref-active="active" class="dropdown pointer" ng-controller="<%=jhiPrefix%>LanguageController as languageVm">
                     <a class="dropdown-toggle" data-toggle="dropdown" href="" ng-if="languageVm.languages.length > 1">
                         <span>
                             <span class="glyphicon glyphicon-flag"></span>

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('Auth', Auth);
 
-    Auth.$inject = ['$rootScope', '$state', '$q', <% if (enableTranslation){ %>'$translate', <% } %>'Principal', 'AuthServerProvider', 'Account', 'LoginService', 'Register', 'Activate', 'Password', 'PasswordResetInit', 'PasswordResetFinish'<% if (websocket === 'spring-websocket') { %>, '<%=jhiPrefix%>TrackerService'<% } %>];
+    Auth.$inject = ['$rootScope', '$state', '$q', <% if (enableTranslation){ %>'$translate', <% } %>'Principal', 'AuthServerProvider', 'Account', 'LoginService', 'Register', 'Activate', 'Password', 'PasswordResetInit', 'PasswordResetFinish'<% if (websocket === 'spring-websocket') { %>, '<%=jhiPrefixCapitalized%>TrackerService'<% } %>];
 
-    function Auth ($rootScope, $state, $q, <% if (enableTranslation){ %>$translate, <% } %>Principal, AuthServerProvider, Account, LoginService, Register, Activate, Password, PasswordResetInit, PasswordResetFinish<% if (websocket === 'spring-websocket') { %>, <%=jhiPrefix%>TrackerService<% } %>) {
+    function Auth ($rootScope, $state, $q, <% if (enableTranslation){ %>$translate, <% } %>Principal, AuthServerProvider, Account, LoginService, Register, Activate, Password, PasswordResetInit, PasswordResetFinish<% if (websocket === 'spring-websocket') { %>, <%=jhiPrefixCapitalized%>TrackerService<% } %>) {
         var service = {
             activateAccount: activateAccount,
             authorize: authorize,
@@ -114,7 +114,7 @@
                     }
                     <%_ } _%>
                     <%_ if (websocket === 'spring-websocket') { _%>
-                    <%=jhiPrefix%>TrackerService.sendActivity();
+                    <%=jhiPrefixCapitalized%>TrackerService.sendActivity();
                     <%_ } _%>
                     deferred.resolve(data);
                 });

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('Auth', Auth);
 
-    Auth.$inject = ['$rootScope', '$state', '$q', <% if (enableTranslation){ %>'$translate', <% } %>'Principal', 'AuthServerProvider', 'Account', 'LoginService', 'Register', 'Activate', 'Password', 'PasswordResetInit', 'PasswordResetFinish'<% if (websocket === 'spring-websocket') { %>, 'Tracker'<% } %>];
+    Auth.$inject = ['$rootScope', '$state', '$q', <% if (enableTranslation){ %>'$translate', <% } %>'Principal', 'AuthServerProvider', 'Account', 'LoginService', 'Register', 'Activate', 'Password', 'PasswordResetInit', 'PasswordResetFinish'<% if (websocket === 'spring-websocket') { %>, 'JhiTrackerService'<% } %>];
 
-    function Auth ($rootScope, $state, $q, <% if (enableTranslation){ %>$translate, <% } %>Principal, AuthServerProvider, Account, LoginService, Register, Activate, Password, PasswordResetInit, PasswordResetFinish<% if (websocket === 'spring-websocket') { %>, Tracker<% } %>) {
+    function Auth ($rootScope, $state, $q, <% if (enableTranslation){ %>$translate, <% } %>Principal, AuthServerProvider, Account, LoginService, Register, Activate, Password, PasswordResetInit, PasswordResetFinish<% if (websocket === 'spring-websocket') { %>, JhiTrackerService<% } %>) {
         var service = {
             activateAccount: activateAccount,
             authorize: authorize,
@@ -114,7 +114,7 @@
                     }
                     <%_ } _%>
                     <%_ if (websocket === 'spring-websocket') { _%>
-                    Tracker.sendActivity();
+                    JhiTrackerService.sendActivity();
                     <%_ } _%>
                     deferred.resolve(data);
                 });

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('Auth', Auth);
 
-    Auth.$inject = ['$rootScope', '$state', '$q', <% if (enableTranslation){ %>'$translate', <% } %>'Principal', 'AuthServerProvider', 'Account', 'LoginService', 'Register', 'Activate', 'Password', 'PasswordResetInit', 'PasswordResetFinish'<% if (websocket === 'spring-websocket') { %>, 'JhiTrackerService'<% } %>];
+    Auth.$inject = ['$rootScope', '$state', '$q', <% if (enableTranslation){ %>'$translate', <% } %>'Principal', 'AuthServerProvider', 'Account', 'LoginService', 'Register', 'Activate', 'Password', 'PasswordResetInit', 'PasswordResetFinish'<% if (websocket === 'spring-websocket') { %>, '<%=jhiPrefix%>TrackerService'<% } %>];
 
-    function Auth ($rootScope, $state, $q, <% if (enableTranslation){ %>$translate, <% } %>Principal, AuthServerProvider, Account, LoginService, Register, Activate, Password, PasswordResetInit, PasswordResetFinish<% if (websocket === 'spring-websocket') { %>, JhiTrackerService<% } %>) {
+    function Auth ($rootScope, $state, $q, <% if (enableTranslation){ %>$translate, <% } %>Principal, AuthServerProvider, Account, LoginService, Register, Activate, Password, PasswordResetInit, PasswordResetFinish<% if (websocket === 'spring-websocket') { %>, <%=jhiPrefix%>TrackerService<% } %>) {
         var service = {
             activateAccount: activateAccount,
             authorize: authorize,
@@ -114,7 +114,7 @@
                     }
                     <%_ } _%>
                     <%_ if (websocket === 'spring-websocket') { _%>
-                    JhiTrackerService.sendActivity();
+                    <%=jhiPrefix%>TrackerService.sendActivity();
                     <%_ } _%>
                     deferred.resolve(data);
                 });

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.session.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.session.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('AuthServerProvider', AuthServerProvider);
 
-    AuthServerProvider.$inject = ['$http', '$localStorage' <% if (websocket == 'spring-websocket') { %>, 'Tracker'<% } %>];
+    AuthServerProvider.$inject = ['$http', '$localStorage' <% if (websocket == 'spring-websocket') { %>, 'JhiTrackerService'<% } %>];
 
-    function AuthServerProvider ($http, $localStorage <% if (websocket == 'spring-websocket') { %>, Tracker<% } %>) {
+    function AuthServerProvider ($http, $localStorage <% if (websocket == 'spring-websocket') { %>, JhiTrackerService<% } %>) {
         var service = {
             getToken: getToken,
             hasValidToken: hasValidToken,
@@ -42,7 +42,7 @@
         }
 
         function logout () {<% if (websocket == 'spring-websocket') { %>
-            Tracker.disconnect();<% } %>
+            JhiTrackerService.disconnect();<% } %>
             // logout from the server
             $http.post('api/logout').success(function (response) {
                 delete $localStorage.authenticationToken;

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.session.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.session.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('AuthServerProvider', AuthServerProvider);
 
-    AuthServerProvider.$inject = ['$http', '$localStorage' <% if (websocket == 'spring-websocket') { %>, '<%=jhiPrefix%>TrackerService'<% } %>];
+    AuthServerProvider.$inject = ['$http', '$localStorage' <% if (websocket == 'spring-websocket') { %>, '<%=jhiPrefixCapitalized%>TrackerService'<% } %>];
 
-    function AuthServerProvider ($http, $localStorage <% if (websocket == 'spring-websocket') { %>, <%=jhiPrefix%>TrackerService<% } %>) {
+    function AuthServerProvider ($http, $localStorage <% if (websocket == 'spring-websocket') { %>, <%=jhiPrefixCapitalized%>TrackerService<% } %>) {
         var service = {
             getToken: getToken,
             hasValidToken: hasValidToken,
@@ -42,7 +42,7 @@
         }
 
         function logout () {<% if (websocket == 'spring-websocket') { %>
-            <%=jhiPrefix%>TrackerService.disconnect();<% } %>
+            <%=jhiPrefixCapitalized%>TrackerService.disconnect();<% } %>
             // logout from the server
             $http.post('api/logout').success(function (response) {
                 delete $localStorage.authenticationToken;

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.session.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.session.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('AuthServerProvider', AuthServerProvider);
 
-    AuthServerProvider.$inject = ['$http', '$localStorage' <% if (websocket == 'spring-websocket') { %>, 'JhiTrackerService'<% } %>];
+    AuthServerProvider.$inject = ['$http', '$localStorage' <% if (websocket == 'spring-websocket') { %>, '<%=jhiPrefix%>TrackerService'<% } %>];
 
-    function AuthServerProvider ($http, $localStorage <% if (websocket == 'spring-websocket') { %>, JhiTrackerService<% } %>) {
+    function AuthServerProvider ($http, $localStorage <% if (websocket == 'spring-websocket') { %>, <%=jhiPrefix%>TrackerService<% } %>) {
         var service = {
             getToken: getToken,
             hasValidToken: hasValidToken,
@@ -42,7 +42,7 @@
         }
 
         function logout () {<% if (websocket == 'spring-websocket') { %>
-            JhiTrackerService.disconnect();<% } %>
+            <%=jhiPrefix%>TrackerService.disconnect();<% } %>
             // logout from the server
             $http.post('api/logout').success(function (response) {
                 delete $localStorage.authenticationToken;

--- a/generators/client/templates/src/main/webapp/app/services/auth/_principal.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_principal.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('Principal', Principal);
 
-    Principal.$inject = ['$q', 'Account'<% if (websocket == 'spring-websocket') { %>, '<%=jhiPrefix%>TrackerService'<% } %>];
+    Principal.$inject = ['$q', 'Account'<% if (websocket == 'spring-websocket') { %>, '<%=jhiPrefixCapitalized%>TrackerService'<% } %>];
 
-    function Principal ($q, Account<% if (websocket == 'spring-websocket') { %>, <%=jhiPrefix%>TrackerService<% } %>) {
+    function Principal ($q, Account<% if (websocket == 'spring-websocket') { %>, <%=jhiPrefixCapitalized%>TrackerService<% } %>) {
         var _identity,
             _authenticated = false;
 
@@ -79,7 +79,7 @@
                 _identity = account.data;
                 _authenticated = true;
                 deferred.resolve(_identity);<% if (websocket == 'spring-websocket') { %>
-                <%=jhiPrefix%>TrackerService.connect();<% } %>
+                <%=jhiPrefixCapitalized%>TrackerService.connect();<% } %>
             }
 
             function getAccountCatch () {

--- a/generators/client/templates/src/main/webapp/app/services/auth/_principal.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_principal.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('Principal', Principal);
 
-    Principal.$inject = ['$q', 'Account'<% if (websocket == 'spring-websocket') { %>, 'JhiTrackerService'<% } %>];
+    Principal.$inject = ['$q', 'Account'<% if (websocket == 'spring-websocket') { %>, '<%=jhiPrefix%>TrackerService'<% } %>];
 
-    function Principal ($q, Account<% if (websocket == 'spring-websocket') { %>, JhiTrackerService<% } %>) {
+    function Principal ($q, Account<% if (websocket == 'spring-websocket') { %>, <%=jhiPrefix%>TrackerService<% } %>) {
         var _identity,
             _authenticated = false;
 
@@ -79,7 +79,7 @@
                 _identity = account.data;
                 _authenticated = true;
                 deferred.resolve(_identity);<% if (websocket == 'spring-websocket') { %>
-                JhiTrackerService.connect();<% } %>
+                <%=jhiPrefix%>TrackerService.connect();<% } %>
             }
 
             function getAccountCatch () {

--- a/generators/client/templates/src/main/webapp/app/services/auth/_principal.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_principal.service.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .factory('Principal', Principal);
 
-    Principal.$inject = ['$q', 'Account'<% if (websocket == 'spring-websocket') { %>, 'Tracker'<% } %>];
+    Principal.$inject = ['$q', 'Account'<% if (websocket == 'spring-websocket') { %>, 'JhiTrackerService'<% } %>];
 
-    function Principal ($q, Account<% if (websocket == 'spring-websocket') { %>, Tracker<% } %>) {
+    function Principal ($q, Account<% if (websocket == 'spring-websocket') { %>, JhiTrackerService<% } %>) {
         var _identity,
             _authenticated = false;
 
@@ -79,7 +79,7 @@
                 _identity = account.data;
                 _authenticated = true;
                 deferred.resolve(_identity);<% if (websocket == 'spring-websocket') { %>
-                Tracker.connect();<% } %>
+                JhiTrackerService.connect();<% } %>
             }
 
             function getAccountCatch () {

--- a/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
+++ b/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
@@ -31,17 +31,17 @@ describe('administration', function () {
     });
 
     it('should load metrics', function () {
-        element(by.css('[ui-sref="<%=jhiPrefix%>metrics"]')).click();
+        element(by.css('[ui-sref="<%=jhiPrefix%>-metrics"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Application Metrics/);
     });
 
     it('should load health', function () {
-        element(by.css('[ui-sref="<%=jhiPrefix%>health"]')).click();
+        element(by.css('[ui-sref="<%=jhiPrefix%>-health"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Health Checks/);
     });
 
     it('should load configuration', function () {
-        element(by.css('[ui-sref="<%=jhiPrefix%>configuration"]')).click();
+        element(by.css('[ui-sref="<%=jhiPrefix%>-configuration"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Configuration/);
     });
 

--- a/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
+++ b/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
@@ -31,7 +31,7 @@ describe('administration', function () {
     });
 
     it('should load metrics', function () {
-        element(by.css('[ui-sref="metrics"]')).click();
+        element(by.css('[ui-sref="<%=jhiPrefix%>metrics"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Application Metrics/);
     });
 

--- a/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
+++ b/generators/client/templates/src/test/javascript/e2e/admin/_administration.js
@@ -36,12 +36,12 @@ describe('administration', function () {
     });
 
     it('should load health', function () {
-        element(by.css('[ui-sref="health"]')).click();
+        element(by.css('[ui-sref="<%=jhiPrefix%>health"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Health Checks/);
     });
 
     it('should load configuration', function () {
-        element(by.css('[ui-sref="configuration"]')).click();
+        element(by.css('[ui-sref="<%=jhiPrefix%>configuration"]')).click();
         expect(element.all(by.css('h2')).first().getText()).toMatch(/Configuration/);
     });
 

--- a/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
+++ b/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
@@ -2,7 +2,7 @@
 
 describe('Controller Tests', function () {
 
-    describe('JhiHealthController', function () {
+    describe('HealthController', function () {
         var $scope; // actual implementations
         var createController; // local utility functions
 
@@ -12,7 +12,7 @@ describe('Controller Tests', function () {
                 '$scope': $scope
             };
             createController = function() {
-                $injector.get('$controller')('JhiHealthController as vm', locals);
+                $injector.get('$controller')('HealthController as vm', locals);
             };
             createController();
         }));

--- a/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
+++ b/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
@@ -2,7 +2,7 @@
 
 describe('Controller Tests', function () {
 
-    describe('HealthController', function () {
+    describe('HealthCheckController', function () {
         var $scope; // actual implementations
         var createController; // local utility functions
 
@@ -12,7 +12,7 @@ describe('Controller Tests', function () {
                 '$scope': $scope
             };
             createController = function() {
-                $injector.get('$controller')('HealthController as vm', locals);
+                $injector.get('$controller')('HealthCheckController as vm', locals);
             };
             createController();
         }));

--- a/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
+++ b/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
@@ -2,7 +2,7 @@
 
 describe('Controller Tests', function () {
 
-    describe('HealthController', function () {
+    describe('JhiHealthController', function () {
         var $scope; // actual implementations
         var createController; // local utility functions
 
@@ -12,7 +12,7 @@ describe('Controller Tests', function () {
                 '$scope': $scope
             };
             createController = function() {
-                $injector.get('$controller')('HealthController as vm', locals);
+                $injector.get('$controller')('JhiHealthController as vm', locals);
             };
             createController();
         }));

--- a/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
+++ b/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
@@ -2,7 +2,7 @@
 
 describe('Controller Tests', function () {
 
-    describe('<%=jhiPrefix%>HealthCheckController', function () {
+    describe('<%=jhiPrefixCapitalized%>HealthCheckController', function () {
         var $scope; // actual implementations
         var createController; // local utility functions
 
@@ -12,7 +12,7 @@ describe('Controller Tests', function () {
                 '$scope': $scope
             };
             createController = function() {
-                $injector.get('$controller')('<%=jhiPrefix%>HealthCheckController as vm', locals);
+                $injector.get('$controller')('<%=jhiPrefixCapitalized%>HealthCheckController as vm', locals);
             };
             createController();
         }));

--- a/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
+++ b/generators/client/templates/src/test/javascript/spec/app/admin/health/_health.controller.spec.js
@@ -2,7 +2,7 @@
 
 describe('Controller Tests', function () {
 
-    describe('HealthCheckController', function () {
+    describe('<%=jhiPrefix%>HealthCheckController', function () {
         var $scope; // actual implementations
         var createController; // local utility functions
 
@@ -12,7 +12,7 @@ describe('Controller Tests', function () {
                 '$scope': $scope
             };
             createController = function() {
-                $injector.get('$controller')('HealthCheckController as vm', locals);
+                $injector.get('$controller')('<%=jhiPrefix%>HealthCheckController as vm', locals);
             };
             createController();
         }));


### PR DESCRIPTION
Fix #2921.
I renamed services that could clash with user-generated services with Jhi prefix. Also renamed Health and Metrics Controllers into HealthCheck and MetricsMonitoring as suggested by @deepu105.