### PR TITLE
schema management for Cassandra

### DIFF
--- a/generators/server/templates/src/main/docker/_cassandra.yml
+++ b/generators/server/templates/src/main/docker/_cassandra.yml
@@ -23,6 +23,8 @@ services:
             - <%=baseName.toLowerCase()%>-cassandra
         environment:
             - CASSANDRA_CONTACT_POINT=<%=baseName.toLowerCase()%>-cassandra
+            - USER=docker-cassandra-migration
+            # - DEBUG_LOG=1 ## uncomment to show debug logs in the migration
         build:
             context: .
             dockerfile: cassandra/Cassandra.Dockerfile

--- a/generators/server/templates/src/main/docker/cassandra/scripts/_execute-cql.sh
+++ b/generators/server/templates/src/main/docker/cassandra/scripts/_execute-cql.sh
@@ -1,10 +1,23 @@
 #!/usr/bin/env bash
 
+KEYSPACE_NAME=<%= baseName.toLowerCase() %>
+
+unset scripts
+declare -A scripts
+
 function log {
     echo "[$(date)]: $*"
 }
 
-KEYSPACE_NAME=<%= baseName.toLowerCase() %>
+function logDebug {
+    ((DEBUG_LOG)) && echo "[DEBUG][$(date)]: $*"
+}
+
+function exitWithError() {
+    echo "ERROR :
+        $*"
+    exit 1
+}
 
 #usage checks
 if [ -z "$1" ]; then
@@ -17,12 +30,94 @@ if [ -z "$CASSANDRA_CONTACT_POINT" ]; then
 fi
 
 cqlFile=$1
+filename=$(basename "$1")
 
-log "execute: " $cqlFile
-cqlsh -k $KEYSPACE_NAME -f $cqlFile $CASSANDRA_CONTACT_POINT
+#load already executed scripts in the `scripts` global variable: dictionary[scriptName->checksum]
+function loadExecutedScripts {
+    #allow spaces in cqlsh output
+    IFS=$'\n'
+    local rows=($(cqlsh -k $KEYSPACE_NAME -e "select * from schema_version" $CASSANDRA_CONTACT_POINT | tail -n+4 | sed '$d' |sed '$d'))
 
-if [ $? -ne 0 ]; then
-    log "fail to apply script " $filename
-    log "stop applying database changes"
-    exit 1
+    for r in "${rows[@]}"
+    do
+        local scriptName=$(echo "$r" |cut -d '|' -f 1 | sed s'/^[[:space:]]*//' | sed s'/[[:space:]]*$//')
+        local checksum=$(echo "$r" |cut -d '|' -f 2 | sed s'/^[[:space:]]*//' | sed s'/[[:space:]]*$//')
+        scripts+=(["$scriptName"]="$checksum")
+    done
+    unset IFS
+}
+
+function exists {
+  if [ "$2" != in ]; then
+    echo "Incorrect usage."
+    echo "Correct usage: exists {key} in {array}"
+    return 1
+  fi
+
+  eval '[ ${'$3'[$1]+exists} ]'
+}
+
+function checksumEquals {
+    local checksum=$(md5sum $cqlFile | cut -d ' ' -f 1)
+    local foundChecksum=${scripts[${filename}]}
+
+    if [[ "$checksum" == "$foundChecksum" ]]; then
+        logDebug "checksum equals for $cqlFile, checksum=$checksum"
+        return 0
+    else
+        logDebug "different checksum found for $cqlFile
+        checksum=$checksum
+   foundChecksum=$foundChecksum"
+        return 1
+    fi
+}
+
+function isExecuted {
+    if exists $filename in scripts; then
+        if checksumEquals $cqlFile; then
+            return 0
+        else
+            exitWithError "$cqlFile has already been executed but has a different checksum logged in the schema_version table.
+            scripts must not be changed after being executed.
+            to resolve this issue you can:
+            - revert the modified script to its initial state and create a new script
+            OR
+            - delete the script entry from the schema_version table
+            "
+        fi
+    else
+        return 1
+    fi
+}
+
+function executeCqlScript {
+    log "execute: " $cqlFile
+    cqlsh -k $KEYSPACE_NAME -f $cqlFile $CASSANDRA_CONTACT_POINT
+
+    # if execution failed
+    if [ $? -ne 0 ]; then
+        exitWithError "fail to apply script $filename
+        stop applying database changes"
+    fi
+}
+
+function logExecutedScript {
+    local duration=$1
+    local checksum=$(md5sum $cqlFile | cut -d ' ' -f 1)
+
+    logDebug "save $cqlFile execution in schema_version table"
+    local query="INSERT INTO schema_version (script_name, checksum, executed_by, executed_on, execution_time, status) VALUES ('$filename', '$checksum', '$USER', toTimestamp(now()), $duration, 'success');"
+    cqlsh -k $KEYSPACE_NAME -e "$query" $CASSANDRA_CONTACT_POINT
+}
+
+loadExecutedScripts
+if isExecuted; then
+    logDebug "skipping $cqlFile already executed"
+else
+    _start=$(date +"%s")
+    executeCqlScript
+    _end=$(date +"%s")
+    duration=`expr $_end - $_start`
+    logExecutedScript $duration
+    log "$cqlFile executed with success in $duration seconds"
 fi

--- a/generators/server/templates/src/main/resources/config/cql/create-tables.cql
+++ b/generators/server/templates/src/main/resources/config/cql/create-tables.cql
@@ -1,3 +1,12 @@
+CREATE TABLE IF NOT EXISTS schema_version (
+    script_name text,
+    checksum text,
+    executed_by text,
+    executed_on timestamp,
+    execution_time int,
+    status text,
+    PRIMARY KEY(script_name)
+);
 <%_ if (databaseType === 'cassandra' && !skipUserManagement) { _%>
 CREATE TABLE IF NOT EXISTS user (
     id text,


### PR DESCRIPTION
This is a follow-up of the discussion with @pascalgrimaud and @jdubois  in #3288

This pull request adds a table to track the cql scripts executed in cassandra and avoid run them twice, similar to what is done by liquibase/flyway.

The `auto-migrate.sh` and `execute-cql.sh` scripts use the `schema_version` table to only run cql scripts from the changelog folder once.
If a cql script is changed after being executed, an error will be reported.

#### Usage:
1. Start the docker container for cassandra with docker-compose:
 - `docker-compose -f src/main/docker/cassandra.yml up -d`
2. Add some cql scripts in the changelog folder
3. Execute the cql scripts (see below)

There are now 3 ways to execute the cql scripts without restarting the cassandra cluster:
- Run the automatic migration from a docker container: 
 - `docker-compose -f src/main/docker/cassandra.yml up <app>-cassandra-migration`
- Run the automatic migration from locally:
 - `src/main/docker/cassandra/scripts/autoMigrate.sh src/main/resources/config/cql/changelog/`
- Execute only the new script from locally:
 - `src/main/docker/cassandra/scripts/execute-cql.sh src/main/resources/config/cql/changelog/<script>.cql`

To run locally there are some dependencies:
- define the `CASSANDRA_CONTACT_POINT` environment variable:
 - `export CASSANDRA_CONTACT_POINT=\`docker-machine ip default\``
- install: bash >4 and md5sum
- have the cqlsh command in the classpath


I'm opening the PR for discussion.
When improvement I'd like to do is to have the `create-tables.cql` script moved to the changelog folder to be managed as well.