### PR TITLE
upgrade to bootstrap 3.3.7

### DIFF
--- a/generators/client/templates/_bower.json
+++ b/generators/client/templates/_bower.json
@@ -27,7 +27,7 @@
     <%_ if (useSass) { _%>
     "bootstrap-sass": "3.3.7",
     <%_ } else { _%>
-    "bootstrap": "3.3.6",
+    "bootstrap": "3.3.7",
     <%_ } _%>
     "bootstrap-ui-datetime-picker": "2.4.3",
     "jquery": "3.1.0",


### PR DESCRIPTION
this bootstrap upgrade depends on jquery 3, used by jhipster,
see http://blog.getbootstrap.com/2016/07/25/bootstrap-3-3-7-released/