### PR TITLE
Add env var to wait before starting a Docker container

### DIFF
--- a/generators/server/templates/src/main/docker/_Dockerfile
+++ b/generators/server/templates/src/main/docker/_Dockerfile
@@ -1,10 +1,13 @@
 FROM java:openjdk-8-jre-alpine
 
+ENV JHIPSTER_SLEEP 0
+
 # add directly the war
 ADD *.war /app.war
 
 RUN sh -c 'touch /app.war'
 VOLUME /tmp
-CMD ["java","-Djava.security.egd=file:/dev/./urandom","-jar","/app.war"]
-
 EXPOSE <%= serverPort %><% if (hibernateCache == 'hazelcast') { %> 5701/udp<% } %>
+CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
+    sleep ${JHIPSTER_SLEEP} && \
+    java -Djava.security.egd=file:/dev/./urandom -jar /app.war


### PR DESCRIPTION
This new ENV in Dockerfiles `JHIPSTER_SLEEP` can be used to wait before starting an application. If not used, same behavior like currently.

With docker engine: -e JHIPSTER_SLEEP=10
With docker-compose: in "environment" session
