### PR TITLE
fix entities that use DTOs with Cassandra

### DIFF
--- a/generators/entity/templates/src/main/java/package/web/rest/_EntityResource.java
+++ b/generators/entity/templates/src/main/java/package/web/rest/_EntityResource.java
@@ -16,8 +16,7 @@ import org.springframework.data.domain.Pageable;<% } %>
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;<% if (dto == 'mapstruct') { %>
-import org.springframework.transaction.annotation.Transactional;<% } %>
+import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.inject.Inject;<% if (validation) { %>


### PR DESCRIPTION
The import statement throws an error when creating an entity using DTOs and Cassandra.

Because `@Transactional` is unused in the EntityResource file, I removed it rather than including it for only SQL