### PR TITLE
Display the line number when import-jdl cannot parse

### DIFF
--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -50,7 +50,7 @@ module.exports = JDLGenerator.extend({
                 this.log('Writing entity JSON files.');
                 jhiCore.exportToJSON(entities, this.options['force']);
             } catch (e) {
-                this.log(e.message || e);
+                this.log(e);
                 this.error(`\nError while parsing entities from JDL\n`);
             }
 


### PR DESCRIPTION
Display the full error when the import-idl does not parse the file, including the number of the line where the error occurred.