### PR TITLE
Update _user-management-detail.html to fix missing 'vm.'

### DIFF
--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-detail.html
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management-detail.html
@@ -26,7 +26,7 @@
         <dt><span translate="userManagement.profiles">Profiles</span></dt>
         <dd>
             <ul class="list-unstyled">
-                <li ng-repeat="authority in user.authorities"><span>{{authority}}</span></li>
+                <li ng-repeat="authority in vm.user.authorities"><span>{{authority}}</span></li>
             </ul>
         </dd>
     </dl>


### PR DESCRIPTION
##### **Overview of the issue**

user-management-detail.html page not displaying the authorities due to missing 'vm.' on the code

##### **JHipster Version(s)** 

I'm using 3.1.0, this might be the issue on 3.0.0 too.


##### **Suggest a Fix** 
Submitted a PR
