### PR TITLE
Add more time to embedded cassandra

### DIFF
--- a/generators/server/templates/src/test/java/package/_AbstractCassandraTest.java
+++ b/generators/server/templates/src/test/java/package/_AbstractCassandraTest.java
@@ -25,9 +25,11 @@ public class AbstractCassandraTest {
 
     public static final String CASSANDRA_UNIT_KEYSPACE = "cassandra_unit_keyspace";
 
+    public static final long CASSANDRA_TIMEOUT = 30000L;
+
     @BeforeClass
     public static void startServer() throws InterruptedException, TTransportException, ConfigurationException, IOException, URISyntaxException  {
-        EmbeddedCassandraServerHelper.startEmbeddedCassandra();
+        EmbeddedCassandraServerHelper.startEmbeddedCassandra(CASSANDRA_TIMEOUT);
         Cluster cluster = new Cluster.Builder().addContactPoints("127.0.0.1").withPort(9142).build();
         Session session = cluster.connect();
         CQLDataLoader dataLoader = new CQLDataLoader(session);


### PR DESCRIPTION
I think the embedded Cassandra need more time than 10000ms to start, else the Unit Tests will fail:
```log
2016-05-13 20:59:51.809 ERROR   --- [           main] o.c.utils.EmbeddedCassandraServerHelper  : Cassandra daemon did not start after 10000 ms. Consider increasing the timeout
Tests run: 1, Failures: 1, Errors: 0, Skipped: 0, Time elapsed: 18.766 sec <<< FAILURE! - in com.mycompany.myapp.CassandraKeyspaceUnitTest
com.mycompany.myapp.CassandraKeyspaceUnitTest  Time elapsed: 18.76 sec  <<< FAILURE!
java.lang.AssertionError: Cassandra daemon did not start within timeout
	at org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.java:132)
	at org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.java:87)
	at org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.java:66)
	at org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.java:58)
	at org.cassandraunit.utils.EmbeddedCassandraServerHelper.startEmbeddedCassandra(EmbeddedCassandraServerHelper.java:54)
	at com.mycompany.myapp.AbstractCassandraTest.startServer(AbstractCassandraTest.java:30)
	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.lang.reflect.Method.invoke(Method.java:498)
```

I put it to 30000ms. Let's see how Travis deal with that.

@raphaelbrugier : I think you will need this, else your PR can failed a lot...