### PR TITLE
Fix cassandra microservice tests

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1017,6 +1017,7 @@ module.exports = JhipsterServerGenerator.extend({
                 this.template(SERVER_MAIN_RES_DIR + 'config/cql/_create-keyspace.cql', SERVER_MAIN_RES_DIR + 'config/cql/create-keyspace.cql', this, {});
                 this.template(SERVER_MAIN_RES_DIR + 'config/cql/_drop-keyspace.cql', SERVER_MAIN_RES_DIR + 'config/cql/drop-keyspace.cql', this, {});
                 this.copy(SERVER_MAIN_RES_DIR + 'config/cql/create-tables.cql', SERVER_MAIN_RES_DIR + 'config/cql/create-tables.cql');
+                this.copy(SERVER_MAIN_RES_DIR + 'config/cql/changelog/README.md', SERVER_MAIN_RES_DIR + 'config/cql/changelog/README.md');
                 if (this.applicationType !== 'microservice') {
                     this.copy(SERVER_MAIN_RES_DIR + 'config/cql/changelog/_insert_default_users.cql', SERVER_MAIN_RES_DIR + 'config/cql/changelog/00000000000000_insert_default_users.cql');
                 }

--- a/generators/server/templates/src/main/resources/config/cql/changelog/README.md
+++ b/generators/server/templates/src/main/resources/config/cql/changelog/README.md
@@ -1,0 +1,12 @@
+The changelog folder for cassandra/cql files is similar to liquibase, but with a minimal tooling.
+
+- The script name should follow the pattern yyyyMMddHHmmss_{script-name}.cql
+  - eg: 20150805124838_added_entity_BankAccount.cql
+- The scripts will be applied sequentially in alphabetical order
+- The scripts will be applied automatically only in two contexts:
+  - Unit tests
+  - Docker-compose for to start a [cassandra cluster for development](http://jhipster.github.io/docker-compose/#in-development)
+   
+Unlike liquibase, the scripts are not currently automatically applied to the database when deployed with a production profile
+
+

--- a/generators/server/templates/src/test/java/package/_AbstractCassandraTest.java
+++ b/generators/server/templates/src/test/java/package/_AbstractCassandraTest.java
@@ -12,6 +12,7 @@ import org.junit.BeforeClass;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.net.URL;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -22,22 +23,28 @@ import java.nio.file.Paths;
  */
 public class AbstractCassandraTest {
 
+    public static final String CASSANDRA_UNIT_KEYSPACE = "cassandra_unit_keyspace";
+
     @BeforeClass
     public static void startServer() throws InterruptedException, TTransportException, ConfigurationException, IOException, URISyntaxException  {
         EmbeddedCassandraServerHelper.startEmbeddedCassandra();
         Cluster cluster = new Cluster.Builder().addContactPoints("127.0.0.1").withPort(9142).build();
         Session session = cluster.connect();
         CQLDataLoader dataLoader = new CQLDataLoader(session);
-        dataLoader.load(new ClassPathCQLDataSet("config/cql/create-tables.cql", true, "cassandra_unit_keyspace"));
+        dataLoader.load(new ClassPathCQLDataSet("config/cql/create-tables.cql", true, CASSANDRA_UNIT_KEYSPACE));
         applyScripts(dataLoader, "config/cql/changelog/", "*.cql");
     }
 
     private static void applyScripts(CQLDataLoader dataLoader, String cqlDir, String pattern) throws IOException, URISyntaxException {
-        Path path = Paths.get(ClassLoader.getSystemResource(cqlDir).toURI());
-        try (DirectoryStream<Path> stream = Files.newDirectoryStream(path, pattern)) {
+        URL dirUrl = ClassLoader.getSystemResource(cqlDir);
+        if (dirUrl == null) { // protect for empty directory
+            return;
+        }
+
+        try (DirectoryStream<Path> stream = Files.newDirectoryStream(Paths.get(dirUrl.toURI()), pattern)) {
             for (Path entry : stream) {
                 String fileName = entry.getFileName().toString();
-                dataLoader.load(new ClassPathCQLDataSet(cqlDir + fileName, false, false, "cassandra_unit_keyspace"));
+                dataLoader.load(new ClassPathCQLDataSet(cqlDir + fileName, false, false, CASSANDRA_UNIT_KEYSPACE));
             }
         }
     }

--- a/generators/server/templates/src/test/java/package/_CassandraKeyspaceUnitTest.java
+++ b/generators/server/templates/src/test/java/package/_CassandraKeyspaceUnitTest.java
@@ -25,8 +25,10 @@ public class CassandraKeyspaceUnitTest extends AbstractCassandraTest {
     private Session session;
 
     @Test
-    public void shouldHaveUserTableCreated() throws Exception {
-        ResultSet result = session.execute("select * from user");
-        assertThat(result.all()).hasSize(4);
+    public void shouldListCassandraUnitKeyspace() throws Exception {
+        ResultSet result = session.execute("SELECT * FROM system.schema_keyspaces;");
+        assertThat(result.all())
+            .extracting(row -> row.getString("keyspace_name"))
+            .containsOnlyOnce((CASSANDRA_UNIT_KEYSPACE));
     }
 }


### PR DESCRIPTION
When generating a microservice with Cassandra database, tests are failing:
- the cql/changelog folder is empty and causes an NPE when trying to iterate in the scripts when starting the cassandra unit cluster
- the User table does not exist for a microservice app, therefore CassandraKeyspaceUnitTest#shouldHaveUserTableCreated() test does not work anymore
