### PR TITLE
Removing exposed ports: nobody listening there

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -67,5 +67,5 @@ RUN \
 USER jhipster
 WORKDIR "/home/jhipster/app"
 VOLUME ["/home/jhipster/app"]
-EXPOSE 8080 3000 3001
+#EXPOSE 8080 3000 3001
 CMD ["tail", "-f", "/home/jhipster/generator-jhipster/generators/server/templates/src/main/resources/banner-no-color.txt"]


### PR DESCRIPTION
Dockerfile exposes ports 8080, 3000 and 3001 but nothing is listening there in the container.
Starting jhipster container as documented

    docker run --name jhipster -v `pwd`:/home/jhipster/app -v ~/.m2:/home/jhipster/.m2 -p 8080:8080 -p 3000:3000 -p 3001:3001 -d -t jhipster/jhipster

blocks these ports so you can run the application only inside the container.

I know that develoers can still run the container without exposing these ports but, since there are other dockerfile definitions (```src/main/docker```) to containerize the application I see no point in exposing these ports here.

