### PR TITLE
add an imagePullPolicy: IfNotPresent to k8s deployment files

### DIFF
--- a/generators/kubernetes/templates/_deployment.yml
+++ b/generators/kubernetes/templates/_deployment.yml
@@ -30,6 +30,7 @@ spec:
       containers:
       - name: <%= app.baseName.toLowerCase() %>
         image: <%= app.targetImageName %>
+        imagePullPolicy: IfNotPresent
         env:
         - name: SPRING_PROFILES_ACTIVE
           value: prod


### PR DESCRIPTION
Following a [discussion on the mailing list](https://groups.google.com/forum/#!topic/jhipster-dev/W44XX9W9Y4Y), I suggest we add this to be able to deploy to minikube without pushing to an external registry (using `eval $(minikube docker-env)`).

It could also be argued that it is a sensible default and should not cause problems if images are tagged properly.