### PR TITLE
Add closing tag for textarea

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
@@ -86,7 +86,7 @@
                 </div>
                 <%_ } else if(fieldTypeBlobContent == 'text') { _%>
                 <textarea class="form-control" name="<%= fieldName %>" id="field_<%= fieldName %>"
-                    ng-model="vm.<%= entityInstance %>.<%= fieldName %>" <%- include ng_validators %> />
+                    ng-model="vm.<%= entityInstance %>.<%= fieldName %>" <%- include ng_validators %> ></textarea>
                 <%_ } else { _%>
             <input type="<%= fieldInputType %>" class="form-control" name="<%= fieldName %>" id="field_<%= fieldName %>"
                     ng-model="vm.<%= entityInstance %>.<%= fieldName %>"


### PR DESCRIPTION
When generating an entity with a field of type CBlob (Text), we use a `textarea` for representing the field in a form. We generate a self-closing `<textarea ... />` field, but it's invalid to do so[1][2]. In my tests, the issue only came to my attention when running my application as an executable fat WAR with the production profile.

What would happen then is that the self-closing `texarea` would eat all the rest of my page contents, leaving me with many missing fields and no submit buttons.

YMMV. I've no idea why it only broke on production builds.

This pull requests fixes this by adding the closing tag `</textarea>`.

Reference:

1. Per [HTML5 spec](https://www.w3.org/TR/html-markup/syntax.html), void elements that are allowed to self-close are: `area, base, br, col, command, embed, hr, img, input, keygen, link, meta, param, source, track, wbr`
2. Google for "self-closing texarea"
