### PR TITLE
import the correct AuthServerProvider based on selected auth

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/components/_common.module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/components/_common.module.ts
@@ -5,7 +5,13 @@ import { AlertServiceConfig } from '../blocks/config/alert.config';
 import { LoginController } from './login/login.controller';
 
 import { Auth } from './auth/auth.service';
+<%_ if (authenticationType === 'oauth2') { _%>
+import { AuthServerProvider } from './auth/auth-oauth2.service';
+<%_ } else if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+import { AuthServerProvider } from './auth/auth-jwt.service';
+<%_ } else { _%>
 import { AuthServerProvider } from './auth/auth-session.service';
+<%_ } _%>
 import { Account } from './auth/account.service';
 import { LoginService } from './login/login.service';
 import { Principal } from './auth/principal.service';
@@ -39,6 +45,6 @@ angular
     .factory('LoginService', LoginService)
     .factory('Principal', Principal)
     .factory('ProfileService',upgradeAdapter.downgradeNg2Provider(ProfileService))
-    .provider('AlertService', AlertService) <% if (enableTranslation) { %>
+    .provider('AlertService', AlertService)<% if (enableTranslation) { %>
     .factory('<%=jhiPrefixCapitalized%>LanguageService', <%=jhiPrefixCapitalized%>LanguageService)<% } %>
     .directive('pageRibbon',  <angular.IDirectiveFactory> upgradeAdapter.downgradeNg2Component(PageRibbonComponent));


### PR DESCRIPTION
This partially fixes OAuth2 and JWT apps for the NG2 branch - error was thrown due to missing `auth-session.service`