### PR TITLE
Isolate Jenkins jobs with docker and support CD in heroku

### DIFF
--- a/generators/heroku/USAGE
+++ b/generators/heroku/USAGE
@@ -7,3 +7,6 @@ Example:
     This will create:
         Procfile
         src/main/java/your_package_name/config/HerokuDatabaseConfiguration.java
+        Jenkinsfile
+        gradle/heroku.gradle
+

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -275,11 +275,18 @@ module.exports = HerokuGenerator.extend({
 
             this.template('_bootstrap-heroku.yml', constants.SERVER_MAIN_RES_DIR + '/config/bootstrap-heroku.yml');
             this.template('_application-heroku.yml', constants.SERVER_MAIN_RES_DIR + '/config/application-heroku.yml');
+            this.template('_Jenkinsfile', 'Jenkinsfile');
             this.template('_Procfile', 'Procfile');
+            this.template('_heroku.gradle', 'gradle/heroku.gradle');
 
             this.conflicter.resolve(function (err) {
                 done();
             });
+        },
+
+        addBuildPlugin: function () {
+            this.addGradlePlugin('gradle.plugin.com.heroku.sdk', 'heroku-gradle', '0.2.0');
+            this.applyFromGradleScript('gradle/heroku');
         }
     },
 

--- a/generators/heroku/templates/_Jenkinsfile
+++ b/generators/heroku/templates/_Jenkinsfile
@@ -5,7 +5,7 @@ node {
         checkout scm
     }
 
-    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS=-Duser.home=./<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
+    docker.image('jhipster/jhipster-ci-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
 <%_ if (applicationType !== 'microservice') { _%>
         stage('check tools') {
             sh "node -v"
@@ -54,7 +54,6 @@ node {
 <%_ if (applicationType !== 'microservice') { _%>
         stage('frontend tests') {
             try {
-                sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
                 sh "gulp test"
             } catch(err) {
                 throw err
@@ -69,10 +68,9 @@ node {
 
 <%_ } _%>
         stage('package and deploy') {
-            sh "git remote add heroku https://git.heroku.com/<%= herokuAppName %>.git || true"
-<%_ if (buildTool === 'maven') { _%
+<%_ if (buildTool === 'maven') { _%>
             // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
-            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod"
+            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
 <%_ } else if (buildTool === 'gradle' ) { _%>
             sh "./gradlew bootRepackage -Pprod -x test"
             // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)

--- a/generators/heroku/templates/_Jenkinsfile
+++ b/generators/heroku/templates/_Jenkinsfile
@@ -1,0 +1,96 @@
+#!/usr/bin/env groovy
+
+node {
+    stage('checkout') {
+        checkout scm
+    }
+
+    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS=-Duser.home=./<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
+<%_ if (applicationType !== 'microservice') { _%>
+        stage('check tools') {
+            sh "node -v"
+            sh "npm -v"
+            sh "bower -v"
+            sh "gulp -v"
+            sh "java -version"
+        }
+
+        stage('npm install') {
+            sh "npm install"
+        }
+
+<%_ } _%>
+<%_ if (buildTool === 'maven') { _%>
+        stage('clean') {
+            sh "./mvnw clean"
+        }
+
+        stage('backend tests') {
+            try {
+                sh "./mvnw test"
+            } catch(err) {
+                throw err
+            } finally {
+                junit '**/target/surefire-reports/TEST-*.xml'
+            }
+        }
+
+<%_ } else if (buildTool === 'gradle') { _%>
+        stage('clean') {
+            sh "./gradlew clean"
+        }
+
+        stage('backend tests') {
+            try {
+                sh "./gradlew test"
+            } catch(err) {
+                throw err
+            } finally {
+                junit '**/build/**/TEST-*.xml'
+            }
+        }
+
+<%_ } _%>
+<%_ if (applicationType !== 'microservice') { _%>
+        stage('frontend tests') {
+            try {
+                sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
+                sh "gulp test"
+            } catch(err) {
+                throw err
+            } finally {
+                <%_ if (buildTool === 'maven') { _%>
+                junit '**/target/test-results/karma/TESTS-*.xml'
+                <%_ } else if (buildTool === 'gradle') { _%>
+                junit '**/build/test-results/karma/TESTS-*.xml'
+                <%_ } _%>
+            }
+        }
+
+<%_ } _%>
+        stage('package and deploy') {
+            sh "git remote add heroku https://git.heroku.com/<%= herokuAppName %>.git || true"
+<%_ if (buildTool === 'maven') { _%
+            // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
+            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod"
+<%_ } else if (buildTool === 'gradle' ) { _%>
+            sh "./gradlew bootRepackage -Pprod -x test"
+            // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
+            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./gradlew deployHeroku"
+<%_ } _%>
+            archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
+        }
+
+        // Uncomment the following block to add Sonar analysis.
+        /*stage('quality analysis') {
+            withSonarQubeEnv('Sonar Server') {
+<%_ if (buildTool === 'maven') { _%>
+                sh "./mvnw sonar:sonar"
+<%_ } else if (buildTool === 'gradle' ) { _%>
+                sh "./gradlew sonarqube"
+<%_ } _%>
+            }
+        }*/
+
+    }
+}

--- a/generators/heroku/templates/_Jenkinsfile
+++ b/generators/heroku/templates/_Jenkinsfile
@@ -5,26 +5,27 @@ node {
         checkout scm
     }
 
-    docker.image('jhipster/jhipster-ci-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
-<%_ if (applicationType !== 'microservice') { _%>
-        stage('check tools') {
-            sh "node -v"
-            sh "npm -v"
-            sh "bower -v"
-            sh "gulp -v"
+    docker.image('openjdk:8').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
+        stage('check java') {
             sh "java -version"
         }
 
-        stage('npm install') {
-            sh "npm install"
-        }
-
-<%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
         stage('clean') {
             sh "./mvnw clean"
         }
 
+    <%_ if (applicationType !== 'microservice') { _%>
+        stage('prepare tools') {
+            sh "./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-npm -DnodeVersion=v6.9.2 -DnpmVersion=3.10.9"
+            sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
+        }
+
+        stage('npm install') {
+            sh "./mvnw com.github.eirslett:frontend-maven-plugin:npm"
+        }
+
+    <%_ } _%>
         stage('backend tests') {
             try {
                 sh "./mvnw test"
@@ -35,14 +36,38 @@ node {
             }
         }
 
+    <%_ if (applicationType !== 'microservice') { _%>
+        stage('frontend tests') {
+            try {
+                sh "./mvnw com.github.eirslett:frontend-maven-plugin:gulp -Dfrontend.gulp.arguments=test"
+            } catch(err) {
+                throw err
+            } finally {
+                junit '**/target/test-results/karma/TESTS-*.xml'
+            }
+        }
+
+    <%_ } _%>
+        stage('package and deploy') {
+             // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
+            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
+            archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
+        }
+
 <%_ } else if (buildTool === 'gradle') { _%>
         stage('clean') {
             sh "./gradlew clean"
         }
+    <%_ if (applicationType !== 'microservice') { _%>
+        stage('npm install') {
+            sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
+            sh "./gradlew npmInstall -PnodeInstall"
+        }
 
+    <%_ } _%>
         stage('backend tests') {
             try {
-                sh "./gradlew test"
+                sh "./gradlew test -PnodeInstall"
             } catch(err) {
                 throw err
             } finally {
@@ -50,35 +75,29 @@ node {
             }
         }
 
-<%_ } _%>
-<%_ if (applicationType !== 'microservice') { _%>
+    <%_ if (applicationType !== 'microservice') { _%>
         stage('frontend tests') {
             try {
-                sh "gulp test"
+                sh "./gradlew gulp_test -PnodeInstall"
             } catch(err) {
                 throw err
             } finally {
-                <%_ if (buildTool === 'maven') { _%>
-                junit '**/target/test-results/karma/TESTS-*.xml'
-                <%_ } else if (buildTool === 'gradle') { _%>
                 junit '**/build/test-results/karma/TESTS-*.xml'
-                <%_ } _%>
             }
         }
 
-<%_ } _%>
-        stage('package and deploy') {
-<%_ if (buildTool === 'maven') { _%>
-            // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
-            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
-<%_ } else if (buildTool === 'gradle' ) { _%>
-            sh "./gradlew bootRepackage -Pprod -x test"
-            // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
-            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./gradlew deployHeroku"
-<%_ } _%>
-            archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
+    <%_ } _%>
+        stage('packaging') {
+            sh "./gradlew bootRepackage -x test -Pprod -PnodeInstall"
+            archiveArtifacts artifacts: '**/build/*.war', fingerprint: true
         }
 
+        stage('deployment') {
+            // Fill with your Heroku API key (get it at https://dashboard.heroku.com/account)
+            sh "HEROKU_API_KEY=\"xxxxxxxx-xxxx-xxxx-xxxx-xxxxxxxxx\" ./gradlew deployHeroku"
+        }
+
+<%_ } _%>
         // Uncomment the following block to add Sonar analysis.
         /*stage('quality analysis') {
             withSonarQubeEnv('Sonar Server') {

--- a/generators/heroku/templates/_heroku.gradle
+++ b/generators/heroku/templates/_heroku.gradle
@@ -1,0 +1,1 @@
+apply plugin: 'com.heroku.sdk.heroku-gradle'

--- a/generators/heroku/templates/_heroku.gradle
+++ b/generators/heroku/templates/_heroku.gradle
@@ -1,1 +1,5 @@
 apply plugin: 'com.heroku.sdk.heroku-gradle'
+
+heroku {
+  appName = "<%= herokuAppName %>"
+}

--- a/generators/server/templates/_Jenkinsfile
+++ b/generators/server/templates/_Jenkinsfile
@@ -5,7 +5,7 @@ node {
         checkout scm
     }
 
-    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS=-Duser.home=./<% } %>') {
+    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS=-Duser.home=./<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
 <%_ if (applicationType !== 'microservice') { _%>
         stage('check tools') {
             sh "node -v"
@@ -37,12 +37,12 @@ node {
 
 <%_ } else if (buildTool === 'gradle') { _%>
         stage('clean') {
-            sh "./gradlew clean -g .gradle"
+            sh "./gradlew clean"
         }
 
         stage('backend tests') {
             try {
-                sh "./gradlew test -g .gradle"
+                sh "./gradlew test"
             } catch(err) {
                 throw err
             } finally {
@@ -72,7 +72,7 @@ node {
 <%_ if (buildTool === 'maven') { _%>
             sh "./mvnw package -Pprod -DskipTests"
 <%_ } else if (buildTool === 'gradle' ) { _%>
-            sh "./gradlew bootRepackage -Pprod -x test -g .gradle"
+            sh "./gradlew bootRepackage -Pprod -x test"
 <%_ } _%>
             archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
         }
@@ -83,7 +83,7 @@ node {
 <%_ if (buildTool === 'maven') { _%>
                 sh "./mvnw sonar:sonar"
 <%_ } else if (buildTool === 'gradle' ) { _%>
-                sh "./gradlew sonarqube -g .gradle"
+                sh "./gradlew sonarqube"
 <%_ } _%>
             }
         }*/

--- a/generators/server/templates/_Jenkinsfile
+++ b/generators/server/templates/_Jenkinsfile
@@ -5,7 +5,7 @@ node {
         checkout scm
     }
 
-    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS=-Duser.home=./<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
+    docker.image('jhipster/jhipster-ci-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
 <%_ if (applicationType !== 'microservice') { _%>
         stage('check tools') {
             sh "node -v"
@@ -54,7 +54,6 @@ node {
 <%_ if (applicationType !== 'microservice') { _%>
         stage('frontend tests') {
             try {
-                sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
                 sh "gulp test"
             } catch(err) {
                 throw err

--- a/generators/server/templates/_Jenkinsfile
+++ b/generators/server/templates/_Jenkinsfile
@@ -1,77 +1,92 @@
+#!/usr/bin/env groovy
+
 node {
     stage('checkout') {
         checkout scm
     }
 
+    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root') {
 <%_ if (applicationType !== 'microservice') { _%>
-    // uncomment these 2 lines and edit the name 'node-4.6.0' according to what you choose in configuration
-    // def nodeHome = tool name: 'node-4.6.0', type: 'jenkins.plugins.nodejs.tools.NodeJSInstallation'
-    // env.PATH = "${nodeHome}/bin:${env.PATH}"
+        stage('check tools') {
+            sh "node -v"
+            sh "npm -v"
+            sh "bower -v"
+            sh "gulp -v"
+        }
 
-    stage('check tools') {
-        sh "node -v"
-        sh "npm -v"
-        sh "bower -v"
-        sh "gulp -v"
-    }
-
-    stage('npm install') {
-        sh "npm install"
-    }
+        stage('npm install') {
+            sh "npm install"
+        }
 
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
-    stage('clean') {
-        sh "./mvnw clean"
-    }
-
-    stage('backend tests') {
-        try {
-            sh "./mvnw test"
-        } catch(err) {
-            throw err
-        } finally {
-            step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+        stage('clean') {
+            writeFile file: 'settings.xml', text: "<settings><localRepository>${pwd()}/.m2repo</localRepository></settings>"
+            sh "./mvnw clean -s settings.xml"
         }
-    }
+
+        stage('backend tests') {
+            try {
+                sh "./mvnw test -s settings.xml"
+            } catch(err) {
+                throw err
+            } finally {
+                step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+            }
+        }
 
 <%_ } else if (buildTool === 'gradle') { _%>
-    stage('clean') {
-        sh "./gradlew clean"
-    }
-
-    stage('backend tests') {
-        try {
-            sh "./gradlew test"
-        } catch(err) {
-            throw err
-        } finally {
-            step([$class: 'JUnitResultArchiver', testResults: '**/build/**/TEST-*.xml'])
+        stage('clean') {
+            sh "./gradlew clean -g .gradle"
         }
-    }
+
+        stage('backend tests') {
+            try {
+                sh "./gradlew test -g .gradle"
+            } catch(err) {
+                throw err
+            } finally {
+                step([$class: 'JUnitResultArchiver', testResults: '**/build/**/TEST-*.xml'])
+            }
+        }
 
 <%_ } _%>
 <%_ if (applicationType !== 'microservice') { _%>
-    stage('frontend tests') {
-        try {
-            sh "gulp test"
-        } catch(err) {
-            throw err
-        } finally {
-            <%_ if (buildTool === 'maven') { _%>
-            step([$class: 'JUnitResultArchiver', testResults: '**/target/test-results/karma/TESTS-*.xml'])
-            <%_ } else if (buildTool === 'gradle') { _%>
-            step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/karma/TESTS-*.xml'])
-            <%_ } _%>
+        stage('frontend tests') {
+            try {
+                sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
+                sh "gulp test"
+            } catch(err) {
+                throw err
+            } finally {
+                <%_ if (buildTool === 'maven') { _%>
+                step([$class: 'JUnitResultArchiver', testResults: '**/target/test-results/karma/TESTS-*.xml'])
+                <%_ } else if (buildTool === 'gradle') { _%>
+                step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/karma/TESTS-*.xml'])
+                <%_ } _%>
+            }
         }
-    }
 
 <%_ } _%>
-    stage('packaging') {
+        stage('packaging') {
 <%_ if (buildTool === 'maven') { _%>
-        sh "./mvnw package -Pprod -DskipTests"
+            sh "./mvnw package -Pprod -DskipTests -s settings.xml"
 <%_ } else if (buildTool === 'gradle' ) { _%>
-        sh "./gradlew bootRepackage -Pprod -x test"
+            sh "./gradlew bootRepackage -Pprod -x test -g .gradle"
 <%_ } _%>
+            step([$class: 'ArtifactArchiver', artifacts: '**/target/*.war', fingerprint: true])
+        }
+
+        // Uncomment the following block to add Sonar analysis.
+        /*stage('quality analysis') {
+            withSonarQubeEnv('Sonar Server') {
+<%_ if (buildTool === 'maven') { _%>
+                sh "./mvnw sonar:sonar -s settings.xml"
+<%_ } else if (buildTool === 'gradle' ) { _%>
+                sh "./gradlew sonarqube -g .gradle"
+<%_ } _%>
+            }
+        }*/
+
     }
 }

--- a/generators/server/templates/_Jenkinsfile
+++ b/generators/server/templates/_Jenkinsfile
@@ -5,26 +5,27 @@ node {
         checkout scm
     }
 
-    docker.image('jhipster/jhipster-ci-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
-<%_ if (applicationType !== 'microservice') { _%>
-        stage('check tools') {
-            sh "node -v"
-            sh "npm -v"
-            sh "bower -v"
-            sh "gulp -v"
+    docker.image('openjdk:8').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
+        stage('check java') {
             sh "java -version"
         }
 
-        stage('npm install') {
-            sh "npm install"
-        }
-
-<%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
         stage('clean') {
             sh "./mvnw clean"
         }
 
+    <%_ if (applicationType !== 'microservice') { _%>
+        stage('prepare tools') {
+            sh "./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-npm -DnodeVersion=v6.9.2 -DnpmVersion=3.10.9"
+            sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
+        }
+
+        stage('npm install') {
+            sh "./mvnw com.github.eirslett:frontend-maven-plugin:npm"
+        }
+
+    <%_ } _%>
         stage('backend tests') {
             try {
                 sh "./mvnw test"
@@ -35,14 +36,37 @@ node {
             }
         }
 
+    <%_ if (applicationType !== 'microservice') { _%>
+        stage('frontend tests') {
+            try {
+                sh "./mvnw com.github.eirslett:frontend-maven-plugin:gulp -Dfrontend.gulp.arguments=test"
+            } catch(err) {
+                throw err
+            } finally {
+                junit '**/target/test-results/karma/TESTS-*.xml'
+            }
+        }
+
+    <%_ } _%>
+        stage('packaging') {
+            sh "./mvnw package -Pprod -DskipTests"
+            archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
+        }
+
 <%_ } else if (buildTool === 'gradle') { _%>
         stage('clean') {
             sh "./gradlew clean"
         }
+    <%_ if (applicationType !== 'microservice') { _%>
+        stage('npm install') {
+            sh "echo '{ \"allow_root\": true }' > /root/.bowerrc"
+            sh "./gradlew npmInstall -PnodeInstall"
+        }
 
+    <%_ } _%>
         stage('backend tests') {
             try {
-                sh "./gradlew test"
+                sh "./gradlew test -PnodeInstall"
             } catch(err) {
                 throw err
             } finally {
@@ -50,32 +74,24 @@ node {
             }
         }
 
-<%_ } _%>
-<%_ if (applicationType !== 'microservice') { _%>
+    <%_ if (applicationType !== 'microservice') { _%>
         stage('frontend tests') {
             try {
-                sh "gulp test"
+                sh "./gradlew gulp_test -PnodeInstall"
             } catch(err) {
                 throw err
             } finally {
-                <%_ if (buildTool === 'maven') { _%>
-                junit '**/target/test-results/karma/TESTS-*.xml'
-                <%_ } else if (buildTool === 'gradle') { _%>
                 junit '**/build/test-results/karma/TESTS-*.xml'
-                <%_ } _%>
             }
         }
 
-<%_ } _%>
+    <%_ } _%>
         stage('packaging') {
-<%_ if (buildTool === 'maven') { _%>
-            sh "./mvnw package -Pprod -DskipTests"
-<%_ } else if (buildTool === 'gradle' ) { _%>
-            sh "./gradlew bootRepackage -Pprod -x test"
-<%_ } _%>
-            archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
+            sh "./gradlew bootRepackage -x test -Pprod -PnodeInstall"
+            archiveArtifacts artifacts: '**/build/*.war', fingerprint: true
         }
 
+<%_ } _%>
         // Uncomment the following block to add Sonar analysis.
         /*stage('quality analysis') {
             withSonarQubeEnv('Sonar Server') {

--- a/generators/server/templates/_Jenkinsfile
+++ b/generators/server/templates/_Jenkinsfile
@@ -5,13 +5,14 @@ node {
         checkout scm
     }
 
-    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root') {
+    docker.image('atomfrede/gitlab-ci-jhipster-stack').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS=-Duser.home=./<% } %>') {
 <%_ if (applicationType !== 'microservice') { _%>
         stage('check tools') {
             sh "node -v"
             sh "npm -v"
             sh "bower -v"
             sh "gulp -v"
+            sh "java -version"
         }
 
         stage('npm install') {
@@ -21,17 +22,16 @@ node {
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
         stage('clean') {
-            writeFile file: 'settings.xml', text: "<settings><localRepository>${pwd()}/.m2repo</localRepository></settings>"
-            sh "./mvnw clean -s settings.xml"
+            sh "./mvnw clean"
         }
 
         stage('backend tests') {
             try {
-                sh "./mvnw test -s settings.xml"
+                sh "./mvnw test"
             } catch(err) {
                 throw err
             } finally {
-                step([$class: 'JUnitResultArchiver', testResults: '**/target/surefire-reports/TEST-*.xml'])
+                junit '**/target/surefire-reports/TEST-*.xml'
             }
         }
 
@@ -46,7 +46,7 @@ node {
             } catch(err) {
                 throw err
             } finally {
-                step([$class: 'JUnitResultArchiver', testResults: '**/build/**/TEST-*.xml'])
+                junit '**/build/**/TEST-*.xml'
             }
         }
 
@@ -60,9 +60,9 @@ node {
                 throw err
             } finally {
                 <%_ if (buildTool === 'maven') { _%>
-                step([$class: 'JUnitResultArchiver', testResults: '**/target/test-results/karma/TESTS-*.xml'])
+                junit '**/target/test-results/karma/TESTS-*.xml'
                 <%_ } else if (buildTool === 'gradle') { _%>
-                step([$class: 'JUnitResultArchiver', testResults: '**/build/test-results/karma/TESTS-*.xml'])
+                junit '**/build/test-results/karma/TESTS-*.xml'
                 <%_ } _%>
             }
         }
@@ -70,18 +70,18 @@ node {
 <%_ } _%>
         stage('packaging') {
 <%_ if (buildTool === 'maven') { _%>
-            sh "./mvnw package -Pprod -DskipTests -s settings.xml"
+            sh "./mvnw package -Pprod -DskipTests"
 <%_ } else if (buildTool === 'gradle' ) { _%>
             sh "./gradlew bootRepackage -Pprod -x test -g .gradle"
 <%_ } _%>
-            step([$class: 'ArtifactArchiver', artifacts: '**/target/*.war', fingerprint: true])
+            archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
         }
 
         // Uncomment the following block to add Sonar analysis.
         /*stage('quality analysis') {
             withSonarQubeEnv('Sonar Server') {
 <%_ if (buildTool === 'maven') { _%>
-                sh "./mvnw sonar:sonar -s settings.xml"
+                sh "./mvnw sonar:sonar"
 <%_ } else if (buildTool === 'gradle' ) { _%>
                 sh "./gradlew sonarqube -g .gradle"
 <%_ } _%>


### PR DESCRIPTION
Using docker in Jenkins allows to:
* simplify the setup of Jenkins (eg. no need to install tools on the nodes)
* isolate the builds and start on clean environments

This PR will:
* Use [CloudBees Docker Pipeline Plugin](https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Pipeline+Plugin) to run builds in docker containers
* Call ArtifactArchiver task at the end of the packaging to archive the generated war.
* Add a SonarQube analysis step (optional, must be uncommented)

Jenkins setup requirements:
* [CloudBees Docker Pipeline Plugin](https://wiki.jenkins-ci.org/display/JENKINS/CloudBees+Docker+Pipeline+Plugin) must be installed
* Docker installed in the Jenkins node
* `jenkins` user has permission to use docker (usermod -aG docker jenkins)
* If you use a dockerized Jenkins, run it with `docker run -d --name jenkins2 -p 18080:8080 -p 50000:50000 -v $(which docker):/usr/bin/docker -v jenkins_home:/var/jenkins_home -v /var/run/docker.sock:/var/run/docker.sock --group-add=$(stat -c %g /var/run/docker.sock) jenkinsci/jenkins` so that it can use the host docker
* Optional but recommended : remap host jenkins user to container's root user (for better security and so that files generated during the build belong to jenkins). To do that add a file /etc/docker/daemon.json with content:
```json
{ 
    "userns-remap": "jenkins"
} 
```
and in /etc/subuid add a line `jenkins:106:1` replacing 106 by the uid of the jenkins user (get it with command `id jenkins`)

TODO/Next:
- [x] Create and use an official jhipster ci docker image
- [ ] Update website doc
- [x] Configure cache dirs through env variables
- [x] Find a way to cache the maven/gradle wrapper (currently downloaded at each build)
- [x] Make the heroku subgen generate a CD stage. For the impatient:
```groovy
        stage('package and deploy') {
            sh "git remote add heroku https://git.heroku.com/jhipstersampleapplication.git || true"
            sh "HEROKU_API_KEY=\"xxxx-xxx-xx-xx-xxxxxx\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -s settings.xml"
            step([$class: 'ArtifactArchiver', artifacts: '**/target/*.war', fingerprint: true])
        }            
```
(a jhipster app is continuously deployed at https://jhipstersampleapplication.herokuapp.com :smile: )