### PR TITLE
Fix SystemJS config and Alert Service error

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
@@ -4,9 +4,7 @@ import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
 
 // TODO change this to NgbModule -->  after complete migration
-import {NgbAlertModule} from '@ng-bootstrap/ng-bootstrap/alert/alert.module';
-import {NgbCollapseModule} from '@ng-bootstrap/ng-bootstrap/collapse/collapse.module';
-import {NgbDropdownModule} from '@ng-bootstrap/ng-bootstrap/dropdown/dropdown.module';
+import {NgbModule} from '@ng-bootstrap/ng-bootstrap';
 
 import { <%=angular2AppName%>SharedModule } from './shared/shared.ng2module';
 import { <%=angular2AppName%>CommonModule } from './components/common.ng2module';
@@ -23,9 +21,7 @@ import { NavbarComponent } from './layouts/navbar/navbar.component';
         BrowserModule,
         FormsModule,
         HttpModule,
-        NgbAlertModule,
-        NgbCollapseModule,
-        NgbDropdownModule,
+        NgbModule,
         <%=angular2AppName%>SharedModule,
         <%=angular2AppName%>CommonModule,
         <%=angular2AppName%>AdminModule,

--- a/generators/client-2/templates/src/main/webapp/app/blocks/interceptor/_notification.interceptor.ts
+++ b/generators/client-2/templates/src/main/webapp/app/blocks/interceptor/_notification.interceptor.ts
@@ -1,6 +1,6 @@
-NotificationInterceptor.$inject = ['$q', 'AlertService'];
+NotificationInterceptor.$inject = ['$q'];
 
-export function NotificationInterceptor ($q, AlertService) {
+export function NotificationInterceptor ($q) {
     var service = {
         response: response
     };
@@ -10,7 +10,7 @@ export function NotificationInterceptor ($q, AlertService) {
     function response (response) {
         var alertKey = response.headers('X-<%=angularAppName%>-alert');
         if (angular.isString(alertKey)) {
-            AlertService.success(alertKey, { param : response.headers('X-<%=angularAppName%>-params')});
+            //AlertService.success(alertKey, { param : response.headers('X-<%=angularAppName%>-params')});
         }
         return response;
     }

--- a/generators/client-2/templates/src/main/webapp/app/components/_common.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/components/_common.ng2module.ts
@@ -1,5 +1,7 @@
 import { NgModule } from '@angular/core';
 import { CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { CommonModule } from '@angular/common';
+
 
 import { <%=angular2AppName%>SharedModule } from '../shared/shared.ng2module';
 
@@ -10,6 +12,7 @@ import { jhiAlertComponent } from "./alert/alert.component";
 
 @NgModule({
     imports: [
+        CommonModule,
         <%=angular2AppName%>SharedModule
     ],
     declarations: [

--- a/generators/client-2/templates/src/main/webapp/system.config.js
+++ b/generators/client-2/templates/src/main/webapp/system.config.js
@@ -17,7 +17,7 @@
     var packages = {
         'app': { main: 'app.main' },
         'rxjs': {},
-        '@ng-bootstrap/ng-bootstrap': {main: 'index.js', defaultExtension: 'js'}
+        '@ng-bootstrap/ng-bootstrap': {main: '/bundles/ng-bootstrap', defaultExtension: 'js'}
     };
     var ngPackageNames = [
         'common',
@@ -30,26 +30,6 @@
         'router',
         'upgrade',
     ];
-    // Packages related to ngbootstrap 
-    var ngBootstrapPackageNames = [
-        'accordion',
-        'alert',
-        'radio',
-        'carousel',
-        'collapse',
-        'datepicker',
-        'dropdown',
-        'modal',
-        'pagination',
-        'popover',
-        'progressbar',
-        'rating',
-        'tabset',
-        'timepicker',
-        'tooltip',
-        'typeahead',
-        'util'
-    ];
 
     // Individual files (~300 requests):
     function packIndex(pkgName) {
@@ -59,15 +39,11 @@
     function packUmd(pkgName) {
         packages['@angular/'+ pkgName] = { main: '/bundles/' + pkgName + '.umd' };
     };
-    // ng-bootstrap index packing
-    function ngBootstrapPackIndex(pkgName) {
-        packages['@ng-bootstrap/ng-bootstrap/' + pkgName] = {main: 'index.js', defaultExtension: 'js'};
-    };
     // Most environments should use UMD; some (Karma) need the individual index files
     var setPackageConfig = System.packageWithIndex ? packIndex : packUmd;
     // Add package entries for angular packages
     ngPackageNames.forEach(setPackageConfig);
-    ngBootstrapPackageNames.forEach(ngBootstrapPackIndex);
+
     var config = {
         map: map,
         packages: packages


### PR DESCRIPTION
I followed ng-bootstrap docs and changelog to fix the `404 traceur not found` issue, it's fixed. As @deepu105 suggested I commented the import in `NotificationInterceptor` so it's partially fixed.

Now the error I get is `Only selectors matching element names are supported, got: [ngbDatepickerMonthView] ` from the UpgradeAdapter.