### PR TITLE
remove comment for config server bootstrap-prod uri

### DIFF
--- a/generators/server/templates/src/main/resources/config/_bootstrap-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_bootstrap-prod.yml
@@ -10,7 +10,7 @@ spring:
                 initial-interval: 1000
                 max-interval: 2000
                 max-attempts: 100
-            #uri: http://localhost:8761/config
+            uri: http://localhost:8761/config
             # name of the config server's property source (file.yml) that we want to use
             name: <%= baseName %>
             profile: prod # profile(s) of the property source


### PR DESCRIPTION
Now that @jdubois introduced retries to wait for the config server, having a commented out URI in bootstrap-prod.yml seems like a bad idea as the app will stay blocked and display no error message if the user forget to set it.