### PR TITLE
Travis: cache improvements

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,12 +4,13 @@ services:
   - docker
 language: node_js
 node_js:
-  - "4.4.3"
+  - "4.4.4"
 jdk:
   - oraclejdk8
 env:
   global:
-    - JHIPSTER_NODE_CACHE=1
+    - JHIPSTER_CACHE_REPO=https://github.com/jhipster/jhipster-travis-cache.git
+    - JHIPSTER_CACHE_BRANCH=160516-springboot-135
     - PROFILE=dev
     - RUN_APP=1
     - PROTRACTOR=0
@@ -30,7 +31,6 @@ env:
     - JHIPSTER=app-mongodb
     - JHIPSTER=app-oauth2
     - JHIPSTER=app-jwt
-
 before_install:
   - sudo /etc/init.d/postgresql stop
   - export DISPLAY=:99.0

--- a/travis/install/01-install-docker-compose.sh
+++ b/travis/install/01-install-docker-compose.sh
@@ -4,7 +4,7 @@ set -ev
 # Upgrade Docker
 #-------------------------------------------------------------------------------
 apt-cache madison docker-engine
-sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.10.1-0~trusty
+sudo apt-get -o Dpkg::Options::="--force-confnew" install -y docker-engine=1.11.1-0~trusty
 
 #-------------------------------------------------------------------------------
 # Install docker-compose

--- a/travis/install/03-checkVersion.sh
+++ b/travis/install/03-checkVersion.sh
@@ -5,7 +5,6 @@ set -ev
 #-------------------------------------------------------------------------------
 java -version
 git --version
-mvn -v
 node -v
 npm -v
 bower -v

--- a/travis/install/04-cache.sh
+++ b/travis/install/04-cache.sh
@@ -1,27 +1,21 @@
 #!/bin/bash
 set -ev
 #-------------------------------------------------------------------------------
-# Use jhipster-travis-build that contain .m2 and node_modules
+# Use jhipster-travis-cache that contain .m2 and node_modules
 #-------------------------------------------------------------------------------
 cd "$TRAVIS_BUILD_DIR"/
-git clone https://github.com/jhipster/jhipster-travis-build.git
-if [ "$JHIPSTER" != 'app-gradle' ]; then
-  rm -Rf "$HOME"/.m2/repository/
-  mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/repository "$HOME"/.m2/
-  ls -al "$HOME"/.m2/
-  ls -al "$HOME"/.m2/repository/
-fi
-if [ "$JHIPSTER_NODE_CACHE" == 1 ]; then
-  mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/node_modules/ "$JHIPSTER_SAMPLES/$JHIPSTER"/
-  ls -al "$JHIPSTER_SAMPLES"/"$JHIPSTER"/
-fi
+git clone -b $JHIPSTER_CACHE_BRANCH $JHIPSTER_CACHE_REPO
+
+rm -Rf "$HOME"/.m2/repository/
+mv "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/repository "$HOME"/.m2/
+
 #-------------------------------------------------------------------------------
 # Use phantomjs cache
 #-------------------------------------------------------------------------------
-tar -xvf "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C "$TRAVIS_BUILD_DIR"/jhipster-travis-build/
+tar -xvf "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/
 sudo mkdir -p /usr/local/phantomjs-2.1.1/
-sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/LICENSE.BSD /usr/local/phantomjs-2.1.1/
-sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-build/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/phantomjs-2.1.1/
+sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/phantomjs-2.1.1-linux-x86_64/LICENSE.BSD /usr/local/phantomjs-2.1.1/
+sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/phantomjs-2.1.1/
 sudo rm /usr/local/phantomjs
 sudo ln -sf /usr/local/phantomjs-2.1.1/ /usr/local/phantomjs
 ls -l /usr/local/

--- a/travis/scripts/01-generate-project.sh
+++ b/travis/scripts/01-generate-project.sh
@@ -9,16 +9,9 @@ mv "$JHIPSTER_TRAVIS"/configstore/*.json "$HOME"/.config/configstore/
 #-------------------------------------------------------------------------------
 # Generate the project with yo jhipster
 #-------------------------------------------------------------------------------
-mv -f "$JHIPSTER_SAMPLES"/"$JHIPSTER" "$HOME"/
-cd "$HOME"/"$JHIPSTER"
-
-rm -Rf "$HOME"/"$JHIPSTER"/node_modules/.bin/*grunt*
-rm -Rf "$HOME"/"$JHIPSTER"/node_modules/*grunt*
-
+mkdir -p "$HOME"/app
+mv -f "$JHIPSTER_SAMPLES"/"$JHIPSTER"/.yo-rc.json "$HOME"/app/
+cd "$HOME"/app
 npm link generator-jhipster
 yo jhipster --force --no-insight
-ls -al "$HOME"/"$JHIPSTER"
-ls -al "$HOME"/"$JHIPSTER"/node_modules/
-ls -al "$HOME"/"$JHIPSTER"/node_modules/generator-jhipster/
-ls -al "$HOME"/"$JHIPSTER"/node_modules/generator-jhipster/generators/
-ls -al "$HOME"/"$JHIPSTER"/node_modules/generator-jhipster/generators/entity/
+ls -al "$HOME"/app

--- a/travis/scripts/02-generate-entities.sh
+++ b/travis/scripts/02-generate-entities.sh
@@ -1,9 +1,11 @@
 #!/bin/bash
 set -ev
-
+#-------------------------------------------------------------------------------
+# Functions
+#-------------------------------------------------------------------------------
 moveEntity() {
   local entity="$1"
-  mv "$JHIPSTER_SAMPLES"/.jhipster/"$entity".json "$HOME"/"$JHIPSTER"/.jhipster/
+  mv "$JHIPSTER_SAMPLES"/.jhipster/"$entity".json "$HOME"/app/.jhipster/
 }
 
 generateEntity() {
@@ -16,7 +18,7 @@ generateEntity() {
 #-------------------------------------------------------------------------------
 # Copy entities json
 #-------------------------------------------------------------------------------
-mkdir -p "$HOME"/"$JHIPSTER"/.jhipster/
+mkdir -p "$HOME"/app/.jhipster/
 if [ "$JHIPSTER" == "app-mongodb" ]; then
   moveEntity MongoBankAccount
 
@@ -87,12 +89,12 @@ else
   moveEntity FieldTestPaginationEntity
 fi
 
-ls -l "$HOME"/"$JHIPSTER"/.jhipster/
+ls -l "$HOME"/app/.jhipster/
 
 #-------------------------------------------------------------------------------
 # Generate the entities with yo jhipster:entity
 #-------------------------------------------------------------------------------
-cd "$HOME"/"$JHIPSTER"
+cd "$HOME"/app
 generateEntity BankAccount
 generateEntity MongoBankAccount
 generateEntity MicroserviceBankAccount
@@ -130,7 +132,7 @@ generateEntity TestOneToOne
 # Check Javadoc generation
 #-------------------------------------------------------------------------------
 if [ "$JHIPSTER" != "app-gradle" ]; then
-  mvn javadoc:javadoc
+  ./mvnw javadoc:javadoc
 else
   ./gradlew javadoc
 fi

--- a/travis/scripts/03-docker-compose.sh
+++ b/travis/scripts/03-docker-compose.sh
@@ -3,7 +3,7 @@ set -ev
 #-------------------------------------------------------------------------------
 # Start docker container
 #-------------------------------------------------------------------------------
-cd "$HOME"/"$JHIPSTER"
+cd "$HOME"/app
 if [[ ("$JHIPSTER" == 'app-cassandra') && (-a src/main/docker/cassandra.yml) ]]; then
   docker-compose -f src/main/docker/cassandra.yml up -d
 elif [[ ("$JHIPSTER" == 'app-mongodb') && (-a src/main/docker/mongodb.yml) ]]; then

--- a/travis/scripts/04-tests.sh
+++ b/travis/scripts/04-tests.sh
@@ -3,9 +3,9 @@ set -ev
 #--------------------------------------------------
 # Launch tests
 #--------------------------------------------------
-cd "$HOME"/"$JHIPSTER"
+cd "$HOME"/app
 if [ "$JHIPSTER" != "app-gradle" ]; then
-  mvn test
+  ./mvnw test
 else
   ./gradlew test
 fi

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#-------------------------------------------------------------------------------
+# Functions
+#-------------------------------------------------------------------------------
 launchProtractor() {
     retryCount=1
     maxRetry=10
@@ -27,10 +30,10 @@ launchProtractor() {
 #-------------------------------------------------------------------------------
 # Start the application
 #-------------------------------------------------------------------------------
-cd "$HOME"/"$JHIPSTER"
+cd "$HOME"/app
 if [ "$RUN_APP" == 1 ]; then
   if [ "$JHIPSTER" != "app-gradle" ]; then
-    mvn package -DskipTests=true -P"$PROFILE"
+    ./mvnw package -DskipTests=true -P"$PROFILE"
     mv target/*.war target/app.war
     java -jar target/app.war --spring.profiles.active="$PROFILE" &
   else


### PR DESCRIPTION
The node_modules cache is completely broken with npm3, so I remove it.

All changes:
- upgrade docker 1.10 to 1.11
- upgrade node 4.4.3 to 4.4.4
- use maven wrapper to be consistent with gradle wrapper
- use new repo jhipster-travis-cache
- use m2 for gradle
- remove the cache for node_modules: doesn't work well with npm3