### PR TITLE
Update Node.js version on generated .travis.yml

### DIFF
--- a/generators/server/templates/_travis.yml
+++ b/generators/server/templates/_travis.yml
@@ -1,6 +1,6 @@
 language: node_js
 node_js:
-  - "0.12"
+  - "4.4.3"
 sudo: false
 before_install: npm install -g gulp
 install: npm install


### PR DESCRIPTION
#3485 
.travis.yml file is currently being generated with Node.js version
0.12, which is outdated and does not build correctly. Current LTS
version is 4.4.3