### PR TITLE
Adding skip-ssl option in mysqld docker command

### DIFF
--- a/generators/server/templates/src/main/docker/_mysql.yml
+++ b/generators/server/templates/src/main/docker/_mysql.yml
@@ -11,4 +11,4 @@ services:
             - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1
+        command: mysqld --lower_case_table_names=1 --skip-ssl


### PR DESCRIPTION
@jdubois saw a warning when the mySQL docker container was starting, saying that "SSL is not configured".
This command sets an unencrypted connection, that's what JHipster does (all datasources have the useSSL=false parameter in their url) so it's fine.