### PR TITLE
Install yarn in Docker image [ci skip]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,11 +31,12 @@ RUN \
   # upgrade npm
   npm install -g npm && \
 
-  # install yeoman bower gulp
+  # install yeoman bower gulp yarn
   npm install -g \
     yo \
     bower \
-    gulp-cli && \
+    gulp-cli \
+    yarn && \
 
   # cleanup
   apt-get clean && \


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/4317
To allow the use of `yo jhipster --yarn` (https://github.com/jhipster/generator-jhipster/pull/4426) with the Docker image