### PR TITLE
skip prompting for relationships to remove when no relationships exist

### DIFF
--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -196,7 +196,7 @@ function askForRelationsToRemove() {
     if (!this.useConfigurationFile || this.updateEntity !== 'remove') {
         return;
     }
-    if (this.databaseType === 'mongodb' || this.databaseType === 'cassandra') {
+    if (this.relNameChoices.length === 0 || this.databaseType === 'mongodb' || this.databaseType === 'cassandra') {
         return;
     }
 

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -136,7 +136,7 @@ function askForFields() {
 
 function askForFieldsToRemove() {
     // prompt only if data is imported from a file
-    if (!this.useConfigurationFile || this.updateEntity !== 'remove') {
+    if (!this.useConfigurationFile || this.updateEntity !== 'remove' || this.fieldNameChoices.length === 0) {
         return;
     }
     var done = this.async();
@@ -146,12 +146,11 @@ function askForFieldsToRemove() {
             type: 'checkbox',
             name: 'fieldsToRemove',
             message: 'Please choose the fields you want to remove',
-            choices: this.fieldNameChoices,
-            default: 'none'
+            choices: this.fieldNameChoices
         },
         {
             when: function (response) {
-                return response.fieldsToRemove !== 'none';
+                return response.fieldsToRemove.length !== 0;
             },
             type: 'confirm',
             name: 'confirmRemove',
@@ -193,10 +192,10 @@ function askForRelationships() {
 
 function askForRelationsToRemove() {
     // prompt only if data is imported from a file
-    if (!this.useConfigurationFile || this.updateEntity !== 'remove') {
+    if (!this.useConfigurationFile || this.updateEntity !== 'remove' || this.relNameChoices.length === 0) {
         return;
     }
-    if (this.relNameChoices.length === 0 || this.databaseType === 'mongodb' || this.databaseType === 'cassandra') {
+    if (this.databaseType === 'mongodb' || this.databaseType === 'cassandra') {
         return;
     }
 
@@ -207,12 +206,11 @@ function askForRelationsToRemove() {
             type: 'checkbox',
             name: 'relsToRemove',
             message: 'Please choose the relationships you want to remove',
-            choices: this.relNameChoices,
-            default: 'none'
+            choices: this.relNameChoices
         },
         {
             when: function (response) {
-                return response.relsToRemove !== 'none';
+                return response.relsToRemove.length !== 0;
             },
             type: 'confirm',
             name: 'confirmRemove',


### PR DESCRIPTION
Fix #4404.  I also fixed the remove confirmation messages which would display even if no entities/relationships were chosen