### PR TITLE
correct Yarn version name  _pom.xml

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -154,7 +154,7 @@
         <%_ } _%>
         <springfox.version>2.6.1</springfox.version>
         <%_ if (clientPackageManager === 'yarn') { _%>
-        <yarn.version>v0.17.10</yarn.version>
+        <yarn.version>0.17.10</yarn.version>
         <%_ } _%>
     </properties>
 

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -154,7 +154,7 @@
         <%_ } _%>
         <springfox.version>2.6.1</springfox.version>
         <%_ if (clientPackageManager === 'yarn') { _%>
-        <yarn.version>0.17.10</yarn.version>
+        <yarn.version>v0.18.1</yarn.version>
         <%_ } _%>
     </properties>
 


### PR DESCRIPTION
Letter v in <yarn.version>**v**0.17.10</yarn.version> parameter couse reinstall Yarn with the same version

[INFO] Yarn 0.17.10 was installed, but we need version v0.17.10
[INFO] Installing Yarn version v0.17.10
[INFO] Unpacking C:\Users\RobertM\.m2\repository\com\github\eirslett\yarn\0.17.10\yarn-0.17.10.\yarn-0.17.10.msi into C:\Temp\jhipster_portfel\node\yarn
[INFO] Installed Yarn locally.
[INFO]