### PR TITLE
Improve error message for parsing JDL's

### DIFF
--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -49,7 +49,7 @@ module.exports = JDLGenerator.extend({
                 this.log('Writing entity JSON files.');
                 jhiCore.exportToJSON(entities);
             } catch (e) {
-                this.error('Error while parsing entities from JDL\n' + e);
+                this.error('Error while parsing entities from JDL\n' + (e.message || e));
             }
 
 


### PR DESCRIPTION
When there is an exception thrown that is of type `Error` the error handling prints "[object Object]". This change checks if there is a message property and prints that, otherwise it assumes its a string. This is the one place I was having issue with, but the same problem exists anywhere that pattern is used.