### PR TITLE
Consul support for Kubernetes and improvements

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -24,7 +24,7 @@ module.exports = DockerComposeGenerator.extend({
 
     initializing: {
         sayHello: function() {
-            this.log(chalk.white('Welcome to the JHipster Docker Compose Sub-Generator '));
+            this.log(chalk.white(chalk.bold('🐳') + '  Welcome to the JHipster Docker Compose Sub-Generator ' + chalk.bold('🐳')));
             this.log(chalk.white('Files will be generated in folder: ' + chalk.yellow(this.destinationRoot())));
         },
 

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -27,7 +27,15 @@ function writeFiles() {
 
         writeRegistryFiles: function() {
             if (this.gatewayNb === 0 && this.microserviceNb === 0) return;
-            this.template('_jhipster-registry.yml', 'registry/jhipster-registry.yml');
+            if (this.serviceDiscoveryType === 'eureka') {
+                this.template('registry/_jhipster-registry.yml', 'registry/jhipster-registry.yml');
+                this.template('registry/_application-configmap.yml', 'registry/application-configmap.yml');
+            }
+            else if (this.serviceDiscoveryType === 'consul') {
+                this.template('registry/_consul.yml', 'registry/consul.yml');
+                this.template('registry/_consul-config-loader.yml', 'registry/consul-config-loader.yml');
+                this.template('registry/_application-configmap.yml', 'registry/application-configmap.yml');
+            }
         }
     };
 }

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -46,7 +46,7 @@ module.exports = KubernetesGenerator.extend({
 
     initializing: {
         sayHello: function() {
-            this.log(chalk.white(chalk.bold('[BETA]') + ' Welcome to the JHipster Kubernetes Generator '));
+            this.log(chalk.white(chalk.bold('⎈') + ' [BETA] Welcome to the JHipster Kubernetes Generator ' + chalk.bold('⎈')));
             this.log(chalk.white('Files will be generated in folder: ' + chalk.yellow(this.destinationRoot())));
         },
 
@@ -90,6 +90,9 @@ module.exports = KubernetesGenerator.extend({
             this.directoryPath = this.config.get('directoryPath');
             this.clusteredDbApps = this.config.get('clusteredDbApps');
             this.serviceDiscoveryType = this.config.get('serviceDiscoveryType');
+            if (this.serviceDiscoveryType === undefined) {
+                this.serviceDiscoveryType = 'eureka';
+            }
             this.adminPassword = this.config.get('adminPassword');
             this.jwtSecretKey = this.config.get('jwtSecretKey');
             this.dockerRepositoryName = this.config.get('dockerRepositoryName');

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -89,6 +89,7 @@ module.exports = KubernetesGenerator.extend({
             this.defaultAppsFolders = this.config.get('appsFolders');
             this.directoryPath = this.config.get('directoryPath');
             this.clusteredDbApps = this.config.get('clusteredDbApps');
+            this.serviceDiscoveryType = this.config.get('serviceDiscoveryType');
             this.adminPassword = this.config.get('adminPassword');
             this.jwtSecretKey = this.config.get('jwtSecretKey');
             this.dockerRepositoryName = this.config.get('dockerRepositoryName');
@@ -96,6 +97,8 @@ module.exports = KubernetesGenerator.extend({
             this.kubernetesNamespace = this.config.get('kubernetesNamespace');
 
             this.DOCKER_JHIPSTER_REGISTRY = constants.DOCKER_JHIPSTER_REGISTRY;
+            this.DOCKER_CONSUL = constants.DOCKER_CONSUL;
+            this.DOCKER_CONSUL_CONFIG_LOADER = constants.DOCKER_CONSUL_CONFIG_LOADER;
             this.DOCKER_MYSQL = constants.DOCKER_MYSQL;
             this.DOCKER_MARIADB = constants.DOCKER_MARIADB;
             this.DOCKER_POSTGRESQL = constants.DOCKER_POSTGRESQL;
@@ -209,6 +212,7 @@ module.exports = KubernetesGenerator.extend({
             this.config.set('appsFolders', this.appsFolders);
             this.config.set('directoryPath', this.directoryPath);
             this.config.set('clusteredDbApps', this.clusteredDbApps);
+            this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
             this.config.set('jwtSecretKey', this.jwtSecretKey);
             this.config.set('dockerRepositoryName', this.dockerRepositoryName);
             this.config.set('dockerPushCommand', this.dockerPushCommand);

--- a/generators/kubernetes/templates/_deployment.yml
+++ b/generators/kubernetes/templates/_deployment.yml
@@ -28,17 +28,25 @@ spec:
         app: <%= app.baseName.toLowerCase() %>
     spec:
       containers:
-      - name: <%= app.baseName.toLowerCase() %>
+      - name: <%= app.baseName.toLowerCase() %>-app
         image: <%= app.targetImageName %>
         imagePullPolicy: IfNotPresent
         env:
         - name: SPRING_PROFILES_ACTIVE
           value: prod
         <%_ if (app.applicationType === 'microservice' || app.applicationType === 'gateway') { _%>
+        <%_ if (app.serviceDiscoveryType === 'eureka') { _%>
         - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
           value: http://admin:<%= adminPassword %>@jhipster-registry.<%= kubernetesNamespace %>.svc.cluster.local:8761/eureka/
         - name: SPRING_CLOUD_CONFIG_URI
           value: http://admin:<%= adminPassword %>@jhipster-registry.<%= kubernetesNamespace %>.svc.cluster.local:8761/config
+        <%_ } _%>
+        <%_ if (app.serviceDiscoveryType === 'consul') { _%>
+        - name: SPRING_CLOUD_CONSUL_HOST
+          value: consul.<%= kubernetesNamespace %>.svc.cluster.local
+        - name: SPRING_CLOUD_CONSUL_PORT
+          value: "8500"
+        <%_ } _%>
         <%_ } _%>
         <%_ if (app.prodDatabaseType === 'mysql') { _%>
         - name: SPRING_DATASOURCE_URL

--- a/generators/kubernetes/templates/registry/_application-configmap.yml
+++ b/generators/kubernetes/templates/registry/_application-configmap.yml
@@ -1,0 +1,19 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: application-config
+  namespace: default
+#common configuration shared between all applications
+data:
+  application.yml: |-
+    configserver:
+      name: <% if (serviceDiscoveryType == 'eureka') { %> JHipster Registry<% } %><% if (serviceDiscoveryType == 'consul') { %>Consul<% } %>
+      status: Connected to <% if (serviceDiscoveryType == 'eureka') { %>the JHipster Registry<% } %><% if (serviceDiscoveryType == 'consul') { %>Consul<% } %> running in Kubernetes
+    jhipster:
+      security:
+        authentication:
+          jwt:
+            secret: <%= jwtSecretKey %>
+  #application-prod.yml: |-
+  #  configserver:
+  #    status: Connected in prod

--- a/generators/kubernetes/templates/registry/_consul-config-loader.yml
+++ b/generators/kubernetes/templates/registry/_consul-config-loader.yml
@@ -1,0 +1,29 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: consul-config-loader
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: consul-config-loader
+    spec:
+      containers:
+      - name: consul-config-loader
+        image: <%= DOCKER_CONSUL_CONFIG_LOADER %>
+        imagePullPolicy: IfNotPresent
+        env:
+        - name: INIT_SLEEP_SECONDS
+          value: "5"
+        - name: CONSUL_URL
+          value: consul.<%= kubernetesNamespace %>.svc.cluster.local
+        - name: CONSUL_PORT
+          value: "8500"
+        volumeMounts:
+        - name: config-volume
+          mountPath: /config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: application-config

--- a/generators/kubernetes/templates/registry/_consul.yml
+++ b/generators/kubernetes/templates/registry/_consul.yml
@@ -1,0 +1,172 @@
+# Based on https://github.com/kubernetes/charts/tree/14bee1e456c1789d1ebdfc2dc7e3ae2b9ea930ce/incubator/consul
+# Note that as this is based on a StatefulSet, it will only work on Kubernetes >= 1.5
+#
+# By default, Consul and its UI is not accessible from outside the cluster for security reasons
+# You setup temporary access to it on localhost:8500 by running :
+#   kubectl port-forward some-consul-pod 8500
+#
+# To check the state of your Consul cluster :
+#   kubectl exec consul-0 -- sh -c 'consul members'
+#
+# To scale your Consul cluster :
+#   kubectl patch statefulset/consul -p '{"spec":{"replicas": 5}}'
+#
+# To check the state of every node
+#   for i in {0..4}; do kubectl exec consul-$i -- sh -c 'consul members'; done
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gossip-key
+type: Opaque
+data:
+  gossip-key: SUcwRzF3N2c4QW5YMDA3cUEwWElqMTJG # a 24 chars base64 encoded string
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: consul
+  labels:
+    app: consul
+  annotations:
+    service.alpha.kubernetes.io/tolerate-unready-endpoints: "true"
+spec:
+  ports:
+  - name: http
+    port: 8500
+  - name: rpc
+    port: 8400
+  - name: serflan-tcp
+    protocol: "TCP"
+    port: 8301
+  - name: serflan-udp
+    protocol: "UDP"
+    port: 8301
+  - name: serfwan-tcp
+    protocol: "TCP"
+    port: 8302
+  - name: serfwan-udp
+    protocol: "UDP"
+    port: 8302
+  - name: server
+    port: 8300
+  - name: consuldns
+    port: 8600
+  clusterIP: None
+  selector:
+    app: consul
+---
+apiVersion: apps/v1beta1
+kind: StatefulSet
+metadata:
+  name: consul
+spec:
+  serviceName: consul
+  replicas: 3
+  template:
+    metadata:
+      name: consul
+      labels:
+        app: consul
+    spec:
+      securityContext:
+        fsGroup: 1000
+      containers:
+      - name: "consul"
+        image: <%= DOCKER_CONSUL %>
+        imagePullPolicy: "Always"
+        ports:
+        - name: http
+          containerPort: 8500
+        - name: rpc
+          containerPort: 8400
+        - name: serflan-tcp
+          protocol: "TCP"
+          containerPort: 8301
+        - name: serflan-udp
+          protocol: "UDP"
+          containerPort: 8301
+        - name: serfwan-tcp
+          protocol: "TCP"
+          containerPort: 8302
+        - name: serfwan-udp
+          protocol: "UDP"
+          containerPort: 8302
+        - name: server
+          containerPort: 8300
+        - name: consuldns
+          containerPort: 8600
+        resources:
+          requests:
+            cpu: "100m"
+            memory: "512Mi"
+        env:
+        - name: INITIAL_CLUSTER_SIZE
+          value: "3"
+        - name: PETSET_NAME
+          value: "consul"
+        - name: PETSET_NAMESPACE
+          valueFrom:
+            fieldRef:
+              fieldPath: metadata.namespace
+        volumeMounts:
+        - name: datadir
+          mountPath: /var/lib/consul
+        - name: gossip-key
+          mountPath: /etc/consul/secrets
+          readOnly: true
+        command:
+          - "/bin/sh"
+          - "-ec"
+          - |
+            IP=$(hostname -i)
+
+            if [ -e /etc/consul/secrets/gossip-key ]; then
+              echo "{\"encrypt\": \"$(base64 /etc/consul/secrets/gossip-key)\"}" > /etc/consul/encrypt.json
+              GOSSIP_KEY="-config-file /etc/consul/encrypt.json"
+            fi
+
+            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                while true; do
+                    echo "Waiting for ${PETSET_NAME}-${i}.${PETSET_NAME} to come up"
+                    ping -W 1 -c 1 ${PETSET_NAME}-${i}.${PETSET_NAME}.${PETSET_NAMESPACE}.svc.cluster.local > /dev/null && break
+                    sleep 1s
+                done
+            done
+
+            PEERS=""
+            for i in $(seq 0 $((${INITIAL_CLUSTER_SIZE} - 1))); do
+                PEERS="${PEERS}${PEERS:+ } -retry-join $(ping -c 1 ${PETSET_NAME}-${i}.${PETSET_NAME}.${PETSET_NAMESPACE}.svc.cluster.local | awk -F'[()]' '/PING/{print $2}')"
+            done
+
+            exec /bin/consul agent \
+              -data-dir=/var/lib/consul \
+              -server \
+              -ui \
+              -bootstrap-expect=${INITIAL_CLUSTER_SIZE} \
+              -bind=0.0.0.0 \
+              -advertise=${IP} \
+              ${PEERS} \
+              ${GOSSIP_KEY} \
+              -client=0.0.0.0
+      volumes:
+      - name: gossip-key
+        secret:
+          secretName: gossip-key
+      #readinessProbe:
+      #  httpGet:
+      #    path: /v1/health/service/consul
+      #    port: 8500
+      #  initialDelaySeconds: 10
+      #  timeoutSeconds: 1
+  volumeClaimTemplates:
+  - metadata:
+      name: datadir
+      annotations:
+        volume.alpha.kubernetes.io/storage-class: anything
+    spec:
+      accessModes:
+        - "ReadWriteOnce"
+      resources:
+        requests:
+          # upstream recommended max is 700M
+          storage: "700M"

--- a/generators/kubernetes/templates/registry/_jhipster-registry.yml
+++ b/generators/kubernetes/templates/registry/_jhipster-registry.yml
@@ -1,21 +1,3 @@
-# Copyright 2016 Google Inc. All Rights Reserved.
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-#
-#   http://www.apache.org/licenses/LICENSE-2.0
-#
-# Unless required by applicable law or agreed to in writing,
-# software distributed under the License is distributed on an
-# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-# KIND, either express or implied.  See the License for the
-# specific language governing permissions and limitations
-# under the License.
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
@@ -34,17 +16,27 @@ spec:
         - containerPort: 8761
         env:
         - name: SPRING_PROFILES_ACTIVE
-          value: prod
+          value: dev
         - name: SECURITY_USER_PASSWORD
           value: <%= adminPassword %>
         - name: JHIPSTER_SECURITY_AUTHENTICATION_JWT_SECRET
           value: my-secret-token-to-change-in-production
         - name: EUREKA_CLIENT_SERVICEURL_DEFAULTZONE
           value: http://admin:<%= adminPassword %>@jhipster-registry.<%= kubernetesNamespace %>.svc.cluster.local:8761/eureka/
+        # Example "prod" configuration
+        # - name: SPRING_PROFILES_ACTIVE
+        #   value: prod
         # - name: GIT_URI
         #   value: https://github.com/jhipster/jhipster-registry/
         # - name: GIT_SEARCH_PATHS
         #   value: central-config
+        volumeMounts:
+        - name: config-volume
+          mountPath: /central-config
+      volumes:
+      - name: config-volume
+        configMap:
+          name: application-config
 ---
 apiVersion: v1
 kind: Service

--- a/test/test-kubernetes.js
+++ b/test/test-kubernetes.js
@@ -7,8 +7,14 @@ var helpers = require('yeoman-test');
 var fse = require('fs-extra');
 
 const expectedFiles = {
-    registry : [
-        'registry/jhipster-registry.yml'
+    eurekaregistry: [
+        'registry/jhipster-registry.yml',
+        'registry/application-configmap.yml'
+    ],
+    consulregistry: [
+        'registry/consul.yml',
+        'registry/consul-config-loader.yml',
+        'registry/application-configmap.yml'
     ],
     jhgate : [
         'jhgate/jhgate-deployment.yml',
@@ -73,7 +79,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 .on('end', done);
         });
         it('creates expected registry files and content', function () {
-            assert.file(expectedFiles.registry);
+            assert.file(expectedFiles.eurekaregistry);
             assert.fileContent('registry/jhipster-registry.yml', /http:\/\/admin:meetup/);
         });
         it('creates expected gateway files and content', function () {
@@ -105,7 +111,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 .on('end', done);
         });
         it('creates expected registry files', function () {
-            assert.file(expectedFiles.registry);
+            assert.file(expectedFiles.eurekaregistry);
         });
         it('creates expected gateway files', function () {
             assert.file(expectedFiles.jhgate);
@@ -137,7 +143,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 .on('end', done);
         });
         it('creates expected registry files', function () {
-            assert.file(expectedFiles.registry);
+            assert.file(expectedFiles.eurekaregistry);
         });
         it('doesn\'t creates gateway files', function () {
             assert.noFile(expectedFiles.jhgate);
@@ -175,7 +181,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 .on('end', done);
         });
         it('creates expected registry files', function () {
-            assert.file(expectedFiles.registry);
+            assert.file(expectedFiles.eurekaregistry);
         });
         it('creates expected gateway files', function () {
             assert.file(expectedFiles.jhgate);
@@ -215,7 +221,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 .on('end', done);
         });
         it('doesn\'t creates registry files', function () {
-            assert.noFile(expectedFiles.registry);
+            assert.noFile(expectedFiles.eurekaregistry);
         });
         it('creates expected default files', function () {
             assert.file(expectedFiles.monolith);
@@ -243,7 +249,7 @@ describe('JHipster Kubernetes Sub Generator', function () {
                 .on('end', done);
         });
         it('doesn\'t creates registry files', function () {
-            assert.noFile(expectedFiles.registry);
+            assert.noFile(expectedFiles.eurekaregistry);
         });
         it('creates expected default files', function () {
             assert.file(expectedFiles.kafka);


### PR DESCRIPTION
It took me quite some time to get everything to work 😄 but now it's glorious !
I also did some changes for the jhipster-registry and now we can set the central config easily from a kubernernetes configmap (`application-config.yml` works the same way for the registry and consul)

Now we are almost at parity with docker-compose, it's only missing monitoring and cassandra (very nice example here : https://github.com/kubernetes/kubernetes/tree/master/examples/storage/cassandra).