### PR TITLE
Remove const restriction for "url" variable for tracker service.

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
@@ -46,7 +46,7 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
         }
         // building absolute path so that websocket doesnt fail when deploying with a context path
         const loc = this.$window.location;
-        const url = '//' + loc.host + loc.pathname + 'websocket/tracker';
+        let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
         <%_ if (authenticationType === 'oauth2') { _%>
         /*jshint camelcase: false */
         const authToken = this.$json.stringify(this.$localStorage.retrieve('authenticationToken')).access_token;


### PR DESCRIPTION
Stateless authentication has to add extra parameters to the "url" variable of the tracker service.
You can reprodude this issue by choosing stateless authentication (JWT, OAuth2...) and spring websocker when generating project.