### PR TITLE
Generate front-end code on Gateway from microservice entity

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -118,7 +118,6 @@ module.exports = EntityGenerator.extend({
             this.languages = this.config.get('languages');
             this.buildTool = this.config.get('buildTool');
             this.testFrameworks = this.config.get('testFrameworks');
-            this.pathConfigs = this._globalConfig.get('pathConfigs');
             // backward compatibility on testing frameworks
             if (this.testFrameworks == null) {
                 this.testFrameworks = ['gatling'];
@@ -135,18 +134,6 @@ module.exports = EntityGenerator.extend({
                 this.log(chalk.green('\nFound the ' + this.filename + ' configuration file, entity can be automatically generated!\n'));
                 this.useConfigurationFile = true;
                 this.fromPath = this.filename;
-            }
-            else {
-                if (this.pathConfigs) {
-                    var pathConfig = this.pathConfigs[this.entityNameCapitalized];
-                    if (pathConfig) {
-                        this.log(chalk.green('\nFound the ' + this.filename + ' configuration file in remote microservice ' +  pathConfig.appName));
-                        this.log(chalk.green('\nUsing configuration file ' + pathConfig.entityPath));
-                        this.useConfigurationFile = true;
-                        this.fromPath = pathConfig.entityPath;
-                        this.microserviceName = pathConfig.appName;
-                    }
-                }
             }
         },
 
@@ -1637,15 +1624,8 @@ module.exports = EntityGenerator.extend({
             if (_.isUndefined(this.microservicePath)) {
                 return;
             }
-
-            if (_.isUndefined(this.pathConfigs)) this.pathConfigs = {};
-
-            this.pathConfigs[this.entityNameCapitalized] = {
-                appName: this.microserviceName,
-                entityPath: this.microservicePath + '/' + this.jhipsterConfigDirectory + '/' + this.entityNameCapitalized + '.json'
-            };
-
-            this._globalConfig.set('pathConfigs', this.pathConfigs);
+            
+            this.copy(this.microservicePath + '/' + this.jhipsterConfigDirectory + '/' + this.entityNameCapitalized + '.json', this.destinationPath(this.jhipsterConfigDirectory + '/' + this.entityNameCapitalized + '.json'));
         },
 
         writeEnumFiles: function() {


### PR DESCRIPTION
Fix #2987.
I worked with @PierreBesson on this. We updated the entity generator by following this use case : 

1. Create an entity in a microservice app with the `--skip-client` flag. We added a "microserviceName" field in the entity JSON. This is only added to the entities generated in a microservice. We do this because we need this information to prefix the service name to the URL in angular services.
So the gateway's client entity knows to request the microservice at `/app1/api/foos` and not at `/api/foos`.

2. Create an entity in the gateway with` --skip-server` flag.

3. You will be asked if you to generate the entity from a microservice. You will have to put the path of the microservice folder (eg :` /home/ippon/microservice`) and it will copy and paste Foo.JSON from the microservice to the `.jhipster` folder of the gateway.

4. Front end is generated in gateway. Everything works, even elasticsearch. Amazing !

NB : Gateway and microservices must have the same secret in application.yml config file.

As we added a field in JSON, the JSON files from jhipster-UML won't work if you try to import it. 
Maybe we can do a fallback and ask the user the microservice name if this field is not present in the JSON ? Or we could ask the jhipster uml guys to support this feature.

Also, should we put the `skip-client` and `skip-server` flags activated by default respectively in microservice and gateway ?

Finally, elasticsearch has to be enabled in the microservice to be available in the gateway. Should we add a "searchable" field in the JSON when generating the entity and then display or not the search bar in the gateway ?

Here is an example JSON entity file. Only a microserviceName field has been added.
```
{
    "relationships": [],
    "fields": [
        {
            "fieldName": "name",
            "fieldType": "String"
        }
    ],
    "changelogDate": "20160303141317",
    "dto": "no",
    "service": "no",
    "entityTableName": "foo",
    "pagination": "no",
    "microserviceName": "app1"
}
```