### PR TITLE
Yarn saved in config

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -84,7 +84,7 @@ module.exports = JhipsterGenerator.extend({
         this.jhiPrefix = this.configOptions.jhiPrefix || this.config.get('jhiPrefix') || this.options['jhi-prefix'];
         this.withEntities = this.options['with-entities'];
         this.checkInstall = this.options['check-install'];
-        this.yarnInstall = this.configOptions.yarnInstall = this.options['yarn'];
+        this.yarnInstall = this.configOptions.yarnInstall = this.options['yarn'] || this.config.get('yarn');
     },
 
     initializing: {
@@ -303,6 +303,7 @@ module.exports = JhipsterGenerator.extend({
                 this.config.set('nativeLanguage', this.nativeLanguage);
                 this.config.set('languages', this.languages);
             }
+            this.yarnInstall && this.config.set('yarn', true);
         }
     },
 

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -117,7 +117,7 @@ module.exports = JhipsterClientGenerator.extend({
         this.totalQuestions = this.configOptions.totalQuestions ? this.configOptions.totalQuestions : QUESTIONS;
         this.baseName = this.configOptions.baseName;
         this.logo = this.configOptions.logo;
-        this.yarnInstall = this.configOptions.yarnInstall || this.options['yarn'];
+        this.yarnInstall = this.configOptions.yarnInstall = this.configOptions.yarnInstall || this.options['yarn'] || this.config.get('yarn');
     },
 
     initializing: {
@@ -211,6 +211,7 @@ module.exports = JhipsterClientGenerator.extend({
                 this.config.set('nativeLanguage', this.nativeLanguage);
                 this.config.set('languages', this.languages);
             }
+            this.yarnInstall && this.config.set('yarn', true);
         }
     },
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -69,6 +69,7 @@ module.exports = JhipsterServerGenerator.extend({
         this.totalQuestions = this.configOptions.totalQuestions ? this.configOptions.totalQuestions : QUESTIONS;
         this.logo = this.configOptions.logo;
         this.baseName = this.configOptions.baseName;
+        this.yarnInstall = this.configOptions.yarnInstall = this.configOptions.yarnInstall || this.options['yarn'] || this.config.get('yarn');
     },
     initializing: {
         displayLogo: function () {

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -41,7 +41,7 @@
         <cucumber.version>1.2.4</cucumber.version>
         <%_ } _%>
         <%_ if (!skipClient) { _%>
-        <frontend-maven-plugin.version>1.0</frontend-maven-plugin.version>
+        <frontend-maven-plugin.version>1.2</frontend-maven-plugin.version>
         <%_ } _%>
         <%_ if (testFrameworks.indexOf('gatling') != -1) { _%>
         <gatling.version>2.2.0</gatling.version>
@@ -1085,15 +1085,16 @@
                                 <pluginExecution>
                                     <pluginExecutionFilter>
                                         <groupId>com.github.eirslett</groupId>
-                                        <artifactId>
-                                            frontend-maven-plugin
-                                        </artifactId>
-                                        <versionRange>
-                                            ${frontend-maven-plugin.version}
-                                        </versionRange>
+                                        <artifactId>frontend-maven-plugin</artifactId>
+                                        <versionRange>${frontend-maven-plugin.version}</versionRange>
                                         <goals>
+                                        <%_ if (yarnInstall) { _%>
+                                            <goal>install-node-and-yarn</goal>
+                                            <goal>yarn</goal>
+                                        <%_ } else { _%>
                                             <goal>install-node-and-npm</goal>
                                             <goal>npm</goal>
+                                        <%_ } _%>
                                             <goal>bower</goal>
                                             <goal>gulp</goal>
                                         </goals>
@@ -1178,8 +1179,41 @@
                     <plugin>
                         <groupId>com.github.eirslett</groupId>
                         <artifactId>frontend-maven-plugin</artifactId>
-                        <version>1.0</version>
+                        <version>${frontend-maven-plugin.version}</version>
                         <executions>
+                        <%_ if (yarnInstall) { _%>
+                            <execution>
+                                <id>install node and yarn</id>
+                                <goals>
+                                    <goal>install-node-and-yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <nodeVersion>v6.9.1</nodeVersion>
+                                    <yarnVersion>v0.17.6</yarnVersion>
+                                </configuration>
+                            </execution>
+                            <%_ if (useSass) { _%>
+                            <execution>
+                                <id>yarn rebuild node-sass</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install --force</arguments>
+                                </configuration>
+                            </execution>
+                            <%_ } else { _%>
+                            <execution>
+                                <id>yarn install</id>
+                                <goals>
+                                    <goal>yarn</goal>
+                                </goals>
+                                <configuration>
+                                    <arguments>install</arguments>
+                                </configuration>
+                            </execution>
+                            <%_ } _%>
+                        <%_ } else { _%>
                             <execution>
                                 <id>install node and npm</id>
                                 <goals>
@@ -1198,7 +1232,8 @@
                                 <configuration>
                                     <arguments>install</arguments>
                                 </configuration>
-                            </execution><% if(useSass) {%>
+                            </execution>
+                            <%_ if (useSass) { _%>
                             <execution>
                                 <id>npm rebuild node-sass</id>
                                 <goals>
@@ -1207,7 +1242,9 @@
                                 <configuration>
                                     <arguments>rebuild node-sass</arguments>
                                 </configuration>
-                            </execution><% } %>
+                            </execution>
+                            <%_ } _%>
+                        <%_ } _%>
                             <execution>
                                 <id>bower install</id>
                                 <goals>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1192,27 +1192,19 @@
                                     <yarnVersion>v0.17.6</yarnVersion>
                                 </configuration>
                             </execution>
-                            <%_ if (useSass) { _%>
-                            <execution>
-                                <id>yarn rebuild node-sass</id>
-                                <goals>
-                                    <goal>yarn</goal>
-                                </goals>
-                                <configuration>
-                                    <arguments>install --force</arguments>
-                                </configuration>
-                            </execution>
-                            <%_ } else { _%>
                             <execution>
                                 <id>yarn install</id>
                                 <goals>
                                     <goal>yarn</goal>
                                 </goals>
                                 <configuration>
+                                    <%_ if (useSass) { _%>
+                                    <arguments>install --force</arguments>
+                                    <%_ } else { _%>
                                     <arguments>install</arguments>
+                                    <%_ } _%>
                                 </configuration>
                             </execution>
-                            <%_ } _%>
                         <%_ } else { _%>
                             <execution>
                                 <id>install node and npm</id>

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -482,10 +482,48 @@ describe('JHipster generator', function () {
         });
     });
 
+    describe('default configuration using yarn flag', function () {
+        beforeEach(function (done) {
+            helpers.run(path.join(__dirname, '../generators/app'))
+                .withOptions({skipInstall: true, checkInstall: false, yarn: true})
+                .withPrompts({
+                    'baseName': 'jhipster',
+                    'packageName': 'com.mycompany.myapp',
+                    'packageFolder': 'com/mycompany/myapp',
+                    'authenticationType': 'session',
+                    'hibernateCache': 'ehcache',
+                    'databaseType': 'sql',
+                    'devDatabaseType': 'h2Memory',
+                    'prodDatabaseType': 'mysql',
+                    'useSass': false,
+                    'enableTranslation': true,
+                    'nativeLanguage': 'en',
+                    'languages': ['fr'],
+                    'buildTool': 'maven',
+                    'rememberMeKey': '5c37379956bd1242f5636c8cb322c2966ad81277',
+                    'skipClient': false,
+                    'skipUserManagement': false,
+                    'serverSideOptions' : []
+                })
+                .on('end', done);
+        });
+
+        it('creates expected default files', function () {
+            assert.file(expectedFiles.server);
+            assert.file(expectedFiles.maven);
+            assert.file(expectedFiles.client);
+            assert.file(expectedFiles.dockerServices);
+            assert.file(expectedFiles.mysql);
+        });
+        it('contains install-node-and-yarn in pom.xml', function () {
+            assert.fileContent('pom.xml', /install-node-and-yarn/);
+        });
+    });
+
     describe('mariadb configuration', function () {
         beforeEach(function (done) {
             helpers.run(path.join(__dirname, '../generators/app'))
-                .withOptions({skipInstall: true})
+                .withOptions({skipInstall: true, checkInstall: false})
                 .withPrompts({
                     'baseName': 'jhipster',
                     'packageName': 'com.mycompany.myapp',


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/4317

Steps:
1) create folder, then, `yarn link generator-jhipster` or `npm link generator-jhipster`
2) generate project: `yo jhipster --yarn` -> the config will save the option in `.yo-rc.json`
3) regenerate project: `yo jhipster --force` -> it will use the config, so yarn

If you choose maven, the `pom.xml` will use the frontend-maven-plugin with yarn
For gradle [here](https://github.com/jhipster/generator-jhipster/blob/master/generators/server/templates/gradle/_profile_prod.gradle#L55), it will still use npm install because the `com.moowork.node` doesn't support yarn yet

I tested with node-sass too

> Travis official support for Yarn is merged and will be activated on monday

So I will update our Travis build in another PR, next week