### PR TITLE
set default serviceDiscoveryType if missing in .yo-rc.json

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -97,6 +97,9 @@ module.exports = DockerComposeGenerator.extend({
             this.useElk = this.config.get('useElk');
             this.useKafka = false;
             this.serviceDiscoveryType = this.config.get('serviceDiscoveryType');
+            if (this.serviceDiscoveryType === undefined) {
+                this.serviceDiscoveryType = 'eureka';
+            }
             this.adminPassword = this.config.get('adminPassword');
             this.jwtSecretKey = this.config.get('jwtSecretKey');
 
@@ -315,7 +318,7 @@ module.exports = DockerComposeGenerator.extend({
             if(this.serviceDiscoveryType === 'consul'){
                 this.template('_consul.yml', 'consul.yml');
             }
-            if(this.serviceDiscoveryType !== 'no'){
+            if(this.serviceDiscoveryType !== false){
                 this.template('central-server-config/_application.yml', 'central-server-config/application.yml');
             }
         },

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -318,7 +318,7 @@ module.exports = DockerComposeGenerator.extend({
             if(this.serviceDiscoveryType === 'consul'){
                 this.template('_consul.yml', 'consul.yml');
             }
-            if(this.serviceDiscoveryType !== false){
+            if(this.serviceDiscoveryType){
                 this.template('central-server-config/_application.yml', 'central-server-config/application.yml');
             }
         },

--- a/generators/docker-compose/prompts.js
+++ b/generators/docker-compose/prompts.js
@@ -175,12 +175,13 @@ function askForServiceDiscovery() {
 
     var serviceDiscoveryEnabledApps = [];
     this.appConfigs.forEach(function (appConfig, index) {
-        if(appConfig.serviceDiscoveryType !== 'no' && (appConfig.applicationType === 'microservice' || appConfig.applicationType === 'gateway')) {
+        if(appConfig.serviceDiscoveryType !== false && (appConfig.applicationType === 'microservice' || appConfig.applicationType === 'gateway')) {
             serviceDiscoveryEnabledApps.push({baseName: appConfig.baseName, serviceDiscoveryType: appConfig.serviceDiscoveryType});
         }
     }, this);
 
     if(serviceDiscoveryEnabledApps.length === 0) {
+        done();
         return;
     }
 

--- a/generators/docker-compose/prompts.js
+++ b/generators/docker-compose/prompts.js
@@ -175,7 +175,7 @@ function askForServiceDiscovery() {
 
     var serviceDiscoveryEnabledApps = [];
     this.appConfigs.forEach(function (appConfig, index) {
-        if(appConfig.serviceDiscoveryType !== false && (appConfig.applicationType === 'microservice' || appConfig.applicationType === 'gateway')) {
+        if(appConfig.serviceDiscoveryType && (appConfig.applicationType === 'microservice' || appConfig.applicationType === 'gateway')) {
             serviceDiscoveryEnabledApps.push({baseName: appConfig.baseName, serviceDiscoveryType: appConfig.serviceDiscoveryType});
         }
     }, this);

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -158,6 +158,9 @@ module.exports = JhipsterServerGenerator.extend({
             }
 
             this.serviceDiscoveryType = this.config.get('serviceDiscoveryType');
+            if (this.serviceDiscoveryType === undefined) {
+                this.serviceDiscoveryType = this.applicationType !== 'monolith' ? 'eureka' : false;
+            }
             this.databaseType = this.config.get('databaseType');
             if (this.databaseType === 'mongodb') {
                 this.devDatabaseType = 'mongodb';

--- a/generators/server/templates/src/main/java/package/_Application.java
+++ b/generators/server/templates/src/main/java/package/_Application.java
@@ -94,7 +94,7 @@ public class <%= mainClass %> {
             InetAddress.getLocalHost().getHostAddress(),
             env.getProperty("server.port"));
 
-        <%_ if (serviceDiscoveryType != 'no' && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
+        <%_ if (serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
         String configServerStatus = env.getProperty("configserver.status");
         log.info("\n----------------------------------------------------------\n\t" +
         "Config Server: \t{}\n----------------------------------------------------------",

--- a/generators/server/templates/src/main/java/package/_Application.java
+++ b/generators/server/templates/src/main/java/package/_Application.java
@@ -94,7 +94,7 @@ public class <%= mainClass %> {
             InetAddress.getLocalHost().getHostAddress(),
             env.getProperty("server.port"));
 
-        <%_ if (serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
+        <%_ if (serviceDiscoveryType && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
         String configServerStatus = env.getProperty("configserver.status");
         log.info("\n----------------------------------------------------------\n\t" +
         "Config Server: \t{}\n----------------------------------------------------------",

--- a/generators/server/templates/src/main/java/package/config/_CacheConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_CacheConfiguration.java
@@ -12,12 +12,12 @@ import com.hazelcast.config.MaxSizeConfig;<% } %>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
+<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 <%_ } _%>
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
+<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 <%_ } _%>
@@ -54,7 +54,7 @@ public class CacheConfiguration {
     private EntityManager entityManager;<% } %><% if (hibernateCache == 'hazelcast') { %>
 
     @Inject
-    private Environment env;<% } %><% if (hibernateCache == 'hazelcast' && serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { %>
+    private Environment env;<% } %><% if (hibernateCache == 'hazelcast' && serviceDiscoveryType && (applicationType == 'microservice' || applicationType == 'gateway')) { %>
 
     @Inject
     private DiscoveryClient discoveryClient;
@@ -133,7 +133,7 @@ public class CacheConfiguration {
         log.debug("Configuring Hazelcast");
         Config config = new Config();
         config.setInstanceName("<%=baseName%>");
-        <%_ if (serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
+        <%_ if (serviceDiscoveryType && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
         // The serviceId is by default the application's name, see Spring Boot's eureka.instance.appname property
         String serviceId = discoveryClient.getLocalServiceInstance().getServiceId();
         log.debug("Configuring Hazelcast clustering for instanceId: {}", serviceId);

--- a/generators/server/templates/src/main/java/package/config/_CacheConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_CacheConfiguration.java
@@ -12,12 +12,12 @@ import com.hazelcast.config.MaxSizeConfig;<% } %>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType != 'no' && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
+<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
 import org.springframework.boot.autoconfigure.web.ServerProperties;
 <%_ } _%>
 import org.springframework.cache.CacheManager;
 import org.springframework.cache.annotation.EnableCaching;
-<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType != 'no' && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
+<%_ if (hibernateCache == 'hazelcast' && serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 <%_ } _%>
@@ -54,7 +54,7 @@ public class CacheConfiguration {
     private EntityManager entityManager;<% } %><% if (hibernateCache == 'hazelcast') { %>
 
     @Inject
-    private Environment env;<% } %><% if (hibernateCache == 'hazelcast' && serviceDiscoveryType != 'no' && (applicationType == 'microservice' || applicationType == 'gateway')) { %>
+    private Environment env;<% } %><% if (hibernateCache == 'hazelcast' && serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { %>
 
     @Inject
     private DiscoveryClient discoveryClient;
@@ -133,7 +133,7 @@ public class CacheConfiguration {
         log.debug("Configuring Hazelcast");
         Config config = new Config();
         config.setInstanceName("<%=baseName%>");
-        <%_ if (serviceDiscoveryType != 'no' && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
+        <%_ if (serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway')) { _%>
         // The serviceId is by default the application's name, see Spring Boot's eureka.instance.appname property
         String serviceId = discoveryClient.getLocalServiceInstance().getServiceId();
         log.debug("Configuring Hazelcast clustering for instanceId: {}", serviceId);

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -50,7 +50,7 @@ public class LoggingConfiguration {
         LogstashSocketAppender logstashAppender = new LogstashSocketAppender();
         logstashAppender.setName("LOGSTASH");
         logstashAppender.setContext(context);
-        <%_ if (serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
+        <%_ if (serviceDiscoveryType && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
         String customFields = "{\"app_name\":\"" + appName + "\",\"app_port\":\"" + serverPort + "\"," +
             "\"instance_id\":\"" + instanceId + "\"}";
         <%_ } else { _%>

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -50,7 +50,7 @@ public class LoggingConfiguration {
         LogstashSocketAppender logstashAppender = new LogstashSocketAppender();
         logstashAppender.setName("LOGSTASH");
         logstashAppender.setContext(context);
-        <%_ if (serviceDiscoveryType != 'no' && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
+        <%_ if (serviceDiscoveryType !== false && (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa')) { _%>
         String customFields = "{\"app_name\":\"" + appName + "\",\"app_port\":\"" + serverPort + "\"," +
             "\"instance_id\":\"" + instanceId + "\"}";
         <%_ } else { _%>


### PR DESCRIPTION
If you run the generator on an old microservice, `serviceDiscoveryType` could be undefined.  This sets the default to `eureka` so the project can compile.

I also changed all comparisons from 'no' to false to match the value put in the .yo-rc.json.  