### PR TITLE
Enable oauth with live reload

### DIFF
--- a/generators/client/templates/gulp/_serve.js
+++ b/generators/client/templates/gulp/_serve.js
@@ -16,6 +16,9 @@ module.exports = function () {
     // to correctly handle them.
     var proxyRoutes = [
     <%_ if (applicationType === 'monolith') { _%>
+      <%_ if (authenticationType == 'oauth2') { _%>
+        '/oauth',
+      <%_ } _%>
         '/api',
         '/management',
         '/swagger-resources',


### PR DESCRIPTION
/oauth was not served by the Browsersync live reload. This patch enables oauth with live reload.