### PR TITLE
Fix Docker compose subgenenrator when using MongoDB Cluster

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -283,6 +283,8 @@ module.exports = yeoman.Base.extend({
                         var mongodbNodeConfig = clusterDbYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-node'];
                         var mongoDbConfigSrvConfig = clusterDbYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-config'];
                         mongodbNodeConfig.build.context = relativePath;
+                        databaseYamlConfig = clusterDbYaml.services[this.appConfigs[i].baseName.toLowerCase() + '-' + database];
+                        delete databaseYamlConfig.ports;
                         parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-node'] = mongodbNodeConfig;
                         parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-' + database + '-config'] = mongoDbConfigSrvConfig;
                     }


### PR DESCRIPTION
The docker compose subgenerator was picking the incorrect service `appname-mongodb`. It was picking the one in the `mongodb.yml` file instead of picking the one in the `mongodb-cluster.yml` one.