### PR TITLE
fix sass imports not updating the main.css file

### DIFF
--- a/generators/client/templates/_gulpfile.js
+++ b/generators/client/templates/_gulpfile.js
@@ -72,7 +72,6 @@ gulp.task('sass', function () {
         gulp.src(config.sassSrc)
         .pipe(plumber({errorHandler: handleErrors}))
         .pipe(expect(config.sassSrc))
-        .pipe(changed(config.cssDir, {extension: '.css'}))
         .pipe(sass({includePaths:config.bower}).on('error', sass.logError))
         .pipe(gulp.dest(config.cssDir)),
         gulp.src(config.bower + '**/fonts/**/*.{woff,woff2,svg,ttf,eot,otf}')


### PR DESCRIPTION
There is an old problem ( http://stackoverflow.com/questions/36411296/gulp-not-refresh-on-changes-to-imported-scss-files )  when using sass if you create some imports inside main.scss and go to one of this imported files and made changes you had to go back to main.scss and save it to the imports changes take effects. 
This problem is related to the "changed" plugin don't letting gulp-sass work like it should.