### PR TITLE
upgrade postgresql version

### DIFF
--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -29,7 +29,7 @@ mongobee_version=0.10<% } %>
 hibernate_validator_version=5.2.1.Final<% if (databaseType == 'cassandra' || applicationType == 'gateway') { %>
 lz4_version=1.3.0<% } %>
 metrics_spring_version=3.1.2<% if (devDatabaseType == 'postgresql' || prodDatabaseType == 'postgresql') { %>
-postgresql_version=9.4-1203-jdbc42<% } %><% if (authenticationType == 'oauth2') { %>
+postgresql_version=9.4.1212<% } %><% if (authenticationType == 'oauth2') { %>
 spring_security_oauth2_version=2.0.9.RELEASE<% } %>
 spring_security_version=4.1.3.RELEASE
 springfox_version=2.6.1

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -86,7 +86,7 @@
         <metrics-spring.version>3.1.3</metrics-spring.version>
         <logstash-logback-encoder.version>4.7</logstash-logback-encoder.version>
         <%_ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
-        <postgresql.version>9.4-1203-jdbc42</postgresql.version>
+        <postgresql.version>9.4.1212</postgresql.version>
         <%_ } _%>
         <run.addResources>false</run.addResources>
         <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>


### PR DESCRIPTION
avoiding the following issue on Postgresql 9.6.1 running 'mvn clean compile liquibase:diff':

[ERROR] Failed to execute goal org.liquibase:liquibase-maven-plugin:3.4.2:diff (default-cli) on project poc: Error setting up or running Liquibase: liquibase.command.CommandExecutionException: liquibase.exception.DatabaseException: liquibase.exception.DatabaseException: org.postgresql.util.PSQLException: ERROR: column am.amcanorder does not exist
