### PR TITLE
docker-compose: fix missing registry when there is no gateway

### DIFF
--- a/generators/docker-compose/templates/_docker-compose.yml
+++ b/generators/docker-compose/templates/_docker-compose.yml
@@ -3,7 +3,7 @@ services:
 <%_ for(var i = 0; i < appConfigs.length; i++) { _%>
 <%- appsYaml[i] %>
 <%_ } _%>
-<%_ if (gatewayNb > 0) { _%>
+<%_ if (gatewayNb + microserviceNb > 0) { _%>
     jhipster-registry:
         extends:
             file: jhipster-registry.yml


### PR DESCRIPTION
Using the docker-compose sub generator.
When no gateway is selected, the jhipster-registry config is not in docker-compose.yml file