### PR TITLE
fix add and remove methods for two relationships with same entity

### DIFF
--- a/generators/entity/templates/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/src/main/java/package/domain/_Entity.java
@@ -267,7 +267,7 @@ public class <%= entityClass %> implements Serializable {
         return this;
     }
 
-    public <%= entityClass %> add<%= otherEntityNameCapitalized %>(<%= otherEntityNameCapitalized %> <%= otherEntityName %>) {
+    public <%= entityClass %> add<%= relationshipNameCapitalized %>(<%= otherEntityNameCapitalized %> <%= otherEntityName %>) {
         <%= relationshipFieldNamePlural %>.add(<%= otherEntityName %>);
             <%_ if (relationshipType == 'one-to-many') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(this);
@@ -278,7 +278,7 @@ public class <%= entityClass %> implements Serializable {
         return this;
     }
 
-    public <%= entityClass %> remove<%= otherEntityNameCapitalized %>(<%= otherEntityNameCapitalized %> <%= otherEntityName %>) {
+    public <%= entityClass %> remove<%= relationshipNameCapitalized %>(<%= otherEntityNameCapitalized %> <%= otherEntityName %>) {
         <%= relationshipFieldNamePlural %>.remove(<%= otherEntityName %>);
             <%_ if (relationshipType == 'one-to-many') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(null);


### PR DESCRIPTION
With fluent methods, the following JDL generates two different `addDevice` and `removeDevice` in DeviceRelationship.java
```
entity Device
entity DeviceRelationship

relationship OneToMany {
  DeviceRelationship{originatingDevice} to Device{originatingDeviceRelationship},
  DeviceRelationship{destinationDevice} to Device{destinationDeviceRelationship}
}
```