### PR TITLE
Gateway filter to rewrite microservices Swagger URL path

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1063,6 +1063,11 @@ module.exports = JhipsterServerGenerator.extend({
             this.template(SERVER_TEST_RES_DIR + 'config/_application.yml', SERVER_TEST_RES_DIR + 'config/application.yml', this, {});
             this.template(SERVER_TEST_RES_DIR + '_logback-test.xml', SERVER_TEST_RES_DIR + 'logback-test.xml', this, {});
 
+            // Create Gateway tests files
+            if (this.applicationType == "gateway"){
+                this.template(SERVER_TEST_SRC_DIR + 'package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java', testDir + 'gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java', this, {});
+            }
+
             if (this.hibernateCache == "ehcache") {
                 this.template(SERVER_TEST_RES_DIR + '_ehcache.xml', SERVER_TEST_RES_DIR + 'ehcache.xml', this, {});
             }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -881,6 +881,7 @@ module.exports = JhipsterServerGenerator.extend({
             this.template(SERVER_MAIN_SRC_DIR + 'package/gateway/ratelimiting/_RateLimitingFilter.java', javaDir + 'gateway/ratelimiting/RateLimitingFilter.java', this, {});
             this.template(SERVER_MAIN_SRC_DIR + 'package/gateway/ratelimiting/_RateLimitingRepository.java', javaDir + 'gateway/ratelimiting/RateLimitingRepository.java', this, {});
             this.template(SERVER_MAIN_SRC_DIR + 'package/gateway/accesscontrol/_AccessControlFilter.java', javaDir + 'gateway/accesscontrol/AccessControlFilter.java', this, {});
+            this.template(SERVER_MAIN_SRC_DIR + 'package/gateway/responserewriting/_SwaggerBasePathRewritingFilter.java', javaDir + 'gateway/responserewriting/SwaggerBasePathRewritingFilter.java', this, {});
             this.template(SERVER_MAIN_SRC_DIR + 'package/web/rest/dto/_RouteDTO.java', javaDir + 'web/rest/dto/RouteDTO.java', this, {});
             this.template(SERVER_MAIN_SRC_DIR + 'package/web/rest/_GatewayResource.java', javaDir + 'web/rest/GatewayResource.java', this, {});
         },

--- a/generators/server/templates/src/main/java/package/config/_GatewayConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_GatewayConfiguration.java
@@ -3,6 +3,7 @@ package <%=packageName%>.config;
 import <%=packageName%>.gateway.ratelimiting.RateLimitingFilter;
 import <%=packageName%>.gateway.ratelimiting.RateLimitingRepository;
 import <%=packageName%>.gateway.accesscontrol.AccessControlFilter;
+import <%=packageName%>.gateway.responserewriting.SwaggerBasePathRewritingFilter;
 
 import javax.inject.Inject;
 
@@ -17,7 +18,16 @@ import com.datastax.driver.core.Session;
 public class GatewayConfiguration {
 
     @Configuration
-    public static class AccessControl {
+    public static class SwaggerBasePathRewritingConfiguration {
+
+        @Bean
+        public SwaggerBasePathRewritingFilter swaggerBasePathRewritingFilter(){
+            return new SwaggerBasePathRewritingFilter();
+        }
+    }
+
+    @Configuration
+    public static class AccessControlFilter {
 
         @Bean
         public AccessControlFilter accessControlFilter(){

--- a/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
@@ -61,9 +61,6 @@ public class SwaggerConfiguration {
 
         Docket docket = new Docket(DocumentationType.SWAGGER_2)
             .apiInfo(apiInfo)
-            <%_ if (applicationType == 'microservice') { _%>
-            .pathMapping("/<%= baseName.toLowerCase() %>")
-            <%_ } _%>
             .forCodeGeneration(true)
             .genericModelSubstitutes(ResponseEntity.class)
             .ignoredParameterTypes(Pageable.class)

--- a/generators/server/templates/src/main/java/package/gateway/responserewriting/_SwaggerBasePathRewritingFilter.java
+++ b/generators/server/templates/src/main/java/package/gateway/responserewriting/_SwaggerBasePathRewritingFilter.java
@@ -1,0 +1,68 @@
+package <%=packageName%>.gateway.responserewriting;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.google.common.io.CharStreams;
+import com.netflix.zuul.context.RequestContext;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cloud.netflix.zuul.filters.post.SendResponseFilter;
+
+import java.io.*;
+import java.util.LinkedHashMap;
+
+/**
+ * Zuul filter to rewrite micro-services Swagger URL Base Path.
+ */
+public class SwaggerBasePathRewritingFilter extends SendResponseFilter {
+
+    private final Logger log = LoggerFactory.getLogger(SwaggerBasePathRewritingFilter.class);
+
+    @Override
+    public String filterType() {
+        return "post";
+    }
+
+    @Override
+    public int filterOrder() {
+        return 100;
+    }
+
+    /**
+     * Filter requests to micro-services Swagger docs.
+     */
+    @Override
+    public boolean shouldFilter() {
+        return RequestContext.getCurrentContext().getRequest().getRequestURI().endsWith("/v2/api-docs");
+    }
+
+    @Override
+    public Object run() {
+        RequestContext context = RequestContext.getCurrentContext();
+        context.getResponse().setCharacterEncoding("UTF-8");
+
+        String rewrittenResponse = rewriteBasePath(context);
+        context.setResponseBody(rewrittenResponse);
+        return null;
+    }
+
+    private String rewriteBasePath(RequestContext context) {
+        InputStream responseDataStream = context.getResponseDataStream();
+        String requestUri = RequestContext.getCurrentContext().getRequest().getRequestURI();
+        try {
+            String response = CharStreams.toString(new InputStreamReader(responseDataStream));
+            if (response != null) {
+                ObjectMapper mapper = new ObjectMapper();
+                LinkedHashMap<String, Object> map = mapper.readValue(response, LinkedHashMap.class);
+
+                String basePath = requestUri.replace("/v2/api-docs","");
+                map.put("basePath",basePath);
+                log.debug("Swagger-docs: rewritten Base URL with correct micro-service route: {}", basePath);
+                return mapper.writeValueAsString(map);
+            }
+        }
+        catch (IOException e){
+            log.error("Swagger-docs filter error: {}", e.getMessage(), e);
+        }
+        return null;
+    }
+}

--- a/generators/server/templates/src/test/java/package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java
+++ b/generators/server/templates/src/test/java/package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java
@@ -51,24 +51,6 @@ public class SwaggerBasePathRewritingFilterTest {
     }
 
     @Test
-    public void run_on_error_404() {
-        MockHttpServletRequest request = new MockHttpServletRequest("GET", DEFAULT_URL);
-        RequestContext context = RequestContext.getCurrentContext();
-        context.setRequest(request);
-
-        // Simulate an HTTP error 404, this should probably be done differently in Zuul
-        // according to SendErrorFilter
-        MockHttpServletResponse response = new MockHttpServletResponse();
-        response.setStatus(404);
-        context.setResponse(response);
-
-        // filter should not fail with an empty body
-
-        filter.run();
-        assertEquals(404, context.getResponseStatusCode());
-    }
-
-    @Test
     public void run_on_valid_response() throws Exception {
         MockHttpServletRequest request = new MockHttpServletRequest("GET", "/service1" + DEFAULT_URL);
         RequestContext context = RequestContext.getCurrentContext();

--- a/generators/server/templates/src/test/java/package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java
+++ b/generators/server/templates/src/test/java/package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java
@@ -1,0 +1,88 @@
+package <%=packageName%>.gateway.responserewriting;
+
+import com.netflix.zuul.context.RequestContext;
+import org.apache.commons.io.IOUtils;
+import org.junit.Test;
+import org.springframework.mock.web.MockHttpServletRequest;
+import org.springframework.mock.web.MockHttpServletResponse;
+import org.springframework.mock.web.MockHttpServletResponse;
+
+import java.io.InputStream;
+
+import static org.junit.Assert.*;
+import static springfox.documentation.swagger2.web.Swagger2Controller.DEFAULT_URL;
+
+/**
+ * Tests SwaggerBasePathRewritingFilter class.
+ */
+public class SwaggerBasePathRewritingFilterTest {
+
+    private SwaggerBasePathRewritingFilter filter = new SwaggerBasePathRewritingFilter();
+
+    @Test
+    public void shouldFilter_on_default_swagger_url() {
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", DEFAULT_URL);
+        RequestContext.getCurrentContext().setRequest(request);
+
+        assertTrue(filter.shouldFilter());
+    }
+
+    /**
+     * Zuul DebugFilter can be triggered by "deug" parameter.
+     */
+    @Test
+    public void shouldFilter_on_default_swagger_url_with_param() {
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", DEFAULT_URL);
+        request.setParameter("debug", "true");
+        RequestContext.getCurrentContext().setRequest(request);
+
+        assertTrue(filter.shouldFilter());
+    }
+
+    @Test
+    public void shouldNotFilter_on_wrong_url() {
+
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/management/info");
+        RequestContext.getCurrentContext().setRequest(request);
+
+        assertFalse(filter.shouldFilter());
+    }
+
+    @Test
+    public void run_on_error_404() {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", DEFAULT_URL);
+        RequestContext context = RequestContext.getCurrentContext();
+        context.setRequest(request);
+
+        // Simulate an HTTP error 404, this should probably be done differently in Zuul
+        // according to SendErrorFilter
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        response.setStatus(404);
+        context.setResponse(response);
+
+        // filter should not fail with an empty body
+
+        filter.run();
+        assertEquals(404, context.getResponseStatusCode());
+    }
+
+    @Test
+    public void run_on_valid_response() throws Exception {
+        MockHttpServletRequest request = new MockHttpServletRequest("GET", "/service1" + DEFAULT_URL);
+        RequestContext context = RequestContext.getCurrentContext();
+        context.setRequest(request);
+
+        MockHttpServletResponse response = new MockHttpServletResponse();
+        context.setResponse(response);
+
+        InputStream in = IOUtils.toInputStream("{\"basePath\":\"/\"}");
+        context.setResponseDataStream(in);
+
+        filter.run();
+
+        assertEquals("UTF-8", response.getCharacterEncoding());
+        assertEquals("{\"basePath\":\"/service1\"}", context.getResponseBody());
+    }
+}


### PR DESCRIPTION
Fix #3046 
Don't rely anymore on a hard-coded path-mapping to access the micro-services API throught Swagger UI. This is achieved by rewriting the "Base URL" (see the bottom part of Swagger UI) when the JSON swagger-docs is passing through the gateway.

![screenshot from 2016-03-08 18 22 44](https://cloud.githubusercontent.com/assets/513471/13609789/c6edc9e6-e55a-11e5-9ba7-ee09269c8cc6.png)
