### PR TITLE
Upgrading to Hibernate Validator 5.3.3.Final

### DIFF
--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -27,7 +27,7 @@ liquibase_slf4j_version=2.0.0
 liquibase_core_version=3.4.2
 liquibase_hibernate5_version=3.6<% } %><% if (databaseType == 'mongodb') { %>
 mongobee_version=0.10<% } %>
-hibernate_validator_version=5.2.1.Final<% if (databaseType == 'cassandra' || applicationType == 'gateway') { %>
+hibernate_validator_version=5.3.3.Final<% if (databaseType == 'cassandra' || applicationType == 'gateway') { %>
 lz4_version=1.3.0<% } %>
 metrics_spring_version=3.1.2<% if (devDatabaseType == 'postgresql' || prodDatabaseType == 'postgresql') { %>
 postgresql_version=9.4.1212<% } %><% if (authenticationType == 'oauth2') { %>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -443,6 +443,7 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
+            <version>5.3.3.Final</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>


### PR DESCRIPTION
This updates HV to the latest and greatest. I'm not 100% sure about the POM change, in that case you seem to get the HV version from the Spring Boot dependencies POM. I can rework or split it up as needed.