### PR TITLE
share .m2 dependencies with gradle build

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -1,6 +1,7 @@
 buildscript {
     repositories {
         mavenLocal()
+        mavenCentral()
         jcenter()
         maven { url "http://repo.spring.io/plugins-release" }
         maven { url "http://repo.spring.io/milestone" }
@@ -104,6 +105,9 @@ configurations {
 }
 
 repositories {
+    mavenLocal()
+    mavenCentral()
+    jcenter()
     maven { url 'http://repo.spring.io/milestone' }
     maven { url 'http://repo.spring.io/snapshot' }
     maven { url 'https://repository.jboss.org/nexus/content/repositories/releases' }


### PR DESCRIPTION
``mavenLocal`` was not used for builds (only for buildScripts) such that each dependency was downloaded again even when it is available already in local maven repository (e.g. ``~/m2``).