### PR TITLE
change foreign key constraint name and validate constraint name length

### DIFF
--- a/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
+++ b/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
@@ -15,10 +15,13 @@
             if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide)) {
                 var constraintName = 'fk_' + getTableName(name.toLowerCase()) + '_' +
                     getTableName(relationshipName.toLowerCase()) + '_id';
-            if(prodDatabaseType === 'oracle' && constraintName.length > 30) {
-                constraintName = 'fk_' + getTableName(name.toLowerCase().substring(0, 3)) + '_' +
-                    getTableName(relationshipName.toLowerCase().substring(0, 3)) + '_id';
-            }%>
+                if (prodDatabaseType === 'oracle' && constraintName.length > 30) {
+                    constraintName = 'fk_' + getTableName(name.toLowerCase().substring(0, 3)) + '_' +
+                        getTableName(relationshipName.toLowerCase().substring(0, 3)) + '_id';
+                } else if (prodDatabaseType === 'mysql' && constraintName.length > 64) {
+                    constraintName = 'fk_' + getTableName(name.toLowerCase().substring(0, 10)) + '_' +
+                        getTableName(relationshipName.toLowerCase().substring(0, 10)) + '_id';
+                }%>
         <addForeignKeyConstraint baseColumnNames="<%= getColumnName(relationshipName) %>_id"
                                  baseTableName="<%= entityTableName %>"
                                  constraintName="<%= constraintName %>"
@@ -27,33 +30,31 @@
                                  var otherEntityTable = getTableName(otherEntityName);
                                  if (otherEntityTable == 'user') { %>jhi_user<% } else { %><%=otherEntityTable %><% } %>"/>
         <%_ } else if (relationshipType == 'many-to-many' && ownerSide) {
-            var joinTableName = entityTableName + '_'+ getTableName(relationshipName);
-            if(prodDatabaseType === 'oracle' && joinTableName.length > 30) {
-                joinTableName = getTableName(name.substring(0, 5)) + '_' +
-                    getTableName(relationshipName.substring(0, 5)) + '_MAPPING';
-            }
-            if(prodDatabaseType === 'mysql' && joinTableName.length > 64) {
-                joinTableName = getTableName(name.substring(0, 10)) + '_' +
-                    getTableName(relationshipName.substring(0, 10)) + '_MAPPING';
-            }
-            var constraintName = 'fk_' + joinTableName + '_' + otherEntityName.toLowerCase() + '_id';
-            var otherEntityConstraintName = 'fk_' + joinTableName + '_' + name.toLowerCase() + '_id';
-            if(prodDatabaseType === 'oracle' && constraintName.length > 30) {
-                constraintName = 'fk_' + getTableName(name.toLowerCase().substring(0, 3)) + '_' +
-                    getTableName(relationshipName.toLowerCase().substring(0, 3)) +  '_' +
-                    getTableName(otherEntityName.toLowerCase().substring(0, 3)) + '_id';
-                otherEntityConstraintName = 'fk_' + getTableName(otherEntityName.toLowerCase().substring(0, 3)) + '_' +
-                    getTableName(relationshipName.toLowerCase().substring(0, 3)) +  '_' +
-                    getTableName(name.toLowerCase().substring(0, 3)) + '_id';
-            }
-            if(prodDatabaseType === 'mysql' && constraintName.length > 64) {
-                constraintName = 'fk_' + getTableName(name.toLowerCase().substring(0, 6)) + '_' +
-                    getTableName(relationshipName.toLowerCase().substring(0, 6)) +  '_' +
-                    getTableName(otherEntityName.toLowerCase().substring(0, 6)) + '_id';
-                otherEntityConstraintName = 'fk_' + getTableName(otherEntityName.toLowerCase().substring(0, 6)) + '_' +
-                    getTableName(relationshipName.toLowerCase().substring(0, 6)) +  '_' +
-                    getTableName(name.toLowerCase().substring(0, 6)) + '_id';
-            }
+                var joinTableName = entityTableName + '_'+ getTableName(relationshipName);
+                if (prodDatabaseType === 'oracle' && joinTableName.length > 30) {
+                    joinTableName = getTableName(name.substring(0, 5)) + '_' +
+                        getTableName(relationshipName.substring(0, 5)) + '_MAPPING';
+                } else if (prodDatabaseType === 'mysql' && joinTableName.length > 64) {
+                    joinTableName = getTableName(name.substring(0, 10)) + '_' +
+                        getTableName(relationshipName.substring(0, 10)) + '_MAPPING';
+                }
+                var constraintName = 'fk_' + joinTableName + '_' + getPluralColumnName(name) + '_id';
+                var otherEntityConstraintName = 'fk_' + joinTableName + '_' + getPluralColumnName(relationshipName) + '_id';
+                if (prodDatabaseType === 'oracle' && (constraintName.length > 30 || otherEntityConstraintName > 30)) {
+                    var tempJoinTableName = getTableName(name.toLowerCase().substring(0, 3)) + '_' +
+                        getTableName(relationshipName.toLowerCase().substring(0, 3)) + '_MAP';
+                    constraintName = 'fk_' + tempJoinTableName +  '_' +
+                        getPluralColumnName(name).substring(0, 6) + '_id';
+                    otherEntityConstraintName = 'fk_' + tempJoinTableName +  '_' +
+                        getPluralColumnName(relationshipName).substring(0, 6) + '_id';
+                } else if (prodDatabaseType === 'mysql' && (constraintName.length > 64 || otherEntityConstraintName > 64)) {
+                    var tempJoinTableName = getTableName(name.toLowerCase().substring(0, 10)) + '_' +
+                        getTableName(relationshipName.toLowerCase().substring(0, 10)) + '_MAP';
+                    constraintName = 'fk_' + tempJoinTableName +  '_' +
+                        getPluralColumnName(name).substring(0, 10) + '_id';
+                    otherEntityConstraintName = 'fk_' + tempJoinTableName +  '_' +
+                        getPluralColumnName(relationshipName).substring(0, 10) + '_id';
+                }
           _%>
 
         <addForeignKeyConstraint baseColumnNames="<%= getPluralColumnName(name) %>_id"
@@ -68,6 +69,6 @@
                                  referencedTableName="<%
                                  var otherEntityTable = getTableName(otherEntityName);
                                  if (otherEntityTable == 'user') { %>jhi_user<% } else { %><%=otherEntityTable %><% } %>"/>
-        <% } %><% } %>
+        <%  } %><% } %>
     </changeSet>
 </databaseChangeLog>


### PR DESCRIPTION
change fk key name for many-to-many relationship to use the correct plural column name,
which was earlier having singular column name and also was interchanged entity and otherEntity name
implement constraint name length check for second foreign key in many-to-many relationship
implement constraint name length check for MySQL foreign key in many-to-one and one-to-one reln

fix jhipster/generator-jhipster#2443, fix jhipster/generator-jhipster#3814, fix jhipster/generator-jhipster#3815