### PR TITLE
Upgrade Hibernate to 5.2.5.Final

### DIFF
--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -22,7 +22,7 @@ jna_version=4.2.2<% } %>
 geronimo_javamail_1_4_mail_version=1.8.4<% if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast') { %>
 hazelcast_version=3.7<% } %><% if (hibernateCache == 'hazelcast') { %>
 hazelcast_hibernate_version=1.1.1<% } %>
-hibernate_version=5.2.4.Final<% if (databaseType == 'sql') { %>
+hibernate_version=5.2.5.Final<% if (databaseType == 'sql') { %>
 liquibase_slf4j_version=2.0.0
 liquibase_core_version=3.4.2
 liquibase_hibernate5_version=3.6<% } %><% if (databaseType == 'mongodb') { %>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -52,7 +52,7 @@
         <hazelcast-hibernate.version>1.1.1</hazelcast-hibernate.version>
         <%_ } _%>
         <%_ if (databaseType === 'sql') { _%>
-        <hibernate.version>5.2.4.Final</hibernate.version>
+        <hibernate.version>5.2.5.Final</hibernate.version>
         <%_ } _%>
         <%_ if (databaseType === 'sql') { _%>
         <hikaricp.version>2.4.6</hikaricp.version>


### PR DESCRIPTION
This is just bug fixes release (https://hibernate.atlassian.net/secure/ReleaseNote.jspa?projectId=10031&version=25600). Don't know why Travis CI is not happy with some of build configs. It shows "The command "sudo apt-key adv --keyserver pgp.mit.edu --recv D101F7899D41F3C3" failed and exited with 2 during" errors
