### PR TITLE
Remove entityUrlType variable in entity subgen

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1584,13 +1584,6 @@ module.exports = EntityGenerator.extend({
             this.entityAngularJSName = this.entityClass + _.camelCase(this.entityAngularJSSuffix);
             this.entityStateName = entityNameSpinalCased + this.entityAngularJSSuffix;
             this.entityUrl = entityNameSpinalCased + this.entityAngularJSSuffix;
-            if (databaseType == 'sql') {
-                this.entityUrlType = 'int';
-            } else if (databaseType == 'mongodb') {
-                this.entityUrlType = '[0-9a-fA-F]{24}';
-            } else if (databaseType == 'cassandra') {
-                this.entityUrlType = '[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}';
-            }
             this.entityTranslationKey = this.entityInstance;
             this.entityTranslationKeyMenu = _.camelCase(this.entityStateName);
 
@@ -1804,7 +1797,6 @@ module.exports = EntityGenerator.extend({
                         entityServiceFileName: this.entityServiceFileName,
                         entityStateName: this.entityStateName,
                         entityUrl: this.entityUrl,
-                        entityUrlType: this.entityUrlType,
                         entityTranslationKey: this.entityTranslationKey
                     };
                     // run through all post entity creation module hooks

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
@@ -61,7 +61,7 @@
         })
         .state('<%= entityStateName %>-detail', {
             parent: 'entity',
-            url: '/<%= entityUrl %>/{id:<%= entityUrlType %>}',
+            url: '/<%= entityUrl %>/{id}',
             data: {
                 authorities: ['ROLE_USER'],
                 pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.detail.title'<% }else{ %>'<%= entityClass %>'<% } %>
@@ -124,7 +124,7 @@
         })
         .state('<%= entityStateName %>.edit', {
             parent: '<%= entityStateName %>',
-            url: '/{id:<%= entityUrlType %>}/edit',
+            url: '/{id}/edit',
             data: {
                 authorities: ['ROLE_USER']
             },
@@ -148,7 +148,7 @@
         })
         .state('<%= entityStateName %>.delete', {
             parent: '<%= entityStateName %>',
-            url: '/{id:<%= entityUrlType %>}/delete',
+            url: '/{id}/delete',
             data: {
                 authorities: ['ROLE_USER']
             },


### PR DESCRIPTION
Fix #3192.
This variable caused bugs when using different DB types in microservice architecture. For example, if the gateway has an SQL DB and a microservice a Mongo one, the type in gateway front-end generated code will be wrong.
Moreover I didn't understand the point of validating the id using a regex (or a type) in client part. It was made by @andidev in b071e5bbb68ca821beb00d8d0c91d111c099ef93 so if you have any suggestion please tell me