### PR TITLE
Docker-compose: use jre-alpine instead of jdk-alpine 

### DIFF
--- a/generators/server/templates/src/main/docker/_Dockerfile
+++ b/generators/server/templates/src/main/docker/_Dockerfile
@@ -1,4 +1,4 @@
-FROM java:openjdk-8-jdk-alpine
+FROM java:openjdk-8-jre-alpine
 
 # add directly the war
 ADD *.war /app.war


### PR DESCRIPTION
It's to save ~40MB on every Docker image

Before:
```shell
REPOSITORY          TAG                 IMAGE ID            CREATED              SIZE
jhigateway          latest              227cf8eb40c0        About a minute ago   296.4 MB
mspsql              latest              4937e453f3b5        7 minutes ago        288.5 MB
msmongo             latest              78de03b54d80        7 minutes ago        264.6 MB
```

After:
```shell
REPOSITORY          TAG                 IMAGE ID            CREATED             SIZE
jhigateway          latest              c6a8058ce055        11 seconds ago      259.4 MB
mspsql              latest              9f10b026c8f7        4 minutes ago       251.3 MB
msmongo             latest              bb1c3f6a53fb        5 minutes ago       227.4 MB
```