### PR TITLE
Git ignore for Java annotation processor in Eclipse

### DIFF
--- a/generators/server/templates/gitignore
+++ b/generators/server/templates/gitignore
@@ -32,6 +32,7 @@ local.properties
 .classpath
 .settings/
 .loadpath
+.factorypath
 /<%= SERVER_MAIN_RES_DIR %>rebel.xml
 
 # External tool builders


### PR DESCRIPTION
 `.factorypath` also needs to be excluded from git for Eclipse users.

More @ https://www.gitignore.io/api/eclipse