### PR TITLE
Add oauth2 client details storage support for mongo

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -561,10 +561,19 @@ module.exports = JhipsterServerGenerator.extend({
 
             if (this.databaseType === 'mongodb' && this.authenticationType === 'oauth2') {
                 this.template(SERVER_MAIN_SRC_DIR + 'package/config/oauth2/_OAuth2AuthenticationReadConverter.java', javaDir + 'config/oauth2/OAuth2AuthenticationReadConverter.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/oauth2/_MongoDBApprovalStore.java', javaDir + 'config/oauth2/MongoDBApprovalStore.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/oauth2/_MongoDBAuthorizationCodeServices.java', javaDir + 'config/oauth2/MongoDBAuthorizationCodeServices.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/config/oauth2/_MongoDBClientDetailsService.java', javaDir + 'config/oauth2/MongoDBClientDetailsService.java', this, {});
                 this.template(SERVER_MAIN_SRC_DIR + 'package/config/oauth2/_MongoDBTokenStore.java', javaDir + 'config/oauth2/MongoDBTokenStore.java', this, {});
                 this.template(SERVER_MAIN_SRC_DIR + 'package/domain/_OAuth2AuthenticationAccessToken.java', javaDir + 'domain/OAuth2AuthenticationAccessToken.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/domain/_OAuth2AuthenticationApproval.java', javaDir + 'domain/OAuth2AuthenticationApproval.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/domain/_OAuth2AuthenticationClientDetails.java', javaDir + 'domain/OAuth2AuthenticationClientDetails.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/domain/_OAuth2AuthenticationCode.java', javaDir + 'domain/OAuth2AuthenticationCode.java', this, {});
                 this.template(SERVER_MAIN_SRC_DIR + 'package/domain/_OAuth2AuthenticationRefreshToken.java', javaDir + 'domain/OAuth2AuthenticationRefreshToken.java', this, {});
                 this.template(SERVER_MAIN_SRC_DIR + 'package/repository/_OAuth2AccessTokenRepository.java', javaDir + 'repository/OAuth2AccessTokenRepository.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/repository/_OAuth2ApprovalRepository.java', javaDir + 'repository/OAuth2ApprovalRepository.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/repository/_OAuth2ClientDetailsRepository.java', javaDir + 'repository/OAuth2ClientDetailsRepository.java', this, {});
+                this.template(SERVER_MAIN_SRC_DIR + 'package/repository/_OAuth2CodeRepository.java', javaDir + 'repository/OAuth2CodeRepository.java', this, {});
                 this.template(SERVER_MAIN_SRC_DIR + 'package/repository/_OAuth2RefreshTokenRepository.java', javaDir + 'repository/OAuth2RefreshTokenRepository.java', this, {});
             }
 

--- a/generators/server/templates/src/main/java/package/config/oauth2/_MongoDBApprovalStore.java
+++ b/generators/server/templates/src/main/java/package/config/oauth2/_MongoDBApprovalStore.java
@@ -1,0 +1,95 @@
+package <%=packageName%>.config.oauth2;
+
+import <%=packageName%>.domain.OAuth2AuthenticationApproval;
+import <%=packageName%>.repository.OAuth2ApprovalRepository;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.security.oauth2.provider.approval.Approval;
+import org.springframework.security.oauth2.provider.approval.ApprovalStore;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Date;
+import java.util.List;
+
+
+public class MongoDBApprovalStore implements ApprovalStore {
+
+    private final Log logger = LogFactory.getLog(getClass());
+
+    private final OAuth2ApprovalRepository oAuth2ApprovalRepository;
+
+    private boolean handleRevocationsAsExpiry = false;
+
+    public MongoDBApprovalStore(final OAuth2ApprovalRepository oAuth2ApprovalRepository) {
+        this.oAuth2ApprovalRepository = oAuth2ApprovalRepository;
+    }
+
+    public void setHandleRevocationsAsExpiry(boolean handleRevocationsAsExpiry) {
+        this.handleRevocationsAsExpiry = handleRevocationsAsExpiry;
+    }
+
+    @Override
+    public boolean addApprovals(Collection<Approval> approvals) {
+        logger.debug(String.format("adding approvals: [%s]", approvals));
+
+        for (final Approval approval : approvals) {
+            List<OAuth2AuthenticationApproval> mongoDBApprovals = this.oAuth2ApprovalRepository
+                .findByUserIdAndClientIdAndScope(approval.getUserId(), approval.getClientId(), approval.getScope());
+
+            if (!mongoDBApprovals.isEmpty()) {
+                for (final OAuth2AuthenticationApproval mongoDBApproval : mongoDBApprovals) {
+                    updateApproval(mongoDBApproval, approval);
+                }
+            } else {
+                updateApproval(new OAuth2AuthenticationApproval(), approval);
+            }
+        }
+        return true;
+    }
+
+
+    private void updateApproval(final OAuth2AuthenticationApproval mongoDBApproval, final Approval approval) {
+        logger.debug(String.format("refreshing approval: [%s]", approval));
+
+        mongoDBApproval.setExpiresAt(approval.getExpiresAt());
+        mongoDBApproval.setStatus(approval.getStatus() == null ? Approval.ApprovalStatus.APPROVED : approval.getStatus());
+        mongoDBApproval.setLastUpdatedAt(approval.getLastUpdatedAt());
+        mongoDBApproval.setUserId(approval.getUserId());
+        mongoDBApproval.setClientId(approval.getClientId());
+        mongoDBApproval.setScope(approval.getScope());
+
+        this.oAuth2ApprovalRepository.save(mongoDBApproval);
+    }
+
+    @Override
+    public boolean revokeApprovals(Collection<Approval> approvals) {
+        logger.debug(String.format("Revoking approvals: [%s]", approvals));
+        boolean success = true;
+
+        for (final Approval approval : approvals) {
+            List<OAuth2AuthenticationApproval> mongoDBApprovals = this.oAuth2ApprovalRepository
+                .findByUserIdAndClientIdAndScope(approval.getUserId(), approval.getClientId(), approval.getScope());
+
+            if (mongoDBApprovals.size() != 1) {
+                success = false;
+            }
+
+            for (final OAuth2AuthenticationApproval mongoDBApproval : mongoDBApprovals) {
+                if (handleRevocationsAsExpiry) {
+                    mongoDBApproval.setExpiresAt(new Date());
+                    this.oAuth2ApprovalRepository.save(mongoDBApproval);
+                } else {
+                    this.oAuth2ApprovalRepository.delete(mongoDBApproval);
+                }
+            }
+        }
+        return success;
+    }
+
+    @Override
+    public Collection<Approval> getApprovals(String userId, String clientId) {
+        return new ArrayList<>(this.oAuth2ApprovalRepository
+            .findByUserIdAndClientId(userId, clientId));
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/oauth2/_MongoDBAuthorizationCodeServices.java
+++ b/generators/server/templates/src/main/java/package/config/oauth2/_MongoDBAuthorizationCodeServices.java
@@ -1,0 +1,29 @@
+package <%=packageName%>.config.oauth2;
+
+import <%=packageName%>.domain.OAuth2AuthenticationCode;
+import <%=packageName%>.repository.OAuth2CodeRepository;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+import org.springframework.security.oauth2.provider.code.RandomValueAuthorizationCodeServices;
+
+public class MongoDBAuthorizationCodeServices extends RandomValueAuthorizationCodeServices {
+
+    private final OAuth2CodeRepository oAuth2CodeRepository;
+
+    public MongoDBAuthorizationCodeServices(OAuth2CodeRepository oAuth2CodeRepository) {
+        this.oAuth2CodeRepository = oAuth2CodeRepository;
+    }
+
+    @Override
+    protected void store(String code, OAuth2Authentication authentication) {
+        this.oAuth2CodeRepository.save( new OAuth2AuthenticationCode(code, authentication) );
+    }
+
+    public OAuth2Authentication remove(String code) {
+        OAuth2AuthenticationCode oAuth2AuthenticationCode = oAuth2CodeRepository.findOneByCode(code);
+        if (oAuth2AuthenticationCode != null && oAuth2AuthenticationCode.getAuthentication() != null) {
+            oAuth2CodeRepository.delete(oAuth2AuthenticationCode);
+            return oAuth2AuthenticationCode.getAuthentication();
+        }
+        return null;
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/oauth2/_MongoDBClientDetailsService.java
+++ b/generators/server/templates/src/main/java/package/config/oauth2/_MongoDBClientDetailsService.java
@@ -1,0 +1,97 @@
+package <%=packageName%>.config.oauth2;
+
+import <%=packageName%>.domain.OAuth2AuthenticationClientDetails;
+import <%=packageName%>.repository.OAuth2ClientDetailsRepository;
+import org.springframework.security.crypto.password.NoOpPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.oauth2.provider.*;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class MongoDBClientDetailsService implements ClientDetailsService, ClientRegistrationService {
+
+    private PasswordEncoder passwordEncoder = NoOpPasswordEncoder.getInstance();
+
+    private OAuth2ClientDetailsRepository oAuth2ClientDetailsRepository;
+
+    public MongoDBClientDetailsService(OAuth2ClientDetailsRepository oAuth2ClientDetailsRepository) {
+        this.oAuth2ClientDetailsRepository = oAuth2ClientDetailsRepository;
+    }
+
+    /**
+     * @param passwordEncoder the password encoder to set
+     */
+    public void setPasswordEncoder(PasswordEncoder passwordEncoder) {
+        this.passwordEncoder = passwordEncoder;
+    }
+
+    @Override
+    public ClientDetails loadClientByClientId(String clientId) throws ClientRegistrationException {
+        OAuth2AuthenticationClientDetails mongoClientDetails = oAuth2ClientDetailsRepository.findOneByClientId(clientId);
+        if (mongoClientDetails == null) {
+            throw new NoSuchClientException("No client with requested id: " + clientId);
+        }
+        return mongoClientDetails;
+    }
+
+    @Override
+    public void addClientDetails(ClientDetails clientDetails) throws ClientAlreadyExistsException {
+        OAuth2AuthenticationClientDetails mongoClientDetails = oAuth2ClientDetailsRepository.findOneByClientId(clientDetails.getClientId());
+        if ( mongoClientDetails != null) {
+            throw new ClientAlreadyExistsException("Client already exists: " + clientDetails.getClientId());
+        }
+        saveClientDetails(mongoClientDetails, clientDetails);
+    }
+
+    @Override
+    public void updateClientDetails(ClientDetails clientDetails) throws NoSuchClientException {
+        if (oAuth2ClientDetailsRepository.findOneByClientId(clientDetails.getClientId()) == null) {
+            throw new NoSuchClientException("No client found with id = " + clientDetails.getClientId());
+        }
+        saveClientDetails(new OAuth2AuthenticationClientDetails(), clientDetails);
+    }
+
+    @Override
+    public void updateClientSecret(String clientId, String secret) throws NoSuchClientException {
+        OAuth2AuthenticationClientDetails mongoClientDetails = oAuth2ClientDetailsRepository.findOneByClientId(clientId);
+        if (mongoClientDetails == null) {
+            throw new NoSuchClientException("No client found with id = " + clientId);
+        }
+        mongoClientDetails.setClientSecret(passwordEncoder.encode(secret));
+        oAuth2ClientDetailsRepository.save(mongoClientDetails);
+    }
+
+    @Override
+    public void removeClientDetails(String clientId) throws NoSuchClientException {
+        OAuth2AuthenticationClientDetails mongoClientDetails = oAuth2ClientDetailsRepository.findOneByClientId(clientId);
+        if (mongoClientDetails == null) {
+            throw new NoSuchClientException("No client found with id = " + clientId);
+        }
+        oAuth2ClientDetailsRepository.delete(mongoClientDetails);
+    }
+
+    @Override
+    public List<ClientDetails> listClientDetails() {
+        return new ArrayList<>(oAuth2ClientDetailsRepository.findAll());
+    }
+
+    public void saveClientDetails(OAuth2AuthenticationClientDetails mongoClientDetails, ClientDetails clientDetails) {
+        mongoClientDetails.setClientId(clientDetails.getClientId());
+        mongoClientDetails.setClientSecret(clientDetails.getClientSecret() != null ? passwordEncoder.encode(clientDetails.getClientSecret()) : null);
+        mongoClientDetails.setScope(clientDetails.getScope());
+        mongoClientDetails.setResourceIds(clientDetails.getResourceIds());
+        mongoClientDetails.setAuthorizedGrantTypes(clientDetails.getAuthorizedGrantTypes());
+        mongoClientDetails.setRegisteredRedirectUri(clientDetails.getRegisteredRedirectUri());
+        mongoClientDetails.setAuthorities(clientDetails.getAuthorities());
+        mongoClientDetails.setAccessTokenValiditySeconds(clientDetails.getAccessTokenValiditySeconds());
+        mongoClientDetails.setRefreshTokenValiditySeconds(clientDetails.getRefreshTokenValiditySeconds());
+        mongoClientDetails.setAdditionalInformation(clientDetails.getAdditionalInformation());
+        if(clientDetails instanceof BaseClientDetails) {
+            mongoClientDetails.setAutoApproveScopes(((BaseClientDetails)clientDetails).getAutoApproveScopes());
+        }
+        oAuth2ClientDetailsRepository.save(mongoClientDetails);
+
+    }
+}

--- a/generators/server/templates/src/main/java/package/domain/_OAuth2AuthenticationApproval.java
+++ b/generators/server/templates/src/main/java/package/domain/_OAuth2AuthenticationApproval.java
@@ -1,0 +1,41 @@
+package <%=packageName%>.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.security.oauth2.provider.approval.Approval;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Document(collection = "OAUTH_AUTHENTICATION_APPROVAL")
+public class OAuth2AuthenticationApproval extends Approval implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private String id;
+
+    @PersistenceConstructor
+    public OAuth2AuthenticationApproval() {
+        super();
+        this.id = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OAuth2AuthenticationApproval that = (OAuth2AuthenticationApproval) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+}

--- a/generators/server/templates/src/main/java/package/domain/_OAuth2AuthenticationClientDetails.java
+++ b/generators/server/templates/src/main/java/package/domain/_OAuth2AuthenticationClientDetails.java
@@ -1,0 +1,42 @@
+package <%=packageName%>.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.security.oauth2.provider.ClientDetails;
+import org.springframework.security.oauth2.provider.client.BaseClientDetails;
+
+import java.util.UUID;
+
+@Document(collection = "OAUTH_AUTHENTICATION_CLIENT_DETAILS")
+public class OAuth2AuthenticationClientDetails extends BaseClientDetails implements ClientDetails {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private String id;
+
+    @PersistenceConstructor
+    public OAuth2AuthenticationClientDetails() {
+        super();
+        this.id = UUID.randomUUID().toString();
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OAuth2AuthenticationClientDetails that = (OAuth2AuthenticationClientDetails) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/domain/_OAuth2AuthenticationCode.java
+++ b/generators/server/templates/src/main/java/package/domain/_OAuth2AuthenticationCode.java
@@ -1,0 +1,54 @@
+package <%=packageName%>.domain;
+
+import org.springframework.data.annotation.Id;
+import org.springframework.data.annotation.PersistenceConstructor;
+import org.springframework.data.mongodb.core.mapping.Document;
+import org.springframework.security.oauth2.provider.OAuth2Authentication;
+
+import java.io.Serializable;
+import java.util.UUID;
+
+@Document(collection = "OAUTH_AUTHENTICATION_CODE")
+public class OAuth2AuthenticationCode implements Serializable {
+
+    private static final long serialVersionUID = 1L;
+
+    @Id
+    private String id;
+
+    private String code;
+
+    private OAuth2Authentication authentication;
+
+    @PersistenceConstructor
+    public OAuth2AuthenticationCode(String code, OAuth2Authentication authentication) {
+        this.id = UUID.randomUUID().toString();
+        this.code = code;
+        this.authentication = authentication;
+    }
+
+    public String getCode() {
+        return code;
+    }
+
+    public OAuth2Authentication getAuthentication() {
+        return authentication;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        OAuth2AuthenticationCode that = (OAuth2AuthenticationCode) o;
+
+        if (id != null ? !id.equals(that.id) : that.id != null) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        return id != null ? id.hashCode() : 0;
+    }
+}

--- a/generators/server/templates/src/main/java/package/repository/_OAuth2ApprovalRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_OAuth2ApprovalRepository.java
@@ -1,0 +1,14 @@
+package <%=packageName%>.repository;
+
+
+import <%=packageName%>.domain.OAuth2AuthenticationApproval;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface OAuth2ApprovalRepository extends MongoRepository<OAuth2AuthenticationApproval, String> {
+
+    public List<OAuth2AuthenticationApproval> findByUserIdAndClientId(String userId, String clientId);
+
+    public List<OAuth2AuthenticationApproval> findByUserIdAndClientIdAndScope(String userId, String clientId, String scope);
+}

--- a/generators/server/templates/src/main/java/package/repository/_OAuth2ClientDetailsRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_OAuth2ClientDetailsRepository.java
@@ -1,0 +1,12 @@
+package <%=packageName%>.repository;
+
+
+import <%=packageName%>.domain.OAuth2AuthenticationClientDetails;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+import java.util.List;
+
+public interface OAuth2ClientDetailsRepository extends MongoRepository<OAuth2AuthenticationClientDetails, String> {
+
+    OAuth2AuthenticationClientDetails findOneByClientId(String clientId);
+}

--- a/generators/server/templates/src/main/java/package/repository/_OAuth2CodeRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_OAuth2CodeRepository.java
@@ -1,0 +1,9 @@
+package <%=packageName%>.repository;
+
+import <%=packageName%>.domain.OAuth2AuthenticationCode;
+import org.springframework.data.mongodb.repository.MongoRepository;
+
+public interface OAuth2CodeRepository extends MongoRepository<OAuth2AuthenticationCode, String> {
+
+    OAuth2AuthenticationCode findOneByCode(String code);
+}


### PR DESCRIPTION
Basically, same as #3772 but this time for mongo.