### PR TITLE
Requires authentication for proxified service APIs on Gateways

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -159,6 +159,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {<% if (
             .antMatchers("/configuration/ui").permitAll()
             .antMatchers("/swagger-ui/index.html").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/protected/**").authenticated() <%if (authenticationType != 'jwt') { %>;<% } %><% if (authenticationType == 'jwt') { %>
+            <%_ if (applicationType == 'gateway') { _%>
+            .antMatchers("/swagger-resources").permitAll()
+            .antMatchers("/").permitAll()
+            .anyRequest().authenticated() <% } %>
         .and()
             .apply(securityConfigurerAdapter());<% } %>
 


### PR DESCRIPTION
Requires authentication to access all non mapped URIs so that proxified service APIs are protected.

Fix #3336