### PR TITLE
make enter submit the form instead of clear blobs

### DIFF
--- a/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
+++ b/generators/entity/templates/src/main/webapp/app/entities/_entity-management-dialog.html
@@ -57,12 +57,12 @@
                     <%_ } else { _%>
                     <span class="pull-left">{{vm.<%= entityInstance %>.<%= fieldName %>ContentType}}, {{vm.byteSize(vm.<%= entityInstance %>.<%= fieldName %>)}}</span>
                     <%_ } _%>
-                    <button ng-click="vm.<%= entityInstance %>.<%= fieldName %>=null;vm.<%= entityInstance %>.<%= fieldName %>ContentType=null;"
+                    <button type="button" ng-click="vm.<%= entityInstance %>.<%= fieldName %>=null;vm.<%= entityInstance %>.<%= fieldName %>ContentType=null;"
                             class="btn btn-default btn-xs pull-right">
                         <span class="glyphicon glyphicon-remove"></span>
                     </button>
                 </div>
-                <button type="file" ngf-select class="btn btn-default btn-block"
+                <button type="button" ngf-select class="btn btn-default btn-block"
                         ngf-change="vm.set<%=fieldNameCapitalized %>($file, vm.<%= entityInstance %>)"<% if (fieldTypeBlobContent == 'image') { %> accept="image/*" data-translate="entity.action.addimage"<% } else { %> data-translate="entity.action.addblob"<% } %>>
                     <% if (fieldTypeBlobContent == 'image') { %>Add image<% } else { %>Add blob<% } %>
                 </button>


### PR DESCRIPTION
If an entity contains a blob field, currently the blob's button 'hijacks' the `enter` to open the file dialog or clear the chosen file.  This fix improves the user experience by making the `enter` button submit the form as usual.  Everything else works the same.

This is part of the entity subgenerator so it doesn't need an Angular2 PR.