### PR TITLE
ng2: fix ui-router-ng2 initialization

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/_app.main.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.main.ts
@@ -1,9 +1,10 @@
 import { UpgradeAdapterRef } from '@angular/upgrade';
 import { upgradeAdapter } from './upgrade_adapter';
+import { UrlRouter } from 'ui-router-ng2';
 import './app.module';
 
 function readyFn(ref: UpgradeAdapterRef) {
-    let $urlRouter = ref.ng1Injector.get('$urlRouter');
+    let $urlRouter = ref.ng2Injector.get(UrlRouter);
     $urlRouter.listen();
     $urlRouter.sync();
 }

--- a/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
@@ -13,6 +13,7 @@ import { XSRFStrategyProvider } from './shared/XSRF-strategy.provider';
 import { HomeComponent } from './home/home.component';
 import { NavbarComponent } from './layouts/navbar/navbar.component';
 import { FooterComponent } from './layouts/footer/footer.component';
+import { ErrorComponent } from './layouts/error/error.component';
 <%_ if (enableTranslation){ _%>
 import { ActiveMenuDirective } from './layouts/navbar/active-menu.directive';
 <%_ } _%>
@@ -35,7 +36,7 @@ let routerConfig = {
     imports: [
         BrowserModule,
         Ng1ToNg2Module,
-        UIRouterModule.forRoot(routerConfig),
+        UIRouterModule.forChild(routerConfig),
         <%=angular2AppName%>SharedModule,
         <%=angular2AppName%>CommonModule,
         <%=angular2AppName%>AdminModule,
@@ -44,6 +45,7 @@ let routerConfig = {
     declarations: [
         HomeComponent,
         NavbarComponent,
+        ErrorComponent,
         FooterComponent<%_ if (enableTranslation){ _%>,
         ActiveMenuDirective
         <%_ } _%>

--- a/generators/client-2/templates/src/main/webapp/app/components/_common.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/components/_common.ng2module.ts
@@ -51,7 +51,7 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         AuthServerProvider
     ],
     exports: [
-        jhiAlertComponent,
+        JhiAlertComponent,
         JhiAlertErrorComponent,
         HasAuthorityDirective,
         HasAnyAuthorityDirective

--- a/generators/client-2/templates/src/main/webapp/app/shared/component/jhi-item-count.component.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/component/jhi-item-count.component.ts
@@ -2,7 +2,7 @@ import { Component, Input } from '@angular/core';
 
 @Component({
     selector: 'jhi-item-count',
-    inputs: ['page', 'total', 'itemsPerPage'],
+    inputs: ['page', 'total', 'itemsPerPage:items-per-page'],
     template: `
         <div class="info">
             Showing {{((page - 1) * itemsPerPage) == 0 ? 1 : ((page - 1) * itemsPerPage + 1)}} -

--- a/generators/client-2/templates/src/main/webapp/app/shared/directive/sort-by.directive.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/directive/sort-by.directive.ts
@@ -3,7 +3,7 @@ import { JhSortDirective } from './sort.directive';
 
 @Directive({
     selector: '[jh-sort-by]',
-    inputs: ['jhSortBy'],
+    inputs: ['jhSortBy:jh-sort-by'],
     host: {
         '(click)': 'onClick()'
     }

--- a/generators/client-2/templates/src/main/webapp/app/shared/directive/sort.directive.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/directive/sort.directive.ts
@@ -2,7 +2,7 @@ import { Directive, Host, OnInit, Renderer, EventEmitter, ElementRef } from '@an
 
 @Directive({
     selector: '[jh-sort]',
-    inputs: ['predicate:jhSort', 'ascending', 'callback'],
+    inputs: ['predicate:jh-sort', 'ascending', 'callback'],
     outputs: ['jhSortChange', 'ascendingChange'],
     host: {
         '(click)': 'onClick()'


### PR DESCRIPTION
inject `UrlRouter` from `ui-router-ng2` triggers ng2 initialization

this is apparently necessary because none of the ui-router-ng2 code was injected, so it never got initialized.  Injecting `UrlRouter` triggers DI which in turn initializes the ng1-to-ng2 code, which in turn registers states, etc.

Fell free to squash or whatever. I merged from deepu105/ng2-ui-router