### PR TITLE
exclude tomcat from global config

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -95,6 +95,7 @@ description = ''
 
 configurations {
     providedRuntime
+    compile.exclude module: "spring-boot-starter-tomcat"
 }
 
 repositories {


### PR DESCRIPTION
exclude tomcat via global config according to offical boot documentation

close #2948 