### PR TITLE
Changed TCP to tcp

### DIFF
--- a/generators/aws/lib/rds.js
+++ b/generators/aws/lib/rds.js
@@ -88,7 +88,7 @@ function authorizeSecurityGroupIngress(params, callback) {
 
     var securityGroupParams = {
         GroupId: params.rdsSecurityGroupId,
-        IpProtocol: 'TCP',
+        IpProtocol: 'tcp',
         FromPort: 0,
         ToPort: 65535,
         CidrIp: '0.0.0.0/0'


### PR DESCRIPTION
### Overview of the issue
Not able to deploy to AWS.

### Motivation for or Use Case
Deploy for evaluation by the team.

### Suggest a Fix 
To get a jHipster project deployed in to AWS the name of the protocol needs to be lowercase 'tcp'.  

Here is my .yo-rc.json file (cleaned):
```
{
  "generator-jhipster": {
    "jhipsterVersion": "3.0.0",
    "baseName": "InDepth2",
    "packageName": "org.tr.indepth",
    "packageFolder": "org/tr/indepth",
    "serverPort": "8080",
    "authenticationType": "session",
    "hibernateCache": "no",
    "clusteredHttpSession": "no",
    "websocket": "no",
    "databaseType": "sql",
    "devDatabaseType": "mysql",
    "prodDatabaseType": "mysql",
    "searchEngine": "no",
    "buildTool": "maven",
    "enableSocialSignIn": false,
    "useSass": false,
    "applicationType": "monolith",
    "testFrameworks": [
      "gatling",
      "cucumber",
      "protractor"
    ],
    "enableTranslation": true,
    "nativeLanguage": "en",
    "languages": [
      "en",
      "es",
      "ta"
    ]
  }
}
```