### PR TITLE
#3172 Jpa EntityListener used to synchronize ElasticSearch with database

### DIFF
--- a/generators/entity/templates/src/main/java/package/common/delete_template.ejs
+++ b/generators/entity/templates/src/main/java/package/common/delete_template.ejs
@@ -1,7 +1,7 @@
 <% if (!viaService) {
     if (databaseType == 'sql' || databaseType == 'mongodb') { %>
         <%= entityInstance %>Repository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
-        <%= entityInstance %>Repository.delete(UUID.fromString(id));<% } %><% if (searchEngine == 'elasticsearch') { %><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+        <%= entityInstance %>Repository.delete(UUID.fromString(id));<% } %><% if (searchEngine == 'elasticsearch') { %><% if (databaseType == 'mongodb') { %>
         <%= entityInstance %>SearchRepository.delete(id);<% } %><% if (databaseType == 'cassandra') { %>
         <%= entityInstance %>SearchRepository.delete(UUID.fromString(id));<% } %><% }
 } else { %>

--- a/generators/entity/templates/src/main/java/package/common/save_template.ejs
+++ b/generators/entity/templates/src/main/java/package/common/save_template.ejs
@@ -11,6 +11,6 @@ if (!viaService) {
         <%= entityInstance %> = <%= entityInstance %>Repository.save(<%= entityInstance %>);
         <%= instanceType %> result = <%= entityToDto %>(<%= entityInstance %>);<% } else {
     resultEntity = 'result'; %>
-        <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine == 'elasticsearch') { %>
+        <%= entityClass %> result = <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine == 'elasticsearch' && databaseType != 'sql') { %>
         <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% }} else { %>
         <%= instanceType %> result = <%= entityInstance %>Service.save(<%= instanceName %>);<% } %>

--- a/generators/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/src/main/java/package/domain/_Entity.java
@@ -15,6 +15,10 @@ import org.springframework.data.mongodb.core.mapping.Document;
 import org.springframework.data.mongodb.core.mapping.Field;<% } %><% if (searchEngine == 'elasticsearch') { %>
 import org.springframework.data.elasticsearch.annotations.Document;<% } %>
 <% if (databaseType == 'sql') { %>
+<%_ if (searchEngine == 'elasticsearch') { _%>
+import <%=packageName%>.config.elasticsearch.ElasticSearchUpdater;
+
+<%_ } _%>
 import javax.persistence.*;<% } %><% if (validation) { %>
 import javax.validation.constraints.*;<% } %>
 import java.io.Serializable;<% if (fieldsContainBigDecimal == true) { %>
@@ -43,7 +47,8 @@ import <%=packageName%>.domain.enumeration.<%= element %>;<% }); %>
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)<% } %><% } %><% if (databaseType == 'mongodb') { %>
 @Document(collection = "<%= entityTableName %>")<% } %><% if (databaseType == 'cassandra') { %>
 @Table(name = "<%= entityInstance %>")<% } %><% if (searchEngine == 'elasticsearch') { %>
-@Document(indexName = "<%= entityInstance.toLowerCase() %>")<% } %>
+@Document(indexName = "<%= entityInstance.toLowerCase() %>")<% if (databaseType == 'sql') { %>
+@EntityListeners(ElasticSearchUpdater.class)<% }} %>
 public class <%= entityClass %> implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1069,7 +1069,11 @@ module.exports = JhipsterServerGenerator.extend({
                 this.template(SERVER_MAIN_SRC_DIR + 'package/config/liquibase/_package-info.java', javaDir + 'config/liquibase/package-info.java', this, {});
             }
             if (this.searchEngine == 'elasticsearch') {
-                this.template(SERVER_MAIN_SRC_DIR + 'package/config/_ElasticSearchConfiguration.java', javaDir + 'config/ElasticSearchConfiguration.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/elasticsearch/_ElasticSearchConfiguration.java', javaDir + 'config/elasticsearch/ElasticSearchConfiguration.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/elasticsearch/_package-info.java', javaDir + 'config/elasticsearch/package-info.java', this, {});
+                if (this.databaseType == "sql") {
+                    this.template(SERVER_MAIN_SRC_DIR + 'package/config/elasticsearch/_ElasticSearchUpdater.java', javaDir + 'config/elasticsearch/ElasticSearchUpdater.java', this, {});
+                }
             }
         },
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1197,6 +1197,9 @@ module.exports = JhipsterServerGenerator.extend({
             // Create ElasticSearch test files
             if (this.searchEngine == 'elasticsearch') {
                 this.template(SERVER_TEST_SRC_DIR + 'package/config/elasticsearch/_AbstractIndexInitializer.java', testDir + 'config/elasticsearch/AbstractIndexInitializer.java', this, {});
+                if (this.databaseType == "sql") {
+                    this.template(SERVER_TEST_SRC_DIR + 'package/config/elasticsearch/_ElasticSearchUpdaterTest.java', testDir + 'config/elasticsearch/ElasticSearchUpdaterTest.java', this, {});
+                }
             }
         },
 

--- a/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
+++ b/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
@@ -44,6 +44,10 @@ public class JHipsterProperties {
 
     private final Gateway gateway = new Gateway();
     <%_ } _%>
+    <%_ if (searchEngine == 'elasticsearch' && databaseType == 'sql') { _%>
+
+    private final ElasticSearch elasticSearch = new ElasticSearch();
+    <%_ } _%>
 
     public Async getAsync() {
         return async;
@@ -86,6 +90,12 @@ public class JHipsterProperties {
 
     public Gateway getGateway() {
         return gateway;
+    }
+    <%_ } _%>
+    <%_ if (searchEngine == 'elasticsearch' && databaseType == 'sql') { _%>
+
+    public ElasticSearch getElasticSearch() {
+        return elasticSearch;
     }
     <%_ } _%>
 
@@ -668,6 +678,21 @@ public class JHipsterProperties {
             public void setLimit(long limit) {
                 this.limit = limit;
             }
+        }
+    }
+<%_ } _%>
+<%_ if (searchEngine == 'elasticsearch' && databaseType == 'sql') { _%>
+
+    public static class ElasticSearch {
+
+        private boolean updateOnCommit = true;
+
+        public boolean isUpdateOnCommit() {
+            return updateOnCommit;
+        }
+
+        public void setUpdateOnCommit(boolean updateOnCommit) {
+            this.updateOnCommit = updateOnCommit;
         }
     }
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchConfiguration.java
@@ -1,8 +1,13 @@
-package <%=packageName%>.config;
+package <%=packageName%>.config.elasticsearch;
 
 import java.io.IOException;
 
+import <%=packageName%>.config.JacksonConfiguration;
+
 import org.elasticsearch.client.Client;
+<%_ if (databaseType == 'sql') { _%>
+import org.springframework.beans.factory.BeanFactory;
+<%_ } _%>
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -22,6 +27,14 @@ public class ElasticSearchConfiguration {
         return new ElasticsearchTemplate(client, new CustomEntityMapper(jackson2ObjectMapperBuilder.createXmlMapper(false).build()));
     }
 
+<%_ if (databaseType == 'sql') { _%>
+    @Bean
+    public static BeanFactoryHolder beanFactoryHolder(BeanFactory beanFactory) {
+        BeanFactoryHolder.INSTANCE = new BeanFactoryHolder(beanFactory);
+        return BeanFactoryHolder.INSTANCE;
+    }
+
+<%_ } _%>
     public class CustomEntityMapper implements EntityMapper {
 
         private ObjectMapper objectMapper;
@@ -42,4 +55,25 @@ public class ElasticSearchConfiguration {
             return objectMapper.readValue(source, clazz);
         }
     }
+    <%_ if (databaseType == 'sql') { _%>
+
+    public static class BeanFactoryHolder {
+
+        private static BeanFactoryHolder INSTANCE;
+
+        private BeanFactory beanFactory;
+
+        private BeanFactoryHolder(BeanFactory beanFactory) {
+            this.beanFactory = beanFactory;
+        }
+
+        public static BeanFactoryHolder beanFactoryHolder() {
+            return INSTANCE;
+        }
+
+        public BeanFactory get() {
+            return beanFactory;
+        }
+    }
+<%_ } _%>
 }

--- a/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchConfiguration.java
@@ -5,8 +5,10 @@ import java.io.IOException;
 import <%=packageName%>.config.JacksonConfiguration;
 
 import org.elasticsearch.client.Client;
+
 <%_ if (databaseType == 'sql') { _%>
 import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.BeanFactoryAware;
 <%_ } _%>
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.context.annotation.Bean;
@@ -20,7 +22,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 
 @Configuration
 @AutoConfigureAfter(value = { JacksonConfiguration.class })
-public class ElasticSearchConfiguration {
+public class ElasticSearchConfiguration <% if (databaseType == 'sql') { %>implements BeanFactoryAware <% } %>{
 
     @Bean
     public ElasticsearchTemplate elasticsearchTemplate(Client client, Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder) {
@@ -28,10 +30,9 @@ public class ElasticSearchConfiguration {
     }
 
 <%_ if (databaseType == 'sql') { _%>
-    @Bean
-    public static BeanFactoryHolder beanFactoryHolder(BeanFactory beanFactory) {
-        BeanFactoryHolder.INSTANCE = new BeanFactoryHolder(beanFactory);
-        return BeanFactoryHolder.INSTANCE;
+    @Override
+    public void setBeanFactory(BeanFactory beanFactory) {
+        ElasticSearchUpdater.setBeanFactory(beanFactory);
     }
 
 <%_ } _%>
@@ -55,25 +56,4 @@ public class ElasticSearchConfiguration {
             return objectMapper.readValue(source, clazz);
         }
     }
-    <%_ if (databaseType == 'sql') { _%>
-
-    public static class BeanFactoryHolder {
-
-        private static BeanFactoryHolder INSTANCE;
-
-        private BeanFactory beanFactory;
-
-        private BeanFactoryHolder(BeanFactory beanFactory) {
-            this.beanFactory = beanFactory;
-        }
-
-        public static BeanFactoryHolder beanFactoryHolder() {
-            return INSTANCE;
-        }
-
-        public BeanFactory get() {
-            return beanFactory;
-        }
-    }
-<%_ } _%>
 }

--- a/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchUpdater.java
+++ b/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchUpdater.java
@@ -1,0 +1,60 @@
+package <%=packageName%>.config.elasticsearch;
+
+import static <%=packageName%>.config.elasticsearch.ElasticSearchConfiguration.BeanFactoryHolder.beanFactoryHolder;
+import static org.apache.commons.lang.StringUtils.uncapitalize;
+
+import java.io.Serializable;
+import javax.persistence.PostPersist;
+import javax.persistence.PostRemove;
+import javax.persistence.PostUpdate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.BeanFactory;
+import org.springframework.beans.factory.NoSuchBeanDefinitionException;
+import org.springframework.data.elasticsearch.repository.ElasticsearchCrudRepository;
+
+public class ElasticSearchUpdater<T> {
+
+    private Logger logger = LoggerFactory.getLogger(getClass());
+
+    @PostPersist
+    @PostUpdate
+    public void saveInElasticSearch(T entity) {
+        ElasticsearchCrudRepository<T, Serializable> repository = repositoryFor(entity);
+        if (repository != null) {
+            logger.debug("Saving entity in ES : {}", entity);
+            repository.save(entity);
+            logger.debug("Saved entity in ES : {}", entity);
+        }
+    }
+
+    @PostRemove
+    public void removeFromElasticSearch(T entity) {
+        ElasticsearchCrudRepository<T, Serializable> repository = repositoryFor(entity);
+        if (repository != null) {
+            logger.debug("Removing entity from ES : {}", entity);
+            repository.delete(entity);
+            logger.debug("Removed entity from ES : {}", entity);
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private ElasticsearchCrudRepository<T, Serializable> repositoryFor(T entity) {
+        BeanFactory beanFactory = beanFactoryHolder().get();
+        String repositoryName = repositoryNameFor(entity);
+    
+        ElasticsearchCrudRepository<T, Serializable> repository = null;
+        try {
+            repository = beanFactory.getBean(repositoryName, ElasticsearchCrudRepository.class);
+        } catch (NoSuchBeanDefinitionException e) {
+            logger.debug("No ElasticSearch repository found with name '{}'", repositoryName);
+        }
+        return repository;
+    }
+
+    private String repositoryNameFor(T entity) {
+        String entityName = entity.getClass().getSimpleName();
+        return uncapitalize(entityName) + "SearchRepository";
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchUpdater.java
+++ b/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchUpdater.java
@@ -1,6 +1,5 @@
 package <%=packageName%>.config.elasticsearch;
 
-import static <%=packageName%>.config.elasticsearch.ElasticSearchConfiguration.BeanFactoryHolder.beanFactoryHolder;
 import static org.apache.commons.lang.StringUtils.uncapitalize;
 
 import java.io.Serializable;
@@ -17,6 +16,8 @@ import org.springframework.data.elasticsearch.repository.ElasticsearchCrudReposi
 public class ElasticSearchUpdater<T> {
 
     private Logger logger = LoggerFactory.getLogger(getClass());
+
+    private static BeanFactory beanFactory;
 
     @PostPersist
     @PostUpdate
@@ -41,7 +42,6 @@ public class ElasticSearchUpdater<T> {
 
     @SuppressWarnings("unchecked")
     private ElasticsearchCrudRepository<T, Serializable> repositoryFor(T entity) {
-        BeanFactory beanFactory = beanFactoryHolder().get();
         String repositoryName = repositoryNameFor(entity);
     
         ElasticsearchCrudRepository<T, Serializable> repository = null;
@@ -56,5 +56,9 @@ public class ElasticSearchUpdater<T> {
     private String repositoryNameFor(T entity) {
         String entityName = entity.getClass().getSimpleName();
         return uncapitalize(entityName) + "SearchRepository";
+    }
+
+    static void setBeanFactory(BeanFactory beanFactory) {
+        ElasticSearchUpdater.beanFactory = beanFactory;
     }
 }

--- a/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchUpdater.java
+++ b/generators/server/templates/src/main/java/package/config/elasticsearch/_ElasticSearchUpdater.java
@@ -1,6 +1,9 @@
 package <%=packageName%>.config.elasticsearch;
 
 import static org.apache.commons.lang.StringUtils.uncapitalize;
+import static org.springframework.transaction.support.TransactionSynchronizationManager.registerSynchronization;
+
+import <%=packageName%>.config.JHipsterProperties;
 
 import java.io.Serializable;
 import javax.persistence.PostPersist;
@@ -12,34 +15,70 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.BeanFactory;
 import org.springframework.beans.factory.NoSuchBeanDefinitionException;
 import org.springframework.data.elasticsearch.repository.ElasticsearchCrudRepository;
+import org.springframework.transaction.support.TransactionSynchronizationAdapter;
 
 public class ElasticSearchUpdater<T> {
 
     private Logger logger = LoggerFactory.getLogger(getClass());
-
+  
     private static BeanFactory beanFactory;
-
+  
     @PostPersist
     @PostUpdate
-    public void saveInElasticSearch(T entity) {
+    public void save(T entity) {
+        if (updateOnCommit()) {
+            registerSynchronization(new TransactionSynchronizationAdapter() {
+                @Override
+                public void afterCommit() {
+                  saveEntity(entity);
+                }
+            });
+        } else {
+            saveEntity(entity);
+        }
+    }
+
+    private void saveEntity(T entity) {
         ElasticsearchCrudRepository<T, Serializable> repository = repositoryFor(entity);
         if (repository != null) {
             logger.debug("Saving entity in ES : {}", entity);
             repository.save(entity);
             logger.debug("Saved entity in ES : {}", entity);
+        } else {
+            logger.debug("No ES repository found for entity {}", entity);
         }
     }
-
+  
     @PostRemove
-    public void removeFromElasticSearch(T entity) {
+    public void remove(T entity) {
+        if (updateOnCommit()) {
+            registerSynchronization(new TransactionSynchronizationAdapter() {
+                @Override
+                public void afterCommit() {
+                  removeEntity(entity);
+                }
+            });
+        } else {
+            removeEntity(entity);
+        }
+    }
+  
+    private void removeEntity(T entity) {
         ElasticsearchCrudRepository<T, Serializable> repository = repositoryFor(entity);
         if (repository != null) {
             logger.debug("Removing entity from ES : {}", entity);
             repository.delete(entity);
             logger.debug("Removed entity from ES : {}", entity);
+        } else {
+            logger.debug("No ES repository found for entity {}", entity);
         }
     }
 
+    private boolean updateOnCommit() {
+        JHipsterProperties properties = beanFactory.getBean(JHipsterProperties.class);
+        return properties.getElasticSearch().isUpdateOnCommit();
+    }
+  
     @SuppressWarnings("unchecked")
     private ElasticsearchCrudRepository<T, Serializable> repositoryFor(T entity) {
         String repositoryName = repositoryNameFor(entity);
@@ -52,12 +91,12 @@ public class ElasticSearchUpdater<T> {
         }
         return repository;
     }
-
+  
     private String repositoryNameFor(T entity) {
         String entityName = entity.getClass().getSimpleName();
         return uncapitalize(entityName) + "SearchRepository";
     }
-
+  
     static void setBeanFactory(BeanFactory beanFactory) {
         ElasticSearchUpdater.beanFactory = beanFactory;
     }

--- a/generators/server/templates/src/main/java/package/config/elasticsearch/_package-info.java
+++ b/generators/server/templates/src/main/java/package/config/elasticsearch/_package-info.java
@@ -1,0 +1,4 @@
+/**
+ * ElasticSearch specific code.
+ */
+package <%=packageName%>.config.elasticsearch;

--- a/generators/server/templates/src/main/java/package/domain/_User.java
+++ b/generators/server/templates/src/main/java/package/domain/_User.java
@@ -1,5 +1,8 @@
 package <%=packageName%>.domain;
-<% if (databaseType == 'cassandra') { %>
+
+<% if (searchEngine == 'elasticsearch' && databaseType == 'sql') { %>
+import <%=packageName%>.config.elasticsearch.ElasticSearchUpdater;
+<%} if (databaseType == 'cassandra') { %>
 import java.util.Date;
 import com.datastax.driver.mapping.annotations.*;<% } %>
 import com.fasterxml.jackson.annotation.JsonIgnore;<% if (hibernateCache != 'no' && databaseType == 'sql') { %>
@@ -32,7 +35,8 @@ import java.time.ZonedDateTime;<% } %>
 @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)<% } %><% if (databaseType == 'mongodb') { %>
 @Document(collection = "jhi_user")<% } %><% if (databaseType == 'cassandra') { %>
 @Table(name = "user")<% } %><% if (searchEngine == 'elasticsearch') { %>
-@Document(indexName = "user")<% } %>
+@Document(indexName = "user")<% if (databaseType == 'sql') { %>
+@EntityListeners(ElasticSearchUpdater.class)<% }} %>
 public class User<% if (databaseType == 'sql' || databaseType == 'mongodb') { %> extends AbstractAuditingEntity<% } %> implements Serializable {
 
     private static final long serialVersionUID = 1L;

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -126,3 +126,6 @@ jhipster:
         redirectAfterSignIn: "/#/home"
         <%_ } _%>
 <%_ } _%>
+<%_ if (searchEngine == 'elasticsearch' && databaseType == 'sql') { _%>
+    elasticSearch.updateOnCommit: true
+<%_ } _%>

--- a/generators/server/templates/src/test/java/package/config/elasticsearch/_ElasticSearchUpdaterTest.java
+++ b/generators/server/templates/src/test/java/package/config/elasticsearch/_ElasticSearchUpdaterTest.java
@@ -1,0 +1,164 @@
+package <%=packageName%>.config.elasticsearch;
+
+import static org.apache.commons.lang.math.RandomUtils.nextInt;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.util.ReflectionTestUtils.setField;
+
+import javax.inject.Inject;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.aop.framework.Advised;
+import org.springframework.aop.support.AopUtils;
+import org.springframework.beans.factory.config.ConfigurableBeanFactory;
+import org.springframework.boot.test.IntegrationTest;
+import org.springframework.boot.test.SpringApplicationConfiguration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.test.context.web.WebAppConfiguration;
+import org.springframework.transaction.PlatformTransactionManager;
+import org.springframework.transaction.TransactionStatus;
+import org.springframework.transaction.support.TransactionCallback;
+import org.springframework.transaction.support.TransactionTemplate;
+
+import <%=packageName%>.<%= mainClass %>;
+import <%=packageName%>.config.JHipsterProperties;
+import <%=packageName%>.repository.UserRepository;
+import <%=packageName%>.repository.search.UserSearchRepository;
+import <%=packageName%>.service.UserService;
+
+
+@RunWith(SpringJUnit4ClassRunner.class)
+@SpringApplicationConfiguration(classes = <%= mainClass %>.class)
+@WebAppConfiguration
+@IntegrationTest
+public class ElasticSearchUpdaterTest {
+
+    @Inject
+    private UserService userService;
+    @Inject
+    private UserRepository userRepository;
+    @Inject
+    private UserSearchRepository userSearchRepository;
+    @Inject
+    private ConfigurableBeanFactory beanFactory;
+    private long countDb;
+    private long countEs;
+    @Inject
+    private PlatformTransactionManager transactionManager;
+    @Inject
+    private JHipsterProperties properties;
+    private boolean actualUpdateOnCommit;
+    private TransactionTemplate transactionTemplate;
+
+    @Before
+    public void prepare() {
+        transactionTemplate = new TransactionTemplate(transactionManager);
+        userSearchRepository.deleteAll();
+        countDb = userRepository.count();
+        countEs = userSearchRepository.count();
+        actualUpdateOnCommit = properties.getElasticSearch().isUpdateOnCommit();
+        properties.getElasticSearch().setUpdateOnCommit(true);
+    }
+
+    private void mockElasticSearchUpdater() {
+        // mock bean factory in ElasticSearchUpdater
+        ConfigurableBeanFactory mock = mock(ConfigurableBeanFactory.class);
+        when(mock.getBean(JHipsterProperties.class)).thenReturn(properties);
+        ElasticSearchUpdater.setBeanFactory(mock);
+    }
+
+    private void mockSearchRepository() {
+        // mock searchRepository call in service
+        UserSearchRepository mock = mock(UserSearchRepository.class);
+        setField(unwrap(userService), "userSearchRepository", mock);
+    }
+
+    @After
+    public void restoreBeanFactory() {
+        ElasticSearchUpdater.setBeanFactory(beanFactory);
+        properties.getElasticSearch().setUpdateOnCommit(actualUpdateOnCommit);
+    }
+
+    @Test
+    public void should_ES_contain_data_after_commit_with_ElasticSearchUpdater() {
+        mockSearchRepository();
+        saveUserAndCommit();
+        assertUserSaved();
+    }
+
+    @Ignore
+    @Test
+    public void should_ES_contain_data_after_commit_without_ElasticSearchUpdater() {
+        mockElasticSearchUpdater();
+        saveUserAndCommit();
+        assertUserSaved();
+    }
+
+    @Test
+    public void should_ES_not_contain_data_after_rollback_with_ElasticSearchUpdater() {
+        mockSearchRepository();
+        saveUserAndRollback();
+        assertUserNotSaved();
+    }
+
+    @Test
+    public void should_ES_not_contain_data_after_rollback_without_ElasticSearchUpdater() {
+        mockElasticSearchUpdater();
+        saveUserAndRollback();
+        assertUserNotSaved();
+    }
+
+    private void saveUserAndCommit() {
+      transactionTemplate.execute(new TransactionCallback<Void>() {
+          @Override
+          public Void doInTransaction(TransactionStatus status) {
+              saveUser();
+              return null;
+          }
+      });
+    }
+
+    private void saveUserAndRollback() {
+        transactionTemplate.execute(new TransactionCallback<Void>() {
+            @Override
+            public Void doInTransaction(TransactionStatus status) {
+                saveUser();
+                status.setRollbackOnly();
+                return null;
+            }
+        });
+    }
+
+    private void saveUser() {
+        String login = "user" + nextInt(10000);
+        userService.createUserInformation(login, "pwd", "", "", login + "@me.com", "en");
+    }
+
+    private void assertUserSaved() {
+        assertThat(userRepository.count()).isEqualTo(countDb + 1);
+        assertThat(userSearchRepository.count()).isEqualTo(countEs + 1);
+    }
+
+    private void assertUserNotSaved() {
+        assertThat(userRepository.count()).isEqualTo(countDb);
+        assertThat(userSearchRepository.count()).isEqualTo(countEs);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T unwrap(T maybeCglibProxy) {
+        if (AopUtils.isAopProxy(maybeCglibProxy) && maybeCglibProxy instanceof Advised) {
+            try {
+                Object target = ((Advised) maybeCglibProxy).getTargetSource().getTarget();
+                return (T) target;
+            } catch (Exception e) {
+                throw new RuntimeException("Unable to unwrap proxy " + maybeCglibProxy, e);
+            }
+        }
+        return maybeCglibProxy;
+    }
+}

--- a/generators/server/templates/src/test/resources/_logback-test.xml
+++ b/generators/server/templates/src/test/resources/_logback-test.xml
@@ -4,6 +4,8 @@
     <include resource="org/springframework/boot/logging/logback/base.xml"/>
 
     <logger name="<%=packageName%>" level="DEBUG"/>
+    <logger name="<%=packageName%>.config.elasticsearch.ElasticSearchUpdater" level="INFO"/>
+
     <logger name="org.hibernate.ejb.HibernatePersistence" level="OFF"/>
     <logger name="org.apache.catalina.startup.DigesterFactory" level="OFF"/>
 

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -132,3 +132,6 @@ jhipster:
         contactEmail:
         license:
         licenseUrl:
+    <%_ if (searchEngine == 'elasticsearch' && databaseType == 'sql') { _%>
+    elasticSearch.updateOnCommit: false
+    <%_ } _%>


### PR DESCRIPTION
- ElasticSearchConfiguration moved to dedicated config.elasticsearch
package
- ElasticSearchUpdater entityListener installed on JPA entities
- removed useless explicit EntitySearchRepository.save/update/delete
calls