### PR TITLE
Fix auth-expired redirect after one failed login attempt

### DIFF
--- a/generators/client/templates/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.js
@@ -40,13 +40,15 @@
         function responseError(response) {
             // If we have an unauthorized request we redirect to the login page
             // Don't do this check on the account API to avoid infinite loop
-            if (response.status === 401 && angular.isDefined(response.data.path) && response.data.path.indexOf('/api/account') === -1){
+            if (response.status === 401 && angular.isDefined(response.data.path) && response.data.path.indexOf('/api/account') === -1) {
                 var Auth = $injector.get('Auth');
                 var to = $rootScope.toState;
                 var params = $rootScope.toStateParams;
                 Auth.logout();
-                $rootScope.previousStateName = to;
-                $rootScope.previousStateNameParams = params;
+                if (to.name !== 'accessdenied') {
+                    $rootScope.previousStateName = to;
+                    $rootScope.previousStateNameParams = params;
+                }
                 var LoginPopupService = $injector.get('LoginService');
                 LoginPopupService.open();
             } else if (response.status === 403 && response.config.method !== 'GET' && getCSRF() === '') {


### PR DESCRIPTION
If a user enters the wrong password on the way to a secured state, the login window reappears but $rootScope.previousStateName changes to 'accessdenied'

This change prevents prevents the 'accessdenied' state from being stored in the previousStateName.  It fixes the flow so that if a user enters an incorrect password but then fixes his mistake on another login attempt, he is correctly redirected to the destination state.