### PR TITLE
Add git commit data to /info endpoint in prod build

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -16,6 +16,7 @@ buildscript {
         classpath "com.moowork.gradle:gradle-gulp-plugin:0.12"<% } %>
         classpath "se.transmode.gradle:gradle-docker:1.2"
         classpath "io.spring.gradle:dependency-management-plugin:0.5.6.RELEASE"
+        classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.4.17"
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1225,6 +1225,20 @@
                             </execution>
                         </executions>
                     </plugin>
+                    <plugin>
+                        <groupId>pl.project13.maven</groupId>
+                        <artifactId>git-commit-id-plugin</artifactId>
+                        <version>2.2.1</version>
+                        <configuration>
+                            <verbose>false</verbose>
+                            <failOnNoGitDirectory>false</failOnNoGitDirectory>
+                            <includeOnlyProperties>
+                                <includeOnlyProperty>^git.commit.id.abbrev$</includeOnlyProperty>
+                                <includeOnlyProperty>^git.commit.id.describe$</includeOnlyProperty>
+                                <includeOnlyProperty>^git.branch$</includeOnlyProperty>
+                            </includeOnlyProperties>
+                        </configuration>
+                    </plugin>
                 </plugins>
             </build>
             <properties>

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -3,6 +3,7 @@ apply plugin: 'spring-boot'<% if(!skipClient) { %>
 apply plugin: 'com.moowork.node'
 apply plugin: 'com.moowork.gulp'
 <% } %>
+apply plugin: 'com.gorylenko.gradle-git-properties'
 
 ext {
     logbackLoglevel = "INFO"
@@ -44,6 +45,10 @@ processResources {
             it.replace('#spring.profiles.active#', profiles)
         }
     }
+}
+
+gitProperties {
+    keys = ['git.branch', 'git.commit.id.abbrev']
 }
 
 <% if (!skipClient) { %>

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -44,7 +44,9 @@ management:
     health:
         mail:
             enabled: false # When using the MailService, configure an SMTP server and set this to true
-
+    info:
+        git:
+            mode: full
 spring:
     application:
         name: <%= baseName %>


### PR DESCRIPTION
Finally fixes #3574 
cc @gmarziou
Add the following in the /info endpoint **only when doing a prod build**
```
	"git": {
		"commit": {
			"id": {
				"abbrev": "324b701",
				"describe": "v1-2-324b701"//only for maven as the gradle git-commit plugin doesn't support it yet
			}
		},
		"branch": "master"
	}
```
What it does:
- Set `management.info.git.mode` to `full` this is needed so that every property present in the `git.properties` file will end up in /info. I think this is the natural way to use it since in the default `simple` mode it will only put the commit id and branch in /info.
- Setup the git-commit plugin for both maven and gradle and restrict it to a subset of git properties : `git.commit.abbrev`, `git.branch` and `git.commit.id.describe` (unfortunately not available for gradle).
Another advantage of restricting the properties is that this way there won't be any unwanted properties like commit user name or email in the `git.properties` file that ship with the war.