### PR TITLE
By default an entity extends AbstractAuditingEntity

### DIFF
--- a/generators/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/src/main/java/package/domain/_Entity.java
@@ -44,7 +44,7 @@ import <%=packageName%>.domain.enumeration.<%= element %>;<% }); %>
 @Document(collection = "<%= entityTableName %>")<% } %><% if (databaseType == 'cassandra') { %>
 @Table(name = "<%= entityInstance %>")<% } %><% if (searchEngine == 'elasticsearch') { %>
 @Document(indexName = "<%= entityInstance.toLowerCase() %>")<% } %>
-public class <%= entityClass %> implements Serializable {
+public class <%= entityClass %> extends AbstractAuditingEntity {
 
     private static final long serialVersionUID = 1L;
 <% if (databaseType == 'sql') { %>


### PR DESCRIPTION
Hi,

I think it could be great that each generated entity extends by default the AbstractAuditingEntity, to gain AOP benefits of automatic createdBy, createdDate , lastModifiedBy and lastModifiedDate fields.