### PR TITLE
revert liquibase to fix mvn:liquibase diff command

### DIFF
--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -23,7 +23,7 @@ geronimo_javamail_1_4_mail_version=1.8.4<% if (clusteredHttpSession == 'hazelcas
 hazelcast_version=3.6.4<% } %>
 hibernate_entitymanager_version=4.3.11.Final
 HikariCP_version=2.4.6<% if (databaseType == 'sql') { %>
-liquibase_slf4j_version=1.2.1
+liquibase_slf4j_version=2.0.0
 liquibase_core_version=3.4.2
 liquibase_hibernate4_version=3.5<% } %><% if (databaseType == 'mongodb') { %>
 mongobee_version=0.10<% } %>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -69,7 +69,7 @@
         <mariadb.version>1.4.4</mariadb.version>
         <%_ } _%>
         <%_ if (databaseType === 'sql') { _%>
-        <liquibase.version>3.5.1</liquibase.version>
+        <liquibase.version>3.4.2</liquibase.version>
         <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
         <liquibase-hibernate4.version>3.5</liquibase-hibernate4.version>
         <%_ } _%>


### PR DESCRIPTION
Starting from the liquibase version bump in #3900, running `mvn liquibase:diff` on a project throws the following error:

`[ERROR] Failed to execute goal org.liquibase:liquibase-maven-plugin:3.5.1:diff (default-cli) on project mastertest: Execution default-cli of goal org.liquibase:liquibase-maven-plugin:3.5.1:diff failed: An API incompatibility was encountered while executing org.liquibase:liquibase-maven-plugin:3.5.1:diff: java.lang.NoSuchMethodError: liquibase.structure.core.ForeignKey.addForeignKeyColumn(Lliquibase/structure/core/Column;)V`

According to https://github.com/liquibase/liquibase-hibernate/issues/117, reverting liquibase from 3.5 -> 3.4.2 is the only option to fix this for now.