### PR TITLE
mvn -Pprod clean should not delete node_modules folder

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1065,9 +1065,6 @@
                                 <fileset>
                                     <directory><%= CLIENT_DIST_DIR %></directory>
                                 </fileset>
-                                <fileset>
-                                    <directory>node_modules</directory>
-                                </fileset>
                             </filesets>
                         </configuration>
                     </plugin>


### PR DESCRIPTION
mvn -Pprod clean should not delete node_modules folder for build performance reason and to be consistent with gradle.