### PR TITLE
correct camel casing of class and variable - RememberMe

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
+++ b/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
@@ -211,14 +211,14 @@ public class JHipsterProperties {
 
     public static class Security {
 
-        private final Rememberme rememberme = new Rememberme();
+        private final RememberMe rememberMe = new RememberMe();
 
         <%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt') { _%>
         private final Authentication authentication = new Authentication();
 
         <%_ } _%>
-        public Rememberme getRememberme() {
-            return rememberme;
+        public RememberMe getRememberMe() {
+            return rememberMe;
         }
 
         <%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt') { _%>
@@ -317,7 +317,7 @@ public class JHipsterProperties {
             <%_ } _%>
         }
         <%_ } _%>
-        public static class Rememberme {
+        public static class RememberMe {
 
             @NotNull
             private String key;

--- a/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -105,7 +105,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
             .rememberMe()
             .rememberMeServices(rememberMeServices)
             .rememberMeParameter("remember-me")
-            .key(env.getProperty("jhipster.security.rememberme.key"))
+            .key(env.getProperty("jhipster.security.rememberMe.key"))
         .and()
             .formLogin()
             .loginProcessingUrl("/api/authentication")

--- a/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -75,7 +75,7 @@ public class CustomPersistentRememberMeServices extends
     public CustomPersistentRememberMeServices(Environment env, org.springframework.security.core.userdetails
         .UserDetailsService userDetailsService) {
 
-        super(env.getProperty("jhipster.security.rememberme.key"), userDetailsService);
+        super(env.getProperty("jhipster.security.rememberMe.key"), userDetailsService);
         random = new SecureRandom();
     }
 

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -103,7 +103,7 @@ jhipster:
                 tokenValidityInSeconds: 1800
     <%_ } _%>
 <%_ } _%>
-        rememberme:
+        rememberMe:
             # security key (this key should be unique for your application, and kept secret)
             key: <%= rememberMeKey %>
     swagger:

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -115,7 +115,7 @@ jhipster:
                 tokenValidityInSeconds: 1800
     <%_ } _%>
 <%_ } _%>
-        rememberme:
+        rememberMe:
             # security key (this key should be unique for your application, and kept secret)
             key: <%= rememberMeKey %>
     metrics: # DropWizard Metrics configuration, used by MetricsConfiguration


### PR DESCRIPTION
camel case generated java class and variable

changed 
- class name: Rememberme to RememberMe  
- variable name: rememberme to rememberMe