### PR TITLE
Remove "Beta" from entity prompts

### DIFF
--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -95,11 +95,11 @@ function askForUpdate() {
                 },
                 {
                     value: 'add',
-                    name: '[BETA] Yes, add more fields and relationships'
+                    name: 'Yes, add more fields and relationships'
                 },
                 {
                     value: 'remove',
-                    name: '[BETA] Yes, remove fields and relationships'
+                    name: 'Yes, remove fields and relationships'
                 },
                 {
                     value: 'none',


### PR DESCRIPTION
During your (excellent!) Devoxx2016 talk you said you wanted to take this out of beta because it always works. 