### PR TITLE
Set default profile

### DIFF
--- a/generators/server/templates/src/main/java/package/_Application.java
+++ b/generators/server/templates/src/main/java/package/_Application.java
@@ -19,7 +19,6 @@ import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 <%_ } _%>
 import org.springframework.context.annotation.ComponentScan;
 import org.springframework.core.env.Environment;
-import org.springframework.core.env.SimpleCommandLinePropertySource;
 
 import javax.annotation.PostConstruct;
 import javax.inject.Inject;
@@ -27,6 +26,8 @@ import java.net.InetAddress;
 import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
 
 @ComponentScan
 @EnableAutoConfiguration(exclude = { MetricFilterAutoConfiguration.class, MetricRepositoryAutoConfiguration.class<% if (clusteredHttpSession == 'hazelcast') { %>, HazelcastAutoConfiguration.class<% } %><% if (applicationType == 'gateway') { %>, MetricsDropwizardAutoConfiguration.class<% } %> })
@@ -54,7 +55,7 @@ public class <%= mainClass %> {
     @PostConstruct
     public void initApplication() {
         if (env.getActiveProfiles().length == 0) {
-            log.warn("No Spring profile configured, running with default configuration");
+            log.warn("No Spring profile configured, running with default profile: {}", Constants.SPRING_PROFILE_DEVELOPMENT);
         } else {
             log.info("Running with Spring profile(s) : {}", Arrays.toString(env.getActiveProfiles()));
             Collection<String> activeProfiles = Arrays.asList(env.getActiveProfiles());
@@ -77,8 +78,7 @@ public class <%= mainClass %> {
      */
     public static void main(String[] args) throws UnknownHostException {
         SpringApplication app = new SpringApplication(<%= mainClass %>.class);
-        SimpleCommandLinePropertySource source = new SimpleCommandLinePropertySource(args);
-        addDefaultProfile(app, source);
+        addDefaultProfile(app);
         Environment env = app.run(args).getEnvironment();
         log.info("\n----------------------------------------------------------\n\t" +
                 "Application '{}' is running! Access URLs:\n\t" +
@@ -98,13 +98,16 @@ public class <%= mainClass %> {
     }
 
     /**
-     * If no profile has been configured, set by default the "dev" profile.
+     * set a default to use when no profile is configured.
      */
-    private static void addDefaultProfile(SpringApplication app, SimpleCommandLinePropertySource source) {
-        if (!source.containsProperty("spring.profiles.active") &&
-                !System.getenv().containsKey("SPRING_PROFILES_ACTIVE")) {
-
-            app.setAdditionalProfiles(Constants.SPRING_PROFILE_DEVELOPMENT);
-        }
+    protected static void addDefaultProfile(SpringApplication app) {
+        Map<String, Object> defProperties =  new HashMap<>();
+        /*
+        * The default profile to use when no other profiles are defined
+        * This cannot be set in the `application.yml` file.
+        * See https://github.com/spring-projects/spring-boot/issues/1219
+        */
+        defProperties.put("spring.profiles.default", Constants.SPRING_PROFILE_DEVELOPMENT);
+        app.setDefaultProperties(defProperties);
     }
 }

--- a/generators/server/templates/src/main/java/package/_ApplicationWebXml.java
+++ b/generators/server/templates/src/main/java/package/_ApplicationWebXml.java
@@ -1,39 +1,20 @@
 package <%=packageName%>;
 
-import <%=packageName%>.config.Constants;
-
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 import org.springframework.boot.builder.SpringApplicationBuilder;
 import org.springframework.boot.context.web.SpringBootServletInitializer;
 
 /**
  * This is a helper Java class that provides an alternative to creating a web.xml.
+ * This will be invoked only when the application is deployed to a servlet container like Tomcat, Jboss etc.
  */
 public class ApplicationWebXml extends SpringBootServletInitializer {
 
-    private final Logger log = LoggerFactory.getLogger(ApplicationWebXml.class);
-
     @Override
     protected SpringApplicationBuilder configure(SpringApplicationBuilder application) {
-        return application.profiles(addDefaultProfile())
-            .sources(<%= mainClass %>.class);
-    }
-
-    /**
-     * Set a default profile if it has not been set.
-     * <p>
-     * Please use -Dspring.profiles.active=dev
-     * </p>
-     */
-    private String addDefaultProfile() {
-        String profile = System.getProperty("spring.profiles.active");
-        if (profile != null) {
-            log.info("Running with Spring profile(s) : {}", profile);
-            return profile;
-        }
-
-        log.warn("No Spring profile configured, running with default configuration");
-        return Constants.SPRING_PROFILE_DEVELOPMENT;
+        /**
+         * set a default to use when no profile is configured.
+         */
+        <%= mainClass %>.addDefaultProfile(application.application());
+        return application.sources(<%= mainClass %>.class);
     }
 }

--- a/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
+++ b/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
@@ -51,7 +51,9 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
 
     @Override
     public void onStartup(ServletContext servletContext) throws ServletException {
-        log.info("Web application configuration, using profiles: {}", Arrays.toString(env.getActiveProfiles()));
+        if (env.getActiveProfiles().length != 0) {
+            log.info("Web application configuration, using profiles: {}", Arrays.toString(env.getActiveProfiles()));
+        }
         EnumSet<DispatcherType> disps = EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.ASYNC);<% if (clusteredHttpSession == 'hazelcast') { %>
         initClusteredHttpSessionFilter(servletContext, disps);<% } %>
         initMetrics(servletContext, disps);<% if (!skipClient) { %>

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -32,6 +32,10 @@ management:
 spring:
     application:
         name: <%= baseName %>
+    profiles:
+        # The commented value for `active` can be replaced with valid spring profiles to load.
+        # This will be overwritten by `--spring.profiles.active` value passed in the commandline or `-Dspring.profiles.active` set in `JAVA_OPTS`
+        active: #spring.profiles.active#
     <%_ if (databaseType == 'sql') { _%>
     jpa:
         open-in-view: false


### PR DESCRIPTION
This is based on the discussion in #3224 

This sets a default profile properly when no profile is passed as `--spring.profiles.active` or `-Dspring.profiles.active` set in `JAVA_OPTS` or as `-Pprod` in build.

I have tested this from IDE, as executable war, via boot run and deployed in tomcat. This seems to work properly.

I have also set the placeholder in `application.yml` so that it can be replaced by the build tool to set an active profile while packaging and that also works in all the above mentioned methods.

Now additional work needs to be done to do the replacement of the value in the file moved to `target|build` folder during `mvn package` or `gradle bootRepackage | gradle war` But I guess that can be done as another PR.

@erikkemperman since ill be away for few days you can give it a shot if you have time.

@jdubois please review if ok