### PR TITLE
Fix i18n copy for the case of a single language

### DIFF
--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -110,7 +110,10 @@ gulp.task('sass', function () {
 
 <%_ if(enableTranslation) { _%>
 gulp.task('languages', function () {
-    return gulp.src(config.bower + 'angular-i18n/angular-locale_{' + yorc.languages.join(',') + '}.js')
+    var locales = yorc.languages.map(function (locale) {
+        return config.bower + 'angular-i18n/angular-locale_' + locale + '.js';
+    });
+    return gulp.src(locales)
         .pipe(plumber({errorHandler: handleErrors}))
         .pipe(changed(config.app + 'i18n/'))
         .pipe(gulp.dest(config.app + 'i18n/'));


### PR DESCRIPTION
I just noticed that the `languages` gulp task doesn't work if `.yo-rc.json` lists only a single language.

It turns out that the glob that was used, `angular-i18n/angular-locale_{...}` doesn't match anything if there is only a single item between the braces! Maybe this is a bug in `glob-stream`, it certainly seems unexpected behaviour to me.

Anyway, this PR remedies the situation by using an array instead of a glob.