### PR TITLE
Fix ng2 jhiPrefix compile errors

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health-modal.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health-modal.component.ts
@@ -11,7 +11,7 @@ export class <%=jhiPrefixCapitalized%>HealthModalComponent {
 
     currentHealth: any;
 
-    constructor(private healthService:JhiHealthService, public activeModal: NgbActiveModal) {}
+    constructor(private healthService:<%=jhiPrefixCapitalized%>HealthService, public activeModal: NgbActiveModal) {}
 
     baseName(name) {
         return this.healthService.getBaseName(name);

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.component.ts
@@ -39,7 +39,7 @@ export class <%=jhiPrefixCapitalized%>HealthCheckComponent implements OnInit {
     }
 
     showHealth(health: any) {
-        const modalRef  = this.modalService.open(JhiHealthModalComponent);
+        const modalRef  = this.modalService.open(<%=jhiPrefixCapitalized%>HealthModalComponent);
         modalRef.componentInstance.currentHealth = health;
         modalRef.result.then((result) => {
             console.log(`Closed with: ${result}`);

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.component.ts
@@ -49,7 +49,7 @@ export class <%=jhiPrefixCapitalized%>MetricsMonitoringComponent implements OnIn
 
     refreshThreadDumpData () {
         this.metricsService.threadDump().subscribe((data) => {
-            const modalRef  = this.modalService.open(JhiMetricsMonitoringModalComponent, { size: 'lg'});
+            const modalRef  = this.modalService.open(<%=jhiPrefixCapitalized%>MetricsMonitoringModalComponent, { size: 'lg'});
             modalRef.componentInstance.threadDump = data;
             modalRef.result.then((result) => {
                 console.log(`Closed with: ${result}`);

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.service.ts
@@ -8,7 +8,7 @@ export class <%=jhiPrefixCapitalized%>MetricsService {
     constructor (private http: Http) {}
 
     getMetrics(): Observable<any> {
-        return this.http.get('management/jhipster/metrics').map((res: Response) => res.json());
+        return this.http.get('management/metrics').map((res: Response) => res.json());
     }
 
     threadDump(): Observable<any> {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/_shared-common.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/_shared-common.module.ts
@@ -11,7 +11,7 @@ import {
     FilterPipe,
     OrderByPipe,
     <%_ if (enableTranslation){ _%>
-    <%=jhiPrefixCapitalized%>Translate,
+    JhiTranslate,
     <%=jhiPrefixCapitalized%>MissingTranslationHandler,
     <%=jhiPrefixCapitalized%>LanguageService,
     FindLanguageFromKeyPipe,
@@ -43,7 +43,7 @@ import {
         CapitalizePipe,
         KeysPipe,
         <%_ if (enableTranslation){ _%>
-        <%=jhiPrefixCapitalized%>Translate,
+        JhiTranslate,
         FindLanguageFromKeyPipe,
         <%_ } _%>
         JhiAlertComponent,
@@ -74,7 +74,7 @@ import {
         CapitalizePipe,
         KeysPipe,
         <%_ if (enableTranslation){ _%>
-        <%=jhiPrefixCapitalized%>Translate,
+        JhiTranslate,
         FindLanguageFromKeyPipe,
         <%_ } _%>
         JhiAlertComponent,


### PR DESCRIPTION
This only fixes compile errors if jhiPrefix is different from default. There could be more things to do to complete ng2-jhiPrefix support.

Also fixed URL in metrics.service.
