### PR TITLE
Better management of plural in relations

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1519,6 +1519,10 @@ module.exports = EntityGenerator.extend({
                     relationship.relationshipNameCapitalized = _.upperFirst(relationship.relationshipName);
                 }
 
+                if (_.isUndefined(relationship.relationshipNameCapitalizedPlural)) {
+                    relationship.relationshipNameCapitalizedPlural = pluralize(_.upperFirst(relationship.relationshipName));
+                }
+
                 if (_.isUndefined(relationship.relationshipNameHumanized)) {
                     relationship.relationshipNameHumanized = _.startCase(relationship.relationshipName);
                 }
@@ -1527,8 +1531,24 @@ module.exports = EntityGenerator.extend({
                     relationship.relationshipFieldName = _.lowerFirst(relationship.relationshipName);
                 }
 
+                if (_.isUndefined(relationship.relationshipFieldNamePlural)) {
+                    relationship.relationshipFieldNamePlural = pluralize(_.lowerFirst(relationship.relationshipName));
+                }
+
+                if (_.isUndefined(relationship.otherEntityRelationshipNamePlural) && (relationship.relationshipType === 'one-to-many' || (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === false) || (relationship.relationshipType === 'one-to-one'))) {
+                    relationship.otherEntityRelationshipNamePlural = pluralize(_.lowerFirst(this.name));
+                }
+
+                if (_.isUndefined(relationship.otherEntityNamePlural)) {
+                    relationship.otherEntityNamePlural = pluralize(relationship.otherEntityName);
+                }
+
                 if (_.isUndefined(relationship.otherEntityNameCapitalized)) {
                     relationship.otherEntityNameCapitalized = _.upperFirst(relationship.otherEntityName);
+                }
+
+                if (_.isUndefined(relationship.otherEntityNameCapitalizedPlural)) {
+                    relationship.otherEntityNameCapitalizedPlural = pluralize(_.upperFirst(relationship.otherEntityName));
                 }
 
                 if (_.isUndefined(relationship.otherEntityFieldCapitalized)) {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1527,6 +1527,10 @@ module.exports = EntityGenerator.extend({
                     relationship.relationshipNameHumanized = _.startCase(relationship.relationshipName);
                 }
 
+                 if (_.isUndefined(relationship.relationshipNamePlural)) {
+                    relationship.relationshipNamePlural = pluralize(_.startCase(relationship.relationshipName));
+                }
+
                 if (_.isUndefined(relationship.relationshipFieldName)) {
                     relationship.relationshipFieldName = _.lowerFirst(relationship.relationshipName);
                 }

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1540,7 +1540,7 @@ module.exports = EntityGenerator.extend({
                 }
 
                 if (_.isUndefined(relationship.otherEntityRelationshipNamePlural) && (relationship.relationshipType === 'one-to-many' || (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === false) || (relationship.relationshipType === 'one-to-one'))) {
-                    relationship.otherEntityRelationshipNamePlural = pluralize(_.lowerFirst(this.name));
+                    relationship.otherEntityRelationshipNamePlural = pluralize(relationship.otherEntityRelationshipName);
                 }
 
                 if (_.isUndefined(relationship.otherEntityNamePlural)) {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1528,7 +1528,7 @@ module.exports = EntityGenerator.extend({
                 }
 
                  if (_.isUndefined(relationship.relationshipNamePlural)) {
-                    relationship.relationshipNamePlural = pluralize(_.startCase(relationship.relationshipName));
+                    relationship.relationshipNamePlural = pluralize(relationship.relationshipName);
                 }
 
                 if (_.isUndefined(relationship.relationshipFieldName)) {

--- a/generators/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/src/main/java/package/domain/_Entity.java
@@ -110,8 +110,10 @@ public class <%= entityClass %> implements Serializable {
     }
     for (idx in relationships) {
         var otherEntityRelationshipName = relationships[idx].otherEntityRelationshipName,
+        otherEntityRelationshipNamePlural = relationships[idx].otherEntityRelationshipNamePlural,
         relationshipName = relationships[idx].relationshipName,
         relationshipFieldName = relationships[idx].relationshipFieldName,
+        relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural,
         joinTableName = entityTableName + '_'+ getTableName(relationshipName),
         relationshipType = relationships[idx].relationshipType,
         otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized,
@@ -136,14 +138,14 @@ public class <%= entityClass %> implements Serializable {
     <%_     if (hibernateCache != 'no') { _%>
     @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
     <%_     } _%>
-    private Set<<%= otherEntityNameCapitalized %>> <%= relationshipFieldName %>s = new HashSet<>();
+    private Set<<%= otherEntityNameCapitalized %>> <%= relationshipFieldNamePlural %> = new HashSet<>();
 
     <%_ } else if (relationshipType == 'many-to-one') { _%>
     @ManyToOne
     private <%= otherEntityNameCapitalized %> <%= relationshipFieldName %>;
 
     <%_ } else if (relationshipType == 'many-to-many') { _%>
-    @ManyToMany<% if (ownerSide == false) { %>(mappedBy = "<%= otherEntityRelationshipName %>s")
+    @ManyToMany<% if (ownerSide == false) { %>(mappedBy = "<%= otherEntityRelationshipNamePlural %>")
     @JsonIgnore
     <%_     } else { _%>
 
@@ -156,7 +158,7 @@ public class <%= entityClass %> implements Serializable {
                joinColumns = @JoinColumn(name="<%= getPluralColumnName(name) %>_id", referencedColumnName="ID"),
                inverseJoinColumns = @JoinColumn(name="<%= getPluralColumnName(relationships[idx].relationshipName) %>_id", referencedColumnName="ID"))
     <%_     } _%>
-    private Set<<%= otherEntityNameCapitalized %>> <%= relationshipFieldName %>s = new HashSet<>();
+    private Set<<%= otherEntityNameCapitalized %>> <%= relationshipFieldNamePlural %> = new HashSet<>();
 
     <%_ } else { _%>
     <%_     if (ownerSide) { _%>
@@ -213,17 +215,20 @@ public class <%= entityClass %> implements Serializable {
 <% } %><%
     for (idx in relationships) {
         var relationshipFieldName = relationships[idx].relationshipFieldName,
+        relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural,
         relationshipType = relationships[idx].relationshipType,
         otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized,
         relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized,
-        otherEntityName = relationships[idx].otherEntityName;
+        relationshipNameCapitalizedPlural = relationships[idx].relationshipNameCapitalizedPlural,
+        otherEntityName = relationships[idx].otherEntityName,
+        otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
     %><% if (relationshipType == 'one-to-many' || relationshipType == 'many-to-many') { %>
-    public Set<<%= otherEntityNameCapitalized %>> get<%= relationshipNameCapitalized %>s() {
-        return <%= relationshipFieldName %>s;
+    public Set<<%= otherEntityNameCapitalized %>> get<%= relationshipNameCapitalizedPlural %>() {
+        return <%= relationshipFieldNamePlural %>;
     }
 
-    public void set<%= relationshipNameCapitalized %>s(Set<<%= otherEntityNameCapitalized %>> <%= otherEntityName %>s) {
-        this.<%= relationshipFieldName %>s = <%= otherEntityName %>s;
+    public void set<%= relationshipNameCapitalizedPlural %>(Set<<%= otherEntityNameCapitalized %>> <%= otherEntityNamePlural %>) {
+        this.<%= relationshipFieldNamePlural %> = <%= otherEntityNamePlural %>;
     }<% } else { %>
     public <%= otherEntityNameCapitalized %> get<%= relationshipNameCapitalized %>() {
         return <%= relationshipFieldName %>;

--- a/generators/entity/templates/src/main/java/package/repository/_EntityRepository.java
+++ b/generators/entity/templates/src/main/java/package/repository/_EntityRepository.java
@@ -31,11 +31,11 @@ public interface <%=entityClass%>Repository extends <% if (databaseType=='sql') 
     List<<%= entityClass %>> findBy<%= relationships[idx].relationshipNameCapitalized %>IsCurrentUser();<% } } %>
 <% if (fieldsContainOwnerManyToMany==true) { %>
     @Query("select distinct <%= entityInstance %> from <%= entityClass %> <%= entityInstance %><% for (idx in relationships) {
-    if (relationships[idx].relationshipType == 'many-to-many' && relationships[idx].ownerSide == true) { %> left join fetch <%=entityInstance%>.<%=relationships[idx].relationshipFieldName%>s<%} }%>")
+    if (relationships[idx].relationshipType == 'many-to-many' && relationships[idx].ownerSide == true) { %> left join fetch <%=entityInstance%>.<%=relationships[idx].relationshipFieldNamePlural%><%} }%>")
     List<<%=entityClass%>> findAllWithEagerRelationships();
 
     @Query("select <%= entityInstance %> from <%= entityClass %> <%= entityInstance %><% for (idx in relationships) {
-    if (relationships[idx].relationshipType == 'many-to-many' && relationships[idx].ownerSide == true) { %> left join fetch <%=entityInstance%>.<%=relationships[idx].relationshipFieldName%>s<%} }%> where <%=entityInstance%>.id =:id")
+    if (relationships[idx].relationshipType == 'many-to-many' && relationships[idx].ownerSide == true) { %> left join fetch <%=entityInstance%>.<%=relationships[idx].relationshipFieldNamePlural%><%} }%> where <%=entityInstance%>.id =:id")
     <%=entityClass%> findOneWithEagerRelationships(@Param("id") Long id);
 <% } %>
 }<% } %><% if (databaseType == 'cassandra') { %>

--- a/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -66,12 +66,13 @@ public class <%= entityClass %>DTO implements Serializable {
     <%_ for (idx in relationships) {
         var otherEntityRelationshipName = relationships[idx].otherEntityRelationshipName,
         relationshipFieldName = relationships[idx].relationshipFieldName,
+        relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural,
         relationshipType = relationships[idx].relationshipType,
         otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized,
         otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized,
         ownerSide = relationships[idx].ownerSide; %><% if (relationshipType == 'many-to-many' && ownerSide == true) { _%>
 
-    private Set<<%= otherEntityNameCapitalized %>DTO> <%= relationshipFieldName %>s = new HashSet<>();
+    private Set<<%= otherEntityNameCapitalized %>DTO> <%= relationshipFieldNamePlural %> = new HashSet<>();
     <%_ } else if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide == true)) { _%>
 
     private Long <%= relationshipFieldName %>Id;<% if (otherEntityFieldCapitalized !='Id' && otherEntityFieldCapitalized != '') { %>
@@ -118,20 +119,23 @@ public class <%= entityClass %>DTO implements Serializable {
     <%_ } } _%>
     <%_ for (idx in relationships) {
         relationshipFieldName = relationships[idx].relationshipFieldName,
+        relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural,
         otherEntityName = relationships[idx].otherEntityName,
+        otherEntityNamePlural = relationships[idx].otherEntityNamePlural,
         relationshipType = relationships[idx].relationshipType,
         otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized,
         otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized,
         relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized,
+        relationshipNameCapitalizedPlural = relationships[idx].relationshipNameCapitalizedPlural,
         ownerSide = relationships[idx].ownerSide;
         if (relationshipType == 'many-to-many' && ownerSide == true) { _%>
 
-    public Set<<%= otherEntityNameCapitalized %>DTO> get<%= relationshipNameCapitalized %>s() {
-        return <%= relationshipFieldName %>s;
+    public Set<<%= otherEntityNameCapitalized %>DTO> get<%= relationshipNameCapitalized %>() {
+        return <%= relationshipFieldNamePlural %>;
     }
 
-    public void set<%= relationshipNameCapitalized %>s(Set<<%= otherEntityNameCapitalized %>DTO> <%= otherEntityName %>s) {
-        this.<%= relationshipFieldName %>s = <%= otherEntityName %>s;
+    public void set<%= relationshipNameCapitalizedPlural %>(Set<<%= otherEntityNameCapitalized %>DTO> <%= otherEntityNamePlural %>) {
+        this.<%= relationshipFieldNamePlural %> = <%= otherEntityNamePlural %>;
     }
     <%_ } else if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide == true)) { _%>
 

--- a/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -130,7 +130,7 @@ public class <%= entityClass %>DTO implements Serializable {
         ownerSide = relationships[idx].ownerSide;
         if (relationshipType == 'many-to-many' && ownerSide == true) { _%>
 
-    public Set<<%= otherEntityNameCapitalized %>DTO> get<%= relationshipNameCapitalized %>() {
+    public Set<<%= otherEntityNameCapitalized %>DTO> get<%= relationshipNameCapitalizedPlural %>() {
         return <%= relationshipFieldNamePlural %>;
     }
 

--- a/generators/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/mapper/_EntityMapper.java
@@ -30,11 +30,12 @@ for (idx in relationships) {
 for (idx in relationships) {
     var relationshipType = relationships[idx].relationshipType;
     var relationshipName = relationships[idx].relationshipName;
+    var relationshipNamePlural = relationships[idx].relationshipNamePlural;
     var ownerSide = relationships[idx].ownerSide;
     if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide == true)) { %>
     @Mapping(source = "<%= relationshipName %>Id", target = "<%= relationshipName %>")<% } else if (relationshipType == 'many-to-many' && ownerSide == false) { %>
-    @Mapping(target = "<%= relationshipName %>s", ignore = true)<% } else if (relationshipType == 'one-to-many') { %>
-    @Mapping(target = "<%= relationshipName %>s", ignore = true)<% } else if (relationshipType == 'one-to-one' && ownerSide == false) { %>
+    @Mapping(target = "<%= relationshipNamePlural %>", ignore = true)<% } else if (relationshipType == 'one-to-many') { %>
+    @Mapping(target = "<%= relationshipNamePlural %>", ignore = true)<% } else if (relationshipType == 'one-to-one' && ownerSide == false) { %>
     @Mapping(target = "<%= relationshipName %>", ignore = true)<% } } %>
     <%= entityClass %> <%= entityInstance %>DTOTo<%= entityClass %>(<%= entityClass %>DTO <%= entityInstance %>DTO);
 

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -33,6 +33,7 @@
                 var ownerSide = relationships[idx].ownerSide;
                 var relationshipName = relationships[idx].relationshipName;
                 var relationshipFieldName = relationships[idx].relationshipFieldName;
+                var relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
                 var relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
                 var otherEntityName = relationships[idx].otherEntityName;
                 var otherEntityStateName = relationships[idx].otherEntityStateName;
@@ -45,7 +46,7 @@
         <dd>
             <%_ if (otherEntityName == 'user') { _%>
                 <%_ if (relationshipType == 'many-to-many') { _%>
-            <span ng-repeat="<%= relationshipFieldName %> in vm.<%= entityInstance %>.<%= relationshipFieldName %>s">
+            <span ng-repeat="<%= relationshipFieldName %> in vm.<%= entityInstance %>.<%= relationshipFieldNamePlural %>">
                 {{<%= relationshipFieldName %>.<%= otherEntityField %>}}{{$last ? '' : ', '}}
             </span>
                 <%_ } else { _%>
@@ -57,7 +58,7 @@
                 <%_ } _%>
             <%_ } else { _%>
                 <%_ if (relationshipType == 'many-to-many') { _%>
-            <span ng-repeat="<%= relationshipFieldName %> in vm.<%= entityInstance %>.<%= relationshipFieldName %>s">
+            <span ng-repeat="<%= relationshipFieldName %> in vm.<%= entityInstance %>.<%= relationshipFieldNamePlural %>">
                 <a ui-sref="<%= otherEntityStateName %>-detail({id: {{<%= relationshipFieldName %>.id}}})">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{$last ? '' : ', '}}
             </span>
                 <%_ } else { _%>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
@@ -25,10 +25,10 @@
                 + "\n            }"
                 + "\n            return " + relationships[idx].otherEntityNameCapitalized + ".get({id : vm." + entityInstance + "." + relationships[idx].relationshipFieldName + (dto == 'no' ? ".id" : "Id") + "}).$promise;"
                 + "\n        }).then(function(" + relationships[idx].relationshipFieldName + ") {"
-                + "\n            vm." + relationships[idx].relationshipFieldName.toLowerCase() + "s.push(" + relationships[idx].relationshipFieldName + ");"
+                + "\n            vm." + relationships[idx].relationshipFieldNamePlural.toLowerCase() + ".push(" + relationships[idx].relationshipFieldName + ");"
                 + "\n        });";
                 } else {
-                    query = 'vm.' + relationships[idx].otherEntityNameCapitalized.toLowerCase() + 's = ' + relationships[idx].otherEntityNameCapitalized + '.query();';
+                    query = 'vm.' + relationships[idx].otherEntityNameCapitalizedPlural.toLowerCase() + ' = ' + relationships[idx].otherEntityNameCapitalized + '.query();';
                 }
                 if (!contains(queries, query)) {
                     queries.push(query);

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
@@ -169,9 +169,11 @@
             var relationshipType = relationships[idx].relationshipType;
             var ownerSide = relationships[idx].ownerSide;
             var otherEntityName = relationships[idx].otherEntityName;
+            var otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
             var relationshipName = relationships[idx].relationshipName;
             var relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
             var relationshipFieldName = relationships[idx].relationshipFieldName;
+            var relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
             var otherEntityField = relationships[idx].otherEntityField;
             var otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
             var translationKey = keyPrefix + relationshipName; _%>
@@ -179,11 +181,11 @@
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
                 <%_ if (dto == 'no') { _%>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=otherEntityNamePlural.toLowerCase() %> track by <%=otherEntityName %>.id">
                 <option value=""></option>
             </select>
                 <%_ } else { _%>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=otherEntityName.toLowerCase() %>s">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=otherEntityNamePlural.toLowerCase() %>">
                 <option value=""></option>
             </select>
                 <%_ } _%>
@@ -192,11 +194,11 @@
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
                 <%_ if (dto == 'no') { _%>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=relationshipFieldName.toLowerCase() %>s | orderBy:'id' track by <%=otherEntityName %>.id">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=relationshipFieldNamePlural.toLowerCase() %> | orderBy:'id' track by <%=otherEntityName %>.id">
                 <option value=""></option>
             </select>
                 <%_ } else { _%>
-            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=relationshipFieldName.toLowerCase() %>s | orderBy:'id'">
+            <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" ng-model="vm.<%= entityInstance %>.<%=relationshipFieldName %>Id" ng-options="<%=otherEntityName %>.id as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=relationshipFieldNamePlural.toLowerCase() %> | orderBy:'id'">
                 <option value=""></option>
             </select>
                 <%_ } _%>
@@ -204,7 +206,7 @@
             <%_ } else if (relationshipType == 'many-to-many' && relationships[idx].ownerSide == true) { _%>
         <div class="form-group">
             <label translate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
-            <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" ng-model="vm.<%=entityInstance %>.<%=relationshipFieldName %>s" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=otherEntityName.toLowerCase() %>s track by <%=otherEntityName %>.id"></select>
+            <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" ng-model="vm.<%=entityInstance %>.<%=relationshipFieldNamePlural %>" ng-options="<%=otherEntityName %> as <%=otherEntityName %>.<%=otherEntityField %> for <%=otherEntityName %> in vm.<%=otherEntityNamePlural.toLowerCase() %> track by <%=otherEntityName %>.id"></select>
         </div>
             <%_ } _%>
         <%_ } _%>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.html
@@ -82,6 +82,7 @@
                             var relationshipType = relationships[idx].relationshipType;
                             var ownerSide = relationships[idx].ownerSide;
                             var relationshipFieldName = relationships[idx].relationshipFieldName;
+                            var relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
                             var otherEntityName = relationships[idx].otherEntityName;
                             var otherEntityStateName = relationships[idx].otherEntityStateName;
                             var otherEntityField = relationships[idx].otherEntityField;
@@ -92,7 +93,7 @@
                     <td>
                             <%_ if (otherEntityName == 'user') { _%>
                                 <%_ if (relationshipType == 'many-to-many') { _%>
-                        <span ng-repeat="<%= relationshipFieldName %> in <%= entityInstance %>.<%= relationshipFieldName %>s">
+                        <span ng-repeat="<%= relationshipFieldName %> in <%= entityInstance %>.<%= relationshipFieldNamePlural %>">
                             {{<%= relationshipFieldName %>.<%= otherEntityField %>}}{{$last ? '' : ', '}}
                         <span>
                                 <%_ } else { _%>
@@ -104,7 +105,7 @@
                                 <%_ } _%>
                             <%_ } else { _%>
                                 <%_ if (relationshipType == 'many-to-many') { _%>
-                        <span ng-repeat="<%= relationshipFieldName %> in <%= entityInstance %>.<%= relationshipFieldName %>s">
+                        <span ng-repeat="<%= relationshipFieldName %> in <%= entityInstance %>.<%= relationshipFieldNamePlural %>">
                             <a class="form-control-static" ui-sref="<%= otherEntityStateName %>-detail({id: {{<%= relationshipFieldName %>.id}}})">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{$last ? '' : ', '}}
                         <span>
                                 <%_ } else { _%>


### PR DESCRIPTION
Hello,

I've changed all declarations and uses of `<% someEntityName %>s` by `<% someEntityNamePlural %>`. Plural version of entity or relation name is calculated before in js with **pluralize**.

This PR is a completion of https://github.com/jhipster/generator-jhipster/pull/2719

Please feel free to comment and criticize.

Thanks,