### PR TITLE
Uniform profile handling maven/gradle

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -115,6 +115,9 @@
         <sonar.sources>${project.basedir}/<%= MAIN_DIR %></sonar.sources>
         <sonar.surefire.reportsPath>${project.testresult.directory}/surefire-reports</sonar.surefire.reportsPath>
         <sonar.tests>${project.basedir}/<%= TEST_DIR %></sonar.tests>
+        <!-- These remain empty unless the corresponding profile is active -->
+        <profile.no-liquibase></profile.no-liquibase>
+        <profile.no-swagger></profile.no-swagger>
     </properties>
 
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
@@ -974,9 +977,6 @@
                     Enable the line below to have remote debugging of your application on port 5005
                     <jvmArguments>-agentlib:jdwp=transport=dt_socket,server=y,suspend=n,address=5005</jvmArguments>
                     -->
-                    <arguments>
-                        <argument>--spring.profiles.active=dev</argument>
-                    </arguments>
                 </configuration>
             </plugin>
             <plugin>
@@ -1058,6 +1058,18 @@
 
     <profiles>
         <profile>
+            <id>no-liquibase</id>
+            <properties>
+                <profile.no-liquibase>,no-liquibase</profile.no-liquibase>
+            </properties>
+        </profile>
+        <profile>
+            <id>no-swagger</id>
+            <properties>
+                <profile.no-swagger>,no-swagger</profile.no-swagger>
+            </properties>
+        </profile>
+        <profile>
             <id>dev</id>
             <activation>
                 <activeByDefault>true</activeByDefault>
@@ -1089,7 +1101,7 @@
                 <!-- log configuration -->
                 <logback.loglevel>DEBUG</logback.loglevel>
                 <!-- default Spring profiles -->
-                <spring.profiles.active>dev</spring.profiles.active>
+                <spring.profiles.active>dev${profile.no-liquibase}${profile.no-swagger}</spring.profiles.active>
             </properties>
         </profile>
         <profile>
@@ -1189,9 +1201,6 @@
                         <artifactId>spring-boot-maven-plugin</artifactId>
                         <configuration>
                             <executable>true</executable>
-                            <arguments>
-                                <argument>--spring.profiles.active=prod</argument>
-                            </arguments>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1200,7 +1209,7 @@
                 <!-- log configuration -->
                 <logback.loglevel>INFO</logback.loglevel>
                 <!-- default Spring profiles -->
-                <spring.profiles.active>prod</spring.profiles.active>
+                <spring.profiles.active>prod${profile.no-liquibase}${profile.no-swagger}</spring.profiles.active>
             </properties>
         </profile>
     </profiles>

--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -16,12 +16,9 @@ if (project.hasProperty('no-liquibase')) {
 if (project.hasProperty('no-swagger')) {
     profiles += ',no-swagger'
 }
-if (project.hasProperty('no-cache')) {
-    profiles += ',no-cache'
-}
 
 bootRun {
-    args = ["--spring.profiles.active=" + profiles]
+    args = []
 }
 <% if (!skipClient) { %>
 war {
@@ -40,7 +37,7 @@ processResources {
     }
     filesMatching('**/application.yml') {
         filter {
-            it.replace('#spring.profiles.active#', 'dev')
+            it.replace('#spring.profiles.active#', profiles)
         }
     }
 }

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -21,12 +21,8 @@ if (project.hasProperty('no-swagger')) {
     profiles += ',no-swagger'
 }
 
-if (project.hasProperty('no-cache')) {
-    profiles += ',no-cache'
-}
-
 bootRun {
-    args = ["--spring.profiles.active=" + profiles]
+    args = []
 }
 <% if (!skipClient) { %>
 task gulpBuildWithOpts(type: GulpTask) {
@@ -45,7 +41,7 @@ processResources {
     }
     filesMatching('**/application.yml') {
         filter {
-            it.replace('#spring.profiles.active#', 'prod')
+            it.replace('#spring.profiles.active#', profiles)
         }
     }
 }


### PR DESCRIPTION
As discussed [here](https://github.com/jhipster/generator-jhipster/commit/d3133965df11716c3271f674d79c286480864cd1#commitcomment-17518049), this makes the handling of profiles (more) uniform across Maven and Gradle builds.

PS @deepu105 You [asked](https://github.com/jhipster/generator-jhipster/pull/3587#issuecomment-219926663) me to update the documentation -- I'll gladly do that, of course, but perhaps let's first deal with this PR, so I don't have to update the docs twice?