### PR TITLE
Fix #3279: Added support for Heroku microservices

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -206,7 +206,7 @@ module.exports = HerokuGenerator.extend({
 
             this.log("");
             this.prompt(prompts, function (props) {
-                var configSetCmd = "heroku config:set " + "JHIPSTER_REGISTRY_URL=" + props.herokuJHipsterRegistry;
+                var configSetCmd = "heroku config:set " + "JHIPSTER_REGISTRY_URL=" + props.herokuJHipsterRegistry + ' --app ' + this.herokuDeployedName;
                 var child = exec(configSetCmd, {}, function (err, stdout, stderr) {
                     if (err) {
                         this.abort = true;

--- a/generators/heroku/templates/_Procfile
+++ b/generators/heroku/templates/_Procfile
@@ -1,1 +1,1 @@
-web: java -jar <% if (buildTool == 'maven') { %>target<% } %><% if (buildTool == 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod,heroku --server.port=$PORT --spring.datasource.maximumPoolSize=10
+web: java -jar <% if (buildTool == 'maven') { %>target<% } %><% if (buildTool == 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod,heroku --server.port=$PORT

--- a/generators/heroku/templates/_application-heroku.yml
+++ b/generators/heroku/templates/_application-heroku.yml
@@ -1,0 +1,20 @@
+# ===================================================================
+# Spring Boot configuration for the "heroku" profile.
+#
+# This configuration overrides the application.yml file.
+# ===================================================================
+
+# ===================================================================
+# Standard Spring Boot properties.
+# Full reference is available at:
+# http://docs.spring.io/spring-boot/docs/current/reference/html/common-application-properties.html
+# ===================================================================
+
+eureka:
+    client:
+        serviceUrl:
+            defaultZone: ${JHIPSTER_REGISTRY_URL}/eureka/
+
+spring:
+  datasource:
+    maximumPoolSize: 10

--- a/generators/heroku/templates/_bootstrap-heroku.yml
+++ b/generators/heroku/templates/_bootstrap-heroku.yml
@@ -1,0 +1,9 @@
+# ===================================================================
+# Spring Cloud Config bootstrap configuration for the "heroku" profile
+# ===================================================================
+
+spring:
+    cloud:
+        config:
+            fail-fast: true
+            uri: ${JHIPSTER_REGISTRY_URL}/config


### PR DESCRIPTION
This PR adds basic support for deploy JHipster microservices to Heroku. It adds the following changes:

* Detects if the app has a database, and added the `HerokuDatabaseConfiguration.java` only if it does.
* Detects if the applicationType is "microservice" or "gateway" and prompts for the Registry URL if it is either.