### PR TITLE
Fix Hazelcast versions and add missing JCache dependency

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -191,10 +191,11 @@ dependencies {
         exclude(module: 'metrics-healthchecks')
     } <% if (hibernateCache == 'hazelcast') { %>
     compile "com.hazelcast:hazelcast:${hazelcast_version}"
-    compile "com.hazelcast:hazelcast-hibernate52:${hazelcast_version}"
-    compile "com.hazelcast:hazelcast-spring:${hazelcast_hibernate_version}"<% } %><% if (clusteredHttpSession == 'hazelcast' && hibernateCache != 'hazelcast') { %>
+    compile "com.hazelcast:hazelcast-hibernate52:${hazelcast_hibernate_version}"
+    compile "com.hazelcast:hazelcast-spring:${hazelcast_version}"<% } %><% if (clusteredHttpSession == 'hazelcast' && hibernateCache != 'hazelcast') { %>
     compile "com.hazelcast:hazelcast:${hazelcast_version}"<% } %><% if (clusteredHttpSession == 'hazelcast') { %>
-    compile "com.hazelcast:hazelcast-wm:${hazelcast_version}"<% } %>
+    compile "com.hazelcast:hazelcast-wm:${hazelcast_version}"<% } %><% if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { %>
+    compile "javax.cache:cache-api:${jcache_version}"<% } %>
     <%_ if (databaseType == 'sql') { _%>
     compile "org.hibernate:hibernate-core:${hibernate_version}"
     compile("com.zaxxer:HikariCP") {

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -21,7 +21,8 @@ jjwt_version=0.7.0<% } %><% if (searchEngine == 'elasticsearch') { %>
 jna_version=4.2.2<% } %>
 geronimo_javamail_1_4_mail_version=1.8.4<% if (clusteredHttpSession == 'hazelcast' || hibernateCache == 'hazelcast') { %>
 hazelcast_version=3.7<% } %><% if (hibernateCache == 'hazelcast') { %>
-hazelcast_hibernate_version=1.1.1<% } %>
+hazelcast_hibernate_version=1.1.1<% } %><% if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { %>
+jcache_version=1.0.0<% } %>
 hibernate_version=5.2.4.Final<% if (databaseType == 'sql') { %>
 liquibase_slf4j_version=2.0.0
 liquibase_core_version=3.4.2


### PR DESCRIPTION
There are some Hazelcast dependency version errors and a missing JCache dependency at Gradle. Both are correct at Maven.

@jdubois you may want to merge this before releasing a Hibernate 5 / Hazelcast related version update.
