### PR TITLE
fix random error/hanging of gradlew after executing gulp plugin in Windows

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -86,6 +86,13 @@ if (OperatingSystem.current().isWindows()) {
             classpath = files("$buildDir/classes/main", "$buildDir/resources/main", pathingJar.archivePath)
         }
     }
+    <%_ if(!skipClient && clientFramework === 'angular1') { _%>
+
+    // avoid random error and hanging in windows, see https://github.com/jhipster/generator-jhipster/pull/4683
+    gulp {
+        bufferOutput = true
+    }
+    <%_ } _%>
 } else {
     bootRun {
         addResources = false


### PR DESCRIPTION
This PR is enhanced version of fix jhipster/generator-jhipster#4683 where gulp bufferOutput=true is assigned only in Windows.
Opening new PR because GitHub doesn't allow updates on closed PR-s.