### PR TITLE
make searches send full queries to API

### DIFF
--- a/generators/entity/templates/src/main/java/package/common/search_stream_template.ejs
+++ b/generators/entity/templates/src/main/java/package/common/search_stream_template.ejs
@@ -3,7 +3,7 @@ var mapper = entityInstance  + 'Mapper';
 var entityToDtoReference = mapper + '::'+ entityInstance +'To' + entityClass + 'DTO'; %>
         <%_ if (!viaService) { _%>
         return StreamSupport
-            .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto == 'mapstruct') { %>
+            .stream(<%= entityInstance %>SearchRepository.search(wrapperQuery(query)).spliterator(), false)<% if (dto == 'mapstruct') { %>
             .map(<%= entityToDtoReference %>)<% } %>
             .collect(Collectors.toList());
         <%_ } else { _%>

--- a/generators/entity/templates/src/main/java/package/common/search_template.ejs
+++ b/generators/entity/templates/src/main/java/package/common/search_template.ejs
@@ -12,7 +12,7 @@
         throws URISyntaxException {
         log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
-        Page<<%= entityClass %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>
+        Page<<%= entityClass %>> page = <%= entityInstance %>SearchRepository.search(wrapperQuery(query), pageable);<% } %>
         HttpHeaders headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, "/api/_search/<%= entityApiUrl %>");
         return new ResponseEntity<>(<% if (!viaService && dto == 'mapstruct') { %><%= entityListToDtoListReference %>(page.getContent())<% } else { %>page.getContent()<% } %>, headers, HttpStatus.OK);
     <% } -%>

--- a/generators/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/generators/entity/templates/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -110,7 +110,7 @@ public class <%= serviceClassName %> <% if (service == 'serviceImpl') { %>implem
         log.debug("Request to search <%= entityClassPlural %> for query {}", query);<%- include('../../common/search_stream_template', {viaService: viaService}); -%>
         <%_ } else { _%>
         log.debug("Request to search for a page of <%= entityClassPlural %> for query {}", query);
-        Page<<%= entityClass %>> result = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);
+        Page<<%= entityClass %>> result = <%= entityInstance %>SearchRepository.search(wrapperQuery(query), pageable);
             <%_ if (dto == 'mapstruct') { _%>
         return result.map(<%= entityInstance %> -> <%= entityToDto %>(<%= entityInstance%>));
             <%_ } else { _%>

--- a/generators/entity/templates/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -29,7 +29,11 @@
         <%_ } else { _%>
             if (vm.currentSearch) {
                 <%= entityClass %>Search.query({
-                    query: vm.currentSearch,
+                    query: {
+                        simple_query_string: {
+                            query: vm.searchQuery
+                        }
+                    },
                     page: vm.page,
                     size: 20,
                     sort: sort()

--- a/generators/entity/templates/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -21,7 +21,13 @@
             if (!vm.searchQuery) {
                 return vm.loadAll();
             }
-            <%= entityClass %>Search.query({query: vm.searchQuery}, function(result) {
+            <%= entityClass %>Search.query({
+                query: {
+                    simple_query_string: {
+                        query: vm.searchQuery
+                    }
+                }
+            }, function(result) {
                 vm.<%= entityInstancePlural %> = result;
             });
         }<%_ } _%>

--- a/generators/entity/templates/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity/templates/src/main/webapp/app/entities/pagination-template.ejs
@@ -27,7 +27,11 @@
         <%_ } else { _%>
             if (pagingParams.search) {
                 <%= entityClass %>Search.query({
-                    query: pagingParams.search,
+                    query: {
+                        simple_query_string: {
+                            query: vm.searchQuery
+                        }
+                    },
                     page: pagingParams.page - 1,
                     size: vm.itemsPerPage,
                     sort: sort()

--- a/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -461,8 +461,11 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
         <%= entityInstance %>SearchRepository.save(<%= entityInstance %>);
 <%_ } _%>
 
+        // Build the search query
+        String searchQuery = "{\"match\":{\"id\":" + <%= entityInstance %>.getId() + "}}";
+
         // Search the <%= entityInstance %>
-        rest<%= entityClass %>MockMvc.perform(get("/api/_search/<%= entityApiUrl %>?query=id:" + <%= entityInstance %>.getId()))
+        rest<%= entityClass %>MockMvc.perform(get("/api/_search/<%= entityApiUrl %>?query={searchQuery}", searchQuery))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE))<% if (databaseType == 'sql') { %>
             .andExpect(jsonPath("$.[*].id").value(hasItem(<%= entityInstance %>.getId().intValue())))<% } %><% if (databaseType == 'mongodb') { %>

--- a/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
@@ -232,7 +232,7 @@ public class UserResource {
     @Timed
     public List<User> search(@PathVariable String query) {
         return StreamSupport
-            .stream(userSearchRepository.search(queryStringQuery(query)).spliterator(), false)
+            .stream(userSearchRepository.search(wrapperQuery(query)).spliterator(), false)
             .collect(Collectors.toList());
     }<% } %>
 }


### PR DESCRIPTION
modify Elasticsearch support to send full queries to the generated API
instead of just the search string for a server-side QueryStringQuery

fix #3805