### PR TITLE
add a length limit for logstash-encoder forwarded stacktraces fix #3364

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -3,6 +3,7 @@ package <%=packageName%>.config;
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.LoggerContext;
 import net.logstash.logback.appender.LogstashSocketAppender;
+import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
@@ -55,6 +56,12 @@ public class LoggingConfiguration {
         logstashAppender.setSyslogHost(jHipsterProperties.getLogging().getLogstash().getHost());
         logstashAppender.setPort(jHipsterProperties.getLogging().getLogstash().getPort());
         logstashAppender.setCustomFields(customFields);
+
+        // Limit the maximum length of the forwarded stacktrace so that it won't exceed the 8KB UDP limit of logstash
+        ShortenedThrowableConverter throwableConverter = new ShortenedThrowableConverter();
+        throwableConverter.setMaxLength(7500);
+        logstashAppender.setThrowableConverter(throwableConverter);
+
         logstashAppender.start();
 
         // Wrap the appender in an Async appender for performance

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -60,6 +60,7 @@ public class LoggingConfiguration {
         // Limit the maximum length of the forwarded stacktrace so that it won't exceed the 8KB UDP limit of logstash
         ShortenedThrowableConverter throwableConverter = new ShortenedThrowableConverter();
         throwableConverter.setMaxLength(7500);
+        throwableConverter.setRootCauseFirst(true);
         logstashAppender.setThrowableConverter(throwableConverter);
 
         logstashAppender.start();


### PR DESCRIPTION
Fix #3364 issue for stacktraces over 8K sent through an UDP socket.