### PR TITLE
Use the swagger profile in docker-compose

### DIFF
--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -31,7 +31,7 @@ services:
             - jhipster-registry:registry
         <%_ } _%>
         environment:
-            - SPRING_PROFILES_ACTIVE=prod
+            - SPRING_PROFILES_ACTIVE=prod,swagger
             <%_ if (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa') { _%>
             - SPRING_CLOUD_CONFIG_URI=http://admin:admin@registry:8761/config
             <%_ } _%>


### PR DESCRIPTION
We finally have swagger/swagger UI working perfectly in docker. Both with src/main/docker/app.yml and the docker-compose subgen.

Big thanks to @ruddell @marcelinobadin for coming after me and fixing some bugs.

This will let us do amazing demos of JHipster microservice.
