### PR TITLE
Gatling update

### DIFF
--- a/generators/entity/templates/src/test/gatling/simulations/_EntityGatlingTest.scala
+++ b/generators/entity/templates/src/test/gatling/simulations/_EntityGatlingTest.scala
@@ -28,7 +28,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
         .acceptHeader("*/*")
         .acceptEncodingHeader("gzip, deflate")
         .acceptLanguageHeader("fr,fr-fr;q=0.8,en-us;q=0.5,en;q=0.3")
-        .connection("keep-alive")
+        .connectionHeader("keep-alive")
         .userAgentHeader("Mozilla/5.0 (Macintosh; Intel Mac OS X 10.10; rv:33.0) Gecko/20100101 Firefox/33.0")
 
     val headers_http = Map(

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -856,7 +856,7 @@ module.exports = JhipsterServerGenerator.extend({
             // Create Gatling test files
             if (this.testFrameworks.indexOf('gatling') !== -1) {
                 this.copy(TEST_DIR + 'gatling/conf/gatling.conf', TEST_DIR + 'gatling/conf/gatling.conf');
-                this.copy(TEST_DIR = 'gatling/conf/logback.xml', TEST_DIR + 'gatling/conf/logback.xml');
+                this.copy(TEST_DIR + 'gatling/conf/logback.xml', TEST_DIR + 'gatling/conf/logback.xml');
                 mkdirp(TEST_DIR + 'gatling/data');
                 mkdirp(TEST_DIR + 'gatling/bodies');
                 mkdirp(TEST_DIR + 'gatling/simulations');

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -856,7 +856,7 @@ module.exports = JhipsterServerGenerator.extend({
             // Create Gatling test files
             if (this.testFrameworks.indexOf('gatling') !== -1) {
                 this.copy(TEST_DIR + 'gatling/conf/gatling.conf', TEST_DIR + 'gatling/conf/gatling.conf');
-                this.copy(TEST_DIR = 'gatling/conf/logback.xml',, TEST_DIR + 'gatling/conf/logback.xml');
+                this.copy(TEST_DIR = 'gatling/conf/logback.xml', TEST_DIR + 'gatling/conf/logback.xml');
                 mkdirp(TEST_DIR + 'gatling/data');
                 mkdirp(TEST_DIR + 'gatling/bodies');
                 mkdirp(TEST_DIR + 'gatling/simulations');

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -856,6 +856,7 @@ module.exports = JhipsterServerGenerator.extend({
             // Create Gatling test files
             if (this.testFrameworks.indexOf('gatling') !== -1) {
                 this.copy(TEST_DIR + 'gatling/conf/gatling.conf', TEST_DIR + 'gatling/conf/gatling.conf');
+                this.copy(TEST_DIR = 'gatling/conf/logback.xml',, TEST_DIR + 'gatling/conf/logback.xml');
                 mkdirp(TEST_DIR + 'gatling/data');
                 mkdirp(TEST_DIR + 'gatling/bodies');
                 mkdirp(TEST_DIR + 'gatling/simulations');

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -301,10 +301,10 @@ dependencies {
     testCompile "com.mattbertolini:liquibase-slf4j:${liquibase_slf4j_version}"<% } %><% if (databaseType == 'mongodb') { %>
     testCompile "de.flapdoodle.embed:de.flapdoodle.embed.mongo"<% } %>
     testCompile "org.hamcrest:hamcrest-library"
-    <% if (testFrameworks.indexOf('gatling') != -1) { %>
+    <%_ if (testFrameworks.indexOf('gatling') != -1) { _%>
     testCompile "io.gatling.highcharts:gatling-charts-highcharts:${gatling_version}"
-    <%_ if (databaseType === 'cassandra') {
-    compile "io.netty:netty-handler:4.0.36.Final"<% }} %>
+    <%_ if (databaseType === 'cassandra') { _%>
+    compile "io.netty:netty-handler:4.0.36.Final"<%_ } _%><%_ } _%>
     <% if (devDatabaseType != 'h2Disk' && devDatabaseType != 'h2Memory') { %>
     testCompile "com.h2database:h2"<% } %><% if (devDatabaseType == 'oracle' || prodDatabaseType == 'oracle') { %>
     <%_ if (messageBroker === 'kafka') { _%>

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -302,7 +302,9 @@ dependencies {
     testCompile "de.flapdoodle.embed:de.flapdoodle.embed.mongo"<% } %>
     testCompile "org.hamcrest:hamcrest-library"
     <% if (testFrameworks.indexOf('gatling') != -1) { %>
-    testCompile "io.gatling.highcharts:gatling-charts-highcharts:${gatling_version}"<% } %>
+    testCompile "io.gatling.highcharts:gatling-charts-highcharts:${gatling_version}"
+    <%_ if (databaseType === 'cassandra') {
+    compile "io.netty:netty-handler:4.0.36.Final"<% }} %>
     <% if (devDatabaseType != 'h2Disk' && devDatabaseType != 'h2Memory') { %>
     testCompile "com.h2database:h2"<% } %><% if (devDatabaseType == 'oracle' || prodDatabaseType == 'oracle') { %>
     <%_ if (messageBroker === 'kafka') { _%>

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -49,7 +49,7 @@ mariadb_java_client_version=1.4.4
 <%_ } _%>
 h2_version=1.4.188
 <% if (testFrameworks.indexOf('gatling') != -1) { %>
-gatling_version=2.1.7<% } %>
+gatling_version=2.2.0<% } %>
 mapstruct_version=1.0.0.Final<% if (enableSocialSignIn) { %>
 spring_social_google_version=1.0.0.RELEASE<% } %>
 

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -345,6 +345,13 @@
             <version>${gatling.version}</version>
             <scope>test</scope>
         </dependency>
+        <!-- include netty handler explicitly to overcome dependency mismatch when using cassandra -->
+        <%_ if (databaseType === 'cassandra') { _%>
+        <dependency>
+            <groupId>io.netty</groupId>
+            <artifactId>netty-handler</artifactId>
+            <version>4.0.36.Final</version>
+        </dependency><%_ } _%>
         <%_ } _%>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -351,7 +351,8 @@
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
             <version>4.0.36.Final</version>
-        </dependency><%_ } _%>
+        </dependency>
+        <%_ } _%>
         <%_ } _%>
         <dependency>
             <groupId>javax.inject</groupId>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -43,8 +43,8 @@
         <frontend-maven-plugin.version>1.0</frontend-maven-plugin.version>
         <%_ } _%>
         <%_ if (testFrameworks.indexOf('gatling') != -1) { _%>
-        <gatling.version>2.1.7</gatling.version>
-        <gatling-maven-plugin.version>2.1.7</gatling-maven-plugin.version>
+        <gatling.version>2.2.0</gatling.version>
+        <gatling-maven-plugin.version>2.2.0</gatling-maven-plugin.version>
         <%_ } _%>
         <%_ if (clusteredHttpSession === 'hazelcast' || hibernateCache === 'hazelcast') { _%>
         <hazelcast.version>3.6.5</hazelcast.version>
@@ -801,6 +801,9 @@
                     <resultsFolder>target/gatling/results</resultsFolder>
                     <bodiesFolder><%= TEST_DIR %>gatling/bodies</bodiesFolder>
                     <simulationsFolder><%= TEST_DIR %>gatling/simulations</simulationsFolder>
+                    <!-- This will run multiple simulations one by one. Useful when doing gatling tests in CI
+                         You must remove the simulationClass property in order to run multiple simulations -->
+                    <!--<runMultipleSimulations>true</runMultipleSimulations>-->
                     <!-- This will force Gatling to ask which simulation to run
                       This is useful when you have multiple simulations -->
                     <simulationClass>*</simulationClass>

--- a/generators/server/templates/gradle/_gatling.gradle
+++ b/generators/server/templates/gradle/_gatling.gradle
@@ -20,27 +20,52 @@ task manifestJar(dependsOn:'compileTestScala',type: Jar) {
     }
 }
 
-task gatlingRun(dependsOn:'manifestJar', type: JavaExec) {
+task gatlingRun(dependsOn:'manifestJar') << {
     group = "gatling"
 
+    println project.properties
+    def String gatlingSimulationClass = "*"
+    if (project.hasProperty('gatlingSimulationClass')) {
+        gatlingSimulationClass = project.property('gatlingSimulationClass')
+    }
     standardInput = System.in
 
-    final def sourceSet = sourceSets.test
-    File configFile = file('<%= TEST_DIR %>gatling/conf/gatling.conf')
+    createGatlingRunTask(gatlingSimulationClassName).dependsOn('manifestJar').execute()
+}
 
-    def String gatlingDataFolder = "$project.rootDir.absolutePath/<%= TEST_DIR %>gatling/data"
-    def String gatlingReportsFolder = "$project.buildDir.absolutePath/reports/gatling"
-    def String gatlingBodiesFolder = "$project.rootDir.absolutePath/<%= TEST_DIR %>gatling/bodies"
-    def String gatlingSimulationsFolder = "$project.rootDir.absolutePath/<%= TEST_DIR %>gatling/simulations"
+task gatlingRunAll(dependsOn: 'manifestJar') << {
+    group = "gatling"
 
-    classpath sourceSet.output + files(manifestJar.archivePath) + files("<%= TEST_DIR %>gatling/conf")
-    main = "io.gatling.app.Gatling"
+    FileTree tree = fileTree(dir: './src/test/gatling/simulations')
+    tree.include '**/*.scala'
+    tree.each {File file ->
+        def simulationClassName = file.name.replaceFirst(".scala", "")
+        createGatlingRunTask(simulationClassName).dependsOn('manifestJar').execute();
+    }
+}
 
-    environment GATLING_HOME:''
+def createGatlingRunTask(def gatlingSimulationClassName) {
+    return tasks.create("gatlingRun${gatlingSimulationClassName}", JavaExec) {
 
-    args '-df', gatlingDataFolder
-    args '-rf', gatlingReportsFolder
-    args '-bdf', gatlingBodiesFolder
-    args "-sf", gatlingSimulationsFolder
+        standardInput = System.in
 
+        final def sourceSet = sourceSets.test
+
+        def String gatlingDataFolder = "$project.rootDir.absolutePath/src/test/gatling/data"
+        def String gatlingReportsFolder = "$project.buildDir.absolutePath/reports/gatling"
+        def String gatlingBodiesFolder = "$project.rootDir.absolutePath/src/test/gatling/bodies"
+        def String gatlingSimulationsFolder = "$project.rootDir.absolutePath/src/test/gatling/simulations"
+
+        classpath sourceSet.output + files(manifestJar.archivePath) + files("src/test/gatling/conf")
+        main = "io.gatling.app.Gatling"
+
+        environment GATLING_HOME:''
+
+        args '-df', gatlingDataFolder
+        args '-rf', gatlingReportsFolder
+        args '-bdf', gatlingBodiesFolder
+        args '-sf', gatlingSimulationsFolder
+        args '-m'
+        args '-s', gatlingSimulationClassName
+    }
 }

--- a/generators/server/templates/gradle/_gatling.gradle
+++ b/generators/server/templates/gradle/_gatling.gradle
@@ -23,12 +23,10 @@ task manifestJar(dependsOn:'compileTestScala',type: Jar) {
 task gatlingRun(dependsOn:'manifestJar') << {
     group = "gatling"
 
-    println project.properties
     def String gatlingSimulationClass = "*"
     if (project.hasProperty('gatlingSimulationClass')) {
         gatlingSimulationClass = project.property('gatlingSimulationClass')
     }
-    standardInput = System.in
 
     createGatlingRunTask(gatlingSimulationClassName).dependsOn('manifestJar').execute()
 }

--- a/generators/server/templates/src/test/gatling/conf/logback.xml
+++ b/generators/server/templates/src/test/gatling/conf/logback.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<configuration>
+
+    <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%-5level] %logger{15} - %msg%n%rEx</pattern>
+            <immediateFlush>false</immediateFlush>
+        </encoder>
+    </appender>
+
+    <!-- Uncomment for logging ALL HTTP request and responses -->
+    <!--    <logger name="io.gatling.http.ahc" level="TRACE" /> -->
+    <!--    <logger name="io.gatling.http.response" level="TRACE" /> -->
+    <!-- Uncomment for logging ONLY FAILED HTTP request and responses -->
+    <!--    <logger name="io.gatling.http.ahc" level="DEBUG" /> -->
+    <!--    <logger name="io.gatling.http.response" level="DEBUG" /> -->
+
+    <root level="WARN">
+        <appender-ref ref="CONSOLE" />
+    </root>
+
+</configuration>


### PR DESCRIPTION
* Upgrade gatling to latest 2.2.0
* Add ``logback.xml`` to overwrite gatling logging at a central place
* Some new gradle tasks and configuration options:
*  ``gatlingRun -PgatlingSimulationClass=SIMULATION_TO_EXECUTE`` you can execute one specific gatling test
*  ``gatlingRunAll`` runs all simulation in ``src/test/gatling/simulations``
* Add commented property to maven plugin to run multiple simulations. Maybe we could add a profile to execute all gatling tests (e.g. in CI) as ``simulationClass`` and ``runMultipleSimulations`` always results in the default behaviour (= asking which simulation to execute). I was able to overwrite ``simulationClass`` via command line parameters, but not ``runMultipleSimulations``

EDIT: I will update the documentation accordingly soon.