### PR TITLE
Translation mismatch in recover/change password

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/it/reset.json
+++ b/generators/languages/templates/src/main/webapp/i18n/it/reset.json
@@ -1,7 +1,7 @@
 {
     "reset": {
         "request": {
-            "title": "Cambia la password",
+            "title": "Reimposta Password",
             "form": {
                 "button": "Reimposta Password"
             },
@@ -14,7 +14,7 @@
 
         },
         "finish" : {
-            "title": "Reimposta Password",
+            "title": "Cambia Password",
             "form": {
                 "button": "Convalida la nuova password"
             },


### PR DESCRIPTION
The italian translation for the recover password form is wrong.