### PR TITLE
Add import-jdl sub generator

### DIFF
--- a/generators/app/USAGE
+++ b/generators/app/USAGE
@@ -1,0 +1,7 @@
+Description:
+    Creates a new JHipster application based on the selected options
+
+Example:
+    yo jhipster
+
+    This will compose jhipster:client, jhipster:server and jhipster:languages to scaffold a full application

--- a/generators/client/USAGE
+++ b/generators/client/USAGE
@@ -1,0 +1,7 @@
+Description:
+    Creates a new JHipster client side application based on the selected options
+
+Example:
+    yo jhipster:client
+
+    This will create an AngularJS client app

--- a/generators/import-jdl/USAGE
+++ b/generators/import-jdl/USAGE
@@ -1,0 +1,8 @@
+Description:
+    Creates a new JHipster service: this is a simple transactional Spring service bean.
+
+Example:
+    yo jhipster:service Foo
+
+    This will create:
+        src/main/java/package/service/FooService.java

--- a/generators/import-jdl/USAGE
+++ b/generators/import-jdl/USAGE
@@ -1,8 +1,4 @@
 Description:
-    Creates a new JHipster service: this is a simple transactional Spring service bean.
-
+    Creates entities from the passed JDL file location
 Example:
-    yo jhipster:service Foo
-
-    This will create:
-        src/main/java/package/service/FooService.java
+    yo jhipster:import-jdl .\model.jh

--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -54,11 +54,9 @@ module.exports = JDLGenerator.extend({
 
         parseJDL: function () {
 
-            Editors = jhuml.editors;
-            self.entityGenerator = jhuml.entityGenerator;
-            self.EntitiesCreator = jhuml.EntitiesCreator;
-            ClassScheduler = jhuml.ClassScheduler;
-            self.cardinalities = cardinalities;
+            var Editors = jhuml.editors;
+            var EntitiesCreator = jhuml.EntitiesCreator;
+            var ClassScheduler = jhuml.ClassScheduler;
 
             var types = this._initDatabaseTypeHolder(this.databaseType);
 
@@ -80,12 +78,11 @@ module.exports = JDLGenerator.extend({
                 parser.databaseTypes,
                 [], {}, {});
 
-                creator.createEntities();
-                if (!this.options['force']) {
-                    scheduledClasses = creator.filterOutUnchangedEntities(scheduledClasses);
-                }
-                creator.writeJSON(scheduledClasses);
+            creator.createEntities();
+            if (!this.options['force']) {
+                scheduledClasses = creator.filterOutUnchangedEntities(scheduledClasses);
             }
+            creator.writeJSON(scheduledClasses);
         },
 
         generateEntities: function () {

--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -1,0 +1,95 @@
+'use strict';
+var util = require('util'),
+shelljs = require('shelljs'),
+generators = require('yeoman-generator'),
+chalk = require('chalk'),
+jhuml = require("jhipster-uml"),
+scriptBase = require('../generator-base');
+
+const constants = require('../generator-constants'),
+SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
+
+var JDLGenerator = generators.Base.extend({});
+
+util.inherits(JDLGenerator, scriptBase);
+
+module.exports = JDLGenerator.extend({
+    constructor: function () {
+        generators.Base.apply(this, arguments);
+        this.argument('jdlFile', {type: String, required: true});
+    },
+
+    initializing: {
+        validate: function () {
+            if (!shelljs.test('-f', this.jdlFile)) {
+                this.env.error(chalk.red('\nCould not find ' + this.jdlFile + ', make sure the path is correct!\n'));
+            }
+        },
+
+        getConfig: function () {
+            this.log('The jdl is being imported.');
+            this.databaseType = this.config.get('databaseType');
+        }
+    },
+
+    _filterScheduledClasses: function(classToFilter, scheduledClasses) {
+        return scheduledClasses.filter(function(element) {
+            return element !== classToFilter;
+        });
+    },
+
+    _initDatabaseTypeHolder: function(databaseTypeName) {
+        switch (databaseTypeName) {
+            case 'sql':
+            return jhuml.SQLTypes;
+            case 'mongodb':
+            return jhuml.MongoDBTypes;
+            case 'cassandra':
+            return jhuml.CassandraTypes;
+            default:
+            return jhuml.SQLTypes;
+        }
+    },
+    default: {
+
+        parseJDL: function () {
+
+            Editors = jhuml.editors;
+            self.entityGenerator = jhuml.entityGenerator;
+            self.EntitiesCreator = jhuml.EntitiesCreator;
+            ClassScheduler = jhuml.ClassScheduler;
+            self.cardinalities = cardinalities;
+
+            var types = this._initDatabaseTypeHolder(this.databaseType);
+
+            var parser = new Editors.Parsers['dsl'](this.jdlFile, types);
+            var parsedData = parser.parse();
+            var scheduler = new ClassScheduler(
+                Object.keys(parsedData.classes),
+                parsedData.associations
+            );
+
+            var scheduledClasses = scheduler.schedule();
+            if (parsedData.userClassId) {
+                scheduledClasses =
+                this._filterScheduledClasses(parsedData.userClassId, scheduledClasses);
+            }
+
+            var creator = new EntitiesCreator(
+                parsedData,
+                parser.databaseTypes,
+                [], {}, {});
+
+                creator.createEntities();
+                if (!this.options['force']) {
+                    scheduledClasses = creator.filterOutUnchangedEntities(scheduledClasses);
+                }
+                creator.writeJSON(scheduledClasses);
+            }
+        },
+
+        generateEntities: function () {
+
+        }
+
+    });

--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -28,6 +28,7 @@ module.exports = JDLGenerator.extend({
 
         getConfig: function () {
             this.log('The jdl is being imported.');
+            this.baseName = this.config.get('baseName');
             this.databaseType = this.config.get('databaseType');
         }
     },
@@ -86,7 +87,28 @@ module.exports = JDLGenerator.extend({
         },
 
         generateEntities: function () {
-
+            this.getExistingEntities().forEach(function (entity) {
+                this.composeWith('jhipster:entity', {
+                    options: {
+                        regenerate: true,
+                        'skip-install': true,
+                    },
+                    args: [entity.name]
+                }, {
+                    local: require.resolve('../entity')
+                });
+            }, this);
         }
+    },
 
-    });
+    install: function () {
+        var injectJsFilesToIndex = function () {
+            this.log('\n' + chalk.bold.green('Running gulp Inject to add javascript to index\n'));
+            this.spawnCommand('gulp', ['inject']);
+        };
+        if (!this.options['skip-install'] && !this.skipClient) {
+            injectJsFilesToIndex.call(this);
+        }
+    }
+
+});

--- a/generators/server/USAGE
+++ b/generators/server/USAGE
@@ -1,0 +1,7 @@
+Description:
+    Creates a new JHipster server side application based on the selected options
+
+Example:
+    yo jhipster:server
+
+    This will create a spring boot server side app

--- a/package.json
+++ b/package.json
@@ -2,6 +2,9 @@
   "name": "generator-jhipster",
   "version": "2.27.0",
   "description": "Java + Spring + JPA + AngularJS complete dev stack",
+  "files": [
+    "generators"
+  ],
   "keywords": [
     "yeoman-generator",
     "Java",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,8 @@
     "wordwrap": "1.0.0",
     "yeoman-generator": "0.22.5",
     "yo": "1.7.0",
-    "semver": "5.1.0"
+    "semver": "5.1.0",
+    "jhipster-uml" : "1.6.1"
   },
   "devDependencies": {
     "fs-extra": "0.26.5",


### PR DESCRIPTION
I would like to keep this as the first iteration of the sub generator (its based on jhuml 1.6.1), this works with JDL files from JDL studio well and I have tested it with few combinations

TODO:
1. Need to move to jhipster-domain-language module instead of JHUML 1.6.1

cc @MathieuAA lets add the feature first so it 3.0 has it and we will move to the new lib when its ready as an enhancement.

fix #3118