### PR TITLE
load entity searchEngine config if present

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -198,6 +198,7 @@ module.exports = EntityGenerator.extend({
         this.service = this.fileData.service;
         this.fluentMethods = this.fileData.fluentMethods;
         this.pagination = this.fileData.pagination;
+        this.searchEngine = this.fileData.searchEngine || this.searchEngine;
         this.javadoc = this.fileData.javadoc;
         this.entityTableName = this.fileData.entityTableName;
         if (_.isUndefined(this.entityTableName)) {
@@ -221,7 +222,6 @@ module.exports = EntityGenerator.extend({
                 this.error(chalk.red('Microservice name for the entity is not found. Entity cannot be generated!'));
             }
             this.skipServer = true;
-            this.searchEngine = this.fileData.searchEngine || this.searchEngine;
         }
     },
     /* end of Helper methods */


### PR DESCRIPTION
If the user manually specifies `no` or `false` for `searchEngine` in the entity.json file, the `@Document` annotation and search repository classes should be skipped.

The `no`/`false` value should be added by JDL when the entity is excluded from searching (ie `search all with elasticsearch except entityB`), but for now it is a manual process.

Related to #3269