### PR TITLE
fix gulp inject task to inject bower dependencies correctly

### DIFF
--- a/generators/client/templates/gulpfile.js
+++ b/generators/client/templates/gulpfile.js
@@ -45,7 +45,7 @@ gulp.task('clean', function () {
 });
 
 gulp.task('copy', function () {
-    return es.merge( <% if(enableTranslation) { /* copy i18n folders only if translation is enabled */ %>
+    return es.merge(<% if(enableTranslation) { /* copy i18n folders only if translation is enabled */ %>
         gulp.src(config.app + 'i18n/**')
         .pipe(plumber({errorHandler: handleErrors}))
         .pipe(changed(config.dist + 'i18n/'))
@@ -128,7 +128,10 @@ gulp.task('styles', [<% if(useSass) { %>'sass'<% } %>], function () {
         .pipe(browserSync.reload({stream: true}));
 });
 
-gulp.task('inject', ['inject:dep', 'inject:app']);
+gulp.task('inject', function() {
+    runSequence('inject:dep', 'inject:app');
+});
+
 gulp.task('inject:dep', ['inject:test', 'inject:vendor']);
 
 gulp.task('inject:app', function () {


### PR DESCRIPTION
This fixes `gulp inject` to inject installed bower dependences from bower.json.  

You can reproduce the issue by installing something with bower (for example `bower install underscore --save`) and running `gulp inject`, the  files will not be found in index.html.  

Another way to reproduce this is to remove any of the files between `<!-- bower:js --><!-- endinject -->` and run `gulp inject`.  No files will be injected.

Originally reported on [StackOverflow](http://stackoverflow.com/questions/37816714/gulp-task-injectvendor-does-not-inject-bower-dependencies/37826202#37826202)