### PR TITLE
Handling cause when it is null

### DIFF
--- a/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -34,12 +34,12 @@ public class LoggingAspect {
     public void logAfterThrowing(JoinPoint joinPoint, Throwable e) {
         if (env.acceptsProfiles(Constants.SPRING_PROFILE_DEVELOPMENT)) {
             log.error("Exception in {}.{}() with cause = \'{}\' and exception = \'{}\'", joinPoint.getSignature().getDeclaringTypeName(),
-                joinPoint.getSignature().getName(), e.getCause(), e.getMessage());
+                joinPoint.getSignature().getName(), (e.getCause() != null? e.getCause() : "NULL"), e.getMessage());
 
             e.printStackTrace();
         } else {
             log.error("Exception in {}.{}() with cause = {}", joinPoint.getSignature().getDeclaringTypeName(),
-                joinPoint.getSignature().getName(), e.getCause());
+                joinPoint.getSignature().getName(), (e.getCause() != null? e.getCause() : "NULL"));
         }
     }
 


### PR DESCRIPTION
The LoggingAspect will fail when an Exception with null cause is catched.

The proposed pr handles this case.