### PR TITLE
install aws subgenerator dependencies if they are missing

### DIFF
--- a/generators/aws/index.js
+++ b/generators/aws/index.js
@@ -13,7 +13,8 @@ util.inherits(AwsGenerator, scriptBase);
 module.exports = AwsGenerator.extend({
     initializing: {
         initAws: function () {
-            this.awsFactory = new AwsFactory(this);
+            var done = this.async();
+            this.awsFactory = new AwsFactory(this, done);
         },
         getGlobalConfig: function () {
             this.existingProject = false;

--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -1,7 +1,6 @@
 'use strict';
 var S3 = require('./s3.js'),
     Rds = require('./rds.js'),
-    chalk = require('chalk'),
     shelljs = require('shelljs'),
     os = require('os'),
     Eb = require('./eb.js');
@@ -12,17 +11,16 @@ var AwsFactory = module.exports = function AwsFactory(generatorRef, cb) {
     generator = generatorRef;
     try {
         Aws = require('aws-sdk');
-        generator.log("Found AWS dependencies");
-        cb()
+        cb();
     } catch (e) {
-        generator.log("Installing AWS dependencies into your JHipster folder");
+        generator.log('Installing AWS dependencies into your JHipster folder');
         var jhipsterPath;
         var applicationType = generator.config.get('applicationType');
         if (applicationType === 'monolith' || applicationType === 'gateway') {
             if (os.platform() === 'win32') {
-                jhipsterPath = 'node_modules\\generator-jhipster\n';
+                jhipsterPath = 'node_modules\\generator-jhipster';
             } else {
-                jhipsterPath = 'node_modules/generator-jhipster\n';
+                jhipsterPath = 'node_modules/generator-jhipster';
             }
         } else {
             var prefix = shelljs.exec('npm config get prefix', {silent:true}).trim();
@@ -32,7 +30,7 @@ var AwsFactory = module.exports = function AwsFactory(generatorRef, cb) {
                 jhipsterPath = prefix + '/lib/node_modules/generator-jhipster';
             }
         }
-        shelljs.exec('npm install aws-sdk progress node-uuid --prefix ' + jhipsterPath, {silent:false}, function (code, msg, err) {
+        shelljs.exec('npm install aws-sdk progress node-uuid --prefix ' + jhipsterPath, {silent:true}, function (code, msg, err) {
             if (code !== 0) generator.error('Something went wrong while installing:\n' + err);
             Aws = require('aws-sdk');
             cb();

--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -14,20 +14,15 @@ var AwsFactory = module.exports = function AwsFactory(generatorRef, cb) {
         cb();
     } catch (e) {
         generator.log('Installing AWS dependencies into your JHipster folder');
-        var jhipsterPath;
-        var applicationType = generator.config.get('applicationType');
-        if (applicationType === 'monolith' || applicationType === 'gateway') {
-            if (os.platform() === 'win32') {
-                jhipsterPath = 'node_modules\\generator-jhipster';
-            } else {
-                jhipsterPath = 'node_modules/generator-jhipster';
-            }
-        } else {
+        var jhipsterPath = 'node_modules/generator-jhipster';
+        var skipClient = generator.config.get('skipClient');
+        // use the global JHipster for apps with no client-side code
+        if (skipClient) {
             var prefix = shelljs.exec('npm config get prefix', {silent:true}).trim();
             if (os.platform() === 'win32') {
-                jhipsterPath = prefix + '\\node_modules\\generator-jhipster';
+                jhipsterPath = prefix + '/' + jhipsterPath;
             } else {
-                jhipsterPath = prefix + '/lib/node_modules/generator-jhipster';
+                jhipsterPath = prefix + '/lib/' + jhipsterPath;
             }
         }
         shelljs.exec('npm install aws-sdk progress node-uuid --prefix ' + jhipsterPath, {silent:true}, function (code, msg, err) {

--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -7,18 +7,26 @@ var S3 = require('./s3.js'),
 var Aws, generator;
 
 var AwsFactory = module.exports = function AwsFactory(generatorRef) {
+    generator = generatorRef;
     try {
         Aws = require('aws-sdk');
-        generator = generatorRef;
     } catch (e) {
+        var windowsPath;
+        var linuxPath;
+        var applicationType = generator.config.get('applicationType');
+        if (applicationType === 'monolith' || applicationType === 'gateway') {
+            windowsPath = 'cd node_modules\\generator-jhipster\n';
+            linuxPath = 'cd node_modules/generator-jhipster\n';
+        } else {
+            windowsPath = 'cd %USERPROFILE%\\AppData\\Roaming\\npm\\node_modules\\generator-jhipster\n';
+            linuxPath = 'cd /usr/local/lib/node_modules/generator-jhipster\n';
+        }
         generator.env.error(chalk.red(
             'You don\'t have the AWS SDK installed. Please install it in the JHipster generator directory.\n\n') +
             chalk.yellow('WINDOWS\n') +
-            chalk.green('cd %USERPROFILE%\\AppData\\Roaming\\npm\\node_modules\\generator-jhipster\n' +
-            'npm install aws-sdk progress node-uuid\n\n') +
+            chalk.green(windowsPath + 'npm install aws-sdk progress node-uuid\n\n') +
             chalk.yellow('LINUX / MAC\n') +
-            chalk.green('cd /usr/local/lib/node_modules/generator-jhipster\n' +
-            'npm install aws-sdk progress node-uuid')
+            chalk.green(linuxPath + 'npm install aws-sdk progress node-uuid')
         );
     }
 };


### PR DESCRIPTION
AWS Subgenerator fails silently because `generator` is set in the `try` after the error occurs.  

I also updated the paths to show the appropriate folder to install aws npm dependencies because monoliths/gateways use the local node_modules.  This should also be updated in the AWS documentation http://jhipster.github.io/aws/