### PR TITLE
Fix for critical bug when social login activated

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/shared/_shared.ng2module.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/_shared.ng2module.ts
@@ -20,12 +20,13 @@ import {
     HasAuthorityDirective,
     HasAnyAuthorityDirective,
 <% if (enableSocialSignIn) { %>
-    <%=jhiPrefixCapitalized%>SocialComponent,
     SocialService,
 <%_ } _%>
     <%=jhiPrefixCapitalized%>LoginModalComponent
 } from './';
-
+<% if (enableSocialSignIn) { %>
+import { <%=jhiPrefixCapitalized%>SocialComponent } from './social/social.component';
+<%_ } _%>
 @NgModule({
     imports: [
         <%=angular2AppName%>SharedLibsModule,


### PR DESCRIPTION
@deepu105 you have moved the import of SocialComponent, and weirdly it causes a critical issue when the social login is activated (the application can't launch). I don't know why it doesn't work directly from './' like other components, but if you do please tell me. Otherwise, merge the PR to fix it. Thanks.