### PR TITLE
Add 'toLowerCase()' to microserviceName in entity services

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/services/_entity-search.service.js
+++ b/generators/entity/templates/src/main/webapp/app/services/_entity-search.service.js
@@ -8,7 +8,7 @@
     <%= entityClass %>Search.$inject = ['$resource'];
 
     function <%= entityClass %>Search($resource) {
-        var resourceUrl = <% if (applicationType == 'gateway' && locals.microserviceName) {%> '<%= microserviceName %>/' +<% } %> 'api/_search/<%= entityApiUrl %>/:id';
+        var resourceUrl = <% if (applicationType == 'gateway' && locals.microserviceName) {%> '<%= microserviceName.toLowerCase() %>/' +<% } %> 'api/_search/<%= entityApiUrl %>/:id';
 
         return $resource(resourceUrl, {}, {
             'query': { method: 'GET', isArray: true}

--- a/generators/entity/templates/src/main/webapp/app/services/_entity.service.js
+++ b/generators/entity/templates/src/main/webapp/app/services/_entity.service.js
@@ -12,7 +12,7 @@ _%>
     <%= entityClass %>.$inject = ['$resource'<% if (hasDate) { %>, 'DateUtils'<% } %>];
 
     function <%= entityClass %> ($resource, DateUtils) {
-        var resourceUrl = <% if (applicationType == 'gateway' && locals.microserviceName) {%> '<%= microserviceName %>/' +<% } %> 'api/<%= entityApiUrl %>/:id';
+        var resourceUrl = <% if (applicationType == 'gateway' && locals.microserviceName) {%> '<%= microserviceName.toLowerCase() %>/' +<% } %> 'api/<%= entityApiUrl %>/:id';
 
         return $resource(resourceUrl, {}, {
             'query': { method: 'GET', isArray: true},


### PR DESCRIPTION
Applications with uppercased characters caused a 404 error in the gateway because the gateway request was for example `myappSQL/api/...` instead of `myappsql/api/...`.
So I added `toLowerCase()` after the microserviceName variable in entity services.