### PR TITLE
Profile switches for no-swager and no-liquibase

### DIFF
--- a/generators/server/templates/gradle/_liquibase.gradle
+++ b/generators/server/templates/gradle/_liquibase.gradle
@@ -1,30 +1,30 @@
 configurations {
-  liquibase
+    liquibase
 }
 
 dependencies {
-  liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate4', version: liquibase_hibernate4_version
+    liquibase group: 'org.liquibase.ext', name: 'liquibase-hibernate4', version: liquibase_hibernate4_version
 }
 
 task liquibaseDiffChangelog(dependsOn: compileJava, type: JavaExec) {
-  group = "liquibase"
+    group = "liquibase"
 
-  classpath sourceSets.main.runtimeClasspath
-  classpath configurations.liquibase
-  main = "liquibase.integration.commandline.Main"
+    classpath sourceSets.main.runtimeClasspath
+    classpath configurations.liquibase
+    main = "liquibase.integration.commandline.Main"
 
-  args "--changeLogFile=<%= SERVER_MAIN_RES_DIR %>config/liquibase/changelog/" + buildTimestamp() +"_changelog.xml"
-  args "--referenceUrl=hibernate:spring:<%=packageName%>.domain?dialect=<% if (devDatabaseType == 'mysql') { %>org.hibernate.dialect.MySQLInnoDBDialect<% } else if (devDatabaseType == 'postgresql') { %>org.hibernate.dialect.PostgreSQL82Dialect<% } else if (devDatabaseType == 'h2Disk') { %>org.hibernate.dialect.H2Dialect<%} else if (devDatabaseType == 'oracle') { %>org.hibernate.dialect.Oracle10gDialect<% }%>&hibernate.ejb.naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringNamingStrategy"
-  args "--username=<% if (devDatabaseType == 'mysql') { %>root<% } else if (devDatabaseType == 'postgresql') { %><%= baseName %><% } %>"
-  args "--password="
-  args "--url=<% if (devDatabaseType == 'mysql') { %>jdbc:mysql://localhost:3306/<%= baseName %><% } else if (devDatabaseType == 'postgresql') { %>jdbc:postgresql://localhost:5432/<%= baseName %><% } else if (devDatabaseType == 'h2Disk') { %>jdbc:h2:file:./target/h2db/db/<%= lowercaseBaseName %><% } else if (devDatabaseType == 'oracle') { %>jdbc:oracle:thin:@localhost:1521:<%= baseName %><% } %>"
-  args "--driver=<% if (devDatabaseType == 'mysql') { %>com.mysql.jdbc.Driver<% } else if (devDatabaseType == 'postgresql') { %>org.postgresql.Driver<% } else if (devDatabaseType == 'h2Disk') { %>org.h2.Driver<% } else if (devDatabaseType == 'oracle') { %>oracle.jdbc.OracleDriver<% } %>"
-  args "diffChangeLog"
-  <% if (authenticationType == 'oauth2') { %>args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details, oauth_client_token, oauth_code, oauth_refresh_token"<% } %>
+    args "--changeLogFile=<%= SERVER_MAIN_RES_DIR %>config/liquibase/changelog/" + buildTimestamp() +"_changelog.xml"
+    args "--referenceUrl=hibernate:spring:<%=packageName%>.domain?dialect=<% if (devDatabaseType == 'mysql') {   %>org.hibernate.dialect.MySQLInnoDBDialect<% } else if (devDatabaseType == 'postgresql') { %>org.hibernate.dialect.PostgreSQL82Dialect<% }   else if (devDatabaseType == 'h2Disk') { %>org.hibernate.dialect.H2Dialect<%} else if (devDatabaseType == 'oracle') {   %>org.hibernate.dialect.Oracle10gDialect<%   }%>&hibernate.ejb.naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringNamingStrategy"
+    args "--username=<% if (devDatabaseType == 'mysql') { %>root<% } else if (devDatabaseType == 'postgresql') { %><%= baseName %><% } %>"
+    args "--password="
+    args "--url=<% if (devDatabaseType == 'mysql') { %>jdbc:mysql://localhost:3306/<%= baseName %><% } else if (devDatabaseType == 'postgresql') {   %>jdbc:postgresql://localhost:5432/<%= baseName %><% } else if (devDatabaseType == 'h2Disk') { %>jdbc:h2:file:./target/h2db/db/<%=   lowercaseBaseName %><% } else if (devDatabaseType == 'oracle') { %>jdbc:oracle:thin:@localhost:1521:<%= baseName %><% } %>"
+    args "--driver=<% if (devDatabaseType == 'mysql') { %>com.mysql.jdbc.Driver<% } else if (devDatabaseType == 'postgresql') {   %>org.postgresql.Driver<% } else if (devDatabaseType == 'h2Disk') { %>org.h2.Driver<% } else if (devDatabaseType == 'oracle') {   %>oracle.jdbc.OracleDriver<% } %>"
+    args "diffChangeLog"
+    <% if (authenticationType == 'oauth2') { %>args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details,   oauth_client_token, oauth_code, oauth_refresh_token"<% } %>
 }
 
 def buildTimestamp() {
-  def date = new Date()
-  def formattedDate = date.format('yyyyMMddHHmmss')
-  return formattedDate
+    def date = new Date()
+    def formattedDate = date.format('yyyyMMddHHmmss')
+    return formattedDate
 }

--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -10,11 +10,11 @@ dependencies {
 }
 
 bootRun {
-  args = ["--spring.profiles.active=dev"]
+    args = ["--spring.profiles.active=dev"]
 }
 <% if (!skipClient) { %>
 war {
-  webAppDirName = '<%= CLIENT_MAIN_SRC_DIR %>'
+    webAppDirName = '<%= CLIENT_MAIN_SRC_DIR %>'
 }<% } %>
 
 task setProdProperties(dependsOn: bootRun) << {

--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -9,8 +9,19 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-tomcat', version: spring_boot_version
 }
 
+def profiles = 'dev'
+if (project.hasProperty('no-liquibase')) {
+    profiles += ',no-liquibase'
+}
+if (project.hasProperty('no-swagger')) {
+    profiles += ',no-swagger'
+}
+if (project.hasProperty('no-cache')) {
+    profiles += ',no-cache'
+}
+
 bootRun {
-    args = ["--spring.profiles.active=dev"]
+    args = ["--spring.profiles.active=" + profiles]
 }
 <% if (!skipClient) { %>
 war {
@@ -19,7 +30,7 @@ war {
 
 task setProdProperties(dependsOn: bootRun) << {
     doFirst {
-        System.setProperty('spring.profiles.active', 'dev')
+        System.setProperty('spring.profiles.active', profiles)
     }
 }
 

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -13,15 +13,15 @@ dependencies {
 }
 
 bootRun {
-  args = ["--spring.profiles.active=prod"]
+    args = ["--spring.profiles.active=prod"]
 }
 <% if (!skipClient) { %>
 task gulpBuildWithOpts(type: GulpTask) {
-   args = ["build", "--no-notification"]
+    args = ["build", "--no-notification"]
 }
 
 war {
-  webAppDirName = '<%= CLIENT_DIST_DIR %>'
+    webAppDirName = '<%= CLIENT_DIST_DIR %>'
 }<% } %>
 
 processResources {

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -12,8 +12,17 @@ dependencies {
     compile group: 'org.springframework.boot', name: 'spring-boot-starter-tomcat', version: spring_boot_version
 }
 
+def profiles = 'prod'
+if (project.hasProperty('no-liquibase')) {
+    profiles += ',no-liquibase'
+}
+
+if (project.hasProperty('no-cache')) {
+    profiles += ',no-cache'
+}
+
 bootRun {
-    args = ["--spring.profiles.active=prod"]
+    args = ["--spring.profiles.active=" + profiles]
 }
 <% if (!skipClient) { %>
 task gulpBuildWithOpts(type: GulpTask) {
@@ -34,7 +43,7 @@ processResources {
 
 task setProdProperties(dependsOn: bootRun) << {
     doFirst {
-        System.setProperty('spring.profiles.active', 'prod')
+        System.setProperty('spring.profiles.active', profiles)
     }
 }
 <% if (!skipClient) { %>

--- a/generators/server/templates/src/main/java/package/config/_Constants.java
+++ b/generators/server/templates/src/main/java/package/config/_Constants.java
@@ -12,6 +12,8 @@ public final class Constants {
     public static final String SPRING_PROFILE_CLOUD = "cloud";
     // Spring profile used when deploying to Heroku
     public static final String SPRING_PROFILE_HEROKU = "heroku";
+    // Spring profile used to Disable swagger
+    public static final String SPRING_PROFILE_NO_SWAGGER = "no-swagger";
 
     public static final String SYSTEM_ACCOUNT = "system";
 

--- a/generators/server/templates/src/main/java/package/config/_Constants.java
+++ b/generators/server/templates/src/main/java/package/config/_Constants.java
@@ -12,8 +12,10 @@ public final class Constants {
     public static final String SPRING_PROFILE_CLOUD = "cloud";
     // Spring profile used when deploying to Heroku
     public static final String SPRING_PROFILE_HEROKU = "heroku";
-    // Spring profile used to Disable swagger
+    // Spring profile used to disable swagger
     public static final String SPRING_PROFILE_NO_SWAGGER = "no-swagger";
+    // Spring profile used to disable running liquibase
+    public static final String SPRING_PROFILE_NO_LIQUIBASE = "no-liquibase";
 
     public static final String SYSTEM_ACCOUNT = "system";
 

--- a/generators/server/templates/src/main/java/package/config/_DatabaseConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_DatabaseConfiguration.java
@@ -81,7 +81,7 @@ public class DatabaseConfiguration <% if (databaseType == 'mongodb') { %>extends
     private MongoProperties mongoProperties;<% } %><% if (databaseType == 'sql') { %>
 
     @Bean(destroyMethod = "close")
-    @ConditionalOnExpression("#{!environment.acceptsProfiles('cloud') && !environment.acceptsProfiles('heroku')}")
+    @ConditionalOnExpression("#{!environment.acceptsProfiles('" + Constants.SPRING_PROFILE_CLOUD + "') && !environment.acceptsProfiles('" + Constants.SPRING_PROFILE_HEROKU + "')}")
     @ConfigurationProperties(prefix = "spring.datasource.hikari")
     public DataSource dataSource(DataSourceProperties dataSourceProperties<% if (hibernateCache == 'hazelcast') { %>, CacheManager cacheManager<% } %>) {
         log.debug("Configuring Datasource");
@@ -132,8 +132,12 @@ public class DatabaseConfiguration <% if (databaseType == 'mongodb') { %>extends
         liquibase.setContexts(liquibaseProperties.getContexts());
         liquibase.setDefaultSchema(liquibaseProperties.getDefaultSchema());
         liquibase.setDropFirst(liquibaseProperties.isDropFirst());
-        liquibase.setShouldRun(liquibaseProperties.isEnabled());
-        log.debug("Configuring Liquibase");
+        if (env.acceptsProfiles(Constants.SPRING_PROFILE_NO_LIQUIBASE)) {
+            liquibase.setShouldRun(false);
+        } else {
+            liquibase.setShouldRun(liquibaseProperties.isEnabled());
+            log.debug("Configuring Liquibase");
+        }
 
         return liquibase;
     }

--- a/generators/server/templates/src/main/java/package/config/apidoc/_GatewaySwaggerResourcesProvider.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_GatewaySwaggerResourcesProvider.java
@@ -1,11 +1,13 @@
 package <%=packageName%>.config.apidoc;
 
+import <%=packageName%>.config.Constants;
 import java.util.ArrayList;
 import java.util.List;
 import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
@@ -20,6 +22,7 @@ import springfox.documentation.swagger.web.SwaggerResourcesProvider;
  */
 @Component
 @Primary
+@ConditionalOnExpression("#{!environment.acceptsProfiles('" + Constants.SPRING_PROFILE_NO_SWAGGER + "') && !environment.acceptsProfiles('" + Constants.SPRING_PROFILE_PRODUCTION + "')}")
 public class GatewaySwaggerResourcesProvider implements SwaggerResourcesProvider {
 
     private final Logger log = LoggerFactory.getLogger(GatewaySwaggerResourcesProvider.class);

--- a/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
@@ -6,6 +6,7 @@ import <%=packageName%>.config.JHipsterProperties;
 import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
 import org.springframework.context.annotation.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -27,7 +28,7 @@ import static springfox.documentation.builders.PathSelectors.regex;
  */
 @Configuration
 @EnableSwagger2
-@Profile("!" + Constants.SPRING_PROFILE_PRODUCTION)
+@ConditionalOnExpression("#{!environment.acceptsProfiles('" + Constants.SPRING_PROFILE_NO_SWAGGER + "') && !environment.acceptsProfiles('" + Constants.SPRING_PROFILE_PRODUCTION + "')}")
 public class SwaggerConfiguration {
 
     private final Logger log = LoggerFactory.getLogger(SwaggerConfiguration.class);

--- a/generators/server/templates/src/main/java/package/config/liquibase/_AsyncSpringLiquibase.java
+++ b/generators/server/templates/src/main/java/package/config/liquibase/_AsyncSpringLiquibase.java
@@ -41,18 +41,22 @@ public class AsyncSpringLiquibase extends SpringLiquibase {
 
     @Override
     public void afterPropertiesSet() throws LiquibaseException {
-        if (env.acceptsProfiles(Constants.SPRING_PROFILE_DEVELOPMENT, Constants.SPRING_PROFILE_HEROKU)) {
-            taskExecutor.execute(() -> {
-                try {
-                    log.warn("Starting Liquibase asynchronously, your database might not be ready at startup!");
-                    initDb();
-                } catch (LiquibaseException e) {
-                    log.error("Liquibase could not start correctly, your database is NOT ready: {}", e.getMessage(), e);
-                }
-            });
+        if (!env.acceptsProfiles(Constants.SPRING_PROFILE_NO_LIQUIBASE)) {
+            if (env.acceptsProfiles(Constants.SPRING_PROFILE_DEVELOPMENT, Constants.SPRING_PROFILE_HEROKU)) {
+                taskExecutor.execute(() -> {
+                    try {
+                        log.warn("Starting Liquibase asynchronously, your database might not be ready at startup!");
+                        initDb();
+                    } catch (LiquibaseException e) {
+                        log.error("Liquibase could not start correctly, your database is NOT ready: {}", e.getMessage(), e);
+                    }
+                });
+            } else {
+                log.debug("Starting Liquibase synchronously");
+                initDb();
+            }
         } else {
-            log.debug("Starting Liquibase synchronously");
-            initDb();
+            log.debug("Liquibase is disabled");
         }
     }
 


### PR DESCRIPTION
profile switches to disable liquibase/swagger

For jar|war it can be added as `--spring.profiles.active=prod|dev,no-liquibase|no-swagger`

For Gradle local bootRun `./gradlew -Pno-liquibase -Pno-swagger` or `./gradlew -Pprod -Pno-liquibase -Pno-swagger`

Can someone check for maven local run 

part of #3151 but no-cache seems to be tougher than I thought will do it as a seperate PR