### PR TITLE
fix status and health check urls that are used by eureka

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -16,7 +16,9 @@ eureka:
     instance:
         appname: <%= baseName %>
         instanceId: <%= baseName %>:${spring.application.instance_id:${random.value}}
-
+        statusPageUrlPath: ${management.context-path}/info
+        healthCheckUrlPath: ${management.context-path}/health
+        
 ribbon:
     eureka:
         enabled: true


### PR DESCRIPTION
From the [Spring Cloud Netflix docs](http://cloud.spring.io/spring-cloud-netflix/spring-cloud-netflix.html), we need to set the management context-path so the urls point to the correct endpoints.
`/health -> /management/health`
`/info -> /management/info`