### PR TITLE
Fix a json syntax error in the user-management pt-br i18n file 

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/user-management.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/user-management.json
@@ -3,7 +3,7 @@
         "home": {
             "title": "Usuários",
             "createLabel": "Adicionar",
-             "createOrEitLabel": "Criar ou editar usuário"
+             "createOrEditLabel": "Criar ou editar usuário"
         },
         "created": "Novo usuário foi criado com a identificação {{ param }}",
         "updated": "Usuário com a identificação {{ param }} foi atualizado ",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/user-management.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/user-management.json
@@ -3,7 +3,7 @@
         "home": {
             "title": "Usuários",
             "createLabel": "Adicionar",
- d            "createOrEitLabel": "Criar ou editar usuário"
+             "createOrEitLabel": "Criar ou editar usuário"
         },
         "created": "Novo usuário foi criado com a identificação {{ param }}",
         "updated": "Usuário com a identificação {{ param }} foi atualizado ",


### PR DESCRIPTION
Fixing a json syntax error in the webapp/i18n/pt-br/user-management.json (a 'd' place in an incorrect place).

