### PR TITLE
Generate Gatling tests for gateway entities from remote microservice

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1624,7 +1624,7 @@ module.exports = EntityGenerator.extend({
             if (_.isUndefined(this.microservicePath)) {
                 return;
             }
-            
+
             this.copy(this.microservicePath + '/' + this.jhipsterConfigDirectory + '/' + this.entityNameCapitalized + '.json', this.destinationPath(this.jhipsterConfigDirectory + '/' + this.entityNameCapitalized + '.json'));
         },
 
@@ -1749,10 +1749,12 @@ module.exports = EntityGenerator.extend({
         },
 
         writeTestFiles: function() {
-            if (this.skipServer) return;
 
-            this.template(SERVER_TEST_SRC_DIR + 'package/web/rest/_EntityResourceIntTest.java',
-                SERVER_TEST_SRC_DIR + this.packageFolder + '/web/rest/' + this.entityClass + 'ResourceIntTest.java', this, {});
+            if (!this.skipServer) {
+                this.template(SERVER_TEST_SRC_DIR + 'package/web/rest/_EntityResourceIntTest.java',
+                    SERVER_TEST_SRC_DIR + this.packageFolder + '/web/rest/' + this.entityClass + 'ResourceIntTest.java', this, {});
+            }
+
 
             if (this.testFrameworks.indexOf('gatling') != -1) {
                 this.template(TEST_DIR + 'gatling/simulations/_EntityGatlingTest.scala',

--- a/generators/entity/templates/src/test/gatling/simulations/_EntityGatlingTest.scala
+++ b/generators/entity/templates/src/test/gatling/simulations/_EntityGatlingTest.scala
@@ -110,12 +110,12 @@ class <%= entityClass %>GatlingTest extends Simulation {
         .pause(10)
         .repeat(2) {
             exec(http("Get all <%= entityInstancePlural %>")
-            .get("/api/<%= entityApiUrl %>")
+            .get(<% if (applicationType == 'gateway' && locals.microserviceName) {%> "/<%= microserviceName.toLowerCase() %>" + <% } %>"/api/<%= entityApiUrl %>")
             .headers(headers_http_authenticated)
             .check(status.is(200)))
             .pause(10 seconds, 20 seconds)
             .exec(http("Create new <%= entityInstance %>")
-            .post("/api/<%= entityApiUrl %>")
+            .post(<% if (applicationType == 'gateway' && locals.microserviceName) {%> "/<%= microserviceName.toLowerCase() %>" + <% } %>"/api/<%= entityApiUrl %>")
             .headers(headers_http_authenticated)
             .body(StringBody("""{"id":null<% for (idx in fields) { %>, "<%= fields[idx].fieldName %>":<% if (fields[idx].fieldType == 'String') { %>"SAMPLE_TEXT"<% } else if (fields[idx].fieldType == 'Integer') { %>"0"<% } else if (fields[idx].fieldType == 'ZonedDateTime' || fields[idx].fieldType == 'LocalDate') { %>"2020-01-01T00:00:00.000Z"<% } else { %>null<% } } %>}""")).asJSON
             .check(status.is(201))
@@ -123,12 +123,12 @@ class <%= entityClass %>GatlingTest extends Simulation {
             .pause(10)
             .repeat(5) {
                 exec(http("Get created <%= entityInstance %>")
-                .get("${new_<%= entityInstance %>_url}")
+                .get(<% if (applicationType == 'gateway' && locals.microserviceName) {%> "/<%= microserviceName.toLowerCase() %>" + <% } %>"${new_<%= entityInstance %>_url}")
                 .headers(headers_http_authenticated))
                 .pause(10)
             }
             .exec(http("Delete created <%= entityInstance %>")
-            .delete("${new_<%= entityInstance %>_url}")
+            .delete(<% if (applicationType == 'gateway' && locals.microserviceName) {%> "/<%= microserviceName.toLowerCase() %>" + <% } %>"${new_<%= entityInstance %>_url}")
             .headers(headers_http_authenticated))
             .pause(10)
         }


### PR DESCRIPTION
Gatling tests weren't generated when the user wanted to generate an entity from a microservice if the user set the `--skip-server` flag. If this flag wasn't set, it generated the gatling tests but URL were wrong (no microservice name before `/api/...`).
Now it properly adds the microservice name prefix to the URL on remote entities gatling tests.