### PR TITLE
docker-compose: remove useless config for monolithic application

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -192,7 +192,7 @@ module.exports = DockerComposeGenerator.extend({
                     }
                 }, this);
                 // Configure the JHipster Registry if it is not already configured
-                if (!spring_cloud_config_uri_configured) {
+                if (!spring_cloud_config_uri_configured && appConfig.applicationType !== 'monolith') {
                     yamlConfig.environment.push('SPRING_CLOUD_CONFIG_URI=http://admin:' +
                         this.adminPassword + '@registry:8761/config');
                 }


### PR DESCRIPTION
When using the sub generator docker-compose for **monolithic** application, the property "SPRING_CLOUD_CONFIG_URI" shouldn't be defined in the `docker-compose.yml` file