### PR TITLE
gulp build is not executed when running in dev mode

### DIFF
--- a/app/templates/_build.gradle
+++ b/app/templates/_build.gradle
@@ -46,7 +46,6 @@ bootRun {
 
 
 test {
-    println 'Starting the Unit and Integration test'
     include '**/*UnitTest*'
     include '**/*IntTest*'
 }

--- a/app/templates/_profile_dev.gradle
+++ b/app/templates/_profile_dev.gradle
@@ -26,3 +26,5 @@ processResources {
         }
     }
 }
+
+setProdProperties.dependsOn 'gulp_ngconstant:dev'

--- a/app/templates/_profile_dev.gradle
+++ b/app/templates/_profile_dev.gradle
@@ -26,5 +26,5 @@ processResources {
         }
     }
 }
-<% }  if(frontendBuilder == 'gulp') {%>
+<% if(frontendBuilder == 'gulp') {%>
 setProdProperties.dependsOn 'gulp_ngconstant:dev'<% } %>

--- a/app/templates/_profile_dev.gradle
+++ b/app/templates/_profile_dev.gradle
@@ -26,5 +26,5 @@ processResources {
         }
     }
 }
-
-setProdProperties.dependsOn 'gulp_ngconstant:dev'
+<% }  if(frontendBuilder == 'gulp') {%>
+setProdProperties.dependsOn 'gulp_ngconstant:dev'<% } %>

--- a/app/templates/_profile_fast.gradle
+++ b/app/templates/_profile_fast.gradle
@@ -26,3 +26,5 @@ task setProdProperties(dependsOn: bootRun) << {
         System.setProperty('spring.profiles.active', 'dev,fast')
     }
 }
+
+setProdProperties.dependsOn 'gulp_ngconstant:dev'

--- a/app/templates/_profile_fast.gradle
+++ b/app/templates/_profile_fast.gradle
@@ -26,5 +26,5 @@ task setProdProperties(dependsOn: bootRun) << {
         System.setProperty('spring.profiles.active', 'dev,fast')
     }
 }
-
-setProdProperties.dependsOn 'gulp_ngconstant:dev'
+<% }  if(frontendBuilder == 'gulp') {%>
+setProdProperties.dependsOn 'gulp_ngconstant:dev'<% } %>

--- a/app/templates/_profile_fast.gradle
+++ b/app/templates/_profile_fast.gradle
@@ -26,5 +26,5 @@ task setProdProperties(dependsOn: bootRun) << {
         System.setProperty('spring.profiles.active', 'dev,fast')
     }
 }
-<% }  if(frontendBuilder == 'gulp') {%>
+<% if(frontendBuilder == 'gulp') {%>
 setProdProperties.dependsOn 'gulp_ngconstant:dev'<% } %>

--- a/app/templates/_profile_prod.gradle
+++ b/app/templates/_profile_prod.gradle
@@ -30,6 +30,8 @@ task setProdProperties(dependsOn: bootRun) << {
     }
 }
 
+setProdProperties.dependsOn 'gulp_ngconstant:prod'
+
 <% if(frontendBuilder == 'grunt') {%>
 task gruntBuild(type: Exec) {
   if (Os.isFamily(Os.FAMILY_WINDOWS)) {

--- a/app/templates/_profile_prod.gradle
+++ b/app/templates/_profile_prod.gradle
@@ -30,7 +30,6 @@ task setProdProperties(dependsOn: bootRun) << {
     }
 }
 
-setProdProperties.dependsOn 'gulp_ngconstant:prod'
 
 <% if(frontendBuilder == 'grunt') {%>
 task gruntBuild(type: Exec) {

--- a/app/templates/_yeoman.gradle
+++ b/app/templates/_yeoman.gradle
@@ -15,8 +15,9 @@ task bower(type: Exec) {
 bower.onlyIf { !project.hasProperty('skipBower') }
 processResources.dependsOn 'bower'
 <% }  if(frontendBuilder == 'gulp') {%>
+bower.onlyIf { !project.hasProperty('skipBower') }
 gulp_build.dependsOn 'npmInstall'
 gulp_build.dependsOn 'bower'
-processResources.dependsOn gulp_build
+processResources.dependsOn 'bower'
 test.dependsOn gulp_test
 <% } %>


### PR DESCRIPTION
``processResources`` doesn't depend on ``gulp build`` anymore. Dev profile excutes ``ngConstansts:dev`` to make sure the constant are on ``dev`` mode even when ``prod`` was used before. 

close #3204