### PR TITLE
add docker task for gradle build

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -24,6 +24,7 @@ targetCompatibility=1.<%= javaVersion %>
 apply plugin: 'maven'
 apply plugin: 'spring-boot'
 apply plugin: 'war'
+apply plugin: 'docker'
 apply plugin: 'propdeps'
 defaultTasks 'bootRun'
 
@@ -50,6 +51,20 @@ test {
 
     ignoreFailures true
     reports.html.enabled = false
+}
+
+task docker(type: Docker, dependsOn: build) {
+    push = false
+    tag = '<%=baseName.toLowerCase()%>'
+    tagVersion = 'latest'
+    dockerfile = file('src/main/docker/Dockerfile')
+    doFirst {
+        copy {
+            from 'build/libs'
+            into stageDir
+            include '*.war*'
+        }
+    }
 }
 
 task cucumberTest(type: Test) {


### PR DESCRIPTION
This is doing the same thing that we currently have on maven.
It adds a docker gradle task to create a docker image using the war in `build/libs`.
Run with `./gradlew build docker`.
Tell me if the task name `docker` is OK. Or if you would like something more explicit like `buildDocker`, `dockerImage`, etc.