### PR TITLE
[Sonar] utility classes should not have a public constructor

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_DefaultProfileUtil.java
+++ b/generators/server/templates/src/main/java/package/config/_DefaultProfileUtil.java
@@ -14,6 +14,9 @@ public final class DefaultProfileUtil {
 
     private static final String SPRING_PROFILE_DEFAULT = "spring.profiles.default";
 
+    private DefaultProfileUtil(){
+    }
+
     /**
      * Set a default to use when no profile is configured.
      *

--- a/generators/server/templates/src/main/java/package/web/rest/util/_HeaderUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_HeaderUtil.java
@@ -7,9 +7,12 @@ import org.springframework.http.HttpHeaders;
 /**
  * Utility class for HTTP headers creation.
  */
-public class HeaderUtil {
+public final class HeaderUtil {
 
     private static final Logger log = LoggerFactory.getLogger(HeaderUtil.class);
+
+    private HeaderUtil(){
+    }
 
     public static HttpHeaders createAlert(String message, String param) {
         HttpHeaders headers = new HttpHeaders();

--- a/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
@@ -13,7 +13,10 @@ import java.net.URISyntaxException;
  * Pagination uses the same principles as the <a href="https://developer.github.com/v3/#pagination">Github API</a>,
  * and follow <a href="http://tools.ietf.org/html/rfc5988">RFC 5988 (Link header)</a>.
  */
-public class PaginationUtil {
+public final class PaginationUtil {
+
+    private PaginationUtil(){
+    }
 
     public static HttpHeaders generatePaginationHttpHeaders(Page<?> page, String baseUrl)
         throws URISyntaxException {


### PR DESCRIPTION
[Sonar] utility classes should not have a public constructor.
This commit will  break code of users who have instanciated these classes or extended them

Also, Joshua Bloch said in Effective Java that the best way to create utiility classes is to use an enum. 
But, I didn't go futher than just making default constructor private and making classes final