### PR TITLE
fix uaa cors with 401

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_UaaConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_UaaConfiguration.java
@@ -24,6 +24,8 @@ import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.security.oauth2.provider.token.store.KeyStoreKeyFactory;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.CorsFilter;
 
 import javax.servlet.http.HttpServletResponse;
 import java.security.KeyPair;
@@ -39,9 +41,12 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter {
 
         private final JHipsterProperties jHipsterProperties;
 
-        public ResourceServerConfiguration(TokenStore tokenStore, JHipsterProperties jHipsterProperties) {
+        private final CorsFilter corsFilter;
+
+        public ResourceServerConfiguration(TokenStore tokenStore, JHipsterProperties jHipsterProperties, CorsFilter corsFilter) {
             this.tokenStore = tokenStore;
             this.jHipsterProperties = jHipsterProperties;
+            this.corsFilter = corsFilter;
         }
 
         @Override
@@ -52,6 +57,7 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter {
             .and()
                 .csrf()
                 .disable()
+                .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
                 .headers()
                 .frameOptions()
                 .disable()

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -140,6 +140,7 @@ jhipster:
         max-pool-size: 50
         queue-capacity: 10000
     # By default CORS is disabled. Uncomment to enable.
+    #cors:
         #allowed-origins: "*"
         #allowed-methods: GET, PUT, POST, DELETE, OPTIONS
         #allowed-headers: "*"


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/4704, I forgot to fix it for UAA.  401s now have the correct CORS headers (when enabled).