### PR TITLE
set up sorting and pagination for user-management to match entities

### DIFF
--- a/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.state.js
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/_user-management.state.js
@@ -11,7 +11,7 @@
         $stateProvider
         .state('user-management', {
             parent: 'admin',
-            url: '/user-management',
+            url: '/user-management?page&sort',
             data: {
                 authorities: ['ROLE_ADMIN'],
                 pageTitle: 'user-management.home.title'
@@ -23,11 +23,31 @@
                     controllerAs: 'vm'
                 }
             },
+            params: {
+                page: {
+                    value: '1',
+                    squash: true
+                },
+                sort: {
+                    value: 'id,asc',
+                    squash: true
+                }
+            },
             resolve: {
+                pagingParams: ['$stateParams', 'PaginationUtil', function ($stateParams, PaginationUtil) {
+                    return {
+                        page: PaginationUtil.parsePage($stateParams.page),
+                        sort: $stateParams.sort,
+                        predicate: PaginationUtil.parsePredicate($stateParams.sort),
+                        ascending: PaginationUtil.parseAscending($stateParams.sort)
+                    };
+                }]<%_ if (enableTranslation){ _%>,
                 translatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
                     $translatePartialLoader.addPart('user-management');
                     return $translate.refresh();
                 }]
+            <%_ } _%>
+                
             }
         })
         .state('user-management-detail', {

--- a/generators/client/templates/src/main/webapp/app/admin/user-management/user-management.html
+++ b/generators/client/templates/src/main/webapp/app/admin/user-management/user-management.html
@@ -11,16 +11,16 @@
     <div class="table-responsive">
         <table class="table table-striped">
             <thead>
-            <tr>
-                <th translate="global.field.id">ID</th>
-                <th translate="userManagement.login">Login</th>
-                <th translate="userManagement.email">Email</th>
+            <tr jh-sort="vm.predicate" ascending="vm.reverse" callback="vm.transition()">
+                <th jh-sort-by="id"><span translate="global.field.id">ID</span> <span class="glyphicon glyphicon-sort"></span></th>
+                <th jh-sort-by="login"><span translate="userManagement.login">Login</span> <span class="glyphicon glyphicon-sort"></span></th>
+                <th jh-sort-by="email"><span translate="userManagement.email">Email</span> <span class="glyphicon glyphicon-sort"></span></th>
                 <th></th>
-                <% if (enableTranslation) { %><th translate="userManagement.langKey">Lang Key</th><% } %>
-                <th translate="userManagement.profiles">Profiles</th><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
-                <th translate="userManagement.createdDate">Created Date</th>
-                <th translate="userManagement.lastModifiedBy">Last Modified By</th>
-                <th translate="userManagement.lastModifiedDate">Last Modified Date</th><% } %>
+                <% if (enableTranslation) { %><th jh-sort-by="langKey"><span translate="userManagement.langKey">Lang Key</span> <span class="glyphicon glyphicon-sort"></span></th><% } %>
+                <th><span translate="userManagement.profiles">Profiles</span></th><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+                <th jh-sort-by="createdDate"><span translate="userManagement.createdDate">Created Date</span> <span class="glyphicon glyphicon-sort"></span></th>
+                <th jh-sort-by="lastModifiedBy"><span translate="userManagement.lastModifiedBy">Last Modified By</span> <span class="glyphicon glyphicon-sort"></span></th>
+                <th jh-sort-by="lastModifiedDate"><span translate="userManagement.lastModifiedDate">Last Modified Date</span> <span class="glyphicon glyphicon-sort"></span></th><% } %>
                 <th></th>
             </tr>
             </thead>
@@ -72,7 +72,8 @@
     </div>
     <%_ if (databaseType == 'sql' || databaseType == 'mongodb') { _%>
     <div class="text-center">
-        <uib-pagination class="pagination-sm" total-items="vm.totalItems" ng-model="vm.page" ng-change="vm.loadAll()"></uib-pagination>
+        <jhi-item-count page="vm.page" total="vm.queryCount" items-per-page="vm.itemsPerPage"></jhi-item-count>
+        <uib-pagination class="pagination-sm" total-items="vm.totalItems" ng-model="vm.page" ng-change="vm.transition()"></uib-pagination>
     </div>
     <%_ } _%>
 </div>


### PR DESCRIPTION
Pagination for user-management still uses the older method (refreshing/viewing/deleting a User resets the page back to 1).  This aligns user-management pagination with the way entities do it, offering a much better user experience.

I will open a separate PR for client-2 (let me know if this isn't the right way)