### PR TITLE
fix angularVersion undefined message for projects without translation

### DIFF
--- a/generators/client-2/index.js
+++ b/generators/client-2/index.js
@@ -219,6 +219,9 @@ module.exports = JhipsterClientGenerator.extend({
             if (this.configOptions.websocket) {
                 this.websocket = this.configOptions.websocket;
             }
+            if (this.configOptions.angularVersion) {
+                this.angularVersion = this.configOptions.angularVersion;
+            }
             if (this.configOptions.databaseType) {
                 this.databaseType = this.configOptions.databaseType;
             }


### PR DESCRIPTION
Similar issue to the one discussed at the bottom of [this commit](https://github.com/jhipster/generator-jhipster/commit/5dc5cfa3c737b72aea3084a4e5cabbeca599bd5d#comments
), but for angularVersion (only affects ng2)