### PR TITLE
change @PostConstruct to @Before in tests

### DIFF
--- a/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -34,7 +34,6 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;<% if (databas
 import org.springframework.transaction.annotation.Transactional;<% } %><% if (fieldsContainBlob == true) { %>
 import org.springframework.util.Base64Utils;<% } %>
 
-import javax.annotation.PostConstruct;
 import javax.inject.Inject;<% if (databaseType == 'sql') { %>
 import javax.persistence.EntityManager;<% } %><% if (fieldsContainLocalDate == true) { %>
 import java.time.LocalDate;<% } %><% if (fieldsContainZonedDateTime == true) { %>
@@ -204,7 +203,7 @@ public class <%= entityClass %>ResourceIntTest <% if (databaseType == 'cassandra
 
     private <%= entityClass %> <%= entityInstance %>;
 
-    @PostConstruct
+    @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource();


### PR DESCRIPTION
Fix #4249

New instances are created for mocked fields of tests between `@PostConstruct` method and `@Before` method.

This is confusing when using Mockito methods in test methods as these are not affect objects used in setup method.

It could be caused by another issue but changing `@PostConstruct` to `@Before` works well.

Is there any specific reason to use `@PostConstruct`?