### PR TITLE
Fix some uaa bugs

### DIFF
--- a/generators/client/templates/src/main/webapp/app/admin/audits/_audits.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/audits/_audits.service.js
@@ -8,7 +8,7 @@
     AuditsService.$inject = ['$resource'];
 
     function AuditsService ($resource) {
-        var service = $resource('api/audits/:id', {}, {
+        var service = $resource(<% if(authenticationType === 'uaa') { %>'<%= uaaBaseName %>/api/audits/:id'<%} else { %>'api/audits/:id'<% } %>, {}, {
             'get': {
                 method: 'GET',
                 isArray: true

--- a/generators/client/templates/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/src/main/webapp/swagger-ui/_index.html
@@ -81,22 +81,22 @@
                 });
 
                 function addApiKeyAuthorization(){
-                <% if (authenticationType == 'session') { %>
+                <% if (authenticationType === 'session') { %>
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-CSRF-TOKEN", getCSRF(), "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <% } %>
-                <% if (authenticationType == 'oauth2') { %>
+                <% if (authenticationType === 'oauth2') { %>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken")).access_token;
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization",
                             "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <% } %>
-                <% if (authenticationType == 'xauth') { %>
+                <% if (authenticationType === 'xauth') { %>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken")).token;
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-Auth-Token", authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <% } %>
-                <% if (authenticationType == 'jwt') { %>
+                <% if (authenticationType === 'jwt' || authenticationType === 'uaa') { %>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken") || sessionStorage.getItem("jhi-authenticationToken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1125,7 +1125,7 @@ module.exports = JhipsterServerGenerator.extend({
         },
 
         writeServerMicroserviceFiles: function () {
-            if (this.applicationType !== 'microservice' && !(this.applicationType === 'gateway' && this.authenticationType === 'uaa') return;
+            if (this.applicationType !== 'microservice' && !(this.applicationType === 'gateway' && this.authenticationType === 'uaa')) return;
 
             this.template(SERVER_MAIN_SRC_DIR + 'package/config/_MicroserviceSecurityConfiguration.java', javaDir + 'config/MicroserviceSecurityConfiguration.java', this, {});
         },

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1125,13 +1125,13 @@ module.exports = JhipsterServerGenerator.extend({
         },
 
         writeServerMicroserviceFiles: function () {
-            if (this.applicationType !== 'microservice') return;
+            if (this.applicationType !== 'microservice' && !(this.applicationType === 'gateway' && this.authenticationType === 'uaa') return;
 
             this.template(SERVER_MAIN_SRC_DIR + 'package/config/_MicroserviceSecurityConfiguration.java', javaDir + 'config/MicroserviceSecurityConfiguration.java', this, {});
         },
 
         writeServerMicroserviceAndGatewayFiles: function () {
-            if (this.applicationType !== 'microservice' && this.applicationType !== 'gateway'  && this.applicationType !== 'uaa') return;
+            if (this.applicationType !== 'microservice' && this.applicationType !== 'gateway' && this.applicationType !== 'uaa') return;
 
             this.template(SERVER_MAIN_RES_DIR + 'config/_bootstrap-dev.yml', SERVER_MAIN_RES_DIR + 'config/bootstrap-dev.yml', this, {});
             this.template(SERVER_MAIN_RES_DIR + 'config/_bootstrap-prod.yml', SERVER_MAIN_RES_DIR + 'config/bootstrap-prod.yml', this, {});


### PR DESCRIPTION
When using uaa authentication:
* MicroserviceSecurityConfiguration needs to be generated for gateways (otherwise requests to "health", "configprops", etc. are unauthorized. The gateway is also a resource server (like microservice applications) in this case.
* Add token for swagger requests (authorization 'uaa' was left out)
* Call uaa server for audits (since audits are on the uaa server, requests must go to /uaa/api/audits instead of api/audits)