### PR TITLE
move oauth2 client details into database

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -834,6 +834,7 @@ module.exports = JhipsterServerGenerator.extend({
                 this.copy(SERVER_MAIN_RES_DIR + 'config/liquibase/users.csv', SERVER_MAIN_RES_DIR + 'config/liquibase/users.csv');
                 this.copy(SERVER_MAIN_RES_DIR + 'config/liquibase/authorities.csv', SERVER_MAIN_RES_DIR + 'config/liquibase/authorities.csv');
                 this.copy(SERVER_MAIN_RES_DIR + 'config/liquibase/users_authorities.csv', SERVER_MAIN_RES_DIR + 'config/liquibase/users_authorities.csv');
+                this.copy(SERVER_MAIN_RES_DIR + 'config/liquibase/oauth_client_details.csv', SERVER_MAIN_RES_DIR + 'config/liquibase/oauth_client_details.csv');
             }
 
             // Email templates

--- a/generators/server/templates/src/main/java/package/config/_OAuth2ServerConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_OAuth2ServerConfiguration.java
@@ -22,17 +22,44 @@ import org.springframework.security.oauth2.config.annotation.web.configurers.Aut
 import org.springframework.security.oauth2.config.annotation.web.configurers.AuthorizationServerSecurityConfigurer;
 
 import org.springframework.security.oauth2.provider.token.TokenStore;<% if (databaseType == 'sql') { %>
+import org.springframework.security.oauth2.config.annotation.web.configurers.ResourceServerSecurityConfigurer;
+import org.springframework.security.oauth2.provider.approval.ApprovalStore;
+import org.springframework.security.oauth2.provider.approval.JdbcApprovalStore;
+import org.springframework.security.oauth2.provider.code.AuthorizationCodeServices;
+import org.springframework.security.oauth2.provider.code.JdbcAuthorizationCodeServices;
 import org.springframework.security.oauth2.provider.token.store.JdbcTokenStore;<% } %>
 
 import javax.inject.Inject;<% if (databaseType == 'sql') { %>
 import javax.sql.DataSource;<% } %>
 
 @Configuration
-public class OAuth2ServerConfiguration {
+public class OAuth2ServerConfiguration {<% if (databaseType == 'sql') { %>
+
+    @Inject
+    private DataSource dataSource;
+
+    @Bean
+    public TokenStore tokenStore() {
+        return new JdbcTokenStore(dataSource);
+    }<% } %><% if (databaseType == 'mongodb') { %>
+
+    @Inject
+    private OAuth2AccessTokenRepository oAuth2AccessTokenRepository;
+
+    @Inject
+    private OAuth2RefreshTokenRepository oAuth2RefreshTokenRepository;
+
+    @Bean
+    public TokenStore tokenStore() {
+        return new MongoDBTokenStore(oAuth2AccessTokenRepository, oAuth2RefreshTokenRepository);
+    }<% } %>
 
     @Configuration
     @EnableResourceServer
-    protected static class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {
+    protected static class ResourceServerConfiguration extends ResourceServerConfigurerAdapter {<% if (databaseType == 'sql') { %>
+
+        @Inject
+        private TokenStore tokenStore;<% } %>
 
         @Inject
         private Http401UnauthorizedEntryPoint authenticationEntryPoint;
@@ -70,6 +97,11 @@ public class OAuth2ServerConfiguration {
                 .antMatchers("/swagger-resources/configuration/ui").permitAll()
                 .antMatchers("/swagger-ui/index.html").hasAuthority(AuthoritiesConstants.ADMIN);
         }
+<% if (databaseType == 'sql') { %>
+        @Override
+        public void configure(ResourceServerSecurityConfigurer resources) throws Exception {
+            resources.resourceId("res_<%= baseName %>").tokenStore(tokenStore);
+        }<% } %>
     }
 
     @Configuration
@@ -77,22 +109,24 @@ public class OAuth2ServerConfiguration {
     protected static class AuthorizationServerConfiguration extends AuthorizationServerConfigurerAdapter {<% if (databaseType == 'sql') { %>
 
         @Inject
-        private DataSource dataSource;<% } %><% if (databaseType == 'mongodb') { %>
-
-        @Inject
-        private OAuth2AccessTokenRepository oAuth2AccessTokenRepository;
-
-        @Inject
-        private OAuth2RefreshTokenRepository oAuth2RefreshTokenRepository;<% } %>
-
+        private DataSource dataSource;<% } %>
+<% if (databaseType != 'sql') { %>
         @Inject
         private JHipsterProperties jHipsterProperties;
-
+}<% } %>
+        @Inject
+        private TokenStore tokenStore;
+<% if (databaseType == 'sql') { %>
         @Bean
-        public TokenStore tokenStore() {
-            return new <% if (databaseType == 'sql') { %>JdbcTokenStore(dataSource);<% } else { %>MongoDBTokenStore(oAuth2AccessTokenRepository, oAuth2RefreshTokenRepository);<% } %>
+        protected AuthorizationCodeServices authorizationCodeServices() {
+            return new JdbcAuthorizationCodeServices(dataSource);
         }
 
+        @Bean
+        public ApprovalStore approvalStore() {
+            return new JdbcApprovalStore(dataSource);
+        }
+<% } %>
         @Inject
         @Qualifier("authenticationManagerBean")
         private AuthenticationManager authenticationManager;
@@ -100,10 +134,11 @@ public class OAuth2ServerConfiguration {
         @Override
         public void configure(AuthorizationServerEndpointsConfigurer endpoints)
                 throws Exception {
-
-            endpoints
-                    .tokenStore(tokenStore())
-                    .authenticationManager(authenticationManager);
+            endpoints<% if (databaseType == 'sql') { %>
+                .authorizationCodeServices(authorizationCodeServices())
+                .approvalStore(approvalStore())<% } %>
+                .tokenStore(tokenStore)
+                .authenticationManager(authenticationManager);
         }
 
         @Override
@@ -112,7 +147,8 @@ public class OAuth2ServerConfiguration {
         }
 
         @Override
-        public void configure(ClientDetailsServiceConfigurer clients) throws Exception {
+        public void configure(ClientDetailsServiceConfigurer clients) throws Exception {<% if (databaseType == 'sql') { %>
+            clients.jdbc(dataSource);<% } else { %>
             clients
                 .inMemory()
                 .withClient(jHipsterProperties.getSecurity().getAuthentication().getOauth().getClientid())
@@ -120,7 +156,7 @@ public class OAuth2ServerConfiguration {
                 .authorities(AuthoritiesConstants.ADMIN, AuthoritiesConstants.USER)
                 .authorizedGrantTypes("password", "refresh_token", "authorization_code", "implicit")
                 .secret(jHipsterProperties.getSecurity().getAuthentication().getOauth().getSecret())
-                .accessTokenValiditySeconds(jHipsterProperties.getSecurity().getAuthentication().getOauth().getTokenValidityInSeconds());
+                .accessTokenValiditySeconds(jHipsterProperties.getSecurity().getAuthentication().getOauth().getTokenValidityInSeconds());<% } %>
         }
     }
 }

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -178,23 +178,23 @@ jhipster:
             maxBytesLocalHeap: 16M
         <%_ } _%>
     <%_ } _%>
-<%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt') { _%>
+    <%_ if (authenticationType == 'jwt') { _%>
     security:
         authentication:
-    <%_ if (authenticationType == 'jwt') { _%>
             jwt:
                 secret: my-secret-token-to-change-in-production
                 # Token is valid 24 hours
                 tokenValidityInSeconds: 86400
     <%_ } _%>
-    <%_ if (authenticationType == 'oauth2') { _%>
+    <%_ if (authenticationType == 'oauth2' && databaseType != 'sql') { _%>
+    security:
+        authentication:
             oauth:
                 clientid: <%= baseName %>app
                 secret: my-secret-token-to-change-in-production
                 # Token is valid 30 minutes
                 tokenValidityInSeconds: 1800
     <%_ } _%>
-<%_ } _%>
 <%_ if (authenticationType == 'session') { _%>
     security:
         rememberMe:

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -166,23 +166,23 @@ jhipster:
             maxBytesLocalHeap: 256M
         <%_ } _%>
     <%_ } _%>
-<%_ if (authenticationType == 'oauth2' || authenticationType == 'jwt') { _%>
+    <%_ if (authenticationType == 'jwt') { _%>
     security:
         authentication:
-    <%_ if (authenticationType == 'jwt') { _%>
             jwt:
                 secret: <%= jwtSecretKey %>
                 # Token is valid 24 hours
                 tokenValidityInSeconds: 86400
     <%_ } _%>
-    <%_ if (authenticationType == 'oauth2') { _%>
+    <%_ if (authenticationType == 'oauth2' && databaseType != 'sql') { _%>
+    security:
+        authentication:
             oauth:
                 clientid: <%= baseName %>app
                 secret: my-secret-token-to-change-in-production
                 # Token is valid 30 minutes
                 tokenValidityInSeconds: 1800
     <%_ } _%>
-<%_ } _%>
 <%_ if (authenticationType == 'session') { _%>
     security:
         rememberMe:

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
@@ -263,6 +263,7 @@
 
         <createTable tableName="oauth_code">
             <column name="code" type="varchar(255)"/>
+            <column name="authentication" type="BLOB"/>
         </createTable>
 
         <createTable tableName="oauth_approvals">
@@ -273,5 +274,10 @@
             <column name="expiresAt" type="timestamp"/>
             <column name="lastModifiedAt" type="timestamp"/>
         </createTable>
+
+        <loadData encoding="UTF-8"
+                  file="config/liquibase/oauth_client_details.csv"
+                  separator=";"
+                  tableName="oauth_client_details"/>
     </changeSet><% } %>
 </databaseChangeLog>

--- a/generators/server/templates/src/main/resources/config/liquibase/oauth_client_details.csv
+++ b/generators/server/templates/src/main/resources/config/liquibase/oauth_client_details.csv
@@ -1,0 +1,2 @@
+client_id;resource_ids;client_secret;scope;authorized_grant_types;web_server_redirect_uri;authorities;access_token_validity;refresh_token_validity;additional_information;autoapprove
+<%= baseName %>app;res_<%= baseName %>;my-secret-token-to-change-in-production;read,write;password,refresh_token,authorization_code,implicit;;ROLE_ADMIN,ROLE_USER;1800;2000;{};true


### PR DESCRIPTION
The previous behavior to config oauth2 client details is just using hardcode. This PR will drop that hardcode and store the oauth2 client details into database.

The details of this PR are:

 1. configure spring security oauth2 with jdbc
 2. configure liquibase to insert oauth2 client details into database

NOTE: this PR **only** modified the sql part, the mongodb part is still using the hardcode.