### PR TITLE
get rid of jhipster's node-uuid deprecation warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "ejs": "2.5.1",
     "glob": "7.0.6",
     "html-wiring": "1.2.0",
-    "insight": "0.8.3",
+    "insight": "0.8.4",
     "jhipster-core": "1.2.4",
     "js-yaml": "3.6.1",
     "lodash": "4.15.0",


### PR DESCRIPTION
Yarn currently complains with `warning generator-jhipster > insight > node-uuid@1.4.7: use uuid module instead`