### PR TITLE
Add --jhi-prefix option in main generator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -63,9 +63,17 @@ module.exports = JhipsterGenerator.extend({
             defaults: true
         });
 
+        // This adds support for a `--jhi-prefix` flag
+        this.option('jhi-prefix', {
+            desc: 'Add prefix before services, controllers and states name',
+            type: String,
+            defaults: 'jhi'
+        });
+
         this.skipClient = configOptions.skipClient = this.options['skip-client'] || this.config.get('skipClient');
         this.skipServer = configOptions.skipServer = this.options['skip-server'] || this.config.get('skipServer');
         this.skipUserManagement = configOptions.skipUserManagement = this.options['skip-user-management'] || this.config.get('skipUserManagement');
+        this.jhiPrefix = configOptions.jhiPrefix = this.options['jhi-prefix'] || this.config.get('jhiPrefix');
         this.withEntities = this.options['with-entities'];
         this.checkInstall = this.options['check-install'];
 

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -73,7 +73,7 @@ module.exports = JhipsterGenerator.extend({
         this.skipClient = configOptions.skipClient = this.options['skip-client'] || this.config.get('skipClient');
         this.skipServer = configOptions.skipServer = this.options['skip-server'] || this.config.get('skipServer');
         this.skipUserManagement = configOptions.skipUserManagement = this.options['skip-user-management'] || this.config.get('skipUserManagement');
-        this.jhiPrefix = configOptions.jhiPrefix = this.options['jhi-prefix'] || this.config.get('jhiPrefix');
+        this.jhiPrefix = configOptions.jhiPrefix = this.options['jhi-prefix'];
         this.withEntities = this.options['with-entities'];
         this.checkInstall = this.options['check-install'];
 
@@ -365,6 +365,7 @@ module.exports = JhipsterGenerator.extend({
             this.config.set('applicationType', this.applicationType);
             this.config.set('baseName', this.baseName);
             this.config.set('testFrameworks', this.testFrameworks);
+            this.config.set('jhiPrefix', this.jhiPrefix);
             this.skipClient && this.config.set('skipClient', true);
             this.skipServer && this.config.set('skipServer', true);
             this.skipUserManagement && this.config.set('skipUserManagement', true);

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -105,7 +105,7 @@ module.exports = JhipsterClientGenerator.extend({
         this.enableSocialSignIn = this.options['social'];
         this.searchEngine = this.options['search-engine'];
         this.hibernateCache = this.options['hb-cache'];
-        this.jhiPrefix = this.options['jhi-prefix'];
+        this.jhiPrefix = configOptions.jhiPrefix || this.options['jhi-prefix'];
         this.jhiPrefixCapitalized = _.upperFirst(this.jhiPrefix);
         this.testFrameworks = [];
         this.options['protractor'] && this.testFrameworks.push('protractor');

--- a/generators/modules/index.js
+++ b/generators/modules/index.js
@@ -55,6 +55,7 @@ module.exports = ModulesGenerator.extend({
         jhipsterVar['languages'] = this.config.get('languages');
         jhipsterVar['enableSocialSignIn'] = this.config.get('enableSocialSignIn');
         jhipsterVar['testFrameworks'] = this.config.get('testFrameworks');
+        jhipsterVar['jhiPrefix'] = this.config.get('jhiPrefix');
 
         jhipsterVar['angularAppName'] = this.getAngularAppName();
         jhipsterVar['mainClassName'] = this.getMainClassName();


### PR DESCRIPTION
Suggested in  #3054 by @deepu105 and @kkorada.
Now the user can pass the --jhi-prefix flag in the main generator : `yo jhipster --jhi-prefix foo` instead of passing it in the client sub-generator.