### PR TITLE
fix Dockerfile to properly clean apt repository

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -35,7 +35,7 @@ RUN \
   npm install -g \
     yo \
     bower \
-    gulp-cli \
+    gulp-cli && \
 
   # cleanup
   apt-get clean && \


### PR DESCRIPTION
From PR #3700, `apt-get clean` is in the same command as `npm install -g` line when it should have `&&` between the two.  It currently installs the npm packages apt-get@0.1.0 and clean@4.0.2