### PR TITLE
[Prometheus] remove uuid generation for the alerting webhook

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -7,7 +7,6 @@ var generators = require('yeoman-generator'),
     jsyaml = require('js-yaml'),
     pathjs = require('path'),
     util = require('util'),
-    uuid = require('uuid'),
     prompts = require('./prompts'),
     writeFiles = require('./files').writeFiles,
     scriptBase = require('../generator-base');
@@ -99,7 +98,6 @@ module.exports = DockerComposeGenerator.extend({
             }
             this.adminPassword = this.config.get('adminPassword');
             this.jwtSecretKey = this.config.get('jwtSecretKey');
-            this.uuid = this.config.get('uuid');
 
             if(this.defaultAppsFolders !== undefined) {
                 this.log('\nFound .yo-rc.json config file...');
@@ -156,13 +154,6 @@ module.exports = DockerComposeGenerator.extend({
         generateJwtSecret: function() {
             if(this.jwtSecretKey === undefined) {
                 this.jwtSecretKey = crypto.randomBytes(20).toString('hex');
-            }
-        },
-
-        // Generate a UUID to setup an alerting webhook on webhook.site
-        generateUuid: function() {
-            if (this.uuid === undefined && this.monitoring !== 'no') {
-                this.uuid = uuid();
             }
         },
 
@@ -314,7 +305,6 @@ module.exports = DockerComposeGenerator.extend({
             this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
             this.config.set('adminPassword', this.adminPassword);
             this.config.set('jwtSecretKey', this.jwtSecretKey);
-            this.config.set('uuid', this.uuid);
         }
     },
 

--- a/generators/docker-compose/templates/alertmanager-conf/_config.yml
+++ b/generators/docker-compose/templates/alertmanager-conf/_config.yml
@@ -8,6 +8,6 @@ route:
 receivers:
 - name: 'webhook'
   webhook_configs:
-  # Open http://webhook.site/#/<%= uuid %> in a browser to view webhooks received in real time
-  - url: 'http://webhook.site/<%= uuid %>'
+  # For testing, create a sample alerting webhook at http://webhook.site/
+  - url: 'http://webhook.site/<UUID>'
     send_resolved: true

--- a/package.json
+++ b/package.json
@@ -49,7 +49,6 @@
     "pluralize": "3.0.0",
     "semver": "5.3.0",
     "shelljs": "0.7.4",
-    "uuid": "3.0.0",
     "yeoman-generator": "0.24.1",
     "yo": "1.8.5"
   },


### PR DESCRIPTION
@jdubois I just noticed that this was merged by mistake. Can it be removed before the release...
It was part of my prometheus PR. I thought I removed it but I must have made a mistake when rebasing.
This is actually useless because it doesn't work.