### PR TITLE
fix showing wrong pages of component jhi-item-count

### DIFF
--- a/generators/client/templates/src/main/webapp/app/components/util/_jhi-item-count.directive.js
+++ b/generators/client/templates/src/main/webapp/app/components/util/_jhi-item-count.directive.js
@@ -3,7 +3,7 @@
 
     var jhiItemCount = {
         template: '<div class="info">' +
-                    'Showing {{(($ctrl.page-1) * 20)==0 ? 1:(($ctrl.page-1) * 20)}} - ' +
+                    'Showing {{(($ctrl.page-1) * 20)==0 ? 1:(($ctrl.page-1) * 20 + 1)}} - ' +
                     '{{($ctrl.page * 20) < $ctrl.queryCount ? ($ctrl.page * 20) : $ctrl.queryCount}} ' +
                     'of {{$ctrl.queryCount}} items.' +
                 '</div>',


### PR DESCRIPTION
Issue: the component jhiItemCount(jhi-item-count.directive.js) will shows the wrong range when the number of entity exceeds to 20, for example:
![2016-05-26 8 04 47](https://cloud.githubusercontent.com/assets/7650839/15574009/7fc66b48-237d-11e6-8e71-084968588b99.png)

just plus 1 to fix it.