### PR TITLE
Fix constraints when customizing table name

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -118,7 +118,6 @@ module.exports = EntityGenerator.extend({
             this.languages = this.config.get('languages');
             this.buildTool = this.config.get('buildTool');
             this.testFrameworks = this.config.get('testFrameworks');
-            this.jhiPrefix = this.config.get('jhiPrefix');
             // backward compatibility on testing frameworks
             if (this.testFrameworks === undefined) {
                 this.testFrameworks = ['gatling'];
@@ -349,7 +348,7 @@ module.exports = EntityGenerator.extend({
                 this.service = 'no';
             }
             if (_.isUndefined(this.entityTableName)) {
-                this.warning('entityTableName is missing in .jhipster/' + this.name + '.json, using no as fallback');
+                this.warning('entityTableName is missing in .jhipster/' + this.name + '.json, using entity name as fallback');
                 this.entityTableName = this.getTableName(this.name);
             }
             if (_.isUndefined(this.pagination)) {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -118,6 +118,7 @@ module.exports = EntityGenerator.extend({
             this.languages = this.config.get('languages');
             this.buildTool = this.config.get('buildTool');
             this.testFrameworks = this.config.get('testFrameworks');
+            this.jhiPrefix = this.config.get('jhiPrefix');
             // backward compatibility on testing frameworks
             if (this.testFrameworks === undefined) {
                 this.testFrameworks = ['gatling'];
@@ -211,7 +212,7 @@ module.exports = EntityGenerator.extend({
         this.service = this.fileData.service;
         this.pagination = this.fileData.pagination;
         this.javadoc = this.fileData.javadoc;
-        this.entityTableName = this.fileData.entityTableName || _.snakeCase(this.name).toLowerCase();
+        this.entityTableName = this.fileData.entityTableName;
         this.fields && this.fields.forEach(function (field) {
             this.fieldNamesUnderscored.push(_.snakeCase(field.fieldName));
             this.fieldNameChoices.push({name: field.fieldName, value: field.fieldName});
@@ -346,6 +347,10 @@ module.exports = EntityGenerator.extend({
             if (_.isUndefined(this.service)) {
                 this.warning('service is missing in .jhipster/' + this.name + '.json, using no as fallback');
                 this.service = 'no';
+            }
+            if (_.isUndefined(this.entityTableName)) {
+                this.warning('entityTableName is missing in .jhipster/' + this.name + '.json, using no as fallback');
+                this.entityTableName = this.getTableName(this.name);
             }
             if (_.isUndefined(this.pagination)) {
                 if (this.databaseType === 'sql' || this.databaseType === 'mongodb') {

--- a/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
+++ b/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
@@ -12,6 +12,11 @@
             relationshipName = relationships[idx].relationshipName,
             ownerSide = relationships[idx].ownerSide,
             otherEntityName = relationships[idx].otherEntityName;
+            if (otherEntityName === 'user') {
+                otherEntityTableName = jhiPrefix + '_user';
+            } else {
+                otherEntityTableName = getEntityProperty(otherEntityName, 'entityTableName');
+            }
             if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide)) {
                 var constraintName = 'fk_' + getTableName(name.toLowerCase()) + '_' +
                     getTableName(relationshipName.toLowerCase()) + '_id';
@@ -26,9 +31,7 @@
                                  baseTableName="<%= entityTableName %>"
                                  constraintName="<%= constraintName %>"
                                  referencedColumnNames="id"
-                                 referencedTableName="<%
-                                 var otherEntityTable = getTableName(otherEntityName);
-                                 if (otherEntityTable == 'user') { %>jhi_user<% } else { %><%=otherEntityTable %><% } %>"/>
+                                 referencedTableName="<%= otherEntityTableName %>"/>
         <%_ } else if (relationshipType == 'many-to-many' && ownerSide) {
                 var joinTableName = entityTableName + '_'+ getTableName(relationshipName);
                 if (prodDatabaseType === 'oracle' && joinTableName.length > 30) {
@@ -66,9 +69,7 @@
                                  baseTableName="<%= joinTableName %>"
                                  constraintName="<%= otherEntityConstraintName %>"
                                  referencedColumnNames="id"
-                                 referencedTableName="<%
-                                 var otherEntityTable = getTableName(otherEntityName);
-                                 if (otherEntityTable == 'user') { %>jhi_user<% } else { %><%=otherEntityTable %><% } %>"/>
+                                 referencedTableName="<%= otherEntityTableName %>"/>
         <%  } %><% } %>
     </changeSet>
 </databaseChangeLog>

--- a/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
+++ b/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
@@ -16,6 +16,9 @@
                 otherEntityTableName = jhiPrefix + '_user';
             } else {
                 otherEntityTableName = getEntityProperty(otherEntityName, 'entityTableName');
+                if (otherEntityTableName === undefined) {
+                    otherEntityTableName = getTableName(otherEntityName);
+                }
             }
             if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide)) {
                 var constraintName = 'fk_' + getTableName(name.toLowerCase()) + '_' +

--- a/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
+++ b/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity_constraints.xml
@@ -13,10 +13,10 @@
             ownerSide = relationships[idx].ownerSide,
             otherEntityName = relationships[idx].otherEntityName;
             if (otherEntityName === 'user') {
-                otherEntityTableName = jhiPrefix + '_user';
+                otherEntityTableName = 'jhi_user';
             } else {
                 otherEntityTableName = getEntityProperty(otherEntityName, 'entityTableName');
-                if (otherEntityTableName === undefined) {
+                if (!otherEntityTableName) {
                     otherEntityTableName = getTableName(otherEntityName);
                 }
             }

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1023,7 +1023,7 @@ Generator.prototype.getModuleHooks = function () {
 };
 
 /**
- * get a property of an entity from th configuration file
+ * get a property of an entity from the configuration file
  * @param {string} file - configuration file name for the entity
  * @param {string} key - key to read
  */
@@ -1031,7 +1031,7 @@ Generator.prototype.getEntityProperty = function (file, key) {
     var property = null;
 
     try {
-        var entityJson = this.fs.readJSON(path.join(JHIPSTER_CONFIG_DIR, file.charAt(0).toUpperCase() + file.slice(1) + '.json'));
+        var entityJson = this.fs.readJSON(path.join(JHIPSTER_CONFIG_DIR, _.upperFirst(file) + '.json'));
         property = entityJson[key];
     } catch (err) {
         this.log(chalk.red('The Jhipster entity configuration file could not be read!') + err);

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1023,6 +1023,24 @@ Generator.prototype.getModuleHooks = function () {
 };
 
 /**
+ * get a property of an entity from th configuration file
+ * @param {string} file - configuration file name for the entity
+ * @param {string} key - key to read
+ */
+Generator.prototype.getEntityProperty = function (file, key) {
+    var property = null;
+
+    try {
+        var entityJson = this.fs.readJSON(path.join(JHIPSTER_CONFIG_DIR, file.charAt(0).toUpperCase() + file.slice(1) + '.json'));
+        property = entityJson[key];
+    } catch (err) {
+        this.log(chalk.red('The Jhipster entity configuration file could not be read!') + err);
+    }
+
+    return property;
+};
+
+/**
  * get sorted list of entities according to changelog date (i.e. the order in which they were added)
  */
 Generator.prototype.getExistingEntities = function () {

--- a/travis/samples/.jhipster/TestCustomTableName.json
+++ b/travis/samples/.jhipster/TestCustomTableName.json
@@ -4,21 +4,27 @@
             "relationshipName": "testManyToOne",
             "otherEntityName": "testManyToOne",
             "relationshipType": "one-to-many",
-            "otherEntityRelationshipName": "testEntity"
+            "otherEntityRelationshipName": "testCustomTableName"
         },
         {
             "relationshipName": "testManyToMany",
             "otherEntityName": "testManyToMany",
             "relationshipType": "many-to-many",
             "ownerSide": false,
-            "otherEntityRelationshipName": "testEntity"
+            "otherEntityRelationshipName": "testCustomTableName"
         },
         {
             "relationshipName": "testOneToOne",
             "otherEntityName": "testOneToOne",
             "relationshipType": "one-to-one",
             "ownerSide": false,
-            "otherEntityRelationshipName": "testEntity"
+            "otherEntityRelationshipName": "testCustomTableName"
+        },
+        {
+            "relationshipName": "testEntity",
+            "otherEntityName": "testEntity",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "id"
         },
         {
             "relationshipName": "userOneToMany",
@@ -40,17 +46,12 @@
             "otherEntityField": "login",
             "ownerSide": true,
             "otherEntityRelationshipName": "parent"
-        },
-        {
-            "relationshipName": "testCustomTableName",
-            "otherEntityName": "testCustomTableName",
-            "relationshipType": "one-to-many",
-            "otherEntityRelationshipName": "testEntity"
         }
     ],
     "fields": [],
     "changelogDate": "20160208210109",
     "dto": "no",
     "service": "no",
+    "entityTableName": "jhi_test_custom_table_name_entity",
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/TestManyToMany.json
+++ b/travis/samples/.jhipster/TestManyToMany.json
@@ -48,6 +48,13 @@
             "relationshipType": "many-to-many",
             "otherEntityField": "id",
             "ownerSide": true
+        },
+        {
+            "relationshipName": "testCustomTableName",
+            "otherEntityName": "testCustomTableName",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "id",
+            "ownerSide": true
         }
     ],
     "fields": [],

--- a/travis/samples/.jhipster/TestManyToOne.json
+++ b/travis/samples/.jhipster/TestManyToOne.json
@@ -41,6 +41,12 @@
             "otherEntityName": "testPagination",
             "relationshipType": "many-to-one",
             "otherEntityField": "id"
+        },
+        {
+            "relationshipName": "testCustomTableName",
+            "otherEntityName": "testCustomTableName",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "id"
         }
     ],
     "fields": [],

--- a/travis/samples/.jhipster/TestOneToOne.json
+++ b/travis/samples/.jhipster/TestOneToOne.json
@@ -55,6 +55,14 @@
             "otherEntityField": "id",
             "ownerSide": true,
             "otherEntityRelationshipName": "testOneToOne"
+        },
+        {
+            "relationshipName": "testCustomTableName",
+            "otherEntityName": "testCustomTableName",
+            "relationshipType": "one-to-one",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "testOneToOne"
         }
     ],
     "fields": [],

--- a/travis/scripts/02-generate-entities.sh
+++ b/travis/scripts/02-generate-entities.sh
@@ -74,6 +74,7 @@ elif [[ ("$JHIPSTER" == "app-mysql") || ("$JHIPSTER" == "app-psql-es-noi18n") ]]
   moveEntity TestManyToOne
   moveEntity TestManyToMany
   moveEntity TestOneToOne
+  moveEntity TestCustomTableName
 
 else
   moveEntity BankAccount
@@ -127,6 +128,7 @@ generateEntity TestPagination
 generateEntity TestManyToOne
 generateEntity TestManyToMany
 generateEntity TestOneToOne
+generateEntity TestCustomTableName
 
 #-------------------------------------------------------------------------------
 # Check Javadoc generation


### PR DESCRIPTION
Fix #3723, this is Option 2 from @jdubois's post in the issue.  It also fixes relationships with user when using a customized jhiPrefix.

Only thing left is to add a test using custom table names to the entity generation step.