### PR TITLE
Name in bower.json should not contain uppercased letters

### DIFF
--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -1,6 +1,6 @@
 {
   "version": "0.0.0",
-  "name": "<%= camelizedBaseName %>",
+  "name": "<%= dasherizedBaseName %>",
   "appPath": "<%= MAIN_SRC_DIR %>",
   "testPath": "<%= TEST_SRC_DIR %>spec",
   "dependencies": {


### PR DESCRIPTION
Use dasherizedBaseName for name in bower.json so an app name with uppercased letters like "gatewayIssue" turns into "gateway-issue".

Fix #3392