### PR TITLE
removes test profile exclusion from feign

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_FeignConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_FeignConfiguration.java
@@ -2,10 +2,8 @@ package <%=packageName%>.config;
 
 import org.springframework.cloud.netflix.feign.EnableFeignClients;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Profile;
 
 @Configuration
-@Profile("!test")
 @EnableFeignClients(basePackages = "<%=packageName%>")
 public class FeignConfiguration {
 


### PR DESCRIPTION
since this is not needed, if using mock beans for testing feign clients.

I have already provided a better documentation how to test components the same way, without activating test profile. As @deepu105 wished to remove all mixups with test stuff, and it is possible to provide the identical solution without test profile exclusion, this PR removes that exclusion