### PR TITLE
enable swagger via application property

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_GatewayConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_GatewayConfiguration.java
@@ -39,7 +39,7 @@ public class GatewayConfiguration {
      * Configures the Zuul filter that limits the number of API calls per user.
      * <p>
      * For this filter to work, you need to have:
-     * <p><ul>
+     * <ul>
      * <li>A working Cassandra cluster
      * <li>A schema with the JHipster rate-limiting tables configured, using the
      * "create_keyspace.cql" and "create_tables.cql" scripts from the
@@ -49,7 +49,7 @@ public class GatewayConfiguration {
      * <li>Spring Data Cassandra running, by removing in your application-*.yml the
      * "spring.autoconfigure.exclude" key that excludes the Cassandra and Spring Data
      * Cassandra auto-configuration.
-     * </ul><p>
+     * </ul>
      */
     @Configuration
     @ConditionalOnProperty("jhipster.gateway.rate-limiting.enabled")

--- a/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
+++ b/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
@@ -366,6 +366,8 @@ public class JHipsterProperties {
 
         private String licenseUrl;
 
+        private Boolean enabled;
+
         public String getTitle() {
             return title;
         }
@@ -436,6 +438,14 @@ public class JHipsterProperties {
 
         public void setLicenseUrl(String licenseUrl) {
             this.licenseUrl = licenseUrl;
+        }
+
+        public Boolean isEnabled() {
+            return enabled;
+        }
+
+        public void setEnabled(Boolean enabled) {
+            this.enabled = enabled;
         }
     }
 

--- a/generators/server/templates/src/main/java/package/config/apidoc/_GatewaySwaggerResourcesProvider.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_GatewaySwaggerResourcesProvider.java
@@ -7,7 +7,8 @@ import javax.inject.Inject;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.*;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
@@ -22,7 +23,8 @@ import springfox.documentation.swagger.web.SwaggerResourcesProvider;
  */
 @Component
 @Primary
-@ConditionalOnExpression("#{!environment.acceptsProfiles('" + Constants.SPRING_PROFILE_NO_SWAGGER + "') && !environment.acceptsProfiles('" + Constants.SPRING_PROFILE_PRODUCTION + "')}")
+@Profile("!" + Constants.SPRING_PROFILE_NO_SWAGGER)
+@ConditionalOnProperty(value="jhipster.swagger.enabled")
 public class GatewaySwaggerResourcesProvider implements SwaggerResourcesProvider {
 
     private final Logger log = LoggerFactory.getLogger(GatewaySwaggerResourcesProvider.class);

--- a/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
@@ -6,7 +6,7 @@ import <%=packageName%>.config.JHipsterProperties;
 import java.util.Date;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnExpression;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.*;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.ResponseEntity;
@@ -28,7 +28,8 @@ import static springfox.documentation.builders.PathSelectors.regex;
  */
 @Configuration
 @EnableSwagger2
-@ConditionalOnExpression("#{!environment.acceptsProfiles('" + Constants.SPRING_PROFILE_NO_SWAGGER + "') && !environment.acceptsProfiles('" + Constants.SPRING_PROFILE_PRODUCTION + "')}")
+@Profile("!" + Constants.SPRING_PROFILE_NO_SWAGGER)
+@ConditionalOnProperty(value="jhipster.swagger.enabled")
 public class SwaggerConfiguration {
 
     private final Logger log = LoggerFactory.getLogger(SwaggerConfiguration.class);

--- a/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/apidoc/_SwaggerConfiguration.java
@@ -29,7 +29,7 @@ import static springfox.documentation.builders.PathSelectors.regex;
 @Configuration
 @EnableSwagger2
 @Profile("!" + Constants.SPRING_PROFILE_NO_SWAGGER)
-@ConditionalOnProperty(value="jhipster.swagger.enabled")
+@ConditionalOnProperty(prefix="jhipster.swagger", name="enabled")
 public class SwaggerConfiguration {
 
     private final Logger log = LoggerFactory.getLogger(SwaggerConfiguration.class);

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -187,3 +187,5 @@ jhipster:
             host: localhost
             port: 5000
             queueSize: 512
+    swagger: # swagger is enabled. It can be disabled by pasing 'no-swagger' profile at run time as well
+        enabled: false

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -188,4 +188,4 @@ jhipster:
             port: 5000
             queueSize: 512
     swagger: # swagger is enabled. It can be disabled by pasing 'no-swagger' profile at run time as well
-        enabled: false
+        enabled: true

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -185,3 +185,5 @@ jhipster:
             host: localhost
             port: 5000
             queueSize: 512
+    swagger: # swagger is disabled. It can be disabled by pasing 'no-swagger' profile at run time as well
+        enabled: false

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -14,6 +14,9 @@
 eureka:
     client:
         enabled: false
+    instance:
+        appname: <%= baseName %>
+        instanceId: <%= baseName %>:${spring.application.instance_id:${random.value}}
 
 <%_ } _%>
 spring:

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -17,6 +17,8 @@ eureka:
 
 <%_ } _%>
 spring:
+    application:
+        name: <%= baseName %>
     <%_ if (applicationType == 'gateway' && databaseType != 'cassandra') { _%>
     autoconfigure:
         exclude: org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration, org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration
@@ -132,3 +134,4 @@ jhipster:
         contactEmail:
         license:
         licenseUrl:
+        enabled: false


### PR DESCRIPTION
This is as per request by @cbornet earlier.

swagger can be enabled or disabled from `application-*.yml` as well. its disabled by default in production to retain current behavior

so if someone wants swagger in production they can enable it by setting `jhipster.swagger.enabled: true` and then they can use the `no-swagger` switch for finer control at run time