### PR TITLE
Fix escaped characters in generated docker compose YML

### DIFF
--- a/generators/docker-compose/templates/_docker-compose.yml
+++ b/generators/docker-compose/templates/_docker-compose.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
 <%_ for(var i = 0; i < appConfigs.length; i++) { _%>
-<%= appsYaml[i] %>
+<%- appsYaml[i] %>
 <%_ } _%>
     jhipster-registry:
         extends:


### PR DESCRIPTION
The `&` character where espaced into `&amp;` which caused issues in the  datasource url envirnoment variable (ie: `SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/sample?useUnicode=true&characterEncoding=utf8&useSSL=false`)

Do I win the award of the smallest PR in the world ? :smile: 