### PR TITLE
add monitoring props in monolith docker-compose env variables

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -317,10 +317,10 @@ module.exports = DockerComposeGenerator.extend({
 
                 // Add monitoring configuration for monolith directly in the docker-compose file as they can't get them from the config server
                 if(this.appConfigs[i].applicationType === 'monolith' && this.useElk) {
-                    yamlConfig.environment.push("JHIPSTER_LOGGING_LOGSTASH_ENABLED=true")
-                    yamlConfig.environment.push("JHIPSTER_LOGGING_LOGSTASH_HOST=elk-logstash")
-                    yamlConfig.environment.push("JHIPSTER_METRICS_LOGS_ENABLED=true")
-                    yamlConfig.environment.push("JHIPSTER_METRICS_LOGS_REPORT_FREQUENCY=60");
+                    yamlConfig.environment.push('JHIPSTER_LOGGING_LOGSTASH_ENABLED=true')
+                    yamlConfig.environment.push('JHIPSTER_LOGGING_LOGSTASH_HOST=elk-logstash')
+                    yamlConfig.environment.push('JHIPSTER_METRICS_LOGS_ENABLED=true')
+                    yamlConfig.environment.push('JHIPSTER_METRICS_LOGS_REPORT_FREQUENCY=60');
                 }
 
                 parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-app'] = yamlConfig;

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -315,6 +315,14 @@ module.exports = DockerComposeGenerator.extend({
                     portIndex++;
                 }
 
+                // Add monitoring configuration for monolith directly in the docker-compose file as they can't get them from the config server
+                if(this.appConfigs[i].applicationType === 'monolith' && this.useElk) {
+                    yamlConfig.environment.push("JHIPSTER_LOGGING_LOGSTASH_ENABLED=true")
+                    yamlConfig.environment.push("JHIPSTER_LOGGING_LOGSTASH_HOST=elk-logstash")
+                    yamlConfig.environment.push("JHIPSTER_METRICS_LOGS_ENABLED=true")
+                    yamlConfig.environment.push("JHIPSTER_METRICS_LOGS_REPORT_FREQUENCY=60");
+                }
+
                 parentConfiguration[this.appConfigs[i].baseName.toLowerCase() + '-app'] = yamlConfig;
 
                 // Add database configuration


### PR DESCRIPTION
Make the docker-compose subgen for monolith automatically activate logs and metrics monitoring if the ELK option as been selected. Those are the same props that we set by default for microservices using the config server.