### PR TITLE
Remove this unused "from" private field.

### DIFF
--- a/generators/server/templates/src/main/java/package/service/_MailService.java
+++ b/generators/server/templates/src/main/java/package/service/_MailService.java
@@ -43,11 +43,6 @@ public class MailService {
     @Inject
     private SpringTemplateEngine templateEngine;
 
-    /**
-     * System default email address that sends the e-mails.
-     */
-    private String from;
-
     @Async
     public void sendEmail(String to, String subject, String content, boolean isMultipart, boolean isHtml) {
         log.debug("Send e-mail[multipart '{}' and html '{}'] to '{}' with subject '{}' and content={}",


### PR DESCRIPTION
SONAR: If a private field is declared but not used in the program, it can be considered dead code and should therefore be removed. This will improve maintainability because developers will not wonder what the variable is used for.