### PR TITLE
Implement additional module installation step in the client generator

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -201,7 +201,9 @@ module.exports = JhipsterGenerator.extend({
 
         askForApplicationType: prompts.askForApplicationType,
 
-        askForModuleName: prompts.askForModuleName
+        askForModuleName: prompts.askForModuleName,
+
+        askForMoreModules: prompts.askForMoreModules,
     },
 
     configuring: {
@@ -209,6 +211,7 @@ module.exports = JhipsterGenerator.extend({
             this.configOptions.skipI18nQuestion = true;
             this.configOptions.baseName = this.baseName;
             this.configOptions.logo = false;
+            this.configOptions.otherModules = this.otherModules;
             this.generatorType = 'app';
             if (this.applicationType === 'microservice') {
                 this.skipClient = true;
@@ -282,6 +285,7 @@ module.exports = JhipsterGenerator.extend({
             insight.trackWithEvent('generator', 'app');
             insight.track('app/applicationType', this.applicationType);
             insight.track('app/testFrameworks', this.testFrameworks);
+            insight.track('app/otherModules', this.otherModules);
         },
 
         composeLanguages: function () {
@@ -295,6 +299,7 @@ module.exports = JhipsterGenerator.extend({
             this.config.set('baseName', this.baseName);
             this.config.set('testFrameworks', this.testFrameworks);
             this.config.set('jhiPrefix', this.jhiPrefix);
+            this.config.set('otherModules', this.otherModules);
             this.skipClient && this.config.set('skipClient', true);
             this.skipServer && this.config.set('skipServer', true);
             this.skipUserManagement && this.config.set('skipUserManagement', true);

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -109,6 +109,7 @@ module.exports = JhipsterClientGenerator.extend({
         this.enableSocialSignIn = this.options['social'];
         this.searchEngine = this.options['search-engine'];
         this.hibernateCache = this.options['hb-cache'];
+        this.otherModules = this.configOptions.otherModules || [];
         this.jhiPrefix = this.configOptions.jhiPrefix || this.config.get('jhiPrefix') || this.options['jhi-prefix'];
         this.jhiPrefixCapitalized = _.upperFirst(this.jhiPrefix);
         this.testFrameworks = [];

--- a/generators/client/templates/_package.json
+++ b/generators/client/templates/_package.json
@@ -74,7 +74,10 @@
     "run-sequence": "1.2.2",
     <%_ if (buildTool == 'maven') { _%>
     "xml2js": "0.4.17",
-    <%_ } _%>
+    <%_ }
+      otherModules.forEach(function(module) { _%>
+    "<%= module.name %>": "<%= module.version %>",
+    <%_ }); %>
     "yargs": "5.0.0"
   },
   "engines": {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -12,6 +12,7 @@ var path = require('path'),
     semver = require('semver'),
     exec = require('child_process').exec,
     os = require('os'),
+    http = require('http'),
     pluralize = require('pluralize');
 
 const JHIPSTER_CONFIG_DIR = '.jhipster';
@@ -1728,3 +1729,22 @@ Generator.prototype.hibernateSnakeCase = function (value) {
 };
 
 Generator.prototype.contains = _.includes;
+
+/**
+ * Function to issue a http get request, and process the result
+ *
+ *  @param {string} url - the url to fetch
+ *  @param onSuccess - function, which gets called when the request succeeds, with the body of the response
+ *  @param onFail - callback when the get failed.
+ */
+Generator.prototype.httpGet = function(url, onSuccess, onFail) {
+    http.get(url, function(res) {
+        var body = '';
+        res.on('data', function(chunk) {
+            body += chunk;
+        });
+        res.on('end', function() {
+            onSuccess(body);
+        });
+    }).on('error', onFail);
+};

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -36,8 +36,8 @@ const JHIPSTER_DOCUMENTATION_URL = 'https://jhipster.github.io';
 const JHIPSTER_DOCUMENTATION_ARCHIVE_PATH = '/documentation-archive/';
 
 const constants = {
-    QUESTIONS: 13, // maximum possible number of questions
-    CLIENT_QUESTIONS: 3,
+    QUESTIONS: 14, // maximum possible number of questions
+    CLIENT_QUESTIONS: 4,
     SERVER_QUESTIONS: 10,
     INTERPOLATE_REGEX: /<%:([\s\S]+?)%>/g, // so that tags in templates do not get mistreated as _ templates
     DOCKER_DIR: MAIN_DIR + 'docker/',


### PR DESCRIPTION
So in the app generator, the generator asks for additional jhipster-generator to install, so it's more easy to discover them.

Open questions, how to detect if the version supports the current one? 