### PR TITLE
missing dependency with gradle and cassandra

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -235,7 +235,7 @@ dependencies {
     compile "org.springframework.social:spring-social-twitter:${spring_social_twitter_version}"<% } %>
     testCompile "com.jayway.awaitility:awaitility:${awaility_version}"
     testCompile "com.jayway.jsonpath:json-path"<% if (databaseType == 'cassandra') { %>
-    testCompile("org.cassandraunit'cassandra-unit-spring:${cassandra_unit_spring_version}") {
+    testCompile("org.cassandraunit:cassandra-unit-spring:${cassandra_unit_spring_version}") {
         exclude(module: 'org.slf4j')
     }<% } %><% if (testFrameworks.indexOf('cucumber') != -1) { %>
     testCompile "info.cukes:cucumber-junit:${cucumber_version}"


### PR DESCRIPTION
On the master, a dependency is missing when generating the app for gradle and cassandra

```
Could not resolve all dependencies for configuration ':testCompileClasspath'.
> Could not find org.cassandraunit'cassandra-unit-spring:2.1.3.1:.
  Required by:
      com.mycompany.myapp:mono-gradle-cass:0.0.1-SNAPSHOT
```

It's a typo in the group name declaration.

The first commit add a travis test case.
I'll add a second commit with the fix after the CI shows the failure.