### PR TITLE
Migration to BS4 + Translation issues

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.component.html
@@ -19,7 +19,7 @@
                     <!-- TODO: Add translation for service name -->
                     <td><% if (enableTranslation) { %>{{'health.indicator.' + baseName(health.name) | translate}}<% } else { %><span class="text-capitalize">{{ baseName(health.name) }}</span><% } %> {{subSystemName(health.name)}}</td>
                     <td class="text-xs-center">
-                        <span class="tag" [ngClass]="getTagClass(health.status)" jhi-translate="'health.status.' + health.status">
+                        <span class="tag" [ngClass]="getTagClass(health.status)" jhi-translate="{{'health.status.' + health.status}}">
                             {{health.status}}
                         </span>
                     </td>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
@@ -53,21 +53,21 @@
                                 [uiParams]="{ login: user.login }"
                                 class="btn btn-info btn-sm">
                             <span class="fa fa-eye"></span>
-                            <span class="hidden-xs hidden-sm" jhi-translate="entity.action.view"></span>
+                            <span class="hidden-sm-down" jhi-translate="entity.action.view"></span>
                         </button>
                         <button type="submit"
                                 uiSref="user-management.edit"
                                 [uiParams]="{ login: user.login }"
                                 class="btn btn-primary btn-sm">
                             <span class="fa fa-pencil"></span>
-                            <span class="hidden-xs hidden-sm" jhi-translate="entity.action.edit"></span>
+                            <span class="hidden-sm-down" jhi-translate="entity.action.edit"></span>
                         </button>
                         <button type="submit"
                                 uiSref="user-management.delete"
                                 [uiParams]="{ login: user.login }"
                                 class="btn btn-danger btn-sm" [disabled]="currentAccount.login==user.login">
                             <span class="fa fa-remove"></span>
-                            <span class="hidden-xs hidden-sm" jhi-translate="entity.action.delete"></span>
+                            <span class="hidden-sm-down" jhi-translate="entity.action.delete"></span>
                         </button>
                     </div>
                 </td>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
@@ -13,7 +13,7 @@
             <li class="nav-item" uiSrefActive="active">
                 <a class="nav-link" uiSref="home" (click)="collapseNavbar()">
                     <i class="fa fa-home" aria-hidden="true"></i>
-                    <span class="hidden-sm" jhi-translate="global.menu.home">Home</span>
+                    <span jhi-translate="global.menu.home">Home</span>
                 </a>
             </li>
             <!-- jhipster-needle-add-element-to-menu - JHipster will add new menu items here -->
@@ -21,7 +21,7 @@
                 <a class="nav-link dropdown-toggle" uiSrefActive="active" ngbDropdownToggle href="javascript:void(0);" id="entity-menu">
                     <span>
                         <i class="fa fa-th-list" aria-hidden="true"></i>
-                        <span class="hidden-sm" jhi-translate="global.menu.entities.main">
+                        <span jhi-translate="global.menu.entities.main">
                             Entities
                         </span>
                         <b class="caret"></b>
@@ -35,7 +35,7 @@
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="account-menu">
                     <span>
                         <i class="fa fa-user" aria-hidden="true"></i>
-                        <span class="hidden-sm" jhi-translate="global.menu.account.main">
+                        <span jhi-translate="global.menu.account.main">
                             Account
                         </span>
                         <b class="caret"></b>
@@ -86,7 +86,7 @@
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="admin-menu">
                     <span>
                         <i class="fa fa-user-plus" aria-hidden="true"></i>
-                        <span class="hidden-sm" jhi-translate="global.menu.admin.main">Administration</span>
+                        <span jhi-translate="global.menu.admin.main">Administration</span>
                         <b class="caret"></b>
                     </span>
                 </a>
@@ -165,7 +165,7 @@
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="languagesnavBarDropdown" *ngIf="languages.length > 1">
                     <span>
                         <i class="fa fa-flag" aria-hidden="true"></i>
-                        <span class="hidden-sm" jhi-translate="global.menu.language">Language</span>
+                        <span jhi-translate="global.menu.language">Language</span>
                         <b class="caret"></b>
                     </span>
                 </a>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-dark jh-navbar">
     <div class="jh-logo-container float-xs-left">
-        <a class="jh-navbar-toggler hidden-lg-up float-xs-left" href="#" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation" (click)="toggleNavbar()">
+        <a class="jh-navbar-toggler hidden-lg-up float-xs-left" href="javascript:void(0);" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation" (click)="toggleNavbar()">
             <i class="fa fa-bars"></i>
         </a>
         <a class="navbar-brand logo float-xs-right" uiSref="home" (click)="collapseNavbar()">

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
@@ -31,6 +31,7 @@ export class NavbarComponent implements OnInit {
         private profileService: ProfileService
     ) {
         this.version = DEBUG_INFO_ENABLED ? 'v' + VERSION : '';
+        this.isNavbarCollapsed = true;
     }
 
     ngOnInit() {

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-detail.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-detail.component.html
@@ -87,6 +87,6 @@
 
     <button type="button" ui-sref="<%= entityStateName %>-detail.edit({id:vm.<%=entityInstance %>.id})" class="btn btn-primary">
         <span class="glyphicon glyphicon-pencil"></span>
-        <span class="hidden-xs hidden-sm" data-translate="entity.action.edit"> Edit</span>
+        <span class="hidden-sm-down" data-translate="entity.action.edit"> Edit</span>
     </button>
 </div>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.html
@@ -7,7 +7,7 @@
             <div class="col-xs-4 no-padding-left">
                 <button class="btn btn-primary" ui-sref="<%= entityStateName %>.new" >
                     <span class="glyphicon glyphicon-plus"></span>
-                    <span <% if (searchEngine == 'elasticsearch') { %>class="hidden-xs" <% } %> data-translate="<%= keyPrefix %>home.createLabel">
+                    <span <% if (searchEngine == 'elasticsearch') { %>class="hidden-xs-down" <% } %> data-translate="<%= keyPrefix %>home.createLabel">
                         Create new <%= entityClassHumanized %>
                     </span>
                 </button>
@@ -130,19 +130,19 @@
                                     ui-sref="<%= entityStateName %>-detail({id:<%= entityInstance %>.id})"
                                     class="btn btn-info btn-sm">
                                 <span class="glyphicon glyphicon-eye-open"></span>
-                                <span class="hidden-xs hidden-sm" data-translate="entity.action.view"></span>
+                                <span class="hidden-sm-down" data-translate="entity.action.view"></span>
                             </button>
                             <button type="submit"
                                     ui-sref="<%= entityStateName %>.edit({id:<%=entityInstance %>.id})"
                                     class="btn btn-primary btn-sm">
                                 <span class="glyphicon glyphicon-pencil"></span>
-                                <span class="hidden-xs hidden-sm" data-translate="entity.action.edit"></span>
+                                <span class="hidden-sm-down" data-translate="entity.action.edit"></span>
                             </button>
                             <button type="submit"
                                     ui-sref="<%= entityStateName %>.delete({id:<%=entityInstance %>.id})"
                                     class="btn btn-danger btn-sm">
                                 <span class="glyphicon glyphicon-remove-circle"></span>
-                                <span class="hidden-xs hidden-sm" data-translate="entity.action.delete"></span>
+                                <span class="hidden-sm-down" data-translate="entity.action.delete"></span>
                             </button>
                         </div>
                     </td>

--- a/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management-detail.html
@@ -87,6 +87,6 @@
 
     <button type="button" ui-sref="<%= entityStateName %>-detail.edit({id:vm.<%=entityInstance %>.id})" class="btn btn-primary">
         <span class="glyphicon glyphicon-pencil"></span>
-        <span class="hidden-xs hidden-sm" data-translate="entity.action.edit"> Edit</span>
+        <span class="hidden-sm-down" data-translate="entity.action.edit"> Edit</span>
     </button>
 </div>

--- a/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management.html
+++ b/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management.html
@@ -7,7 +7,7 @@
             <div class="col-xs-4 no-padding-left">
                 <button class="btn btn-primary" ui-sref="<%= entityStateName %>.new" >
                     <span class="glyphicon glyphicon-plus"></span>
-                    <span <% if (searchEngine == 'elasticsearch') { %>class="hidden-xs" <% } %> data-translate="<%= keyPrefix %>home.createLabel">
+                    <span <% if (searchEngine == 'elasticsearch') { %>class="hidden-xs-down" <% } %> data-translate="<%= keyPrefix %>home.createLabel">
                         Create new <%= entityClassHumanized %>
                     </span>
                 </button>
@@ -130,19 +130,19 @@
                                     ui-sref="<%= entityStateName %>-detail({id:<%= entityInstance %>.id})"
                                     class="btn btn-info btn-sm">
                                 <span class="glyphicon glyphicon-eye-open"></span>
-                                <span class="hidden-xs hidden-sm" data-translate="entity.action.view"></span>
+                                <span class="hidden-sm-down" data-translate="entity.action.view"></span>
                             </button>
                             <button type="submit"
                                     ui-sref="<%= entityStateName %>.edit({id:<%=entityInstance %>.id})"
                                     class="btn btn-primary btn-sm">
                                 <span class="glyphicon glyphicon-pencil"></span>
-                                <span class="hidden-xs hidden-sm" data-translate="entity.action.edit"></span>
+                                <span class="hidden-sm-down" data-translate="entity.action.edit"></span>
                             </button>
                             <button type="submit"
                                     ui-sref="<%= entityStateName %>.delete({id:<%=entityInstance %>.id})"
                                     class="btn btn-danger btn-sm">
                                 <span class="glyphicon glyphicon-remove-circle"></span>
-                                <span class="hidden-xs hidden-sm" data-translate="entity.action.delete"></span>
+                                <span class="hidden-sm-down" data-translate="entity.action.delete"></span>
                             </button>
                         </div>
                     </td>


### PR DESCRIPTION
Hello, fixing issues in #4407

- bootstrap show/hide elements based on screensize doesnt work might be a class rename issue

- missing translations in health screen

Some explanations for bootstrap :
Right now we are hidding elements only in a specific media size but in bootstrap4 we cannot hide in specific media size anymore so it had to go. I didn't replace it because we are now toggling our navbar when we  reach md size (`<div class="collapse navbar-toggleable-md` in navbar.component.html) while with in ng1 we were toggling the navbar at xs size so theres no need to hide anything.

Correct me if I'm wrong !
@deepu105  Btw you can also update 

-  User Management pagination doesnt work properly

- metrics page needs update once #4454 is merged to master

They are done.

