### PR TITLE
Microservices: fix generator-jhipster version in package json

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -159,6 +159,9 @@ module.exports = JhipsterGenerator.extend({
             }
             this.baseName = this.config.get('baseName');
             this.jhipsterVersion = this.config.get('jhipsterVersion');
+            if (this.jhipsterVersion === undefined) {
+                this.jhipsterVersion = packagejs.version;
+            }
             this.clientFramework = this.config.get('clientFramework');
             if (!this.clientFramework) {
                 /* for backward compatibility */
@@ -347,8 +350,7 @@ module.exports = JhipsterGenerator.extend({
                 if (this.clientPackageManager === 'yarn') {
                     this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using yarn`));
                     this.spawnCommand('yarn', ['install']);
-                }
-                else if (this.clientPackageManager === 'npm') {
+                } else if (this.clientPackageManager === 'npm') {
                     this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using npm`));
                     this.npmInstall();
                 }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -340,19 +340,21 @@ module.exports = JhipsterGenerator.extend({
 
     end: {
         localInstall: function() {
-            if (this.skipClient && !this.options['skip-install']) {
+            if (this.skipClient) {
                 if (this.otherModules === undefined) {
                     this.otherModules = [];
                 }
                 // Generate a package.json file containing the current version of the generator as dependency
                 this.template('_skipClientApp.package.json', 'package.json', this, {});
 
-                if (this.clientPackageManager === 'yarn') {
-                    this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using yarn`));
-                    this.spawnCommand('yarn', ['install']);
-                } else if (this.clientPackageManager === 'npm') {
-                    this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using npm`));
-                    this.npmInstall();
+                if (!this.options['skip-install']) {
+                    if (this.clientPackageManager === 'yarn') {
+                        this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using yarn`));
+                        this.spawnCommand('yarn', ['install']);
+                    } else if (this.clientPackageManager === 'npm') {
+                        this.log(chalk.bold(`\nInstalling generator-jhipster@${this.jhipsterVersion} locally using npm`));
+                        this.npmInstall();
+                    }
                 }
             }
         },

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -14,7 +14,6 @@ const constants = require('../generators/generator-constants'),
     SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR,
     TEST_DIR = constants.TEST_DIR;
 
-
 describe('JHipster generator', function () {
 
     describe('default configuration', function () {
@@ -865,7 +864,7 @@ describe('JHipster generator', function () {
                 enableTranslation: true,
                 authenticationType: 'session',
                 testFrameworks: []
-            }));
+            }, '', ['package.json']));
         });
     });
 
@@ -900,7 +899,7 @@ describe('JHipster generator', function () {
                 enableTranslation: true,
                 authenticationType: 'session',
                 testFrameworks: []
-            }));
+            },'' , ['package.json']));
             assert.noFile(['gradle/yeoman.gradle']);
         });
     });

--- a/test/test-expected-files.js
+++ b/test/test-expected-files.js
@@ -395,7 +395,8 @@ const expectedFiles = {
     ],
 
     microservice: [
-        SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/config/MicroserviceSecurityConfiguration.java'
+        SERVER_MAIN_SRC_DIR + 'com/mycompany/myapp/config/MicroserviceSecurityConfiguration.java',
+        'package.json'
     ],
 
     microserviceGradle: [

--- a/test/test-utils.js
+++ b/test/test-utils.js
@@ -6,7 +6,11 @@ module.exports = {
     getFilesForOptions: getFilesForOptions
 };
 
-function getFilesForOptions(files, options, prefix) {
+function getFilesForOptions(files, options, prefix, excludeFiles) {
     let generator = options;
-    return Generator.prototype.writeFilesToDisk(files, generator, true, prefix);
+    if (excludeFiles === undefined) {
+        return Generator.prototype.writeFilesToDisk(files, generator, true, prefix);
+    }
+    return Generator.prototype.writeFilesToDisk(files, generator, true, prefix)
+        .filter(file => excludeFiles.indexOf(file) === -1);
 }


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/pull/4597

When generating a microservice application, the package.json is

```yaml
{
  "devDependencies": {
    "generator-jhipster": ""
  }
}
```

It should be instead:

```yaml
{
  "devDependencies": {
    "generator-jhipster": "3.12.1"
  }
}
```

Another thing: https://github.com/jhipster/generator-jhipster/blob/master/generators/app/index.js#L340-L355

The goal of skip install is to skip `npm install` or `yarn install`, with the `package.json` created.

In the case of microservices, the `package.json` is not created. Is it intentional @PierreBesson ?

I should write npm test too, but I don't have time tonight. It can be done later
