### PR TITLE
Upgrade npm and bower dependencies to latest versions

### DIFF
--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -6,7 +6,7 @@
   "dependencies": {
     "angular": "1.5.8",
     "angular-aria": "1.5.8",
-    "angular-bootstrap": "2.0.0",
+    "angular-bootstrap": "1.3.3",
     "angular-cache-buster": "0.4.3",
     "angular-cookies": "1.5.8",
     <%_ if (enableTranslation) { _%>

--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -78,6 +78,7 @@
   },
   "resolutions": {
     "angular": "1.5.8",
-    "angular-bootstrap": "2.0.0"
+    "angular-bootstrap": "2.0.0",
+    "jquery": "3.1.0"
   }
 }

--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -48,7 +48,7 @@
   "overrides": {
     "angular": {
       "dependencies": {
-        "jquery": "2.2.4"
+        "jquery": "3.1.0"
       }
     },
     "angular-cache-buster": {

--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -78,6 +78,6 @@
   },
   "resolutions": {
     "angular": "1.5.8",
-    "angular-bootstrap": "2.0.0",
+    "angular-bootstrap": "2.0.0"
   }
 }

--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -4,46 +4,46 @@
   "appPath": "<%= MAIN_SRC_DIR %>",
   "testPath": "<%= TEST_SRC_DIR %>spec",
   "dependencies": {
-    "angular": "1.5.5",
-    "angular-aria": "1.5.5",
-    "angular-bootstrap": "1.3.3",
+    "angular": "1.5.8",
+    "angular-aria": "1.5.8",
+    "angular-bootstrap": "2.0.0",
     "angular-cache-buster": "0.4.3",
-    "angular-cookies": "1.5.5",
+    "angular-cookies": "1.5.8",
     <%_ if (enableTranslation) { _%>
     "angular-dynamic-locale": "0.1.32",
-    "angular-i18n": "1.5.5",
+    "angular-i18n": "1.5.8",
     <%_ } _%>
     "ngstorage": "0.3.10",
     "angular-loading-bar": "0.9.0",
-    "angular-resource": "1.5.5",
-    "angular-sanitize": "1.5.5",
+    "angular-resource": "1.5.8",
+    "angular-sanitize": "1.5.8",
     <%_ if (enableTranslation) { _%>
-    "angular-translate": "2.11.0",
-    "angular-translate-interpolation-messageformat": "2.11.0",
-    "angular-translate-loader-partial": "2.11.0",
-    "angular-translate-storage-cookie": "2.11.0",
+    "angular-translate": "2.11.1",
+    "angular-translate-interpolation-messageformat": "2.11.1",
+    "angular-translate-loader-partial": "2.11.1",
+    "angular-translate-storage-cookie": "2.11.1",
     <%_ } _%>
-    "angular-ui-router": "0.3.0",
+    "angular-ui-router": "0.3.1",
     <%_ if (useSass) { _%>
-    "bootstrap-sass": "3.3.6",
+    "bootstrap-sass": "3.3.7",
     <%_ } else { _%>
     "bootstrap": "3.3.6",
     <%_ } _%>
-    "bootstrap-ui-datetime-picker": "2.4.0",
-    "jquery": "2.2.4",
+    "bootstrap-ui-datetime-picker": "2.4.3",
+    "jquery": "3.1.0",
     "json3": "3.3.2",
     "messageformat": "0.3.1",
     "modernizr": "3.3.1",
     "ng-file-upload": "12.0.4",
-    "ngInfiniteScroll": "1.2.2",
+    "ngInfiniteScroll": "1.3.0",
     <%_ if (websocket == 'spring-websocket') { _%>
     "sockjs-client": "1.1.1",
     "stomp-websocket": "2.3.4",
     <%_ } _%>
-    "swagger-ui": "2.1.4"
+    "swagger-ui": "2.1.5"
   },
   "devDependencies": {
-    "angular-mocks": "1.5.5"
+    "angular-mocks": "1.5.8"
   },
   "overrides": {
     "angular": {
@@ -53,13 +53,13 @@
     },
     "angular-cache-buster": {
       "dependencies": {
-        "angular": "1.5.5"
+        "angular": "1.5.8"
       }
     },
     <%_ if (enableTranslation) { _%>
     "angular-dynamic-locale": {
       "dependencies": {
-        "angular": "1.5.5"
+        "angular": "1.5.8"
       }
     },
     <%_ } if (useSass) { _%>
@@ -77,9 +77,7 @@
     <%_ } _%>
   },
   "resolutions": {
-    "angular": "1.5.5",
-    "angular-cookies": "1.5.5",
-    "angular-bootstrap": "1.3.3",
-    "jquery": "2.2.4"
+    "angular": "1.5.8",
+    "angular-bootstrap": "2.0.0",
   }
 }

--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -9,27 +9,27 @@
   ],
   "devDependencies": {
     "bower": "1.7.9",
-    "browser-sync": "2.12.10",
-    "del": "2.2.0",
+    "browser-sync": "2.13.0",
+    "del": "2.2.1",
     "eslint-config-angular": "0.5.0",
-    "eslint-plugin-angular": "1.0.1",
-    "event-stream": "3.3.2",
+    "eslint-plugin-angular": "1.3.1",
+    "event-stream": "3.3.4",
     "generator-jhipster": "<%= packagejs.version %>",
     "gulp": "3.9.1",
     "gulp-angular-filesort": "1.1.1",
-    "gulp-angular-templatecache": "1.9.0",
+    "gulp-angular-templatecache": "2.0.0",
     "gulp-autoprefixer": "3.1.0",
-    "gulp-changed": "1.3.0",
+    "gulp-changed": "1.3.1",
     "gulp-cssnano": "2.1.2",
-    "gulp-eslint": "2.0.0",
+    "gulp-eslint": "3.0.1",
     <%_ if (useSass) { _%>
     "gulp-expect-file": "0.0.7",
     <%_ } _%>
-    "gulp-flatten": "0.2.0",
+    "gulp-flatten": "0.3.0",
     "gulp-footer": "1.0.5",
     "gulp-htmlmin": "2.0.0",
     "gulp-if": "2.0.1",
-    "gulp-imagemin": "3.0.1",
+    "gulp-imagemin": "3.0.2",
     "gulp-inject": "4.1.0",
     "gulp-natural-sort": "0.1.1",
     "gulp-ng-annotate": "2.0.0",
@@ -39,43 +39,43 @@
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
-    "gulp-protractor": "2.4.0",
+    "gulp-protractor": "2.5.0",
     "gulp-util": "3.0.7",
     <%_ } _%>
-    "gulp-rev": "7.0.0",
+    "gulp-rev": "7.1.0",
     "gulp-rev-replace": "0.4.3",
     <%_ if (useSass) { _%>
-    "gulp-sass": "2.3.1",
+    "gulp-sass": "2.3.2",
     <%_ } _%>
     "gulp-sourcemaps": "1.6.0",
-    "gulp-uglify": "1.5.3",
+    "gulp-uglify": "1.5.4",
     "gulp-useref": "3.1.0",
     "jasmine-core": "2.4.1",
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
-    "jasmine-reporters": "2.1.1",
+    "jasmine-reporters": "2.2.0",
     <%_ } _%>
-    "karma": "0.13.22",
+    "karma": "1.1.2",
     "karma-chrome-launcher": "1.0.1",
-    "karma-coverage": "1.0.0",
+    "karma-coverage": "1.1.1",
     "karma-jasmine": "1.0.2",
-    "karma-junit-reporter": "1.0.0",
-    "karma-phantomjs-launcher": "1.0.0",
+    "karma-junit-reporter": "1.1.0",
+    "karma-phantomjs-launcher": "1.0.1",
     "karma-script-launcher": "1.0.0",
     "lazypipe": "1.0.1",
-    "lodash": "4.13.1",
+    "lodash": "4.14.0",
     "main-bower-files": "2.13.1",
     "map-stream": "0.0.6",
-    "phantomjs-prebuilt": "2.1.7",
+    "phantomjs-prebuilt": "2.1.8",
     <%_ if (testFrameworks.indexOf('protractor') > -1) { _%>
-    "protractor": "3.3.0",
-    "protractor-jasmine2-screenshot-reporter": "0.3.1",
+    "protractor": "4.0.0",
+    "protractor-jasmine2-screenshot-reporter": "0.3.2",
     <%_ } _%>
     "proxy-middleware": "0.15.0",
-    "run-sequence": "1.2.1",
+    "run-sequence": "1.2.2",
     <%_ if (buildTool == 'maven') { _%>
     "xml2js": "0.4.16",
     <%_ } _%>
-    "yargs": "4.7.1"
+    "yargs": "4.8.1"
   },
   "engines": {
     "node": "^4.3"

--- a/generators/client/templates/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/src/test/javascript/_protractor.conf.js
@@ -4,7 +4,7 @@ var JasmineReporters = require('jasmine-reporters');
 var prefix = '<%= TEST_SRC_DIR %>'.replace(/[^/]+/g,'..');
 
 exports.config = {
-    seleniumServerJar: prefix + 'node_modules/protractor/selenium/selenium-server-standalone-2.52.0.jar',
+    seleniumServerJar: prefix + 'node_modules/protractor/node_modules/webdriver-manager/selenium/selenium-server-standalone-2.53.1.jar',
     chromeDriver: prefix + 'node_modules/protractor/selenium/chromedriver',
     allScriptsTimeout: 20000,
 


### PR DESCRIPTION
This also upgrades Protractor to 4.0 and fixes the out-of-the-box experience with `gulp itest`.

Fixes #3887.