### PR TITLE
Fixing callback url when deployed behind reverse proxy

### DIFF
--- a/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
@@ -48,7 +48,7 @@ public class SocialConfiguration implements SocialConfigurer {
             ConnectionRepository connectionRepository) {
 
         ConnectController controller = new ConnectController(connectionFactoryLocator, connectionRepository);
-        controller.setApplicationUrl(environment.getProperty("application.url"));
+        controller.setApplicationUrl(environment.getProperty("spring.application.url"));
         return controller;
     }
 

--- a/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
@@ -26,7 +26,6 @@ import org.springframework.social.security.AuthenticationNameUserIdSource;
 import org.springframework.social.twitter.connect.TwitterConnectionFactory;
 // jhipster-needle-add-social-connection-factory-import-package
 
-
 import javax.inject.Inject;
 
 /**

--- a/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
@@ -14,7 +14,9 @@ import org.springframework.social.config.annotation.ConnectionFactoryConfigurer;
 import org.springframework.social.config.annotation.EnableSocial;
 import org.springframework.social.config.annotation.SocialConfigurer;
 import org.springframework.social.connect.ConnectionFactoryLocator;
+import org.springframework.social.connect.ConnectionRepository;
 import org.springframework.social.connect.UsersConnectionRepository;
+import org.springframework.social.connect.web.ConnectController;
 import org.springframework.social.connect.web.ProviderSignInController;
 import org.springframework.social.connect.web.ProviderSignInUtils;
 import org.springframework.social.connect.web.SignInAdapter;
@@ -23,6 +25,7 @@ import org.springframework.social.google.connect.GoogleConnectionFactory;
 import org.springframework.social.security.AuthenticationNameUserIdSource;
 import org.springframework.social.twitter.connect.TwitterConnectionFactory;
 // jhipster-needle-add-social-connection-factory-import-package
+
 
 import javax.inject.Inject;
 

--- a/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
@@ -40,6 +40,18 @@ public class SocialConfiguration implements SocialConfigurer {
     @Inject
     private SocialUserConnectionRepository socialUserConnectionRepository;
 
+    @Inject
+    Environment environment;
+
+    @Bean
+    public ConnectController connectController(ConnectionFactoryLocator connectionFactoryLocator,
+            ConnectionRepository connectionRepository) {
+
+        ConnectController controller = new ConnectController(connectionFactoryLocator, connectionRepository);
+        controller.setApplicationUrl(environment.getProperty("application.url"));
+        return controller;
+    }
+
     @Override
     public void addConnectionFactories(ConnectionFactoryConfigurer connectionFactoryConfigurer, Environment environment) {
         // Google configuration
@@ -109,6 +121,7 @@ public class SocialConfiguration implements SocialConfigurer {
     public ProviderSignInController providerSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter) throws Exception {
         ProviderSignInController providerSignInController = new ProviderSignInController(connectionFactoryLocator, usersConnectionRepository, signInAdapter);
         providerSignInController.setSignUpUrl("/social/signup");
+        providerSignInController.setApplicationUrl(environment.getProperty("spring.application.url"));
         return providerSignInController;
     }
 


### PR DESCRIPTION
When deployed behind a reverse proxy, the application pushed towards the social (google, facebook, ...) a callback url computed on the request: which normally leads to http://localhost:8080/signin/google behing refused by the social app as non granted.

Both ```ConnectController``` and  ```ProviderSigninController``` accept the applicationUrl parameter which can be declared in Environment as spring.application.url. 
See http://docs.spring.io/spring-social/docs/current/reference/htmlsingle/#creating-connections-with-connectcontroller