### PR TITLE
Travis phantomjs cache

### DIFF
--- a/travis/install/04-cache.sh
+++ b/travis/install/04-cache.sh
@@ -15,3 +15,14 @@ if [ "$JHIPSTER_NODE_CACHE" == 1 ]; then
   mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/node_modules/ "$JHIPSTER_SAMPLES/$JHIPSTER"/
   ls -al "$JHIPSTER_SAMPLES"/"$JHIPSTER"/
 fi
+#-------------------------------------------------------------------------------
+# Use phantomjs cache
+#-------------------------------------------------------------------------------
+tar -xvf "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C "$TRAVIS_BUILD_DIR"/jhipster-travis-build/
+mkdir -p /usr/local/phantomjs-2.1.1/
+mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/LICENSE.BSD /usr/local/phantomjs-2.1.1/
+mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/phantomjs-2.1.1/
+ln -sf /usr/local/phantomjs-2.1.1/ /usr/local/phantomjs
+ls -l /usr/local/
+ls -l /usr/local/phantomjs/
+ls -l /usr/local/phantomjs-2.1.1/

--- a/travis/install/04-cache.sh
+++ b/travis/install/04-cache.sh
@@ -19,10 +19,11 @@ fi
 # Use phantomjs cache
 #-------------------------------------------------------------------------------
 tar -xvf "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C "$TRAVIS_BUILD_DIR"/jhipster-travis-build/
-mkdir -p /usr/local/phantomjs-2.1.1/
-mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/LICENSE.BSD /usr/local/phantomjs-2.1.1/
-mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/phantomjs-2.1.1/
-ln -sf /usr/local/phantomjs-2.1.1/ /usr/local/phantomjs
+sudo mkdir -p /usr/local/phantomjs-2.1.1/
+sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/LICENSE.BSD /usr/local/phantomjs-2.1.1/
+sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/phantomjs-2.1.1/
+sudo rm /usr/local/phantomjs
+sudo ln -sf /usr/local/phantomjs-2.1.1/ /usr/local/phantomjs
 ls -l /usr/local/
 ls -l /usr/local/phantomjs/
 ls -l /usr/local/phantomjs-2.1.1/


### PR DESCRIPTION
Travis provides by default: phantomjs 2.0.0
We use phantomjs 2.1.1

Fix https://github.com/jhipster/jhipster-travis-build/issues/1