### PR TITLE
Update _mysql.yml set mysql charset

### DIFF
--- a/generators/server/templates/src/main/docker/_mysql.yml
+++ b/generators/server/templates/src/main/docker/_mysql.yml
@@ -11,4 +11,4 @@ services:
             - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8


### PR DESCRIPTION
yo jhipster:docker-compose generate docker-compose.yml . and not set mysql charset , although  [application-prod.ym](https://github.com/jhipster/generator-jhipster/blob/master/generators/server/templates/src/main/resources/config/_application-prod.yml#L64) set the jdbc string use utf-8 but it was still throw exception when insert the unicode character( e.g. chinese )