### PR TITLE
Create a profile (called IDE) that includes mapstruct processor

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1249,5 +1249,15 @@
                 <spring.profiles.active>prod${profile.swagger}${profile.no-liquibase}</spring.profiles.active>
             </properties>
         </profile>
+        <profile>
+            <id>IDE</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.mapstruct</groupId>
+                    <artifactId>mapstruct-processor</artifactId>
+                    <version>${mapstruct.version}</version>
+                </dependency>
+            </dependencies>
+        </profile>
     </profiles>
 </project>


### PR DESCRIPTION
Create a profile (called IDE) that includes mapstruct processor and any tweaks that should be only applied to the IDE.

I didn't find that Gradle needs such a profile. Please correct me if I'm wrong, I'm no Gradle expert.

Docs being updated in jhipster/jhipster.github.io#307