### PR TITLE
fix configserver.status URL so that it can be opened in a browser

### DIFF
--- a/generators/docker-compose/templates/central-server-config/_application.yml
+++ b/generators/docker-compose/templates/central-server-config/_application.yml
@@ -1,6 +1,6 @@
 #common configuration shared between all applications
 configserver:
-    status: ${spring.cloud.config.uri}/${spring.cloud.config.label}/${spring.cloud.config.name}-${spring.cloud.config.profile}.yml
+    status: ${spring.cloud.config.uri}/${spring.cloud.config.label}/${spring.cloud.config.name}-${spring.cloud.config.profile}.yml/
 jhipster:
     security:
         authentication:


### PR DESCRIPTION
Add a trailing slash to fix it. Same as here: https://github.com/jhipster/jhipster-registry/pull/27