### PR TITLE
Add Spring CSRF default implementation [ng2]

### DIFF
--- a/generators/client-2/index.js
+++ b/generators/client-2/index.js
@@ -481,7 +481,6 @@ module.exports = JhipsterClientGenerator.extend({
             this.template(ANGULAR_DIR + 'shared/_index.ts', ANGULAR_DIR + 'shared/index.ts', this, {});
             this.template(ANGULAR_DIR + 'shared/_shared.ng2module.ts', ANGULAR_DIR + 'shared/shared.ng2module.ts', this, {});
             this.template(ANGULAR_DIR + 'shared/_shared-libs.ng2module.ts', ANGULAR_DIR + 'shared/shared-libs.ng2module.ts', this, {});
-            this.template(ANGULAR_DIR + 'shared/_XSRF-strategy.provider.ts', ANGULAR_DIR + 'shared/XSRF-strategy.provider.ts', this, {});
             this.template(ANGULAR_DIR + 'shared/constants/_pagination.constants.ts', ANGULAR_DIR + 'shared/constants/pagination.constants.ts', this, {});
 
             this.template(ANGULAR_DIR + 'shared/model/_account.model.ts', ANGULAR_DIR + 'shared/model/account.model.ts', this, {});

--- a/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/_app.ng2module.ts
@@ -4,7 +4,7 @@ import { UIRouterModule } from 'ui-router-ng2';
 import { Ng1ToNg2Module } from 'ui-router-ng1-to-ng2';
 import { Ng2Webstorage } from 'ng2-webstorage';
 
-import { <%=angular2AppName%>SharedModule, XSRFStrategyProvider } from './shared';
+import { <%=angular2AppName%>SharedModule } from './shared';
 import { <%=angular2AppName%>AdminModule } from './admin/admin.ng2module'; //TODO these couldnt be used from barrels due to an error
 import { <%=angular2AppName%>AccountModule } from './account/account.ng2module';
 
@@ -56,7 +56,6 @@ let routerConfig = {
     ],
     providers: [
         ProfileService,
-        XSRFStrategyProvider,
         { provide: Window, useValue: window },
         { provide: Document, useValue: document }
     ],

--- a/generators/client-2/templates/src/main/webapp/app/blocks/config/_http.config.ts
+++ b/generators/client-2/templates/src/main/webapp/app/blocks/config/_http.config.ts
@@ -1,11 +1,6 @@
 HttpConfig.$inject = ['$urlRouterProvider', '$httpProvider', 'httpRequestInterceptorCacheBusterProvider', '$urlMatcherFactoryProvider'];
 
 export function HttpConfig($urlRouterProvider, $httpProvider, httpRequestInterceptorCacheBusterProvider, $urlMatcherFactoryProvider) {
-    <% if (authenticationType == 'session') { %>
-    //enable CSRF
-    $httpProvider.defaults.xsrfCookieName = 'CSRF-TOKEN';
-    $httpProvider.defaults.xsrfHeaderName = 'X-CSRF-TOKEN';
-    <% } %>
     //Cache everything except rest api requests
     httpRequestInterceptorCacheBusterProvider.setMatchlist([/.*api.*/, /.*protected.*/], true);
 

--- a/generators/client-2/templates/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
+++ b/generators/client-2/templates/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
@@ -46,39 +46,7 @@ export function AuthExpiredInterceptor($rootScope, $q, $injector, $document) {
             }
             //var LoginService = $injector.get('LoginService');
             //LoginService.open();
-        } else if (response.status === 403 && response.config.method !== 'GET' && getCSRF() === '') {
-            // If the CSRF token expired, then try to get a new CSRF token and retry the old request
-            var $http = $injector.get('$http');
-            return $http.get('/').finally(function() { return afterCSRFRenewed(response); });
         }
         return $q.reject(response);
-    }
-    // use the CSRFService
-    function getCSRF() {
-        var doc = $document[0];
-        if (doc) {
-            var name = 'CSRF-TOKEN=';
-            var ca = doc.cookie.split(';');
-            for (var i = 0; i < ca.length; i++) {
-                var c = ca[i];
-                while (c.charAt(0) === ' ') {c = c.substring(1);}
-
-                if (c.indexOf(name) !== -1) {
-                    return c.substring(name.length, c.length);
-                }
-            }
-        }
-        return '';
-    }
-
-    function afterCSRFRenewed(oldResponse) {
-        if (getCSRF() !== '') {
-            // retry the old request after the new CSRF-TOKEN is obtained
-            var $http = $injector.get('$http');
-            return $http(oldResponse.config);
-        } else {
-            // unlikely get here but reject with the old response any way and avoid infinite loop
-            return $q.reject(oldResponse);
-        }
     }
 }<% } %>

--- a/generators/client-2/templates/src/main/webapp/app/shared/_XSRF-strategy.provider.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/_XSRF-strategy.provider.ts
@@ -1,6 +1,0 @@
-import { XSRFStrategy, CookieXSRFStrategy } from '@angular/http';
-
-export const XSRFStrategyProvider: any = {
-    provide: XSRFStrategy,
-    useValue:  new CookieXSRFStrategy('CSRF-TOKEN', 'X-CSRF-TOKEN')
-}

--- a/generators/client-2/templates/src/main/webapp/app/shared/_index.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/_index.ts
@@ -48,7 +48,6 @@ export * from './service/data-util.service';
 export * from './service/date-util.service';
 export * from './service/pagination-util.service';
 export * from './service/parse-links.service';
-export * from './XSRF-strategy.provider';
 export * from './shared-libs.ng2module';
 export * from './shared-common.ng2module';
 export * from './shared.ng2module';

--- a/generators/client-2/templates/src/main/webapp/app/shared/auth/_csrf.service.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/auth/_csrf.service.ts
@@ -6,7 +6,7 @@ export class CSRFService {
     constructor(private $document: Document) {}
 
     getCSRF(name?: string) {
-        name = `${name ? name : 'CSRF-TOKEN'}=`;
+        name = `${name ? name : 'XSRF-TOKEN'}=`;
         let doc = this.$document;
         if (doc) {
             let ca = doc.cookie.split(';');

--- a/generators/client-2/templates/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client-2/templates/src/main/webapp/swagger-ui/_index.html
@@ -82,7 +82,7 @@
 
                 function addApiKeyAuthorization(){
                 <% if (authenticationType === 'session') { %>
-                    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-CSRF-TOKEN", getCSRF(), "header");
+                    var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-XSRF-TOKEN", getCSRF(), "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <% } %>
                 <% if (authenticationType === 'oauth2') { %>
@@ -104,7 +104,7 @@
                 }
 
                 function getCSRF() {
-                    var name = "CSRF-TOKEN=";
+                    var name = "XSRF-TOKEN=";
                     var ca = document.cookie.split(';');
                     for(var i=0; i<ca.length; i++) {
                         var c = ca[i];


### PR DESCRIPTION
Hi,

This [pull ](https://github.com/jhipster/generator-jhipster/pull/4368) enables default CSRF for spring and angular when session auth. I'm managed to get it work for angular, but bad news is that I couldn't make it to work with websockets (it's working with ng1 and will be enabled from v3.10). For some reason stomp client is ignoring any headers provided in tracker.service.ts, so I'm stucked with it.

Any help/suggestion?