### PR TITLE
fix boolean and blob field types for postgresql

### DIFF
--- a/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/generators/entity/templates/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -50,7 +50,7 @@
             } else if (fieldType == 'ZonedDateTime') {
                 columnType="timestamp";
             } else if (fieldType == 'byte[]' && fieldTypeBlobContent != 'text') {
-                if (prodDatabaseType === 'mysql') {
+                if (prodDatabaseType === 'mysql' || prodDatabaseType === 'postgresql') {
                     columnType="longblob";
                 } else {
                     columnType="blob";
@@ -58,7 +58,11 @@
             } else if (fieldTypeBlobContent == 'text') {
                 columnType="clob";
             } else if (fieldType == 'Boolean') {
-                columnType="bit";
+                if (prodDatabaseType === 'postgresql') {
+                    columnType="boolean";
+                } else {
+                    columnType="bit";
+                }
             }
             %>
             <column name="<%=columnName %>" type="<%=columnType %>">


### PR DESCRIPTION
Liquibase recently changed how Postgresql handles blobs ([link](https://github.com/liquibase/liquibase/pull/600)), it now generates an `oid` for `blob` instead of `bytea`.  Changing it to `longblob` keeps the current behavior.

We should also be using `boolean` instead of `bit` for the Boolean type to let Liquibase determine the correct field type for the database.  It currently is hardcoded to `bit` which breaks Booleans for Postgresql (and maybe Oracle?).  To avoid a checksum change for everyone, I only changed this for Postgresql apps.

To reproduce the issue, generate an app that uses Postgresql and an entity with a boolean or blob.  Attempting to create that entity will give a 500 error