### PR TITLE
add missing vm prefixes and change register translation

### DIFF
--- a/generators/client/templates/src/main/webapp/app/account/register/register.html
+++ b/generators/client/templates/src/main/webapp/app/account/register/register.html
@@ -120,7 +120,7 @@
             </form>
             <p></p>
             <div class="alert alert-warning" translate="global.messages.info.authenticated" translate-compile>
-                If you want to <a class="alert-link" href="" ng-click="login()">sign in</a>, you can try the default accounts:<br/>- Administrator (login="admin" and password="admin") <br/>- User (login="user" and password="user").
+                If you want to <a class="alert-link" href="" ng-click="vm.login()">sign in</a>, you can try the default accounts:<br/>- Administrator (login="admin" and password="admin") <br/>- User (login="user" and password="user").
             </div>
         </div>
         <%_ if (enableSocialSignIn) { _%>

--- a/generators/client/templates/src/main/webapp/app/account/reset/finish/reset.finish.html
+++ b/generators/client/templates/src/main/webapp/app/account/reset/finish/reset.finish.html
@@ -16,7 +16,7 @@
             </div>
 
             <div class="alert alert-success" ng-show="vm.success">
-                <p translate="reset.finish.messages.success" translate-compile><strong>Your password has been reset.</strong> Please <a class="alert-link" href="" ng-click="login">sign in</a>.</p>
+                <p translate="reset.finish.messages.success" translate-compile><strong>Your password has been reset.</strong> Please <a class="alert-link" href="" ng-click="vm.login()">sign in</a>.</p>
             </div>
 
             <div class="alert alert-danger" ng-show="vm.doNotMatch" translate="global.messages.error.dontmatch">

--- a/generators/client/templates/src/main/webapp/app/admin/audits/audits.html
+++ b/generators/client/templates/src/main/webapp/app/admin/audits/audits.html
@@ -36,6 +36,6 @@
     </table>
 
     <div class="text-center">
-        <uib-pagination class="pagination-sm" total-items="vm.totalItems" ng-model="vm.page" ng-change="vm.loadPage(page)"></uib-pagination>
+        <uib-pagination class="pagination-sm" total-items="vm.totalItems" ng-model="vm.page" ng-change="vm.loadPage(vm.page)"></uib-pagination>
     </div>
 </div>

--- a/generators/client/templates/src/main/webapp/app/home/_home.controller.js
+++ b/generators/client/templates/src/main/webapp/app/home/_home.controller.js
@@ -13,6 +13,7 @@
         vm.account = null;
         vm.isAuthenticated = null;
         vm.login = LoginService.open;
+        vm.register = register;
         $scope.$on('authenticationSuccess', function() {
             getAccount();
         });
@@ -24,6 +25,9 @@
                 vm.account = account;
                 vm.isAuthenticated = Principal.isAuthenticated;
             });
+        }
+        function register () {
+            $state.go('register');
         }
     }
 })();

--- a/generators/languages/templates/src/main/webapp/i18n/ca/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Si vol <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">autenticar-se</a>, pot usar els comptes per defect:<br/>- Administrador (nom d'usuari=\"admin\" i contrasenya=\"admin\") <br/>- Usuari (nom d'usuari=\"user\" i contrasenya=\"user\").",
-                "register": "No disposa d'un compte encara? <a class=\"alert-link\" ui-sref=\"register\">Registri un nou compte</a>"
+                "register": "No disposa d'un compte encara? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Registri un nou compte</a>"
             },
             "error": {
                 "dontmatch" : "La contrasenya i la confirmació no coincideixen!"

--- a/generators/languages/templates/src/main/webapp/i18n/da/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/da/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Hvis du ønsker at <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">logge ind</a>, så kan du prøve det med:<br/>- Administrator (brugernavn=\"admin\" and kodeord=\"admin\") <br/>- User (brugernavn=\"user\" and kodeord=\"user\").",
-                "register": "You don't have an account yet? <a class=\"alert-link\" ui-sref=\"register\">Register a new account</a>"
+                "register": "You don't have an account yet? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Register a new account</a>"
             },
             "error": {
                 "dontmatch": "Kodeordet og dets bekræftelse matcher ikke!"

--- a/generators/languages/templates/src/main/webapp/i18n/de/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/de/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Wenn Sie sich <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">anmelden</a> möchten, versuchen Sie es mit <br/>- Administrator (Name=\"admin\" und Passwort=\"admin\")<br/>- Benutzer (Name=\"user\" und Passwort=\"user\").",
-                "register": "Sie haben noch keinen Zugang? <a class=\"alert-link\" ui-sref=\"register\">Registrieren Sie sich</a>"
+                "register": "Sie haben noch keinen Zugang? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Registrieren Sie sich</a>"
             },
             "error": {
                 "dontmatch": "Das bestätigte Passwort entspricht nicht dem neuen Passwort!"

--- a/generators/languages/templates/src/main/webapp/i18n/el/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/el/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Αν θέλετε να <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">συνδεθείτε</a>, μπορείτε να δοκιμάσετε τους ακολουθους ήδη ύπαρξη λογαριασμούς:<br/>- Διαχειριστής (login=\"admin\" και κωδικός=\"admin\") <br/>- Χρηστης (login=\"user\" και κωδικός=\"user\").",
-                "register": "Δεν έχετε λογαριασμό; <a class=\"alert-link\" ui-sref=\"register\">Δημιουργήστε έναν νέο λογαριασμό</a>"
+                "register": "Δεν έχετε λογαριασμό; <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Δημιουργήστε έναν νέο λογαριασμό</a>"
             },
             "error": {
                 "dontmatch": "Ο κωδικός και η επιβεβαίωση του δεν ταιριάζουν"

--- a/generators/languages/templates/src/main/webapp/i18n/en/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "If you want to <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">sign in</a>, you can try the default accounts:<br/>- Administrator (login=\"admin\" and password=\"admin\") <br/>- User (login=\"user\" and password=\"user\").",
-                "register": "You don't have an account yet? <a class=\"alert-link\" ui-sref=\"register\">Register a new account</a>"
+                "register": "You don't have an account yet? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Register a new account</a>"
             },
             "error": {
                 "dontmatch": "The password and its confirmation do not match!"

--- a/generators/languages/templates/src/main/webapp/i18n/es/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/es/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Si desea <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">iniciar una sesión</a>, puede intentar con las cuentas predeterminadas:<br/>- Administrator (usuario=\"admin\" y contraseña=\"admin\") <br/>- Usuario (usuario=\"user\" y contraseña=\"user\").",
-                "register": "¿No tienes una cuenta todavía? <a class=\"alert-link\" ui-sref=\"register\">Crea una cuenta</a>"
+                "register": "¿No tienes una cuenta todavía? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Crea una cuenta</a>"
             },
             "error": {
                 "dontmatch" : "¡La contraseña y la confirmación de contraseña no coinciden!"

--- a/generators/languages/templates/src/main/webapp/i18n/fr/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Si vous voulez vous <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">connecter</a>, vous pouvez utiliser les comptes par défaut : <br/> - Administrateur (nom d'utilisateur=\"admin\" et mot de passe =\"admin\") <br/> - Utilisateur (nom d'utilisateur=\"user\" et mot de passe =\"user\").",
-                "register": "Vous n'avez pas encore de compte ? <a class=\"alert-link\" ui-sref=\"register\">Créer un compte</a>"
+                "register": "Vous n'avez pas encore de compte ? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Créer un compte</a>"
             },
             "error": {
                 "dontmatch": "Le nouveau mot de passe et sa confirmation ne sont pas égaux!"

--- a/generators/languages/templates/src/main/webapp/i18n/gl/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Se desexa <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">iniciar unha sesión</a>, pode intentalo coas contas predeterminadas:<br/>- Administrator (usuario=\"admin\" e contrasinal=\"admin\") <br/>- Usuario (usuario=\"user\" e contrasinal=\"user\").",
-                "register": "Aínda non tes unha conta de usuario? <a class=\"alert-link\" ui-sref=\"register\">Crea unha conta</a>"
+                "register": "Aínda non tes unha conta de usuario? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Crea unha conta</a>"
             },
             "error": {
                 "dontmatch" : "O contrasinal e a confirmación non coinciden!"

--- a/generators/languages/templates/src/main/webapp/i18n/hi/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "आप <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">साइन इन</a> करने के लिए चाहते हैं, तो आप डिफ़ॉल्ट खातों का प्रयास कर सकते हैं <br/>- व्यवस्थापक (लॉगिन = \"admin\" और पासवर्ड = \"admin\") <br/>- उपयोगकर्ता(लॉगिन \"user\" और पासवर्ड= \"user\")",
-                "register": "आपका खाता मौजूद नहीं है? <a class=\"alert-link\" ui-sref=\"register\">एक नया खाता पंजीकृत करें</a>"
+                "register": "आपका खाता मौजूद नहीं है? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">एक नया खाता पंजीकृत करें</a>"
             },
             "error": {
                 "dontmatch": "पासवर्ड और इसकी पुष्टि से मेल नहीं खाती!"

--- a/generators/languages/templates/src/main/webapp/i18n/hu/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Ha be akar <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">lépni</a>, kipróbálhatja az alapértelmezett azonosítókat:<br/>- Adminisztrátori (azonosító=\"admin\" és a jelszó=\"admin\") <br/>- Felhasználó (azonosító=\"user\" és jelszó=\"user\").",
-                "register": "Nincs még hozzáférése? <a class=\"alert-link\" ui-sref=\"register\">Regisztráljon</a>"
+                "register": "Nincs még hozzáférése? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Regisztráljon</a>"
             },
             "error": {
                 "dontmatch" : "A jelszó és a jelszó megerősítés nem egyezik meg!"

--- a/generators/languages/templates/src/main/webapp/i18n/it/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/it/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Se si vuole <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\"> avviare una sessione</a> , è possibile provare ad utilizzare gli account di default: <br/> - Amministratore (user = \" admin \"e la password = \"admin \") <br/> - utente (user = \"user \" e la password = \"user \")",
-                "register": "Non hai ancora un account <a class=\"alert-link\" ui-sref=\"register\">Crea un account?</a>"
+                "register": "Non hai ancora un account <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Crea un account?</a>"
             },
             "error": {
                 "dontmatch" : "La password e la conferma non corrispondono!"

--- a/generators/languages/templates/src/main/webapp/i18n/ja/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ja/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "<a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">認証</a>を試したければ, デフォルトアカウント:<br/>- 管理者 (ユーザー名=\"admin\", パスワード=\"admin\") <br/>- ユーザー (login=\"user\", password=\"user\").",
-                "register": "アカウントをまだお持ちでないですか? <a class=\"alert-link\" ui-sref=\"register\">アカウントを登録する</a>"
+                "register": "アカウントをまだお持ちでないですか? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">アカウントを登録する</a>"
             },
             "error": {
                 "dontmatch" : "パスワードが一致しません!"

--- a/generators/languages/templates/src/main/webapp/i18n/ko/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "<a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">인증</a>을 원하시면, 기본 계정을 사용할 수 있습니다:<br/>- 관리자 (아이디=\"admin\", 비밀번호=\"admin\") <br/>- 사용자 (아이디=\"user\", 비밀번호=\"user\").",
-                "register": "아직 계정이 없습니까? <a class=\"alert-link\" ui-sref=\"register\">새로운 계정을 등록하세요</a>"
+                "register": "아직 계정이 없습니까? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">새로운 계정을 등록하세요</a>"
             },
             "error": {
                 "dontmatch" : "비밀번호가 일치하지 않습니다!"

--- a/generators/languages/templates/src/main/webapp/i18n/mr/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "आपण <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">साइन इन</a> करू इच्छित असल्यास, तुम्ही मुलभूत खाती प्रयत्न करू शकता:<br/>- प्रशासक (लॉग इन=\"admin\" आणि पासवर्ड=\"admin\") <br/>- वापरकर्ता (लॉग इन=\"user\" आणि पासवर्ड=\"user\").",
-                "register": "आपण खाते नाही? <a class=\"alert-link\" ui-sref=\"register\">नवीन खाते नोंदणी करू</a>"
+                "register": "आपण खाते नाही? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">नवीन खाते नोंदणी करू</a>"
             },
             "error": {
                 "dontmatch": "पासवर्ड आणि त्याची पुष्टीकरण जुळत नाही!"

--- a/generators/languages/templates/src/main/webapp/i18n/nl/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Indien u wilt <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">aanmelden</a>, dan kan u de standaard gebruikers proberen:<br/>- Administrator (login=\"admin\" en wachtwoord=\"admin\") <br/>- Gebruiker (login=\"user\" en wachtwoord=\"user\").",
-                "register": "U heeft nog geen gebruiker? <a class=\"alert-link\" ui-sref=\"register\">Registreer een nieuwe gebruiker</a>"
+                "register": "U heeft nog geen gebruiker? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Registreer een nieuwe gebruiker</a>"
             },
             "error": {
                 "dontmatch" : "Het wachtwoord en zijn bevestiging komen niet overeen!"

--- a/generators/languages/templates/src/main/webapp/i18n/pl/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Jeśli chcesz się <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">zalogować</a>, możesz spróbować któregoś z domyślnych kont:<br/>- Administrator (login=\"admin\" i hasło=\"admin\") <br/>- Użytkownik (login=\"user\" i hasło=\"user\").",
-                "register": "Nie masz jeszcze konta? <a class=\"alert-link\" ui-sref=\"register\">Zarejestruj się</a>"
+                "register": "Nie masz jeszcze konta? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Zarejestruj się</a>"
             },
             "error": {
                 "dontmatch": "Hasło i potwierdzenie nie zgadzają się!"

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Para <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">entrar</a>, utilize as seguintes contas padrões:<br/>- Administrador (usuário=\"admin\" and senha=\"admin\") <br/>- Usuário (usuário=\"user\" and senha=\"user\").",
-                "register": "Não possui uma conta ainda? <a class=\"alert-link\" ui-sref=\"register\">Crie uma nova conta</a>"
+                "register": "Não possui uma conta ainda? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Crie uma nova conta</a>"
             },
             "error": {
                 "dontmatch" : "A senha e sua confirmação devem ser iguais!"

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Para <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">entrar</a>, utilize as seguintes contas:<br/>- Administrador (utilizador=\"admin\" e palavra-passe=\"admin\") <br/>- Utilizador (utilizador=\"user\" e palavra-passe=\"user\").",
-                "register": "Ainda não tem uma conta? <a class=\"alert-link\" ui-sref=\"register\">Crie uma nova conta</a>"
+                "register": "Ainda não tem uma conta? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Crie uma nova conta</a>"
             },
             "error": {
                 "dontmatch" : "A palavra-passe e a sua confirmação devem ser iguais!"

--- a/generators/languages/templates/src/main/webapp/i18n/ro/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/_global.json
@@ -58,7 +58,7 @@
         "messages": {
             "info": {
                 "authenticated": "Dacă doriți să vă <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">autentificați</a>, puteți încerca conturile implicite:<br/>- Administrator (login=\"admin\" si parola=\"admin\") <br/>- Utilizator (login=\"user\" si parola=\"user\").",
-                "register": "Înca nu aveți un cont? <a class=\"alert-link\" ui-sref=\"register\">Înregistrați un nou cont</a>"
+                "register": "Înca nu aveți un cont? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Înregistrați un nou cont</a>"
             },
             "error": {
                 "dontmatch" : "Parola si confirmarea ei nu corespund!"

--- a/generators/languages/templates/src/main/webapp/i18n/ru/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Если вы хотите <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">авторизироваться</a>, вы можете попробовать аккаунты по умолчанию:<br/>- Администратор (логин=\"admin\" и пароль=\"admin\") <br/>- Пользователь (логин=\"user\" и пароль=\"user\").",
-                "register": "У вас нет аккаунта? <a class=\"alert-link\" ui-sref=\"register\">Создать новый аккаунт</a>"
+                "register": "У вас нет аккаунта? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Создать новый аккаунт</a>"
             },
             "error": {
                 "dontmatch": "Пароль и его подтверждение не совпадают!"

--- a/generators/languages/templates/src/main/webapp/i18n/sv/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "Om du vill <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">logga in</a> - prova med standard kontot:<br/>- Administratör (användarnamn=\"admin\" och lösenord=\"admin\") <br/>- Användare (login=\"user\" och lösenord=\"user\").",
-                "register": "Har du inget konto? <a class=\"alert-link\" ui-sref=\"register\">Du kan registrera ett konto</a>"
+                "register": "Har du inget konto? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Du kan registrera ett konto</a>"
             },
             "error": {
                 "dontmatch" : "Lösenorden stämmer inte med varandra!"

--- a/generators/languages/templates/src/main/webapp/i18n/ta/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "<a href=\"#/login\">அங்கீகரிக்க</a>, நீங்கள் இயல்புநிலை கணக்குகள் முயற்சி செய்யலாம்:<br/>- Administrator (login=\"admin\" and password=\"admin\") <br/>- User (login=\"user\" and password=\"user\").",
-                "register": "உங்களுக்கு கணக்கு இல்லை? <a class=\"alert-link\" ui-sref=\"register\">புதிய கணக்கு பதிவு செய்க!</a>"
+                "register": "உங்களுக்கு கணக்கு இல்லை? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">புதிய கணக்கு பதிவு செய்க!</a>"
             },
             "error": {
                 "dontmatch" : "கடவுச்சொல் மற்றும் அதன் உறுதி பொருந்தவில்லை!"

--- a/generators/languages/templates/src/main/webapp/i18n/tr/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "<a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">Giriş</a> yapmak istiyorsanız, varsayılan hesaplardan birini deneyebilirsiniz:<br/>- Yönetici (kullanıcı adı=\"admin\" ve şifre=\"admin\") <br/>- Kullanıcı (kullanıcı adı=\"user\" and şifre=\"user\").",
-                "register": "Henüz bir hesabınız yok mu? <a class=\"alert-link\" ui-sref=\"register\">Yeni hesap oluştur</a>"
+                "register": "Henüz bir hesabınız yok mu? <a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">Yeni hesap oluştur</a>"
             },
             "error": {
                 "dontmatch" : "Şifreler eşleşmedi!"

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "如果您要<a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">登录</a>, 您可以使用默认账号:<br/>- 管理员 (账号=\"admin\"和密码=\"admin\") <br/>- 普通用户 (账号=\"user\"和密码=\"user\").",
-                "register": "您还没有账号？<a class=\"alert-link\" ui-sref=\"register\">注册一个新账号</a>"
+                "register": "您还没有账号？<a class=\"alert-link\" href=\"\" ng-click=\"vm.register()\">注册一个新账号</a>"
             },
             "error": {
                 "dontmatch" : "您输入的密码和确认确认密码不匹配!"

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/_global.json
@@ -49,7 +49,7 @@
         "messages": {
             "info": {
                 "authenticated": "如果您要<a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">登入</a>, 您可以使用預設帳號:<br/>- 管理者 (帳號=\"admin\"與密碼=\"admin\") <br/>- 使用者 (帳號=\"user\"與密碼=\"user\").",
-                "register": "您還沒有帳號？<a class=\"alert-link\" ui-sref=\"register\">註冊一個新帳號</a>"
+                "register": "您還沒有帳號？<a class=\"alert-link\" ng-click=\"vm.register()\">註冊一個新帳號</a>"
             },
             "error": {
                 "dontmatch" : "您輸入的密碼與密碼確認不符合!"


### PR DESCRIPTION
Add more vm's to the app where they are needed.  

Also the register link on the login window was overwritten by the translation which used ui-sref.  This changes the state to register but the login dialog stays open.  I changed the translation to use the vm.register function declared in the LoginController.  This means I had to add a register method to the HomeController so the same translation can be used to get to the register state.  The only other way I could think to do this is copy the translation into the login.json set.