### PR TITLE
Add docker-compose sugenerator

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -39,7 +39,6 @@ module.exports = yeoman.generators.Base.extend({
         loadConfig: function() {
 
             this.defaultAppsFolders = this.config.get('appsFolders');
-            this.appConfigs = this.config.get('appConfigs');
             this.useElk = this.config.get('useElk');
             this.profile = this.config.get('profile');
             this.jwtSecretKey = this.config.get('jwtSecretKey');
@@ -226,7 +225,6 @@ module.exports = yeoman.generators.Base.extend({
         saveConfig: function() {
             if(this.abort) return;
             this.config.set('appsFolders', this.appsFolders);
-            this.config.set('appConfigs', this.appConfigs);
             this.config.set('useElk', this.useElk);
             this.config.set('profile', this.profile);
             this.config.set('jwtSecretKey', this.jwtSecretKey);

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -69,7 +69,7 @@ module.exports = yeoman.Base.extend({
                             if(file.isDirectory()) {
                                 if(shelljs.test('-f', file.name + '/.yo-rc.json')) {
                                     var fileData = this.fs.readJSON(file.name + '/.yo-rc.json');
-                                    if(fileData['generator-jhipster'] !== undefined) {
+                                    if(fileData['generator-jhipster'].baseName !== undefined) {
                                         this.appsFolders.push(file.name.match(/([^\/]*)\/*$/)[1]);
                                     }
                                 }

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -189,7 +189,6 @@ module.exports = yeoman.Base.extend({
             this.log('\nChecking Docker images in applications directories...');
 
             for (var i = 0; i < this.appsFolders.length; i++) {
-                this.log(this.appConfigs[i]);
                 if(this.appConfigs[i].buildTool === 'maven') {
                     var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/target/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
                     var runCommand = 'mvn package docker:build';

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -15,7 +15,7 @@ module.exports = yeoman.generators.Base.extend({
                 chalk.green('  ██    ██') + chalk.red('  ██    ██     ██     ██             ██     ██     ██        ██   ██\n') +
                 chalk.green('   ██████ ') + chalk.red('  ██    ██  ████████  ██        ██████      ██     ████████  ██    ██\n'));
             this.log(chalk.white.bold('                            http://jhipster.github.io\n'));
-            this.log(chalk.white('Welcome to the JHipster Docker Compose Generator '));
+            this.log(chalk.white('Welcome to the JHipster Docker Compose Sub-Generator '));
             this.log(chalk.white('Files will be generated in folder: ' + chalk.yellow(this.destinationRoot())));
         },
 

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -5,7 +5,7 @@ var shelljs = require('shelljs');
 var crypto = require('crypto');
 var _ = require('lodash');
 
-module.exports = yeoman.generators.Base.extend({
+module.exports = yeoman.Base.extend({
     initializing: {
         sayHello: function() {
             this.log(chalk.white('Welcome to the JHipster Docker Compose Sub-Generator '));

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -1,0 +1,264 @@
+'use strict';
+var yeoman = require('yeoman-generator');
+var chalk = require('chalk');
+var shelljs = require('shelljs');
+var crypto = require('crypto');
+var _ = require('lodash');
+
+module.exports = yeoman.generators.Base.extend({
+    initializing: {
+        printJHipsterLogo: function() {
+            this.log(' \n' +
+                chalk.green('        ██') + chalk.red('  ██    ██  ████████  ███████    ██████  ████████  ████████  ███████\n') +
+                chalk.green('        ██') + chalk.red('  ██    ██     ██     ██    ██  ██          ██     ██        ██    ██\n') +
+                chalk.green('        ██') + chalk.red('  ████████     ██     ███████    █████      ██     ██████    ███████\n') +
+                chalk.green('  ██    ██') + chalk.red('  ██    ██     ██     ██             ██     ██     ██        ██   ██\n') +
+                chalk.green('   ██████ ') + chalk.red('  ██    ██  ████████  ██        ██████      ██     ████████  ██    ██\n'));
+            this.log(chalk.white.bold('                            http://jhipster.github.io\n'));
+            this.log(chalk.white('Welcome to the JHipster Docker Compose Generator '));
+            this.log(chalk.white('Files will be generated in folder: ' + chalk.yellow(this.destinationRoot())));
+        },
+
+        checkDocker: function() {
+            var done = this.async();
+
+            shelljs.exec('docker -v', {silent:true},function(code, stdout, stderr) {
+                if (stderr) {
+                    this.log(chalk.yellow.bold('WARNING!') + ' docker is not found on your computer.\n' +
+                        '         Read http://docs.docker.com/engine/installation/#installation\n');
+                }
+                done();
+            }.bind(this));
+        },
+
+        checkDockerCompose: function() {
+            var done = this.async();
+
+            shelljs.exec('docker-compose -v', {silent:true}, function(code, stdout, stderr) {
+                if (stderr) {
+                    this.log(chalk.yellow.bold('WARNING!') + ' docker-compose is not found on your computer.\n' +
+                        '         Read https://docs.docker.com/compose/install/\n');
+                }
+                done();
+            }.bind(this));
+        },
+
+        loadConfig: function() {
+
+            this.defaultAppsFolders = this.config.get('appsFolders');
+            this.appConfigs = this.config.get('appConfigs');
+            this.useElk = this.config.get('useElk');
+            this.profile = this.config.get('profile');
+            this.jwtSecretKey = this.config.get('jwtSecretKey');
+
+            if(this.defaultAppsFolders !== undefined) {
+                this.regenerate = true;
+                this.log('\nFound .yo-rc.json config file...');
+            }
+        }
+    },
+
+    prompting: {
+        askForPath: function() {
+            var done = this.async();
+
+            var prompts = [{
+                type: 'input',
+                name: 'directoryPath',
+                message: 'Where are the applications located ?',
+                default: '../',
+                validate: function (input) {
+                    var path = this.destinationPath(input);
+                    if(shelljs.test('-d', path)) {
+                        var files = shelljs.ls('-l',this.destinationPath(input));
+                        this.appsFolders = [];
+
+                        files.forEach(function(file) {
+                            if(file.isDirectory()) {
+                                if(shelljs.test('-f', file.name + '/.yo-rc.json')) {
+                                    var fileData = this.fs.readJSON(file.name + '/.yo-rc.json');
+                                    if(fileData['generator-jhipster'] !== undefined) {
+                                        this.appsFolders.push(file.name.match(/([^\/]*)\/*$/)[1]);
+                                    }
+                                }
+                            }
+                        }, this);
+
+                        if(this.appsFolders.length === 0) {
+                            return 'No microservice or gateway found in ' + this.destinationPath(input);
+                        } else {
+                            return true;
+                        }
+                    } else {
+                        return path + ' is not a directory or doesn\'t exist';
+                    }
+
+                }.bind(this)
+            }];
+
+            this.prompt(prompts, function (props) {
+                this.directoryPath = props.directoryPath;
+
+                //Removing monolithic apps and registry from appsFolders
+                for(var i = 0; i < this.appsFolders.length; i++) {
+                    var path = this.destinationPath(this.directoryPath + this.appsFolders[i]+'/.yo-rc.json');
+                    var fileData = this.fs.readJSON(path);
+                    var config = fileData['generator-jhipster'];
+                    if(config.applicationType === 'monolith' || this.appsFolders[i]==='jhipster-registry' || this.appsFolders[i] === 'registry') {
+                        this.appsFolders.splice(i,1);
+                        i--;
+                    }
+                }
+
+                this.log(chalk.green(this.appsFolders.length + ' applications found at ' + this.destinationPath(this.directoryPath) + '\n'));
+
+                done();
+            }.bind(this));
+        },
+
+        askForApps: function() {
+            if(this.abort) return;
+            var done = this.async();
+
+            var prompts = [{
+                type: 'checkbox',
+                name: 'chosenApps',
+                message: 'Which applications do you want in your DockerFile ?',
+                choices: this.appsFolders,
+                default: this.defaultAppsFolders,
+                validate: function (input) {
+                    if(input.length === 0) {
+                        return 'Please choose at least one application';
+                    } else return true;
+                }
+            }];
+
+            this.prompt(prompts, function (props) {
+                this.appsFolders = props.chosenApps;
+
+                this.appConfigs = [];
+
+                //Loading configs
+                for(var i = 0; i < this.appsFolders.length; i++) {
+                    var path = this.destinationPath(this.directoryPath + this.appsFolders[i]+'/.yo-rc.json');
+                    var fileData = this.fs.readJSON(path);
+                    var config = fileData['generator-jhipster'];
+                    this.appConfigs.push(config);
+                }
+
+                done();
+            }.bind(this));
+        },
+
+        askForElk: function() {
+            if(this.abort) return;
+            var done = this.async();
+
+            var prompts = [{
+                type: 'confirm',
+                name: 'elk',
+                message: 'Do you want ELK to monitor your applications ?',
+                default: this.useElk && true
+            }];
+
+            this.prompt(prompts, function(props) {
+                this.useElk = props.elk;
+
+                done();
+            }.bind(this));
+        },
+
+        askForProfile: function() {
+            if(this.abort) return;
+            var done = this.async();
+
+            var choices = ['dev', 'prod'];
+
+            var prompts = [{
+                type: 'list',
+                name: 'profile',
+                message: 'Which profile do you want to use ?',
+                choices: choices,
+                default: this.profile || 'dev'
+            }];
+
+            this.prompt(prompts, function(props) {
+                this.profile = props.profile;
+
+                done();
+            }.bind(this));
+        }
+    },
+
+    configuring: {
+        checkImages: function() {
+            if(this.abort) return;
+
+            this.log('\nChecking Docker images in applications directories...');
+
+            for (var i = 0; i < this.appsFolders.length; i++) {
+                var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/target/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
+                if (!shelljs.test('-f', imagePath)) {
+                    this.log(chalk.red('\nDocker Image not found at ' + imagePath));
+                    this.log(chalk.red('Please run "mvn package docker:build" in ' + this.destinationPath(this.directoryPath + this.appsFolders[i]) + ' to generate Docker image'));
+                    this.abort = true;
+                }
+            }
+
+            if(!this.abort) this.log(chalk.green('Found Docker images, writing files...\n'));
+        },
+
+        generateJwtSecret: function() {
+            if(this.jwtSecretKey === undefined) {
+                this.jwtSecretKey = crypto.randomBytes(20).toString('hex');
+            }
+        },
+
+        setAppsFolderPaths: function() {
+            this.appsFolderPaths = [];
+            for (var i = 0; i < this.appsFolders.length; i++) {
+                var path = this.destinationPath(this.directoryPath + this.appsFolders[i]);
+                this.appsFolderPaths.push(path);
+            }
+        },
+
+        saveConfig: function() {
+            if(this.abort) return;
+            this.config.set('appsFolders', this.appsFolders);
+            this.config.set('appConfigs', this.appConfigs);
+            this.config.set('useElk', this.useElk);
+            this.config.set('profile', this.profile);
+            this.config.set('jwtSecretKey', this.jwtSecretKey);
+        }
+    },
+
+    writing: {
+        writeDockerCompose: function() {
+            if(this.abort) return;
+
+            this.template('_docker-compose.yml', 'docker-compose.yml');
+        },
+
+        writeRegistryFiles: function() {
+            if(this.abort) return;
+
+            this.copy('registry.yml', 'registry.yml');
+            this.template('central-server-config/_application.yml', 'central-server-config/application.yml');
+        },
+
+        writeElkFiles: function() {
+            if(!this.useElk || this.abort) return;
+
+            this.copy('elk.yml', 'elk.yml');
+            this.copy('log-monitoring/log-config/logstash.conf', 'log-monitoring/log-config/logstash.conf');
+            this.copy('log-monitoring/log-data/.gitignore', 'log-monitoring/log-data/.gitignore');
+        }
+    },
+    end: function() {
+        if(this.abort) return;
+
+        this.log('\n' + chalk.bold.green('##### USAGE #####'));
+        this.log('First launch the JHipster Registry by running : ' + chalk.cyan('docker-compose up -d jhipster-registry'));
+        this.log('Wait a minute, then launch all your applications by running : ' + chalk.cyan('docker-compose up -d'));
+    }
+});

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -197,10 +197,18 @@ module.exports = yeoman.generators.Base.extend({
             this.log('\nChecking Docker images in applications directories...');
 
             for (var i = 0; i < this.appsFolders.length; i++) {
-                var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/target/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
+                this.log(this.appConfigs[i]);
+                if(this.appConfigs[i].buildTool === 'maven') {
+                    var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/target/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
+                    var runCommand = 'mvn package docker:build';
+                } else {
+                    var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/build/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
+                    var runCommand = 'gradle bootRepackage buildDocker';
+                }
+
                 if (!shelljs.test('-f', imagePath)) {
                     this.log(chalk.red('\nDocker Image not found at ' + imagePath));
-                    this.log(chalk.red('Please run "mvn package docker:build" in ' + this.destinationPath(this.directoryPath + this.appsFolders[i]) + ' to generate Docker image'));
+                    this.log(chalk.red('Please run "' + runCommand + '" in ' + this.destinationPath(this.directoryPath + this.appsFolders[i]) + ' to generate Docker image'));
                     this.abort = true;
                 }
             }

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -7,14 +7,7 @@ var _ = require('lodash');
 
 module.exports = yeoman.generators.Base.extend({
     initializing: {
-        printJHipsterLogo: function() {
-            this.log(' \n' +
-                chalk.green('        ██') + chalk.red('  ██    ██  ████████  ███████    ██████  ████████  ████████  ███████\n') +
-                chalk.green('        ██') + chalk.red('  ██    ██     ██     ██    ██  ██          ██     ██        ██    ██\n') +
-                chalk.green('        ██') + chalk.red('  ████████     ██     ███████    █████      ██     ██████    ███████\n') +
-                chalk.green('  ██    ██') + chalk.red('  ██    ██     ██     ██             ██     ██     ██        ██   ██\n') +
-                chalk.green('   ██████ ') + chalk.red('  ██    ██  ████████  ██        ██████      ██     ████████  ██    ██\n'));
-            this.log(chalk.white.bold('                            http://jhipster.github.io\n'));
+        sayHello: function() {
             this.log(chalk.white('Welcome to the JHipster Docker Compose Sub-Generator '));
             this.log(chalk.white('Files will be generated in folder: ' + chalk.yellow(this.destinationRoot())));
         },

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -195,7 +195,7 @@ module.exports = yeoman.generators.Base.extend({
                     var runCommand = 'mvn package docker:build';
                 } else {
                     var imagePath = this.destinationPath(this.directoryPath + this.appsFolders[i] + '/build/docker/' + _.kebabCase(this.appConfigs[i].baseName) + '-0.0.1-SNAPSHOT.war');
-                    var runCommand = 'gradle bootRepackage buildDocker';
+                    var runCommand = './gradlew bootRepackage buildDocker';
                 }
 
                 if (!shelljs.test('-f', imagePath)) {

--- a/generators/docker-compose/templates/_docker-compose.yml
+++ b/generators/docker-compose/templates/_docker-compose.yml
@@ -1,0 +1,42 @@
+version: '2'
+services:
+    jhipster-registry:
+        extends:
+            file: registry.yml
+            service: jhipster-registry
+        volumes:
+            - ./central-server-config:/central-config
+        environment:
+        <%_ if(profile=='dev') {_%>
+            - SPRING_PROFILES_ACTIVE=dev,native
+        <%_ } else { _%>
+            - GIT_URI=https://github.com/jhipster/jhipster-registry/
+            - GIT_SEARCH_PATH=central-config
+        <%_ } _%>
+<%_ for(var i=0; i<appConfigs.length; i++) { _%>
+
+    <%= appConfigs[i].baseName.toLowerCase() %>:
+        extends:
+            file: <%= appsFolderPaths[i] %>/src/main/docker/app.<%= profile %>.yml
+            service: <%= appConfigs[i].baseName.toLowerCase() %>-<% if(profile=='dev') {%><%= profile %>-<%}%>app
+<%_ if(profile=='prod') {_%>
+    <%= appConfigs[i].baseName.toLowerCase() %>-<%= appConfigs[i].prodDatabaseType %>:
+        extends:
+            file: <%= appsFolderPaths[i] %>/src/main/docker/db.prod.yml
+            service: <%= appConfigs[i].baseName.toLowerCase() %>-<%= appConfigs[i].prodDatabaseType %>
+<%_ }} _%>
+<%_ if (useElk) { _%>
+
+    elk-elasticsearch:
+        extends:
+            file: elk.yml
+            service: elk-elasticsearch
+    elk-logstash:
+        extends:
+          file: elk.yml
+          service: elk-logstash
+    jhipster-console:
+        extends:
+            file: elk.yml
+            service: jhipster-console
+<%_ } _%>

--- a/generators/docker-compose/templates/central-server-config/_application.yml
+++ b/generators/docker-compose/templates/central-server-config/_application.yml
@@ -1,0 +1,18 @@
+#common config shared between all apps
+configserver:
+    status: ${spring.cloud.config.uri}/${spring.cloud.config.label}/${spring.cloud.config.name}-${spring.cloud.config.profile}.yml
+jhipster:
+    security:
+        authentication:
+            jwt:
+                secret: <%= jwtSecretKey %>
+<%_ if (useElk) { _%>
+    logging:
+        logstash: # forward logs to ELK
+            enabled: true
+            host: elk-logstash
+    metrics:
+        logs: # report metrics in the logs
+            enabled: true
+            reportFrequency: 60 # in seconds
+<%_ } _%>

--- a/generators/docker-compose/templates/elk.yml
+++ b/generators/docker-compose/templates/elk.yml
@@ -1,0 +1,22 @@
+version: '2'
+services:
+    elk-elasticsearch:
+        image: elasticsearch:2.2.0
+        ports:
+            - "9200:9200"
+            - "9300:9300"
+        volumes:
+            - ./log-monitoring/log-data:/usr/share/elasticsearch/data
+    elk-logstash:
+        image: logstash:2.2.2
+        volumes:
+            - ./log-monitoring/log-config/:/config-dir
+        command: logstash -f /config-dir/logstash.conf
+        ports:
+            - "5000:5000/udp"
+    jhipster-console:
+        image: jhipster/jhipster-console
+        ports:
+            - "5601:5601"
+        environment:
+            - ELASTICSEARCH_URL=http://elk-elasticsearch:9200

--- a/generators/docker-compose/templates/log-monitoring/log-config/logstash.conf
+++ b/generators/docker-compose/templates/log-monitoring/log-config/logstash.conf
@@ -1,0 +1,47 @@
+input {
+    udp {
+        port => 5000
+        type => syslog
+        codec => json
+    }
+}
+
+filter {
+    if [logger_name] =~ "metrics" {
+        kv {
+            source => "message"
+            field_split => ", "
+            prefix => "metric_"
+        }
+	mutate {
+          convert => { "metric_value" => "float" }
+          convert => { "metric_count" => "integer" }
+          convert => { "metric_min" => "float" }
+          convert => { "metric_max" => "float" }
+          convert => { "metric_mean" => "float" }
+          convert => { "metric_stddev" => "float" }
+          convert => { "metric_median" => "float" }
+          convert => { "metric_p75" => "float" }
+          convert => { "metric_p95" => "float" }
+          convert => { "metric_p98" => "float" }
+          convert => { "metric_p99" => "float" }
+          convert => { "metric_p999" => "float" }
+          convert => { "metric_mean_rate" => "float" }
+          convert => { "metric_m1" => "float" }
+          convert => { "metric_m5" => "float" }
+          convert => { "metric_m15" => "float" }
+        }
+    }
+    mutate {
+    	add_field => { "instance_name" => "%{app_name}-%{host}:%{app_port}" }
+    }
+}
+
+output {
+    elasticsearch {
+        hosts => ["elk-elasticsearch"]
+    }
+    stdout {
+        codec => rubydebug
+    }
+}

--- a/generators/docker-compose/templates/log-monitoring/log-data/.gitignore
+++ b/generators/docker-compose/templates/log-monitoring/log-data/.gitignore
@@ -1,0 +1,2 @@
+*
+!.gitignore

--- a/generators/docker-compose/templates/registry.yml
+++ b/generators/docker-compose/templates/registry.yml
@@ -1,0 +1,7 @@
+version: '2'
+services:
+    jhipster-registry:
+        container_name: jhipster-registry
+        image: jhipster/jhipster-registry
+        ports:
+            - "8761:8761"


### PR DESCRIPTION
Fix #3193 .
Just a migration of the [Jhipster docker compose generator](https://github.com/jhipster/generator-jhipster-docker-compose). 
For now it works with SQL and Mongo databases, I got some trouble with Cassandra so if someone can help on this I'd be pleased.
As we discussed, shall I remove the question about profile as docker will be probably used to deploy application in production profile ?