### PR TITLE
Travis: change baseName and force no insight

### DIFF
--- a/travis/configstore/insight-generator-jhipster.json
+++ b/travis/configstore/insight-generator-jhipster.json
@@ -1,0 +1,4 @@
+{
+	"clientId": 495049364328,
+	"optOut": true
+}

--- a/travis/configstore/insight-yo.json
+++ b/travis/configstore/insight-yo.json
@@ -1,0 +1,4 @@
+{
+	"clientId": 495049364328,
+	"optOut": true
+}

--- a/travis/install/02-install-jhipster-stack.sh
+++ b/travis/install/02-install-jhipster-stack.sh
@@ -17,3 +17,7 @@ cd "$TRAVIS_BUILD_DIR"/
 npm install
 npm link
 npm test
+#-------------------------------------------------------------------------------
+# Force no insight
+#-------------------------------------------------------------------------------
+mv "$JHIPSTER_TRAVIS"/configstore/*.json "$HOME"/.config/configstore/

--- a/travis/install/02-install-jhipster-stack.sh
+++ b/travis/install/02-install-jhipster-stack.sh
@@ -20,4 +20,5 @@ npm test
 #-------------------------------------------------------------------------------
 # Force no insight
 #-------------------------------------------------------------------------------
+mkdir -p "$HOME"/.config/configstore/
 mv "$JHIPSTER_TRAVIS"/configstore/*.json "$HOME"/.config/configstore/

--- a/travis/install/02-install-jhipster-stack.sh
+++ b/travis/install/02-install-jhipster-stack.sh
@@ -17,8 +17,3 @@ cd "$TRAVIS_BUILD_DIR"/
 npm install
 npm link
 npm test
-#-------------------------------------------------------------------------------
-# Force no insight
-#-------------------------------------------------------------------------------
-mkdir -p "$HOME"/.config/configstore/
-mv "$JHIPSTER_TRAVIS"/configstore/*.json "$HOME"/.config/configstore/

--- a/travis/samples/app-cassandra/.yo-rc.json
+++ b/travis/samples/app-cassandra/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleCassandra",
+    "baseName": "travisCassandra",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -18,9 +18,10 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "cc15d9676c1f804a5a1cf653d0cb9ae1f9d6ea47",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-default-from-scratch/.yo-rc.json
+++ b/travis/samples/app-default-from-scratch/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleDefaultFromScratch",
+    "baseName": "travisDefaultFromScratch",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -21,6 +21,7 @@
     "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-gateway/.yo-rc.json
+++ b/travis/samples/app-gateway/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "gateway",
-    "baseName": "sampleDefault",
+    "baseName": "travisDefault",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "jwt",
@@ -21,6 +21,7 @@
     "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-gradle/.yo-rc.json
+++ b/travis/samples/app-gradle/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleGradle",
+    "baseName": "travisGradle",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -18,10 +18,11 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "0b557a1f94eb8ea76db0a95b5e8b64bec08bb869",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling",
       "protractor"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-hazelcast-cucumber/.yo-rc.json
+++ b/travis/samples/app-hazelcast-cucumber/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleHazelcastCucumber",
+    "baseName": "travisHazelcastCucumber",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -18,10 +18,11 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "c6d1cbd204e019098d31fef0224d3462cb89f22d",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling",
       "cucumber"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-jwt/.yo-rc.json
+++ b/travis/samples/app-jwt/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "SampleJwt",
+    "baseName": "travisJwt",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "jwt",
@@ -18,9 +18,10 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "aa7cd1151a7181987d053a4a7e2667036abac16a",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-microservice/.yo-rc.json
+++ b/travis/samples/app-microservice/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "microservice",
-    "baseName": "sampleDefault",
+    "baseName": "travisMicroservice",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "jwt",
@@ -25,6 +25,7 @@
     ],
     "enableSocialSignIn": false,
     "skipClient": true,
-    "skipUserManagement": true
+    "skipUserManagement": true,
+    "travis": true
   }
 }

--- a/travis/samples/app-mongodb/.yo-rc.json
+++ b/travis/samples/app-mongodb/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleMongo",
+    "baseName": "travisMongo",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -18,9 +18,10 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "4207b631feea9ca5dc7d09b5dd45cf3c30222854",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-mysql/.yo-rc.json
+++ b/travis/samples/app-mysql/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleMysql",
+    "baseName": "travisMysql",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -18,10 +18,11 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "338224d584859bd80d093bc4346526637190816b",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling",
       "protractor"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-oauth2/.yo-rc.json
+++ b/travis/samples/app-oauth2/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "SampleOauth2",
+    "baseName": "travisOauth2",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "oauth2",
@@ -18,9 +18,10 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": false,
-    "rememberMeKey": "aa7cd1151a7181987d053a4a7e2667036abac16a",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-psql-es-noi18n/.yo-rc.json
+++ b/travis/samples/app-psql-es-noi18n/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "samplePsqlEsNoi18n",
+    "baseName": "travisPsqlEsNoi18n",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -16,10 +16,11 @@
     "buildTool": "maven",
     "enableTranslation": false,
     "enableSocialSignIn": false,
-    "rememberMeKey": "efaf561e5400af2877060b33324f34288d671c97",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling",
       "protractor"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/samples/app-social-websocket/.yo-rc.json
+++ b/travis/samples/app-social-websocket/.yo-rc.json
@@ -1,7 +1,7 @@
 {
   "generator-jhipster": {
     "applicationType": "monolith",
-    "baseName": "sampleSocialWebsocket",
+    "baseName": "travisSocialWebsocket",
     "packageName": "com.mycompany.myapp",
     "packageFolder": "com/mycompany/myapp",
     "authenticationType": "session",
@@ -18,10 +18,11 @@
     "nativeLanguage": "en",
     "languages": ["en", "fr"],
     "enableSocialSignIn": true,
-    "rememberMeKey": "cb7ffe96c2de12a54c69ec0940d49c36d596375f",
+    "rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb",
     "testFrameworks": [
       "gatling",
       "protractor"
-    ]
+    ],
+    "travis": true
   }
 }

--- a/travis/scripts/01-generate-project.sh
+++ b/travis/scripts/01-generate-project.sh
@@ -1,6 +1,12 @@
 #!/bin/bash
 set -ev
 #-------------------------------------------------------------------------------
+# Force no insight
+#-------------------------------------------------------------------------------
+mkdir -p "$HOME"/.config/configstore/
+mv "$JHIPSTER_TRAVIS"/configstore/*.json "$HOME"/.config/configstore/
+
+#-------------------------------------------------------------------------------
 # Generate the project with yo jhipster
 #-------------------------------------------------------------------------------
 mv -f "$JHIPSTER_SAMPLES"/"$JHIPSTER" "$HOME"/

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -8,8 +8,8 @@ if [ "$RUN_APP" == 1 ]; then
   if [ "$JHIPSTER" != "app-gradle" ]; then
     if [ "$JHIPSTER" == 'app-cassandra' ]; then
       chmod -R 777 src/main/resources/config/cql/
-      docker cp src/main/resources/config/cql/ samplecassandra-cassandra:/
-      docker exec -it samplecassandra-cassandra init
+      docker cp src/main/resources/config/cql/ traviscassandra-cassandra:/
+      docker exec -it traviscassandra-cassandra init
     fi
     mvn package -DskipTests=true -P"$PROFILE"
     mv target/*.war target/app.war


### PR DESCRIPTION
@jdubois : I made some change, so it will be easy for you to filter/track these projects by baseName / rememberMeKey
- change all baseName to `travis*`
- all `"rememberMeKey": "f19f0827c622eb9b81f5227a869ccd44932d78eb"`
- add no-insight json to travis build

We already use [`yo jhipster --force --no-insight`](https://github.com/jhipster/generator-jhipster/blob/master/travis/scripts/01-generate-project.sh#L14) but to be sure for JHipster stats