### PR TITLE
import-jdl load skipClient config to skip gulp for microservices

### DIFF
--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -29,6 +29,7 @@ module.exports = JDLGenerator.extend({
         getConfig: function () {
             this.baseName = this.config.get('baseName');
             this.prodDatabaseType = this.config.get('prodDatabaseType');
+            this.skipClient = this.config.get('skipClient');
         }
     },
 


### PR DESCRIPTION
There is already a check in the code, but this.skipClient was undefined so it always tried to run `gulp inject:app`