### PR TITLE
Cluster Mode for MongoDB

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -278,6 +278,9 @@ module.exports = JhipsterClientGenerator.extend({
             if (configOptions.languages != null) {
                 this.languages = configOptions.languages;
             }
+            if (configOptions.mongoCluster != null) {
+                this.mongoCluster = configOptions.mongoCluster;
+            }
 
             // Make dist dir available in templates
             if (configOptions.buildTool === 'maven') {

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -233,9 +233,17 @@ module.exports = yeoman.Base.extend({
                     var databaseYaml = jsyaml.load(this.fs.read(path + '/src/main/docker/' + database + '.yml'));
                     var databaseYamlConfig = databaseYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database];
                     delete databaseYamlConfig.ports;
-                    if(this.appConfigs[i].devDatabaseType === 'cassandra') {
+                    if(database === 'cassandra') {
                         var relativePath = pathjs.relative(this.destinationRoot(), path + '/src/main/docker');
                         databaseYamlConfig.build.context = relativePath;
+                    }
+                    if(database === 'mongodb' && this.appConfigs[i].mongoCluster) {
+                        var relativePath = pathjs.relative(this.destinationRoot(), path + '/src/main/docker');
+                        var mongodbNodeConfig = databaseYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-node'];
+                        var mongoDbConfigSrvConfig = databaseYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-config'];
+                        mongodbNodeConfig.build.context = relativePath;
+                        parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-node'] = mongodbNodeConfig;
+                        parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-config'] = mongoDbConfigSrvConfig;
                     }
                     parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-' + database] = databaseYamlConfig;
                 }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -116,6 +116,7 @@ module.exports = JhipsterServerGenerator.extend({
                 this.devDatabaseType = 'mongodb';
                 this.prodDatabaseType = 'mongodb';
                 this.hibernateCache = 'no';
+                this.mongoCluster = this.config.get('mongoCluster');
             } else if (this.databaseType == 'cassandra') {
                 this.devDatabaseType = 'cassandra';
                 this.prodDatabaseType = 'cassandra';
@@ -406,6 +407,19 @@ module.exports = JhipsterServerGenerator.extend({
                 },
                 {
                     when: function (response) {
+                        return response.databaseType == 'mongodb';
+                    },
+                    type: 'confirm',
+                    name: 'mongoCluster',
+                    message: function (response) {
+                        return getNumberedQuestion('Do you want to use Mongo in cluster mode?', currentQuestion, totalQuestions, function (current) {
+                            currentQuestion = current;
+                        }, response.databaseType == 'mongodb');
+                    },
+                    default: false
+                },
+                {
+                    when: function (response) {
                         return response.databaseType == 'sql';
                     },
                     type: 'list',
@@ -666,6 +680,7 @@ module.exports = JhipsterServerGenerator.extend({
                     this.devDatabaseType = 'mongodb';
                     this.prodDatabaseType = 'mongodb';
                     this.hibernateCache = 'no';
+                    this.mongoCluster = props.mongoCluster;
                 } else if (this.databaseType == 'cassandra') {
                     this.devDatabaseType = 'cassandra';
                     this.prodDatabaseType = 'cassandra';
@@ -689,6 +704,7 @@ module.exports = JhipsterServerGenerator.extend({
             configOptions.totalQuestions = totalQuestions;
             configOptions.packageName = this.packageName;
             configOptions.hibernateCache = this.hibernateCache;
+            configOptions.mongoCluster = this.mongoCluster;
             configOptions.clusteredHttpSession = this.clusteredHttpSession;
             configOptions.websocket = this.websocket;
             configOptions.databaseType = this.databaseType;
@@ -760,6 +776,7 @@ module.exports = JhipsterServerGenerator.extend({
             this.config.set('serverPort', this.serverPort);
             this.config.set('authenticationType', this.authenticationType);
             this.config.set('hibernateCache', this.hibernateCache);
+            this.config.set('mongoCluster', this.mongoCluster);
             this.config.set('clusteredHttpSession', this.clusteredHttpSession);
             this.config.set('websocket', this.websocket);
             this.config.set('databaseType', this.databaseType);

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -841,6 +841,10 @@ module.exports = JhipsterServerGenerator.extend({
             }
             if (this.prodDatabaseType == "mongodb") {
                 this.template(DOCKER_DIR + '_mongodb.yml', DOCKER_DIR + 'mongodb.yml', this, {});
+                if(this.mongoCluster) {
+                    this.copy(DOCKER_DIR + 'mongodb/MongoDB.Dockerfile', DOCKER_DIR + 'mongodb/MongoDB.Dockerfile', this, {});
+                    this.template(DOCKER_DIR + 'mongodb/scripts/init_replicaset.js', DOCKER_DIR + 'mongodb/scripts/init_replicaset.js', this, {});
+                }
             }
             if (this.applicationType == 'gateway' || this.prodDatabaseType == "cassandra") {
                 this.template(DOCKER_DIR + '_cassandra.yml', DOCKER_DIR + 'cassandra.yml', this, {});

--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -70,7 +70,16 @@ services:
         extends:
             file: mongodb.yml
             service: <%= baseName.toLowerCase() %>-mongodb
-    <%_ } _%>
+    <%_ if (mongoCluster) { _%>
+    <%= baseName.toLowerCase() %>-mongodb-node:
+        extends:
+            file: mongodb.yml
+            service: <%= baseName.toLowerCase() %>-mongodb-node
+    <%= baseName.toLowerCase() %>-mongodb-config:
+        extends:
+            file: mongodb.yml
+            service: <%= baseName.toLowerCase() %>-mongodb-config
+    <%_ }} _%>
     <%_ if (prodDatabaseType == 'cassandra') { _%>
     <%= baseName.toLowerCase() %>-cassandra:
         extends:

--- a/generators/server/templates/src/main/docker/_mongodb.yml
+++ b/generators/server/templates/src/main/docker/_mongodb.yml
@@ -6,9 +6,9 @@ services:
         build:
             context: .
             dockerfile: mongodb/MongoDB.Dockerfile
-        command: mongos --port 27017
-        expose:
-            - "27017"
+        command: mongos
+        ports:
+            - "27017:27017"
         <%_ } else { _%>
         image: mongo:3.2.3
         # volumes:

--- a/generators/server/templates/src/main/docker/_mongodb.yml
+++ b/generators/server/templates/src/main/docker/_mongodb.yml
@@ -9,7 +9,7 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/
         <%_ } else { _%>
-        command: mongos --configdb mongo-config
+        command: mongos --configdb mongodb-config
     <%= baseName.toLowerCase() %>-mongodb-node:
         build:
             context: .
@@ -17,9 +17,9 @@ services:
         expose:
             - "27017"
         command: mongod --replSet rs1 --noprealloc --smallfiles
-    <%= baseName.toLowerCase() %>-mongo-config:
+    <%= baseName.toLowerCase() %>-mongodb-config:
         image: mongo:3.2.3
-        container_name: mongo-config
+        container_name: mongodb-config
         expose:
             - "27019"
         command: mongod --noprealloc --smallfiles --configsvr --dbpath /data/db

--- a/generators/server/templates/src/main/docker/_mongodb.yml
+++ b/generators/server/templates/src/main/docker/_mongodb.yml
@@ -2,8 +2,24 @@ version: '2'
 services:
     <%= baseName.toLowerCase() %>-mongodb:
         container_name: <%= baseName.toLowerCase() %>-mongodb
+        <%_ if (mongoCluster) { _%>
+        build:
+            context: .
+            dockerfile: mongodb/MongoDB.Dockerfile
+        command: mongos --port 27017
+        expose:
+            - "27017"
+        <%_ } else { _%>
         image: mongo:3.2.3
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/
         ports:
             - 27017:27017
+        <%_ } _%>
+    <%= baseName.toLowerCase() %>-mongodb-node:
+        build:
+            context: .
+            dockerfile: mongodb/MongoDB.Dockerfile
+        expose:
+            - "27017"
+        command: mongod --replSet rs1 --noprealloc --smallfiles

--- a/generators/server/templates/src/main/docker/_mongodb.yml
+++ b/generators/server/templates/src/main/docker/_mongodb.yml
@@ -9,7 +9,7 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/
         <%_ } else { _%>
-        command: mongos --configdb mongodb-config
+        command: mongos --configdb <%= baseName.toLowerCase() %>-mongodb-config
     <%= baseName.toLowerCase() %>-mongodb-node:
         build:
             context: .
@@ -19,7 +19,7 @@ services:
         command: mongod --replSet rs1 --noprealloc --smallfiles
     <%= baseName.toLowerCase() %>-mongodb-config:
         image: mongo:3.2.3
-        container_name: mongodb-config
+        container_name: <%= baseName.toLowerCase() %>-mongodb-config
         expose:
             - "27019"
         command: mongod --noprealloc --smallfiles --configsvr --dbpath /data/db

--- a/generators/server/templates/src/main/docker/_mongodb.yml
+++ b/generators/server/templates/src/main/docker/_mongodb.yml
@@ -14,13 +14,9 @@ services:
         build:
             context: .
             dockerfile: mongodb/MongoDB.Dockerfile
-        expose:
-            - "27017"
         command: mongod --replSet rs1 --noprealloc --smallfiles
     <%= baseName.toLowerCase() %>-mongodb-config:
         image: mongo:3.2.3
         container_name: <%= baseName.toLowerCase() %>-mongodb-config
-        expose:
-            - "27019"
         command: mongod --noprealloc --smallfiles --configsvr --dbpath /data/db
     <%_ } _%>

--- a/generators/server/templates/src/main/docker/_mongodb.yml
+++ b/generators/server/templates/src/main/docker/_mongodb.yml
@@ -2,20 +2,14 @@ version: '2'
 services:
     <%= baseName.toLowerCase() %>-mongodb:
         container_name: <%= baseName.toLowerCase() %>-mongodb
-        <%_ if (mongoCluster) { _%>
-        build:
-            context: .
-            dockerfile: mongodb/MongoDB.Dockerfile
-        command: mongos
+        image: mongo:3.2.3
         ports:
             - "27017:27017"
-        <%_ } else { _%>
-        image: mongo:3.2.3
+        <%_ if (!mongoCluster) { _%>
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/
-        ports:
-            - 27017:27017
-        <%_ } _%>
+        <%_ } else { _%>
+        command: mongos --configdb mongo-config
     <%= baseName.toLowerCase() %>-mongodb-node:
         build:
             context: .
@@ -23,3 +17,10 @@ services:
         expose:
             - "27017"
         command: mongod --replSet rs1 --noprealloc --smallfiles
+    <%= baseName.toLowerCase() %>-mongo-config:
+        image: mongo:3.2.3
+        container_name: mongo-config
+        expose:
+            - "27019"
+        command: mongod --noprealloc --smallfiles --configsvr --dbpath /data/db
+    <%_ } _%>

--- a/generators/server/templates/src/main/docker/mongodb/MongoDB.Dockerfile
+++ b/generators/server/templates/src/main/docker/mongodb/MongoDB.Dockerfile
@@ -1,0 +1,2 @@
+FROM mongo:3.2.3
+ADD mongodb/scripts/init_replicaset.js init_replicaset.js

--- a/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
+++ b/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
@@ -4,8 +4,8 @@ if(status.errmsg === 'no replset config has been received') {
 }
 for (var i = 1; i <= param; i++) {
     if(i!==1)
-        rs.add("docker_<%= baseName.toLowerCase() %>-mongodb-node_" + i + ":27017");
+        rs.add(folder+"_<%= baseName.toLowerCase() %>-mongodb-node_" + i + ":27017");
 }
 cfg = rs.conf();
-cfg.members[0].host = "docker_<%= baseName.toLowerCase() %>-mongodb-node_1:27017";
+cfg.members[0].host = folder+"_<%= baseName.toLowerCase() %>-mongodb-node_1:27017";
 rs.reconfig(cfg);

--- a/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
+++ b/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
@@ -4,8 +4,8 @@ if(status.errormsg === 'no replset config has been received') {
 }
 for (var i = 1; i <= param; i++) {
     if(i!==1)
-        rs.add("docker_mongodb-node_" + i + ":27017");
+        rs.add("docker_<%= baseName.toLowerCase() %>-mongodb-node_" + i + ":27017");
 }
 cfg = rs.conf();
-cfg.members[0].host = "docker_mongodb-node_1:27017";
+cfg.members[0].host = "docker_<%= baseName.toLowerCase() %>-mongodb-node_1:27017";
 rs.reconfig(cfg);

--- a/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
+++ b/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
@@ -1,0 +1,11 @@
+var status = rs.status();
+if(status.errormsg === 'no replset config has been received') {
+    rs.initiate();
+}
+for (var i = 1; i <= param; i++) {
+    if(i!==1)
+        rs.add("docker_mongodb-node_" + i + ":27017");
+}
+cfg = rs.conf();
+cfg.members[0].host = "docker_mongodb-node_1:27017";
+rs.reconfig(cfg);

--- a/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
+++ b/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js
@@ -1,5 +1,5 @@
 var status = rs.status();
-if(status.errormsg === 'no replset config has been received') {
+if(status.errmsg === 'no replset config has been received') {
     rs.initiate();
 }
 for (var i = 1; i <= param; i++) {


### PR DESCRIPTION
As the title says, I'm adding a cluster support when the user wants to use a MongoDB database. I used [this guide](https://sebastianvoss.com/docker-mongodb-sharded-cluster.html) to help me configure MongoDB.

### What it actually does :
* Create a replicaset of X node
* Create a server config node
* Add a shard of this replicaset into the Mongo router (`mongos`)

### How to use it :
1. Create an app with MongoDB Cluster Mode (I added a question)
2. Build the image : `docker-compose -f src/main/docker/mongo.yml build`
3. Run the DB : `docker-compose -f src/main/docker/mongo.yml up -d `
4. Scale the mongodb-node : `docker-compose -f src/main/docker/mongo.yml scale appname-mongodb-node=3`
Please note that[ you have to use an odd number of node](https://docs.mongodb.org/manual/core/replication-introduction/).
5. Init the replicaset by running `docker exec -it docker_mongodb-node_1 mongo --eval 'var param=3, folder="docker"' init_replicaset.js`
param is the number of nodes, folder is the folder where the docker-compose YML file is located (I need this to complete the container name in JS file)
6. Init the shard by running `docker exec -it appname-mongodb mongo --eval 'sh.addShard("rs1/docker_mongodb-node_1:27017")'`
7. Start the app : `docker-compose -f src/main/docker/app.yml up -d`

This is a bit hacky but maybe someone will file a cleaner way to do this, for example to get automatically the docker containers name in the init_replicaset.js file.