### PR TITLE
Travis: use new system matrix cache by Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,13 +4,18 @@ services:
   - docker
 language: node_js
 node_js:
-  - "4.4.4"
+  - "4.4.5"
 jdk:
   - oraclejdk8
+cache:
+  directories:
+    - node_modules
+    - $HOME/.m2
+    - $HOME/.gradle
+    - $HOME/app/node_modules
+    - $HOME/app/node
 env:
   global:
-    - JHIPSTER_CACHE_REPO=https://github.com/jhipster/jhipster-travis-cache.git
-    - JHIPSTER_CACHE_BRANCH=160516-springboot-135
     - PROFILE=dev
     - RUN_APP=1
     - PROTRACTOR=0
@@ -19,18 +24,18 @@ env:
     - JHIPSTER_SAMPLES=$JHIPSTER_TRAVIS/samples
     - JHIPSTER_SCRIPTS=$JHIPSTER_TRAVIS/scripts
   matrix:
-    - JHIPSTER=app-default-from-scratch JHIPSTER_NODE_CACHE=0
+    - JHIPSTER=app-default-from-scratch
     - JHIPSTER=app-gradle PROTRACTOR=1
     - JHIPSTER=app-mysql PROFILE=prod PROTRACTOR=1
     - JHIPSTER=app-psql-es-noi18n PROFILE=prod PROTRACTOR=1
     - JHIPSTER=app-social-websocket PROTRACTOR=1
     - JHIPSTER=app-cassandra
-    - JHIPSTER=app-microservice
-    - JHIPSTER=app-gateway
     - JHIPSTER=app-hazelcast-cucumber
     - JHIPSTER=app-mongodb
     - JHIPSTER=app-oauth2
     - JHIPSTER=app-jwt
+    - JHIPSTER=app-gateway
+    - JHIPSTER=app-microservice
 before_install:
   - sudo /etc/init.d/postgresql stop
   - export DISPLAY=:99.0

--- a/travis/install/04-cache.sh
+++ b/travis/install/04-cache.sh
@@ -1,23 +1,12 @@
 #!/bin/bash
 set -ev
 #-------------------------------------------------------------------------------
-# Use jhipster-travis-cache that contain .m2 and node_modules
+# Check the cache from Travis
 #-------------------------------------------------------------------------------
-cd "$TRAVIS_BUILD_DIR"/
-git clone -b $JHIPSTER_CACHE_BRANCH $JHIPSTER_CACHE_REPO
-
-rm -Rf "$HOME"/.m2/repository/
-mv "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/repository "$HOME"/.m2/
-
-#-------------------------------------------------------------------------------
-# Use phantomjs cache
-#-------------------------------------------------------------------------------
-tar -xvf "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/phantomjs/phantomjs-2.1.1-linux-x86_64.tar.bz2 -C "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/
-sudo mkdir -p /usr/local/phantomjs-2.1.1/
-sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/phantomjs-2.1.1-linux-x86_64/LICENSE.BSD /usr/local/phantomjs-2.1.1/
-sudo mv "$TRAVIS_BUILD_DIR"/jhipster-travis-cache/phantomjs-2.1.1-linux-x86_64/bin/phantomjs /usr/local/phantomjs-2.1.1/
-sudo rm /usr/local/phantomjs
-sudo ln -sf /usr/local/phantomjs-2.1.1/ /usr/local/phantomjs
-ls -l /usr/local/
-ls -l /usr/local/phantomjs/
-ls -l /usr/local/phantomjs-2.1.1/
+if [ ! -f "$HOME"/.m2/cache.txt ]; then
+    echo "No cache.txt, generate one for the next time"
+    echo "[$(date)] $JHIPSTER" > "$HOME"/.m2/cache.txt
+else
+    echo "Found cache.txt"
+    cat "$HOME"/.m2/cache.txt
+fi

--- a/travis/scripts/02-generate-entities.sh
+++ b/travis/scripts/02-generate-entities.sh
@@ -131,8 +131,8 @@ generateEntity TestOneToOne
 #-------------------------------------------------------------------------------
 # Check Javadoc generation
 #-------------------------------------------------------------------------------
-if [ "$JHIPSTER" != "app-gradle" ]; then
+if [ -f "mvnw" ]; then
   ./mvnw javadoc:javadoc
-else
+elif [ -f "gradlew" ]; then
   ./gradlew javadoc
 fi

--- a/travis/scripts/04-tests.sh
+++ b/travis/scripts/04-tests.sh
@@ -4,11 +4,11 @@ set -ev
 # Launch tests
 #--------------------------------------------------
 cd "$HOME"/app
-if [ "$JHIPSTER" != "app-gradle" ]; then
+if [ -f "mvnw" ]; then
   ./mvnw test
-else
+elif [ -f "gradlew" ]; then
   ./gradlew test
 fi
-if [ "$JHIPSTER" != "app-microservice" ]; then
+if [ -f "gulpfile.js" ]; then
   gulp test --no-notification
 fi

--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -32,14 +32,17 @@ launchProtractor() {
 #-------------------------------------------------------------------------------
 cd "$HOME"/app
 if [ "$RUN_APP" == 1 ]; then
-  if [ "$JHIPSTER" != "app-gradle" ]; then
+  if [ -f "mvnw" ]; then
     ./mvnw package -DskipTests=true -P"$PROFILE"
     mv target/*.war target/app.war
     java -jar target/app.war --spring.profiles.active="$PROFILE" &
-  else
+  elif [ -f "gradlew" ]; then
     ./gradlew bootRepackage -P"$PROFILE" -x test
     mv build/libs/*.war build/libs/app.war
     java -jar build/libs/app.war --spring.profiles.active="$PROFILE" &
+  else
+    echo "No mvnw or gradlew"
+    exit 0
   fi
   sleep 20
   #-------------------------------------------------------------------------------


### PR DESCRIPTION
15 days ago, Travis improved their cache system.
See here : https://github.com/travis-ci/travis-ci/issues/4393
Official doc: https://docs.travis-ci.com/user/caching/

It fits perfectly what we need here, because every build is too different. And these new caches will be available to all PR.

What have been done here:
- upgrade to node 4.4.5 LTS
- add cache for every build
- no need to clone : [jhipster-travis-build](https://github.com/jhipster/jhipster-travis-build) or [jhipster-travis-cache](https://github.com/jhipster/jhipster-travis-cache)
- check maven or gradle wrapper instead of application's name

We won't see any improvment until this PR is merged, and after the merge, the 1st full build will cache everything, so benefits will be seen for the next builds.

@jdubois :
At the moment, let keep the 2 repo [jhipster-travis-build](https://github.com/jhipster/jhipster-travis-build) or [jhipster-travis-cache](https://github.com/jhipster/jhipster-travis-cache)
I will tell you when you can delete them, maybe in 3 weeks~ to be sure this system works

@jhipster/developers :
You can manage cache here https://travis-ci.org/jhipster/generator-jhipster/caches
So when needed, we can delete them to let Travis rebuild correctly the cache
