### PR TITLE
fix activated checkbox to be disabled when creating a user

### DIFF
--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.html
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-dialog.html
@@ -82,7 +82,7 @@
         </div>
         <div class="form-group">
             <label for="activated">
-                <input ng-disabled="vm.user.id === undefined" type="checkbox" id="activated" ng-model="vm.user.activated">
+                <input ng-disabled="vm.user.id === null" type="checkbox" id="activated" ng-model="vm.user.activated">
                 <span translate="userManagement.activated">Activated</span>
             </label>
         </div><% if (enableTranslation) { %>


### PR DESCRIPTION
Currently user-management.state.js sets user.id to null on the /new state entry, making the comparison `user.id === undefined` false.  This changes the comparison to `user.id === null` which will return the correct value.

This issue comes from #3343.  This comparison to null is appropriate because we explicitly set user.id to null (meeting the condition stated in the referenced PR).