### PR TITLE
Fix 3454 Clean up Auth JS services and remove previous state erase in Auth.logout()

### DIFF
--- a/generators/client/templates/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.js
@@ -28,9 +28,9 @@
             return $q.reject(response);
         }
     }<% } %><% if (authenticationType === 'session') { %>
-    authExpiredInterceptor.$inject = ['$rootScope', '$q', '$injector', '$document', '$sessionStorage'];
+    authExpiredInterceptor.$inject = ['$rootScope', '$q', '$injector', '$document'];
 
-    function authExpiredInterceptor($rootScope, $q, $injector, $document, $sessionStorage) {
+    function authExpiredInterceptor($rootScope, $q, $injector, $document) {
         var service = {
             responseError: responseError
         };
@@ -46,8 +46,7 @@
                 var params = $rootScope.toStateParams;
                 Auth.logout();
                 if (to.name !== 'accessdenied') {
-                    $sessionStorage.previousStateName = to.name;
-                    $sessionStorage.previousStateParams = params;
+                    Auth.storePreviousState(to.name, params);
                 }
                 var LoginService = $injector.get('LoginService');
                 LoginService.open();

--- a/generators/client/templates/src/main/webapp/app/components/login/_login.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/login/_login.controller.js
@@ -51,9 +51,9 @@
                 // previousState was set in the authExpiredInterceptor before being redirected to login modal.
                 // since login is succesful, go to stored previousState and clear previousState
                 if (Auth.getPreviousState()) {
-                    var ps = Auth.getPreviousState();
+                    var previousState = Auth.getPreviousState();
                     Auth.resetPreviousState();
-                    $state.go(ps.previousStateName, ps.previousStateParams);
+                    $state.go(previousState.name, previousState.params);
                 }
             }).catch(function () {
                 vm.authenticationError = true;

--- a/generators/client/templates/src/main/webapp/app/components/login/_login.controller.js
+++ b/generators/client/templates/src/main/webapp/app/components/login/_login.controller.js
@@ -5,9 +5,9 @@
         .module('<%=angularAppName%>')
         .controller('LoginController', LoginController);
 
-    LoginController.$inject = ['$rootScope', '$state', '$sessionStorage', '$timeout', 'Auth', '$uibModalInstance'];
+    LoginController.$inject = ['$rootScope', '$state', '$timeout', 'Auth', '$uibModalInstance'];
 
-    function LoginController ($rootScope, $state, $sessionStorage, $timeout, Auth, $uibModalInstance) {
+    function LoginController ($rootScope, $state, $timeout, Auth, $uibModalInstance) {
         var vm = this;
 
         vm.authenticationError = false;
@@ -50,12 +50,10 @@
 
                 // previousState was set in the authExpiredInterceptor before being redirected to login modal.
                 // since login is succesful, go to stored previousState and clear previousState
-                if ($sessionStorage.previousStateName) {
-                    var previousStateName = $sessionStorage.previousStateName;
-                    var previousStateParams = $sessionStorage.previousStateParams;
-                    delete $sessionStorage.previousStateName;
-                    delete $sessionStorage.previousStateParams;
-                    $state.go(previousStateName, previousStateParams);
+                if (Auth.getPreviousState()) {
+                    var ps = Auth.getPreviousState();
+                    Auth.resetPreviousState();
+                    $state.go(ps.previousStateName, ps.previousStateParams);
                 }
             }).catch(function () {
                 vm.authenticationError = true;

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
@@ -145,9 +145,6 @@
         function logout () {
             AuthServerProvider.logout();
             Principal.authenticate(null);
-
-            // Reset state memory
-            resetPreviousState();
         }
 
         function resetPasswordFinish (keyAndPassword, callback) {

--- a/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
+++ b/generators/client/templates/src/main/webapp/app/services/auth/_auth.service.js
@@ -55,9 +55,9 @@
 
                 // recover and clear previousState after external login redirect (e.g. oauth2)
                 if (isAuthenticated && !$rootScope.fromState.name && getPreviousState()) {
-                    var ps = getPreviousState();
+                    var previousState = getPreviousState();
                     resetPreviousState();
-                    $state.go(ps.previousStateName, ps.previousStateParams);
+                    $state.go(previousState.name, previousState.params);
                 }
 
                 if ($rootScope.toState.data.authorities && $rootScope.toState.data.authorities.length > 0 && !Principal.hasAnyAuthority($rootScope.toState.data.authorities)) {
@@ -180,24 +180,17 @@
         }
 
         function getPreviousState() {
-            var previousStateName = $sessionStorage.previousStateName;
-            var previousStateParams = $sessionStorage.previousStateParams;
-
-            if(!previousStateName) {
-                return null;
-            }
-
-            return { "previousStateName": previousStateName, "previousStateParams": previousStateParams };
+            var previousState = $sessionStorage.previousState;
+            return previousState;
         }
 
         function resetPreviousState() {
-            delete $sessionStorage.previousStateName;
-            delete $sessionStorage.previousStateParams;
+            delete $sessionStorage.previousState;
         }
 
         function storePreviousState(previousStateName, previousStateParams) {
-            $sessionStorage.previousStateName = previousStateName;
-            $sessionStorage.previousStateParams = previousStateParams;
+            var previousState = { "name": previousStateName, "params": previousStateParams };
+            $sessionStorage.previousState = previousState;
         }
     }
 })();


### PR DESCRIPTION
https://github.com/jhipster/generator-jhipster/issues/3454

Looks like the Auth.logout() is not actually required:
- If we are already logged out the previous state is the one we want to get back to - do not erase it.
- If we are just hitting logout button, the sessionStorage is already empty anyway, nothing to erase.