### PR TITLE
Support monolithic apps in docker-compose subgenerator

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -164,6 +164,7 @@ module.exports = yeoman.Base.extend({
                 this.appConfigs = [];
                 this.gatewayNb = 0;
                 this.monolithicNb = 0;
+                this.microserviceNb = 0;
 
                 //Loading configs
                 for(var i = 0; i < this.appsFolders.length; i++) {
@@ -173,9 +174,10 @@ module.exports = yeoman.Base.extend({
 
                     if(config.applicationType === 'monolith') {
                         this.monolithicNb++;
-                    }
-                    if(config.applicationType === 'gateway') {
+                    } else if(config.applicationType === 'gateway') {
                         this.gatewayNb++;
+                    } else if(config.applicationType === 'microservice') {
+                        this.microserviceNb++;
                     }
 
                     this.portsToBind = this.monolithicNb + this.gatewayNb;
@@ -363,7 +365,7 @@ module.exports = yeoman.Base.extend({
         },
 
         writeRegistryFiles: function() {
-            if(this.gatewayNb === 0) return;
+            if(this.gatewayNb === 0 && this.microserviceNb === 0) return;
 
             this.copy('jhipster-registry.yml', 'jhipster-registry.yml');
             this.template('central-server-config/_application.yml', 'central-server-config/application.yml');

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -385,5 +385,16 @@ module.exports = yeoman.Base.extend({
             this.log('\n' + chalk.bold.green('Docker Compose configuration successfully generated!'));
         }
         this.log('You can launch all your infrastructure by running : ' + chalk.cyan('docker-compose up -d'));
+        if (this.gatewayNb+this.monolithicNb>1) {
+            this.log('\nYour applications will be accessible on those URLs:');
+            var portIndex = 8080;
+            for (var i = 0; i < this.appsFolders.length; i++) {
+                if(this.appConfigs[i].applicationType === 'gateway' || this.appConfigs[i].applicationType === 'monolith') {
+                    this.log('\t- '+this.appConfigs[i].baseName + ':' + ' http://localhost:'+portIndex);
+                    portIndex++;
+                }
+            }
+            this.log();
+        }
     }
 });

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -170,8 +170,8 @@ module.exports = yeoman.Base.extend({
                     var path = this.destinationPath(this.directoryPath + this.appsFolders[i]+'/.yo-rc.json');
                     var fileData = this.fs.readJSON(path);
                     var config = fileData['generator-jhipster'];
-                    this.log(config.applicationType);
-                    if(config.applicationType === 'monolithic') {
+
+                    if(config.applicationType === 'monolith') {
                         this.monolithicNb++;
                     }
                     if(config.applicationType === 'gateway') {
@@ -282,6 +282,8 @@ module.exports = yeoman.Base.extend({
 
         setAppsYaml: function() {
             this.appsYaml = [];
+
+            var portIndex=8080;
             for (var i = 0; i < this.appsFolders.length; i++) {
                 var parentConfiguration = {};
                 var path = this.destinationPath(this.directoryPath + this.appsFolders[i]);
@@ -289,6 +291,12 @@ module.exports = yeoman.Base.extend({
                 // Add application configuration
                 var yaml = jsyaml.load(this.fs.read(path + '/src/main/docker/app.yml'));
                 var yamlConfig = yaml.services[this.appConfigs[i].baseName.toLowerCase() + '-app'];
+                this.log(this.appConfigs[i].applicationType);
+                if(this.appConfigs[i].applicationType === 'gateway' || this.appConfigs[i].applicationType === 'monolith') {
+                    yamlConfig.ports[0] = portIndex + ':' + portIndex;
+                    portIndex++;
+                }
+
                 parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-app'] = yamlConfig;
 
                 // Add database configuration

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -291,9 +291,11 @@ module.exports = yeoman.Base.extend({
                 // Add application configuration
                 var yaml = jsyaml.load(this.fs.read(path + '/src/main/docker/app.yml'));
                 var yamlConfig = yaml.services[this.appConfigs[i].baseName.toLowerCase() + '-app'];
-                this.log(this.appConfigs[i].applicationType);
+
                 if(this.appConfigs[i].applicationType === 'gateway' || this.appConfigs[i].applicationType === 'monolith') {
-                    yamlConfig.ports[0] = portIndex + ':' + portIndex;
+                    var ports = yamlConfig.ports[0].split(':');
+                    ports[0] = portIndex;
+                    yamlConfig.ports[0] = ports.join(':');
                     portIndex++;
                 }
 

--- a/generators/docker-compose/templates/_docker-compose.yml
+++ b/generators/docker-compose/templates/_docker-compose.yml
@@ -1,12 +1,14 @@
 version: '2'
 services:
 <%_ for(var i = 0; i < appConfigs.length; i++) { _%>
-<%= appsYaml[i] %>
+<%- appsYaml[i] %>
 <%_ } _%>
+<%_ if (gatewayNb > 0) { _%>
     jhipster-registry:
         extends:
             file: jhipster-registry.yml
             service: jhipster-registry
+<%_ } _%>
 <%_ if (useElk) { _%>
     elk-elasticsearch:
         extends:


### PR DESCRIPTION
Fix #3380 
So now we can select monolithic apps in the subgenerator docker-compose. If it detects that there are more than 1 gateway or monolithic, it map each app port starting from 8080.
At the end it shows the mapping to inform the user about the URL of each app.

As we map the port, we can't scale the gateway or monolithic app for the moment. 