### PR TITLE
Travis: keep phantomjs prebuilt

### DIFF
--- a/travis/scripts/01-generate-project.sh
+++ b/travis/scripts/01-generate-project.sh
@@ -14,7 +14,6 @@ cd "$HOME"/"$JHIPSTER"
 
 rm -Rf "$HOME"/"$JHIPSTER"/node_modules/.bin/*grunt*
 rm -Rf "$HOME"/"$JHIPSTER"/node_modules/*grunt*
-rm -Rf "$HOME"/"$JHIPSTER"/node_modules/*phantom*
 
 npm link generator-jhipster
 yo jhipster --force --no-insight


### PR DESCRIPTION
The dependencies has been updated here : https://github.com/jhipster/jhipster-travis-build/issues/1
So now, the phantomjs cache is correct, no need to delete before yo jhipster

The main issue was travis failed randomly to download phantomjs-2.1.1 :
```yaml
Error requesting archive.
Status: 403
Request options: {
  "uri": "https://bitbucket.org/ariya/phantomjs/downloads/phantomjs-2.1.1-linux-x86_64.tar.bz2",
  "encoding": null,
  "followRedirect": true,
  "headers": {
    "User-Agent": "npm/2.14.20 node/v4.4.1 linux x64"
  },
  "strictSSL": true
}
Response headers: {
  "x-amz-request-id": "CE53C953C448DC25",
  "x-amz-id-2": "M7eyD4paNl+LiHllYkA/OKdrhJvo+IyU93irKSeod1w3s7dDjvzXZMsL8gVQHZme1fwIiK3IGq4=",
  "content-type": "application/xml",
  "transfer-encoding": "chunked",
  "date": "Wed, 23 Mar 2016 08:07:17 GMT",
  "server": "AmazonS3",
  "connection": "close"
}
Make sure your network and proxy settings are correct.
``` 