### PR TITLE
Only inject DateUtils into angular factory when entity has a date field

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/services/_entity.service.js
+++ b/generators/entity/templates/src/main/webapp/app/services/_entity.service.js
@@ -11,7 +11,7 @@ _%>
 
     <%= entityClass %>.$inject = ['$resource'<% if (hasDate) { %>, 'DateUtils'<% } %>];
 
-    function <%= entityClass %> ($resource, DateUtils) {
+    function <%= entityClass %> ($resource<% if (hasDate) { %>, DateUtils<% } %>) {
         var resourceUrl = <% if (applicationType == 'gateway' && locals.microserviceName) {%> '<%= microserviceName.toLowerCase() %>/' +<% } %> 'api/<%= entityApiUrl %>/:id';
 
         return $resource(resourceUrl, {}, {


### PR DESCRIPTION
When no date field is found in the entity, DateUtils is not injected into the factory but is still found in the function parameters.