### PR TITLE
remove translation on enum type correctly

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -856,7 +856,7 @@ Generator.prototype.copyTemplate = function (source, dest, action, generator, op
     var regex;
     switch (action) {
     case 'stripHtml' :
-        regex = /( translate\="([a-zA-Z0-9](\.)?)+")|( translate-values\="\{([a-zA-Z]|\d|\:|\{|\}|\[|\]|\-|\'|\s|\.)*?\}")|( translate-compile)|( translate-value-max\="[0-9\{\}\(\)\|]*")/g;
+        regex = /( translate\="([a-zA-Z0-9\ \+\{\}\'](\.)?)+")|( translate-values\="\{([a-zA-Z]|\d|\:|\{|\}|\[|\]|\-|\'|\s|\.)*?\}")|( translate-compile)|( translate-value-max\="[0-9\{\}\(\)\|]*")/g;
             //looks for something like translate="foo.bar.message" and translate-values="{foo: '{{ foo.bar }}'}"
         jhipsterUtils.copyWebResource(source, dest, regex, 'html', _this, _opt, template);
         break;


### PR DESCRIPTION
This changes the stripHtml regex to also check for `translate=` attributes containing `\ \+\{\}\'` (spaces, plus signs, brackets, single quotes).   The following line now has translation removed correctly: 
`-            <span translate="{{'notransApp.Specialty.' + vm.foo.specialty}}">{{vm.foo.specialty}}</span>		`
`+            <span>{{vm.foo.specialty}}</span>`
From https://github.com/ruddell/translation-removal-example/commit/2614377c7e26d02082826fb1280f21f01782043d

Fix #3851 