### PR TITLE
Reset language cookie if language is not installed

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -328,6 +328,7 @@ module.exports = JhipsterClientGenerator.extend({
             if (this.enableTranslation) {
                 this.template(ANGULAR_DIR + 'blocks/handlers/_translation.handler.js', ANGULAR_DIR + 'blocks/handlers/translation.handler.js', this, {});
                 this.template(ANGULAR_DIR + 'blocks/config/_translation.config.js', ANGULAR_DIR + 'blocks/config/translation.config.js', this, {});
+                this.template(ANGULAR_DIR + 'blocks/config/_translation.storage.js', ANGULAR_DIR + 'blocks/config/translation.storage.js', this, {});
             }
             this.template(ANGULAR_DIR + 'blocks/config/_alert.config.js', ANGULAR_DIR + 'blocks/config/alert.config.js', this, {});
             this.template(ANGULAR_DIR + 'blocks/config/_http.config.js', ANGULAR_DIR + 'blocks/config/http.config.js', this, {});
@@ -633,6 +634,7 @@ module.exports = JhipsterClientGenerator.extend({
                 appScripts = appScripts.concat([
                     'app/blocks/handlers/translation.handler.js',
                     'app/blocks/config/translation.config.js',
+                    'app/blocks/config/translation.storage.js',
                     'app/components/language/language.service.js',
                     'app/components/language/language.constants.js',
                     'app/components/language/language.filter.js',

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -328,7 +328,7 @@ module.exports = JhipsterClientGenerator.extend({
             if (this.enableTranslation) {
                 this.template(ANGULAR_DIR + 'blocks/handlers/_translation.handler.js', ANGULAR_DIR + 'blocks/handlers/translation.handler.js', this, {});
                 this.template(ANGULAR_DIR + 'blocks/config/_translation.config.js', ANGULAR_DIR + 'blocks/config/translation.config.js', this, {});
-                this.template(ANGULAR_DIR + 'blocks/config/_translation.storage.js', ANGULAR_DIR + 'blocks/config/translation.storage.js', this, {});
+                this.template(ANGULAR_DIR + 'blocks/config/_translation-storage.provider.js', ANGULAR_DIR + 'blocks/config/translation-storage.provider.js', this, {});
             }
             this.template(ANGULAR_DIR + 'blocks/config/_alert.config.js', ANGULAR_DIR + 'blocks/config/alert.config.js', this, {});
             this.template(ANGULAR_DIR + 'blocks/config/_http.config.js', ANGULAR_DIR + 'blocks/config/http.config.js', this, {});
@@ -634,7 +634,7 @@ module.exports = JhipsterClientGenerator.extend({
                 appScripts = appScripts.concat([
                     'app/blocks/handlers/translation.handler.js',
                     'app/blocks/config/translation.config.js',
-                    'app/blocks/config/translation.storage.js',
+                    'app/blocks/config/translation-storage.provider.js',
                     'app/components/language/language.service.js',
                     'app/components/language/language.constants.js',
                     'app/components/language/language.filter.js',

--- a/generators/client/templates/src/main/webapp/app/blocks/config/_translation-storage.provider.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/config/_translation-storage.provider.js
@@ -3,11 +3,11 @@
 
     angular
         .module('<%=angularAppName%>')
-        .factory('translationStorage', translationStorage);
+        .factory('translationStorageProvider', translationStorageProvider);
 
-    translationStorage.$inject = ['$cookies', '$log', 'LANGUAGES'];
+    translationStorageProvider.$inject = ['$cookies', '$log', 'LANGUAGES'];
 
-    function translationStorage($cookies, $log, LANGUAGES) {
+    function translationStorageProvider($cookies, $log, LANGUAGES) {
         return {
             get: get,
             put: put

--- a/generators/client/templates/src/main/webapp/app/blocks/config/_translation.config.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/config/_translation.config.js
@@ -14,7 +14,7 @@
         });
 
         $translateProvider.preferredLanguage('<%= nativeLanguageShortName %>');
-        $translateProvider.useCookieStorage();
+        $translateProvider.useStorage('translationStorage');
         $translateProvider.useSanitizeValueStrategy('escaped');
         $translateProvider.addInterpolation('$translateMessageFormatInterpolation');
 

--- a/generators/client/templates/src/main/webapp/app/blocks/config/_translation.config.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/config/_translation.config.js
@@ -14,7 +14,7 @@
         });
 
         $translateProvider.preferredLanguage('<%= nativeLanguageShortName %>');
-        $translateProvider.useStorage('translationStorage');
+        $translateProvider.useStorage('translationStorageProvider');
         $translateProvider.useSanitizeValueStrategy('escaped');
         $translateProvider.addInterpolation('$translateMessageFormatInterpolation');
 

--- a/generators/client/templates/src/main/webapp/app/blocks/config/_translation.storage.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/config/_translation.storage.js
@@ -1,0 +1,28 @@
+(function() {
+    'use strict';
+
+    angular
+        .module('<%=angularAppName%>')
+        .factory('translationStorage', translationStorage);
+
+    translationStorage.$inject = ['$cookies', '$log', 'LANGUAGES'];
+
+    function translationStorage($cookies, $log, LANGUAGES) {
+        return {
+            get: get,
+            put: put
+        };
+
+        function get(name) {
+            if (LANGUAGES.indexOf($cookies.getObject(name)) === -1) {
+                $log.info('Resetting invalid cookie language "' + $cookies.getObject(name) + '" to prefered language "<%= nativeLanguageShortName %>"');
+                $cookies.putObject(name, '<%= nativeLanguageShortName %>');
+            }
+            return $cookies.getObject(name);
+        }
+
+        function put(name, value) {
+            $cookies.putObject(name, value);
+        }
+    }
+})();

--- a/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
+++ b/generators/client/templates/src/main/webapp/app/components/language/_language.service.js
@@ -25,10 +25,6 @@
             var deferred = $q.defer();
             var language = $translate.storage().get('NG_TRANSLATE_LANG_KEY');
 
-            if (angular.isUndefined(language)) {
-                language = '<%= nativeLanguageShortName %>';
-            }
-
             deferred.resolve(language);
 
             return deferred.promise;

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -194,6 +194,7 @@ const expectedFiles = {
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/localstorage.config.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/alert.config.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.config.js',
+        CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.storage.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/compile.config.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/handlers/state.handler.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/handlers/translation.handler.js',
@@ -316,6 +317,7 @@ const expectedFiles = {
         CLIENT_MAIN_SRC_DIR + 'app/components/language/language.filter.js',
         CLIENT_MAIN_SRC_DIR + 'app/components/language/language.constants.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.config.js',
+        CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.storage.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/handlers/translation.handler.js'
     ],
 

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -194,7 +194,7 @@ const expectedFiles = {
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/localstorage.config.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/alert.config.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.config.js',
-        CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.storage.js',
+        CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation-storage.provider.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/compile.config.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/handlers/state.handler.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/handlers/translation.handler.js',
@@ -317,7 +317,7 @@ const expectedFiles = {
         CLIENT_MAIN_SRC_DIR + 'app/components/language/language.filter.js',
         CLIENT_MAIN_SRC_DIR + 'app/components/language/language.constants.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.config.js',
-        CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation.storage.js',
+        CLIENT_MAIN_SRC_DIR + 'app/blocks/config/translation-storage.provider.js',
         CLIENT_MAIN_SRC_DIR + 'app/blocks/handlers/translation.handler.js'
     ],
 


### PR DESCRIPTION
Language cookie should be cleared if the language is not installed in the running jhipster application.

This is to prevent a cryptic error when running two different jhipster applications with different language support localhost.

e.g. see atomfreds comment https://github.com/jhipster/generator-jhipster/pull/2970#issuecomment-191408930