### PR TITLE
Improve comment in app.yml to use docker cassandra for rate limiting

### DIFF
--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -1,3 +1,10 @@
+<%_ if (applicationType == 'gateway' && prodDatabaseType != 'cassandra') { _%>
+#-------------------------------------------------------------------------------
+# Note for using the rate-limiting:
+#   The comment part won't be copied if you use the subgenerator docker-compose
+#   you have to manually copy it
+#-------------------------------------------------------------------------------
+<%_ } _%>
 version: '2'
 services:
     <%= baseName.toLowerCase() %>-app:
@@ -106,10 +113,17 @@ services:
             - CREATE_KEYSPACE_SCRIPT=create-keyspace-prod.cql
     <%_ } _%>
     <%_ if (applicationType == 'gateway' && prodDatabaseType != 'cassandra') { _%>
-        # Uncomment to have Cassandra working with the gateway
-        # extends:
-        #     file: cassandra-cluster.yml
-        #     service: <%= baseName.toLowerCase() %>-cassandra
+    # Uncomment to have Cassandra working with the gateway
+    # <%= baseName.toLowerCase() %>-cassandra:
+    #     extends:
+    #         file: cassandra-cluster.yml
+    #         service: <%= baseName.toLowerCase() %>-cassandra
+    # <%= baseName.toLowerCase() %>-cassandra-migration:
+    #     extends:
+    #         file: cassandra-migration.yml
+    #         service: <%= baseName.toLowerCase() %>-cassandra-migration
+    #     environment:
+    #         - CREATE_KEYSPACE_SCRIPT=create-keyspace-prod.cql
     <%_ } _%>
     <%_ if (searchEngine == 'elasticsearch') { _%>
     <%= baseName.toLowerCase() %>-elasticsearch:


### PR DESCRIPTION
Find by @eoinverling on gitter

When generating a gateway project, in `src/main/docker/app.yml` file, the comment part about using docker cassandra is incorrect

Another minor issue:
- when using the docker-compose sub generator, the cassandra part is not generated in the new `docker-compose.yml` file. It's because we have to detect if it's commented or not. So for the moment, I suggested the user to copy it manually