### PR TITLE
adds an usefull annotation for emulating OAuth2 security contextes in tests

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -799,6 +799,11 @@ module.exports = JhipsterServerGenerator.extend({
                 this.template(SERVER_TEST_SRC_DIR + 'package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java', testDir + 'gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java', this, {});
             }
 
+            if (this.authenticationType === 'uaa') {
+                this.template(SERVER_TEST_SRC_DIR + 'package/security/_WithMockOAuth2Authentication.java', testDir + 'security/WithMockOAuth2Authentication.java', this, {});
+                this.template(SERVER_TEST_SRC_DIR + 'package/security/_WithMockedOAuthUserSecurityContextFactory.java', testDir + 'security/WithMockedOAuthUserSecurityContextFactory.java', this, {});
+            }
+
             if (this.hibernateCache === 'ehcache') {
                 this.template(SERVER_TEST_RES_DIR + '_ehcache.xml', SERVER_TEST_RES_DIR + 'ehcache.xml', this, {});
             }

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -268,6 +268,7 @@ dependencies {
     testCompile "info.cukes:cucumber-junit:${cucumber_version}"
     testCompile "info.cukes:cucumber-spring:${cucumber_version}"<% } %>
     testCompile "org.springframework.boot:spring-boot-starter-test"
+    testCompile "org.springframework.security:spring-security-test"
     testCompile "org.springframework.boot:spring-boot-test"
     testCompile "org.assertj:assertj-core:${assertj_core_version}"
     testCompile "junit:junit"

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -510,7 +510,6 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
-        </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -510,6 +510,12 @@
             <artifactId>spring-boot-starter-test</artifactId>
             <scope>test</scope>
         </dependency>
+        </dependency>
+        <dependency>
+            <groupId>org.springframework.security</groupId>
+            <artifactId>spring-security-test</artifactId>
+            <scope>test</scope>
+        </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-test</artifactId>

--- a/generators/server/templates/src/test/java/package/security/_WithMockOAuth2Authentication.java
+++ b/generators/server/templates/src/test/java/package/security/_WithMockOAuth2Authentication.java
@@ -1,0 +1,20 @@
+package <%=packageName%>.security;
+
+import org.springframework.security.test.context.support.WithSecurityContext;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+@Retention(RetentionPolicy.RUNTIME)
+@WithSecurityContext(factory = WithMockedOAuthUserSecurityContextFactory.class)
+public @interface WithMockOAuth2Authentication {
+    String username() default "TestUser";
+    String password() default "TestUser";
+
+    String clientId() default "testClient";
+    String[] scope() default {"default.read", "default.write"};
+
+    String[] roles() default {"USER", "ADMIN"};
+
+
+}

--- a/generators/server/templates/src/test/java/package/security/_WithMockOAuth2Authentication.java
+++ b/generators/server/templates/src/test/java/package/security/_WithMockOAuth2Authentication.java
@@ -10,11 +10,7 @@ import java.lang.annotation.RetentionPolicy;
 public @interface WithMockOAuth2Authentication {
     String username() default "TestUser";
     String password() default "TestUser";
-
     String clientId() default "testClient";
     String[] scope() default {"default.read", "default.write"};
-
     String[] roles() default {"USER", "ADMIN"};
-
-
 }

--- a/generators/server/templates/src/test/java/package/security/_WithMockedOAuthUserSecurityContextFactory.java
+++ b/generators/server/templates/src/test/java/package/security/_WithMockedOAuthUserSecurityContextFactory.java
@@ -1,0 +1,62 @@
+package <%=packageName%>.security;
+
+import org.mockito.internal.util.collections.Sets;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.context.SecurityContext;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.OAuth2Request;
+import org.springframework.security.test.context.support.WithSecurityContextFactory;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+public class WithMockedOAuthUserSecurityContextFactory implements WithSecurityContextFactory<WithMockOAuth2Authentication> {
+
+
+    @Override
+    public SecurityContext createSecurityContext(WithMockOAuth2Authentication withClient) {
+        // Get the username
+        String username = withClient.username();
+        if (username == null) {
+            throw new IllegalArgumentException("Username cannot be null");
+        }
+
+        // Get the user roles
+        List<GrantedAuthority> authorities = new ArrayList<>();
+        for (String role : withClient.roles()) {
+            if (role.startsWith("ROLE_")) {
+                throw new IllegalArgumentException("roles cannot start with ROLE_ Got " + role);
+            }
+            authorities.add(new SimpleGrantedAuthority("ROLE_" + role));
+        }
+
+        // Get the client id
+        String clientId = withClient.clientId();
+        // get the oauth scopes
+        String[] scopes = withClient.scope();
+        Set<String> scopeCollection = Sets.newSet(scopes);
+
+        // Create the UsernamePasswordAuthenticationToken
+        User principal = new User(username, withClient.password(), true, true, true, true, authorities);
+        Authentication authentication = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(),
+            principal.getAuthorities());
+
+
+        // Create the authorization request and OAuth2Authentication object
+        OAuth2Request authRequest = new OAuth2Request(null, clientId, null, true, scopeCollection, null, null, null,
+            null);
+        OAuth2Authentication oAuth = new OAuth2Authentication(authRequest, authentication);
+
+        // Add the OAuth2Authentication object to the security context
+        SecurityContext context = SecurityContextHolder.createEmptyContext();
+        context.setAuthentication(oAuth);
+
+        return context;
+    }
+}

--- a/generators/server/templates/src/test/java/package/security/_WithMockedOAuthUserSecurityContextFactory.java
+++ b/generators/server/templates/src/test/java/package/security/_WithMockedOAuthUserSecurityContextFactory.java
@@ -18,7 +18,6 @@ import java.util.Set;
 
 public class WithMockedOAuthUserSecurityContextFactory implements WithSecurityContextFactory<WithMockOAuth2Authentication> {
 
-
     @Override
     public SecurityContext createSecurityContext(WithMockOAuth2Authentication withClient) {
         // Get the username
@@ -47,7 +46,6 @@ public class WithMockedOAuthUserSecurityContextFactory implements WithSecurityCo
         Authentication authentication = new UsernamePasswordAuthenticationToken(principal, principal.getPassword(),
             principal.getAuthorities());
 
-
         // Create the authorization request and OAuth2Authentication object
         OAuth2Request authRequest = new OAuth2Request(null, clientId, null, true, scopeCollection, null, null, null,
             null);
@@ -60,3 +58,4 @@ public class WithMockedOAuthUserSecurityContextFactory implements WithSecurityCo
         return context;
     }
 }
+


### PR DESCRIPTION
so the developer may test the security behaviour, without physically interact
with an uaa or other OAuth2 authorization server, using users may not really
exists.

You simply annotate test methods with 
    `@WithMockOAuth2Authentication`
or
 `@WithMockOAuth2Authentication(scope = "web-app")`
or
 `@WithMockOAuth2Authentication(roles = { ... })`

partially solving my ideas mentioned in #3797

the usage is quite simple and can be reviewed here: https://github.com/ExtremeEnvironment/message-service/blob/master/src/test/java/de/extremeenvironment/messageservice/web/rest/MessageResourceIntTest.java

I am about writing UAA docs currenty, and would cover this, too. I already used that approach several times and it helps a lot during development using uaa.