### PR TITLE
remove jhipster prefix for maven docker build

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -116,8 +116,6 @@
         <sonar.sources>${project.basedir}/<%= MAIN_DIR %></sonar.sources>
         <sonar.surefire.reportsPath>${project.testresult.directory}/surefire-reports</sonar.surefire.reportsPath>
         <sonar.tests>${project.basedir}/<%= TEST_DIR %></sonar.tests>
-        <!-- Docker properties -->
-        <docker.image.prefix>jhipster</docker.image.prefix>
     </properties>
 
     <dependencies>
@@ -921,7 +919,7 @@
                 <artifactId>docker-maven-plugin</artifactId>
                 <version>0.4.1</version>
                 <configuration>
-                    <imageName>${docker.image.prefix}/<%= baseName.toLowerCase() %></imageName>
+                    <imageName><%= baseName.toLowerCase() %></imageName>
                     <dockerDirectory>src/main/docker</dockerDirectory>
                     <resources>
                         <resource>


### PR DESCRIPTION
The "jhipster/" prefix should not be added to users docker images.
They are now generated without prefix.