### PR TITLE
update swagger resources to match latest version

### DIFF
--- a/generators/client/templates/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/src/main/webapp/swagger-ui/_index.html
@@ -10,15 +10,17 @@
     <link href='../bower_components/swagger-ui/dist/css/screen.css' media='screen' rel='stylesheet' type='text/css'/>
     <link href='../bower_components/swagger-ui/dist/css/reset.css' media='print' rel='stylesheet' type='text/css'/>
     <link href='../bower_components/swagger-ui/dist/css/print.css' media='print' rel='stylesheet' type='text/css'/>
+    <script src='../bower_components/swagger-ui/dist/lib/object-assign-pollyfill.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/jquery-1.8.0.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/jquery.slideto.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/jquery.wiggle.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/jquery.ba-bbq.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/handlebars-2.0.0.js' type='text/javascript'></script>
-    <script src='../bower_components/swagger-ui/dist/lib/underscore-min.js' type='text/javascript'></script>
+    <script src='../bower_components/swagger-ui/dist/lib/lodash.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/backbone-min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/swagger-ui.js' type='text/javascript'></script>
-    <script src='../bower_components/swagger-ui/dist/lib/highlight.7.3.pack.js' type='text/javascript'></script>
+    <script src='../bower_components/swagger-ui/dist/lib/highlight.9.1.0.pack.js' type='text/javascript'></script>
+    <script src='../bower_components/swagger-ui/dist/lib/highlight.9.1.0.pack_extended.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/jsoneditor.min.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/marked.js' type='text/javascript'></script>
     <script src='../bower_components/swagger-ui/dist/lib/swagger-oauth.js' type='text/javascript'></script>


### PR DESCRIPTION
Swagger is broken on master, v2.1.4 used underscore.js and v2.1.5 (latest) uses lodash.js

Client-2 still has the older version of bower.json (updated in #3888) so this doesn't affect it yet.  