### PR TITLE
Fix for issue with upgrading projects generated prior JHipster 3.4.0 #3761

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -158,7 +158,7 @@ module.exports = UpgradeGenerator.extend({
                 this.log('Installing JHipster ' + version + ' locally');
                 shelljs.exec('npm install ' + GENERATOR_JHIPSTER + '@' + version, {silent:true}, function (code, msg, err) {
                     if (code === 0) this.log(chalk.green('Installed ' + GENERATOR_JHIPSTER + '@' + version));
-                    else this.error('Something went wrong while installing generator! ' + msg + ' ' + err);
+                    else this.error('Something went wrong while installing the JHipster generator! ' + msg + ' ' + err);
                     callback();
                 }.bind(this));
             }.bind(this);

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -45,6 +45,15 @@ module.exports = UpgradeGenerator.extend({
         }
     },
 
+    _installJhipsterLocally: function (version, callback) {
+        this.log('Installing JHipster ' + version + ' locally');
+        shelljs.exec('npm install ' + GENERATOR_JHIPSTER + '@' + version, {silent:true}, function (code, msg, err) {
+            if (code === 0) this.log(chalk.green('Installed ' + GENERATOR_JHIPSTER + '@' + version));
+            else this.error('Something went wrong while installing generator! ' + msg + ' ' + err);
+            callback();
+        }.bind(this));
+    },
+
     _generate: function(version, callback) {
         this.log('Regenerating app with jhipster ' + version + '...');
         shelljs.exec('yo jhipster --with-entities --force', {silent:false}, function (code, msg, err) {
@@ -70,11 +79,13 @@ module.exports = UpgradeGenerator.extend({
 
     _regenerate: function(version, callback) {
         this._cleanUp();
-        this._generate(version, function() {
-            this._gitCommitAll('Generated with JHipster ' + version, function() {
-                callback();
+        this._installJhipsterLocally(version, function () {
+            this._generate(version, function() {
+                this._gitCommitAll('Generated with JHipster ' + version, function() {
+                    callback();
+                }.bind(this));
             }.bind(this));
-        }.bind(this));
+        }.bind(this));        
     },
 
     configuring: {


### PR DESCRIPTION
I've added a task which installs jhipster locally right before the app generation, so now when you run 
`yo jhipster:upgrade`
it will:

1. check out on the jhipster_upgrade branch
2. clean up the folder (_cleanUp task)
3. install jhipster with needed versioin
4. and then run _generate task, which will use installed locally jhipster and generate correct app

So now upgrade process is independent of the installed globally version and we can upgrade projects generated before 3.4.0. And it also fixes issues when we have several projects generated with different jhipster versions. 