### PR TITLE
add edit button to detail page

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -685,6 +685,7 @@ module.exports = EntityGenerator.extend({
             if (this.skipClient) {
                 return;
             }
+            
             this.copyHtml(ANGULAR_DIR + 'entities/_entity-management.html', ANGULAR_DIR + 'entities/' + this.entityFolderName + '/' + this.entityPluralFileName + '.html', this, {}, true);
             this.copyHtml(ANGULAR_DIR + 'entities/_entity-management-detail.html', ANGULAR_DIR + 'entities/' + this.entityFolderName + '/' + this.entityFileName + '-detail.html', this, {}, true);
             this.copyHtml(ANGULAR_DIR + 'entities/_entity-management-dialog.html', ANGULAR_DIR + 'entities/' + this.entityFolderName + '/' + this.entityFileName + '-dialog.html', this, {}, true);

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.controller.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.controller.js
@@ -5,12 +5,13 @@
         .module('<%=angularAppName%>')
         .controller('<%= entityAngularJSName %>DetailController', <%= entityAngularJSName %>DetailController);
 
-    <%= entityAngularJSName %>DetailController.$inject = ['$scope', '$rootScope', '$stateParams'<% if (fieldsContainBlob) { %>, 'DataUtils'<% } %>, 'entity'<% for (idx in differentTypes) { %>, '<%= differentTypes[idx] %>'<% } %>];
+    <%= entityAngularJSName %>DetailController.$inject = ['$scope', '$rootScope', '$stateParams', 'previousState'<% if (fieldsContainBlob) { %>, 'DataUtils'<% } %>, 'entity'<% for (idx in differentTypes) { %>, '<%= differentTypes[idx] %>'<% } %>];
 
-    function <%= entityAngularJSName %>DetailController($scope, $rootScope, $stateParams<% if (fieldsContainBlob) { %>, DataUtils<% } %>, entity<% for (idx in differentTypes) { %>, <%= differentTypes[idx] %><% } %>) {
+    function <%= entityAngularJSName %>DetailController($scope, $rootScope, $stateParams, previousState<% if (fieldsContainBlob) { %>, DataUtils<% } %>, entity<% for (idx in differentTypes) { %>, <%= differentTypes[idx] %><% } %>) {
         var vm = this;
 
         vm.<%= entityInstance %> = entity;
+        vm.previousState = previousState.name;
         <%_ if (fieldsContainBlob) { _%>
         vm.byteSize = DataUtils.byteSize;
         vm.openFile = DataUtils.openFile;

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -79,7 +79,6 @@
         <%_ } _%>
     </dl>
 
-{{vm.previousState}}
     <button type="submit"
             ui-sref="{{ vm.previousState }}"
             class="btn btn-info">

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -79,14 +79,15 @@
         <%_ } _%>
     </dl>
 
+{{vm.previousState}}
     <button type="submit"
             ui-sref="{{ vm.previousState }}"
             class="btn btn-info">
         <span class="glyphicon glyphicon-arrow-left"></span>&nbsp;<span translate="entity.action.back"> Back</span>
     </button>
 
-    <button type="submit" ui-sref="<%= entityStateName %>.edit({id:vm.<%=entityInstance %>.id})" class="btn btn-primary btn-sm">
+    <button type="button" ui-sref="<%= entityStateName %>-detail.edit({id:vm.<%=entityInstance %>.id})" class="btn btn-primary">
         <span class="glyphicon glyphicon-pencil"></span>
-        <span class="hidden-xs hidden-sm" translate="entity.action.edit"></span>
+        <span class="hidden-xs hidden-sm" translate="entity.action.edit"> Edit</span>
     </button>
 </div>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -80,7 +80,7 @@
     </dl>
 
     <button type="submit"
-            onclick="window.history.back()"
+            ui-sref="{{ vm.previousState }}"
             class="btn btn-info">
         <span class="glyphicon glyphicon-arrow-left"></span>&nbsp;<span translate="entity.action.back"> Back</span>
     </button>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -84,4 +84,9 @@
             class="btn btn-info">
         <span class="glyphicon glyphicon-arrow-left"></span>&nbsp;<span translate="entity.action.back"> Back</span>
     </button>
+
+    <button type="submit" ui-sref="<%= entityStateName %>.edit({id:vm.<%=entityInstance %>.id})" class="btn btn-primary btn-sm">
+        <span class="glyphicon glyphicon-pencil"></span>
+        <span class="hidden-xs hidden-sm" translate="entity.action.edit"></span>
+    </button>
 </div>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
@@ -83,6 +83,14 @@
                 }],<% } %>
                 entity: ['$stateParams', '<%= entityClass %>', function($stateParams, <%= entityClass %>) {
                     return <%= entityClass %>.get({id : $stateParams.id}).$promise;
+                }],
+                previousState: ["$state", function ($state) {
+                    var currentStateData = {
+                        name: $state.current.name || 'participant',
+                        params: $state.params,
+                        url: $state.href($state.current.name, $state.params)
+                    };
+                    return currentStateData;
                 }]
             }
         })

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
@@ -86,7 +86,7 @@
                 }],
                 previousState: ["$state", function ($state) {
                     var currentStateData = {
-                        name: $state.current.name || 'participant',
+                        name: $state.current.name || '<%= entityStateName %>',
                         params: $state.params,
                         url: $state.href($state.current.name, $state.params)
                     };
@@ -94,6 +94,31 @@
                 }]
             }
         })
+        .state('<%= entityStateName %>-detail.edit', {
+               parent: '<%= entityStateName %>-detail',
+               url: '/{id}/edit',
+               data: {
+                   authorities: ['ROLE_USER']
+               },
+               onEnter: ['$stateParams', '$state', '$uibModal', function($stateParams, $state, $uibModal) {
+                   $uibModal.open({
+                       templateUrl: 'app/entities/<%= entityFolderName %>/<%= entityFileName %>-dialog.html',
+                       controller: '<%= entityAngularJSName %>DialogController',
+                       controllerAs: 'vm',
+                       backdrop: 'static',
+                       size: 'lg',
+                       resolve: {
+                           entity: ['<%= entityClass %>', function(<%= entityClass %>) {
+                               return <%= entityClass %>.get({id : $stateParams.id}).$promise;
+                           }]
+                       }
+                   }).result.then(function() {
+                       $state.go('^', {}, { reload: true });
+                   }, function() {
+                       $state.go('^');
+                   });
+               }]
+           })
         .state('<%= entityStateName %>.new', {
             parent: '<%= entityStateName %>',
             url: '/new',

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
@@ -113,7 +113,7 @@
                            }]
                        }
                    }).result.then(function() {
-                       $state.go('^', {}, { reload: true });
+                       $state.go('^', {}, { reload: false });
                    }, function() {
                        $state.go('^');
                    });

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.state.js
@@ -96,7 +96,7 @@
         })
         .state('<%= entityStateName %>-detail.edit', {
                parent: '<%= entityStateName %>-detail',
-               url: '/{id}/edit',
+               url: '/detail/edit',
                data: {
                    authorities: ['ROLE_USER']
                },

--- a/generators/entity/templates/src/test/javascript/spec/app/entities/_entity-management-detail.controller.spec.js
+++ b/generators/entity/templates/src/test/javascript/spec/app/entities/_entity-management-detail.controller.spec.js
@@ -4,20 +4,22 @@ describe('Controller Tests', function() {
 
     describe('<%= entityClass %> Management Detail Controller', function() {
         var $scope, $rootScope;
-        var MockEntity<% for (idx in differentTypes) { %>, Mock<%= differentTypes[idx] %><%}%>;
+        var MockEntity, MockPreviousState<% for (idx in differentTypes) { %>, Mock<%= differentTypes[idx] %><%}%>;
         var createController;
 
         beforeEach(inject(function($injector) {
             $rootScope = $injector.get('$rootScope');
             $scope = $rootScope.$new();
             MockEntity = jasmine.createSpy('MockEntity');
+            MockPreviousState = jasmine.createSpy('MockPreviousState');
             <% for (idx in differentTypes) { %>Mock<%= differentTypes[idx] %> = jasmine.createSpy('Mock<%= differentTypes[idx] %>');
             <%}%>
 
             var locals = {
                 '$scope': $scope,
                 '$rootScope': $rootScope,
-                'entity': MockEntity <% for (idx in differentTypes) { %>,
+                'entity': MockEntity,
+                'previousState': MockPreviousState<% for (idx in differentTypes) { %>,
                 '<%= differentTypes[idx] %>': Mock<%= differentTypes[idx] %><% } %>
             };
             createController = function() {


### PR DESCRIPTION
* add new state for detail editing, such that the user can stay on the detail page
* don't use back anymore, because otherwise the edit dialog will open again
* therefore publish the previous state to the detail page (in case not found, the entity list is used)

close #3695