### PR TITLE
hide id field while creating an entity

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
@@ -8,7 +8,7 @@
     </div>
     <div class="modal-body">
         <jhi-alert-error></jhi-alert-error>
-        <div class="form-group">
+        <div class="form-group" ng-show="vm.<%=entityInstance %>.id">
             <label for="id" translate="global.field.id">ID</label>
             <input type="text" class="form-control" id="id" name="id"
                     ng-model="vm.<%=entityInstance %>.id" readonly />


### PR DESCRIPTION
The id does not provide any meaningful information in the entity creation dialog as the actual database id has not been assigned yet anyway.

fix #3401.