### PR TITLE
Add on option to report actuator metrics in the logs

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1086,6 +1086,7 @@ module.exports = JhipsterServerGenerator.extend({
             this.template(SERVER_MAIN_SRC_DIR + 'package/config/locale/_package-info.java', javaDir + 'config/locale/package-info.java', this, {});
             this.template(SERVER_MAIN_SRC_DIR + 'package/config/locale/_AngularCookieLocaleResolver.java', javaDir + 'config/locale/AngularCookieLocaleResolver.java', this, {});
 
+            this.template(SERVER_MAIN_SRC_DIR + 'package/config/metrics/_LogMetricWriter.java', javaDir + 'config/metrics/LogMetricWriter.java', this, {});
             if (this.databaseType === 'cassandra') {
                 this.template(SERVER_MAIN_SRC_DIR + 'package/config/metrics/_package-info.java', javaDir + 'config/metrics/package-info.java', this, {});
                 this.template(SERVER_MAIN_SRC_DIR + 'package/config/metrics/_JHipsterHealthIndicatorConfiguration.java', javaDir + 'config/metrics/JHipsterHealthIndicatorConfiguration.java', this, {});

--- a/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
+++ b/generators/server/templates/src/main/java/package/config/_JHipsterProperties.java
@@ -7,9 +7,11 @@ import javax.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.web.cors.CorsConfiguration;
 
+import java.util.List;
+import java.util.ArrayList;
+import java.util.Arrays;
 <%_ if (applicationType == 'gateway') { _%>
 import java.util.LinkedHashMap;
-import java.util.List;
 import java.util.Map;
 <%_ } _%>
 
@@ -597,7 +599,11 @@ public class JHipsterProperties {
 
         private final Logstash logstash = new Logstash();
 
+        private final ActuatorMetrics actuatorMetrics = new ActuatorMetrics();
+
         public Logstash getLogstash() { return logstash; }
+
+        public ActuatorMetrics getActuatorMetrics() { return actuatorMetrics; }
 
         public static class Logstash {
 
@@ -624,6 +630,22 @@ public class JHipsterProperties {
             public int getQueueSize() { return queueSize; }
 
             public void setQueueSize(int queueSize) { this.queueSize = queueSize; }
+        }
+
+
+        public static class ActuatorMetrics {
+
+            private boolean enabled = false;
+
+            private List<String> prefixExclusionList = new ArrayList<String>(Arrays.asList("jvm.", "com.", "net.", "HikariPool", "cache."));
+
+            public boolean isEnabled() { return enabled; }
+
+            public void setEnabled(boolean enabled) { this.enabled = enabled; }
+
+            public List<String> getPrefixExclusionList() { return prefixExclusionList; }
+
+            public void setPrefixExclusionList(List<String> prefixExclusionList) { this.prefixExclusionList = prefixExclusionList; }
         }
     }
 

--- a/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
@@ -1,5 +1,6 @@
 package <%=packageName%>.config;
 
+import <%=packageName%>.config.metrics.LogMetricWriter;
 import com.codahale.metrics.JmxReporter;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
@@ -12,7 +13,12 @@ import com.ryantenney.metrics.spring.config.annotation.MetricsConfigurerAdapter;
 import fr.ippon.spark.metrics.SparkReporter;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.autoconfigure.ExportMetricWriter;
+import org.springframework.boot.actuate.endpoint.MetricsEndpoint;
+import org.springframework.boot.actuate.endpoint.MetricsEndpointMetricReader;
+import org.springframework.boot.actuate.metrics.writer.MetricWriter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.*;
 
 import javax.annotation.PostConstruct;
@@ -132,5 +138,21 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
                 sparkReporter.start(1, TimeUnit.MINUTES);
             }
         }
+    }
+
+
+    /* Spring Boot Actuator metrics log reporting */
+    @Bean
+    @ConditionalOnProperty("jhipster.logging.actuator-metrics.enabled")
+    public MetricsEndpointMetricReader metricsEndpointMetricReader(MetricsEndpoint metricsEndpoint) {
+        log.info("Initializing Actuator Metrics Log reporting");
+        return new MetricsEndpointMetricReader(metricsEndpoint);
+    }
+
+    @Bean
+    @ExportMetricWriter
+    @ConditionalOnProperty("jhipster.logging.actuator-metrics.enabled")
+    MetricWriter metricWriter() {
+        return new LogMetricWriter();
     }
 }

--- a/generators/server/templates/src/main/java/package/config/metrics/_LogMetricWriter.java
+++ b/generators/server/templates/src/main/java/package/config/metrics/_LogMetricWriter.java
@@ -1,0 +1,50 @@
+package <%=packageName%>.config.metrics;
+
+import <%=packageName%>.config.JHipsterProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.actuate.metrics.Metric;
+import org.springframework.boot.actuate.metrics.writer.Delta;
+import org.springframework.boot.actuate.metrics.writer.MetricWriter;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+/**
+ * Log reporter for Spring Boot metrics
+ *
+ * Output Spring Boot metrics to logs, using the same format as Dropwizard's Sfl4jReporter
+ */
+public class LogMetricWriter implements MetricWriter {
+
+    private final Logger log = LoggerFactory.getLogger("metrics");
+
+    @Inject
+    private JHipsterProperties jHipsterProperties;
+
+    @Override
+    public void set(Metric<?> metric) {
+        String metricName = metric.getName();
+
+        // Don't set a metric if its prefix is in the exclusion list
+        for(String prefix : jHipsterProperties.getLogging().getActuatorMetrics().getPrefixExclusionList()){
+            if(metricName.startsWith(prefix)){
+                return;
+            }
+        }
+
+        log.info("type=GAUGE, name={}, value={}", metric.getName(), metric.getValue());
+    }
+
+    @Override
+    public void increment(Delta<?> metric) {
+        log.info("type=COUNTER, name={}, count={}", metric.getName(), metric.getValue());
+    }
+
+    @Override
+    public void reset(String metricName) {
+        // Not implemented
+    }
+}

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -178,7 +178,7 @@ jhipster:
             host: localhost
             port: 2003
             prefix: <%= baseName %>
-        logs: # report metrics in the logs
+        logs: # Reports Dropwizard metrics in the logs
             enabled: false
             reportFrequency: 60 # in seconds
     logging:
@@ -187,5 +187,8 @@ jhipster:
             host: localhost
             port: 5000
             queueSize: 512
+        actuator-metrics: # Reports Spring Boot Actuator metrics in the logs
+            enabled: false
+            # edit spring.metrics.export.delay-millis to set report frequency
     swagger: # swagger is enabled. It can be disabled by pasing 'no-swagger' profile at run time as well
         enabled: true

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -176,7 +176,7 @@ jhipster:
             host: localhost
             port: 2003
             prefix: <%= baseName %>
-        logs: # report metrics in the logs
+        logs: # Reports Dropwizard metrics in the logs
             enabled: false
             reportFrequency: 60 # in seconds
     logging:
@@ -185,5 +185,8 @@ jhipster:
             host: localhost
             port: 5000
             queueSize: 512
+        actuator-metrics: # Reports Spring Boot Actuator metrics in the logs
+            enabled: false
+            # edit spring.metrics.export.delay-millis to set report frequency
     swagger: # swagger is disabled. It can be disabled by pasing 'no-swagger' profile at run time as well
         enabled: false


### PR DESCRIPTION
The goal is to retrieve useful metrics that are not already reported by Dropwizard metrics. It will be especially useful for retrieve circuit breakers metrics.

I tried to make this as simple as possible. I'm not a big fan of my "exclusion list" but I don't see a better way.