### PR TITLE
Return $promise in entity management state resolves

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
@@ -82,7 +82,7 @@
                     return $translate.refresh();
                 }],<% } %>
                 entity: ['$stateParams', '<%= entityClass %>', function($stateParams, <%= entityClass %>) {
-                    return <%= entityClass %>.get({id : $stateParams.id});
+                    return <%= entityClass %>.get({id : $stateParams.id}).$promise;
                 }]
             }
         })
@@ -138,7 +138,7 @@
                     size: 'lg',
                     resolve: {
                         entity: ['<%= entityClass %>', function(<%= entityClass %>) {
-                            return <%= entityClass %>.get({id : $stateParams.id});
+                            return <%= entityClass %>.get({id : $stateParams.id}).$promise;
                         }]
                     }
                 }).result.then(function() {
@@ -162,7 +162,7 @@
                     size: 'md',
                     resolve: {
                         entity: ['<%= entityClass %>', function(<%= entityClass %>) {
-                            return <%= entityClass %>.get({id : $stateParams.id});
+                            return <%= entityClass %>.get({id : $stateParams.id}).$promise;
                         }]
                     }
                 }).result.then(function() {


### PR DESCRIPTION
We need to resolve promise before displaying modal to create/edit/delete an entity. To do so, we should return `$promise` when we get the entity from her service.

If we do not resolve the promise we could open the dialog without the data inside if the server is too slow.

We don't have to do `$promise.then(...)` because [ui-router](https://github.com/angular-ui/ui-router/wiki#resolve) will automatically wait for the promise to be resolved:

> If any of these dependencies are promises, they will be resolved and converted to a value before the controller is instantiated