### PR TITLE
migrate home states to ui-router-ng2

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/_app.module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.module.ts
@@ -31,10 +31,6 @@ import { AuthInterceptor } from './blocks/interceptor/auth.interceptor';
 import { ErrorHandlerInterceptor } from './blocks/interceptor/errorhandler.interceptor';
 import { NotificationInterceptor } from './blocks/interceptor/notification.interceptor';
 
-import { AppStateConfig } from './app.state';
-import { HomeStateConfig } from './home/home.state';
-import { ErrorStateConfig } from './layouts/error/error.state';
-
 angular
     .module('<%=angularAppName%>.app', [
         'ngStorage',<% if (enableTranslation) { %>
@@ -60,9 +56,6 @@ angular
     .config(LocalStorageConfig)
     .config(PagerConfig)
     .config(PaginationConfig)
-    .config(AppStateConfig)
-    .config(HomeStateConfig)
-    .config(ErrorStateConfig)
     .config(UIRouterDeferInterceptConfig)
     .directive('home', <angular.IDirectiveFactory> upgradeAdapter.downgradeNg2Component(HomeComponent))
     .directive('navbar', <angular.IDirectiveFactory> upgradeAdapter.downgradeNg2Component(NavbarComponent))

--- a/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
@@ -1,5 +1,6 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
+import { UIRouterModule } from 'ui-router-ng2';
 import { Ng1ToNg2Module } from 'ui-router-ng1-to-ng2';
 
 import { <%=angular2AppName%>SharedModule } from './shared/shared.ng2module';
@@ -16,10 +17,25 @@ import { FooterComponent } from './layouts/footer/footer.component';
 import { ActiveMenuDirective } from './layouts/navbar/active-menu.directive';
 <%_ } _%>
 
+import { appState } from './app.state';
+import { homeState } from './home/home.state';
+import { errorState, accessdeniedState } from './layouts/error/error.state';
+
+let routerConfig = {
+    otherwise: '/',
+    states: [
+        appState,
+        homeState,
+        errorState,
+        accessdeniedState
+    ]
+};
+
 @NgModule({
     imports: [
         BrowserModule,
         Ng1ToNg2Module,
+        UIRouterModule.forRoot(routerConfig),
         <%=angular2AppName%>SharedModule,
         <%=angular2AppName%>CommonModule,
         <%=angular2AppName%>AdminModule,

--- a/generators/client-2/templates/src/main/webapp/app/_app.state.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.state.ts
@@ -1,23 +1,19 @@
+import { NavbarComponent } from './layouts/navbar/navbar.component';
 
-AppStateConfig.$inject = ['$stateProvider'];
-
-export function AppStateConfig($stateProvider) {
-    $stateProvider.state('app', {
-        abstract: true,
-        views: {
-            'navbar@': {
-                template: '<navbar></navbar>'
+export const appState = {
+    name: 'app',
+    abstract: true,
+    views: {
+        'navbar@': { component: NavbarComponent }
+    },
+    resolve: {
+        authorize: ['Auth',
+            function (Auth) {
+                return Auth.authorize();
             }
-        },
-        resolve: {
-            authorize: ['Auth',
-                function (Auth) {
-                    return Auth.authorize();
-                }
-            ]<% if (enableTranslation) { %>,
-            translatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
-                $translatePartialLoader.addPart('global');
-            }]<% } %>
-        }
-    });
-}
+        ],
+        translatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
+            $translatePartialLoader.addPart('global');
+        }]
+    }
+};

--- a/generators/client-2/templates/src/main/webapp/app/home/_home.state.ts
+++ b/generators/client-2/templates/src/main/webapp/app/home/_home.state.ts
@@ -1,22 +1,19 @@
-    HomeStateConfig.$inject = ['$stateProvider'];
+import { HomeComponent } from './home.component';
 
-    export function HomeStateConfig($stateProvider) {
-        $stateProvider.state('home', {
-            parent: 'app',
-            url: '/',
-            data: {
-                authorities: []
-            },
-            views: {
-                'content@': {
-                    template: '<home></home>'
-                }
-            },
-            resolve: {
-                mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
-                    $translatePartialLoader.addPart('home');
-                    return $translate.refresh();
-                }]
-            }
-        });
+export const homeState = {
+    name: 'home',
+    parent: 'app',
+    url: '/',
+    data: {
+        authorities: []
+    },
+    views: {
+        'content@': { component: HomeComponent }
+    },
+    resolve: {
+        mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
+            $translatePartialLoader.addPart('home');
+            return $translate.refresh();
+        }]
     }
+}

--- a/generators/client-2/templates/src/main/webapp/app/layouts/error/_error.state.ts
+++ b/generators/client-2/templates/src/main/webapp/app/layouts/error/_error.state.ts
@@ -1,42 +1,38 @@
-ErrorStateConfig.$inject = ['$stateProvider'];
+import { ErrorComponent } from './error.component';
 
-export function ErrorStateConfig($stateProvider) {
-    $stateProvider
-        .state('error', {
-            parent: 'app',
-            url: '/error',
-            data: {
-                authorities: [],
-                pageTitle: 'error.title'
-            },
-            views: {
-                'content@': {
-                    template: '<error></error>'
-                }
-            },
-            resolve: {
-                mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
-                    $translatePartialLoader.addPart('error');
-                    return $translate.refresh();
-                }]
-            }
-        })
-        .state('accessdenied', {
-            parent: 'app',
-            url: '/accessdenied',
-            data: {
-                authorities: []
-            },
-            views: {
-                'content@': {
-                    template: '<error></error>'
-                }
-            },
-            resolve: {
-                mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
-                    $translatePartialLoader.addPart('error');
-                    return $translate.refresh();
-                }]
-            }
-        });
+export const errorState = {
+    name: 'error',
+    parent: 'app',
+    url: '/error',
+    data: {
+        authorities: [],
+        pageTitle: 'error.title'
+    },
+    views: {
+        'content@': { component: ErrorComponent }
+    },
+    resolve: {
+        mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
+            $translatePartialLoader.addPart('error');
+            return $translate.refresh();
+        }]
+    }
+}
+
+export const accessdeniedState = {
+    name: 'accessdenied',
+    parent: 'app',
+    url: '/accessdenied',
+    data: {
+        authorities: []
+    },
+    views: {
+        'content@': { component: ErrorComponent }
+    },
+    resolve: {
+        mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
+            $translatePartialLoader.addPart('error');
+            return $translate.refresh();
+        }]
+    }
 }


### PR DESCRIPTION
@christopherthielen I migrated the admin routes to ui-router-ng2 but when i tried the same for the app state and home state it doesnt work. any hints? I tried both `UIRouterModule.forRoot` and `UIRouterModule.forChild` but nothing happens and there is no console error