### PR TITLE
Added additional dir for processor-plugin

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -865,6 +865,11 @@
                     <defaultOutputDirectory>
                         ${project.build.directory}/generated-sources
                     </defaultOutputDirectory>
+                    <additionalSourceDirectories>
+                        <additionalSourceDirectory>
+                            ${project.build.directory}/generated-sources
+                        </additionalSourceDirectory>
+                    </additionalSourceDirectories>
                     <processors>
                         <processor>org.mapstruct.ap.MappingProcessor</processor>
                     </processors>


### PR DESCRIPTION
This plugin adds a default, but without this option, you can not add other plugins that generate sources