### PR TITLE
Table name prompt for oracle

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -235,6 +235,7 @@ module.exports = EntityGenerator.extend({
         askForFieldsToRemove: prompts.askForFieldsToRemove,
         askForRelationships: prompts.askForRelationships,
         askForRelationsToRemove: prompts.askForRelationsToRemove,
+        askForTableName: prompts.askForTableName,
         askForDTO: prompts.askForDTO,
         askForService: prompts.askForService,
         askForPagination: prompts.askForPagination

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -83,7 +83,7 @@ module.exports = EntityGenerator.extend({
 
         this.regenerate = this.options['regenerate'];
         this.fluentMethods = this.options['fluent-methods'];
-        this.entityTableName = _.snakeCase(this.options['table-name'] || this.name).toLowerCase();
+        this.entityTableName = this.getTableName(this.options['table-name'] || this.name);
         this.entityNameCapitalized = _.upperFirst(this.name);
         this.entityAngularJSSuffix = this.options['angular-suffix'];
         this.skipServer = this.config.get('skipServer') || this.options['skip-server'];

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -207,6 +207,10 @@ module.exports = EntityGenerator.extend({
         this.pagination = this.fileData.pagination;
         this.javadoc = this.fileData.javadoc;
         this.entityTableName = this.fileData.entityTableName;
+        if (_.isUndefined(this.entityTableName)) {
+            this.warning(`entityTableName is missing in .jhipster/${ this.name }.json, using entity name as fallback`);
+            this.entityTableName = this.getTableName(this.name);
+        }
         this.fields && this.fields.forEach(function (field) {
             this.fieldNamesUnderscored.push(_.snakeCase(field.fieldName));
             this.fieldNameChoices.push({name: field.fieldName, value: field.fieldName});
@@ -342,10 +346,6 @@ module.exports = EntityGenerator.extend({
             if (_.isUndefined(this.service)) {
                 this.warning(`service is missing in .jhipster/${ this.name }.json, using no as fallback`);
                 this.service = 'no';
-            }
-            if (_.isUndefined(this.entityTableName)) {
-                this.warning(`entityTableName is missing in .jhipster/${ this.name }.json, using entity name as fallback`);
-                this.entityTableName = this.getTableName(this.name);
             }
             if (_.isUndefined(this.pagination)) {
                 if (this.databaseType === 'sql' || this.databaseType === 'mongodb') {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -166,7 +166,10 @@ module.exports = EntityGenerator.extend({
                 this.error(chalk.red(`The table name cannot contain a ${prodDatabaseType.toUpperCase()} reserved keyword`));
             } else if (prodDatabaseType === 'oracle' && this.entityTableName.length > 26) {
                 this.error(chalk.red('The table name is too long for Oracle, try a shorter name'));
+            } else if (prodDatabaseType === 'oracle' && this.entityTableName.length > 14) {
+                this.warning('The table name is long for Oracle, long table names can cause issues when used to create constraint names and join table names');
             }
+
         },
 
         setupVars: function () {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -83,9 +83,8 @@ module.exports = EntityGenerator.extend({
 
         this.regenerate = this.options['regenerate'];
         this.fluentMethods = this.options['fluent-methods'];
-        this.entityTableName = this.options['table-name'] || this.name;
+        this.entityTableName = _.snakeCase(this.options['table-name'] || this.name).toLowerCase();
         this.entityNameCapitalized = _.upperFirst(this.name);
-        this.entityTableName = _.snakeCase(this.entityTableName).toLowerCase();
         this.entityAngularJSSuffix = this.options['angular-suffix'];
         this.skipServer = this.config.get('skipServer') || this.options['skip-server'];
         if (this.entityAngularJSSuffix && !this.entityAngularJSSuffix.startsWith('-')){
@@ -165,7 +164,7 @@ module.exports = EntityGenerator.extend({
                 this.error(chalk.red('The table name cannot be empty'));
             } else if (jhiCore.isReservedTableName(this.entityTableName, prodDatabaseType)) {
                 this.error(chalk.red(`The table name cannot contain a ${prodDatabaseType.toUpperCase()} reserved keyword`));
-            } else if (prodDatabaseType === 'oracle' && _.snakeCase(this.entityTableName).length > 26) {
+            } else if (prodDatabaseType === 'oracle' && this.entityTableName.length > 26) {
                 this.error(chalk.red('The table name is too long for Oracle, try a shorter name'));
             }
         },

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -242,7 +242,7 @@ function askForTableName() {
     // don't prompt if there are no relationships
     var entityTableName = this.entityTableName;
     var prodDatabaseType = this.prodDatabaseType;
-    if (this.relationships.length > 0 && ((prodDatabaseType === 'oracle' && entityTableName.length > 14) || entityTableName.length > 30)) {
+    if (this.relationships.length === 0 || !((prodDatabaseType === 'oracle' && entityTableName.length > 14) || entityTableName.length > 30)) {
         return;
     }
     var cb = this.async();

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -13,6 +13,7 @@ module.exports = {
     askForFieldsToRemove,
     askForRelationships,
     askForRelationsToRemove,
+    askForTableName,
     askForDTO,
     askForService,
     askForPagination
@@ -234,6 +235,45 @@ function askForRelationsToRemove() {
         }
         cb();
 
+    }.bind(this));
+}
+
+function askForTableName() {
+    // don't prompt if there are no relationships
+    var entityTableName = this.entityTableName;
+    var prodDatabaseType = this.prodDatabaseType;
+    if (this.relationships.length > 0 && ((prodDatabaseType === 'oracle' && entityTableName.length > 14) || entityTableName.length > 30)) {
+        return;
+    }
+    var cb = this.async();
+    var prompts = [
+        {
+            type: 'input',
+            name: 'entityTableName',
+            message: 'The table name for this entity is too long to form constraint names. Please use a shorter table name',
+            validate: function (input) {
+                if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
+                    return 'The table name cannot contain special characters';
+                } else if (input === '') {
+                    return 'The table name cannot be empty';
+                } else if (jhiCore.isReservedTableName(input, prodDatabaseType)) {
+                    return `The table name cannot contain a ${prodDatabaseType.toUpperCase()} reserved keyword`;
+                } else if (prodDatabaseType === 'oracle' && input.length > 14) {
+                    return 'The table name is too long for Oracle, try a shorter name';
+                } else if (input.length > 30) {
+                    return 'The table name is too long, try a shorter name';
+                }
+                return true;
+            },
+            default: entityTableName
+        }
+    ];
+    this.prompt(prompts, function (props) {
+        /* overwrite the table name for the entity using name obtained from the user*/
+        if (props.entityTableName !== this.entityTableName) {
+            this.entityTableName = _.snakeCase(props.entityTableName).toLowerCase();
+        }
+        cb();
     }.bind(this));
 }
 
@@ -906,37 +946,12 @@ function askForRelationship(cb) {
     var name = this.name;
     this.log(chalk.green('\nGenerating relationships to other entities\n'));
     var fieldNamesUnderscored = this.fieldNamesUnderscored;
-    var entityTableName = this.entityTableName;
-    var prodDatabaseType = this.prodDatabaseType;
     var prompts = [
         {
             type: 'confirm',
             name: 'relationshipAdd',
             message: 'Do you want to add a relationship to another entity?',
             default: true
-        },
-        {
-            when: function (response) {
-                return (response.relationshipAdd === true && ((prodDatabaseType === 'oracle' && entityTableName.length > 14) || entityTableName.length > 30));
-            },
-            type: 'input',
-            name: 'entityTableName',
-            message: 'The table name for this entity is too long to form constraint names. Please use a shorter table name',
-            validate: function (input) {
-                if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
-                    return 'The table name cannot contain special characters';
-                } else if (input === '') {
-                    return 'The table name cannot be empty';
-                } else if (jhiCore.isReservedTableName(input, prodDatabaseType)) {
-                    return `The table name cannot contain a ${prodDatabaseType.toUpperCase()} reserved keyword`;
-                } else if (prodDatabaseType === 'oracle' && input.length > 14) {
-                    return 'The table name is too long for Oracle, try a shorter name';
-                } else if (input.length > 30) {
-                    return 'The table name is too long, try a shorter name';
-                }
-                return true;
-            },
-            default: entityTableName
         },
         {
             when: function (response) {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1157,8 +1157,8 @@ Generator.prototype.getJoinTableName = function (entityName, relationshipName, p
     }
     if (limit > 0) {
         var halfLimit = Math.floor(limit/2),
-        entityTable = this.getTableName(entityName.substring(0, halfLimit)),
-        relationTable = this.getTableName(relationshipName.substring(0, halfLimit - 1));
+            entityTable = this.getTableName(entityName.substring(0, halfLimit)),
+            relationTable = this.getTableName(relationshipName.substring(0, halfLimit - 1));
         return `${entityTable}_${relationTable}`;
     }
     return joinTableName;
@@ -1194,8 +1194,8 @@ Generator.prototype.getConstraintName = function (entityName, relationshipName, 
     }
     if (limit > 0) {
         var halfLimit = Math.floor(limit/2),
-        entityTable = noSnakeCase ? entityName : this.getTableName(entityName.substring(0, halfLimit)),
-        relationTable = noSnakeCase ? relationshipName: this.getTableName(relationshipName.substring(0, halfLimit - 1));
+            entityTable = noSnakeCase ? entityName : this.getTableName(entityName.substring(0, halfLimit)),
+            relationTable = noSnakeCase ? relationshipName: this.getTableName(relationshipName.substring(0, halfLimit - 1));
         return `${entityTable}_${relationTable}_id`;
     }
     return constraintName;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1145,15 +1145,21 @@ Generator.prototype.getPluralColumnName = function (value) {
  */
 Generator.prototype.getJoinTableName = function (entityName, relationshipName, prodDatabaseType) {
     var joinTableName = this.getTableName(entityName) + '_'+ this.getTableName(relationshipName);
+    var limit = 0;
     if (prodDatabaseType === 'oracle' && joinTableName.length > 30) {
         this.warning(`The generated join table "${ joinTableName }" is too long for Oracle (which has a 30 characters limit). It will be truncated!`);
 
-        joinTableName = joinTableName.substring(0, 30);
-    }
-    if (prodDatabaseType === 'mysql' && joinTableName.length > 64) {
+        limit = 30;
+    } else if (prodDatabaseType === 'mysql' && joinTableName.length > 64) {
         this.warning(`The generated join table "${ joinTableName }" is too long for MySQL (which has a 64 characters limit). It will be truncated!`);
 
-        joinTableName = joinTableName.substring(0, 64);
+        limit = 64;
+    }
+    if (limit > 0) {
+        var halfLimit = Math.floor(limit/2),
+        entityTable = getTableName(entityName.substring(0, halfLimit)),
+        relationTable = getTableName(relationshipName.substring(0, halfLimit-1));
+        return `${entityTable}_${relationTable}`;
     }
     return joinTableName;
 };

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1157,8 +1157,8 @@ Generator.prototype.getJoinTableName = function (entityName, relationshipName, p
     }
     if (limit > 0) {
         var halfLimit = Math.floor(limit/2),
-        entityTable = getTableName(entityName.substring(0, halfLimit)),
-        relationTable = getTableName(relationshipName.substring(0, halfLimit-1));
+        entityTable = this.getTableName(entityName.substring(0, halfLimit)),
+        relationTable = this.getTableName(relationshipName.substring(0, halfLimit - 1));
         return `${entityTable}_${relationTable}`;
     }
     return joinTableName;
@@ -1181,15 +1181,22 @@ Generator.prototype.getConstraintName = function (entityName, relationshipName, 
         constraintName = 'fk_' + this.getTableName(entityName) + '_' +
             this.getTableName(relationshipName) + '_id';
     }
+    var limit = 0;
 
     if (prodDatabaseType === 'oracle' && constraintName.length > 30) {
         this.warning(`The generated constraint name "${ constraintName }" is too long for Oracle (which has a 30 characters limit). It will be truncated!`);
 
-        constraintName = constraintName.substring(0, 27) + '_id';
+        limit = 28;
     } else if (prodDatabaseType === 'mysql' && constraintName.length > 64) {
         this.warning(`The generated constraint name "${ constraintName }" is too long for MySQL (which has a 64 characters limit). It will be truncated!`);
 
-        constraintName = constraintName.substring(0, 61) + '_id';
+        limit = 62;
+    }
+    if (limit > 0) {
+        var halfLimit = Math.floor(limit/2),
+        entityTable = noSnakeCase ? entityName : this.getTableName(entityName.substring(0, halfLimit)),
+        relationTable = noSnakeCase ? relationshipName: this.getTableName(relationshipName.substring(0, halfLimit - 1));
+        return `${entityTable}_${relationTable}_id`;
     }
     return constraintName;
 };

--- a/travis/samples/.jhipster/TestCustomTableName.json
+++ b/travis/samples/.jhipster/TestCustomTableName.json
@@ -53,6 +53,6 @@
     "changelogDate": "20160208210109",
     "dto": "no",
     "service": "no",
-    "entityTableName": "jhi_test_custom_table_name_entity",
+    "entityTableName": "test_custom_table_name_entity",
     "pagination": "no"
 }


### PR DESCRIPTION
Prompts the user to enter a shorter table name when the entity has relationships and DB is Oracle or if table name is more 30 char long.
Also updates the logic of creating joint table names and constraint names as per discussion in #3839

@jdubois please see if this is ok for you

fix #3974
