### PR TITLE
Use baseUrl in tsconfig.json for shorter imports

### DIFF
--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -9,7 +9,7 @@
         "removeComments": false,
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
-        "baseUrl": "<%= CLIENT_MAIN_SRC_DIR %>",
+        "baseUrl": "<%= MAIN_SRC_DIR %>",
         "outDir": "<%= DIST_DIR %>app",
         "lib": ["es6", "dom"],
         "typeRoots": [

--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -9,7 +9,7 @@
         "removeComments": false,
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
-        "baseUrl": "<%= MAIN_SRC_DIR %>",
+        "baseUrl": "<%= MAIN_SRC_DIR %>app",
         "outDir": "<%= DIST_DIR %>app",
         "lib": ["es6", "dom"],
         "typeRoots": [

--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -9,6 +9,7 @@
         "removeComments": false,
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
+        "baseUrl": "<%= CLIENT_MAIN_SRC_DIR %>",
         "outDir": "<%= DIST_DIR %>app",
         "lib": ["es6", "dom"],
         "typeRoots": [

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/_health.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/_health.component.spec.ts
@@ -1,8 +1,8 @@
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {MockBackend} from '@angular/http/testing';
 import {Http, BaseRequestOptions} from '@angular/http';
-import {<%=jhiPrefixCapitalized%>HealthCheckComponent} from '../../../../../../main/webapp/app/admin/health/health.component'
-import {<%=jhiPrefixCapitalized%>HealthService} from '../../../../../../main/webapp/app/admin/health/health.service';
+import {<%=jhiPrefixCapitalized%>HealthCheckComponent} from 'main/webapp/app/admin/health/health.component'
+import {<%=jhiPrefixCapitalized%>HealthService} from 'main/webapp/app/admin/health/health.service';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 <%_ if (enableTranslation) { _%>
 import {TranslatePipe} from 'ng2-translate'


### PR DESCRIPTION
~~~ts
import {JhiHealthCheckComponent} from '../../../../../../main/webapp/app/admin/health/health.component'
import {JhiHealthService} from '../../../../../../main/webapp/app/admin/health/health.service';
~~~

can be replaced by

~~~ts
import {JhiHealthCheckComponent} from 'admin/health/health.component'
import {JhiHealthService} from 'admin/health/health.service';
~~~
