### PR TITLE
migrate the java docker image from _/java to _/openjdk

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -2,7 +2,7 @@
 
 // version of docker images
 const DOCKER_JHIPSTER_REGISTRY = 'jhipster/jhipster-registry:v2.5.0';
-const DOCKER_JAVA_JRE = 'java:openjdk-8-jre-alpine';
+const DOCKER_JAVA_JRE = 'openjdk:8-jre-alpine';
 const DOCKER_MYSQL = 'mysql:5.7.15';
 const DOCKER_MARIADB = 'mariadb:10.1.17';
 const DOCKER_POSTGRESQL = 'postgres:9.5.4';


### PR DESCRIPTION
Fix #4127