### PR TITLE
Fix possible NPE in SocialService

### DIFF
--- a/generators/server/templates/src/main/java/package/service/_SocialService.java
+++ b/generators/server/templates/src/main/java/package/service/_SocialService.java
@@ -64,7 +64,10 @@ public class SocialService {
 
     private User createUserIfNotExist(UserProfile userProfile, String langKey, String providerId) {
         String email = userProfile.getEmail();
-        String userName = userProfile.getUsername().toLowerCase(Locale.ENGLISH);
+        String userName = userProfile.getUsername();
+        if (!StringUtils.isBlank(userName)) {
+            userName = userName.toLowerCase(Locale.ENGLISH);
+        }
         if (StringUtils.isBlank(email) && StringUtils.isBlank(userName)) {
             log.error("Cannot create social user because email and login are null");
             throw new IllegalArgumentException("Email and login cannot be null");


### PR DESCRIPTION
In some cases, facebook does not provide a username, which caused the old implementation to crash