### PR TITLE
Replacing null triple equal comparisons by undefined

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -142,13 +142,13 @@ module.exports = JhipsterClientGenerator.extend({
             var clientConfigFound = this.useSass !== undefined;
             if (clientConfigFound) {
                 // If translation is not defined, it is enabled by default
-                if (this.enableTranslation === null) {
+                if (this.enableTranslation === undefined) {
                     this.enableTranslation = true;
                 }
-                if (this.nativeLanguage === null) {
+                if (this.nativeLanguage === undefined) {
                     this.nativeLanguage = 'en';
                 }
-                if (this.languages === null) {
+                if (this.languages === undefined) {
                     this.languages = ['en', 'fr'];
                 }
 

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.html
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.html
@@ -82,7 +82,7 @@
         </div>
         <div class="form-group">
             <label for="activated">
-                <input ng-disabled="vm.user.id === null" type="checkbox" id="activated" ng-model="vm.user.activated">
+                <input ng-disabled="vm.user.id === undefined" type="checkbox" id="activated" ng-model="vm.user.activated">
                 <span translate="userManagement.activated">Activated</span>
             </label>
         </div><% if (enableTranslation) { %>

--- a/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/handlers/_state.handler.js
@@ -65,7 +65,7 @@
 
             function back() {
                 // If previous state is 'activate' or do not exist go to 'home'
-                if ($rootScope.previousStateName === 'activate' || $state.get($rootScope.previousStateName) === null) {
+                if ($rootScope.previousStateName === 'activate' || $state.get($rootScope.previousStateName) === undefined) {
                     $state.go('home');
                 } else {
                     $state.go($rootScope.previousStateName, $rootScope.previousStateParams);

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -125,7 +125,7 @@ module.exports = EntityGenerator.extend({
             this.buildTool = this.config.get('buildTool');
             this.testFrameworks = this.config.get('testFrameworks');
             // backward compatibility on testing frameworks
-            if (this.testFrameworks === null) {
+            if (this.testFrameworks === undefined) {
                 this.testFrameworks = ['gatling'];
             }
 

--- a/generators/modules/index.js
+++ b/generators/modules/index.js
@@ -19,7 +19,7 @@ module.exports = ModulesGenerator.extend({
 
         var jhipsterVar = this.options.jhipsterVar;
         var jhipsterFunc = this.options.jhipsterFunc;
-        if (jhipsterVar === null || jhipsterVar.moduleName === null) {
+        if (jhipsterVar === undefined || jhipsterVar.moduleName === undefined) {
             this.env.error(chalk.red('ERROR! This sub-generator must be used by JHipster modules, and the module name is not defined.'));
         }
 
@@ -29,7 +29,7 @@ module.exports = ModulesGenerator.extend({
         var packageName = this.config.get('packageName');
         var packageFolder = this.config.get('packageFolder');
 
-        if (!this.options.skipValidation && (baseName === null || packageName === null)) {
+        if (!this.options.skipValidation && (baseName === undefined || packageName === undefined)) {
             this.log(chalk.red('ERROR! There is no existing JHipster configuration file in this directory.'));
             this.env.error('JHipster ' + jhipsterVar.moduleName + ' is a JHipster module, and needs a .yo-rc.json configuration file made by JHipster.');
         }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -169,28 +169,28 @@ module.exports = JhipsterServerGenerator.extend({
             if (this.baseName !== undefined && serverConfigFound) {
 
                 // Generate remember me key if key does not already exist in config
-                if (this.authenticationType === 'session' && this.rememberMeKey === null) {
+                if (this.authenticationType === 'session' && this.rememberMeKey === undefined) {
                     this.rememberMeKey = crypto.randomBytes(20).toString('hex');
                 }
 
                 // Generate JWT secert key if key does not already exist in config
-                if (this.authenticationType === 'jwt' && this.jwtSecretKey === null) {
+                if (this.authenticationType === 'jwt' && this.jwtSecretKey === undefined) {
                     this.jwtSecretKey = crypto.randomBytes(20).toString('hex');
                 }
 
                 // If social sign in is not defined, it is disabled by default
-                if (this.enableSocialSignIn === null) {
+                if (this.enableSocialSignIn === undefined) {
                     this.enableSocialSignIn = false;
                 }
 
                 // If translation is not defined, it is enabled by default
-                if (this.enableTranslation === null) {
+                if (this.enableTranslation === undefined) {
                     this.enableTranslation = true;
                 }
-                if (this.nativeLanguage === null) {
+                if (this.nativeLanguage === undefined) {
                     this.nativeLanguage = 'en';
                 }
-                if (this.languages === null) {
+                if (this.languages === undefined) {
                     this.languages = ['en', 'fr'];
                 }
 
@@ -670,7 +670,7 @@ module.exports = JhipsterServerGenerator.extend({
                     this.prodDatabaseType = 'cassandra';
                     this.hibernateCache = 'no';
                 }
-                if (this.searchEngine === null) {
+                if (this.searchEngine === undefined) {
                     this.searchEngine = 'no';
                 }
 


### PR DESCRIPTION
Doing `=== null` can cause problems as null doesn't equals `undefined` in some cases.
In our case, we have to do `=== undefined` to check if a variable is defined or not. `=== null` has to be used only when we explicitly set a variable to `null`.