### PR TITLE
For microservices and gateways, create application properties for Registry

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -860,9 +860,13 @@ module.exports = JhipsterServerGenerator.extend({
             this.template(SERVER_MAIN_RES_DIR + '_logback-spring.xml', SERVER_MAIN_RES_DIR + 'logback-spring.xml', this, {'interpolate': INTERPOLATE_REGEX});
 
             this.template(SERVER_MAIN_RES_DIR + 'config/_application.yml', SERVER_MAIN_RES_DIR + 'config/application.yml', this, {});
-            this.template(SERVER_MAIN_RES_DIR + 'config/_application-dev.yml', SERVER_MAIN_RES_DIR + 'config/application-dev.yml', this, {});
-            this.template(SERVER_MAIN_RES_DIR + 'config/_application-prod.yml', SERVER_MAIN_RES_DIR + 'config/application-prod.yml', this, {});
-
+            if (this.applicationType == 'microservice' || this.applicationType == 'gateway') {
+                this.template(SERVER_MAIN_RES_DIR + 'config/_application-dev.yml', SERVER_MAIN_RES_DIR + 'config/' + this.baseName + '-dev.yml', this, {});
+                this.template(SERVER_MAIN_RES_DIR + 'config/_application-prod.yml', SERVER_MAIN_RES_DIR + 'config/' + this.baseName + '-prod.yml', this, {});
+            } else {
+                this.template(SERVER_MAIN_RES_DIR + 'config/_application-dev.yml', SERVER_MAIN_RES_DIR + 'config/application-dev.yml', this, {});
+                this.template(SERVER_MAIN_RES_DIR + 'config/_application-prod.yml', SERVER_MAIN_RES_DIR + 'config/application-prod.yml', this, {});
+            }
             if (this.databaseType == "sql") {
                 this.template(SERVER_MAIN_RES_DIR + '/config/liquibase/changelog/_initial_schema.xml', SERVER_MAIN_RES_DIR + 'config/liquibase/changelog/00000000000000_initial_schema.xml', this, {'interpolate': INTERPOLATE_REGEX});
                 this.copy(SERVER_MAIN_RES_DIR + '/config/liquibase/master.xml', SERVER_MAIN_RES_DIR + 'config/liquibase/master.xml');

--- a/generators/server/templates/src/main/java/package/_Application.java
+++ b/generators/server/templates/src/main/java/package/_Application.java
@@ -13,6 +13,8 @@ import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 <%_ if (applicationType == 'microservice' || applicationType == 'gateway') { _%>
 import org.springframework.cloud.netflix.eureka.EnableEurekaClient;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.core.io.Resource;
 <%_ } _%>
 <%_ if (applicationType == 'gateway') { _%>
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
@@ -70,6 +72,19 @@ public class <%= mainClass %> {
         }
     }
 
+<%_ if (applicationType == 'microservice' || applicationType == 'gateway') { _%>
+    /**
+     * Checks that <%= baseName %> application properties are not stored in resources, they must be moved to Registry.
+     */
+    public static void checkCentralConfigFiles() {
+        Resource config = new ClassPathResource("config/<%= baseName %>.yml");
+        if (config.exists()) {
+            String error= "You must move src/main/resources/config/<%= baseName %>*.yml files to JHipster Registry's central-config folder";
+            throw new IllegalStateException(error);
+        }
+    }
+<%_ } _%>
+
     /**
      * Main method, used to run the application.
      *
@@ -77,6 +92,9 @@ public class <%= mainClass %> {
      * @throws UnknownHostException if the local host name could not be resolved into an address
      */
     public static void main(String[] args) throws UnknownHostException {
+<%_ if (applicationType == 'microservice' || applicationType == 'gateway') { _%>
+        checkCentralConfigFiles();
+<%_ } _%>
         SpringApplication app = new SpringApplication(<%= mainClass %>.class);
         SimpleCommandLinePropertySource source = new SimpleCommandLinePropertySource(args);
         addDefaultProfile(app, source);

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -346,6 +346,8 @@ const expectedFiles = {
     ],
 
     gateway: [
+        SERVER_MAIN_RES_DIR + 'config/jhipster-dev.yml',
+        SERVER_MAIN_RES_DIR + 'config/jhipster-prod.yml',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/config/GatewayConfiguration.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/gateway/ratelimiting/RateLimitingFilter.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/gateway/ratelimiting/RateLimitingRepository.java',
@@ -358,6 +360,8 @@ const expectedFiles = {
     ],
 
     microservice: [
+        SERVER_MAIN_RES_DIR + 'config/jhipster-dev.yml',
+        SERVER_MAIN_RES_DIR + 'config/jhipster-prod.yml',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/config/MicroserviceSecurityConfiguration.java'
     ],
 


### PR DESCRIPTION
For microservices and gateways, create application properties named according to app baseName so that they can be moved to Registry.

In main application, check that t(hese files are not present in resources otherwise exit with instructions as below.

~~~
Exception in thread "main" java.lang.IllegalStateException: You must move src/main/resources/config/srv1*.yml files to JHipster Registry's central-config folder
	at com.mycompany.myapp.Srv1App.checkCentralConfigFiles(Srv1App.java:71)
~~~