### PR TITLE
Simplify Angular 1.x vs. 2.x choice. Upgrade to Angular 2 rc2.

### DIFF
--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -133,7 +133,7 @@ function askForClient() {
             return (applicationType !== 'microservice');
         },
         message: function (response) {
-            return getNumberedQuestion('Which *Angular* version would you like to use for the client side?', applicationType !== 'microservice');
+            return getNumberedQuestion('Which *Angular* version would you like to use for the client?', applicationType !== 'microservice');
         },
         choices: [
             {

--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -133,16 +133,16 @@ function askForClient() {
             return (applicationType !== 'microservice');
         },
         message: function (response) {
-            return getNumberedQuestion('Which *AngularJS* version would you like to use for the client side?', applicationType !== 'microservice');
+            return getNumberedQuestion('Which *Angular* version would you like to use for the client side?', applicationType !== 'microservice');
         },
         choices: [
             {
                 value: 'angular1',
-                name: 'I`ll use AngularJS 1 (stable)'
+                name: 'Angular 1.x (stable)'
             },
             {
                 value: 'angular2',
-                name: 'I want to try AngularJS 2 (Please note that this is still in beta)'
+                name: 'Angular 2.x (rc2)'
             }
         ],
         default: 'angular1'

--- a/generators/client-2/templates/_package.json
+++ b/generators/client-2/templates/_package.json
@@ -8,14 +8,14 @@
     "<%= MAIN_SRC_DIR %>bower_components"
   ],
   "dependencies": {
-    "@angular/common": "2.0.0-rc.1",
-    "@angular/compiler": "2.0.0-rc.1",
-    "@angular/core": "2.0.0-rc.1",
-    "@angular/http": "2.0.0-rc.1",
-    "@angular/platform-browser": "2.0.0-rc.1",
-    "@angular/platform-browser-dynamic": "2.0.0-rc.1",
-    "@angular/router": "2.0.0-rc.1",
-    "@angular/upgrade":  "2.0.0-rc.1",
+    "@angular/common": "2.0.0-rc.2",
+    "@angular/compiler": "2.0.0-rc.2",
+    "@angular/core": "2.0.0-rc.2",
+    "@angular/http": "2.0.0-rc.2",
+    "@angular/platform-browser": "2.0.0-rc.2",
+    "@angular/platform-browser-dynamic": "2.0.0-rc.2",
+    "@angular/router": "2.0.0-rc.2",
+    "@angular/upgrade":  "2.0.0-rc.2",
 
     "core-js": "2.4.0",
     "rxjs": "5.0.0-beta.6",


### PR DESCRIPTION
RC2 came out yesterday. We should keep up with the latest and greatest. 

Question: Does anyone know what the difference between `core-js` and `es6-shim` is? angular-cli uses es6-shim, but it looks like angular2-seed uses core-js.

* angular-cli: https://github.com/angular/angular-cli/commit/4113f3060d919a1aad2ce47c1609f96c12f2ab99
* angular2-seed: https://github.com/mgechev/angular2-seed/blob/master/package.json