### PR TITLE
Add error handler for app injections

### DIFF
--- a/generators/client/templates/gulp/_inject.js
+++ b/generators/client/templates/gulp/_inject.js
@@ -22,6 +22,7 @@ module.exports = {
 function app() {
     return gulp.src(config.app + 'index.html')
         .pipe(inject(gulp.src(config.app + 'app/**/*.js')
+            .pipe(plumber({errorHandler: handleErrors}))
             .pipe(naturalSort())
             .pipe(angularFilesort()), {relative: true}))
         .pipe(gulp.dest(config.app));


### PR DESCRIPTION
Add error handler for app injections, without this any code mistake is going to fail all the app to injects the js files silently