### PR TITLE
Rename missing component templateUrls

### DIFF
--- a/generators/client-2/templates/src/main/webapp/app/admin/health/_health-modal.component.ts
+++ b/generators/client-2/templates/src/main/webapp/app/admin/health/_health-modal.component.ts
@@ -4,7 +4,7 @@ import { <%=jhiPrefixCapitalized%>HealthService } from './health.service';
 
 @Component({
     selector: '<%=jhiPrefix%>-health-modal',
-    templateUrl: 'app/admin/health/health-modal.html'
+    templateUrl: 'app/admin/health/health-modal.component.html'
 })
 export class <%=jhiPrefixCapitalized%>HealthModalComponent {
 

--- a/generators/client-2/templates/src/main/webapp/app/admin/metrics/_metrics-modal.component.ts
+++ b/generators/client-2/templates/src/main/webapp/app/admin/metrics/_metrics-modal.component.ts
@@ -3,7 +3,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 @Component({
     selector: '<%=jhiPrefix%>-metrics-modal',
-    templateUrl: 'app/admin/metrics/metrics-modal.html'
+    templateUrl: 'app/admin/metrics/metrics-modal.component.html'
 })
 export class <%=jhiPrefixCapitalized%>MetricsMonitoringModalComponent implements OnInit {
 


### PR DESCRIPTION
Fixed missing two templateUrl renamings at 195524a46af8d2f3dfeb8d26d4f4163a12f79924
