### PR TITLE
add default troubleshooting steps fix #3541

### DIFF
--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -137,7 +137,6 @@ gulp.task('inject:app', function () {
         .pipe(gulp.dest(config.app));
 });
 
-
 gulp.task('inject:vendor', function () {
     var stream = gulp.src(config.app + 'index.html')
         .pipe(plumber({errorHandler: handleErrors}))
@@ -167,6 +166,21 @@ gulp.task('inject:test', function () {
             }
         }))
         .pipe(gulp.dest(config.test));
+});
+
+gulp.task('inject:troubleshoot', function () {
+    /* this task removes the troubleshooting content from index.html*/
+    return gulp.src(config.app + 'index.html')
+        .pipe(plumber({errorHandler: handleErrors}))
+        /* having empty src as we dont have to read any files*/
+        .pipe(inject(gulp.src('', {read: false}), {
+            starttag: '<!-- inject:troubleshoot -->',
+            removeTags: true,
+            transform: function () {
+                return '<!-- Angular views -->';
+            }
+        }))
+        .pipe(gulp.dest(config.app));
 });
 
 gulp.task('assets:prod', ['images', 'styles', 'html'], build);
@@ -282,7 +296,7 @@ gulp.task('watch', function () {
 });
 
 gulp.task('install', function () {
-    runSequence(['inject:dep', 'ngconstant:dev']<% if(useSass) { %>, 'sass'<% } %><% if(enableTranslation) { %>, 'languages'<% } %>, 'inject:app');
+    runSequence(['inject:dep', 'ngconstant:dev']<% if(useSass) { %>, 'sass'<% } %><% if(enableTranslation) { %>, 'languages'<% } %>, 'inject:app', 'inject:troubleshoot');
 });
 
 gulp.task('serve', function () {
@@ -290,7 +304,7 @@ gulp.task('serve', function () {
 });
 
 gulp.task('build', ['clean'], function (cb) {
-    runSequence(['copy', 'inject:vendor', 'ngconstant:prod'<% if(enableTranslation) { %>, 'languages'<% } %>], 'inject:app', 'assets:prod', cb);
+    runSequence(['copy', 'inject:vendor', 'ngconstant:prod'<% if(enableTranslation) { %>, 'languages'<% } %>], 'inject:app', 'inject:troubleshoot', 'assets:prod', cb);
 });
 
 gulp.task('default', ['serve']);

--- a/generators/client/templates/src/main/webapp/_index.html
+++ b/generators/client/templates/src/main/webapp/_index.html
@@ -28,7 +28,19 @@
     <page-ribbon></page-ribbon>
     <div ui-view="navbar" ng-cloak></div>
     <div class="container">
-        <div class="well" ui-view="content"></div>
+        <div class="well" ui-view="content">
+            <!-- inject:troubleshoot -->
+            <!-- This content is for troubleshooting purpose and will be removed by `gulp install` task -->
+            <p>If you are seeing this, it means something went wrong during the initial setup of the application.</p>
+            <p>Please make sure the below steps have completed successfully, else please run the steps in below order</p>
+            <ol>
+                <li>Install npm dependency with command <code style="color:red">npm install</code></li>
+                <li>Install bower dependency with command <code style="color:red">bower install</code></li>
+                <li>Run initial setup using gulp with command <code style="color:red">gulp install</code></li>
+            </ol>
+            <p>If you are re generating an existing JHipster application then please use command <code style="color:red">yo jhipster --with-entities</code> to regenerate your entities along with application.</p>
+            <!-- endinject -->
+        </div>
 
         <div class="footer" ng-cloak>
             <p translate="footer">This is your footer</p>


### PR DESCRIPTION
@jdubois please see if the steps are ok. @jhipster/developers let me know if any more steps needs to be added.

The gulp task is required only if we dont want the content in html at all, else angular takes care of not showing the content if gulp install runs successfully

fix #3541 