### PR TITLE
Update heroku generator for new cli package install

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -104,7 +104,7 @@ module.exports = HerokuGenerator.extend({
             if (this.abort) return;
             var done = this.async();
             this.log(chalk.bold('\nInstalling Heroku CLI deployment plugin'));
-            var child = exec('heroku plugins:install https://github.com/heroku/heroku-deploy', function (err, stdout) {
+            var child = exec('heroku plugins:install heroku-cli-deploy', function (err, stdout) {
                 if (err) {
                     this.abort = true;
                     this.log.error(err);
@@ -279,9 +279,9 @@ module.exports = HerokuGenerator.extend({
             var done = this.async();
             this.log(chalk.bold('\nDeploying application'));
 
-            var herokuDeployCommand = 'heroku deploy:jar --jar target/*.war';
+            var herokuDeployCommand = 'heroku deploy:jar target/*.war';
             if (this.buildTool === 'gradle') {
-                herokuDeployCommand = 'heroku deploy:jar --jar build/libs/*.war';
+                herokuDeployCommand = 'heroku deploy:jar build/libs/*.war';
             }
 
             herokuDeployCommand += ' --app ' + this.herokuDeployedName;


### PR DESCRIPTION
This PR updates the Heroku generator to use the new [heroku-cli-deploy](https://www.npmjs.com/package/heroku-cli-deploy) plugin instead of the old Github repo for the plugin. The latter with soon be obsolete. 

You may notice that the `--jar` option has been removed. However, this flag is still supported in the new version (but it's undocumented). This should make the transition easy for anyone already using the plugin.