### PR TITLE
Fixing Docker Compose subgen if no MongoDB applications

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -163,16 +163,16 @@ module.exports = yeoman.Base.extend({
 
         askForClustersMode: function () {
             if(this.abort) return;
-            var done = this.async();
-            var mongoApps = [];
 
+            var mongoApps = [];
             for (var i = 0; i < this.appConfigs.length; i++) {
                 if(this.appConfigs[i].prodDatabaseType === 'mongodb') {
                     mongoApps.push(this.appsFolders[i]);
                 }
             }
-
             if(mongoApps.length===0) return;
+
+            var done = this.async();
 
             var prompts = [{
                 type: 'checkbox',


### PR DESCRIPTION
Because of my PR #3301 the docker-compose subgenerator was exiting after asking for apps if there was no MongoDB apps in the directory.
I was calling `return` after an `async()` call, so now I do this `return` before and it works !

Sorry for this 