### PR TITLE
Upgrade commons-lang

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -167,7 +167,7 @@ dependencies {
     <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
     compile "commons-codec:commons-codec:${commons_codec_version}"
     <%_ } _%>
-    compile "commons-lang:commons-lang:${commons_lang_version}"
+    compile "org.apache.commons:commons-lang3:${commons_lang_version}"
     compile "commons-io:commons-io:${commons_io_version}"
     compile "javax.inject:javax.inject:${javax_inject_version}"
     compile "javax.transaction:javax.transaction-api"<% if (databaseType == 'cassandra' || applicationType == 'gateway') { %>

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -5,7 +5,7 @@ awaility_version=1.7.0
 <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
 commons_codec_version=1.10
 <%_ } _%>
-commons_lang_version=2.6
+commons_lang_version=3.4
 commons_io_version=2.5<% if (databaseType == 'cassandra') { %>
 cassandra_unit_spring_version=3.0.0.1<% } %><% if (testFrameworks.indexOf('cucumber') != -1) { %>
 cucumber_version=1.2.4<% } %>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -38,7 +38,7 @@
         <commons-codec.version>1.10</commons-codec.version>
         <%_ } _%>
         <commons-io.version>2.5</commons-io.version>
-        <commons-lang.version>2.6</commons-lang.version>
+        <commons-lang.version>3.4</commons-lang.version>
         <%_ if (testFrameworks.indexOf('cucumber') != -1) { _%>
         <cucumber.version>1.2.4</cucumber.version>
         <%_ } _%>
@@ -323,8 +323,8 @@
             <version>${commons-io.version}</version>
         </dependency>
         <dependency>
-            <groupId>commons-lang</groupId>
-            <artifactId>commons-lang</artifactId>
+            <groupId>org.apache.commons</groupId>
+            <artifactId>commons-lang3</artifactId>
             <version>${commons-lang.version}</version>
         </dependency>
         <%_ if (databaseType === 'mongodb') { _%>

--- a/generators/server/templates/src/main/java/package/config/_ThymeleafConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_ThymeleafConfiguration.java
@@ -1,6 +1,6 @@
 package <%=packageName%>.config;
 
-import org.apache.commons.lang.CharEncoding;
+import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.annotation.*;

--- a/generators/server/templates/src/main/java/package/security/_AjaxLogoutSuccessHandler.java
+++ b/generators/server/templates/src/main/java/package/security/_AjaxLogoutSuccessHandler.java
@@ -1,6 +1,6 @@
 package <%=packageName%>.security;
 <% if (authenticationType == 'oauth2') { %>
-import org.apache.commons.lang.StringUtils;<% } %>
+import org.apache.commons.lang3.StringUtils;<% } %>
 import org.springframework.security.core.Authentication;<% if (authenticationType == 'oauth2') { %>
 import org.springframework.security.oauth2.common.OAuth2AccessToken;
 import org.springframework.security.oauth2.provider.token.TokenStore;<% } %>

--- a/generators/server/templates/src/main/java/package/service/_MailService.java
+++ b/generators/server/templates/src/main/java/package/service/_MailService.java
@@ -3,7 +3,7 @@ package <%=packageName%>.service;
 import <%=packageName%>.config.JHipsterProperties;
 import <%=packageName%>.domain.User;
 
-import org.apache.commons.lang.CharEncoding;
+import org.apache.commons.lang3.CharEncoding;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
@@ -13,7 +13,7 @@ import org.springframework.scheduling.annotation.Async;
 import org.springframework.stereotype.Service;
 import org.thymeleaf.context.Context;
 import org.thymeleaf.spring4.SpringTemplateEngine;
-<% if (enableSocialSignIn) { %>import org.apache.commons.lang.WordUtils;<% } %>
+<% if (enableSocialSignIn) { %>import org.apache.commons.lang3.StringUtils;<% } %>
 
 import javax.inject.Inject;
 import javax.mail.internet.MimeMessage;
@@ -108,7 +108,7 @@ public class MailService {
         Locale locale = Locale.forLanguageTag(user.getLangKey());
         Context context = new Context(locale);
         context.setVariable(USER, user);
-        context.setVariable("provider", WordUtils.capitalize(provider));
+        context.setVariable("provider", StringUtils.capitalize(provider));
         String content = templateEngine.process("socialRegistrationValidationEmail", context);
         String subject = messageSource.getMessage("email.social.registration.title", null, locale);
         sendEmail(user.getEmail(), subject, content, false, true);

--- a/generators/server/templates/src/main/java/package/service/_SocialService.java
+++ b/generators/server/templates/src/main/java/package/service/_SocialService.java
@@ -5,7 +5,7 @@ import <%=packageName%>.domain.User;
 import <%=packageName%>.repository.AuthorityRepository;
 import <%=packageName%>.repository.UserRepository;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/generators/server/templates/src/main/java/package/service/util/_RandomUtil.java
+++ b/generators/server/templates/src/main/java/package/service/util/_RandomUtil.java
@@ -1,6 +1,6 @@
 package <%=packageName%>.service.util;
 
-import org.apache.commons.lang.RandomStringUtils;
+import org.apache.commons.lang3.RandomStringUtils;
 
 /**
  * Utility class for generating random Strings.

--- a/generators/server/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -14,7 +14,7 @@ import <%=packageName%>.web.rest.vm.KeyAndPasswordVM;
 import <%=packageName%>.web.rest.vm.ManagedUserVM;
 import <%=packageName%>.web.rest.util.HeaderUtil;
 
-import org.apache.commons.lang.StringUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.HttpHeaders;


### PR DESCRIPTION
I was aligning some versions and noticed that jhipster depends on a [5.5 years old version](https://mvnrepository.com/artifact/commons-lang/commons-lang) of commons-lang :-)

Guess it happened because they sneakily changed the groupId and artifactId.

Anyway, this PR brings this dependency [up to date](https://mvnrepository.com/artifact/org.apache.commons/commons-lang3).