### PR TITLE
load initial UAA servers from discovery client if not using hazelcast

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
@@ -73,6 +73,9 @@ public class MicroserviceSecurityConfiguration extends WebSecurityConfigurerAdap
 import <%=packageName%>.security.AuthoritiesConstants;
 
 import org.springframework.beans.factory.annotation.Qualifier;
+<%_ if (hibernateCache !== 'hazelcast') { _%>
+import org.springframework.cloud.client.discovery.DiscoveryClient;
+<%_ } _%>
 import org.springframework.cloud.client.loadbalancer.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -100,6 +103,11 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
 
     @Inject
     JHipsterProperties jHipsterProperties;
+
+    <%_ if (hibernateCache !== 'hazelcast') { _%>
+    @Inject
+    DiscoveryClient discoveryClient;
+    <%_ } _%>
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
@@ -144,6 +152,10 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
     private RestTemplate keyUriRestTemplate;
 
     private String getKeyFromAuthorizationServer() {
+        <%_ if (hibernateCache !== 'hazelcast') { _%>
+        // Load available UAA servers
+        discoveryClient.getServices();
+        <%_ } _%>
         HttpEntity<Void> request = new HttpEntity<Void>(new HttpHeaders());
         return (String) this.keyUriRestTemplate
             .exchange("http://<%= uaaBaseName %>/oauth/token_key", HttpMethod.GET, request, Map.class).getBody()

--- a/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
@@ -73,9 +73,7 @@ public class MicroserviceSecurityConfiguration extends WebSecurityConfigurerAdap
 import <%=packageName%>.security.AuthoritiesConstants;
 
 import org.springframework.beans.factory.annotation.Qualifier;
-<%_ if (hibernateCache !== 'hazelcast') { _%>
 import org.springframework.cloud.client.discovery.DiscoveryClient;
-<%_ } _%>
 import org.springframework.cloud.client.loadbalancer.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -104,10 +102,8 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
     @Inject
     JHipsterProperties jHipsterProperties;
 
-    <%_ if (hibernateCache !== 'hazelcast') { _%>
     @Inject
     DiscoveryClient discoveryClient;
-    <%_ } _%>
 
     @Override
     public void configure(HttpSecurity http) throws Exception {
@@ -152,10 +148,8 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
     private RestTemplate keyUriRestTemplate;
 
     private String getKeyFromAuthorizationServer() {
-        <%_ if (hibernateCache !== 'hazelcast') { _%>
         // Load available UAA servers
         discoveryClient.getServices();
-        <%_ } _%>
         HttpEntity<Void> request = new HttpEntity<Void>(new HttpHeaders());
         return (String) this.keyUriRestTemplate
             .exchange("http://<%= uaaBaseName %>/oauth/token_key", HttpMethod.GET, request, Map.class).getBody()


### PR DESCRIPTION
Fix #4005

This was the cleanest way I could find to fix the issue.  Normally Hazelcast calls the discovery client in CacheConfiguration.  You can confirm the call to `discoveryClient.getInstances(serviceId)` is the reason the app works by commenting it out and the app won't find any UAA servers (the issue).   Without a call to the discovery client, the UAA route is never loaded.  Please let me know if there's a better way.

Pinging @xetys as he was the other person working on the issue.