### PR TITLE
add eureka info into jhipster-registry's application.yml generated in src/main/docker

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -169,7 +169,6 @@ module.exports = DockerComposeGenerator.extend({
 
                 // Re-configure the JHipster Registry if it is already configured
                 var spring_cloud_config_uri_configured = false;
-                var eureka_client_serviceurl_defaultzone_configured = false;
                 yamlConfig.environment.forEach(function (env, index, envArr) {
 
                     if (env.startsWith('SPRING_CLOUD_CONFIG_URI')) {
@@ -177,20 +176,11 @@ module.exports = DockerComposeGenerator.extend({
                             this.adminPassword + '@registry:8761/config';
                         spring_cloud_config_uri_configured = true;
                     }
-                    if (env.startsWith('EUREKA_CLIENT_SERVICEURL_DEFAULTZONE')) {
-                        envArr[index] = 'EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://admin:' +
-                            this.adminPassword + '@registry:8761/eureka';
-                        eureka_client_serviceurl_defaultzone_configured = true;
-                    }
                 }, this);
                 // Configure the JHipster Registry if it is not already configured
                 if (!spring_cloud_config_uri_configured) {
                     yamlConfig.environment.push('SPRING_CLOUD_CONFIG_URI=http://admin:' +
                         this.adminPassword + '@registry:8761/config');
-                }
-                if (!eureka_client_serviceurl_defaultzone_configured) {
-                    yamlConfig.environment.push('EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://admin:' +
-                        this.adminPassword + '@registry:8761/eureka');
                 }
 
                 parentConfiguration[lowercaseBaseName + '-app'] = yamlConfig;

--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -34,6 +34,7 @@ services:
             - SPRING_PROFILES_ACTIVE=prod
             <%_ if (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa') { _%>
             - SPRING_CLOUD_CONFIG_URI=http://admin:admin@registry:8761/config
+            - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://admin:admin@registry:8761/eureka
             <%_ } _%>
             <%_ if (prodDatabaseType == 'mysql') { _%>
             - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/<%= baseName.toLowerCase() %>?useUnicode=true&characterEncoding=utf8&useSSL=false

--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -34,7 +34,6 @@ services:
             - SPRING_PROFILES_ACTIVE=prod
             <%_ if (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa') { _%>
             - SPRING_CLOUD_CONFIG_URI=http://admin:admin@registry:8761/config
-            - EUREKA_CLIENT_SERVICEURL_DEFAULTZONE=http://admin:admin@registry:8761/eureka
             <%_ } _%>
             <%_ if (prodDatabaseType == 'mysql') { _%>
             - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/<%= baseName.toLowerCase() %>?useUnicode=true&characterEncoding=utf8&useSSL=false

--- a/generators/server/templates/src/main/docker/central-server-config/application.yml
+++ b/generators/server/templates/src/main/docker/central-server-config/application.yml
@@ -8,3 +8,8 @@ jhipster:
         authentication:
             jwt:
                 secret: my-secret-token-to-change-in-production
+
+eureka:
+    client:
+        serviceUrl:
+            defaultZone: http://admin:admin@registry:8761/eureka/


### PR DESCRIPTION
This line disappeared from app.yml in [this change](
https://github.com/jhipster/generator-jhipster/commit/ed91094d943794f25273e933eaf6ee36b6f33560#diff-0eb6bd7d70ceede187ac70836f037149).  Without it, the gateways and microservices throws the error when running `docker-compose -f src/main/docker/app.yml up` :
```
2016-07-17 02:06:24.622  INFO 8 --- [           main] com.netflix.discovery.DiscoveryClient    : Getting all instance registry info from the eureka server
optionsgateway-app_1            | 2016-07-17 02:06:24.751 ERROR 8 --- [           main] c.n.d.s.t.d.RedirectingEurekaHttpClient  : Request execution error
optionsgateway-app_1            | 
optionsgateway-app_1            | com.sun.jersey.api.client.ClientHandlerException: java.net.ConnectException: Connection refused
```