### PR TITLE
set access_token for websockets when using UAA

### DIFF
--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -6,9 +6,9 @@
         .module('<%=angularAppName%>')
         .factory('<%=jhiPrefixCapitalized%>TrackerService', <%=jhiPrefixCapitalized%>TrackerService);
 
-    <%=jhiPrefixCapitalized%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt' || authenticationType == 'uaa') { %>, 'AuthServerProvider'<%}%><% if (authenticationType == 'oauth2') { %>, '$localStorage'<%}%>];
+    <%=jhiPrefixCapitalized%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType === 'jwt' || authenticationType === 'uaa') { %>, 'AuthServerProvider'<%}%><% if (authenticationType === 'oauth2') { %>, '$localStorage'<%}%>];
 
-    function <%=jhiPrefixCapitalized%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt' || authenticationType == 'uaa') { %>, AuthServerProvider<%}%><% if (authenticationType == 'oauth2') { %>, $localStorage<%}%>) {
+    function <%=jhiPrefixCapitalized%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType === 'jwt' || authenticationType === 'uaa') { %>, AuthServerProvider<%}%><% if (authenticationType === 'oauth2') { %>, $localStorage<%}%>) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();
@@ -29,10 +29,10 @@
         function connect () {
             //building absolute path so that websocket doesnt fail when deploying with a context path
             var loc = $window.location;
-            var url = '//' + loc.host + loc.pathname + 'websocket/tracker';<% if (authenticationType == 'oauth2') { %>
+            var url = '//' + loc.host + loc.pathname + 'websocket/tracker';<% if (authenticationType === 'oauth2') { %>
             /*jshint camelcase: false */
             var authToken = angular.fromJson($localStorage.authenticationToken).access_token;
-            url += '?access_token=' + authToken;<% } %><% if (authenticationType == 'jwt' || authenticationType == 'uaa') { %>
+            url += '?access_token=' + authToken;<% } %><% if (authenticationType === 'jwt' || authenticationType === 'uaa') { %>
             var authToken = AuthServerProvider.getToken();
             if(authToken){
                 url += '?access_token=' + authToken;
@@ -40,7 +40,7 @@
             var socket = new SockJS(url);
             stompClient = Stomp.over(socket);
             var stateChangeStart;
-            var headers = {};<% if (authenticationType == 'session') { %>
+            var headers = {};<% if (authenticationType === 'session') { %>
             headers['X-CSRF-TOKEN'] = $cookies[$http.defaults.xsrfCookieName];<% } %>
             stompClient.connect(headers, function() {
                 connected.resolve('success');

--- a/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -6,9 +6,9 @@
         .module('<%=angularAppName%>')
         .factory('<%=jhiPrefixCapitalized%>TrackerService', <%=jhiPrefixCapitalized%>TrackerService);
 
-    <%=jhiPrefixCapitalized%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt') { %>, 'AuthServerProvider'<%}%><% if (authenticationType == 'oauth2') { %>, '$localStorage'<%}%>];
+    <%=jhiPrefixCapitalized%>TrackerService.$inject = ['$rootScope', '$window', '$cookies', '$http', '$q'<% if (authenticationType == 'jwt' || authenticationType == 'uaa') { %>, 'AuthServerProvider'<%}%><% if (authenticationType == 'oauth2') { %>, '$localStorage'<%}%>];
 
-    function <%=jhiPrefixCapitalized%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt') { %>, AuthServerProvider<%}%><% if (authenticationType == 'oauth2') { %>, $localStorage<%}%>) {
+    function <%=jhiPrefixCapitalized%>TrackerService ($rootScope, $window, $cookies, $http, $q<% if (authenticationType == 'jwt' || authenticationType == 'uaa') { %>, AuthServerProvider<%}%><% if (authenticationType == 'oauth2') { %>, $localStorage<%}%>) {
         var stompClient = null;
         var subscriber = null;
         var listener = $q.defer();
@@ -32,7 +32,7 @@
             var url = '//' + loc.host + loc.pathname + 'websocket/tracker';<% if (authenticationType == 'oauth2') { %>
             /*jshint camelcase: false */
             var authToken = angular.fromJson($localStorage.authenticationToken).access_token;
-            url += '?access_token=' + authToken;<% } %><% if (authenticationType == 'jwt') { %>
+            url += '?access_token=' + authToken;<% } %><% if (authenticationType == 'jwt' || authenticationType == 'uaa') { %>
             var authToken = AuthServerProvider.getToken();
             if(authToken){
                 url += '?access_token=' + authToken;


### PR DESCRIPTION
No websocket access token was set when using UAA, resulting with an Access Is Denied error.  Originally reported [here](http://stackoverflow.com/questions/38879751/executorsubscribablechannelclientinboundchannel-access-denied)