### PR TITLE
added injection of jhipsterproperties to CustomPersistentRememberMeServices

### DIFF
--- a/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -4,6 +4,7 @@ import <%=packageName%>.domain.PersistentToken;<% if (databaseType == 'sql' || d
 import <%=packageName%>.domain.User;<%}%>
 import <%=packageName%>.repository.PersistentTokenRepository;
 import <%=packageName%>.repository.UserRepository;
+import <%=packageName%>.config.JHipsterProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.core.env.Environment;

--- a/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -72,10 +72,10 @@ public class CustomPersistentRememberMeServices extends
     private UserRepository userRepository;
 
     @Inject
-    public CustomPersistentRememberMeServices(Environment env, org.springframework.security.core.userdetails
+    public CustomPersistentRememberMeServices(Environment env, JHipsterProperties jhipsterProperties, org.springframework.security.core.userdetails
         .UserDetailsService userDetailsService) {
 
-        super(env.getProperty("jhipster.security.rememberMe.key"), userDetailsService);
+        super(jhipsterProperties.getSecurity().getRememberme().getKey(), userDetailsService);
         random = new SecureRandom();
     }
 

--- a/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
+++ b/generators/server/templates/src/main/java/package/security/_CustomPersistentRememberMeServices.java
@@ -76,7 +76,7 @@ public class CustomPersistentRememberMeServices extends
     public CustomPersistentRememberMeServices(Environment env, JHipsterProperties jhipsterProperties, org.springframework.security.core.userdetails
         .UserDetailsService userDetailsService) {
 
-        super(jhipsterProperties.getSecurity().getRememberme().getKey(), userDetailsService);
+        super(jhipsterProperties.getSecurity().getRememberMe().getKey(), userDetailsService);
         random = new SecureRandom();
     }
 


### PR DESCRIPTION
If the jhipsterproperties class gets refactored (i.e. name change), then the CustomPersistentRememberMeServices would not work as it was looking for the properties in a kind of hard-coded way. 

By injecting the JHIpster properties to the constructor method, we have a cleaner way of creating the CustomPersistentRememberMeServices instance without hard-coded properties.