### PR TITLE
Add a gradle flag to build using downloaded node/npm

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -1,3 +1,4 @@
+import groovy.json.JsonSlurper
 import org.gradle.internal.os.OperatingSystem
 
 buildscript {
@@ -15,10 +16,7 @@ buildscript {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}"
         classpath "org.springframework.build.gradle:propdeps-plugin:0.0.7"
         <%_ if(!skipClient) { _%>
-        classpath "com.moowork.gradle:gradle-node-plugin:0.14"
-            <%_ if(clientFw === 'angular1') { _%>
-        classpath "com.moowork.gradle:gradle-gulp-plugin:0.13"
-            <%_ } _%>
+        classpath "com.moowork.gradle:gradle-node-plugin:1.0.1"
         <%_ } _%>
         classpath "io.spring.gradle:dependency-management-plugin:0.6.1.RELEASE"
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
@@ -32,6 +30,12 @@ apply plugin: 'maven'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'war'
 apply plugin: 'propdeps'
+<%_ if(!skipClient) { _%>
+apply plugin: 'com.moowork.node'
+    <%_ if (clientFw === 'angular1') { _%>
+apply plugin: 'com.moowork.gulp'
+    <%_ } _%>
+<%_ } _%>
 apply plugin: 'io.spring.dependency-management'
 <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa' || messageBroker === 'kafka') { _%>
 dependencyManagement {
@@ -369,7 +373,29 @@ task wrapper(type: Wrapper) {
 
 task stage(dependsOn: 'bootRepackage') {
 }
+<% if(!skipClient) { %>
+if (project.hasProperty('nodeInstall')) {
+    node {
+        version = '6.9.2'
+        npmVersion = '3.10.9'
+        download = true
+    }
 
+    // Workaround for https://github.com/srs/gradle-node-plugin/issues/134
+    task installLocalNpm {
+        def npmVersion = ''
+        def packageFile = file( new File( (File) node.nodeModulesDir, 'node_modules/npm/package.json' ) )
+        if (packageFile.exists()) {
+            def json = new JsonSlurper().parseText(packageFile.text)
+            npmVersion = json.version
+        }
+        if (npmVersion != node.npmVersion) {
+            npmInstall.dependsOn 'npm_install_npm@' + node.npmVersion
+        }
+    }
+    npmInstall.dependsOn installLocalNpm
+}
+<% } %>
 compileJava.dependsOn processResources
 processResources.dependsOn cleanResources,bootBuildInfo
 bootBuildInfo.mustRunAfter cleanResources

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -69,12 +69,17 @@ processResources {
 
 <%_ if (!skipClient) { _%>
     <%_ if (yarnInstall) { _%>
-gulpBuildWithOpts.dependsOn 'yarn_install'
+// Workaround for https://github.com/srs/gradle-node-plugin/issues/134 doesn't work with yarn
+if (!project.hasProperty('nodeInstall')) {
+    gulpBuildWithOpts.dependsOn yarn_install
+} else {
+    gulpBuildWithOpts.dependsOn npmInstall
+}
     <%_ } else { _%>
-gulpBuildWithOpts.dependsOn 'npmInstall'
+gulpBuildWithOpts.dependsOn npmInstall
     <%_ } _%>
     <%_ if (clientFw === 'angular1') { _%>
-gulpBuildWithOpts.dependsOn 'bower'
+gulpBuildWithOpts.dependsOn bower
 processResources.dependsOn gulpBuildWithOpts
 test.dependsOn gulp_test
 bootRun.dependsOn gulp_test

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -1,4 +1,3 @@
-import org.apache.tools.ant.taskdefs.condition.Os
 apply plugin: 'org.springframework.boot'
 <%_ if(!skipClient) { _%>
 apply plugin: 'com.moowork.node'
@@ -35,12 +34,7 @@ task gulpBuildWithOpts(type: GulpTask) {
 }
     <%_ } else { _%>
 task webpack(type: NodeTask, dependsOn: 'npmInstall') {
-    def osName = System.getProperty("os.name").toLowerCase();
-    if (osName.contains("windows")) {
-      script = project.file('node_modules/webpack/bin/webpack.js')
-    } else {
-      script = project.file('node_modules/.bin/webpack')
-    }
+    script = project.file('node_modules/webpack/bin/webpack.js')
     args = ["-p", "--config", "webpack/webpack.prod.js"]
 }
     <%_ } _%>

--- a/generators/server/templates/gradle/_yeoman.gradle
+++ b/generators/server/templates/gradle/_yeoman.gradle
@@ -1,12 +1,20 @@
-import org.apache.tools.ant.taskdefs.condition.Os
-apply plugin: 'com.moowork.gulp'
+apply plugin: 'com.moowork.node'
 
-task bower(type: Exec) {
-    if (Os.isFamily(Os.FAMILY_WINDOWS)) {
-        commandLine 'cmd', '/c', 'bower', 'install'
-    }else{
-        commandLine 'bower', 'install'
-    }
+task bower(type: NodeTask) {
+    description = "Installs dependencies using Bower"
+    script = file("${project.projectDir}/node_modules/bower/bin/bower")
+    args = ['install']
 }
-processResources.dependsOn 'bower'
+
+<%_ if (yarnInstall) { _%>
+// Workaround for https://github.com/srs/gradle-node-plugin/issues/134 doesn't work with yarn
+if (!project.hasProperty('nodeInstall')) {
+    bower.dependsOn yarn_install
+} else {
+    bower.dependsOn npmInstall
+}
+<%_ } else { _%>
+bower.dependsOn npmInstall
+<%_ } _%>
+processResources.dependsOn bower
 bower.onlyIf { !project.hasProperty('skipBower') }


### PR DESCRIPTION
* Add a nodeDl property to use a downloaded node/npm (as with frontend-maven-plugin). Default is deactivated.
* Add a workaround for gradle-node-plugin/issues/134 (only works for npm so even if yarn was used at project generation, it fallsback to npm if nodeDl flag is on)

Fix #4667