### PR TITLE
Fix configuration when translation is disabled

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.state.ts
@@ -1,5 +1,5 @@
 import { ActivateComponent } from './activate.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const activateState = {
     name: 'activate',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.state.ts
@@ -1,5 +1,5 @@
 import { PasswordResetFinishComponent } from './password-reset-finish.component';
-import { JhiLanguageService  } from '../../../shared';
+import { JhiLanguageService } from '../../../shared';
 
 export const finishResetState = {
     name: 'finishReset',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.state.ts
@@ -1,5 +1,5 @@
 import {PasswordResetInitComponent} from './password-reset-init.component';
-import { JhiLanguageService  } from '../../../shared';
+import { JhiLanguageService } from '../../../shared';
 
 export const requestResetState = {
     name: 'requestReset',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.state.ts
@@ -1,5 +1,5 @@
 import { PasswordComponent } from './password.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const passwordState = {
     name: 'password',

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/_register.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/_register.state.ts
@@ -1,5 +1,5 @@
 import { RegisterComponent } from './register.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const registerState = {
     name: 'register',

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.state.ts
@@ -1,5 +1,5 @@
 import { SessionsComponent } from './sessions.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const sessionsState = {
     name: 'sessions',

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.component.ts
@@ -12,7 +12,7 @@ export class SettingsComponent implements OnInit {
     settingsAccount: any;
     languages: any[];
 
-    constructor(private account: AccountService, private principal: Principal<% if (enableTranslation){ %>, private languageService: JhiLanguageService  <% } %>) {}
+    constructor(private account: AccountService, private principal: Principal<% if (enableTranslation){ %>, private languageService: JhiLanguageService <% } %>) {}
 
     ngOnInit () {
         this.principal.identity().then((account) => {

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.state.ts
@@ -1,5 +1,5 @@
 import { SettingsComponent } from './settings.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const settingsState = {
     name: 'settings',

--- a/generators/client/templates/angular/src/main/webapp/app/account/social/_social.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/social/_social.state.ts
@@ -3,7 +3,7 @@ import { SocialRegisterComponent } from './social-register.component';
 import { SocialAuthComponent } from './social-auth.component';
 <%_ } _%>
 <%_ if (enableTranslation){ _%>
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 <%_ } _%>
 
 export const socialRegisterState = {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.state.ts
@@ -1,5 +1,5 @@
 import { AuditsComponent } from './audits.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const auditState = {
     name: 'audits',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>ConfigurationComponent } from './configuration.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const configState = {
     name: '<%=jhiPrefix%>-configuration',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>GatewayComponent } from './gateway.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const gatewayState = {
     name: 'gateway',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>HealthCheckComponent } from './health.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const healthState = {
     name: '<%=jhiPrefix%>-health',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.state.ts
@@ -1,5 +1,5 @@
 import { LogsComponent } from './logs.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const logsState = {
     name: 'logs',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>MetricsMonitoringComponent } from './metrics.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const metricsState = {
     name: '<%=jhiPrefix%>-metrics',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.ts
@@ -4,7 +4,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { User } from './user.model';
 import { UserService } from './user.service';
 <%_ if (enableTranslation){ _%>
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 <%_ }_%>
 import { EventManager } from '../../shared/service/event-manager.service';
 

--- a/generators/client/templates/angular/src/main/webapp/app/home/_home.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_home.state.ts
@@ -1,5 +1,5 @@
 import { HomeComponent } from './home.component';
-import { JhiLanguageService  } from '../shared';
+import { JhiLanguageService } from '../shared';
 
 export const homeState = {
     name: 'home',

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/_error.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/_error.state.ts
@@ -1,5 +1,5 @@
 import { ErrorComponent } from './error.component';
-import { JhiLanguageService  } from '../../shared';
+import { JhiLanguageService } from '../../shared';
 
 export const errorState = {
     name: 'error',

--- a/generators/client/templates/angular/src/main/webapp/app/shared/language/_language.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/language/_language.service.ts
@@ -6,7 +6,7 @@ import { LANGUAGES } from './language.constants';
 import { TranslatePartialLoader } from './translate-partial-loader.provider';
 
 @Injectable()
-export class JhiLanguageService  {
+export class JhiLanguageService {
 
     defaultLang = '<%= nativeLanguage %>';
     defaultLocation = 'global';

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Renderer, ElementRef } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { StateService } from 'ui-router-ng2';
 <%_ if (enableTranslation){ _%>
-import { JhiLanguageService  } from '../language/language.service';
+import { JhiLanguageService } from '../language/language.service';
 <%_ } _%>
 import { LoginService } from '../login/login.service';
 import { StateStorageService } from '../auth/state-storage.service';

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 
 <%_ if (enableTranslation){ _%>
-import { JhiLanguageService  } from '../language/language.service';
+import { JhiLanguageService } from '../language/language.service';
 <%_ } _%>
 import { Principal } from '../auth/principal.service';
 <%_ if (authenticationType === 'oauth2') { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/social/_social.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/social/_social.component.ts
@@ -2,7 +2,7 @@ import { Component, Input, OnInit } from '@angular/core';
 import { SocialService } from './social.service';
 import { CSRFService } from '../auth/csrf.service';
 <%_ if (enableTranslation){ _%>
-import { JhiLanguageService  } from '../language/language.service';
+import { JhiLanguageService } from '../language/language.service';
 <%_ } _%>
 
 @Component({


### PR DESCRIPTION
The regexp doesn't expect multiple whitespaces.
This is introduced with this commit: 
https://github.com/jhipster/generator-jhipster/commit/350d0e659367333ef0a4f3213a64c1d2d7cabbba