### PR TITLE
Better microservice and gateway config for Heroku profile

### DIFF
--- a/generators/heroku/templates/_Procfile
+++ b/generators/heroku/templates/_Procfile
@@ -1,1 +1,1 @@
-web: java -jar <% if (buildTool == 'maven') { %>target<% } %><% if (buildTool == 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod,heroku --server.port=$PORT
+web: java <% if (applicationType == 'gateway') { %>-Xmx256m<% } %> -jar <% if (buildTool == 'maven') { %>target<% } %><% if (buildTool == 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod,heroku --server.port=$PORT

--- a/generators/heroku/templates/_application-heroku.yml
+++ b/generators/heroku/templates/_application-heroku.yml
@@ -11,9 +11,15 @@
 # ===================================================================
 
 eureka:
-    client:
-        serviceUrl:
-            defaultZone: ${JHIPSTER_REGISTRY_URL}/eureka/
+<%_ if (applicationType != 'gateway') { _%>
+  instance:
+    hostname: <%= herokuDeployedName %>.herokuapp.com
+    non-secure-port: 80
+    prefer-ip-address: false
+<%_ } _%>
+  client:
+    serviceUrl:
+      defaultZone: ${JHIPSTER_REGISTRY_URL}/eureka/
 
 spring:
   datasource:


### PR DESCRIPTION
For microservice applications:

* Set the `eureka.instance.hostname` and `non-secure-port` automatically
* Set `eureka.instance.prefer-ip-address` to false 

For gateway applications:

* Add `-Xmx256m` to the default `Procfile`

I've found that the gateway uses very little heap and a lot of off-heap memory (probably for buffers and streams). Setting max heap lower will allow more room for off-heap as to not exceed the quota on a free dyno (i.e. prevents [R14 errors](https://devcenter.heroku.com/articles/error-codes#r14-memory-quota-exceeded))