### PR TITLE
Add listener to re-add logstash appender when config is reset

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -1,7 +1,10 @@
 package <%=packageName%>.config;
 
 import ch.qos.logback.classic.AsyncAppender;
+import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.spi.LoggerContextListener;
+import ch.qos.logback.core.spi.ContextAwareBase;
 import net.logstash.logback.appender.LogstashSocketAppender;
 import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
 import org.slf4j.Logger;
@@ -40,11 +43,16 @@ public class LoggingConfiguration {
     @PostConstruct
     private void init() {
         if (jHipsterProperties.getLogging().getLogstash().isEnabled()) {
-            addLogstashAppender();
+            addLogstashAppender(context);
+
+            // Add context listener
+            LogbackLoggerContextListener loggerContextListener = new LogbackLoggerContextListener();
+            loggerContextListener.setContext(context);
+            context.addListener(loggerContextListener);
         }
     }
 
-    public void addLogstashAppender() {
+    public void addLogstashAppender(LoggerContext context) {
         log.info("Initializing Logstash logging");
 
         LogstashSocketAppender logstashAppender = new LogstashSocketAppender();
@@ -80,4 +88,37 @@ public class LoggingConfiguration {
 
         context.getLogger("ROOT").addAppender(asyncLogstashAppender);
     }
+
+
+    /**
+     * Logback configuration is achieved by configuration file and API.
+     * When configuration file change is detected, the configuration is reset.
+     * This listener ensures that the programmatic configuration is also re-applied after reset.
+     */
+    class LogbackLoggerContextListener extends ContextAwareBase implements LoggerContextListener {
+
+        @Override
+        public boolean isResetResistant() {
+            return true;
+        }
+
+        @Override
+        public void onStart(LoggerContext context) {
+            addLogstashAppender(context);
+        }
+
+        @Override
+        public void onReset(LoggerContext context) {
+            addLogstashAppender(context);
+        }
+
+        @Override
+        public void onStop(LoggerContext context) {
+        }
+
+        @Override
+        public void onLevelChange(ch.qos.logback.classic.Logger logger, Level level) {
+        }
+    }
+
 }


### PR DESCRIPTION
Logback configuration is achieved by configuration file and API.
When configuration file change is detected, the configuration is reset.
This listener ensures that the programmatic configuration is also re-applied after reset.

Fixes #4031