### PR TITLE
Travis: add uaa+gateway build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -39,6 +39,7 @@ env:
     - JHIPSTER=app-microservice-eureka
     - JHIPSTER=app-gateway-consul
     - JHIPSTER=app-microservice-consul
+    - JHIPSTER=app-gateway-uaa
 
 before_install:
   - sudo /etc/init.d/postgresql stop

--- a/travis/samples/app-gateway-uaa/.yo-rc.json
+++ b/travis/samples/app-gateway-uaa/.yo-rc.json
@@ -1,0 +1,33 @@
+{
+  "generator-jhipster": {
+    "baseName": "travisDefault",
+    "packageName": "io.github.jhipster.travis",
+    "packageFolder": "io/github/jhipster/travis",
+    "serverPort": "8080",
+    "authenticationType": "uaa",
+    "uaaBaseName": "travisUaa",
+    "hibernateCache": "hazelcast",
+    "clusteredHttpSession": false,
+    "websocket": false,
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": false,
+    "messageBroker": false,
+    "serviceDiscoveryType": "eureka",
+    "buildTool": "maven",
+    "enableSocialSignIn": false,
+    "useSass": false,
+    "applicationType": "gateway",
+    "testFrameworks": [
+      "gatling"
+    ],
+    "jhiPrefix": "jhi",
+    "enableTranslation": true,
+    "nativeLanguage": "en",
+    "languages": [
+      "en"
+    ],
+  "travis": true
+  }
+}

--- a/travis/samples/app-gateway-uaa/uaa/.yo-rc.json
+++ b/travis/samples/app-gateway-uaa/uaa/.yo-rc.json
@@ -1,0 +1,32 @@
+{
+  "generator-jhipster": {
+    "baseName": "travisUaa",
+    "packageName": "io.github.jhipster.travis",
+    "packageFolder": "io/github/jhipster/travis",
+    "serverPort": "9999",
+    "authenticationType": "uaa",
+    "hibernateCache": "hazelcast",
+    "clusteredHttpSession": false,
+    "websocket": false,
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": false,
+    "messageBroker": false,
+    "serviceDiscoveryType": "eureka",
+    "buildTool": "maven",
+    "enableSocialSignIn": false,
+    "enableTranslation": true,
+    "applicationType": "uaa",
+    "testFrameworks": [
+      "gatling"
+    ],
+    "jhiPrefix": "jhi",
+    "skipClient": true,
+    "nativeLanguage": "en",
+    "languages": [
+      "en"
+    ],
+  "travis": true
+  }
+}

--- a/travis/scripts/01-generate-project.sh
+++ b/travis/scripts/01-generate-project.sh
@@ -9,6 +9,14 @@ mv "$JHIPSTER_TRAVIS"/configstore/*.json "$HOME"/.config/configstore/
 #-------------------------------------------------------------------------------
 # Generate the project with yo jhipster
 #-------------------------------------------------------------------------------
+if [ "$JHIPSTER" == "app-gateway-uaa" ]; then
+    mkdir -p "$HOME"/uaa
+    mv -f "$JHIPSTER_SAMPLES"/"$JHIPSTER"/uaa/.yo-rc.json "$HOME"/uaa/
+    cd "$HOME"/uaa
+    yo jhipster --force --no-insight
+    ls -al "$HOME"/uaa
+fi
+
 mkdir -p "$HOME"/app
 mv -f "$JHIPSTER_SAMPLES"/"$JHIPSTER"/.yo-rc.json "$HOME"/app/
 cd "$HOME"/app

--- a/travis/scripts/02-generate-entities.sh
+++ b/travis/scripts/02-generate-entities.sh
@@ -89,6 +89,15 @@ elif [[ ("$JHIPSTER" == "app-mysql") || ("$JHIPSTER" == "app-psql-es-noi18n") ]]
   moveEntity EntityWithServiceImplAndPagination
   moveEntity EntityWithServiceImplPaginationAndDTO
 
+elif [ "$JHIPSTER" == "app-gateway-uaa" ]; then
+  moveEntity FieldTestEntity
+  moveEntity FieldTestMapstructEntity
+  moveEntity FieldTestServiceClassEntity
+  moveEntity FieldTestServiceImplEntity
+  moveEntity FieldTestInfiniteScrollEntity
+  moveEntity FieldTestPagerEntity
+  moveEntity FieldTestPaginationEntity
+
 else
   moveEntity BankAccount
   moveEntity Label

--- a/travis/scripts/03-docker-compose.sh
+++ b/travis/scripts/03-docker-compose.sh
@@ -38,6 +38,11 @@ elif [[ ("$JHIPSTER" == 'app-gateway-consul') || ("$JHIPSTER" == 'app-microservi
     if [ -a src/main/docker/consul.yml ]; then
         docker-compose -f src/main/docker/consul.yml up -d
     fi
+
+elif [[ "$JHIPSTER" == 'app-gateway-uaa' ]]; then
+    if [ -a src/main/docker/jhipster-registry.yml ]; then
+        docker-compose -f src/main/docker/jhipster-registry.yml up -d
+    fi
 fi
 
 docker ps -a

--- a/travis/scripts/04-tests.sh
+++ b/travis/scripts/04-tests.sh
@@ -1,14 +1,22 @@
 #!/bin/bash
 set -ev
+#-------------------------------------------------------------------------------
+# Launch UAA tests
+#-------------------------------------------------------------------------------
+if [ "$JHIPSTER" == "app-gateway-uaa" ]; then
+    cd "$HOME"/uaa
+    ./mvnw test
+fi
+
 #--------------------------------------------------
 # Launch tests
 #--------------------------------------------------
 cd "$HOME"/app
 if [ -f "mvnw" ]; then
-  ./mvnw test
+    ./mvnw test
 elif [ -f "gradlew" ]; then
-  ./gradlew test
+    ./gradlew test
 fi
 if [ -f "gulpfile.js" ]; then
-  gulp test --no-notification
+    gulp test --no-notification
 fi


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/4280

Here all the changes:
- add travis build for uaa
    - it was a little bit complex because we need to generate 2 apps (uaa + gateway), test both and start both
    - it is a perfect to test https://github.com/jhipster/generator-jhipster/issues/4283
- launch curl or protractor -> that means we will now test if the application is correctly started

See the previous build in 3.9.0 which failed:
https://travis-ci.org/pascalgrimaud/generator-jhipster/builds/166540393

With 3.9.1, it should be fixed

To resume:
- total of 16 builds
- 4 slots left to test NG2
- Elapsed time: 40min~
