### PR TITLE
Use JSR310 dates for cassandra

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -488,8 +488,12 @@ module.exports = EntityGenerator.extend({
                         name: 'BigDecimal'
                     },
                     {
-                        value: 'Date',
-                        name: 'Date'
+                        value: 'LocalDate',
+                        name: 'LocalDate (Warning: only compatible with cassandra v3)'
+                    },
+                    {
+                        value: 'ZonedDateTime',
+                        name: 'ZonedDateTime'
                     },
                     {
                         value: 'Boolean',
@@ -647,7 +651,6 @@ module.exports = EntityGenerator.extend({
                         (response.fieldType === 'LocalDate' ||
                         response.fieldType === 'ZonedDateTime' ||
                         response.fieldType === 'UUID' ||
-                        response.fieldType === 'Date' ||
                         response.fieldType === 'Boolean' ||
                         response.fieldType === 'ByteBuffer' ||
                         response.fieldIsEnum === true);
@@ -1514,7 +1517,6 @@ module.exports = EntityGenerator.extend({
 
             this.fieldsContainZonedDateTime = false;
             this.fieldsContainLocalDate = false;
-            this.fieldsContainDate = false;
             this.fieldsContainBigDecimal = false;
             this.fieldsContainBlob = false;
             this.validation = false;
@@ -1531,7 +1533,7 @@ module.exports = EntityGenerator.extend({
             // Load in-memory data for fields
             this.fields && this.fields.forEach( function (field) {
                 // Migration from JodaTime to Java Time
-                if (field.fieldType === 'DateTime') {
+                if (field.fieldType === 'DateTime' || field.fieldType === 'Date') {
                     field.fieldType = 'ZonedDateTime';
                 }
                 var fieldType = field.fieldType;
@@ -1582,8 +1584,6 @@ module.exports = EntityGenerator.extend({
                     this.fieldsContainZonedDateTime = true;
                 } else if (fieldType === 'LocalDate') {
                     this.fieldsContainLocalDate = true;
-                } else if (fieldType === 'Date') {
-                    this.fieldsContainDate = true;
                 } else if (fieldType === 'BigDecimal') {
                     this.fieldsContainBigDecimal = true;
                 } else if (fieldType === 'byte[]' || fieldType === 'ByteBuffer') {
@@ -1866,7 +1866,6 @@ module.exports = EntityGenerator.extend({
                         fieldsContainOneToMany: this.fieldsContainOneToMany,
                         fieldsContainZonedDateTime: this.fieldsContainZonedDateTime,
                         fieldsContainLocalDate: this.fieldsContainLocalDate,
-                        fieldsContainDate: this.fieldsContainDate,
                         fieldsContainBigDecimal: this.fieldsContainBigDecimal,
                         fieldsContainBlob: this.fieldsContainBlob,
                         pkType: this.pkType,

--- a/generators/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/src/main/java/package/domain/_Entity.java
@@ -21,8 +21,7 @@ import java.io.Serializable;<% if (fieldsContainBigDecimal == true) { %>
 import java.math.BigDecimal;<% } %><% if (fieldsContainBlob && databaseType === 'cassandra') { %>
 import java.nio.ByteBuffer;<% } %><% if (fieldsContainLocalDate == true) { %>
 import java.time.LocalDate;<% } %><% if (fieldsContainZonedDateTime == true) { %>
-import java.time.ZonedDateTime;<% } %><% if (fieldsContainDate == true) { %>
-import java.util.Date;<% } %><% if (importSet == true) { %>
+import java.time.ZonedDateTime;<% } %><% if (importSet == true) { %>
 import java.util.HashSet;
 import java.util.Set;<% } %>
 import java.util.Objects;<% if (databaseType == 'cassandra') { %>

--- a/generators/entity/templates/src/main/java/package/repository/_EntityRepository.java
+++ b/generators/entity/templates/src/main/java/package/repository/_EntityRepository.java
@@ -13,7 +13,9 @@ import org.springframework.data.mongodb.repository.MongoRepository;<% } %><% if 
 import org.springframework.stereotype.Repository;
 
 import javax.annotation.PostConstruct;
-import javax.inject.Inject;
+import javax.inject.Inject;<% if (fieldsContainLocalDate == true) { %>
+import java.time.LocalDate;<% } %><% if (fieldsContainZonedDateTime == true) { %>
+import java.time.ZonedDateTime;<% } %>
 import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;<% } %>
@@ -72,8 +74,9 @@ public class <%= entityClass %>Repository {
                     var fieldNameUnderscored = fields[idx].fieldNameUnderscored;
                     if (fields[idx].fieldType == 'Integer') { %>
                 <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getInt("<%= fieldName %>"));<% } else if (fields[idx].fieldType == 'BigDecimal') { %>
-                <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getDecimal("<%= fieldName %>"));<% } else if (fields[idx].fieldType == 'Date') { %>
-                <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getTimestamp("<%= fieldName %>"));<% } else if (fields[idx].fieldType == 'Boolean') { %>
+                <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getDecimal("<%= fieldName %>"));<% } else if (fields[idx].fieldType == 'LocalDate') { %>
+                <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.get("<%= fieldName %>", LocalDate.class));<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>
+                <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.get("<%= fieldName %>", ZonedDateTime.class));<% } else if (fields[idx].fieldType == 'Boolean') { %>
                 <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getBool("<%= fieldName %>"));<% } else if (fields[idx].fieldType == 'Text') { %>
                 <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getString("<%= fieldName %>"));<% } else if (fields[idx].fieldType === 'ByteBuffer') { %>
                 <%= entityInstance %>.set<%= fieldInJavaBeanMethod %>(row.getBytes("<%= fieldName %>"));

--- a/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/dto/_EntityDTO.java
@@ -5,8 +5,7 @@ import java.time.ZonedDateTime;<% } %><% if (validation) { %>
 import javax.validation.constraints.*;<% } %>
 import java.io.Serializable;<% if (fieldsContainBigDecimal == true) { %>
 import java.math.BigDecimal;<% } %><% if (fieldsContainBlob && databaseType === 'cassandra') { %>
-import java.nio.ByteBuffer;<% } %><% if (fieldsContainDate == true) { %>
-import java.util.Date;<% } %><% if (relationships.length > 0) { %>
+import java.nio.ByteBuffer;<% } %><% if (relationships.length > 0) { %>
 import java.util.HashSet;
 import java.util.Set;<% } %>
 import java.util.Objects;<% if (databaseType == 'cassandra') { %>

--- a/generators/entity/templates/src/main/resources/config/cql/changelog/_added_entity.cql
+++ b/generators/entity/templates/src/main/resources/config/cql/changelog/_added_entity.cql
@@ -12,7 +12,8 @@ CREATE TABLE IF NOT EXISTS <%= entityInstance %> (
     <%= fieldName %> bigint,<% } else if (fieldType == 'Float') { %>
     <%= fieldName %> float,<% } else if (fieldType == 'Double') { %>
     <%= fieldName %> double,<% } else if (fieldType == 'BigDecimal') { %>
-    <%= fieldName %> decimal,<% } else if (fieldType == 'Date') { %>
+    <%= fieldName %> decimal,<% } else if (fieldType == 'LocalDate') { %>
+    <%= fieldName %> date,<% } else if (fieldType == 'ZonedDateTime') { %>
     <%= fieldName %> timestamp,<% } else if (fieldType == 'Boolean') { %>
     <%= fieldName %> boolean,<% } else if (fieldType === 'ByteBuffer') { %>
     <%= fieldName %> blob,<% if (fieldTypeBlobContent !== 'text') { %>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -19,7 +19,7 @@
                 </a>
                 {{vm.<%= entityInstance %>.<%= fieldName %>ContentType}}, {{vm.byteSize(vm.<%= entityInstance %>.<%= fieldName %>)}}
             </div>
-            <%_ } else if (fieldType == 'ZonedDateTime' || fieldType == 'Date') { _%>
+            <%_ } else if (fieldType == 'ZonedDateTime') { _%>
             <span>{{vm.<%=entityInstance %>.<%= fieldName %> | date:'medium'}}</span>
             <%_ } else if (fieldType == 'LocalDate') { _%>
             <span>{{vm.<%=entityInstance %>.<%= fieldName %> | date:'mediumDate'}}</span>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
@@ -62,7 +62,7 @@
         vm.clear = function() {
             $uibModalInstance.dismiss('cancel');
         };
-        <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate || fieldsContainDate) { _%>
+        <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 
         vm.datePickerOpenStatus = {};
         <%_ } _%>
@@ -92,7 +92,7 @@
         vm.openFile = DataUtils.openFile;
         vm.byteSize = DataUtils.byteSize;
         <%_ } _%>
-        <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate || fieldsContainDate) { _%>
+        <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 
         vm.openCalendar = function(date) {
             vm.datePickerOpenStatus[date] = true;

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
@@ -24,7 +24,7 @@
             var translationKey = keyPrefix + fieldName;
             if (fieldType == 'Integer' || fieldType == 'Long' || fieldType == 'Float' || fieldType == 'Double' || fieldType == 'BigDecimal') {
                 fieldInputType = 'number';
-            } else if (fieldType == 'LocalDate' || fieldType == 'Date') {
+            } else if (fieldType == 'LocalDate') {
                 fieldInputType = 'date';
             } else if (fieldType == 'ZonedDateTime') {
                 fieldInputType = 'datetime-local';
@@ -68,7 +68,7 @@
                 </button>
             </div>
                 <%_ } _%>
-                <%_ if (fieldType == 'LocalDate' || fieldType == 'Date') { _%>
+                <%_ if (fieldType == 'LocalDate') { _%>
                 <div class="input-group">
                     <input id="field_<%= fieldName %>" type="text" class="form-control" name="<%= fieldName %>" uib-datepicker-popup="{{dateformat}}" ng-model="vm.<%= entityInstance %>.<%= fieldName %>" is-open="vm.datePickerOpenStatus.<%=fieldName %>"
                     <%- include ng_validators %>/>
@@ -153,7 +153,7 @@
                     This field should be a number.
                 </p>
                 <%_ } _%>
-                <%_ if (fieldType == 'ZonedDateTime' || fieldType == 'Date') { _%>
+                <%_ if (fieldType == 'ZonedDateTime') { _%>
                 <p class="help-block"
                     ng-show="editForm.<%= fieldName %>.$error.ZonedDateTimelocal" translate="entity.validation.ZonedDateTimelocal">
                     This field should be a date and time.

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.html
@@ -75,7 +75,7 @@
                     </td>
                         <%_ } else if (fields[idx].fieldIsEnum) { _%>
                     <td translate="{{'<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>}}">{{<%= entityInstance %>.<%= fieldName %>}}</td>
-                        <%_ } else if (fieldType == 'ZonedDateTime' || fieldType == 'Date') { _%>
+                        <%_ } else if (fieldType == 'ZonedDateTime') { _%>
                     <td>{{<%=entityInstance %>.<%=fieldName%> | date:'medium'}}</td>
                     <%_ } else if (fieldType == 'LocalDate') { _%>
                         <td>{{<%=entityInstance %>.<%=fieldName%> | date:'mediumDate'}}</td>

--- a/generators/entity/templates/src/main/webapp/app/services/_entity.service.js
+++ b/generators/entity/templates/src/main/webapp/app/services/_entity.service.js
@@ -1,7 +1,7 @@
 (function() {
     'use strict';
 <%_ var hasDate = false;
-    if (fieldsContainZonedDateTime || fieldsContainLocalDate || fieldsContainDate) {
+    if (fieldsContainZonedDateTime || fieldsContainLocalDate) {
         hasDate = true;
     }
 _%>
@@ -21,7 +21,7 @@ _%>
                 transformResponse: function (data) {
                     if (data) {
                         data = angular.fromJson(data);<% for (idx in fields) { if (fields[idx].fieldType == 'LocalDate') { %>
-                        data.<%=fields[idx].fieldName%> = DateUtils.convertLocalDateFromServer(data.<%=fields[idx].fieldName%>);<% }if (fields[idx].fieldType == 'ZonedDateTime' || fields[idx].fieldType == 'Date') { %>
+                        data.<%=fields[idx].fieldName%> = DateUtils.convertLocalDateFromServer(data.<%=fields[idx].fieldName%>);<% }if (fields[idx].fieldType == 'ZonedDateTime') { %>
                         data.<%=fields[idx].fieldName%> = DateUtils.convertDateTimeFromServer(data.<%=fields[idx].fieldName%>);<% } }%>
                     }
                     return data;

--- a/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -35,8 +35,7 @@ import java.time.ZonedDateTime;
 import java.time.format.DateTimeFormatter;<% } %><% if (fieldsContainLocalDate == true || fieldsContainZonedDateTime == true) { %>
 import java.time.ZoneId;<% } %><% if (fieldsContainBigDecimal == true) { %>
 import java.math.BigDecimal;;<% } %><% if (fieldsContainBlob == true && databaseType === 'cassandra') { %>
-import java.nio.ByteBuffer;<% } %><% if (fieldsContainDate == true) { %>
-import java.util.Date;<% } %>
+import java.nio.ByteBuffer;<% } %>
 import java.util.List;<% if (databaseType == 'cassandra') { %>
 import java.util.UUID;<% } %>
 
@@ -133,10 +132,7 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
     private static final BigDecimal <%=updatedValueName %> = new BigDecimal(<%= updatedValue %>);<% } else if (fieldType == 'UUID') { %>
 
     private static final UUID <%=defaultValueName %> = UUID.randomUUID();
-    private static final UUID <%=updatedValueName %> = UUID.randomUUID();<% } else if (fieldType == 'Date') { %>
-
-    private static final Date <%=defaultValueName %> = new Date();
-    private static final Date <%=updatedValueName %> = new Date();<% } else if (fieldType == 'LocalDate') { %>
+    private static final UUID <%=updatedValueName %> = UUID.randomUUID();<% } else if (fieldType == 'LocalDate') { %>
 
     private static final LocalDate <%=defaultValueName %> = LocalDate.ofEpochDay(0L);
     private static final LocalDate <%=updatedValueName %> = LocalDate.now(ZoneId.systemDefault());<% } else if (fieldType == 'ZonedDateTime') { %>
@@ -286,7 +282,7 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
                 <%_ if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { _%>
                 .andExpect(jsonPath("$.[*].<%=fields[idx].fieldName%>ContentType").value(hasItem(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>_CONTENT_TYPE)))
                 <%_ } _%>
-                .andExpect(jsonPath("$.[*].<%=fields[idx].fieldName%>").value(hasItem(<% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%><% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %><% if (databaseType == 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType == 'Integer') { %><% } else if (fields[idx].fieldType == 'Long') { %>.intValue()<% } else if (fields[idx].fieldType == 'Float' || fields[idx].fieldType == 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>_STR<% } else if (fields[idx].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>)))<% } %>;
+                .andExpect(jsonPath("$.[*].<%=fields[idx].fieldName%>").value(hasItem(<% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%><% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %><% if (databaseType == 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType == 'Integer') { %><% } else if (fields[idx].fieldType == 'Long') { %>.intValue()<% } else if (fields[idx].fieldType == 'Float' || fields[idx].fieldType == 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>_STR<% } else { %>.toString()<% } %>)))<% } %>;
     }
 
     @Test<% if (databaseType == 'sql') { %>
@@ -305,7 +301,7 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
             <%_ if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType == 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { _%>
             .andExpect(jsonPath("$.<%=fields[idx].fieldName%>ContentType").value(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>_CONTENT_TYPE))
             <%_ } _%>
-            .andExpect(jsonPath("$.<%=fields[idx].fieldName%>").value(<% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%><% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType == 'Integer') { %><% } else if (fields[idx].fieldType == 'Long') { %>.intValue()<% } else if (fields[idx].fieldType == 'Float' || fields[idx].fieldType == 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>_STR<% } else if (fields[idx].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>))<% } %>;
+            .andExpect(jsonPath("$.<%=fields[idx].fieldName%>").value(<% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%><% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType == 'Integer') { %><% } else if (fields[idx].fieldType == 'Long') { %>.intValue()<% } else if (fields[idx].fieldType == 'Float' || fields[idx].fieldType == 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>_STR<% } else { %>.toString()<% } %>))<% } %>;
     }
 
     @Test<% if (databaseType == 'sql') { %>
@@ -416,6 +412,6 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
             <%_ if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { _%>
             .andExpect(jsonPath("$.[*].<%=fields[idx].fieldName%>ContentType").value(hasItem(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>_CONTENT_TYPE)))
             <%_ } _%>
-            .andExpect(jsonPath("$.[*].<%=fields[idx].fieldName%>").value(hasItem(<% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%><% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType == 'Integer') { %><% } else if (fields[idx].fieldType == 'Long') { %>.intValue()<% } else if (fields[idx].fieldType == 'Float' || fields[idx].fieldType == 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>_STR<% } else if (fields[idx].fieldType == 'Date') { %>.getTime()<% } else { %>.toString()<% } %>)))<% } %>;
+            .andExpect(jsonPath("$.[*].<%=fields[idx].fieldName%>").value(hasItem(<% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %>Base64Utils.encodeToString(<% } %><%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%><% if ((fields[idx].fieldType == 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent != 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType == 'Integer') { %><% } else if (fields[idx].fieldType == 'Long') { %>.intValue()<% } else if (fields[idx].fieldType == 'Float' || fields[idx].fieldType == 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType == 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType == 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType == 'ZonedDateTime') { %>_STR<% } else { %>.toString()<% } %>)))<% } %>;
     }<% } %>
 }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -1201,7 +1201,9 @@ module.exports = JhipsterServerGenerator.extend({
             }
 
             if (this.databaseType === 'cassandra' || this.applicationType === 'gateway') {
-                this.template(SERVER_MAIN_SRC_DIR + 'package/config/_CassandraConfiguration.java', javaDir + 'config/CassandraConfiguration.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/cassandra/_CassandraConfiguration.java', javaDir + 'config/cassandra/CassandraConfiguration.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/cassandra/_CustomZonedDateTimeCodec.java', javaDir + 'config/cassandra/CustomZonedDateTimeCodec.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/cassandra/_package-info.java', javaDir + 'config/cassandra/package-info.java', this, {});
             }
 
             if (this.hibernateCache === 'hazelcast') {

--- a/generators/server/templates/src/main/java/package/config/_JacksonConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_JacksonConfiguration.java
@@ -1,8 +1,7 @@
 package <%=packageName%>.config;
 
 import <%=packageName%>.domain.util.*;
-<% if (databaseType != 'cassandra') { %>
-import com.fasterxml.jackson.databind.SerializationFeature;<% } %>
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import java.time.*;
 import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
@@ -20,8 +19,8 @@ public class JacksonConfiguration {
         module.addSerializer(LocalDateTime.class, JSR310DateTimeSerializer.INSTANCE);
         module.addSerializer(Instant.class, JSR310DateTimeSerializer.INSTANCE);
         module.addDeserializer(LocalDate.class, JSR310LocalDateDeserializer.INSTANCE);
-        return new Jackson2ObjectMapperBuilder()<% if (databaseType != 'cassandra') { %>
-                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)<% } %>
+        return new Jackson2ObjectMapperBuilder()
+                .featuresToDisable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
                 .findModulesViaServiceLoader(true)
                 .modulesToInstall(module);
     }

--- a/generators/server/templates/src/main/java/package/config/cassandra/_CassandraConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/cassandra/_CassandraConfiguration.java
@@ -1,4 +1,4 @@
-package <%=packageName%>.config;
+package <%=packageName%>.config.cassandra;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -74,13 +74,12 @@ public class CassandraConfiguration {
 
         Cluster cluster = builder.build();
 
-        TupleType tupleType = cluster.getMetadata()
-                .newTupleType(DataType.timestamp(), DataType.varchar());
         cluster.getConfiguration().getCodecRegistry()
                 .register(LocalDateCodec.instance)
-                .register(new ZonedDateTimeCodec(tupleType));
+                .register(CustomZonedDateTimeCodec.instance);
 
         if (metricRegistry != null) {
+            cluster.init();
             metricRegistry.registerAll(cluster.getMetrics().getRegistry());
         }
 

--- a/generators/server/templates/src/main/java/package/config/cassandra/_CustomZonedDateTimeCodec.java
+++ b/generators/server/templates/src/main/java/package/config/cassandra/_CustomZonedDateTimeCodec.java
@@ -1,0 +1,90 @@
+package <%=packageName%>.config.cassandra;
+
+import com.datastax.driver.core.*;
+import com.datastax.driver.core.exceptions.InvalidTypeException;
+
+import java.nio.ByteBuffer;
+import java.time.Instant;
+import java.time.ZoneOffset;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.time.format.DateTimeFormatterBuilder;
+import java.time.format.DateTimeParseException;
+
+import static com.datastax.driver.core.ParseUtils.isLongLiteral;
+import static com.datastax.driver.core.ParseUtils.quote;
+import static java.time.temporal.ChronoField.*;
+
+public class CustomZonedDateTimeCodec extends TypeCodec<ZonedDateTime> {
+
+    public static final CustomZonedDateTimeCodec instance = new CustomZonedDateTimeCodec();
+
+    private static final DateTimeFormatter FORMATTER = new DateTimeFormatterBuilder()
+            .parseCaseSensitive()
+            .parseStrict()
+            .append(DateTimeFormatter.ISO_LOCAL_DATE)
+            .optionalStart()
+            .appendLiteral('T')
+            .appendValue(HOUR_OF_DAY, 2)
+            .appendLiteral(':')
+            .appendValue(MINUTE_OF_HOUR, 2)
+            .optionalEnd()
+            .optionalStart()
+            .appendLiteral(':')
+            .appendValue(SECOND_OF_MINUTE, 2)
+            .optionalEnd()
+            .optionalStart()
+            .appendFraction(NANO_OF_SECOND, 0, 9, true)
+            .optionalEnd()
+            .optionalStart()
+            .appendZoneOrOffsetId()
+            .optionalEnd()
+            .toFormatter()
+            .withZone(ZoneOffset.UTC);
+
+    private CustomZonedDateTimeCodec() {
+        super(DataType.timestamp(), ZonedDateTime.class);
+    }
+
+    @Override
+    public ByteBuffer serialize(ZonedDateTime value, ProtocolVersion protocolVersion) {
+        if (value == null)
+            return null;
+        long millis = value.toInstant().toEpochMilli();
+        return bigint().serializeNoBoxing(millis, protocolVersion);
+    }
+
+    @Override
+    public ZonedDateTime deserialize(ByteBuffer bytes, ProtocolVersion protocolVersion) {
+        if (bytes == null || bytes.remaining() == 0)
+            return null;
+        long millis = bigint().deserializeNoBoxing(bytes, protocolVersion);
+        return Instant.ofEpochMilli(millis).atZone(ZoneOffset.UTC);
+    }
+
+    @Override
+    public String format(ZonedDateTime value) {
+        return quote(FORMATTER.format(value));
+    }
+
+    @Override
+    public ZonedDateTime parse(String value) {
+            // strip enclosing single quotes, if any
+            if (ParseUtils.isQuoted(value))
+                value = ParseUtils.unquote(value);
+            if (isLongLiteral(value)) {
+                try {
+                    long millis = Long.parseLong(value);
+                    return ZonedDateTime.ofInstant(Instant.ofEpochMilli(millis), ZoneOffset.UTC);
+                } catch (NumberFormatException e) {
+                    throw new InvalidTypeException(String.format("Cannot parse timestamp value from \"%s\"", value));
+                }
+            }
+            try {
+                return ZonedDateTime.from(FORMATTER.parse(value));
+            } catch (DateTimeParseException e) {
+                throw new InvalidTypeException(String.format("Cannot parse timestamp value from \"%s\"", value));
+            }
+     }
+
+}

--- a/generators/server/templates/src/main/java/package/config/cassandra/_package-info.java
+++ b/generators/server/templates/src/main/java/package/config/cassandra/_package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Cassandra specific configuration.
+ */
+package <%=packageName%>.config.cassandra;


### PR DESCRIPTION
LocalDate is mapped to the new "date" CQL type (cassandra v3 only)
ZonedDatetime is mapped to "timestamp" instead of ```tuple<timestamp,varchar>``` thanks to a custom codec.

Fix #3548 