### PR TITLE
jhipster re-generation get's the correct angular2 option

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -165,6 +165,7 @@ module.exports = JhipsterServerGenerator.extend({
             this.nativeLanguage = this.config.get('nativeLanguage');
             this.languages = this.config.get('languages');
             this.uaaBaseName = this.config.get('uaaBaseName');
+            this.angularVersion = this.config.get('angularVersion');
             var testFrameworks = this.config.get('testFrameworks');
             if (testFrameworks) {
                 this.testFrameworks = testFrameworks;


### PR DESCRIPTION
When a .yo-rson file has already been created, js files are generated instead of ts files. 