### PR TITLE
skip table and field validation for apps that skip server

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -144,7 +144,7 @@ module.exports = EntityGenerator.extend({
                 this.error(chalk.red('The entity name cannot be empty'));
             } else if (this.name.indexOf('Detail', this.name.length - 'Detail'.length) !== -1) {
                 this.error(chalk.red('The entity name cannot end with \'Detail\''));
-            } else if (jhiCore.isReservedClassName(this.name)) {
+            } else if (!this.skipServer && jhiCore.isReservedClassName(this.name)) {
                 this.error(chalk.red('The entity name cannot contain a Java or JHipster reserved keyword'));
             }
         },
@@ -155,7 +155,7 @@ module.exports = EntityGenerator.extend({
                 this.error(chalk.red('The table name cannot contain special characters'));
             } else if (this.entityTableName === '') {
                 this.error(chalk.red('The table name cannot be empty'));
-            } else if (jhiCore.isReservedTableName(this.entityTableName, prodDatabaseType)) {
+            } else if (!this.skipServer && jhiCore.isReservedTableName(this.entityTableName, prodDatabaseType)) {
                 this.error(chalk.red(`The table name cannot contain a ${prodDatabaseType.toUpperCase()} reserved keyword`));
             } else if (prodDatabaseType === 'oracle' && this.entityTableName.length > 26) {
                 this.error(chalk.red('The table name is too long for Oracle, try a shorter name'));
@@ -329,7 +329,7 @@ module.exports = EntityGenerator.extend({
             if (_.isUndefined(this.changelogDate)
                 && (this.databaseType === 'sql' || this.databaseType === 'cassandra')) {
                 var currentDate = this.dateFormatForLiquibase();
-                this.warning(`hangelogDate is missing in .jhipster/${ this.name }.json, using ${ currentDate } as fallback`);
+                this.warning(`changelogDate is missing in .jhipster/${ this.name }.json, using ${ currentDate } as fallback`);
                 this.changelogDate = currentDate;
             }
             if (_.isUndefined(this.dto)) {

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -278,8 +278,8 @@ function askForTableName() {
 }
 
 function askForDTO() {
-    // don't prompt if data is imported from a file
-    if (this.useConfigurationFile) {
+    // don't prompt if data is imported from a file or server is skipped
+    if (this.useConfigurationFile || this.skipServer) {
         return;
     }
     var done = this.async();
@@ -308,8 +308,8 @@ function askForDTO() {
 }
 
 function askForService() {
-    // don't prompt if data are imported from a file
-    if (this.useConfigurationFile) {
+    // don't prompt if data is imported from a file or server is skipped
+    if (this.useConfigurationFile || this.skipServer) {
         return;
     }
     var done = this.async();
@@ -388,6 +388,7 @@ function askForPagination() {
  */
 function askForField(done) {
     this.log(chalk.green('\nGenerating field #' + (this.fields.length + 1) + '\n'));
+    var skipServer = this.skipServer;
     var prodDatabaseType = this.prodDatabaseType;
     var databaseType = this.databaseType;
     var fieldNamesUnderscored = this.fieldNamesUnderscored;
@@ -413,7 +414,7 @@ function askForField(done) {
                     return 'Your field name cannot start with a upper case letter';
                 } else if (input === 'id' || fieldNamesUnderscored.indexOf(_.snakeCase(input)) !== -1) {
                     return 'Your field name cannot use an already existing field name';
-                } else if (jhiCore.isReservedFieldName(input, prodDatabaseType)) {
+                } else if (!skipServer && jhiCore.isReservedFieldName(input, prodDatabaseType)) {
                     return `Your field name cannot contain a Java or ${ prodDatabaseType.toUpperCase() } reserved keyword`;
                 } else if (prodDatabaseType === 'oracle' && input.length > 30) {
                     return 'The field name cannot be of more than 30 characters';
@@ -424,7 +425,7 @@ function askForField(done) {
         },
         {
             when: function (response) {
-                return response.fieldAdd === true && (databaseType === 'sql' || databaseType === 'mongodb');
+                return response.fieldAdd === true && (skipServer || databaseType === 'sql' || databaseType === 'mongodb');
             },
             type: 'list',
             name: 'fieldType',


### PR DESCRIPTION
Skip table and field validation for apps that use `--skip-server`.  Also don't prompt for entity DTO and Service options as those only affect the server.

Fix #4399
