### PR TITLE
Update maven docker plugin to get around docker for mac issue

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -984,7 +984,7 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.4.5</version>
+                <version>0.4.10</version>
                 <configuration>
                     <imageName><%= baseName.toLowerCase() %></imageName>
                     <dockerDirectory>src/main/docker</dockerDirectory>


### PR DESCRIPTION

Updating the maven docker plugins to the latest version that includes a fix for building images using docker for mac (see https://github.com/spotify/docker-maven-plugin/issues/218)