### PR TITLE
check for underscore in microservice base names and fix message

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1324,11 +1324,14 @@ Generator.prototype.askModuleName = function (generator) {
         type: 'input',
         name: 'baseName',
         validate: function (input) {
-            if (/^([a-zA-Z0-9_]*)$/.test(input) && input !== 'application') return true;
-            if (input === 'application') {
+            if (!(/^([a-zA-Z0-9_]*)$/.test(input))) {
+                return 'Your application name cannot contain special characters or a blank space';
+            } else if (generator.applicationType === 'microservice' && /_/.test(input)) {
+                return 'Your microservice name cannot contain underscores as this does not meet the URI spec';
+            } else if (input === 'application') {
                 return 'Your application name cannot be named \'application\' as this is a reserved name for Spring Boot';
             }
-            return 'Your application name cannot contain special characters or a blank space, using the default name instead';
+            return true;
         },
         message: function (response) {
             return getNumberedQuestion('What is the base name of your application?', true);


### PR DESCRIPTION
Fix #3984

The phrase "using the default name instead" was removed from the error message because the user is re-prompted.