### PR TITLE
add kafka to the kubernetes generator

### DIFF
--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -19,6 +19,9 @@ function writeFiles() {
                 if (this.app.searchEngine === 'elasticsearch') {
                     this.template('db/_elasticsearch.yml', appName + '/' + appName + '-' + 'elasticsearch.yml');
                 }
+                if (this.app.messageBroker === 'kafka') {
+                    this.template('db/_kafka.yml', appName + '/' + appName + '-' + 'kafka.yml');
+                }
             }
         },
 

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -101,6 +101,8 @@ module.exports = KubernetesGenerator.extend({
             this.DOCKER_POSTGRESQL = constants.DOCKER_POSTGRESQL;
             this.DOCKER_MONGODB = constants.DOCKER_MONGODB;
             this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
+            this.DOCKER_KAFKA = constants.DOCKER_KAFKA;
+            this.DOCKER_ZOOKEEPER = constants.DOCKER_ZOOKEEPER;
 
             if (this.defaultAppsFolders !== undefined) {
                 this.log('\nFound .yo-rc.json config file...');

--- a/generators/kubernetes/templates/_deployment.yml
+++ b/generators/kubernetes/templates/_deployment.yml
@@ -61,5 +61,11 @@ spec:
         - name: SPRING_DATA_ELASTICSEARCH_CLUSTER_NODES
           value: <%= app.baseName.toLowerCase() %>-elasticsearch.<%= kubernetesNamespace %>.svc.cluster.local:9300
         <%_ } _%>
+        <%_ if (app.messageBroker === 'kafka') { _%>
+        - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS
+          value: <%= app.baseName.toLowerCase() %>-kafka
+        - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
+          value: <%= app.baseName.toLowerCase() %>-zookeeper
+        <%_ } _%>
         ports:
         - containerPort: <%= app.serverPort %>

--- a/generators/kubernetes/templates/_deployment.yml
+++ b/generators/kubernetes/templates/_deployment.yml
@@ -63,9 +63,9 @@ spec:
         <%_ } _%>
         <%_ if (app.messageBroker === 'kafka') { _%>
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS
-          value: <%= app.baseName.toLowerCase() %>-kafka
+          value: <%= app.baseName.toLowerCase() %>-kafka.<%= kubernetesNamespace %>.svc.cluster.local
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
-          value: <%= app.baseName.toLowerCase() %>-zookeeper
+          value: <%= app.baseName.toLowerCase() %>-zookeeper.<%= kubernetesNamespace %>.svc.cluster.local
         <%_ } _%>
         ports:
         - containerPort: <%= app.serverPort %>

--- a/generators/kubernetes/templates/db/_kafka.yml
+++ b/generators/kubernetes/templates/db/_kafka.yml
@@ -14,11 +14,11 @@ spec:
         image: <%= DOCKER_KAFKA %>
         env:
         - name: KAFKA_ADVERTISED_HOST_NAME
-          value: localhost
+          value: <%= app.baseName.toLowerCase() %>-kafka.<%= kubernetesNamespace %>.svc.cluster.local
         - name: KAFKA_ADVERTISED_PORT
           value: '9092'
         - name: KAFKA_ZOOKEEPER_CONNECT
-          value: <%= app.baseName.toLowerCase() %>-zookeeper:2181
+          value: <%= app.baseName.toLowerCase() %>-zookeeper.<%= kubernetesNamespace %>.svc.cluster.local:2181
         - name: KAFKA_CREATE_TOPICS
           value: 'topic-jhipster:1:1'
         ports:

--- a/generators/kubernetes/templates/db/_kafka.yml
+++ b/generators/kubernetes/templates/db/_kafka.yml
@@ -1,0 +1,62 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-kafka
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: <%= app.baseName.toLowerCase() %>-kafka
+    spec:
+      containers:
+      - name: kafka
+        image: <%= DOCKER_KAFKA %>
+        env:
+        - name: KAFKA_ADVERTISED_HOST_NAME
+          value: localhost
+        - name: KAFKA_ADVERTISED_PORT
+          value: '9092'
+        - name: KAFKA_ZOOKEEPER_CONNECT
+          value: <%= app.baseName.toLowerCase() %>-zookeeper:2181
+        - name: KAFKA_CREATE_TOPICS
+          value: 'topic-jhipster:1:1'
+        ports:
+        - containerPort: 9092
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-kafka
+spec:
+  selector:
+    app: <%= app.baseName.toLowerCase() %>-kafka
+  ports:
+  - port: 9092
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-zookeeper
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: <%= app.baseName.toLowerCase() %>-zookeeper
+    spec:
+      containers:
+      - name: zookeeper
+        image: <%= DOCKER_ZOOKEEPER %>
+        ports:
+        - containerPort: 2181
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-zookeeper
+spec:
+  selector:
+    app: <%= app.baseName.toLowerCase() %>-zookeeper
+  ports:
+  - port: 2181

--- a/test/templates/compose/09-kafka/.yo-rc.json
+++ b/test/templates/compose/09-kafka/.yo-rc.json
@@ -1,0 +1,32 @@
+{
+    "generator-jhipster": {
+        "jhipsterVersion": "3.10.0",
+        "baseName": "sampleKafka",
+        "packageName": "com.mycompany.myapp",
+        "packageFolder": "com/mycompany/myapp",
+        "serverPort": "8080",
+        "authenticationType": "session",
+        "hibernateCache": "ehcache",
+        "clusteredHttpSession": false,
+        "websocket": false,
+        "databaseType": "sql",
+        "devDatabaseType": "h2Disk",
+        "prodDatabaseType": "mysql",
+        "searchEngine": false,
+        "messageBroker": "kafka",
+        "buildTool": "maven",
+        "enableSocialSignIn": false,
+        "rememberMeKey": "92b92094c42ee1d918471b00f1543c604888f041",
+        "useSass": false,
+        "applicationType": "monolith",
+        "testFrameworks": [
+            "gatling"
+        ],
+        "jhiPrefix": "jhi",
+        "enableTranslation": true,
+        "nativeLanguage": "en",
+        "languages": [
+            "en"
+        ]
+    }
+}

--- a/test/templates/compose/09-kafka/src/main/docker/app.yml
+++ b/test/templates/compose/09-kafka/src/main/docker/app.yml
@@ -1,0 +1,30 @@
+version: '2'
+services:
+    samplekafka-app:
+        image: samplekafka
+        external_links:
+            - samplekafka-mysql:mysql
+            - kafka:kafka
+            - zookeeper:zookeeper
+        environment:
+            - SPRING_PROFILES_ACTIVE=prod,swagger
+            - SPRING_DATASOURCE_URL=jdbc:mysql://mysql:3306/samplekafka?useUnicode=true&characterEncoding=utf8&useSSL=false
+            - JHIPSTER_SLEEP=10 # gives time for the database to boot before the application
+            - SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=kafka
+            - SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES=zookeeper
+        ports:
+            - 8080:8080
+    samplekafka-mysql:
+        extends:
+            file: mysql.yml
+            service: samplekafka-mysql
+    kafka:
+        extends:
+            file: kafka.yml
+            service: kafka
+        environment:
+            - KAFKA_ADVERTISED_HOST_NAME=kafka
+    zookeeper:
+        extends:
+            file: kafka.yml
+            service: zookeeper

--- a/test/templates/compose/09-kafka/src/main/docker/kafka.yml
+++ b/test/templates/compose/09-kafka/src/main/docker/kafka.yml
@@ -1,0 +1,17 @@
+version: '2'
+services:
+    zookeeper:
+        container_name: zookeeper
+        image: wurstmeister/zookeeper:3.4.6
+        ports:
+          - 2181:2181
+    kafka:
+        container_name: kafka
+        image: wurstmeister/kafka:0.10.0.1
+        environment:
+            KAFKA_ADVERTISED_HOST_NAME: localhost
+            KAFKA_ADVERTISED_PORT: 9092
+            KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+            KAFKA_CREATE_TOPICS: "topic-jhipster:1:1"
+        ports:
+            - 9092:9092

--- a/test/templates/compose/09-kafka/src/main/docker/mysql.yml
+++ b/test/templates/compose/09-kafka/src/main/docker/mysql.yml
@@ -1,0 +1,14 @@
+version: '2'
+services:
+    samplekafka-mysql:
+        container_name: samplekafka-mysql
+        image: mysql:5.7.13
+        # volumes:
+        #     - ~/volumes/jhipster/sampleKafka/mysql/:/var/lib/mysql/
+        environment:
+            - MYSQL_USER=root
+            - MYSQL_ALLOW_EMPTY_PASSWORD=yes
+            - MYSQL_DATABASE=samplekafka
+        ports:
+            - 3306:3306
+        command: mysqld --lower_case_table_names=1 --skip-ssl

--- a/test/test-kubernetes.js
+++ b/test/test-kubernetes.js
@@ -42,6 +42,12 @@ const expectedFiles = {
         'samplemysql/samplemysql-service.yml',
         'samplemysql/samplemysql-elasticsearch.yml'
     ],
+    kafka : [
+        'samplekafka/samplekafka-deployment.yml',
+        'samplekafka/samplekafka-mysql.yml',
+        'samplekafka/samplekafka-service.yml',
+        'samplekafka/samplekafka-kafka.yml'
+    ],
 };
 
 describe('JHipster Kubernetes Sub Generator', function () {
@@ -208,11 +214,39 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 })
                 .on('end', done);
         });
-        it('creates expected registry files', function () {
+        it('doesn\'t creates registry files', function () {
             assert.noFile(expectedFiles.registry);
         });
         it('creates expected default files', function () {
             assert.file(expectedFiles.monolith);
+        });
+    });
+
+    describe('kafka application', function () {
+        beforeEach(function (done) {
+            helpers
+                .run(require.resolve('../generators/kubernetes'))
+                .inTmpDir(function (dir) {
+                    fse.copySync(path.join(__dirname, './templates/compose/'), dir);
+                })
+                .withOptions({checkInstall: false})
+                .withPrompts({
+                    composeApplicationType: 'monolith',
+                    directoryPath: './',
+                    chosenApps: [
+                        '09-kafka'
+                    ],
+                    dockerRepositoryName: 'jhipster',
+                    dockerPushCommand: 'docker push',
+                    kubernetesNamespace: 'default'
+                })
+                .on('end', done);
+        });
+        it('doesn\'t creates registry files', function () {
+            assert.noFile(expectedFiles.registry);
+        });
+        it('creates expected default files', function () {
+            assert.file(expectedFiles.kafka);
         });
     });
 


### PR DESCRIPTION
I'm opening this PR to track the progress in adding the Kafka support to the Kubernetes generator.
The initial ticket to add supports for all technologies to the kubernetes generator is #4205


# Current status
The implementation adds a Kafka and a Zookeepeer deployment.

## Monolith 
The monolith works, both in GKE and minikube.

## Microservices

The microservices version don't work on minikube or GKE.
Both the gateway and the service can not reach the Kafka node.

But even without Kafka, a microservice architecture don't start on my local minikube.
Without Kafka, it is working on GKE thought


> Can someone confirm microservices work locally on minikube w/o Kafka and test my generator microservice?


### MicroService alternative

The current implementation generates a different Kafka/Zookeeper pair for every Gateway/microservice

In contrast, the docker-compose generator generates only one pair. But both the gateway and microservice send events to the same Kafka topic.

I can implement something similar in kubernetes, for a microservice architecture the generated layout will be:

```
- k8s/
 - jhigate/
  - jhigate-deployment.yml
  - jhigate-mysql.yml
  - jhigate-service.yml
 - service1/
  - service1-deployment.yml
  - service1-mysql.yml
  - service1-service.yml
 - registry/
  - jhipster-registry.yml
 - kafka/
    - kafka.yml
    - zookeeper.yml
```

This will add a new `kafka` folder.
What do you think?

