### PR TITLE
Separate configuration sources used by jhipster-registry.yml and app.yml

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -418,7 +418,8 @@ module.exports = JhipsterServerGenerator.extend({
             }
 
             if (this.applicationType === 'microservice' || this.applicationType === 'gateway' || this.applicationType === 'uaa') {
-                this.copy(DOCKER_DIR + 'central-server-config/application.yml', DOCKER_DIR + 'central-server-config/application.yml');
+                this.copy(DOCKER_DIR + 'central-server-config/localhost-config/application.yml', DOCKER_DIR + 'central-server-config/localhost-config/application.yml');
+                this.copy(DOCKER_DIR + 'central-server-config/docker-config/application.yml', DOCKER_DIR + 'central-server-config/docker-config/application.yml');
                 this.template(DOCKER_DIR + '_jhipster-registry.yml', DOCKER_DIR + 'jhipster-registry.yml', this, {});
             }
             this.template(DOCKER_DIR + '_sonar.yml', DOCKER_DIR + 'sonar.yml', this, {});

--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -122,4 +122,6 @@ services:
         extends:
             file: jhipster-registry.yml
             service: jhipster-registry
+        environment:
+            - SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCH_LOCATIONS=file:./central-config/docker-config/
     <%_ } _%>

--- a/generators/server/templates/src/main/docker/_jhipster-registry.yml
+++ b/generators/server/templates/src/main/docker/_jhipster-registry.yml
@@ -5,13 +5,14 @@ services:
         image: <%= DOCKER_JHIPSTER_REGISTRY %>
         volumes:
             - ./central-server-config:/central-config
-        # By default the JHipster Registry runs with the "prod" and "native"
-        # Spring profiles.
-        # "native" profile means the filesystem is used to store data, see
-        # http://cloud.spring.io/spring-cloud-config/spring-cloud-config.html
+        # When run with the "dev" Spring profile, the JHipster Registry will
+        # read the config from the local filesystem (central-server-config directory)
+        # When run with the "prod" Spring profile, it will read the config from a git repository
+        # See http://jhipster.github.io/microservices-architecture/#registry_app_configuration
         environment:
-            - SPRING_PROFILES_ACTIVE=dev,native
+            - SPRING_PROFILES_ACTIVE=dev
             - SECURITY_USER_PASSWORD=admin
+            - SPRING_CLOUD_CONFIG_SERVER_NATIVE_SEARCH_LOCATIONS=file:./central-config/localhost-config/
             # - GIT_URI=https://github.com/jhipster/jhipster-registry/
             # - GIT_SEARCH_PATH=central-config
         ports:

--- a/generators/server/templates/src/main/docker/central-server-config/README
+++ b/generators/server/templates/src/main/docker/central-server-config/README
@@ -1,0 +1,7 @@
+# Central configuration sources details
+
+The JHipster-Registry will use the following directories as its configuration source :
+- localhost-config : when running the registry with the jhipster-registry.yml docker-compose file
+- docker-config : when running the registry with the app.yml docker-compose file
+
+For more info, refer to http://jhipster.github.io/microservices-architecture/#registry_app_configuration

--- a/generators/server/templates/src/main/docker/central-server-config/docker-config/application.yml
+++ b/generators/server/templates/src/main/docker/central-server-config/docker-config/application.yml
@@ -1,0 +1,15 @@
+# Common configuration shared between all applications
+configserver:
+    name: Docker JHipster Registry
+    status: Connected to the JHipster Registry running in Docker
+
+jhipster:
+    security:
+        authentication:
+            jwt:
+                secret: my-secret-token-to-change-in-production
+
+eureka:
+    client:
+        serviceUrl:
+            defaultZone: http://admin:admin@registry:8761/eureka/

--- a/generators/server/templates/src/main/docker/central-server-config/localhost-config/application.yml
+++ b/generators/server/templates/src/main/docker/central-server-config/localhost-config/application.yml
@@ -1,4 +1,4 @@
-#common configuration shared between all applications
+# Common configuration shared between all applications
 configserver:
     name: Docker JHipster Registry
     status: Connected to the JHipster Registry running in Docker
@@ -12,4 +12,4 @@ jhipster:
 eureka:
     client:
         serviceUrl:
-            defaultZone: http://admin:admin@registry:8761/eureka/
+            defaultZone: http://admin:admin@localhost:8761/eureka/

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -399,7 +399,8 @@ const expectedFiles = {
     ],
 
     containerizeWithDocker: [
-        DOCKER_DIR + 'central-server-config/application.yml',
+        DOCKER_DIR + 'central-server-config/localhost-config/application.yml',
+        DOCKER_DIR + 'central-server-config/docker-config/application.yml',
         DOCKER_DIR + 'jhipster-registry.yml',
         DOCKER_DIR + 'Dockerfile',
         DOCKER_DIR + 'app.yml'


### PR DESCRIPTION
Fix #4097

After considering the problem all morning and discussing this at the office with @jdubois. I have found a solution that fixes the issue with service discovery not working when the registry is  in docker and the app started the normal way. Thanks @pascalgrimaud for submitting the bug and finding its cause :+1:.

So basically I put 2 configuration dirs, a `docker-config` for app.yml and a `localhost-config` for jhipster-registry.yml.