### PR TITLE
remove translation from projects with it disabled [ng1]

### DIFF
--- a/generators/client/files-angularjs.js
+++ b/generators/client/files-angularjs.js
@@ -275,7 +275,7 @@ const files = {
             path: ANGULAR_DIR,
             templates: [
                 { file: 'components/login/_login.html', method: 'copyHtml' },
-                'components/login/_login.service.js',
+                { file: 'components/login/_login.service.js', method: 'copyJs' },
                 'components/login/_login.controller.js',
                 'components/form/_show-validation.directive.js',
                 'components/form/_maxbytes.directive.js',

--- a/generators/client/templates/angularjs/src/main/webapp/app/layouts/error/_error.state.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/layouts/error/_error.state.js
@@ -22,7 +22,7 @@
                     }
                 },
                 resolve: {
-                    mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
+                    translatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
                         $translatePartialLoader.addPart('error');
                         return $translate.refresh();
                     }]
@@ -40,7 +40,7 @@
                     }
                 },
                 resolve: {
-                    mainTranslatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate,$translatePartialLoader) {
+                    translatePartialLoader: ['$translate', '$translatePartialLoader', function ($translate, $translatePartialLoader) {
                         $translatePartialLoader.addPart('error');
                         return $translate.refresh();
                     }]


### PR DESCRIPTION
This fixes:
 - login.service.js which prevented logging in for Angular 1 apps without translation
 - error.state.js missed by regex due to different format

Fixes the second bullet point under Angular 1 in @pascalgrimaud's comment #4549