### PR TITLE
Webpack stats are now generated in target folder

### DIFF
--- a/generators/client/templates/angular/webpack/_webpack.prod.js
+++ b/generators/client/templates/angular/webpack/_webpack.prod.js
@@ -14,6 +14,9 @@ module.exports = webpackMerge(commonConfig({env: ENV}), {
     },
     plugins: [
         new ExtractTextPlugin('[hash].styles.css'),
-        new Visualizer()
+        new Visualizer({
+            // Webpack statistics in target folder
+            filename: '../stats.html'
+        })
     ]
 });


### PR DESCRIPTION
Previously, the `stats.html` file (4.5 MB) was generated in `target/www` folder and so was included in war file.