### PR TITLE
Use authorization server's public key on resource servers

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1137,6 +1137,36 @@ Generator.prototype.warning = function(msg) {
 };
 
 /**
+ * Generate a KeyStore for uaa authorization server.
+ */
+Generator.prototype.generateKeyStore = function() {
+    const keyStoreFile = SERVER_MAIN_RES_DIR + 'keystore.jks';
+    if (this.fs.exists(keyStoreFile)) {
+        this.log(chalk.cyan('\nKeyStore \'' + keyStoreFile + '\' already exists. Leaving unchanged.\n'));
+    } else {
+        shelljs.mkdir('-p', SERVER_MAIN_RES_DIR);
+        var parent = this;
+        shelljs.exec('keytool '+
+            '-genkey ' +
+            '-noprompt ' +
+            '-keyalg RSA ' +
+            '-alias selfsigned ' +
+            '-keystore ' + keyStoreFile + ' ' +
+            '-storepass password ' +
+            '-keypass password ' +
+            '-keysize 2048 ' +
+            '-dname "CN=Java Hipster, OU=Development, O=' + this.packageName + ', L=, ST=, C="'
+        , function(code) {
+            if (code !== 0) {
+                parent.env.error(chalk.red(`\nFailed to create a KeyStore with \'keytool\'`), code);
+            } else {
+                parent.log(chalk.green('\nKeyStore \'' + keyStoreFile + '\' generated successfully.\n'));
+            }
+        });
+    }
+};
+
+/**
  * Prints a JHipster logo.
  */
 Generator.prototype.printJHipsterLogo = function () {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -473,6 +473,33 @@ module.exports = JhipsterServerGenerator.extend({
                     this.template(SERVER_MAIN_RES_DIR + 'config/cql/changelog/_insert_default_users.cql', SERVER_MAIN_RES_DIR + 'config/cql/changelog/00000000000001_insert_default_users.cql', this, {});
                 }
             }
+
+            if (this.applicationType === 'uaa') {
+                const keyStoreFile = SERVER_MAIN_RES_DIR + 'keystore.jks';
+                if (this.fs.exists(keyStoreFile)) {
+                    this.log(chalk.cyan('\nKeyStore \'' + keyStoreFile + '\' already exists. Leaving unchanged.\n'));
+                } else {
+                    shelljs.mkdir('-p', SERVER_MAIN_RES_DIR);
+                    var parent = this;
+                    shelljs.exec('keytool '+
+                        '-genkey ' +
+                        '-noprompt ' +
+                        '-keyalg RSA ' +
+                        '-alias selfsigned ' +
+                        '-keystore ' + keyStoreFile + ' ' +
+                        '-storepass password ' +
+                        '-keypass password ' +
+                        '-keysize 2048 ' +
+                        '-dname "CN=Java Hipster, OU=Development, O=' + this.packageName + ', L=, ST=, C="'
+                    , function(code) {
+                        if (code !== 0) {
+                            parent.env.error(chalk.red(`\nFailed to create a KeyStore with \'keytool\'`), code);
+                        } else {
+                            parent.log(chalk.green('\nKeyStore \'' + keyStoreFile + '\' generated successfully.\n'));
+                        }
+                    });
+                }
+            }
         },
 
         writeServerPropertyFiles: function () {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -7,8 +7,7 @@ var util = require('util'),
     scriptBase = require('../generator-base'),
     packagejs = require('../../package.json'),
     crypto = require('crypto'),
-    mkdirp = require('mkdirp'),
-    shelljs = require('shelljs');
+    mkdirp = require('mkdirp');
 
 var JhipsterServerGenerator = generators.Base.extend({});
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -476,30 +476,7 @@ module.exports = JhipsterServerGenerator.extend({
             }
 
             if (this.applicationType === 'uaa') {
-                const keyStoreFile = SERVER_MAIN_RES_DIR + 'keystore.jks';
-                if (this.fs.exists(keyStoreFile)) {
-                    this.log(chalk.cyan('\nKeyStore \'' + keyStoreFile + '\' already exists. Leaving unchanged.\n'));
-                } else {
-                    shelljs.mkdir('-p', SERVER_MAIN_RES_DIR);
-                    var parent = this;
-                    shelljs.exec('keytool '+
-                        '-genkey ' +
-                        '-noprompt ' +
-                        '-keyalg RSA ' +
-                        '-alias selfsigned ' +
-                        '-keystore ' + keyStoreFile + ' ' +
-                        '-storepass password ' +
-                        '-keypass password ' +
-                        '-keysize 2048 ' +
-                        '-dname "CN=Java Hipster, OU=Development, O=' + this.packageName + ', L=, ST=, C="'
-                    , function(code) {
-                        if (code !== 0) {
-                            parent.env.error(chalk.red(`\nFailed to create a KeyStore with \'keytool\'`), code);
-                        } else {
-                            parent.log(chalk.green('\nKeyStore \'' + keyStoreFile + '\' generated successfully.\n'));
-                        }
-                    });
-                }
+                this.generateKeyStore();
             }
         },
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -7,7 +7,8 @@ var util = require('util'),
     scriptBase = require('../generator-base'),
     packagejs = require('../../package.json'),
     crypto = require('crypto'),
-    mkdirp = require('mkdirp');
+    mkdirp = require('mkdirp'),
+    shelljs = require('shelljs');
 
 var JhipsterServerGenerator = generators.Base.extend({});
 

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -100,12 +100,12 @@ function askForServerSideOpts() {
         },
         {
             when: function (response) {
-                return (applicationType === 'gateway' && response.authenticationType === 'uaa');
+                return ((applicationType === 'gateway' || applicationType === 'microservice') && response.authenticationType === 'uaa');
             },
             type: 'input',
             name: 'uaaBaseName',
             message: function (response) {
-                return getNumberedQuestion('What is the folder path of your UAA application?.', applicationType === 'gateway' && response.authenticationType === 'uaa');
+                return getNumberedQuestion('What is the folder path of your UAA application?.', (applicationType === 'gateway' || applicationType === 'microservice') && response.authenticationType === 'uaa');
             },
             default: '../uaa',
             validate: function (input) {
@@ -480,7 +480,7 @@ function askForServerSideOpts() {
             this.rememberMeKey = crypto.randomBytes(20).toString('hex');
         }
 
-        if (this.authenticationType === 'jwt' || this.authenticationType === 'uaa' || this.applicationType === 'microservice' || this.applicationType === 'uaa') {
+        if (this.authenticationType === 'jwt' || this.applicationType === 'microservice') {
             this.jwtSecretKey = crypto.randomBytes(20).toString('hex');
         }
 

--- a/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
@@ -133,15 +133,14 @@ package <%=packageName%>.config;
       }
 
       @Bean
-      @Qualifier("LoadBalancedRestTemplate")
-      public RestTemplate restTemplate(RestTemplateCustomizer customizer) {
+      public RestTemplate loadBalancedRestTemplate(RestTemplateCustomizer customizer) {
           RestTemplate restTemplate = new RestTemplate();
           customizer.customize(restTemplate);
           return restTemplate;
       }
 
       @Inject
-      @Qualifier("LoadBalancedRestTemplate")
+      @Qualifier("loadBalancedRestTemplate")
       private RestTemplate keyUriRestTemplate;
 
       private String getKeyFromAuthorizationServer() {

--- a/generators/server/templates/src/main/java/package/config/_UaaConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_UaaConfiguration.java
@@ -5,6 +5,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -14,13 +15,16 @@ import org.springframework.security.oauth2.config.annotation.web.configuration.E
 import org.springframework.security.oauth2.config.annotation.web.configuration.EnableResourceServer;
 import org.springframework.security.oauth2.config.annotation.web.configuration.ResourceServerConfigurerAdapter;
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerEndpointsConfigurer;
+import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
 import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
+import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
 
 import javax.inject.Inject;
 import javax.servlet.http.HttpServletResponse;
+import java.security.KeyPair;
 
 @Configuration
 @EnableAuthorizationServer
@@ -87,9 +91,8 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter {
          */
         clients.inMemory()
             .withClient("web_app")
-            .scopes("web-app")
+            .scopes("openid")
             .autoApprove(true)
-            .accessTokenValiditySeconds((int) jHipsterProperties.getSecurity().getAuthentication().getJwt().getTokenValidityInSeconds())
             .authorizedGrantTypes("implicit","refresh_token", "password", "authorization_code")
             .and()
             .withClient("internal")
@@ -100,34 +103,41 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter {
 
     @Override
     public void configure(AuthorizationServerEndpointsConfigurer endpoints) throws Exception {
-        endpoints.tokenStore(tokenStore()).tokenEnhancer(jwtTokenEnhancer()).authenticationManager(authenticationManager);
+        endpoints.authenticationManager(authenticationManager).accessTokenConverter(
+                jwtAccessTokenConverter());
     }
 
     @Autowired
     @Qualifier("authenticationManagerBean")
     private AuthenticationManager authenticationManager;
 
-    @Inject
-    private JHipsterProperties jHipsterProperties;
-
     /**
      * Apply the token converter (and enhander) for token store.
      */
     @Bean
     public JwtTokenStore tokenStore() {
-        return new JwtTokenStore(jwtTokenEnhancer());
+        return new JwtTokenStore(jwtAccessTokenConverter());
     }
 
     /**
      * This bean generates an token enhancer, which manages the exchange between JWT acces tokens and Authentication
      * in both direction.
      *
-     * @return an access token converter configured with JHipsters secret key
+     * @return an access token converter configured with the authorization server's public/private keys
      */
     @Bean
-    public JwtAccessTokenConverter jwtTokenEnhancer() {
+    public JwtAccessTokenConverter jwtAccessTokenConverter() {
         JwtAccessTokenConverter converter = new JwtAccessTokenConverter();
-        converter.setSigningKey(jHipsterProperties.getSecurity().getAuthentication().getJwt().getSecret());
+        KeyPair keyPair = new KeyStoreKeyFactory(
+             new ClassPathResource("keystore.jks"), "password".toCharArray())
+             .getKeyPair("selfsigned");
+        converter.setKeyPair(keyPair);
         return converter;
+    }
+
+    @Override
+    public void configure(AuthorizationServerSecurityConfigurer oauthServer) throws Exception {
+        oauthServer.tokenKeyAccess("permitAll()").checkTokenAccess(
+                "isAuthenticated()");
     }
 }

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -176,10 +176,10 @@ jhipster:
             maxBytesLocalHeap: 16M
         <%_ } _%>
     <%_ } _%>
-<%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt' || authenticationType == 'uaa') { _%>
+<%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt') { _%>
     security:
         authentication:
-    <%_ if (authenticationType == 'jwt' || authenticationType == 'uaa') { _%>
+    <%_ if (authenticationType == 'jwt') { _%>
             jwt:
                 secret: my-secret-token-to-change-in-production
                 # Token is valid 24 hours

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -166,10 +166,10 @@ jhipster:
             maxBytesLocalHeap: 256M
         <%_ } _%>
     <%_ } _%>
-<%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt' || authenticationType == 'uaa') { _%>
+<%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt') { _%>
     security:
         authentication:
-    <%_ if (authenticationType == 'jwt' || authenticationType == 'uaa') { _%>
+    <%_ if (authenticationType == 'jwt') { _%>
             jwt:
                 secret: <%= jwtSecretKey %>
                 # Token is valid 24 hours


### PR DESCRIPTION
# Motivation

A shared secret with which to sign JWTs is great when there is no single service responsible for all JWT creation. However, in the case of OAuth2, the authorization server creates and usually signs the token with its private key. The authorization server also exposes its public key to other services so that they can verify the JWT and grant/deny access accordingly.

Some advantages of asymmetric (i.e. public/private key) cryptography vs symmetric (i.e. shared secret) cryptography are:

1. Simpler key management. Asymmetric cryptography only needs to keep the private key safe (on the authorization server) while the public key can be freely exposed. Furthermore, resource servers can dynamically ask the authorization server for its public key. Symmetric cryptography means that the secret must be distributed to all communicating parties (increasing the danger of it being exposed).
2. Non-repudiation: Since the private key of the authorization server is never shared, you can be assured that the JWT was signed by the authorization server and only the authorization server. Symmetric key messages could have come from anyone with the shared secret key.

# Notes

With this PR,

1. A single default keypair is generated on the authorization server (UAA) when it is created. There should be different keypairs for dev/prod. I could use feedback on how we'd like to generate these (e.g. 'silently', 'interactively', is there a proper yeoman way to do this?)
1. Currently, the jhipster-registry assumes JHipsterProperties has a shared secret property on all jhipster apps it's coordinating. I'd like to delete references to the shared secret in jhipster apps that use UAA but can't without changing jhipster-registry. Suggestions?
1. We could have relied on default resource server .yml configuration for the `security.oauth2.resource.jwt.keyUri` property except that is can't handle "discoverable" URIs yet (see
http://stackoverflow.com/questions/36900650/using-security-oauth2-resource-jwt-keyuri-with-a-discoverable-service-name). I've had to manually configure this on initialization. Still, the URL be moved to JHipsterProperties configuration...especially to handle differences in dev/production for http vs https?

I don't imagine this PR is ready to merge but I'd appreciate any feedback to get it closer (ping @xetys)

I should also say that this would take us a step close to being able to do Single Sign On with OAuth2. There are still many permutations of OAuth2 configurations though (including SSO)...and JHipster can't support all of them. It might be worthwhile discussion which one(s) it should support out-of-the-box)
