### PR TITLE
Simplify mongo configuration

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_CloudDatabaseConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_CloudDatabaseConfiguration.java
@@ -73,10 +73,6 @@ public class CloudDatabaseConfiguration extends AbstractCloudConfig {
         <%_ } _%>
         converterList.add(DateToZonedDateTimeConverter.INSTANCE);
         converterList.add(ZonedDateTimeToDateConverter.INSTANCE);
-        converterList.add(DateToLocalDateConverter.INSTANCE);
-        converterList.add(LocalDateToDateConverter.INSTANCE);
-        converterList.add(DateToLocalDateTimeConverter.INSTANCE);
-        converterList.add(LocalDateTimeToDateConverter.INSTANCE);
         return new CustomConversions(converterList);
     }
 

--- a/generators/server/templates/src/main/java/package/config/_DatabaseConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_DatabaseConfiguration.java
@@ -31,10 +31,8 @@ import org.springframework.context.annotation.Import;<% } %><% if (databaseType 
 import org.springframework.core.env.Environment;<% } %><% if (databaseType == 'mongodb') { %>
 import org.springframework.core.convert.converter.Converter;<% } %><% if (searchEngine == 'elasticsearch') { %>
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;<% } %><% if (databaseType == 'mongodb') { %>
-import org.springframework.data.mongodb.config.AbstractMongoConfiguration;
 import org.springframework.data.mongodb.config.EnableMongoAuditing;
-import org.springframework.data.mongodb.core.convert.CustomConversions;<% } %><% if (databaseType == 'mongodb' && authenticationType == 'oauth2') { %>
-import org.springframework.data.mongodb.core.convert.CustomConversions;<% } %><% if (databaseType == 'mongodb') { %>
+import org.springframework.data.mongodb.core.convert.CustomConversions;
 import org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener;
 import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;<% } %>
@@ -64,18 +62,12 @@ import java.util.List;
 @EnableMongoRepositories("<%=packageName%>.repository")
 @Import(value = MongoAutoConfiguration.class)
 @EnableMongoAuditing(auditorAwareRef = "springSecurityAuditorAware")<% } %>
-public class DatabaseConfiguration <% if (databaseType == 'mongodb') { %>extends AbstractMongoConfiguration <% } %>{
+public class DatabaseConfiguration {
 
     private final Logger log = LoggerFactory.getLogger(DatabaseConfiguration.class);<% if (databaseType == 'sql') { %>
 
     @Inject
-    private Environment env;<% } %><% if (databaseType == 'mongodb') { %>
-
-    @Inject
-    private Mongo mongo;
-
-    @Inject
-    private MongoProperties mongoProperties;<% } %><% if (databaseType == 'sql') { %>
+    private Environment env;<% } %><% if (databaseType == 'sql') { %>
 <%_ if (devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory') { _%>
 
     /**
@@ -125,31 +117,17 @@ public class DatabaseConfiguration <% if (databaseType == 'mongodb') { %>extends
         return new LocalValidatorFactoryBean();
     }
 
-    @Override
-    protected String getDatabaseName() {
-        return mongoProperties.getDatabase();
-    }
-
-    @Override
-    public Mongo mongo() throws Exception {
-        return mongo;
-    }
-
     @Bean
     public CustomConversions customConversions() {
         List<Converter<?, ?>> converters = new ArrayList<>();<% if (authenticationType == 'oauth2') { %>
         converters.add(new OAuth2AuthenticationReadConverter());<% } %>
         converters.add(DateToZonedDateTimeConverter.INSTANCE);
         converters.add(ZonedDateTimeToDateConverter.INSTANCE);
-        converters.add(DateToLocalDateConverter.INSTANCE);
-        converters.add(LocalDateToDateConverter.INSTANCE);
-        converters.add(DateToLocalDateTimeConverter.INSTANCE);
-        converters.add(LocalDateTimeToDateConverter.INSTANCE);
         return new CustomConversions(converters);
     }
 
     @Bean
-    public Mongobee mongobee() {
+    public Mongobee mongobee(Mongo mongo, MongoProperties mongoProperties) {
         log.debug("Configuring Mongobee");
         Mongobee mongobee = new Mongobee(mongo);
         mongobee.setDbName(mongoProperties.getDatabase());


### PR DESCRIPTION
* Most of JSR310 types are already handled by CustomConversions so they can be removed
* Use spring-data-mongo auto-configuration instead of extending AbstractMongoConfiguration