### PR TITLE
Use baseUrl in tsconfig.json for shorter imports

### DIFF
--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -9,7 +9,7 @@
         "removeComments": false,
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
-        "baseUrl": "<%= CLIENT_MAIN_SRC_DIR %>",
+        "baseUrl": "<%= MAIN_SRC_DIR %>",
         "outDir": "<%= DIST_DIR %>app",
         "lib": ["es6", "dom"],
         "typeRoots": [

--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -9,7 +9,7 @@
         "removeComments": false,
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
-        "baseUrl": "<%= MAIN_SRC_DIR %>",
+        "baseUrl": "<%= MAIN_SRC_DIR %>app",
         "outDir": "<%= DIST_DIR %>app",
         "lib": ["es6", "dom"],
         "typeRoots": [

--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -9,6 +9,7 @@
         "removeComments": false,
         "noImplicitAny": false,
         "suppressImplicitAnyIndexErrors": true,
+        "baseUrl": "<%= CLIENT_MAIN_SRC_DIR %>",
         "outDir": "<%= DIST_DIR %>app",
         "lib": ["es6", "dom"],
         "typeRoots": [

--- a/generators/client/templates/angular/src/main/webapp/app/account/_account.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/_account.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { UIRouterModule } from 'ui-router-ng2';
 
-import { <%=angular2AppName%>SharedModule } from '../shared';
+import { <%=angular2AppName%>SharedModule } from 'shared';
 
 import {
     Register,

--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import { Activate } from './activate.service';
-import { LoginModalService } from '../../shared';
+import { LoginModalService } from 'shared';
 
 import { Transition } from 'ui-router-ng2';
 

--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.state.ts
@@ -1,5 +1,5 @@
 import { ActivateComponent } from './activate.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const activateState = {
     name: 'activate',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Renderer, ElementRef } from '@angular/core';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import { PasswordResetFinish } from './password-reset-finish.service';
-import { LoginModalService } from '../../../shared';
+import { LoginModalService } from 'shared';
 
 import { Transition } from 'ui-router-ng2';
 

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.state.ts
@@ -1,5 +1,5 @@
 import { PasswordResetFinishComponent } from './password-reset-finish.component';
-import { JhiLanguageService } from '../../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const finishResetState = {
     name: 'finishReset',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.state.ts
@@ -1,5 +1,5 @@
 import {PasswordResetInitComponent} from './password-reset-init.component';
-import { JhiLanguageService } from '../../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const requestResetState = {
     name: 'requestReset',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { Principal } from '../../shared';
+import { Principal } from 'shared';
 import { Password } from './password.service';
 
 @Component({

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.state.ts
@@ -1,5 +1,5 @@
 import { PasswordComponent } from './password.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const passwordState = {
     name: 'password',

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/_register.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/_register.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit, Renderer, ElementRef } from '@angular/core';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import { Register } from './register.service';
-import { LoginModalService<% if (enableTranslation) { %>, JhiLanguageService<% }%> } from '../../shared';
+import { LoginModalService<% if (enableTranslation) { %>, JhiLanguageService<% }%> } from 'shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-register',

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/_register.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/_register.state.ts
@@ -1,5 +1,5 @@
 import { RegisterComponent } from './register.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const registerState = {
     name: 'register',

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 
 import { Session } from './session.model';
 import { SessionsService } from './sessions.service';
-import { Principal } from '../../shared';
+import { Principal } from 'shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-sessions',

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.state.ts
@@ -1,5 +1,5 @@
 import { SessionsComponent } from './sessions.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const sessionsState = {
     name: 'sessions',

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit } from '@angular/core';
 
-import { Principal, AccountService<% if (enableTranslation) { %>, JhiLanguageService<% } %> } from '../../shared';
+import { Principal, AccountService<% if (enableTranslation) { %>, JhiLanguageService<% } %> } from 'shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-settings',

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.state.ts
@@ -1,5 +1,5 @@
 import { SettingsComponent } from './settings.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const settingsState = {
     name: 'settings',

--- a/generators/client/templates/angular/src/main/webapp/app/account/social/_social-auth.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/social/_social-auth.component.ts
@@ -1,6 +1,6 @@
 import { Component, OnInit, Inject } from '@angular/core';
 import { StateService } from 'ui-router-ng2';
-import { AuthService, LoginService } from '../../shared';
+import { AuthService, LoginService } from 'shared';
 import { CookieService } from 'angular2-cookie/core';
 
 @Component({

--- a/generators/client/templates/angular/src/main/webapp/app/account/social/_social.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/social/_social.state.ts
@@ -3,7 +3,7 @@ import { SocialRegisterComponent } from './social-register.component';
 import { SocialAuthComponent } from './social-auth.component';
 <%_ } _%>
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 <%_ } _%>
 
 export const socialRegisterState = {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/_admin.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/_admin.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { UIRouterModule } from 'ui-router-ng2';
 
-import { <%=angular2AppName%>SharedModule, ParseLinks } from '../shared';
+import { <%=angular2AppName%>SharedModule, ParseLinks } from 'shared';
 
 import {
     AuditsComponent,

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.component.ts
@@ -3,7 +3,7 @@ import { DatePipe } from '@angular/common';
 
 import { Audit } from './audit.model';
 import { AuditsService } from './audits.service';
-import { ParseLinks, ITEMS_PER_PAGE } from '../../shared';
+import { ParseLinks, ITEMS_PER_PAGE } from 'shared';
 
 @Component({
   selector: '<%=jhiPrefix%>-audit',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.state.ts
@@ -1,5 +1,5 @@
 import { AuditsComponent } from './audits.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const auditState = {
     name: 'audits',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>ConfigurationComponent } from './configuration.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const configState = {
     name: '<%=jhiPrefix%>-configuration',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>GatewayComponent } from './gateway.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const gatewayState = {
     name: 'gateway',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>HealthCheckComponent } from './health.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const healthState = {
     name: '<%=jhiPrefix%>-health',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.state.ts
@@ -1,5 +1,5 @@
 import { LogsComponent } from './logs.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const logsState = {
     name: 'logs',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.state.ts
@@ -1,5 +1,5 @@
 import { <%=jhiPrefixCapitalized%>MetricsMonitoringComponent } from './metrics.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const metricsState = {
     name: '<%=jhiPrefix%>-metrics',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/_tracker.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/_tracker.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit } from '@angular/core';
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../../shared';
+import { <%=jhiPrefixCapitalized%>TrackerService } from 'shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-tracker',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/_tracker.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/_tracker.state.ts
@@ -1,6 +1,6 @@
 import { Transition } from 'ui-router-ng2';
 import { <%=jhiPrefixCapitalized%>TrackerComponent } from './tracker.component';
-import { <% if (enableTranslation) { %>JhiLanguageService, <% } %><%=jhiPrefixCapitalized%>TrackerService } from '../../shared';
+import { <% if (enableTranslation) { %>JhiLanguageService, <% } %><%=jhiPrefixCapitalized%>TrackerService } from 'shared';
 
 export const trackerState = {
     name: '<%=jhiPrefix%>-tracker',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-delete-dialog.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-delete-dialog.component.ts
@@ -3,7 +3,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { User } from './user.model';
 import { UserService } from './user.service';
-import { EventManager } from '../../shared/service/event-manager.service';
+import { EventManager } from 'shared/service/event-manager.service';
 
 @Component({
     selector: '<%=jhiPrefix%>-user-mgmt-delete-dialog',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.ts
@@ -4,9 +4,9 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { User } from './user.model';
 import { UserService } from './user.service';
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 <%_ }_%>
-import { EventManager } from '../../shared/service/event-manager.service';
+import { EventManager } from 'shared/service/event-manager.service';
 
 @Component({
     selector: '<%=jhiPrefix%>-user-mgmt-dialog',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.ts
@@ -5,7 +5,7 @@ import { StateService } from 'ui-router-ng2';
 
 import { User } from './user.model';
 import { UserService } from './user.service';
-import { AlertService, EventManager, ITEMS_PER_PAGE, PaginationUtil, ParseLinks, Principal } from '../../shared';
+import { AlertService, EventManager, ITEMS_PER_PAGE, PaginationUtil, ParseLinks, Principal } from 'shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-user-mgmt',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.state.ts
@@ -1,14 +1,14 @@
 import { Transition } from 'ui-router-ng2';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { PaginationConfig } from '../../blocks/config/uib-pagination.config';
+import { PaginationConfig } from 'blocks/config/uib-pagination.config';
 import { UserMgmtComponent } from './user-management.component';
 import { UserMgmtDetailComponent } from './user-management-detail.component';
 import { UserMgmtDialogComponent } from './user-management-dialog.component';
 import { UserMgmtDeleteDialogComponent } from './user-management-delete-dialog.component';
 import { User } from './user.model';
 import { UserService } from './user.service';
-import { <% if (enableTranslation) { %>JhiLanguageService, <% } %>PaginationUtil } from '../../shared';
+import { <% if (enableTranslation) { %>JhiLanguageService, <% } %>PaginationUtil } from 'shared';
 
 export const userMgmtState = {
     name: 'user-management',

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_prod.config.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_prod.config.ts
@@ -1,5 +1,5 @@
 import { enableProdMode } from '@angular/core';
-import { DEBUG_INFO_ENABLED } from '../../app.constants';
+import { DEBUG_INFO_ENABLED } from 'app.constants';
 
 export function ProdConfig() {
     // disable debug data on prod profile to improve performance

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_register-transition-hooks.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_register-transition-hooks.ts
@@ -1,5 +1,5 @@
 import { TransitionService, Transition } from 'ui-router-ng2';
-import { Principal, StateStorageService, AuthService<% if (enableTranslation) { %>, JhiLanguageService<% } %> } from '../../shared';
+import { Principal, StateStorageService, AuthService<% if (enableTranslation) { %>, JhiLanguageService<% } %> } from 'shared';
 
 export function registerTransitionHooks($transitions: TransitionService) {
     $transitions.onStart({}, (transition: Transition) => {

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_router.config.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_router.config.ts
@@ -1,6 +1,6 @@
 import { Injectable } from '@angular/core';
 import { UIRouter, trace, Category } from 'ui-router-ng2';
-import { DEBUG_INFO_ENABLED } from '../../app.constants';
+import { DEBUG_INFO_ENABLED } from 'app.constants';
 import { registerTransitionHooks } from './register-transition-hooks';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_translation-storage.provider.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_translation-storage.provider.ts
@@ -1,4 +1,4 @@
-import {LANGUAGES} from '../../shared';
+import {LANGUAGES} from 'shared';
 
 // TranslationStorageProvider.$inject = ['$cookies', '$log'];
 

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_uib-pager.config.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_uib-pager.config.ts
@@ -1,4 +1,4 @@
-import { ITEMS_PER_PAGE } from '../../shared';
+import { ITEMS_PER_PAGE } from 'shared';
 
 //PagerConfig.$inject = ['uibPagerConfig'];
 

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_uib-pagination.config.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_uib-pagination.config.ts
@@ -1,4 +1,4 @@
-import { ITEMS_PER_PAGE } from '../../shared';
+import { ITEMS_PER_PAGE } from 'shared';
 import {Injectable} from '@angular/core';
 import { NgbPaginationConfig} from '@ng-bootstrap/ng-bootstrap';
 

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
@@ -3,17 +3,17 @@ import { RequestOptionsArgs, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 import { Injector } from '@angular/core';
 <%_ if (authenticationType === 'oauth2' || authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
-import { AuthService } from '../../shared/auth/auth.service';
-import { Principal } from '../../shared/auth/principal.service';
+import { AuthService } from 'shared/auth/auth.service';
+import { Principal } from 'shared/auth/principal.service';
     <%_ if (authenticationType === 'oauth2') { _%>
-import { AuthServerProvider } from '../../shared/auth/auth-oauth2.service';
+import { AuthServerProvider } from 'shared/auth/auth-oauth2.service';
     <%_ } else { _%>
-import {AuthServerProvider} from '../../shared/auth/auth-jwt.service';
+import {AuthServerProvider} from 'shared/auth/auth-jwt.service';
     <%_ } _%>
 <%_ } if (authenticationType === 'session') { _%>
-import { AuthServerProvider } from '../../shared/auth/auth-session.service';
-import { StateStorageService } from '../../shared/auth/state-storage.service';
-import { LoginModalService } from '../../shared/login/login-modal.service';
+import { AuthServerProvider } from 'shared/auth/auth-session.service';
+import { StateStorageService } from 'shared/auth/state-storage.service';
+import { LoginModalService } from 'shared/login/login-modal.service';
 <%_ } _%>
 
 export class AuthExpiredInterceptor extends HttpInterceptable {

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_errorhandler.interceptor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_errorhandler.interceptor.ts
@@ -1,7 +1,7 @@
 import { HttpInterceptable } from './http.interceptable';
 import { RequestOptionsArgs, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
-import { EventManager } from '../../shared/service/event-manager.service';
+import { EventManager } from 'shared/service/event-manager.service';
 
 export class ErrorHandlerInterceptor extends HttpInterceptable {
 

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
@@ -5,13 +5,13 @@ import { HttpInterceptor } from './http.interceptor';
 import { AuthInterceptor } from './auth.interceptor';
 import { LocalStorageService, SessionStorageService } from 'ng2-webstorage';
 <%_ } if (authenticationType === 'session') { _%>
-import { StateStorageService } from '../../shared/auth/state-storage.service';
+import { StateStorageService } from 'shared/auth/state-storage.service';
 <%_ } _%>
 import { AuthExpiredInterceptor } from './auth-expired.interceptor';
 import { ErrorHandlerInterceptor } from './errorhandler.interceptor';
 import { NotificationInterceptor } from './notification.interceptor';
 
-import { EventManager } from '../../shared/service/event-manager.service';
+import { EventManager } from 'shared/service/event-manager.service';
 
 export const customHttpProvider = () => ({
     provide: Http,

--- a/generators/client/templates/angular/src/main/webapp/app/entities/_entity.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/entities/_entity.module.ts
@@ -1,7 +1,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { UIRouterModule } from 'ui-router-ng2';
 
-import { <%=angular2AppName%>SharedModule } from '../shared';
+import { <%=angular2AppName%>SharedModule } from 'shared';
 
 let ENTITY_STATES = [
 

--- a/generators/client/templates/angular/src/main/webapp/app/home/_home.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_home.component.ts
@@ -2,7 +2,7 @@ import { Component, OnInit } from '@angular/core';
 import { StateService } from 'ui-router-ng2';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
-import { Account, LoginModalService, Principal, EventManager } from '../shared';
+import { Account, LoginModalService, Principal, EventManager } from 'shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-home',

--- a/generators/client/templates/angular/src/main/webapp/app/home/_home.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_home.state.ts
@@ -1,5 +1,5 @@
 import { HomeComponent } from './home.component';
-import { JhiLanguageService } from '../shared';
+import { JhiLanguageService } from 'shared';
 
 export const homeState = {
     name: 'home',

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/_error.state.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/_error.state.ts
@@ -1,5 +1,5 @@
 import { ErrorComponent } from './error.component';
-import { JhiLanguageService } from '../../shared';
+import { JhiLanguageService } from 'shared';
 
 export const errorState = {
     name: 'error',

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
@@ -2,10 +2,10 @@ import { Component, OnInit } from '@angular/core';
 import { StateService } from 'ui-router-ng2';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
-import { ProfileService } from '../profiles/profile.service'; // barrel doesn't work here
-import { <% if (enableTranslation) { %>JhiLanguageService, <% } %>Principal, LoginModalService, LoginService } from '../../shared';
+import { ProfileService } from 'layouts/profiles/profile.service'; // barrel doesn't work here
+import { <% if (enableTranslation) { %>JhiLanguageService, <% } %>Principal, LoginModalService, LoginService } from 'shared';
 
-import { VERSION, DEBUG_INFO_ENABLED } from '../../app.constants';
+import { VERSION, DEBUG_INFO_ENABLED } from 'app.constants';
 
 @Component({
     selector: '<%=jhiPrefix%>-navbar',

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/_alert-error.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/_alert-error.component.ts
@@ -4,7 +4,7 @@ import { TranslateService } from 'ng2-translate/ng2-translate';
 <%_ } _%>
 
 import { AlertService } from './alert.service';
-import { EventManager } from '../service/event-manager.service';
+import { EventManager } from 'shared/service/event-manager.service';
 import { Subscription } from 'rxjs/Rx';
 
 @Component({

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-oauth2.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-oauth2.service.ts
@@ -5,7 +5,7 @@ import { LocalStorageService } from 'ng2-webstorage';
 
 import { Base64 } from './base64.service';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';
+import { <%=jhiPrefixCapitalized%>TrackerService } from 'tracker/tracker.service';
 <%_ } _%>
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
@@ -3,7 +3,7 @@ import { Http, Response, Headers } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 import { LocalStorageService } from 'ng2-webstorage';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';
+import { <%=jhiPrefixCapitalized%>TrackerService } from 'tracker/tracker.service';
 <%_ } _%>
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth.service.ts
@@ -1,7 +1,7 @@
 import { Injectable } from '@angular/core';
 import { StateService } from 'ui-router-ng2';
 
-import { LoginModalService } from '../login/login-modal.service';
+import { LoginModalService } from 'shared/login/login-modal.service';
 import { Principal } from './principal.service';
 import { StateStorageService } from './state-storage.service';
 

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_principal.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_principal.service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { AccountService } from './account.service';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';//Barrel doesnt work here. No idea why!
+import { <%=jhiPrefixCapitalized%>TrackerService } from 'tracker/tracker.service';//Barrel doesnt work here. No idea why!
 <%_ } _%>
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
@@ -2,13 +2,13 @@ import { Component, OnInit, AfterViewInit, Renderer, ElementRef } from '@angular
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { StateService } from 'ui-router-ng2';
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from '../language/language.service';
+import { JhiLanguageService } from 'shared/language/language.service';
 <%_ } _%>
-import { LoginService } from '../login/login.service';
-import { StateStorageService } from '../auth/state-storage.service';
-import { EventManager } from '../service/event-manager.service';
+import { LoginService } from 'shared/login/login.service';
+import { StateStorageService } from 'shared/auth/state-storage.service';
+import { EventManager } from 'shared/service/event-manager.service';
 <%_ if (enableSocialSignIn) { _%>
-import { SocialService } from '../social/social.service';
+import { SocialService } from 'shared/social/social.service';
 <%_ } _%>
 
 @Component({

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.service.ts
@@ -1,18 +1,18 @@
 import { Injectable } from '@angular/core';
 
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from '../language/language.service';
+import { JhiLanguageService } from 'shared/language/language.service';
 <%_ } _%>
-import { Principal } from '../auth/principal.service';
+import { Principal } from 'shared/auth/principal.service';
 <%_ if (authenticationType === 'oauth2') { _%>
-import { AuthServerProvider } from '../auth/auth-oauth2.service';
+import { AuthServerProvider } from 'shared/auth/auth-oauth2.service';
 <%_ } else if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
-import { AuthServerProvider } from '../auth/auth-jwt.service';
+import { AuthServerProvider } from 'shared/auth/auth-jwt.service';
 <%_ } else { _%>
-import { AuthServerProvider } from '../auth/auth-session.service';
+import { AuthServerProvider } from 'shared/auth/auth-session.service';
 <%_ } _%>
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';
+import { <%=jhiPrefixCapitalized%>TrackerService } from 'shared/tracker/tracker.service';
 <%_ } _%>
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/social/_social.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/social/_social.component.ts
@@ -1,8 +1,8 @@
 import { Component, Input, OnInit } from '@angular/core';
 import { SocialService } from './social.service';
-import { CSRFService } from '../auth/csrf.service';
+import { CSRFService } from 'auth/csrf.service';
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from '../language/language.service';
+import { JhiLanguageService } from 'language/language.service';
 <%_ } _%>
 
 @Component({

--- a/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
@@ -6,9 +6,9 @@ import { Observable, Observer } from 'rxjs/Rx';
 import { LocalStorageService } from 'ng2-webstorage';
 <%_ } _%>
 
-import { CSRFService } from '../auth/csrf.service';
+import { CSRFService } from 'shared/auth/csrf.service';
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
-import { AuthServerProvider } from '../auth/auth-jwt.service';
+import { AuthServerProvider } from 'shared/auth/auth-jwt.service';
 <%_ } _%>
 
 @Injectable()

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts
@@ -1,6 +1,6 @@
 import {ComponentFixture, TestBed, async } from '@angular/core/testing';
 
-import {PasswordStrengthBarComponent} from '../../../../../../main/webapp/app/account/password/password-strength-bar.component';
+import {PasswordStrengthBarComponent} from 'account/password/password-strength-bar.component';
 
 describe('Controller Tests', () => {
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/_health.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/_health.component.spec.ts
@@ -1,8 +1,8 @@
 import {ComponentFixture, TestBed, async} from '@angular/core/testing';
 import {MockBackend} from '@angular/http/testing';
 import {Http, BaseRequestOptions} from '@angular/http';
-import {<%=jhiPrefixCapitalized%>HealthCheckComponent} from '../../../../../../main/webapp/app/admin/health/health.component';
-import {<%=jhiPrefixCapitalized%>HealthService} from '../../../../../../main/webapp/app/admin/health/health.service';
+import {<%=jhiPrefixCapitalized%>HealthCheckComponent} from 'admin/health/health.component';
+import {<%=jhiPrefixCapitalized%>HealthService} from 'admin/health/health.service';
 import {NgbModal} from '@ng-bootstrap/ng-bootstrap';
 <%_ if (enableTranslation) { _%>
 import {TranslatePipe} from 'ng2-translate';

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.state.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.state.ts
@@ -16,7 +16,7 @@ import { UserMgmtDialogComponent } from './user-management-dialog.component';
 import { UserMgmtDeleteDialogComponent } from './user-management-delete-dialog.component';
 import { User } from './user.model';
 import { UserService } from './user.service';
-import { JhiLanguageService, PaginationUtil } from '../../shared';
+import { JhiLanguageService, PaginationUtil } from 'shared';
 
 export const <%= entityInstance %>State = {
     name: '<%= entityStateName %>',


### PR DESCRIPTION
Same as #4786 which was for entity-ng2 branch.

~~~ts
import {JhiHealthCheckComponent} from '../../../../../../main/webapp/app/admin/health/health.component'
import {JhiHealthService} from '../../../../../../main/webapp/app/admin/health/health.service';
~~~

can be replaced by

~~~ts
import {JhiHealthCheckComponent} from 'admin/health/health.component'
import {JhiHealthService} from 'admin/health/health.service';
~~~
