### PR TITLE
Use app name for a gateway file on config server

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -26,7 +26,7 @@ eureka:
 
 <%_ if (applicationType == 'gateway') { _%>
 # Prevent services from being automatically added to new routes
-# In production, routes should be explictly defined in the config server's gateway-prod.yml
+# In production, routes should be explictly defined in the config server's <%= baseName %>-prod.yml
 zuul:
     ignoredServices: '*'
 <%_ } _%>

--- a/generators/server/templates/src/main/resources/config/_bootstrap-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_bootstrap-dev.yml
@@ -7,11 +7,7 @@ spring:
         config:
             uri: http://localhost:8761/config
             # name of the config server's property source (file.yml) that we want to use
-            <%_ if (applicationType == 'gateway') { _%>
-            name: gateway
-            <%_ } else { _%>
             name: <%= baseName %>
-            <%_ } _%>
             profile: dev # profile(s) of the property source
             label: master # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the config source git repository

--- a/generators/server/templates/src/main/resources/config/_bootstrap-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_bootstrap-prod.yml
@@ -7,11 +7,7 @@ spring:
         config:
             #uri: http://localhost:8761/config
             # name of the config server's property source (file.yml) that we want to use
-            <%_ if (applicationType == 'gateway') { _%>
-            name: gateway
-            <%_ } else { _%>
             name: <%= baseName %>
-            <%_ } _%>
             profile: prod # profile(s) of the property source
             label: master # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the config source git repository


### PR DESCRIPTION
Use app name for a gateway file on config server rather than always "gateway" which does not work when you have multiple gateways.

Fix #3161