### PR TITLE
fix https://github.com/jhipster/generator-jhipster/issues/4309

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1630,11 +1630,11 @@ Generator.prototype.formatAsFieldJavadoc = function (text) {
 };
 
 Generator.prototype.formatAsApiModel = function (text) {
-    return jhipsterUtils.wordwrap(text.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"'), WORD_WRAP_WIDTH - 9, '"\n    + "', true);
+    return text;
 };
 
 Generator.prototype.formatAsApiModelProperty = function (text) {
-    return jhipsterUtils.wordwrap(text.replace(/\\/g, '\\\\').replace(/\"/g, '\\\"'), WORD_WRAP_WIDTH - 13, '"\n        + "', true);
+    return text;
 };
 
 Generator.prototype.isNumber = function (input) {


### PR DESCRIPTION
fix [issues/4309](https://github.com/jhipster/generator-jhipster/issues/4309)

the [wordwrap](https://github.com/jhipster/generator-jhipster/blob/master/generators/util.js#L200)
```javascript
function wordwrap (text, width, seperator, keepLF) {
    var wrappedText = '';
    var rows = text.split('\n');
    for (var i = 0; i < rows.length; i++) {
        var row = rows[i];
        if (keepLF === true && i !== 0) {
            wrappedText = wrappedText + '\\n';
        }
        wrappedText = wrappedText + seperator + _.padEnd(row,width) + seperator;
    }
    return wrappedText;
}
```
because of _loadjson(in the [entity/index.js#L197](https://github.com/jhipster/generator-jhipster/blob/master/generators/entity/index.js#L197))

```javascript
 try {
            this.fileData = this.fs.readJSON(this.fromPath);
        } catch (err) {
            this.error(chalk.red('\nThe entity configuration file could not be read!\n'));
        }
```

this.fileData.javadoc  result allways in one line,so ,wordwrap [rows](https://github.com/jhipster/generator-jhipster/blob/master/generators/util.js#L202) allways eq 1,

so `wrappedText = wrappedText + seperator + _.padEnd(row,width) + seperator;` == `wrappedText =seperator + _.padEnd(row,width) + seperator;`


and many space because of _.[padEnd](https://lodash.com/docs/4.16.4#padEnd)(row,[width](https://github.com/jhipster/generator-jhipster/blob/master/generators/generator-base.js#L19))
padding width-row.length space to wrappedText

i don't think need to keep wordwrap function in @ApiOperation.

 [4309/#issuecomment-254116002](https://github.com/jhipster/generator-jhipster/issues/4309/#issuecomment-254116002)