### PR TITLE
Fixed new password and email validation messages (EN, CS)

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/cs/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/_global.json
@@ -57,18 +57,18 @@
             "validate": {
                 "newpassword": {
                     "required": "Heslo je povinné.",
-                    "minlength": "Vaše heslo musí mít alespoň 5 znaků.",
+                    "minlength": "Vaše heslo musí mít alespoň 4 znaky.",
                     "maxlength": "Vaše heslo nemůže být delší než 50 znaků.",
-                    "strength": "Sila hesla:"
+                    "strength": "Síla hesla:"
                 },
                 "confirmpassword": {
                     "required": "Potvrzení hesla je povinné.",
-                    "minlength": "Vaše potvrzení hesla musí mít alespoň 5 znaků.",
+                    "minlength": "Vaše potvrzení hesla musí mít alespoň 4 znaky.",
                     "maxlength": "Vaše potvrzení hesla nemůže být delší než 50 znaků."
                 },
                 "email": {
                     "required": "E-mail je povinný.",
-                    "invalid": "Zadaný e-mail není validný.",
+                    "invalid": "Zadaný e-mail není validní.",
                     "minlength": "Váš e-mail musí mít alespoň 5 znaků.",
                     "maxlength": "Váš e-mail nemůže být delší než 50 znaků."
                 }

--- a/generators/languages/templates/src/main/webapp/i18n/en/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/_global.json
@@ -57,13 +57,13 @@
             "validate": {
                 "newpassword": {
                     "required": "Your password is required.",
-                    "minlength": "Your password is required to be at least 5 characters.",
+                    "minlength": "Your password is required to be at least 4 characters.",
                     "maxlength": "Your password cannot be longer than 50 characters.",
                     "strength": "Password strength:"
                 },
                 "confirmpassword": {
                     "required": "Your confirmation password is required.",
-                    "minlength": "Your confirmation password is required to be at least 5 characters.",
+                    "minlength": "Your confirmation password is required to be at least 4 characters.",
                     "maxlength": "Your confirmation password cannot be longer than 50 characters."
                 },
                 "email": {


### PR DESCRIPTION
The app checks if a new password is at least 4 characters long, but the message says 5. Fixed for EN and CS.
Also fixed minor typos in CS.