### PR TITLE
PaginationUtil: if baseUrl already contains request-params, no second '?' should be added

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
@@ -2,6 +2,7 @@ package <%=packageName%>.web.rest.util;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
+import org.springframework.web.util.UriComponentsBuilder;
 
 import java.net.URI;
 import java.net.URISyntaxException;
@@ -22,22 +23,29 @@ public class PaginationUtil {
         headers.add("X-Total-Count", "" + page.getTotalElements());
         String link = "";
         if ((page.getNumber() + 1) < page.getTotalPages()) {
-            link = "<" + (new URI(baseUrl + "?page=" + (page.getNumber() + 1) + "&size=" + page.getSize())).toString() + ">; rel=\"next\",";
+            link = "<" + generateUri(baseUrl, page.getNumber() + 1, page.getSize()) + ">; rel=\"next\",";
         }
         // prev link
         if ((page.getNumber()) > 0) {
-            link += "<" + (new URI(baseUrl + "?page=" + (page.getNumber() - 1) + "&size=" + page.getSize())).toString() + ">; rel=\"prev\",";
+            link += "<" + generateUri(baseUrl, page.getNumber() - 1, page.getSize()) + ">; rel=\"prev\",";
         }
         // last and first link
         int lastPage = 0;
         if (page.getTotalPages() > 0) {
             lastPage = page.getTotalPages() - 1;
         }
-        link += "<" + (new URI(baseUrl + "?page=" + lastPage + "&size=" + page.getSize())).toString() + ">; rel=\"last\",";
-        link += "<" + (new URI(baseUrl + "?page=" + 0 + "&size=" + page.getSize())).toString() + ">; rel=\"first\"";
+        link += "<" + generateUri(baseUrl, lastPage, page.getSize()) + ">; rel=\"last\",";
+        link += "<" + generateUri(baseUrl, 0, page.getSize()) + ">; rel=\"first\"";
         headers.add(HttpHeaders.LINK, link);
         return headers;
-    }<% if (searchEngine == 'elasticsearch') { %>
+    }
+
+    private static String generateUri(String baseUrl, int page, int size) throws URISyntaxException {
+        return UriComponentsBuilder.fromUriString(baseUrl).queryParam("page", page).queryParam("size", size).toUriString();
+    }
+
+
+    <% if (searchEngine == 'elasticsearch') { %>
 
     public static HttpHeaders generateSearchPaginationHttpHeaders(String query, Page<?> page, String baseUrl)
         throws URISyntaxException {
@@ -46,19 +54,19 @@ public class PaginationUtil {
         headers.add("X-Total-Count", "" + page.getTotalElements());
         String link = "";
         if ((page.getNumber() + 1) < page.getTotalPages()) {
-            link = "<" + (new URI(baseUrl + "?page=" + (page.getNumber() + 1) + "&size=" + page.getSize())).toString() + "&query=" + query + ">; rel=\"next\",";
+            link = "<" + generateUri(baseUrl, page.getNumber() + 1, page.getSize()) + "&query=" + query + ">; rel=\"next\",";
         }
         // prev link
         if ((page.getNumber()) > 0) {
-            link += "<" + (new URI(baseUrl + "?page=" + (page.getNumber() - 1) + "&size=" + page.getSize())).toString() + "&query=" + query + ">; rel=\"prev\",";
+            link += "<" + generateUri(baseUrl, page.getNumber() - 1, page.getSize()) + "&query=" + query + ">; rel=\"prev\",";
         }
         // last and first link
         int lastPage = 0;
         if (page.getTotalPages() > 0) {
             lastPage = page.getTotalPages() - 1;
         }
-        link += "<" + (new URI(baseUrl + "?page=" + lastPage + "&size=" + page.getSize())).toString() + "&query=" + query + ">; rel=\"last\",";
-        link += "<" + (new URI(baseUrl + "?page=" + 0 + "&size=" + page.getSize())).toString() + "&query=" + query + ">; rel=\"first\"";
+        link += "<" + generateUri(baseUrl, lastPage, page.getSize()) + "&query=" + query + ">; rel=\"last\",";
+        link += "<" + generateUri(baseUrl, 0, page.getSize()) + "&query=" + query + ">; rel=\"first\"";
         headers.add(HttpHeaders.LINK, link);
         return headers;
     }<% } %>

--- a/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
@@ -45,7 +45,7 @@ public class PaginationUtil {
     }
 
 
-    <% if (searchEngine == 'elasticsearch') { %>
+    <% if (searchEngine === 'elasticsearch') { %>
 
     public static HttpHeaders generateSearchPaginationHttpHeaders(String query, Page<?> page, String baseUrl)
         throws URISyntaxException {


### PR DESCRIPTION
I had an issue using the `PaginationUtil`

In my case, I provided a baseUrl already containing request-params: `"/api/reports?filter=true"`

Then the old implementations added `page` and `size` parameters without checking, resulting in:  `"/api/reports?filter=true?page=1&size=20"`

This result contains 2 `?`

This fix uses Spring `UriComponentsBuilder` for handling such cases.