### PR TITLE
fix the order of the generator questions

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -206,6 +206,7 @@ module.exports = JhipsterGenerator.extend({
             this.configOptions.logo = false;
             this.configOptions.clientFramework = this.clientFramework;
             this.configOptions.otherModules = this.otherModules;
+            this.configOptions.lastQuestion = this.currentQuestion;
             this.generatorType = 'app';
             if (this.applicationType === 'microservice') {
                 this.skipClient = true;


### PR DESCRIPTION
fix #4729 

After the change the order is correct:
![after](https://cloud.githubusercontent.com/assets/3299903/21383259/76c5e14c-c76d-11e6-95d5-3bd6ebe6a43d.png)
