### PR TITLE
fix test for relation one-to-many

### DIFF
--- a/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -260,7 +260,7 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
         <%= otherEntityNameCapitalized %> <%= relationshipFieldName %> = <%= otherEntityNameCapitalized %>ResourceIntTest.createEntity(em);
         em.persist(<%= relationshipFieldName %>);
         em.flush();
-            <%_ if (relationshipType == 'many-to-many') { _%>
+            <%_ if (relationshipType == 'many-to-many' || relationshipType == 'one-to-many') { _%>
         <%= entityInstance %>.get<%= relationshipNameCapitalizedPlural %>().add(<%= relationshipFieldName %>);
             <%_ } else { _%>
         <%= entityInstance %>.set<%= relationshipNameCapitalized %>(<%= relationshipFieldName %>);


### PR DESCRIPTION
The entity generator create the following tests lines in createEntity for one to many relation :

`A.setBs(B);`

But Bs is a Set<B> because it's a one to many relation so we expect to have the same line as many to many relation :
`A.getBs().add(B);`