### PR TITLE
Bootstrap 4 - dl-horizontal has been dropped

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-detail.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-detail.component.html
@@ -1,6 +1,6 @@
 <div *ngIf="user">
     <h2><span jhiTranslate="userManagement.detail.title">User</span> "{{user.login}}"</h2>
-    <dl class="dl-horizontal">
+    <dl class="row">
         <dt><span jhiTranslate="userManagement.login">Login</span></dt>
         <dd><span>{{user.login}}</span></dd>
         <dt><span jhiTranslate="userManagement.firstName">First Name</span></dt>

--- a/generators/client/templates/angular/src/main/webapp/content/css/_main.css
+++ b/generators/client/templates/angular/src/main/webapp/content/css/_main.css
@@ -329,16 +329,16 @@ entity tables helpers
 /* ==========================================================================
 entity detail page css
 ========================================================================== */
-.dl-horizontal.jh-entity-details > dd {
+.row.jh-entity-details > dd {
     margin-bottom: 15px;
 }
 
 @media screen and (min-width: 768px) {
-    .dl-horizontal.jh-entity-details > dt {
+    .row.jh-entity-details > dt {
         margin-bottom: 15px;
     }
 
-    .dl-horizontal.jh-entity-details > dd {
+    .row.jh-entity-details > dd {
         border-bottom: 1px solid #eee;
         padding-left: 180px;
         margin-left: 0;

--- a/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management-detail.html
+++ b/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management-detail.html
@@ -1,6 +1,6 @@
 <div>
     <h2><span data-translate="userManagement.detail.title">User</span> "{{vm.user.login}}"</h2>
-    <dl class="dl-horizontal">
+    <dl class="row">
         <dt><span data-translate="userManagement.login">Login</span></dt>
         <dd><span>{{vm.user.login}}</span></dd>
         <dt><span data-translate="userManagement.firstName">First Name</span></dt>

--- a/generators/client/templates/angularjs/src/main/webapp/content/css/_main.css
+++ b/generators/client/templates/angularjs/src/main/webapp/content/css/_main.css
@@ -296,16 +296,16 @@ entity tables helpers
 /* ==========================================================================
 entity detail page css
 ========================================================================== */
-.dl-horizontal.jh-entity-details > dd {
+.row.jh-entity-details > dd {
     margin-bottom: 15px;
 }
 
 @media screen and (min-width: 768px) {
-    .dl-horizontal.jh-entity-details > dt {
+    .row.jh-entity-details > dt {
         margin-bottom: 15px;
     }
 
-    .dl-horizontal.jh-entity-details > dd {
+    .row.jh-entity-details > dd {
         border-bottom: 1px solid #eee;
         padding-left: 180px;
         margin-left: 0;

--- a/generators/client/templates/angularjs/src/main/webapp/scss/_main.scss
+++ b/generators/client/templates/angularjs/src/main/webapp/scss/_main.scss
@@ -305,14 +305,14 @@ entity tables helpers
 /* ==========================================================================
 entity detail page css
 ========================================================================== */
-.dl-horizontal.jh-entity-details > {
+.row.jh-entity-details > {
     dd {
         margin-bottom: 15px;
     }
 }
 
 @media screen and (min-width: 768px) {
-    .dl-horizontal.jh-entity-details > {
+    .row.jh-entity-details > {
         dt {
             margin-bottom: 15px;
         }

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-detail.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-detail.component.html
@@ -3,7 +3,7 @@
     <h2><span jhiTranslate="<%= keyPrefix %>.detail.title"><%= entityClassHumanized %></span> {{<%= entityInstance %>.id}}</h2>
     <hr>
     <jhi-alert-error></jhi-alert-error>
-    <dl class="dl-horizontal">
+    <dl class="row">
         <%_ for (idx in fields) {
         var fieldName = fields[idx].fieldName;
         var fieldType = fields[idx].fieldType;

--- a/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management-detail.html
+++ b/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management-detail.html
@@ -3,7 +3,7 @@
     <h2><span data-translate="<%= keyPrefix %>.detail.title"><%= entityClassHumanized %></span> {{vm.<%= entityInstance %>.id}}</h2>
     <hr>
     <jhi-alert-error></jhi-alert-error>
-    <dl class="dl-horizontal jh-entity-details">
+    <dl class="row jh-entity-details">
         <%_ for (idx in fields) {
             var fieldName = fields[idx].fieldName;
             var fieldType = fields[idx].fieldType;


### PR DESCRIPTION
From the Migration documents of Bootstrap 4
`.dl-horizontal has been dropped. Instead, use .row on <dl> and use grid column classes (or mixins) on its <dt> and <dd> children.`
