### PR TITLE
Fix generated README [ci skip]

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -186,6 +186,9 @@ module.exports = JhipsterServerGenerator.extend({
             this.buildTool = this.config.get('buildTool');
             this.enableSocialSignIn = this.config.get('enableSocialSignIn');
             this.jhipsterVersion = this.config.get('jhipsterVersion');
+            if (this.jhipsterVersion === undefined) {
+                this.jhipsterVersion = packagejs.version;
+            }
             this.authenticationType = this.config.get('authenticationType');
             if (this.authenticationType === 'session') {
                 this.rememberMeKey = this.config.get('rememberMeKey');


### PR DESCRIPTION
Fix the current README which has all links broken, with undefined value:

```
# jhipster

This application was generated using JHipster , you can find documentation and help at [https://jhipster.github.io/documentation-archive/vundefined](https://jhipster.github.io/documentation-archive/vundefined).
```

```
[JHipster Homepage and latest documentation]: https://jhipster.github.io
[JHipster  archive]: https://jhipster.github.io/documentation-archive/vundefined

[Using JHipster in development]: https://jhipster.github.io/documentation-archive/vundefined/development/
[Using Docker and Docker-Compose]: https://jhipster.github.io/documentation-archive/vundefined/docker-compose
[Using JHipster in production]: https://jhipster.github.io/documentation-archive/vundefined/production/
[Running tests page]: https://jhipster.github.io/documentation-archive/vundefined/running-tests/
[Setting up Continuous Integration]: https://jhipster.github.io/documentation-archive/vundefined/setting-up-ci/
```