### PR TITLE
Docker-compose subgenerator: fix monolith application

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -107,6 +107,8 @@ module.exports = DockerComposeGenerator.extend({
     },
 
     prompting: {
+        askForApplicationType: prompts.askForApplicationType,
+
         askForPath: prompts.askForPath,
 
         askForApps: prompts.askForApps,

--- a/generators/kubernetes/prompts.js
+++ b/generators/kubernetes/prompts.js
@@ -4,37 +4,10 @@ var _ = require('lodash'),
     dockerComposePrompts = require('../docker-compose/prompts');
 
 module.exports = _.extend({
-    askForApplicationType,
     askForKubernetesNamespace,
     askForDockerRepositoryName,
     askForDockerPushCommand
 }, dockerComposePrompts);
-
-function askForApplicationType() {
-    var done = this.async();
-
-    var prompts = [{
-        type: 'list',
-        name: 'kubernetesApplicationType',
-        message: 'Which *type* of application would you like to deploy?',
-        choices: [
-            {
-                value: 'monolith',
-                name: 'Monolithic application'
-            },
-            {
-                value: 'microservice',
-                name: 'Microservice application'
-            }
-        ],
-        default: 'monolith'
-    }];
-
-    this.prompt(prompts).then(function(props) {
-        this.kubernetesApplicationType = props.kubernetesApplicationType;
-        done();
-    }.bind(this));
-}
 
 function askForKubernetesNamespace() {
     var done = this.async();

--- a/test/test-docker-compose.js
+++ b/test/test-docker-compose.js
@@ -15,6 +15,9 @@ const expectedFiles = {
     elk : [
         'jhipster-console.yml',
         'log-conf/logstash.conf'
+    ],
+    monolith : [
+        'docker-compose.yml'
     ]
 };
 
@@ -28,6 +31,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway'
@@ -50,6 +54,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '02-mysql'
@@ -72,6 +77,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway',
@@ -95,6 +101,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway',
@@ -122,6 +129,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                 })
                 .withOptions({force: true})
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway',
@@ -149,6 +157,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway',
@@ -178,6 +187,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway',
@@ -208,6 +218,7 @@ describe('JHipster Docker Compose Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     'chosenApps': [
                         '01-gateway',
@@ -223,6 +234,29 @@ describe('JHipster Docker Compose Sub Generator', function () {
         });
         it('creates expected elk files', function () {
             assert.file(expectedFiles.elk);
+        });
+    });
+
+    describe('monolith', function () {
+        beforeEach(function (done) {
+            helpers
+                .run(require.resolve('../generators/docker-compose'))
+                .inTmpDir(function (dir) {
+                    fse.copySync(path.join(__dirname, './templates/compose/'), dir);
+                })
+                .withPrompts({
+                    composeApplicationType: 'monolith',
+                    directoryPath: './',
+                    'chosenApps': [
+                        '08-monolith'
+                    ],
+                    clusteredDbApps: [],
+                    elk: true
+                })
+                .on('end', done);
+        });
+        it('creates expected default files', function () {
+            assert.file(expectedFiles.monolith);
         });
     });
 });

--- a/test/test-kubernetes.js
+++ b/test/test-kubernetes.js
@@ -51,7 +51,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
-                    kubernetesApplicationType: 'microservice',
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     chosenApps: [
                         '01-gateway'
@@ -82,7 +82,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
-                    kubernetesApplicationType: 'microservice',
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     chosenApps: [
                         '01-gateway',
@@ -113,7 +113,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
-                    kubernetesApplicationType: 'microservice',
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     chosenApps: [
                         '02-mysql',
@@ -147,7 +147,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
-                    kubernetesApplicationType: 'microservice',
+                    composeApplicationType: 'microservice',
                     directoryPath: './',
                     chosenApps: [
                         '01-gateway',
@@ -190,7 +190,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                     fse.copySync(path.join(__dirname, './templates/compose/'), dir);
                 })
                 .withPrompts({
-                    kubernetesApplicationType: 'monolith',
+                    composeApplicationType: 'monolith',
                     directoryPath: './',
                     chosenApps: [
                         '08-monolith'
@@ -201,7 +201,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 })
                 .on('end', done);
         });
-        it('create expected registry files', function () {
+        it('creates expected registry files', function () {
             assert.noFile(expectedFiles.registry);
         });
         it('creates expected default files', function () {


### PR DESCRIPTION
I'm working on kubernetes sub generator and I found that the sub generator for docker-compose is broken when I choose monolith application.
So I'm fixing it and I added npm tests for these configurations