### PR TITLE
Fix broken language subgenerator

### DIFF
--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -84,7 +84,7 @@ module.exports = LanguagesGenerator.extend({
     },
 
     prompting: function () {
-        if (this.currentLanguages || this.languages) return;
+        //if (this.currentLanguages || this.languages) return;
 
         var cb = this.async();
         var languageOptions = this.getAllSupportedLanguageOptions();

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -84,7 +84,7 @@ module.exports = LanguagesGenerator.extend({
     },
 
     prompting: function () {
-        //if (this.currentLanguages || this.languages) return;
+        if (this.languages) return;
 
         var cb = this.async();
         var languageOptions = this.getAllSupportedLanguageOptions();


### PR DESCRIPTION
Fix #3334
Removing currentLanguages from if block before prompting (or not) the user for the languages to install as suggested by @andidev 