### PR TITLE
Define a constant instead of duplicating this literal "user" 4 times.

### DIFF
--- a/generators/server/templates/src/main/java/package/service/_MailService.java
+++ b/generators/server/templates/src/main/java/package/service/_MailService.java
@@ -30,6 +30,9 @@ import java.util.Locale;
 public class MailService {
 
     private final Logger log = LoggerFactory.getLogger(MailService.class);
+    
+    private static final String USER = "user";
+    private static final String BASE_URL = "baseUrl";
 
     @Inject
     private JHipsterProperties jHipsterProperties;
@@ -73,8 +76,8 @@ public class MailService {
         log.debug("Sending activation e-mail to '{}'", user.getEmail());
         Locale locale = Locale.forLanguageTag(user.getLangKey());
         Context context = new Context(locale);
-        context.setVariable("user", user);
-        context.setVariable("baseUrl", baseUrl);
+        context.setVariable(USER, user);
+        context.setVariable(BASE_URL, baseUrl);
         String content = templateEngine.process("activationEmail", context);
         String subject = messageSource.getMessage("email.activation.title", null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
@@ -85,8 +88,8 @@ public class MailService {
         log.debug("Sending creation e-mail to '{}'", user.getEmail());
         Locale locale = Locale.forLanguageTag(user.getLangKey());
         Context context = new Context(locale);
-        context.setVariable("user", user);
-        context.setVariable("baseUrl", baseUrl);
+        context.setVariable(USER, user);
+        context.setVariable(BASE_URL, baseUrl);
         String content = templateEngine.process("creationEmail", context);
         String subject = messageSource.getMessage("email.activation.title", null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
@@ -97,8 +100,8 @@ public class MailService {
         log.debug("Sending password reset e-mail to '{}'", user.getEmail());
         Locale locale = Locale.forLanguageTag(user.getLangKey());
         Context context = new Context(locale);
-        context.setVariable("user", user);
-        context.setVariable("baseUrl", baseUrl);
+        context.setVariable(USER, user);
+        context.setVariable(BASE_URL, baseUrl);
         String content = templateEngine.process("passwordResetEmail", context);
         String subject = messageSource.getMessage("email.reset.title", null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);
@@ -109,7 +112,7 @@ public class MailService {
         log.debug("Sending social registration validation e-mail to '{}'", user.getEmail());
         Locale locale = Locale.forLanguageTag(user.getLangKey());
         Context context = new Context(locale);
-        context.setVariable("user", user);
+        context.setVariable(USER, user);
         context.setVariable("provider", WordUtils.capitalize(provider));
         String content = templateEngine.process("socialRegistrationValidationEmail", context);
         String subject = messageSource.getMessage("email.social.registration.title", null, locale);


### PR DESCRIPTION
Define a constant instead of duplicating this literal "baseUrl" 3 times.
Define a constant instead of duplicating this literal "user" 4 times.

SONAR: Duplicated string literals make the process of refactoring error-prone, since you must be sure to update all occurrences. On the other hand, constants can be referenced from many places, but only need to be updated in a single place.