### PR TITLE
differentiate between win32 and linux/mac environment when running

### DIFF
--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -1,6 +1,7 @@
 'use strict';
 var util = require('util'),
     path = require('path'),
+    os = require('os'),
     generators = require('yeoman-generator'),
     childProcess = require('child_process'),
     chalk = require('chalk'),
@@ -161,7 +162,12 @@ module.exports = CloudFoundryGenerator.extend({
         if (this.buildTool === 'maven') {
             buildCmd = 'mvn package -DskipTests';
         } else if (this.buildTool === 'gradle') {
-            buildCmd = 'gradlew bootRepackage -x test';
+            if (os.platform() === 'win32') {
+                buildCmd = 'gradlew bootRepackage -x test';
+            } else {
+                buildCmd = './gradlew bootRepackage -x test';
+            }
+
         }
         if (this.cloudfoundryProfile == 'prod') {
             this.log(chalk.bold('\nBuilding the application with the production profile'));
@@ -191,7 +197,17 @@ module.exports = CloudFoundryGenerator.extend({
                 buildCmd = 'mvn package -DskipTests';
             } else if (this.buildTool === 'gradle') {
                 cloudfoundryDeployCommand += ' build/libs/*.war';
-                buildCmd = 'gradlew bootRepackage -x test';
+                if (os.platform() === 'win32') {
+                    buildCmd = 'gradlew bootRepackage -x test';
+                } else {
+                    buildCmd = './gradlew bootRepackage -x test';
+                }
+
+                if (this.cloudfoundryProfile == 'prod') {
+                    this.log(chalk.bold('\nBuilding the application with the production profile'));
+                    buildCmd += ' -Pprod';
+                }
+
             }
 
             this.log(chalk.bold('\nPushing the application to Cloud Foundry'));


### PR DESCRIPTION
use ``./gradlew`` on linux/mac and just ``gradlew`` on windows. 

@jdubois  @deepu105 Why is the build command generated again (and without ``-Pprod``) when setting up the push command? It is not used afterwards as far as I can tell.