### PR TITLE
Travis: sonar analyze for official repo

### DIFF
--- a/travis/scripts/06-sonar.sh
+++ b/travis/scripts/06-sonar.sh
@@ -5,7 +5,7 @@ set -ev
 #--------------------------------------------------
 cd "$HOME"/app
 if [ "$JHIPSTER" == "app-default-from-scratch" ]; then
-  if [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+  if [ "$TRAVIS_REPO_SLUG" = "jhipster/generator-jhipster"] && [ "$TRAVIS_BRANCH" = "master" ] && [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
     ./mvnw clean org.jacoco:jacoco-maven-plugin:prepare-agent package sonar:sonar -Dsonar.host.url=https://sonarqube.com -Dsonar.login=$SONAR_TOKEN
   fi
 fi


### PR DESCRIPTION
Very minor improvement
Only try launch sonar analyze to sonarsource if the repo is jhipster/generator-jhipster
