### PR TITLE
AWS Subgenerator Polish

### DIFF
--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -2,7 +2,6 @@
 var S3 = require('./s3.js'),
     Rds = require('./rds.js'),
     shelljs = require('shelljs'),
-    os = require('os'),
     Eb = require('./eb.js');
 
 var Aws, generator;
@@ -14,18 +13,7 @@ var AwsFactory = module.exports = function AwsFactory(generatorRef, cb) {
         cb();
     } catch (e) {
         generator.log('Installing AWS dependencies into your JHipster folder');
-        var jhipsterPath = 'node_modules/generator-jhipster';
-        var skipClient = generator.config.get('skipClient');
-        // use the global JHipster for apps with no client-side code
-        if (skipClient) {
-            var prefix = shelljs.exec('npm config get prefix', {silent:true}).trim();
-            if (os.platform() === 'win32') {
-                jhipsterPath = prefix + '/' + jhipsterPath;
-            } else {
-                jhipsterPath = prefix + '/lib/' + jhipsterPath;
-            }
-        }
-        shelljs.exec('npm install aws-sdk progress node-uuid --prefix ' + jhipsterPath, {silent:true}, function (code, msg, err) {
+        shelljs.exec('npm install aws-sdk progress uuid --prefix node_modules/generator-jhipster', {silent: true}, function (code, msg, err) {
             if (code !== 0) generator.error('Something went wrong while installing:\n' + err);
             Aws = require('aws-sdk');
             cb();

--- a/generators/aws/lib/eb.js
+++ b/generators/aws/lib/eb.js
@@ -1,25 +1,13 @@
 'use strict';
-
-var chalk = require('chalk');
-
 var aws;
-var uuid;
-
+var uuidV4;
 
 var Eb = module.exports = function Eb(Aws, generator) {
     aws = Aws;
     try {
-        uuid = require('node-uuid');
+        uuidV4 = require('uuid/v4');
     } catch (e) {
-        generator.env.error(chalk.red(
-            'You don\'t have the AWS SDK installed. Please install it in the JHipster generator directory.\n\n') +
-            chalk.yellow('WINDOWS\n') +
-            chalk.green('cd %USERPROFILE%\\AppData\\Roaming\\npm\\node_modules\\generator-jhipster\n' +
-            'npm install aws-sdk progress node-uuid\n\n') +
-            chalk.yellow('LINUX / MAC\n') +
-            chalk.green('cd /usr/local/lib/node_modules/generator-jhipster\n' +
-            'npm install aws-sdk progress node-uuid')
-        );
+        generator.error('Something went wrong while running jhipster:aws:\n' + e);
     }
 };
 
@@ -27,7 +15,7 @@ Eb.prototype.createApplication = function createApplication(params, callback) {
     var applicationName = params.applicationName,
         bucketName = params.bucketName,
         warKey = params.warKey,
-        versionLabel = this.warKey + '-' + uuid.v4(),
+        versionLabel = this.warKey + '-' + uuidV4(),
         environmentName = params.environmentName,
         dbUrl = params.dbUrl,
         dbUsername = params.dbUsername,

--- a/generators/aws/lib/s3.js
+++ b/generators/aws/lib/s3.js
@@ -1,6 +1,5 @@
 'use strict';
-var fs = require('fs'),
-    chalk = require('chalk');
+var fs = require('fs');
 
 const FILE_EXTENSION = '.original',
     S3_STANDARD_REGION = 'us-east-1';
@@ -13,15 +12,7 @@ var S3 = module.exports = function S3(Aws, generator) {
     try {
         progressbar = require('progress');
     } catch (e) {
-        generator.env.error(chalk.red(
-            'You don\'t have the AWS SDK installed. Please install it in the JHipster generator directory.\n\n') +
-            chalk.yellow('WINDOWS\n') +
-            chalk.green('cd %USERPROFILE%\\AppData\\Roaming\\npm\\node_modules\\generator-jhipster\n' +
-            'npm install aws-sdk progress node-uuid\n\n') +
-            chalk.yellow('LINUX / MAC\n') +
-            chalk.green('cd /usr/local/lib/node_modules/generator-jhipster\n' +
-            'npm install aws-sdk progress node-uuid')
-        );
+        generator.error('Something went wrong while running jhipster:aws:\n' + e);
     }
 };
 


### PR DESCRIPTION
 - The npm package `node-uuid` was deprecated in favor of `uuid`
 - Microservices now have a local generator-jhipster so the config is very simple
 - We install the npm packages for the users, so the error messages should just say what went wrong