### PR TITLE
For microservice, default server port should be 8081

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -233,7 +233,7 @@ module.exports = JhipsterServerGenerator.extend({
                             currentQuestion = current;
                         }, applicationType == 'gateway' || applicationType == 'microservice');
                     },
-                    default: '8080'
+                    default: applicationType == 'gateway' ? '8080' : '8081'
                 },
                 {
                     type: 'input',


### PR DESCRIPTION
When application type is microservice, default server port should be 8081.