### PR TITLE
changes the token call for uaa auth

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
+++ b/generators/client-2/templates/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from '@angular/core';
-import { Http, Response, Headers } from '@angular/http';
+import { Http, Response, Headers, URLSearchParams } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 import { LocalStorageService, SessionStorageService } from 'ng2-webstorage';
 
@@ -17,11 +17,11 @@ export class AuthServerProvider {
 
     login (credentials): Observable<any> {
 <%_ if(authenticationType === 'uaa') { _%>
-        let data = {
-            username: credentials.username,
-            password: credentials.password,
-            grant_type: "password"
-        };
+        let data = new URLSearchParams();
+        data.append('grant_type', 'password');
+        data.append('username', credentials.username);
+        data.append('password', credentials.password);
+
         let headers = new Headers ({
             'Content-Type': 'application/x-www-form-urlencoded',
             "Authorization" : "Basic d2ViX2FwcDo="
@@ -29,14 +29,6 @@ export class AuthServerProvider {
 
         return this.http.post('<%= uaaBaseName.toLowerCase() %>/oauth/token', data, {
             headers: headers
-            //TODO this needs to be handled
-            /*transformRequest: function(obj) {
-                var str = [];
-                for (var p in obj) {
-                    str.push(encodeURIComponent(p) + '=' + encodeURIComponent(obj[p]));
-                }
-                return str.join('&');
-            }*/
         }).map((resp) => {
             let accessToken = resp.json().data["access_token"];
             if (accessToken) {


### PR DESCRIPTION
a little start on fixing UAA auth in client-2

the 2nd part would be to store this in localstorage and intercept **all** api HTTP calls using some interceptor.

However, intercepting was a quite straigt forward task in ng1 and got somehow more tricky in ng2...currently there is a WIP PR pending (#4414) with this. To be honest, I am not sure what is wrong with that PR, but I cant start my own one here, coz its double work...

this little change can be merged anywhere, as this part has to be done anyway