### PR TITLE
Fix Cassandra Dockerfile path in docker-compose subgenerator

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -5,6 +5,8 @@ var shelljs = require('shelljs');
 var crypto = require('crypto');
 var _ = require('lodash');
 var jsyaml = require('js-yaml');
+var pathjs = require('path');
+
 
 module.exports = yeoman.Base.extend({
     initializing: {
@@ -231,6 +233,10 @@ module.exports = yeoman.Base.extend({
                     var databaseYaml = jsyaml.load(this.fs.read(path + '/src/main/docker/' + database + '.yml'));
                     var databaseYamlConfig = databaseYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database];
                     delete databaseYamlConfig.ports;
+                    if(this.appConfigs[i].devDatabaseType === 'cassandra') {
+                        var relativePath = pathjs.relative(this.destinationRoot(), path + '/src/main/docker');
+                        databaseYamlConfig.build.context = relativePath;
+                    }
                     parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-' + database] = databaseYamlConfig;
                 }
                 // Add search engine configuration


### PR DESCRIPTION
Fix #3238 
Now putting the relative path to the dockerfile in `context` property.