### PR TITLE
Use stable older version of yeoman

### DIFF
--- a/travis/install/02-install-jhipster-stack.sh
+++ b/travis/install/02-install-jhipster-stack.sh
@@ -7,7 +7,8 @@ npm install -g npm
 #-------------------------------------------------------------------------------
 # Install yeoman, bower and gulp
 #-------------------------------------------------------------------------------
-npm install -g yo
+# use stable version of yeoman until new tab completion is stable
+npm install -g yo@1.8.1
 npm install -g bower
 npm install -g gulp-cli
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Related to https://github.com/yeoman/yo/issues/441
Here the error logs in our Travis build:
```
yo --version
/home/travis/.nvm/versions/node/v4.4.4/lib/node_modules/yo/lib/cli.js:18
var tabtab = new (require('tabtab').Commands.default)({
             ^
TypeError: require(...).Commands.default is not a function
    at Object.<anonymous> (/home/travis/.nvm/versions/node/v4.4.4/lib/node_modules/yo/lib/cli.js:18:14)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
    at Function.Module._load (module.js:300:12)
    at Function.Module.runMain (module.js:441:10)
    at startup (node.js:139:18)
    at node.js:968:3
```
