### PR TITLE
Remove workaround to set default profile

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1120,7 +1120,7 @@
                 <!-- log configuration -->
                 <logback.loglevel>DEBUG</logback.loglevel>
                 <!-- default Spring profiles -->
-                <spring.profiles.active>dev${profile.no-liquibase}</spring.profiles.active>
+                <spring.profiles.active>dev,swagger${profile.no-liquibase}</spring.profiles.active>
             </properties>
         </profile>
         <profile>

--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -8,7 +8,7 @@ dependencies {
     compile "org.springframework.boot:spring-boot-devtools"
 }
 
-def profiles = 'dev'
+def profiles = 'dev,swagger'
 if (project.hasProperty('no-liquibase')) {
     profiles += ',no-liquibase'
 }

--- a/generators/server/templates/src/main/java/package/config/_DefaultProfileUtil.java
+++ b/generators/server/templates/src/main/java/package/config/_DefaultProfileUtil.java
@@ -1,14 +1,9 @@
 package <%=packageName%>.config;
 
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.config.YamlPropertiesFactoryBean;
 import org.springframework.boot.SpringApplication;
-import org.springframework.core.io.ClassPathResource;
 
 import java.util.HashMap;
 import java.util.Map;
-import java.util.Properties;
 
 /**
  * Utility class to load a Spring profile to be used as default
@@ -17,31 +12,7 @@ import java.util.Properties;
  */
 public final class DefaultProfileUtil {
 
-    private static final long serialVersionUID = 1L;
-
-    private static final Logger log = LoggerFactory.getLogger(DefaultProfileUtil.class);
-
-    private static final String SPRING_PROFILE_ACTIVE = "spring.profiles.active";
-
-    private static final Properties BUILD_PROPERTIES = readProperties();
-
-    /**
-     * Get a default profile from <code>application.yml</code>.
-     *
-     * @return the default active profile
-     */
-    public static String getDefaultActiveProfiles(){
-        if (BUILD_PROPERTIES != null) {
-            String activeProfile = BUILD_PROPERTIES.getProperty(SPRING_PROFILE_ACTIVE);
-            if (activeProfile != null && !activeProfile.isEmpty() &&
-                (activeProfile.contains(Constants.SPRING_PROFILE_DEVELOPMENT) ||
-                    activeProfile.contains(Constants.SPRING_PROFILE_PRODUCTION))) {
-                return activeProfile;
-            }
-        }
-        log.warn("No Spring profile configured, running with default profile: {}", Constants.SPRING_PROFILE_DEVELOPMENT);
-        return Constants.SPRING_PROFILE_DEVELOPMENT;
-    }
+    private static final String SPRING_PROFILE_DEFAULT = "spring.profiles.default";
 
     /**
      * Set a default to use when no profile is configured.
@@ -55,23 +26,7 @@ public final class DefaultProfileUtil {
         * This cannot be set in the <code>application.yml</code> file.
         * See https://github.com/spring-projects/spring-boot/issues/1219
         */
-        defProperties.put(SPRING_PROFILE_ACTIVE, getDefaultActiveProfiles());
+        defProperties.put(SPRING_PROFILE_DEFAULT, Constants.SPRING_PROFILE_DEVELOPMENT);
         app.setDefaultProperties(defProperties);
-    }
-
-    /**
-     * Load application.yml from classpath.
-     *
-     * @return the YAML Properties
-     */
-    private static Properties readProperties() {
-        try {
-            YamlPropertiesFactoryBean factory = new YamlPropertiesFactoryBean();
-            factory.setResources(new ClassPathResource("config/application.yml"));
-            return factory.getObject();
-        } catch (Exception e) {
-            log.error("Failed to read application.yml to get default profile");
-        }
-        return null;
     }
 }

--- a/generators/server/templates/src/main/java/package/config/_DefaultProfileUtil.java
+++ b/generators/server/templates/src/main/java/package/config/_DefaultProfileUtil.java
@@ -1,9 +1,9 @@
 package <%=packageName%>.config;
 
 import org.springframework.boot.SpringApplication;
+import org.springframework.core.env.Environment;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.util.*;
 
 /**
  * Utility class to load a Spring profile to be used as default
@@ -28,5 +28,18 @@ public final class DefaultProfileUtil {
         */
         defProperties.put(SPRING_PROFILE_DEFAULT, Constants.SPRING_PROFILE_DEVELOPMENT);
         app.setDefaultProperties(defProperties);
+    }
+
+    /**
+     * Get the profiles that are applied else get default profiles.
+     * @param env
+     * @return
+     */
+    public static String[] getActiveProfiles(Environment env) {
+        String[] profiles = env.getActiveProfiles();
+        if (profiles.length == 0) {
+            return env.getDefaultProfiles();
+        }
+        return profiles;
     }
 }

--- a/generators/server/templates/src/main/java/package/web/rest/_ProfileInfoResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_ProfileInfoResource.java
@@ -1,18 +1,17 @@
 package <%=packageName%>.web.rest;
 
+import <%=packageName%>.config.DefaultProfileUtil;
 import <%=packageName%>.config.JHipsterProperties;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.List;
-
-import javax.inject.Inject;
-
 import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestMethod;
 import org.springframework.web.bind.annotation.RestController;
+
+import javax.inject.Inject;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
 
 @RestController
 @RequestMapping("/api")
@@ -28,11 +27,11 @@ public class ProfileInfoResource {
         method = RequestMethod.GET,
         produces = MediaType.APPLICATION_JSON_VALUE)
     public ProfileInfoResponse getActiveProfiles() {
-        return new ProfileInfoResponse(env.getActiveProfiles(), getRibbonEnv());
+        return new ProfileInfoResponse(DefaultProfileUtil.getActiveProfiles(env), getRibbonEnv());
     }
 
     private String getRibbonEnv() {
-        String[] activeProfiles = env.getActiveProfiles();
+        String[] activeProfiles = DefaultProfileUtil.getActiveProfiles(env);
         String[] displayOnActiveProfiles = jHipsterProperties.getRibbon().getDisplayOnActiveProfiles();
 
         if (displayOnActiveProfiles == null) {

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -140,8 +140,6 @@ spring:
         cache-seconds: 1
     thymeleaf:
         cache: false
-    profiles:
-        include: swagger # automatically set the 'swagger' profile
 
 <%_ if (databaseType === 'sql') { _%>
 liquibase:


### PR DESCRIPTION
There is a minor glitch, which can be solved by documentation.

When the app is run from an IDE using the Application.java main file only dev profile will be activated by default. the swagger profile would need to be explicitly enabled if required. This is due to the issue [here ](https://github.com/spring-projects/spring-boot/issues/6833#issuecomment-246026401)
This issue does not affect bootRun or running packaged war.
Fix #4059 