### PR TITLE
add missing spectator dependency for microservices gradle build

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -193,6 +193,7 @@ dependencies {
     compile "org.springframework.cloud:spring-cloud-starter-ribbon"
     compile "org.springframework.cloud:spring-cloud-starter-eureka"
     compile "org.springframework.cloud:spring-cloud-starter-hystrix"
+    compile "org.springframework.cloud:spring-cloud-starter-spectator"
     compile "org.springframework.cloud:spring-cloud-starter-config"
     compile "org.springframework.retry:spring-retry"
     <%_ } _%>


### PR DESCRIPTION
The build was broken on master for microservices and gateways as I had forgotten to also add the spectator depency for gradle.