### PR TITLE
Detect properly if setDocumentRoot will work

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
+++ b/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
@@ -106,7 +106,7 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
     }<% } %>
 
     /**
-     * Set up Mime types.
+     * Set up Mime types and, if needed, set the document root.
      */
     @Override
     public void customize(ConfigurableEmbeddedServletContainer container) {
@@ -117,13 +117,15 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
         mappings.add("json", "text/html;charset=utf-8");
         container.setMimeMappings(mappings);<% if (!skipClient) { %>
 
-        // Set document root if we're not running from a jar/war
-        if (getClass().getProtectionDomain().getCodeSource().getLocation().getProtocol().equals("file")) {
-            if (env.acceptsProfiles(Constants.SPRING_PROFILE_PRODUCTION)) {
-                container.setDocumentRoot(new File("<%= CLIENT_DIST_DIR %>"));
-            } else if (env.acceptsProfiles(Constants.SPRING_PROFILE_DEVELOPMENT)) {
-                container.setDocumentRoot(new File("<%= CLIENT_MAIN_SRC_DIR %>"));
-            }
+        // When running in an IDE or with <% if (buildTool == 'gradle') { %>gradle bootRun<% } else { %>mvn spring-boot:run<% } %>, set location of the static web assets.
+        File root;
+        if (env.acceptsProfiles(Constants.SPRING_PROFILE_PRODUCTION)) {
+            root = new File("<%= CLIENT_DIST_DIR %>");
+        } else {
+            root = new File("<%= CLIENT_MAIN_SRC_DIR %>");
+        }
+        if (root.exists() && root.isDirectory()) {
+            container.setDocumentRoot(root);
         }<% } %>
     }<% if (!skipClient) { %>
 


### PR DESCRIPTION
I believe this (finally) addresses [#3220](https://github.com/jhipster/generator-jhipster/issues/3220) properly.

Tested cases:
- running in IDE
- running with `mvn spring-boot:run`
- running with `java -jar target/foo.war` from an abitrary cwd
- deploying to external servlet container (tomcat 8)