### PR TITLE
Travis: give more time to uaa build

### DIFF
--- a/travis/scripts/05-run.sh
+++ b/travis/scripts/05-run.sh
@@ -64,7 +64,7 @@ if [ "$RUN_APP" == 1 ]; then
     if [ "$JHIPSTER" == "app-gateway-uaa" ]; then
         cd "$HOME"/uaa
         java -jar target/*.war --spring.profiles.active="$PROFILE" &
-        sleep 40
+        sleep 80
     fi
 
     cd "$HOME"/app


### PR DESCRIPTION
I'm trying to add more time to uaa build.

Otherwise, we can have this. Here 2 differents logs from Travis, for the same uaa build:

Build failed:
```
2016-10-19 05:15:23.583  INFO 6693 --- [           main] com.netflix.discovery.DiscoveryClient    : Getting all instance registry info from the eureka server
2016-10-19 05:15:23.828  INFO 6693 --- [           main] com.netflix.discovery.DiscoveryClient    : The response status is 200
2016-10-19 05:15:23.831  INFO 6693 --- [           main] com.netflix.discovery.DiscoveryClient    : Starting heartbeat executor: renew interval is: 30
2016-10-19 05:15:23.837  INFO 6693 --- [           main] c.n.discovery.InstanceInfoReplicator     : InstanceInfoReplicator onDemand update allowed rate per min is 4
2016-10-19 05:15:23.845  INFO 6693 --- [           main] com.netflix.discovery.DiscoveryClient    : Discovery Client initialized at timestamp 1476854123844 with initial instances count: 0
```

Build success:
```
2016-10-18 21:32:06.582  INFO 6816 --- [           main] com.netflix.discovery.DiscoveryClient    : Getting all instance registry info from the eureka server
2016-10-18 21:32:06.837  INFO 6816 --- [           main] com.netflix.discovery.DiscoveryClient    : The response status is 200
2016-10-18 21:32:06.840  INFO 6816 --- [           main] com.netflix.discovery.DiscoveryClient    : Starting heartbeat executor: renew interval is: 30
2016-10-18 21:32:06.849  INFO 6816 --- [           main] c.n.discovery.InstanceInfoReplicator     : InstanceInfoReplicator onDemand update allowed rate per min is 4
2016-10-18 21:32:06.855  INFO 6816 --- [           main] com.netflix.discovery.DiscoveryClient    : Discovery Client initialized at timestamp 1476826326854 with initial instances count: 1
```