### PR TITLE
Entity controllers polish to follow JohnPapa Style

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-delete-dialog.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-delete-dialog.controller.js
@@ -9,15 +9,20 @@
 
     function <%= entityAngularJSName %>DeleteController($uibModalInstance, entity, <%= entityClass %>) {
         var vm = this;
+
         vm.<%= entityInstance %> = entity;
-        vm.clear = function() {
+        vm.clear = clear;
+        vm.confirmDelete = confirmDelete;
+        
+        function clear () {
             $uibModalInstance.dismiss('cancel');
-        };
-        vm.confirmDelete = function (id) {
+        }
+
+        function confirmDelete (id) {
             <%= entityClass %>.delete({id: id},
                 function () {
                     $uibModalInstance.close(true);
                 });
-        };
+        }
     }
 })();

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.controller.js
@@ -9,16 +9,16 @@
 
     function <%= entityAngularJSName %>DetailController($scope, $rootScope, $stateParams<% if (fieldsContainBlob) { %>, DataUtils<% } %>, entity<% for (idx in differentTypes) { %>, <%= differentTypes[idx] %><% } %>) {
         var vm = this;
-        vm.<%= entityInstance %> = entity;
-        
-        var unsubscribe = $rootScope.$on('<%=angularAppName%>:<%= entityInstance %>Update', function(event, result) {
-            vm.<%= entityInstance %> = result;
-        });
-        $scope.$on('$destroy', unsubscribe);
 
+        vm.<%= entityInstance %> = entity;
         <%_ if (fieldsContainBlob) { _%>
         vm.byteSize = DataUtils.byteSize;
         vm.openFile = DataUtils.openFile;
         <%_ } _%>
+
+        var unsubscribe = $rootScope.$on('<%=angularAppName%>:<%= entityInstance %>Update', function(event, result) {
+            vm.<%= entityInstance %> = result;
+        });
+        $scope.$on('$destroy', unsubscribe);
     }
 })();

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
@@ -12,6 +12,14 @@
 
         vm.<%= entityInstance %> = entity;
         vm.clear = clear;
+        <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
+        vm.datePickerOpenStatus = {};
+        vm.openCalendar = openCalendar;
+        <%_ } _%>
+        <%_ if (fieldsContainBlob) { _%>
+        vm.byteSize = DataUtils.byteSize;
+        vm.openFile = DataUtils.openFile;
+        <%_ } _%>
         vm.save = save;<%
             var queries = [];
             for (idx in relationships) {
@@ -65,10 +73,7 @@
         function onSaveError () {
             vm.isSaving = false;
         }
-        <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 
-        vm.datePickerOpenStatus = {};
-        <%_ } _%>
         <%_ for (idx in fields) {
             if (fields[idx].fieldType === 'LocalDate' || fields[idx].fieldType === 'ZonedDateTime') { _%>
         vm.datePickerOpenStatus.<%= fields[idx].fieldName %> = false;
@@ -90,16 +95,11 @@
             }
         };
         <%_ } } _%>
-        <%_ if (fieldsContainBlob) { _%>
 
-        vm.openFile = DataUtils.openFile;
-        vm.byteSize = DataUtils.byteSize;
-        <%_ } _%>
         <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
-
-        vm.openCalendar = function(date) {
+        function openCalendar (date) {
             vm.datePickerOpenStatus[date] = true;
-        };
+        }
         <%_ } _%>
     }
 })();

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.controller.js
@@ -9,7 +9,10 @@
 
     function <%= entityAngularJSName %>DialogController ($timeout, $scope, $stateParams, $uibModalInstance<% if (fieldsContainOwnerOneToOne) { %>, $q<% } %><% if (fieldsContainBlob) { %>, DataUtils<% } %>, entity, <%= entityClass %><% for (idx in differentTypes) { if (differentTypes[idx] != entityClass) {%>, <%= differentTypes[idx] %><% } } %>) {
         var vm = this;
-        vm.<%= entityInstance %> = entity;<%
+
+        vm.<%= entityInstance %> = entity;
+        vm.clear = clear;
+        vm.save = save;<%
             var queries = [];
             for (idx in relationships) {
                 var query;
@@ -40,28 +43,28 @@
             angular.element('.form-group:eq(1)>input').focus();
         });
 
-        var onSaveSuccess = function (result) {
-            $scope.$emit('<%=angularAppName%>:<%= entityInstance %>Update', result);
-            $uibModalInstance.close(result);
-            vm.isSaving = false;
-        };
+        function clear () {
+            $uibModalInstance.dismiss('cancel');
+        }
 
-        var onSaveError = function () {
-            vm.isSaving = false;
-        };
-
-        vm.save = function () {
+        function save () {
             vm.isSaving = true;
             if (vm.<%= entityInstance %>.id !== null) {
                 <%= entityClass %>.update(vm.<%= entityInstance %>, onSaveSuccess, onSaveError);
             } else {
                 <%= entityClass %>.save(vm.<%= entityInstance %>, onSaveSuccess, onSaveError);
             }
-        };
+        }
 
-        vm.clear = function() {
-            $uibModalInstance.dismiss('cancel');
-        };
+        function onSaveSuccess (result) {
+            $scope.$emit('<%=angularAppName%>:<%= entityInstance %>Update', result);
+            $uibModalInstance.close(result);
+            vm.isSaving = false;
+        }
+
+        function onSaveError () {
+            vm.isSaving = false;
+        }
         <%_ if (fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 
         vm.datePickerOpenStatus = {};

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.controller.js
@@ -9,12 +9,13 @@
 
     function <%= entityAngularJSName %>Controller ($scope, $state<% if (fieldsContainBlob) { %>, DataUtils<% } %>, <%= entityClass %><% if (searchEngine == 'elasticsearch') { %>, <%= entityClass %>Search<% } %><% if (pagination != 'no') { %>, ParseLinks, AlertService<% } %> <%_ if (pagination == 'pager' || pagination == 'pagination'){ %>, pagingParams, paginationConstants<% } %>) {
         var vm = this;
+        
         <%_ if (pagination == 'pagination' || pagination == 'pager') { _%>
 <%- include('pagination-template'); -%>
         <%_ } else if (pagination == 'infinite-scroll') { _%>
 <%- include('infinite-scroll-template'); -%>
         <%_ } else { _%>
 <%- include('no-pagination-template'); -%>
-        <% } %>
+        <%_ } _%>
     }
 })();

--- a/generators/entity/templates/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -1,12 +1,21 @@
         vm.<%= entityInstancePlural %> = [];
-        vm.predicate = 'id';
-        vm.reverse = true;
+        vm.loadPage = loadPage;
         vm.page = 0;
+        vm.predicate = 'id';
+        vm.reset = reset;
+        vm.reverse = true;
+        <%_ if (searchEngine == 'elasticsearch') { _%>
+        vm.clear = clear;
+        vm.search = search;
+        <%_ } _%>
         <%_ if (fieldsContainBlob) { _%>
         vm.openFile = DataUtils.openFile;
         vm.byteSize = DataUtils.byteSize;
         <%_ } _%>
-        vm.loadAll = function() {
+
+        loadAll();
+
+        function loadAll () {
         <%_ if (searchEngine != 'elasticsearch') { _%>
             <%= entityClass %>.query({
                 page: vm.page,
@@ -46,19 +55,32 @@
             function onError(error) {
                 AlertService.error(error.data.message);
             }
-        };
-        vm.reset = function() {
+        }
+
+        function reset () {
             vm.page = 0;
             vm.<%= entityInstancePlural %> = [];
-            vm.loadAll();
-        };
-        vm.loadPage = function(page) {
+            loadAll();
+        }
+
+        function loadPage(page) {
             vm.page = page;
-            vm.loadAll();
-        };
+            loadAll();
+        }
         <%_ if (searchEngine == 'elasticsearch') { _%>
 
-        vm.search = function (searchQuery) {
+        function clear () {
+            vm.<%= entityInstancePlural %> = [];
+            vm.links = null;
+            vm.page = 0;
+            vm.predicate = 'id';
+            vm.reverse = true;
+            vm.searchQuery = null;
+            vm.currentSearch = null;
+            vm.loadAll();
+        }
+
+        function search (searchQuery) {
             if (!searchQuery){
                 return vm.clear();
             }
@@ -69,18 +91,5 @@
             vm.reverse = false;
             vm.currentSearch = searchQuery;
             vm.loadAll();
-        };
-
-        vm.clear = function () {
-            vm.<%= entityInstancePlural %> = [];
-            vm.links = null;
-            vm.page = 0;
-            vm.predicate = 'id';
-            vm.reverse = true;
-            vm.searchQuery = null;
-            vm.currentSearch = null;
-            vm.loadAll();
-        };
+        }
         <%_ } _%>
-
-        vm.loadAll();

--- a/generators/entity/templates/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -3,20 +3,24 @@
         vm.openFile = DataUtils.openFile;
         vm.byteSize = DataUtils.byteSize;
         <%_ } _%>
-        vm.loadAll = function() {
+        <%_ if (searchEngine == 'elasticsearch') { _%>
+        vm.search = search;
+        <%_ } _%>
+
+        loadAll();
+
+        function loadAll() {
             <%= entityClass %>.query(function(result) {
                 vm.<%= entityInstancePlural %> = result;
             });
-        };
+        }
         <%_ if (searchEngine == 'elasticsearch') { _%>
 
-        vm.search = function () {
+        function search () {
             if (!vm.searchQuery) {
                 return vm.loadAll();
             }
             <%= entityClass %>Search.query({query: vm.searchQuery}, function(result) {
                 vm.<%= entityInstancePlural %> = result;
             });
-        };<%_ } _%>
-
-        vm.loadAll();
+        }<%_ } _%>

--- a/generators/entity/templates/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/pagination-template.ejs
@@ -1,4 +1,3 @@
-        vm.loadAll = loadAll;
         vm.loadPage = loadPage;
         vm.predicate = pagingParams.predicate;
         vm.reverse = pagingParams.ascending;
@@ -13,7 +12,8 @@
         vm.openFile = DataUtils.openFile;
         vm.byteSize = DataUtils.byteSize;
         <%_ } _%>
-        vm.loadAll();
+
+        loadAll();
 
         function loadAll () {
         <%_ if (searchEngine != 'elasticsearch') { _%>


### PR DESCRIPTION
Some polish in entities controllers:
* Declaring functions on the bottom and assign them to `vm` in the top of the file: [Rule Y033](https://github.com/johnpapa/angular-styleguide/tree/master/a1#style-y033)
* Not assign `loadAll` function to `vm`, it's never called from the view it's an useless assignment.