### PR TITLE
Disable Karma JS minification to help debugging if it's run with --debug

### DIFF
--- a/generators/client/templates/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/src/test/javascript/_karma.conf.js
@@ -1,6 +1,17 @@
 // Karma configuration
 // http://karma-runner.github.io/0.10/config/configuration-file.html
 
+var sourcePreprocessors = ['coverage'];
+
+function isDebug() {
+    return process.argv.indexOf('--debug') >= 0;
+}
+
+if (isDebug()) {
+    // Disable JS minification if Karma is run with debug option.
+    sourcePreprocessors = [];
+}
+
 module.exports = function (config) {
     config.set({
         // base path, that will be used to resolve files and exclude
@@ -27,7 +38,7 @@ module.exports = function (config) {
         exclude: [<% if (testFrameworks.indexOf('protractor') > -1) { %>'<%= TEST_SRC_DIR %>e2e/**'<% } %>],
 
         preprocessors: {
-            './**/*.js': ['coverage']
+            './**/*.js': sourcePreprocessors
         },
 
         reporters: ['dots', 'jenkins', 'coverage', 'progress'],


### PR DESCRIPTION
The current Karma config minifies JS and adds cover information. However, if it's run from the command line with the --debug option it would help if the developer if the JS files remain readable.

Sample command line start:
```
./node_modules/karma/bin/karma start src/test/javascript/karma.conf.js --debug
# Then navigate to http://localhost:9876/debug.html
```

It might be worthwhile to add this to this page too:
http://jhipster.github.io/running-tests/