### PR TITLE
Java main class name backward compatible and avoiding compilation issue

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1290,9 +1290,11 @@ Generator.prototype.getAngularAppName = function () {
  * get the java main class name.
  */
 Generator.prototype.getMainClassName = function () {
-    // Don't name by baseName because numbers can cause compilation issues.
-    // https://github.com/jhipster/generator-jhipster/issues/3889
-    return 'Application';
+     
+    var main = _.upperFirst(this.getAngularAppName());
+    var acceptableForJava = new RegExp('^[A-Z][a-zA-Z0-9_]*$');
+
+    return acceptableForJava.test(main) ? main : 'Application';
 };
 
 /**

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -64,7 +64,7 @@ const expectedFiles = {
         SERVER_MAIN_RES_DIR + 'mails/activationEmail.html',
         SERVER_MAIN_RES_DIR + 'mails/passwordResetEmail.html',
         SERVER_MAIN_RES_DIR + 'i18n/messages.properties',
-        SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/Application.java',
+        SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/JhipsterApp.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/ApplicationWebXml.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/aop/logging/LoggingAspect.java',
         SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/config/apidoc/package-info.java',
@@ -548,9 +548,44 @@ describe('JHipster generator', function () {
 
         it('creates expected files with correct package names', function () {
             assert.file([
+                SERVER_MAIN_SRC_DIR + 'com/otherpackage/JhipsterApp.java'
+            ]);
+            assert.fileContent(SERVER_MAIN_SRC_DIR + 'com/otherpackage/JhipsterApp.java', /package com\.otherpackage;/);
+            assert.fileContent(SERVER_MAIN_SRC_DIR + 'com/otherpackage/JhipsterApp.java', /public class JhipsterApp/);
+        });
+    });
+
+    describe('bad application name for java', function () {
+        beforeEach(function (done) {
+            helpers.run(path.join(__dirname, '../generators/app'))
+                .withOptions({skipInstall: true, checkInstall: false})
+                .withPrompts({
+                    'baseName': '21Points',
+                    'packageName': 'com.otherpackage',
+                    'packageFolder': 'com/otherpackage',
+                    'authenticationType': 'session',
+                    'hibernateCache': 'ehcache',
+                    'clusteredHttpSession': 'no',
+                    'websocket': 'no',
+                    'databaseType': 'sql',
+                    'devDatabaseType': 'h2Memory',
+                    'prodDatabaseType': 'mysql',
+                    'useSass': false,
+                    'enableTranslation': true,
+                    'nativeLanguage': 'en',
+                    'languages': ['fr'],
+                    'buildTool': 'maven',
+                    'rememberMeKey': '5c37379956bd1242f5636c8cb322c2966ad81277',
+                    'searchEngine': 'no'
+                })
+                .on('end', done);
+        });
+
+        it('creates expected files with default application name', function () {
+            assert.file([
                 SERVER_MAIN_SRC_DIR + 'com/otherpackage/Application.java'
             ]);
-            assert.fileContent(SERVER_MAIN_SRC_DIR + 'com/otherpackage/Application.java', /package com\.otherpackage;/);
+            assert.fileContent(SERVER_MAIN_SRC_DIR + 'com/otherpackage/Application.java', /public class Application/);
         });
     });
 


### PR DESCRIPTION
PR #3890 introduced a backward compatibility for projects generated since JHipster 3.x

As discussed in the issue, I propose an alternative fix that preserves backward compatibility, is motre convenient for microservices architecture and fixes #3889 with base names that are not valid java classes.

Fix #3889