### PR TITLE
Missing clientFw when using sub generator entities

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -117,6 +117,7 @@ module.exports = EntityGenerator.extend({
             if (this.testFrameworks === undefined) {
                 this.testFrameworks = ['gatling'];
             }
+            this.clientFw = this.config.get('clientFw');
 
             this.skipClient = this.applicationType === 'microservice' || this.config.get('skipClient') || this.options['skip-client'];
 


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/4549

Still issue with the build : app-psql-es-noi18n
The user can't log into the application, so the protractor failed

