### PR TITLE
Fix unused variables injected in angular controllers and unused gulp require

### DIFF
--- a/generators/client/templates/_eslintrc.json
+++ b/generators/client/templates/_eslintrc.json
@@ -15,7 +15,7 @@
     "wrap-iife": [2, "inside"],
     "eqeqeq": 2,
     "no-use-before-define": [2, "nofunc"],
-    "no-unused-vars": 2,
+    "no-unused-vars": [2, {"vars": "local", "args": "none"}],
     "no-multi-str": 2,
     "no-irregular-whitespace": 2,
     "semi": [2, "always"],

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -2,7 +2,6 @@
 'use strict';
 
 var gulp = require('gulp'),
-    gutil = require('gulp-util'),
     prefix = require('gulp-autoprefixer'),
     cssnano = require('gulp-cssnano'),
     usemin = require('gulp-usemin'),
@@ -15,6 +14,7 @@ var gulp = require('gulp'),
     ngConstant = require('gulp-ng-constant-fork'),
     eslint = require('gulp-eslint'),
     rev = require('gulp-rev'),<% if (testFrameworks.indexOf('protractor') > -1) { %>
+    gutil = require('gulp-util'),
     protractor = require('gulp-protractor').protractor,<% } %>
     es = require('event-stream'),
     flatten = require('gulp-flatten'),


### PR DESCRIPTION
Fix #3105 
As suggested by @gmarziou in [this discussion](https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jhipster-dev/DqVSbTskrjw/cipLhz6KAgAJ), I updated the eslint rule to check only local variables and to not check function arguments.
I also fixed an unused gulp require `gulp-util` when protractor wasn't selected as a test framework.