### PR TITLE
Allow setting server port for monolith apps

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angular/src/test/javascript/_protractor.conf.js
@@ -18,7 +18,7 @@ exports.config = {
 
     directConnect: true,
 
-    baseUrl: 'http://localhost:8080/',
+    baseUrl: 'http://localhost:<%= serverPort %>/',
 
     framework: 'jasmine2',
 

--- a/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
@@ -31,7 +31,7 @@ exports.config = {
 
     directConnect: true,
 
-    baseUrl: 'http://localhost:8080/',
+    baseUrl: 'http://localhost:<%= serverPort %>/',
 
     framework: 'jasmine2',
 

--- a/generators/server/templates/_README.md
+++ b/generators/server/templates/_README.md
@@ -62,7 +62,7 @@ To ensure everything worked, run:
     java -jar target/*.war<% } %><% if (buildTool == 'gradle') { %>
     java -jar build/libs/*.war<% } %>
 
-<% if(!skipClient) { %>Then navigate to [http://localhost:8080](http://localhost:8080) in your browser.
+<% if(!skipClient) { %>Then navigate to [http://localhost:<%= serverPort %>](http://localhost:<%= serverPort %>) in your browser.
 <% } %>
 Refer to [Using JHipster in production][] for more details.
 

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -184,11 +184,7 @@ liquibase:
 <%_ } _%>
 
 server:
-<%_ if (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa') { _%>
     port: <%= serverPort %>
-<%_ } else { _%>
-    port: 8080
-<%_ } _%>
 
 # ===================================================================
 # JHipster specific properties
@@ -252,7 +248,7 @@ jhipster:
 <%_ } _%>
     mail: # specific JHipster mail property, for standard properties see MailProperties
         from: <%= baseName %>@localhost
-        base-url: http://127.0.0.1:8080
+        base-url: http://127.0.0.1:<%= serverPort %>
     metrics: # DropWizard Metrics configuration, used by MetricsConfiguration
         jmx.enabled: true
         graphite: # Use the "graphite" Maven profile to have the Graphite dependencies

--- a/generators/server/templates/src/main/resources/config/_application-prod.yml
+++ b/generators/server/templates/src/main/resources/config/_application-prod.yml
@@ -164,11 +164,7 @@ liquibase:
 <%_ } _%>
 
 server:
-<%_ if (applicationType == 'microservice' || applicationType == 'gateway' || applicationType == 'uaa') { _%>
     port: <%= serverPort %>
-<%_ } else { _%>
-    port: 8080
-<%_ } _%>
     compression:
         enabled: true
         mime-types: text/html,text/xml,text/plain,text/css, application/javascript, application/json


### PR DESCRIPTION
On my PC, I have a service running at port 8080, so each time I generate a monolith, I have to manually change the port to a different value in several files.

This allows me to change port in `.yo-rc.json` and re-generate.

I only changed the templated files, there are probably other files to modify too but I'd like to get feedback before going further.