### PR TITLE
Fix typo in `i18n/_entity_it.json`

### DIFF
--- a/generators/entity/templates/src/main/webapp/i18n/_entity_it.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_it.json
@@ -4,7 +4,7 @@
             "home": {
                 "title": "<%= entityClassPlural %>",
                 "createLabel": "Genera un nuovo <%= entityClassHumanized %>",
-                "createOrEditLabel": "Genera o modifica us <%= entityClassHumanized %>",
+                "createOrEditLabel": "Genera o modifica un <%= entityClassHumanized %>",
                 "search": "Cerca <%= entityClassHumanized %>"
             },
             "created": "&Egrave; stato generato un nuovo <%= entityClassHumanized %> con identificatore { param }}",


### PR DESCRIPTION
changed `us` to `un` - correct italian version.