### PR TITLE
Cleanup Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,50 +1,50 @@
-FROM ubuntu:trusty
-
-# environment variables
-ENV JAVA_VERSION 8
-ENV JAVA_HOME /usr/lib/jvm/java-8-oracle
-
-ENV MAVEN_VERSION 3.3.9
-ENV MAVEN_HOME /usr/share/maven
-ENV PATH "$PATH:$MAVEN_HOME/bin"
-
-# install utilities
-RUN apt-get -y install wget vim git sudo zip bzip2 fontconfig curl
-
-# install maven
-RUN wget -O /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz http://archive.apache.org/dist/maven/maven-3/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz
-RUN echo "516923b3955b6035ba6b0a5b031fbd8b /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz" | md5sum -c
-RUN tar xzf /tmp/apache-maven-${MAVEN_VERSION}-bin.tar.gz -C /opt/
-
-# install java8
-RUN echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list && \
-    echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list && \
-    apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
-    apt-get update && \
-    echo oracle-java${JAVA_VERSION}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
-    apt-get install -y --force-yes --no-install-recommends oracle-java${JAVA_VERSION}-installer oracle-java${JAVA_VERSION}-set-default
-
-# install node.js
-RUN curl -sL https://deb.nodesource.com/setup_4.x | sudo bash -
-RUN apt-get install -y nodejs python g++ build-essential
-
-# install yeoman bower gulp
-RUN npm install -g yo bower gulp-cli
-
-# clean
-RUN apt-get clean && \
-    rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/* /var/cache/oracle-jdk${JAVA_VERSION}-installer
-
-# install JHipster
-COPY . /home/jhipster/generator-jhipster
-RUN npm install -g /home/jhipster/generator-jhipster/
+FROM isuper/java-oracle:jdk_8
 
 # configure the "jhipster" user
-RUN groupadd jhipster && useradd jhipster -s /bin/bash -m -g jhipster -G jhipster && adduser jhipster sudo
-RUN echo 'jhipster:jhipster' |chpasswd
-RUN mkdir -p /home/jhipster/app
-RUN cd /home && chown -R jhipster:jhipster /home/jhipster
-RUN chown -R jhipster:jhipster /usr/lib/node_modules/
+RUN \
+  groupadd jhipster && \
+  useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
+  echo 'jhipster:jhipster' |chpasswd && \
+  mkdir /home/jhipster/app
+
+COPY . /home/jhipster/generator-jhipster
+
+RUN \
+  # install utilities & node.js
+  curl -sL https://deb.nodesource.com/setup_4.x | sudo bash - && \
+  apt-get update && \
+  apt-get install -y \
+     wget \
+     vim \
+     git \
+     zip \
+     bzip2 \
+     fontconfig \
+     python \
+     g++ \
+     build-essential \
+     nodejs && \
+
+  # upgrade npm
+  npm install -g npm && \
+
+  # install yeoman bower gulp jhipster
+  npm install -g \
+    yo \
+    bower \
+    gulp-cli \
+    /home/jhipster/generator-jhipster && \
+
+  chown -R jhipster:jhipster \
+    /home/jhipster \
+    /usr/lib/node_modules && \
+
+  # cleanup
+  apt-get clean && \
+  rm -rf \
+    /var/lib/apt/lists/* \
+    /tmp/* \
+    /var/tmp/*
 
 # expose the working directory, the Tomcat port, the BrowserSync ports
 USER jhipster

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,9 @@
-FROM isuper/java-oracle:jdk_8
+FROM ubuntu:trusty
 
-# configure the "jhipster" user
+ENV JAVA_VERSION 8
+ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-oracle
+
+# configure the "jhipster" user before copying generator-jhipster source files so home folder is properly created
 RUN \
   groupadd jhipster && \
   useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
@@ -10,11 +13,21 @@ RUN \
 COPY . /home/jhipster/generator-jhipster
 
 RUN \
-  # install utilities & node.js
-  curl -sL https://deb.nodesource.com/setup_4.x | sudo bash - && \
+
+  # install oracle jdk 8
+  echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list && \
+  echo "deb-src http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list && \
+  apt-key adv --keyserver keyserver.ubuntu.com --recv-keys C2518248EEA14886 && \
   apt-get update && \
+  echo oracle-java${JAVA_VERSION}-installer shared/accepted-oracle-license-v1-1 select true | sudo /usr/bin/debconf-set-selections && \
+  apt-get install -y --force-yes --no-install-recommends \
+    oracle-java${JAVA_VERSION}-installer \
+    oracle-java${JAVA_VERSION}-set-default && \
+
+  # install utilities
   apt-get install -y \
      wget \
+     curl \
      vim \
      git \
      zip \
@@ -22,8 +35,11 @@ RUN \
      fontconfig \
      python \
      g++ \
-     build-essential \
-     nodejs && \
+     build-essential && \
+
+  # install node.js
+  curl -sL https://deb.nodesource.com/setup_4.x | sudo bash - && \
+  apt-get install -y nodejs && \
 
   # upgrade npm
   npm install -g npm && \
@@ -35,6 +51,7 @@ RUN \
     gulp-cli \
     /home/jhipster/generator-jhipster && \
 
+  # fix jhipster user permissions
   chown -R jhipster:jhipster \
     /home/jhipster \
     /usr/lib/node_modules && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,16 +3,12 @@ FROM ubuntu:trusty
 ENV JAVA_VERSION 8
 ENV JAVA_HOME /usr/lib/jvm/java-${JAVA_VERSION}-oracle
 
-# configure the "jhipster" user before copying generator-jhipster source files so home folder is properly created
 RUN \
+  # configure the "jhipster" user
   groupadd jhipster && \
   useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
   echo 'jhipster:jhipster' |chpasswd && \
-  mkdir /home/jhipster/app
-
-COPY . /home/jhipster/generator-jhipster
-
-RUN \
+  mkdir /home/jhipster/app && \
 
   # install oracle jdk 8
   echo "deb http://ppa.launchpad.net/webupd8team/java/ubuntu trusty main" >> /etc/apt/sources.list && \
@@ -44,12 +40,18 @@ RUN \
   # upgrade npm
   npm install -g npm && \
 
-  # install yeoman bower gulp jhipster
+  # install yeoman bower gulp
   npm install -g \
     yo \
     bower \
-    gulp-cli \
-    /home/jhipster/generator-jhipster && \
+    gulp-cli
+
+# copy sources
+COPY . /home/jhipster/generator-jhipster
+
+RUN \
+  # install jhipster
+  npm install -g /home/jhipster/generator-jhipster && \
 
   # fix jhipster user permissions
   chown -R jhipster:jhipster \


### PR DESCRIPTION
Based on comments from https://github.com/jhipster/jhipster-docker/pull/19:

* Use [oracle-jdk8](https://hub.docker.com/r/isuper/java-oracle/) (ubuntu) image as parent
* Optimize number of layers following Docker [best practices] (https://docs.docker.com/engine/userguide/eng-image/dockerfile_best-practices).