### PR TITLE
remove double brace to be consistent and allow other ID types

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-detail.html
@@ -64,7 +64,7 @@
             <%_ } else { _%>
                 <%_ if (relationshipType == 'many-to-many') { _%>
             <span ng-repeat="<%= relationshipFieldName %> in vm.<%= entityInstance %>.<%= relationshipFieldNamePlural %>">
-                <a ui-sref="<%= otherEntityStateName %>-detail({id: {{<%= relationshipFieldName %>.id}}})">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{$last ? '' : ', '}}
+                <a ui-sref="<%= otherEntityStateName %>-detail({id: <%= relationshipFieldName %>.id})">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{$last ? '' : ', '}}
             </span>
                 <%_ } else { _%>
                     <%_ if (dto == 'no') { _%>

--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management.html
@@ -111,7 +111,7 @@
                             <%_ } else { _%>
                                 <%_ if (relationshipType == 'many-to-many') { _%>
                         <span ng-repeat="<%= relationshipFieldName %> in <%= entityInstance %>.<%= relationshipFieldNamePlural %>">
-                            <a class="form-control-static" ui-sref="<%= otherEntityStateName %>-detail({id: {{<%= relationshipFieldName %>.id}}})">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{$last ? '' : ', '}}
+                            <a class="form-control-static" ui-sref="<%= otherEntityStateName %>-detail({id: <%= relationshipFieldName %>.id})">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{$last ? '' : ', '}}
                         </span>
                                 <%_ } else { _%>
                                     <%_ if (dto == 'no') { _%>


### PR DESCRIPTION
Tested this to ensure it works with both the default Long id and the user-customized String id that some users prefer.

Fix #3858