### PR TITLE
hide password reset error messages on form submission

### DIFF
--- a/generators/client/templates/src/main/webapp/app/account/reset/finish/_reset.finish.controller.js
+++ b/generators/client/templates/src/main/webapp/app/account/reset/finish/_reset.finish.controller.js
@@ -22,6 +22,8 @@
         $timeout(function (){angular.element('#password').focus();});
 
         function finishReset() {
+            vm.doNotMatch = null;
+            vm.error = null;
             if (vm.resetAccount.password !== vm.confirmPassword) {
                 vm.doNotMatch = 'ERROR';
             } else {


### PR DESCRIPTION
The form error messages should be cleared when submitting the password reset form.  

Fixes: If you enter non-matching passwords then submit the form correctly, the error messages remains displayed under the success message.  