### PR TITLE
fix many-to-many relationship when User is the target Entity

### DIFF
--- a/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
+++ b/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
@@ -109,6 +109,10 @@ public class UserDTO {
         return login;
     }
 
+    public void setLogin(String login) {
+        this.login = login;
+    }
+
     public String getFirstName() {
         return firstName;
     }

--- a/generators/server/templates/src/main/java/package/service/mapper/_UserMapper.java
+++ b/generators/server/templates/src/main/java/package/service/mapper/_UserMapper.java
@@ -29,7 +29,6 @@ public interface UserMapper {
     <%_ if ((authenticationType == 'session') && (databaseType == 'sql')) { _%>
     @Mapping(target = "persistentTokens", ignore = true)
     <%_ } } _%>
-    @Mapping(target = "id", ignore = true)
     @Mapping(target = "activationKey", ignore = true)
     @Mapping(target = "resetKey", ignore = true)
     @Mapping(target = "resetDate", ignore = true)


### PR DESCRIPTION
When creating a many-to-many relationship to a User using the generator:

- UserDTO needs the id field to make the JPA relation. I moved it from ManagedUserVM.
- UserDTO needs the login (to show in the table when there is no pagination)

I had to remove `@Mapping(target = "id", ignore = true)`, was it necessary before for some reasons ?

As the User is the target entity it is a **unidirectional** many-to-many, too hard or risky to change the User class right ?

So after the generation we have:
`public EntityA addUser(User user) {`
       ` this.users.add(user);`
        `user.getEntityAS().add(this);` //does not compile and need to be remove manually (so far)
        `return this;`
`    }`

The strange thing about this PR is that we have the 'id' field in UserDTO which is mainly use in the subclass ManagedUserVM. 
The id field in UserDTO is only used to solve this 'many-to-many relationship to a User' use case...

this use case using the generator creating an EntityA (EntityA.json) :
{
    "fluentMethods": true,
    "relationships": [
        {
            "relationshipName": "user",
            "otherEntityName": "user",
            "relationshipType": "many-to-many",
            "otherEntityField": "login",
            "ownerSide": true,
            "otherEntityRelationshipName": "entityA"
        }
    ],
    "fields": [],
    "changelogDate": "20170115151136",
    "dto": "mapstruct",
    "service": "serviceClass",
    "entityTableName": "entitya",
    "pagination": "no"
}
