### PR TITLE
Revert mainClassName to be 'Application'

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1215,7 +1215,9 @@ Generator.prototype.getAngularAppName = function () {
  * get the java main class name.
  */
 Generator.prototype.getMainClassName = function () {
-    return _.upperFirst(this.getAngularAppName());
+    // Don't name by baseName because numbers can cause compilation issues.
+    // https://github.com/jhipster/generator-jhipster/issues/3889
+    return 'Application';
 };
 
 /**

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -64,7 +64,7 @@ const expectedFiles = {
         SERVER_MAIN_RES_DIR + 'mails/activationEmail.html',
         SERVER_MAIN_RES_DIR + 'mails/passwordResetEmail.html',
         SERVER_MAIN_RES_DIR + 'i18n/messages.properties',
-        SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/JhipsterApp.java',
+        SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/Application.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/ApplicationWebXml.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/aop/logging/LoggingAspect.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/config/apidoc/package-info.java',
@@ -542,9 +542,9 @@ describe('JHipster generator', function () {
 
         it('creates expected files with correct package names', function () {
             assert.file([
-                SERVER_MAIN_SRC_DIR + 'com/otherpackage/JhipsterApp.java'
+                SERVER_MAIN_SRC_DIR + 'com/otherpackage/Application.java'
             ]);
-            assert.fileContent(SERVER_MAIN_SRC_DIR + 'com/otherpackage/JhipsterApp.java', /package com\.otherpackage;/);
+            assert.fileContent(SERVER_MAIN_SRC_DIR + 'com/otherpackage/Application.java', /package com\.otherpackage;/);
         });
     });
 


### PR DESCRIPTION
This fixes #3889, where `baseName` can create class names that have invalid Java syntax for class names.