### PR TITLE
fix infinite-scroll template (sent multiple requests on page load)

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -1,6 +1,9 @@
         vm.<%= entityInstancePlural %> = [];
         vm.loadPage = loadPage;
         vm.page = 0;
+        vm.links = {
+            last: 0
+        };
         vm.predicate = 'id';
         vm.reset = reset;
         vm.reverse = true;


### PR DESCRIPTION
If i enabled infinite scroll on a page, the angular sent lots and lots of requests to the server because vm.links.last was not declared