### PR TITLE
Removing unused Gulp imports and fix eslint errors

### DIFF
--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -40,7 +40,6 @@
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
     "gulp-protractor": "2.1.0",
     "gulp-util": "3.0.7",
-    "yargs": "4.2.0",
     <%_ } _%>
     "gulp-rev": "7.0.0",
     "gulp-rev-replace": "^0.4.3",
@@ -71,9 +70,11 @@
     <%_ } _%>
     "proxy-middleware": "0.15.0",
     "run-sequence": "1.1.5",
-    "wiredep": "3.0.0"<%_ if (buildTool == 'maven') { _%>,
-    "xml2js": "0.4.16"
+    "wiredep": "3.0.0",
+    <%_ if (buildTool == 'maven') { _%>
+    "xml2js": "0.4.16",
     <%_ } _%>
+    "yargs": "4.2.0"
   },
   "engines": {
     "node": "^4.3"

--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -71,8 +71,7 @@
     <%_ } _%>
     "proxy-middleware": "0.15.0",
     "run-sequence": "1.1.5",
-    "wiredep": "3.0.0",
-    <%_ if (buildTool == 'maven') { _%>
+    "wiredep": "3.0.0"<%_ if (buildTool == 'maven') { _%>,
     "xml2js": "0.4.16"
     <%_ } _%>
   },

--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -39,6 +39,8 @@
     "gulp-plumber": "1.1.0",
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
     "gulp-protractor": "2.1.0",
+    "gulp-util": "3.0.7",
+    "yargs": "4.2.0"
     <%_ } _%>
     "gulp-rev": "7.0.0",
     "gulp-rev-replace": "^0.4.3",
@@ -48,7 +50,6 @@
     "gulp-sourcemaps": "1.6.0",
     "gulp-uglify": "1.5.3",
     "gulp-useref": "3.0.7",
-    "gulp-util": "3.0.7",
     "jasmine-core": "2.4.1",
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
     "jasmine-reporters": "2.1.1",
@@ -74,7 +75,6 @@
     <%_ if (buildTool == 'maven') { _%>
     "xml2js": "0.4.16",
     <%_ } _%>
-    "yargs": "4.2.0"
   },
   "engines": {
     "node": "^4.3"

--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -40,7 +40,7 @@
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
     "gulp-protractor": "2.1.0",
     "gulp-util": "3.0.7",
-    "yargs": "4.2.0"
+    "yargs": "4.2.0",
     <%_ } _%>
     "gulp-rev": "7.0.0",
     "gulp-rev-replace": "^0.4.3",
@@ -73,7 +73,7 @@
     "run-sequence": "1.1.5",
     "wiredep": "3.0.0",
     <%_ if (buildTool == 'maven') { _%>
-    "xml2js": "0.4.16",
+    "xml2js": "0.4.16"
     <%_ } _%>
   },
   "engines": {

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -10,7 +10,7 @@ var gulp = require('gulp'),<% if(useSass) { %>
     imagemin = require('gulp-imagemin'),
     ngConstant = require('gulp-ng-constant-fork'),
     eslint = require('gulp-eslint'),<% if (testFrameworks.indexOf('protractor') > -1) { %>
-    argv = require('yargs').argv;
+    argv = require('yargs').argv,
     gutil = require('gulp-util'),
     protractor = require('gulp-protractor').protractor,<% } %>
     es = require('event-stream'),
@@ -24,7 +24,7 @@ var gulp = require('gulp'),<% if(useSass) { %>
     changed = require('gulp-changed'),
     gulpIf = require('gulp-if'),
     inject = require('gulp-inject'),
-    angularFilesort = require('gulp-angular-filesort'),
+    angularFilesort = require('gulp-angular-filesort');
 
 var handleErrors = require('./gulp/handleErrors'),
     serve = require('./gulp/serve'),

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -10,6 +10,7 @@ var gulp = require('gulp'),<% if(useSass) { %>
     imagemin = require('gulp-imagemin'),
     ngConstant = require('gulp-ng-constant-fork'),
     eslint = require('gulp-eslint'),<% if (testFrameworks.indexOf('protractor') > -1) { %>
+    argv = require('yargs').argv;
     gutil = require('gulp-util'),
     protractor = require('gulp-protractor').protractor,<% } %>
     es = require('event-stream'),
@@ -24,7 +25,6 @@ var gulp = require('gulp'),<% if(useSass) { %>
     gulpIf = require('gulp-if'),
     inject = require('gulp-inject'),
     angularFilesort = require('gulp-angular-filesort'),
-    argv = require('yargs').argv;
 
 var handleErrors = require('./gulp/handleErrors'),
     serve = require('./gulp/serve'),

--- a/generators/client/templates/src/main/webapp/app/blocks/interceptor/_auth.interceptor.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/interceptor/_auth.interceptor.js
@@ -24,7 +24,7 @@
             }
             <% } %><% if (authenticationType == 'jwt') { %>
             if (token) {
-              config.headers.Authorization = 'Bearer ' + token;
+                config.headers.Authorization = 'Bearer ' + token;
             }
             <% } %>
             return config;

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.jwt.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.jwt.service.js
@@ -36,7 +36,7 @@
 
             function authenticateSuccess (data, status, headers) {
                 var bearerToken = headers('Authorization');
-                if (bearerToken !== undefined && bearerToken.slice(0, 7) === 'Bearer ') {
+                if (angular.isUndefined(bearerToken) && bearerToken.slice(0, 7) === 'Bearer ') {
                     var jwt = bearerToken.slice(7, bearerToken.length);
                     if(credentials.rememberMe){
                         $localStorage.authenticationToken = jwt;

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.jwt.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.jwt.service.js
@@ -36,7 +36,7 @@
 
             function authenticateSuccess (data, status, headers) {
                 var bearerToken = headers('Authorization');
-                if (angular.isUndefined(bearerToken) && bearerToken.slice(0, 7) === 'Bearer ') {
+                if (angular.isDefined(bearerToken) && bearerToken.slice(0, 7) === 'Bearer ') {
                     var jwt = bearerToken.slice(7, bearerToken.length);
                     if(credentials.rememberMe){
                         $localStorage.authenticationToken = jwt;


### PR DESCRIPTION
While working on an application without protractor, I saw that eslint throwed some errors about unused imports. 
So I removed the yargs import if the application is not using protractor and two other eslint errors in the same time (one indent and one "use angular.isDefined instead of !== undefined").
I also removed the gulp-util from package.json if the app doesn't use protractor.