### PR TITLE
Revert "prevent services from being automatically routed on the gatew…

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -24,13 +24,6 @@ eureka:
             defaultZone: http://localhost:8761/eureka/
 <%_ } _%>
 
-<%_ if (applicationType == 'gateway') { _%>
-# Prevent services from being automatically added to new routes
-# In production, routes should be explictly defined in the config server's <%= baseName %>-prod.yml
-zuul:
-    ignoredServices: '*'
-<%_ } _%>
-
 spring:
     <%_ if (applicationType == 'gateway' && databaseType != 'cassandra') { _%>
     autoconfigure:


### PR DESCRIPTION
In a previous commit (https://github.com/jhipster/generator-jhipster/commit/fa8357b4cd2488216d59c6fd9f44a1f0281d4b8e), I added a default config for gateway to prevent those from automatically routing to new microservice in prod

This will confuse the user if setup by default. Moreover it should be done from the registry not in local conf.