### PR TITLE
remove angular-scenario in bower.js from devDependencies since it is deprecated

### DIFF
--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -42,8 +42,7 @@
     "swagger-ui": "2.1.4"
   },
   "devDependencies": {
-    "angular-mocks": "1.5.2",
-    "angular-scenario": "1.5.2"
+    "angular-mocks": "1.5.2"
   },
   "overrides": {
     "angular" : {

--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -151,9 +151,6 @@ gulp.task('wiredep:test', function () {
     return gulp.src(config.test + 'karma.conf.js')
         .pipe(plumber({errorHandler: handleErrors}))
         .pipe(wiredep({
-            exclude: [
-                /angular-scenario/
-            ],
             ignorePath: /\.\.\/\.\.\//, // remove ../../ from paths of injected JavaScript files
             devDependencies: true,
             fileTypes: {


### PR DESCRIPTION
Not sure that this is okey to do but I cant find where angular-scenario is used and it works without it and it is deprecated since angular 1.2. Though lets see if the CI builds pass first.

Could someone comment on this if this is no problem? If it's a problem please close this issue.