### PR TITLE
Use a custom matcher for ZonedDateTime test

### DIFF
--- a/generators/server/templates/src/test/java/package/web/rest/_TestUtil.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_TestUtil.java
@@ -3,11 +3,14 @@ package <%=packageName%>.web.rest;
 import com.fasterxml.jackson.annotation.JsonInclude;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
+import org.hamcrest.Description;
+import org.hamcrest.TypeSafeDiagnosingMatcher;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
 import java.nio.charset.Charset;
 import java.time.ZonedDateTime;
+import java.time.format.DateTimeParseException;
 
 /**
  * Utility class for testing REST controllers.
@@ -52,4 +55,46 @@ public class TestUtil {
         }
         return byteArray;
     }
+
+    /**
+     * A matcher that tests that the examined string represents the same instant as the reference datetime.
+     */
+    public static class ZonedDateTimeMatcher extends TypeSafeDiagnosingMatcher<String> {
+
+        private final ZonedDateTime date;
+
+        public ZonedDateTimeMatcher(ZonedDateTime date) {
+            this.date = date;
+        }
+
+        @Override
+        protected boolean matchesSafely(String item, Description mismatchDescription) {
+            try {
+                if (!date.isEqual(ZonedDateTime.parse(item))) {
+                    mismatchDescription.appendText("was ").appendValue(item);
+                    return false;
+                }
+                return true;
+            } catch (DateTimeParseException e) {
+                mismatchDescription.appendText("was ").appendValue(item)
+                    .appendText(", which could not be parsed as a ZonedDateTime");
+                return false;
+            }
+
+        }
+
+        @Override
+        public void describeTo(Description description) {
+            description.appendText("a String representing the same Instant as ").appendValue(date);
+        }
+    }
+
+    /**
+     * Creates a matcher that matches when the examined string reprensents the same instant as the reference datetime
+     * @param date the reference datetime against which the examined string is checked
+     */
+    public static ZonedDateTimeMatcher sameInstant(ZonedDateTime date) {
+        return new ZonedDateTimeMatcher(date);
+    }
+
 }


### PR DESCRIPTION
The matcher matches if the Instant represented by the string is the same as the one hold by the reference ZonedDateTime.

Fix #4491