### PR TITLE
Refactoring password-strength-bar directive

### DIFF
--- a/generators/client/templates/src/main/webapp/app/account/password/_password-strength-bar.directive.js
+++ b/generators/client/templates/src/main/webapp/app/account/password/_password-strength-bar.directive.js
@@ -26,7 +26,7 @@
 
         /* private helper methods*/
 
-        function linkFunc(scope, iElement, attr) {
+        function linkFunc(scope, iElement) {
             var strength = {
                 colors: ['#F00', '#F90', '#FF0', '#9F0', '#0F0'],
                 mesureStrength: function (p) {

--- a/generators/client/templates/src/main/webapp/app/account/password/_password-strength-bar.directive.js
+++ b/generators/client/templates/src/main/webapp/app/account/password/_password-strength-bar.directive.js
@@ -16,6 +16,9 @@
                 '<li class="point"></li><li class="point"></li><li class="point"></li><li class="point"></li><li class="point"></li>' +
                 '</ul>' +
                 '</div>',
+            scope: {
+                passwordToCheck: '='
+            }
             link: linkFunc
         };
 
@@ -77,7 +80,8 @@
                     return { idx: idx + 1, col: this.colors[idx] };
                 }
             };
-            scope.$watch(attr.passwordToCheck, function (password) {
+            scope.$watch(scope.passwordToCheck, function (password) {
+                console.log("test");
                 if (password) {
                     var c = strength.getColor(strength.mesureStrength(password));
                     iElement.removeClass('ng-hide');

--- a/generators/client/templates/src/main/webapp/app/account/password/_password-strength-bar.directive.js
+++ b/generators/client/templates/src/main/webapp/app/account/password/_password-strength-bar.directive.js
@@ -18,7 +18,7 @@
                 '</div>',
             scope: {
                 passwordToCheck: '='
-            }
+            },
             link: linkFunc
         };
 
@@ -80,8 +80,7 @@
                     return { idx: idx + 1, col: this.colors[idx] };
                 }
             };
-            scope.$watch(scope.passwordToCheck, function (password) {
-                console.log("test");
+            scope.$watch('passwordToCheck', function (password) {
                 if (password) {
                     var c = strength.getColor(strength.mesureStrength(password));
                     iElement.removeClass('ng-hide');


### PR DESCRIPTION
Switched from the attrs.passwordToCheck into a scope value, which is a proper way to pass attributes in directives as it isolates the scope.