### PR TITLE
Fix mysql version and travis mysql build

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1196,7 +1196,15 @@ Generator.prototype.getConstraintName = function (entityName, relationshipName, 
         var halfLimit = Math.floor(limit/2),
             entityTable = noSnakeCase ? entityName : this.getTableName(entityName.substring(0, halfLimit)),
             relationTable = noSnakeCase ? relationshipName: this.getTableName(relationshipName.substring(0, halfLimit - 1));
-        return `${entityTable}_${relationTable}_id`;
+
+        constraintName = `${entityTable}_${relationTable}_id`;
+        if (prodDatabaseType === 'oracle' && constraintName.length > 30) {
+            this.warning(`The generated constraint name "${ constraintName }" is too long for Oracle (which has a 30 characters limit). It will be truncated!`);
+            constraintName = constraintName.substring(0, 27) + '_id';
+        } else if (prodDatabaseType === 'mysql' && constraintName.length > 64) {
+            this.warning(`The generated constraint name "${ constraintName }" is too long for MySQL (which has a 64 characters limit). It will be truncated!`);
+            constraintName = constraintName.substring(0, 61) + '_id';
+        }
     }
     return constraintName;
 };

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -3,7 +3,7 @@
 // version of docker images
 const DOCKER_JHIPSTER_REGISTRY = 'jhipster/jhipster-registry:v2.4.0';
 const DOCKER_JAVA_JRE = 'java:openjdk-8-jre-alpine';
-const DOCKER_MYSQL = 'mysql:5.7.14';
+const DOCKER_MYSQL = 'mysql:5.7.13';
 const DOCKER_MARIADB = 'mariadb:10.1.16';
 const DOCKER_POSTGRESQL = 'postgres:9.5.3';
 const DOCKER_MONGODB = 'mongo:3.3.9';


### PR DESCRIPTION
I fix 2 issues here:

### ZonedDateTime problem with MySQL 5.7.14

In https://github.com/jhipster/generator-jhipster/issues/4009, @tsaqova mentionned

> here are my schema, i change mysql version to 5.7.13 as workaround because 5.7.14 can't have 2 timestamp column (from zonedatetime) in one table by default

Here the error log on Travis build:

```
liquibase.exception.DatabaseException: Invalid default value for 'zoned_date_time_required_field' [Failed SQL: CREATE TABLE travisMysql.field_test_entity (id BIGINT AUTO_INCREMENT NOT NULL, string_field VARCHAR(255) NULL, string_required_field VARCHAR(255) NOT NULL, string_minlength_field VARCHAR(255) NULL, string_maxlength_field VARCHAR(20) NULL, string_pattern_field VARCHAR(255) NULL, integer_field INT NULL, integer_required_field INT NOT NULL, integer_min_field INT NULL, integer_max_field INT NULL, long_field BIGINT NULL, long_required_field BIGINT NOT NULL, long_min_field BIGINT NULL, long_max_field BIGINT NULL, float_field FLOAT NULL, float_required_field FLOAT NOT NULL, float_min_field FLOAT NULL, float_max_field FLOAT NULL, double_required_field DOUBLE NOT NULL, double_min_field DOUBLE NULL, double_max_field DOUBLE NULL, big_decimal_required_field DECIMAL(10, 2) NOT NULL, big_decimal_min_field DECIMAL(10, 2) NULL, big_decimal_max_field DECIMAL(10, 2) NULL, local_date_field date NULL, local_date_required_field date NOT NULL, zoned_date_time_field timestamp NULL, zoned_date_time_required_field timestamp NOT NULL, boolean_field BIT NULL, boolean_required_field BIT NOT NULL, enum_field VARCHAR(255) NULL, enum_required_field VARCHAR(255) NOT NULL, byte_image_field LONGBLOB NULL, byte_image_field_content_type VARCHAR(255) NULL, byte_image_required_field LONGBLOB NOT NULL, byte_image_required_field_content_type VARCHAR(255) NOT NULL, byte_image_minbytes_field LONGBLOB NULL, byte_image_minbytes_field_content_type VARCHAR(255) NULL, byte_image_maxbytes_field LONGBLOB NULL, byte_image_maxbytes_field_content_type VARCHAR(255) NULL, byte_any_field LONGBLOB NULL, byte_any_field_content_type VARCHAR(255) NULL, byte_any_required_field LONGBLOB NOT NULL, byte_any_required_field_content_type VARCHAR(255) NOT NULL, byte_any_minbytes_field LONGBLOB NULL, byte_any_minbytes_field_content_type VARCHAR(255) NULL, byte_any_maxbytes_field LONGBLOB NULL, byte_any_maxbytes_field_content_type VARCHAR(255) NULL, byte_text_field LONGTEXT NULL, byte_text_required_field LONGTEXT NOT NULL, byte_text_minbytes_field LONGTEXT NULL, byte_text_maxbytes_field LONGTEXT NULL, CONSTRAINT PK_FIELD_TEST_ENTITY PRIMARY KEY (id))]
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:301)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:55)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:107)
	at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1251)
	at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1234)
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:554)
	at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:51)
	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:73)
	at liquibase.Liquibase.update(Liquibase.java:212)
	at liquibase.Liquibase.update(Liquibase.java:192)
```

I simply use MySQL 5.7.13 instead of 5.7.14.
When I have time, I'll try to investigate to find if there is a specific environment variable to put in docker-compose file for mysql or something else.

### ConstraintName for MySQL and Oracle

Here the error log on Travis build:

```
2016-08-25 07:52:34.383 ERROR 6726 --- [           main] liquibase                                : classpath:config/liquibase/master.xml: classpath:config/liquibase/changelog/20160208210534_added_entity_constraints_TestManyToMany.xml::20160208210534-2::jhipster: Change Set classpath:config/liquibase/changelog/20160208210534_added_entity_constraints_TestManyToMany.xml::20160208210534-2::jhipster failed.  Error: Identifier name 'test_many_to_many_test_custom_table_name_test_custom_table_names_id' is too long [Failed SQL: ALTER TABLE travisMysql.test_many_to_many_test_custom_table_name ADD CONSTRAINT test_many_to_many_test_custom_table_name_test_custom_table_names_id FOREIGN KEY (test_custom_table_names_id) REFERENCES travisMysql.test_custom_table_name_entity (id)]
liquibase.exception.DatabaseException: Identifier name 'test_many_to_many_test_custom_table_name_test_custom_table_names_id' is too long [Failed SQL: ALTER TABLE travisMysql.test_many_to_many_test_custom_table_name ADD CONSTRAINT test_many_to_many_test_custom_table_name_test_custom_table_names_id FOREIGN KEY (test_custom_table_names_id) REFERENCES travisMysql.test_custom_table_name_entity (id)]
	at liquibase.executor.jvm.JdbcExecutor$ExecuteStatementCallback.doInStatement(JdbcExecutor.java:301)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:55)
	at liquibase.executor.jvm.JdbcExecutor.execute(JdbcExecutor.java:107)
	at liquibase.database.AbstractJdbcDatabase.execute(AbstractJdbcDatabase.java:1251)
	at liquibase.database.AbstractJdbcDatabase.executeStatements(AbstractJdbcDatabase.java:1234)
	at liquibase.changelog.ChangeSet.execute(ChangeSet.java:554)
	at liquibase.changelog.visitor.UpdateVisitor.visit(UpdateVisitor.java:51)
	at liquibase.changelog.ChangeLogIterator.run(ChangeLogIterator.java:73)
	at liquibase.Liquibase.update(Liquibase.java:212)
	at liquibase.Liquibase.update(Liquibase.java:192
```

It happens when on the code, `noSnakeCase` is true and `entityName + relationshipName + '_id'` is too long
Don't hesitate to change it if someone has a better idea for that.