### PR TITLE
Fix TypeScript Compilation

### DIFF
--- a/generators/client-2/templates/_tsconfig.json
+++ b/generators/client-2/templates/_tsconfig.json
@@ -1,6 +1,6 @@
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "system",
         "moduleResolution": "node",
         "sourceMap": true,
@@ -10,9 +10,5 @@
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
         "outDir": "<%= DIST_DIR %>app"
-    },
-    "exclude": [
-        "node_modules",
-        "typings/index.d.ts"
-    ]
+    }
 }


### PR DESCRIPTION
Following[ this discussion](https://github.com/angular/angular/issues/7280).
In order to fix the `Cannot find name 'Promise' errors`, we should target `es6`. By doing this, we can remove the exclude property which cleans up a bit our `tsconfig` file.