### PR TITLE
fix many-to-many to same entity

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/server/src/main/java/package/domain/_Entity.java
@@ -270,7 +270,7 @@ public class <%= entityClass %> implements Serializable {
     }
 
     public <%= entityClass %> add<%= relationshipNameCapitalized %>(<%= otherEntityNameCapitalized %> <%= otherEntityName %>) {
-        <%= relationshipFieldNamePlural %>.add(<%= otherEntityName %>);
+        this.<%= relationshipFieldNamePlural %>.add(<%= otherEntityName %>);
             <%_ if (relationshipType == 'one-to-many') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(this);
             <%_ } else if (otherEntityRelationshipNameCapitalizedPlural != '' && relationshipType == 'many-to-many') {
@@ -281,7 +281,7 @@ public class <%= entityClass %> implements Serializable {
     }
 
     public <%= entityClass %> remove<%= relationshipNameCapitalized %>(<%= otherEntityNameCapitalized %> <%= otherEntityName %>) {
-        <%= relationshipFieldNamePlural %>.remove(<%= otherEntityName %>);
+        this.<%= relationshipFieldNamePlural %>.remove(<%= otherEntityName %>);
             <%_ if (relationshipType == 'one-to-many') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(null);
             <%_ } else if (otherEntityRelationshipNameCapitalizedPlural != '' && relationshipType == 'many-to-many') {


### PR DESCRIPTION
If `relationshipFieldNamePlural` matches `otherEntityName`, it doesn't add/remove the entity from the correct relationship.

Thanks to @brunnels for pointing this out

Example entity name that causes this issue is `ToolDeviceData`:
```java
    public ImportIssue addToolDeviceData(ToolDeviceData toolDeviceData) {
        toolDeviceData.add(toolDeviceData);
        toolDeviceData.getImportIssues().add(this);
        return this;
    }

    public ImportIssue removeToolDeviceData(ToolDeviceData toolDeviceData) {
        toolDeviceData.remove(toolDeviceData);
        toolDeviceData.getImportIssues().remove(this);
        return this;
    }
```
After this change:
```java
    public ImportIssue addToolDeviceData(ToolDeviceData toolDeviceData) {
        this.toolDeviceData.add(toolDeviceData);
        toolDeviceData.getImportIssues().add(this);
        return this;
    }

    public ImportIssue removeToolDeviceData(ToolDeviceData toolDeviceData) {
        this.toolDeviceData.remove(toolDeviceData);
        toolDeviceData.getImportIssues().remove(this);
        return this;
    }
```