### PR TITLE
Add remote shell

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -102,6 +102,12 @@ if (project.hasProperty('prod')) {
     apply from: 'gradle/profile_dev.gradle'
 }
 
+if (project.hasProperty('shell')) {
+    dependencies {
+        compile "org.springframework.boot:spring-boot-starter-remote-shell"
+    }
+}
+
 group = '<%= packageName %>'
 version = '0.0.1-SNAPSHOT'
 

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1103,6 +1103,15 @@
             </properties>
         </profile>
         <profile>
+            <id>shell</id>
+            <dependencies>
+                <dependency>
+                    <groupId>org.springframework.boot</groupId>
+                    <artifactId>spring-boot-starter-remote-shell</artifactId>
+                </dependency>
+            </dependencies>
+        </profile>
+        <profile>
             <id>dev</id>
             <activation>
                 <activeByDefault>true</activeByDefault>


### PR DESCRIPTION
Using a profile not activated by default.
To use, activate the "shell" maven profile in the IDE. With maven use ```./mvnw -Pdev,shell ... ```

Fix #4167