### PR TITLE
Fix #3290 - automaticaly pick all CQL scripts

### DIFF
--- a/generators/server/templates/src/test/java/package/_AbstractCassandraTest.java
+++ b/generators/server/templates/src/test/java/package/_AbstractCassandraTest.java
@@ -11,6 +11,11 @@ import org.junit.AfterClass;
 import org.junit.BeforeClass;
 
 import java.io.IOException;
+import java.net.URISyntaxException;
+import java.nio.file.DirectoryStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
 
 /**
  * Base class for starting/stopping Cassandra during tests.
@@ -18,12 +23,23 @@ import java.io.IOException;
 public class AbstractCassandraTest {
 
     @BeforeClass
-    public static void startServer() throws InterruptedException, TTransportException, ConfigurationException, IOException {
+    public static void startServer() throws InterruptedException, TTransportException, ConfigurationException, IOException, URISyntaxException  {
         EmbeddedCassandraServerHelper.startEmbeddedCassandra();
         Cluster cluster = new Cluster.Builder().addContactPoints("127.0.0.1").withPort(9142).build();
         Session session = cluster.connect();
         CQLDataLoader dataLoader = new CQLDataLoader(session);
         dataLoader.load(new ClassPathCQLDataSet("config/cql/create-tables.cql", true, "cassandra_unit_keyspace"));
+        applyScripts(dataLoader, "config/cql/", "*_added_entity_*.cql");
+    }
+
+    private static void applyScripts(CQLDataLoader dataLoader, String cqlDir, String pattern) throws IOException, URISyntaxException {
+        Path path = Paths.get(ClassLoader.getSystemResource(cqlDir).toURI());
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, pattern)) {
+            for (Path entry : stream) {
+                String fileName = entry.getFileName().toString();
+                dataLoader.load(new ClassPathCQLDataSet(cqlDir + fileName, false, false, "cassandra_unit_keyspace"));
+            }
+        }
     }
 
     @AfterClass

--- a/travis/scripts/02-generate-entities.sh
+++ b/travis/scripts/02-generate-entities.sh
@@ -10,9 +10,6 @@ generateEntity() {
   local entity="$1"
   if [ -a .jhipster/"$entity".json ]; then
     yo jhipster:entity "$entity" --force --no-insight
-    if [ "$JHIPSTER" == "app-cassandra" ]; then
-      cat src/main/resources/config/cql/*_added_entity_"$entity".cql >> src/main/resources/config/cql/create-tables.cql
-    fi
   fi
 }
 


### PR DESCRIPTION
when starting the embedded cassandra for the tests, also apply all the cql scripts, *_added_entity_*.cql generated by the jhipster:entity generator