### PR TITLE
Fix jhipster-registry.yml for a development usecase

### DIFF
--- a/generators/server/templates/src/main/docker/central-server-config/application.yml
+++ b/generators/server/templates/src/main/docker/central-server-config/application.yml
@@ -8,8 +8,3 @@ jhipster:
         authentication:
             jwt:
                 secret: my-secret-token-to-change-in-production
-
-eureka:
-    client:
-        serviceUrl:
-            defaultZone: http://admin:admin@registry:8761/eureka/


### PR DESCRIPTION
Remove the default conf for eureka in jhipster-registry.yml as this will make clients not running in docker fail.

The usecase in question:
- launch the registry with: `docker-compose -f src/main/docker/jhipster-registry up -d`
- develop your app and launch using mvn or IDE