### PR TITLE
#3135 AbstractAuditEntity does not need to have @NotNull

### DIFF
--- a/generators/server/templates/src/main/java/package/domain/_AbstractAuditingEntity.java
+++ b/generators/server/templates/src/main/java/package/domain/_AbstractAuditingEntity.java
@@ -30,14 +30,12 @@ public abstract class AbstractAuditingEntity implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @CreatedBy<% if (databaseType == 'sql') { %>
-    @NotNull
     @Column(name = "created_by", nullable = false, length = 50, updatable = false)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("created_by")<% } %>
     @JsonIgnore
     private String createdBy;
 
     @CreatedDate<% if (databaseType == 'sql') { %>
-    @NotNull
     @Column(name = "created_date", nullable = false)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("created_date")<% } %>
     @JsonIgnore


### PR DESCRIPTION
Removed unnecessary @NotNull annotations in fields with @CreatedBy and @CreatedDate