### PR TITLE
update sortpom maven plugin

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -77,7 +77,7 @@
         <mapstruct.version>1.0.0.Final</mapstruct.version>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
-        <maven-sortpom-plugin.version>2.3.1</maven-sortpom-plugin.version>
+        <sortpom-maven-plugin.version>2.5.0</sortpom-maven-plugin.version>
         <metrics-spark-reporter.version>1.2</metrics-spark-reporter.version>
         <metrics-spring.version>3.1.3</metrics-spring.version>
         <logstash-logback-encoder.version>4.6</logstash-logback-encoder.version>
@@ -691,9 +691,9 @@
         <%_ } _%>
         <plugins>
             <plugin>
-                <groupId>com.google.code.sortpom</groupId>
-                <artifactId>maven-sortpom-plugin</artifactId>
-                <version>${maven-sortpom-plugin.version}</version>
+                <groupId>com.github.ekryd.sortpom</groupId>
+                <artifactId>sortpom-maven-plugin</artifactId>
+                <version>${sortpom-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <phase>verify</phase>


### PR DESCRIPTION
I get the following deprecated warning when running `mvn clean install`

```
[INFO] --- maven-sortpom-plugin:2.3.1:sort (default) @ forskolenatet ---
[WARNING] DEPRECATED: The SortPom plugin has moved to <groupId>com.github.ekryd.sortpom</groupId> <artifactId>sortpom-maven-plugin</artifactId>
[WARNING] DEPRECATED: Please update the plugin reference
```

the sortpom maven plugin seems to be renamed and moved to github so I updated the pom.xml