### PR TITLE
Get microservice alert and error headers from gateway

### DIFF
--- a/generators/client/templates/src/main/webapp/app/blocks/interceptor/_notification.interceptor.js
+++ b/generators/client/templates/src/main/webapp/app/blocks/interceptor/_notification.interceptor.js
@@ -15,9 +15,12 @@
         return service;
 
         function response (response) {
-            var alertKey = response.headers('X-<%=angularAppName%>-alert');
+            var headers = Object.keys(response.headers()).filter(function (header) {
+                return header.endsWith('app-alert') || header.endsWith('app-params')
+            }).sort();
+            var alertKey = response.headers(headers[0]);
             if (angular.isString(alertKey)) {
-                AlertService.success(alertKey, { param : response.headers('X-<%=angularAppName%>-params')});
+                AlertService.success(alertKey, { param : response.headers(headers[1])});
             }
             return response;
         }

--- a/generators/client/templates/src/main/webapp/app/components/alert/_alert-error.directive.js
+++ b/generators/client/templates/src/main/webapp/app/components/alert/_alert-error.directive.js
@@ -63,8 +63,11 @@
                 break;
 
             case 400:
-                var errorHeader = httpResponse.headers('X-<%=angularAppName%>-error');
-                var entityKey = httpResponse.headers('X-<%=angularAppName%>-params');
+                var headers = Object.keys(httpResponse.headers()).filter(function (header) {
+                    return header.endsWith('app-error') || header.endsWith('app-params')
+                }).sort();
+                var errorHeader = httpResponse.headers(headers[0]);
+                var entityKey = httpResponse.headers(headers[1]);
                 if (errorHeader) {
                     var entityName = <% if (enableTranslation) { %>$translate.instant('global.menu.entities.' + entityKey)<% }else{ %>entityKey<% } %>;
                     addErrorAlert(errorHeader, errorHeader, {entityName: entityName});

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -123,6 +123,7 @@ module.exports = EntityGenerator.extend({
             this.angularAppName = this.getAngularAppName();
             this.jhipsterConfigDirectory = '.jhipster';
             this.mainClass = this.getMainClassName();
+            this.microserviceAppName = '';
 
             this.filename = this.jhipsterConfigDirectory + '/' + this.entityNameCapitalized + '.json';
             if (shelljs.test('-f', this.filename)) {
@@ -222,8 +223,12 @@ module.exports = EntityGenerator.extend({
             if (!this.microserviceName) {
                 this.error(chalk.red('Microservice name for the entity is not found. Entity cannot be generated!'));
             }
+            this.microserviceAppName = this._getMicroserviceAppName();
             this.skipServer = true;
         }
+    },
+    _getMicroserviceAppName: function () {
+        return _.camelCase(this.microserviceName, true) + (this.microserviceName.endsWith('App') ? '' : 'App');
     },
     /* end of Helper methods */
 

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_ca.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_ca.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_cs.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_cs.json
@@ -6,10 +6,10 @@
                 "createLabel": "Vytvořit <%= entityClassHumanized %>",
                 "createOrEditLabel": "Vytvořit nebo upravit <%= entityClassHumanized %>",
                 "search": "Vyhledat <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Byl vytvořen potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }}",
             "updated": "Potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }} byl upravený.",
-            "deleted": "Potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }} bol smazaný.",
+            "deleted": "Potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }} bol smazaný.",<% } %>
             "delete": {
                 "question": "Jste si jisti, že chcete smazat <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Byl vytvořen potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }}",
+            "updated": "Potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }} byl upravený.",
+            "deleted": "Potomek entity <%= entityClassHumanized %> s identifikátorem {{ param }} bol smazaný."
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_da.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_da.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_de.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_de.json
@@ -6,10 +6,10 @@
                 "createLabel": "<%= entityClassHumanized %> erstellen",
                 "createOrEditLabel": "<%= entityClassHumanized %> erstellen oder bearbeiten",
                 "search": "Suche nach <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "<%= entityClassHumanized %> erstellt mit ID {{ param }}",
             "updated": "<%= entityClassHumanized %> aktualisiert mit ID {{ param }}",
-            "deleted": "<%= entityClassHumanized %> gelöscht mit ID {{ param }}",
+            "deleted": "<%= entityClassHumanized %> gelöscht mit ID {{ param }}",<% } %>
             "delete": {
                 "question": "Soll <%= entityClassHumanized %> {{ id }} wirklich dauerhaft gelöscht werden?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "<%= entityClassHumanized %> erstellt mit ID {{ param }}",
+            "updated": "<%= entityClassHumanized %> aktualisiert mit ID {{ param }}",
+            "deleted": "<%= entityClassHumanized %> gelöscht mit ID {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_el.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_el.json
@@ -6,10 +6,10 @@
                 "createLabel": "Δημιουργήστε ένα νέο <%= entityClassHumanized %>",
                 "createOrEditLabel": "Δημιουργήστε η επεξεργαστείτε ένα <%= entityClassHumanized %>",
                 "search": "Αναζήτηση για <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Ένα νέο <%= entityClassHumanized %> έχει δημιουργηθεί με αναγνωριστικό {{ param }}",
             "updated": "Ένα <%= entityClassHumanized %> έχει ενημερωθεί με αναγνωριστικό {{ param }}",
-            "deleted": "Ένα <%= entityClassHumanized %> έχει διαγραφτεί με αναγνωριστικό {{ param }}",
+            "deleted": "Ένα <%= entityClassHumanized %> έχει διαγραφτεί με αναγνωριστικό {{ param }}",<% } %>
             "delete": {
                 "question": "Είστε βέβαιοι όταν θέλετε να διαγράψετε το ακόλουθο <%= entityClassHumanized %> {{ id }};"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Ένα νέο <%= entityClassHumanized %> έχει δημιουργηθεί με αναγνωριστικό {{ param }}",
+            "updated": "Ένα <%= entityClassHumanized %> έχει ενημερωθεί με αναγνωριστικό {{ param }}",
+            "deleted": "Ένα <%= entityClassHumanized %> έχει διαγραφτεί με αναγνωριστικό {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_en.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_en.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_es.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_es.json
@@ -6,10 +6,10 @@
                 "createLabel": "Crear nuevo <%= entityClassHumanized %>",
                 "createOrEditLabel": "Crear o editar <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Un nuevo <%= entityClassHumanized %> ha sido creado con el identificador {{ param }}",
             "updated": "Un <%= entityClassHumanized %> ha sido actualizado con el identificador {{ param }}",
-            "deleted": "Un <%= entityClassHumanized %> ha sido eliminado con el identificador {{ param }}",
+            "deleted": "Un <%= entityClassHumanized %> ha sido eliminado con el identificador {{ param }}",<% } %>
             "delete": {
                 "question": "¿Seguro que quiere eliminar <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Un nuevo <%= entityClassHumanized %> ha sido creado con el identificador {{ param }}",
+            "updated": "Un <%= entityClassHumanized %> ha sido actualizado con el identificador {{ param }}",
+            "deleted": "Un <%= entityClassHumanized %> ha sido eliminado con el identificador {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_fr.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_fr.json
@@ -6,10 +6,10 @@
                 "createLabel": "Créer un nouveau <%= entityClassHumanized %>",
                 "createOrEditLabel": "Créer ou éditer un <%= entityClassHumanized %>",
                 "search": "Recherche pour <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Un nouveau <%= entityClassHumanized %> a été créé avec l'identifiant {{ param }}",
             "updated": "Le <%= entityClassHumanized %> avec l'identifiant {{ param }} a été mis à jour",
-            "deleted": "Le <%= entityClassHumanized %> avec l'identifiant {{ param }} a été supprimé",
+            "deleted": "Le <%= entityClassHumanized %> avec l'identifiant {{ param }} a été supprimé",<% } %>
             "delete": {
                 "question": "Etes-vous certain de vouloir supprimer le <%= entityClassHumanized %> {{ id }} ?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Un nouveau <%= entityClassHumanized %> a été créé avec l'identifiant {{ param }}",
+            "updated": "Le <%= entityClassHumanized %> avec l'identifiant {{ param }} a été mis à jour",
+            "deleted": "Le <%= entityClassHumanized %> avec l'identifiant {{ param }} a été supprimé"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_gl.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_gl.json
@@ -6,10 +6,10 @@
                 "createLabel": "Crear novo <%= entityClassHumanized %>",
                 "createOrEditLabel": "Crear ou editar <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Un novo <%= entityClassHumanized %> foi creado co identificador {{ param }}",
             "updated": "Un <%= entityClassHumanized %> foi actualizado co identificador {{ param }}",
-            "deleted": "Un <%= entityClassHumanized %> foi eliminado co identificador {{ param }}",
+            "deleted": "Un <%= entityClassHumanized %> foi eliminado co identificador {{ param }}",<% } %>
             "delete": {
                 "question": "Seguro que desexa eliminar <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Un novo <%= entityClassHumanized %> foi creado co identificador {{ param }}",
+            "updated": "Un <%= entityClassHumanized %> foi actualizado co identificador {{ param }}",
+            "deleted": "Un <%= entityClassHumanized %> foi eliminado co identificador {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_hi.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_hi.json
@@ -6,10 +6,10 @@
                 "createLabel": "नया <%= entityClassHumanized %> बनाएँ",
                 "createOrEditLabel": "<%= entityClassHumanized %> बनाएँ या संपादित करें",
                 "search": "<%= entityClassHumanized %> खोजें"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "एक नया <%= entityClassHumanized %> [identifier: {{ param }}] तैयार है",
             "updated": "एक <%= entityClassHumanized %> [identifier: {{ param }}] का अद्यतन हुआ है",
-            "deleted": "<%= entityClassHumanized %> [identifier: {{ param }}] हटा दिया है",
+            "deleted": "<%= entityClassHumanized %> [identifier: {{ param }}] हटा दिया है",<% } %>
             "delete": {
                 "question": "<%= entityClassHumanized %> [id: {{ id }}] हटाने की पुष्टि करें"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "एक नया <%= entityClassHumanized %> [identifier: {{ param }}] तैयार है",
+            "updated": "एक <%= entityClassHumanized %> [identifier: {{ param }}] का अद्यतन हुआ है",
+            "deleted": "<%= entityClassHumanized %> [identifier: {{ param }}] हटा दिया है"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_hu.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_hu.json
@@ -6,10 +6,10 @@
                 "createLabel": "Egy új <%= entityClassHumanized %> létrehozása",
                 "createOrEditLabel": "Hozzon létre, vagy módosítson <%= entityClassHumanized %>t",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Biztos benne, hogy törölni szeretné az <%= entityClassHumanized %>t {{ id }} azonosítóval?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_it.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_it.json
@@ -6,10 +6,10 @@
                 "createLabel": "Genera un nuovo <%= entityClassHumanized %>",
                 "createOrEditLabel": "Genera o modifica un <%= entityClassHumanized %>",
                 "search": "Cerca <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "&Egrave; stato generato un nuovo <%= entityClassHumanized %> con identificatore { param }}",
             "updated": "&Egrave; stato aggiornato <%= entityClassHumanized %> identificato da {{ param }}",
-            "deleted": "&Egrave; stato eliminato <%= entityClassHumanized %> con identificatore {{ param }}",
+            "deleted": "&Egrave; stato eliminato <%= entityClassHumanized %> con identificatore {{ param }}",<% } %>
             "delete": {
                 "question": "Sei sicuro di volere eliminare <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "&Egrave; stato generato un nuovo <%= entityClassHumanized %> con identificatore { param }}",
+            "updated": "&Egrave; stato aggiornato <%= entityClassHumanized %> identificato da {{ param }}",
+            "deleted": "&Egrave; stato eliminato <%= entityClassHumanized %> con identificatore {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_ja.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_ja.json
@@ -6,10 +6,10 @@
                 "createLabel": "<%= entityClassHumanized %> を追加",
                 "createOrEditLabel": "<%= entityClassHumanized %>を追加または編集",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "<%= entityClassHumanized %> {{ id }}を削除してもよろしいですか？"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_kr.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_kr.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_mr.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_mr.json
@@ -6,10 +6,10 @@
                 "createLabel": "नवीन <%= entityClassHumanized %> तयार करा",
                 "createOrEditLabel": "<%= entityClassHumanized %> तयार किंवा संपादित करा",
                 "search": "<%= entityClassHumanized %> शोधा"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "<%= entityClassHumanized %> [identifier: {{ param }}] तयार आहे",
             "updated": "<%= entityClassHumanized %> [identifier: {{ param }}] सुधारित केले आहे",
-            "deleted": "<%= entityClassHumanized %> [identifier: {{ param }}] हटविले आहे",
+            "deleted": "<%= entityClassHumanized %> [identifier: {{ param }}] हटविले आहे",<% } %>
             "delete": {
                 "question": "<%= entityClassHumanized %> [id: {{ id }}] काढून टाकण्याबाबत पुष्टी?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "<%= entityClassHumanized %> [identifier: {{ param }}] तयार आहे",
+            "updated": "<%= entityClassHumanized %> [identifier: {{ param }}] सुधारित केले आहे",
+            "deleted": "<%= entityClassHumanized %> [identifier: {{ param }}] हटविले आहे"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_nl.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_nl.json
@@ -6,10 +6,10 @@
                 "createLabel": "Maak een nieuwe <%= entityClassHumanized %>",
                 "createOrEditLabel": "Maak of wijzig een <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Bent u zeker dat u <%= entityClassHumanized %> {{ id }} wilt verwijderen?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_pl.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_pl.json
@@ -6,10 +6,10 @@
                 "createLabel": "Dodaj <%= entityClassHumanized %>",
                 "createOrEditLabel": "Dodaj lub edytuj: <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Czy na pewno chcesz usunąć <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_pt-br.json
@@ -6,10 +6,10 @@
                 "createLabel": "Criar novo <%= entityClassHumanized %>",
                 "createOrEditLabel": "Criar ou editar <%= entityClassHumanized %>",
                 "search": "Pesquisar por <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Um novo <%= entityClassHumanized %> é criado com o identificador {{ param }}",
             "updated": "Um <%= entityClassHumanized %> é atualizado com o identificador {{ param }}",
-            "deleted": "Um <%= entityClassHumanized %> é deletado com o identificador {{ param }}",
+            "deleted": "Um <%= entityClassHumanized %> é deletado com o identificador {{ param }}",<% } %>
             "delete": {
                 "question": "Tem certeza de que deseja excluir <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Um novo <%= entityClassHumanized %> é criado com o identificador {{ param }}",
+            "updated": "Um <%= entityClassHumanized %> é atualizado com o identificador {{ param }}",
+            "deleted": "Um <%= entityClassHumanized %> é deletado com o identificador {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_pt-pt.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_pt-pt.json
@@ -6,10 +6,10 @@
                 "createLabel": "Criar um(a) novo(a) <%= entityClassHumanized %>",
                 "createOrEditLabel": "Criar ou editar um(a) <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Tem a certeza que pretende eliminar o(a) <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_ro.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_ro.json
@@ -6,10 +6,10 @@
                 "createLabel": "Crează o nouă <%= entityClassHumanized %>",
                 "createOrEditLabel": "Crează sau editează o <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "O nouă <%= entityClassHumanized %> este creată cu identificatorul {{ param }}",
             "updated": "O <%= entityClassHumanized %> este editată cu identificatorul {{ param }}",
-            "deleted": "O <%= entityClassHumanized %> este stearsă cu identificatorul {{ param }}",
+            "deleted": "O <%= entityClassHumanized %> este stearsă cu identificatorul {{ param }}",<% } %>
             "delete": {
                 "question": "Ești sigur că dorești să stergi <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "O nouă <%= entityClassHumanized %> este creată cu identificatorul {{ param }}",
+            "updated": "O <%= entityClassHumanized %> este editată cu identificatorul {{ param }}",
+            "deleted": "O <%= entityClassHumanized %> este stearsă cu identificatorul {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_ru.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_ru.json
@@ -6,10 +6,10 @@
                 "createLabel": "Создать новый <%= entityClassHumanized %>",
                 "createOrEditLabel": "Создать или отредактировать <%= entityClassHumanized %>",
                 "search": "Найти <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Новый <%= entityClassHumanized %> создан с идентификатором {{ param }}",
             "updated": "<%= entityClassHumanized %> обновлен с идентификатором {{ param }}",
-            "deleted": "<%= entityClassHumanized %> удален с идентификатором {{ param }}",
+            "deleted": "<%= entityClassHumanized %> удален с идентификатором {{ param }}",<% } %>
             "delete": {
                 "question": "Вы уверены что хотите удалить <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Новый <%= entityClassHumanized %> создан с идентификатором {{ param }}",
+            "updated": "<%= entityClassHumanized %> обновлен с идентификатором {{ param }}",
+            "deleted": "<%= entityClassHumanized %> удален с идентификатором {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_sk.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_sk.json
@@ -6,10 +6,10 @@
                 "createLabel": "Pridať <%= entityClassHumanized %>",
                 "createOrEditLabel": "Pridať alebo upraviť <%= entityClassHumanized %>",
                 "search": "Vyhľadať <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "Bol vytvorený potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }}",
             "updated": "Potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }} bol upravený.",
-            "deleted": "Potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }} bol vymazaný.",
+            "deleted": "Potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }} bol vymazaný.",<% } %>
             "delete": {
                 "question": "Ste si istý, že chcete vymazať <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Bol vytvorený potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }}",
+            "updated": "Potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }} bol upravený.",
+            "deleted": "Potomok entity <%= entityClassHumanized %> s identifikátorom {{ param }} bol vymazaný."
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_sv.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_sv.json
@@ -6,10 +6,10 @@
                 "createLabel": "Skapa en ny <%= entityClassHumanized %>",
                 "createOrEditLabel": "Skapa eller ändra en <%= entityClassHumanized %>",
                 "search": "Sök efter <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "En ny <%= entityClassHumanized %> är skapad med id {{ param }}",
             "updated": "En <%= entityClassHumanized %> är uppdaterad med id  {{ param }}",
-            "deleted": "En <%= entityClassHumanized %> är borttagen med id  {{ param }}",
+            "deleted": "En <%= entityClassHumanized %> är borttagen med id  {{ param }}",<% } %>
             "delete": {
                 "question": "Är du säker på att du vill ta bort <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "En ny <%= entityClassHumanized %> är skapad med id {{ param }}",
+            "updated": "En <%= entityClassHumanized %> är uppdaterad med id  {{ param }}",
+            "deleted": "En <%= entityClassHumanized %> är borttagen med id  {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_ta.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_ta.json
@@ -6,10 +6,10 @@
                 "createLabel": "<%= entityClassHumanized %>-ஐ உருவாக்கு",
                 "createOrEditLabel": "<%= entityClassHumanized %> -ஐ மாற்று (அ) உருவாக்கு",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "<%= entityClassHumanized %> புதிதாக உருவாக்கப்பட்டது, அடையாளம் {{ param }}",
             "updated": "<%= entityClassHumanized %> மாற்றப்பட்டது, அடையாளம்  {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> நீக்கப்பட்டது, அடையாளம {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> நீக்கப்பட்டது, அடையாளம {{ param }}",<% } %>
             "delete": {
                 "question": "நீக்குவதற்கு உறுதி செய் <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "<%= entityClassHumanized %> புதிதாக உருவாக்கப்பட்டது, அடையாளம் {{ param }}",
+            "updated": "<%= entityClassHumanized %> மாற்றப்பட்டது, அடையாளம்  {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> நீக்கப்பட்டது, அடையாளம {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_tr.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_tr.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_zh-cn.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_zh-cn.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }

--- a/generators/entity/templates/src/main/webapp/i18n/_entity_zh-tw.json
+++ b/generators/entity/templates/src/main/webapp/i18n/_entity_zh-tw.json
@@ -6,10 +6,10 @@
                 "createLabel": "Create a new <%= entityClassHumanized %>",
                 "createOrEditLabel": "Create or edit a <%= entityClassHumanized %>",
                 "search": "Search for <%= entityClassHumanized %>"
-            },
+            },<% if (!microserviceAppName) { %>
             "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
             "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
-            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}",<% } %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
@@ -19,5 +19,12 @@
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
             "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
         }
-    }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "A new <%= entityClassHumanized %> is created with identifier {{ param }}",
+            "updated": "A <%= entityClassHumanized %> is updated with identifier {{ param }}",
+            "deleted": "A <%= entityClassHumanized %> is deleted with identifier {{ param }}"
+        }
+    }<% } %>
 }


### PR DESCRIPTION
Fix #4075

Entity created/updated/deleted alert messages are moved under `microserviceAppName` if the generated entity belongs to a microservice to be able to show them.