### PR TITLE
fix gradle error/hanging in windows

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -86,11 +86,23 @@ if (OperatingSystem.current().isWindows()) {
             classpath = files("$buildDir/classes/main", "$buildDir/resources/main", pathingJar.archivePath)
         }
     }
-    <%_ if (!skipClient && clientFramework === 'angular1') { _%>
+    <%_ if (!skipClient) { _%>
 
-    // avoid random error and hanging in windows, see https://github.com/jhipster/generator-jhipster/pull/4683
-    gulp {
-        bufferOutput = true
+    // avoid random error and hanging in windows, see https://github.com/jhipster/generator-jhipster/pull/4809
+    tasks.withType(NodeTask) {
+        doLast {
+            println()
+        }
+    }
+    tasks.withType(com.moowork.gradle.node.npm.NpmInstallTask) {
+        doLast {
+            println()
+        }
+    }
+    tasks.withType(com.moowork.gradle.node.yarn.YarnTask) {
+        doLast {
+            println()
+        }
     }
     <%_ } _%>
 } else {


### PR DESCRIPTION
reverts #4683 and replaces with better solution for gulp
resolves error/hanging on executing npmInstall and yarn_install
my comment in open gradle issue: https://github.com/gradle/gradle/issues/882#issuecomment-269996978