### PR TITLE
change http to https so search box appears on websites with https

### DIFF
--- a/generators/server/templates/src/main/resources/templates/error.html
+++ b/generators/server/templates/src/main/resources/templates/error.html
@@ -156,7 +156,7 @@
         var GOOG_FIXURL_LANG = '[[${#locale.language}]]', GOOG_FIXURL_SITE = location.host;
         /*]]>*/
     </script>
-    <script src="http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
+    <script src="https://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js"></script>
 </div>
 </body>
 </html>


### PR DESCRIPTION
Error pages served via https currently give the following error:

```
Mixed Content: The page at 'https://jhipsterwebsite.org/non-existent-path' was loaded over HTTPS, but requested an insecure script 'http://linkhelp.clients.google.com/tbproxy/lh/wm/fixurl.js'. This request has been blocked; the content must be served over HTTPS.```