### PR TITLE
Run 'gulp build' from maven with --no-notification option

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1053,6 +1053,7 @@
                                 </goals>
                                 <configuration>
                                     <buildTool>gulp</buildTool>
+                                    <buildArgs>build --no-notification</buildArgs>
                                 </configuration>
                             </execution>
                         </executions>


### PR DESCRIPTION
Run 'gulp build' from maven with --no-notification option to avoid blocking on Windows.

Fix #3110