### PR TITLE
Add generator-jhipster as an npm/yarn dependency if the app is a microservice

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -344,11 +344,11 @@ module.exports = JhipsterGenerator.extend({
                 // Generate a package.json file containing the current version of the generator as dependency
                 this.template('_skipClientApp.package.json', 'package.json', this, {});
 
-                if (this.yarnInstall) {
+                if (this.clientPackageManager === 'yarn') {
                     this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using yarn`));
                     this.spawnCommand('yarn', ['install']);
                 }
-                else {
+                else if (this.clientPackageManager === 'npm') {
                     this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using npm`));
                     this.npmInstall();
                 }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,6 +6,7 @@ var util = require('util'),
     cleanup = require('../cleanup'),
     prompts = require('./prompts'),
     packagejs = require('../../package.json'),
+    shelljs = require('shelljs'),
     exec = require('child_process').exec;
 
 var JhipsterGenerator = generators.Base.extend({});
@@ -132,7 +133,7 @@ module.exports = JhipsterGenerator.extend({
         },
 
         checkYarn: function () {
-            if (this.skipChecks || this.skipClient || !this.yarnInstall) return;
+            if (this.skipChecks || !this.yarnInstall) return;
             var done = this.async();
             exec('yarn --version', function (err) {
                 if (err) {
@@ -335,6 +336,29 @@ module.exports = JhipsterGenerator.extend({
     },
 
     end: {
+        localInstall: function() {
+            if (this.skipClient === true) {
+                // Generate a package.json file containing the current version of the generator as dependency
+                this.template('_skipClientApp.package.json', 'package.json', this, {});
+
+                var done = this.async();
+                var errorLocalJhipsterInstall = function (err) {
+                    if (err) {
+                        this.warning('Could not install generator-jhipster locally.');
+                    }
+                    done();
+                };
+                if(this.yarnInstall) {
+                    this.log(chalk.bold('\nInstalling generator-jhipster locally using yarn'));
+                    shelljs.exec('yarn install', errorLocalJhipsterInstall);
+                }
+                else {
+                    this.log(chalk.bold('\nInstalling generator-jhipster locally using npm'));
+                    shelljs.exec('npm install', errorLocalJhipsterInstall);
+                }
+            }
+        },
+
         afterRunHook: function () {
             try {
                 var modules = this.getModuleHooks();

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -341,20 +341,13 @@ module.exports = JhipsterGenerator.extend({
                 // Generate a package.json file containing the current version of the generator as dependency
                 this.template('_skipClientApp.package.json', 'package.json', this, {});
 
-                var done = this.async();
-                var errorLocalJhipsterInstall = function (err) {
-                    if (err) {
-                        this.warning('Could not install generator-jhipster locally.');
-                    }
-                    done();
-                };
                 if(this.yarnInstall) {
-                    this.log(chalk.bold('\nInstalling generator-jhipster locally using yarn'));
-                    shelljs.exec('yarn install', errorLocalJhipsterInstall);
+                    this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using yarn`));
+                    this.spawnCommand('yarn', ['install']);
                 }
                 else {
-                    this.log(chalk.bold('\nInstalling generator-jhipster locally using npm'));
-                    shelljs.exec('npm install', errorLocalJhipsterInstall);
+                    this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using npm`));
+                    this.npmInstall();
                 }
             }
         },

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -337,7 +337,7 @@ module.exports = JhipsterGenerator.extend({
 
     end: {
         localInstall: function() {
-            if (this.skipClient === true) {
+            if (this.skipClient && !this.options['skip-install']) {
                 if (this.otherModules === undefined) {
                     this.otherModules = [];
                 }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -6,7 +6,6 @@ var util = require('util'),
     cleanup = require('../cleanup'),
     prompts = require('./prompts'),
     packagejs = require('../../package.json'),
-    shelljs = require('shelljs'),
     exec = require('child_process').exec;
 
 var JhipsterGenerator = generators.Base.extend({});
@@ -165,6 +164,7 @@ module.exports = JhipsterGenerator.extend({
                 /* for backward compatibility */
                 this.clientFramework = 'angular1';
             }
+            this.otherModules = this.config.get('otherModules');
             this.testFrameworks = this.config.get('testFrameworks');
             this.enableTranslation = this.config.get('enableTranslation');
             this.nativeLanguage = this.config.get('nativeLanguage');
@@ -338,10 +338,13 @@ module.exports = JhipsterGenerator.extend({
     end: {
         localInstall: function() {
             if (this.skipClient === true) {
+                if (this.otherModules === undefined) {
+                    this.otherModules = [];
+                }
                 // Generate a package.json file containing the current version of the generator as dependency
                 this.template('_skipClientApp.package.json', 'package.json', this, {});
 
-                if(this.yarnInstall) {
+                if (this.yarnInstall) {
                     this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using yarn`));
                     this.spawnCommand('yarn', ['install']);
                 }

--- a/generators/app/templates/_skipClientApp.package.json
+++ b/generators/app/templates/_skipClientApp.package.json
@@ -1,5 +1,8 @@
 {
-  "dependencies": {
+  "devDependencies": {
+    <%_ otherModules.forEach(function(module) { _%>
+    "<%= module.name %>": "<%= module.version %>",
+    <%_ }); _%>
     "generator-jhipster": "<%= jhipsterVersion %>"
   }
 }

--- a/generators/app/templates/_skipClientApp.package.json
+++ b/generators/app/templates/_skipClientApp.package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "generator-jhipster": "<%= jhipsterVersion %>"
+  }
+}


### PR DESCRIPTION
Fix #4218
Add a minimal package.json and npm/yarn install step after generation for skipClient apps. 

TODO
- [x] more testing
- [x] a flag to disable the feature
- [x] checking that it works with the additional module installation question 