### PR TITLE
Add a sub generator for various CI/CD pipelines

### DIFF
--- a/generators/ci-cd/USAGE
+++ b/generators/ci-cd/USAGE
@@ -1,0 +1,5 @@
+Description:
+    Creates pipeline scripts for various CI/CD tools based on the selected options
+
+Example:
+    yo jhipster:ci-cd

--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -2,6 +2,7 @@
 var util = require('util'),
     chalk = require('chalk'),
     generators = require('yeoman-generator'),
+    prompts = require('./prompts'),
     scriptBase = require('../generator-base');
 
 var PipelineGenerator = generators.Base.extend({});
@@ -33,75 +34,8 @@ module.exports = PipelineGenerator.extend({
     },
 
     prompting: {
-        askPipelines: function () {
-            if (this.abort) return;
-            var done = this.async();
-            var prompts = [
-                {
-                    type: 'checkbox',
-                    name: 'pipelines',
-                    message: 'What CI/CD pipeline do you want to generate ?',
-                    default: [],
-                    choices: [
-                        {name: 'Jenkins pipeline', value: 'jenkins'},
-                        {name: 'Gitlab CI', value: 'gitlab'},
-                        {name: 'Circle CI', value: 'circle'}
-                    ]
-                }
-            ];
-            this.prompt(prompts).then(props => {
-                if(props.pipelines.length === 0) {
-                    this.abort = true;
-                }
-                this.pipelines = props.pipelines;
-                done();
-            });
-        },
-        askIntegrations: function () {
-            if (this.abort) return;
-            var done = this.async();
-            var choices = [];
-            if (this.pipelines.includes('jenkins') || this.pipelines.includes('gitlab')) {
-                choices.push({name: '[Docker] Perform the build in a docker container', value: 'docker'});
-            }
-            if(this.pipelines.includes('jenkins')) {
-                choices.push({name: '[Sonar] Analyze code with Sonar', value: 'sonar'});
-                choices.push({name: '[Gitlab] Send build status to Gitlab', value: 'gitlab'});
-            }
-            if(this.herokuAppName) {
-                choices.push({name: '[Heroku] Deploy to heroku', value: 'heroku'});
-            }
-
-            var prompts = [
-                {
-                    type: 'checkbox',
-                    name: 'integrations',
-                    message: 'What tasks/integrations do you want to include ?',
-                    default: [],
-                    choices: choices
-                },
-                {
-                    when: response => this.pipelines.includes('jenkins') && response.integrations.includes('sonar'),
-                    type: 'input',
-                    name: 'jenkinsSonarName',
-                    message: 'What is the name of the Sonar server ?',
-                    default: 'Sonar'
-                },
-                {
-                    when: response => response.integrations.includes('heroku'),
-                    type: 'input',
-                    name: 'herokuApiKey',
-                    message: 'What is the Heroku API Key ?',
-                    default: ''
-                },
-            ];
-            this.prompt(prompts).then(props => {
-                this.integrations = props.integrations;
-                this.jenkinsSonarName = props.jenkinsSonarName;
-                this.herokuApiKey = props.herokuApiKey;
-                done();
-            });
-        }
+        askPipelines: prompts.askPipelines,
+        askIntegrations: prompts.askIntegrations
     },
     configuring: {
         insight: function () {

--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -1,0 +1,131 @@
+'use strict';
+var util = require('util'),
+    chalk = require('chalk'),
+    generators = require('yeoman-generator'),
+    scriptBase = require('../generator-base');
+
+var PipelineGenerator = generators.Base.extend({});
+
+util.inherits(PipelineGenerator, scriptBase);
+
+module.exports = PipelineGenerator.extend({
+    constructor: function () {
+        generators.Base.apply(this, arguments);
+    },
+
+    initializing: {
+        sayHello: function() {
+            this.log(chalk.white('[Beta] Welcome to the JHipster CI/CD Sub-Generator'));
+        },
+        getConfig: function () {
+            this.skipClient = this.config.get('skipClient');
+            this.clientPackageManager = this.config.get('clientPackageManager');
+            this.buildTool = this.config.get('buildTool');
+            this.herokuAppName = this.config.get('herokuAppName');
+            this.clientFramework = this.config.get('clientFramework');
+            this.testFrameworks = this.config.get('testFrameworks');
+            this.abort = false;
+            if(this.clientFramework === 'angular2') {
+                this.log(chalk.red('Angular > 1 is currently not supported, exiting...'));
+                this.abort = true;
+            }
+        }
+    },
+
+    prompting: {
+        askPipelines: function () {
+            if (this.abort) return;
+            var done = this.async();
+            var prompts = [
+                {
+                    type: 'checkbox',
+                    name: 'pipelines',
+                    message: 'What CI/CD pipeline do you want to generate ?',
+                    default: [],
+                    choices: [
+                        {name: 'Jenkins pipeline', value: 'jenkins'},
+                        {name: 'Gitlab CI', value: 'gitlab'},
+                        {name: 'Circle CI', value: 'circle'}
+                    ]
+                }
+            ];
+            this.prompt(prompts).then(props => {
+                if(props.pipelines.length === 0) {
+                    this.abort = true;
+                }
+                this.pipelines = props.pipelines;
+                done();
+            });
+        },
+        askIntegrations: function () {
+            if (this.abort) return;
+            var done = this.async();
+            var choices = [];
+            if (this.pipelines.includes('jenkins') || this.pipelines.includes('gitlab')) {
+                choices.push({name: '[Docker] Perform the build in a docker container', value: 'docker'});
+            }
+            if(this.pipelines.includes('jenkins')) {
+                choices.push({name: '[Sonar] Analyze code with Sonar', value: 'sonar'});
+                choices.push({name: '[Gitlab] Send build status to Gitlab', value: 'gitlab'});
+            }
+            if(this.herokuAppName) {
+                choices.push({name: '[Heroku] Deploy to heroku', value: 'heroku'});
+            }
+
+            var prompts = [
+                {
+                    type: 'checkbox',
+                    name: 'integrations',
+                    message: 'What tasks/integrations do you want to include ?',
+                    default: [],
+                    choices: choices
+                },
+                {
+                    when: response => this.pipelines.includes('jenkins') && response.integrations.includes('sonar'),
+                    type: 'input',
+                    name: 'jenkinsSonarName',
+                    message: 'What is the name of the Sonar server ?',
+                    default: 'Sonar'
+                },
+                {
+                    when: response => response.integrations.includes('heroku'),
+                    type: 'input',
+                    name: 'herokuApiKey',
+                    message: 'What is the Heroku API Key ?',
+                    default: ''
+                },
+            ];
+            this.prompt(prompts).then(props => {
+                this.integrations = props.integrations;
+                this.jenkinsSonarName = props.jenkinsSonarName;
+                this.herokuApiKey = props.herokuApiKey;
+                done();
+            });
+        }
+    },
+    configuring: {
+        insight: function () {
+            if (this.abort) return;
+            var insight = this.insight();
+            insight.trackWithEvent('generator', 'ci-cd');
+        },
+        setTemplateVariables: function() {
+            this.gitLabIndent = this.integrations.includes('gitlab') ? '    ' : '';
+            this.indent = this.integrations.includes('docker') ? '    ' : '';
+            this.indent += this.gitLabIndent;
+        }
+    },
+
+    writing: function () {
+        if (this.pipelines.includes('jenkins')) {
+            this.template('_Jenkinsfile', 'Jenkinsfile');
+        }
+        if (this.pipelines.includes('gitlab')) {
+            this.template('_.gitlab-ci.yml', '.gitlab-ci.yml');
+        }
+        if (this.pipelines.includes('circle')) {
+            this.template('_circle.yml', '.circle.yml');
+        }
+    }
+
+});

--- a/generators/ci-cd/prompts.js
+++ b/generators/ci-cd/prompts.js
@@ -1,0 +1,77 @@
+'use strict';
+
+module.exports = {
+    askPipelines,
+    askIntegrations
+};
+
+function askPipelines() {
+    if (this.abort) return;
+    var done = this.async();
+    var prompts = [
+        {
+            type: 'checkbox',
+            name: 'pipelines',
+            message: 'What CI/CD pipeline do you want to generate ?',
+            default: [],
+            choices: [
+                {name: 'Jenkins pipeline', value: 'jenkins'},
+                {name: 'Gitlab CI', value: 'gitlab'},
+                {name: 'Circle CI', value: 'circle'}
+            ]
+        }
+    ];
+    this.prompt(prompts).then(props => {
+        if(props.pipelines.length === 0) {
+            this.abort = true;
+        }
+        this.pipelines = props.pipelines;
+        done();
+    });
+}
+
+function askIntegrations() {
+    if (this.abort) return;
+    var done = this.async();
+    var choices = [];
+    if (this.pipelines.includes('jenkins') || this.pipelines.includes('gitlab')) {
+        choices.push({name: '[Docker] Perform the build in a docker container', value: 'docker'});
+    }
+    if(this.pipelines.includes('jenkins')) {
+        choices.push({name: '[Sonar] Analyze code with Sonar', value: 'sonar'});
+        choices.push({name: '[Gitlab] Send build status to Gitlab', value: 'gitlab'});
+    }
+    if(this.herokuAppName) {
+        choices.push({name: '[Heroku] Deploy to heroku', value: 'heroku'});
+    }
+
+    var prompts = [
+        {
+            type: 'checkbox',
+            name: 'integrations',
+            message: 'What tasks/integrations do you want to include ?',
+            default: [],
+            choices: choices
+        },
+        {
+            when: response => this.pipelines.includes('jenkins') && response.integrations.includes('sonar'),
+            type: 'input',
+            name: 'jenkinsSonarName',
+            message: 'What is the name of the Sonar server ?',
+            default: 'Sonar'
+        },
+        {
+            when: response => response.integrations.includes('heroku'),
+            type: 'input',
+            name: 'herokuApiKey',
+            message: 'What is the Heroku API Key ?',
+            default: ''
+        },
+    ];
+    this.prompt(prompts).then(props => {
+        this.integrations = props.integrations;
+        this.jenkinsSonarName = props.jenkinsSonarName;
+        this.herokuApiKey = props.herokuApiKey;
+        done();
+    });
+}

--- a/generators/ci-cd/templates/_.gitlab-ci.yml
+++ b/generators/ci-cd/templates/_.gitlab-ci.yml
@@ -1,0 +1,145 @@
+<%_ if (integrations.includes('docker')) { _%>
+image: openjdk:8
+<%_ } _%>
+
+<%_ if (buildTool == 'gradle') { _%>
+cache:
+    key: "$CI_BUILD_REF_NAME"
+    paths:
+        - node_modules
+        - .gradle/wrapper
+        - .gradle/caches
+<%_ } _%>
+<%_ if (buildTool == 'maven') { _%>
+cache:
+    key: "$CI_BUILD_REF_NAME"
+    paths:
+        - node_modules
+        - .maven
+<%_ } _%>
+stages:
+    - build
+    - test
+    - package
+    - release
+    - deploy
+
+<%_ if (buildTool == 'gradle') { _%>
+before_script:
+    - export GRADLE_USER_HOME=`pwd`/.gradle
+    <%_ if (!skipClient) { _%>
+    - ./gradlew npmInstall -PnodeInstall --no-daemon
+    <%_ } _%>
+
+gradle-build:
+    stage: build
+    script:
+        - ./gradlew compileJava -x check --no-daemon
+    <%_ if (!skipClient) { _%>
+gulp-build:
+    stage: build
+    script:
+        - ./gradlew gulp_build -PnodeInstall --no-daemon
+    <%_ } _%>
+gradle-test:
+    stage: test
+    script:
+        - ./gradlew check --no-daemon
+    artifacts:
+        paths:
+            - build/reports/tests/*
+    <%_ if (testFrameworks.includes('gatling')) { _%>
+gatling-test:
+    stage: test
+    allow_failure: true
+    script:
+        - ./gradlew gatlingRun -x cleanResources --no-daemon
+    before_script:
+        <%_ if (!skipClient) { _%>
+        - ./gradlew npmInstall -PnodeInstall --no-daemon
+        <%_ } _%>
+        - ./gradlew bootRun &
+    artifacts:
+        paths:
+            - build/reports/gatling/*
+    <%_ } _%>
+gradle-repackage:
+    stage: package
+    script:
+        - ./gradlew bootRepackage -Pprod -x check --no-daemon
+    artifacts:
+        paths:
+            - build/libs/*.war
+    <%_ if (integrations.includes('heroku')) { _%>
+gradle-deploy:
+    stage: deploy
+    script:
+        - HEROKU_API_KEY="<%= herokuApiKey %>" ./gradlew deployHeroku --no-daemon
+    <%_ } _%>
+<%_ } _%>
+<%_ if (buildTool == 'maven') { _%>
+before_script:
+    - export MAVEN_USER_HOME=`pwd`/.maven
+    <%_ if (!skipClient) { _%>
+        <%_ if (clientPackageManager === 'yarn') { _%>
+    - ./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-yarn -DnodeVersion=v6.9.4 -DyarnVersion=v0.18.1
+    - ./mvnw com.github.eirslett:frontend-maven-plugin:yarn
+        <%_ } else if (clientPackageManager === 'npm') { _%>
+    - ./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-npm -DnodeVersion=v6.9.4 -DnpmVersion=3.10.9
+    - ./mvnw com.github.eirslett:frontend-maven-plugin:npm
+        <%_ } _%>
+    <%_ } _%>
+
+maven-build:
+    stage: build
+    script: ./mvnw compile -Dmaven.repo.local=$MAVEN_USER_HOME
+
+    <%_ if (!skipClient) { _%>
+gulp-build:
+    stage: build
+    script:
+        - ./mvnw com.github.eirslett:frontend-maven-plugin:gulp -Dfrontend.gulp.arguments=build
+    <%_ } _%>
+maven-test:
+    stage: test
+    script:
+        - ./mvnw test -Dmaven.repo.local=$MAVEN_USER_HOME
+    artifacts:
+        paths:
+            - target/surefire-reports/*
+    <%_ if (testFrameworks.includes('gatling')) { _%>
+gatling-test:
+    stage: test
+    allow_failure: true
+    script:
+        - ./mvnw gatling:execute -Dmaven.repo.local=$MAVEN_USER_HOME
+    before_script:
+        <%_ if (!skipClient) { _%>
+            <%_ if (clientPackageManager === 'yarn') { _%>
+        - ./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-yarn -DnodeVersion=v6.9.4 -DyarnVersion=v0.18.1
+        - ./mvnw com.github.eirslett:frontend-maven-plugin:yarn
+            <%_ } else if (clientPackageManager === 'npm') { _%>
+        - ./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-npm -DnodeVersion=v6.9.4 -DnpmVersion=3.10.9
+        - ./mvnw com.github.eirslett:frontend-maven-plugin:npm
+            <%_ } _%>
+        <%_ } _%>
+        - ./mvnw &
+    artifacts:
+        paths:
+            - target/gatling/*
+    <%_ } _%>
+    <%_ if (integrations.includes('heroku')) { _%>
+maven-deploy:
+    stage: deploy
+     script:
+        - HEROKU_API_KEY=\"<%= herokuApiKey %>\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+    <%_ } else { _%>
+maven-package:
+    stage: package
+    script:
+        - ./mvnw package -Pprod -DskipTests -Dmaven.repo.local=$MAVEN_USER_HOME
+    <%_ } _%>
+    artifacts:
+        paths:
+            - target/*.war
+<%_ } _%>

--- a/generators/ci-cd/templates/_Jenkinsfile
+++ b/generators/ci-cd/templates/_Jenkinsfile
@@ -1,0 +1,138 @@
+#!/usr/bin/env groovy
+
+node {
+    stage('checkout') {
+        checkout scm
+    }
+
+<%_ if (integrations.includes('gitlab')) { _%>
+    gitlabCommitStatus('build') {
+<%_ } _%>
+<%_ if (integrations.includes('docker')) { _%>
+<%= gitLabIndent %>    docker.image('openjdk:8').inside('-u root<% if (buildTool === 'maven') { %> -e MAVEN_OPTS="-Duser.home=./"<% } else if (buildTool === 'gradle') { %> -e GRADLE_USER_HOME=.gradle<% } %>') {
+<%_ } _%>
+<%= indent %>    stage('check java') {
+<%= indent %>        sh "java -version"
+<%= indent %>    }
+
+<%_ if (buildTool === 'maven') { _%>
+<%= indent %>    stage('clean') {
+<%= indent %>        sh "./mvnw clean"
+<%= indent %>    }
+
+    <%_ if (!skipClient) { _%>
+        <%_ if (clientPackageManager === 'yarn') { _%>
+<%= indent %>    stage('install tools') {
+<%= indent %>        sh "./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-yarn -DnodeVersion=v6.9.4 -DyarnVersion=v0.18.1"
+<%= indent %>    }
+
+<%= indent %>    stage('yarn install') {
+<%= indent %>        sh "./mvnw com.github.eirslett:frontend-maven-plugin:yarn"
+<%= indent %>    }
+
+        <%_ } else if (clientPackageManager === 'npm') { _%>
+<%= indent %>    stage('install tools') {
+<%= indent %>        sh "./mvnw com.github.eirslett:frontend-maven-plugin:install-node-and-npm -DnodeVersion=v6.9.4 -DnpmVersion=3.10.9"
+<%= indent %>    }
+
+<%= indent %>    stage('npm install') {
+<%= indent %>        sh "./mvnw com.github.eirslett:frontend-maven-plugin:npm"
+<%= indent %>    }
+
+        <%_ } _%>
+    <%_ } _%>
+<%= indent %>    stage('backend tests') {
+<%= indent %>        try {
+<%= indent %>            sh "./mvnw test"
+<%= indent %>        } catch(err) {
+<%= indent %>            throw err
+<%= indent %>        } finally {
+<%= indent %>            junit '**/target/surefire-reports/TEST-*.xml'
+<%= indent %>        }
+<%= indent %>    }
+
+    <%_ if (!skipClient) { _%>
+<%= indent %>    stage('frontend tests') {
+<%= indent %>        try {
+<%= indent %>            sh "./mvnw com.github.eirslett:frontend-maven-plugin:gulp -Dfrontend.gulp.arguments=test"
+<%= indent %>        } catch(err) {
+<%= indent %>            throw err
+<%= indent %>        } finally {
+<%= indent %>            junit '**/target/test-results/karma/TESTS-*.xml'
+<%= indent %>        }
+<%= indent %>    }
+
+    <%_ } _%>
+    <%_ if (integrations.includes('heroku')) { _%>
+<%= indent %>    stage('package and deploy') {
+<%= indent %>        sh "HEROKU_API_KEY=\"<%= herokuApiKey %>\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
+    <%_ } else { _%>
+<%= indent %>    stage('packaging') {
+<%= indent %>        sh "./mvnw package -Pprod -DskipTests"
+    <%_ } _%>
+<%= indent %>        archiveArtifacts artifacts: '**/target/*.war', fingerprint: true
+<%= indent %>    }
+
+<%_ } else if (buildTool === 'gradle') { _%>
+<%= indent %>    stage('clean') {
+<%= indent %>        sh "./gradlew clean --no-daemon"
+<%= indent %>    }
+
+    <%_ if (!skipClient) { _%>
+<%= indent %>    stage('npm install') {
+<%= indent %>        sh "./gradlew npmInstall -PnodeInstall --no-daemon"
+<%= indent %>    }
+
+    <%_ } _%>
+<%= indent %>    stage('backend tests') {
+<%= indent %>        try {
+<%= indent %>            sh "./gradlew test -PnodeInstall --no-daemon"
+<%= indent %>        } catch(err) {
+<%= indent %>            throw err
+<%= indent %>        } finally {
+<%= indent %>            junit '**/build/**/TEST-*.xml'
+<%= indent %>        }
+<%= indent %>    }
+
+    <%_ if (!skipClient) { _%>
+<%= indent %>    stage('frontend tests') {
+<%= indent %>        try {
+<%= indent %>            sh "./gradlew gulp_test -PnodeInstall --no-daemon"
+<%= indent %>        } catch(err) {
+<%= indent %>            throw err
+<%= indent %>        } finally {
+<%= indent %>            junit '**/build/test-results/karma/TESTS-*.xml'
+<%= indent %>        }
+<%= indent %>    }
+
+    <%_ } _%>
+<%= indent %>    stage('packaging') {
+<%= indent %>        sh "./gradlew bootRepackage -x test -Pprod -PnodeInstall --no-daemon"
+<%= indent %>        archiveArtifacts artifacts: '**/build/*.war', fingerprint: true
+<%= indent %>    }
+
+    <%_ if (integrations.includes('heroku')) { _%>
+<%= indent %>    stage('deployment') {
+<%= indent %>        sh "HEROKU_API_KEY=\"<%= herokuApiKey %>\" ./gradlew deployHeroku --no-daemon"
+<%= indent %>    }
+
+     <%_ } _%>
+<%_ } _%>
+<%_ if (integrations.includes('sonar')) { _%>
+<%= indent %>    stage('quality analysis') {
+<%= indent %>        withSonarQubeEnv('<%= jenkinsSonarName %>') {
+    <%_ if (buildTool === 'maven') { _%>
+<%= indent %>            sh "./mvnw sonar:sonar"
+    <%_ } else if (buildTool === 'gradle' ) { _%>
+<%= indent %>            sh "./gradlew sonarqube --no-daemon"
+    <%_ } _%>
+<%= indent %>        }
+<%= indent %>    }
+<%_ } _%>
+<%_ if (integrations.includes('docker')) { _%>
+<%= gitLabIndent %>    }
+<%_ } _%>
+<%_ if (integrations.includes('gitlab')) { _%>
+    }
+<%_ } _%>
+}

--- a/generators/ci-cd/templates/_circle.yml
+++ b/generators/ci-cd/templates/_circle.yml
@@ -1,0 +1,56 @@
+machine:
+    services:
+        - docker
+    java:
+        version: oraclejdk8
+    node:
+        version: 4.5.0
+dependencies:
+    cache_directories:
+        <%_ if (!skipClient) { _%>
+        - node
+        - node_modules
+        <%_ } _%>
+        <%_ if (buildTool === 'maven') { _%>
+        - ~/.m2
+        <%_ } else if (buildTool === 'gradle') { _%>
+        - ~/.gradle
+        <%_ } _%>
+    <%_ if (!skipClient) { _%>
+    override:
+        - npm install -g npm
+        - npm install -g bower gulp
+        - node -v
+        - npm -v
+        - bower -v
+        - gulp -v
+        - java -version
+        - npm install
+    <%_ } else { _%>
+    override:
+        - java -version
+    <%_ } _%>
+test:
+    override:
+<%_ if (buildTool === 'maven') { _%>
+        - ./mvnw clean
+        - ./mvnw test
+<%_ } else if (buildTool === 'gradle') { _%>
+        - ./gradlew clean
+        - ./gradlew test --no-daemon
+<%_ } _%>
+<%_ if (!skipClient) { _%>
+        - gulp test
+<%_ } _%>
+<%_ if (buildTool === 'maven') { _%>
+    <%_ if (integrations.includes('heroku')) { _%>
+        - HEROKU_API_KEY=\"<%= herokuApiKey %>\" ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+    <%_ } else { _%>
+        - ./mvnw package -Pprod -DskipTests
+    <%_ } _%>
+<%_ } else if (buildTool === 'gradle') { _%>
+        - ./gradlew bootRepackage -Pprod -x test --no-daemon
+    <%_ if (integrations.includes('heroku')) { _%>
+        - HEROKU_API_KEY="<%= herokuApiKey %>" ./gradlew deployHeroku --no-daemon
+    <%_ } _%>
+<%_ } _%>

--- a/generators/heroku/USAGE
+++ b/generators/heroku/USAGE
@@ -7,3 +7,4 @@ Example:
     This will create:
         Procfile
         src/main/java/your_package_name/config/HerokuDatabaseConfiguration.java
+        gradle/heroku.gradle

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -277,10 +277,19 @@ module.exports = HerokuGenerator.extend({
             this.template('_bootstrap-heroku.yml', constants.SERVER_MAIN_RES_DIR + '/config/bootstrap-heroku.yml');
             this.template('_application-heroku.yml', constants.SERVER_MAIN_RES_DIR + '/config/application-heroku.yml');
             this.template('_Procfile', 'Procfile');
+            if (this.buildTool === 'gradle') {
+                this.template('_heroku.gradle', 'gradle/heroku.gradle');
+            }
 
             this.conflicter.resolve(function (err) {
                 done();
             });
+        },
+
+        addHerokuBuildPlugin: function () {
+            if (this.buildTool !== 'gradle') return;
+            this.addGradlePlugin('gradle.plugin.com.heroku.sdk', 'heroku-gradle', '0.2.0');
+            this.applyFromGradleScript('gradle/heroku');
         }
     },
 

--- a/generators/heroku/templates/_heroku.gradle
+++ b/generators/heroku/templates/_heroku.gradle
@@ -1,0 +1,6 @@
+apply plugin: 'com.heroku.sdk.heroku-gradle'
+
+heroku {
+  appName = "<%= herokuAppName %>"
+}
+


### PR DESCRIPTION
Following discussion on #4600 
This PR is for a subgen to generate CI/CD config files with options

Currently supported pipelines and integrations are:

Feature | Jenkins | Gitlab | Circle |
| ----- |:-------:|:------:|:------:|
Yarn|x (Maven)|x (Maven)|
Gitlab status|x|N/A|
SonarQube|x|
Build in Docker|x|x|N/A|
Gatling tests| |x (for basic apps)
Deploy to Heroku|x|x|x|

TODO/Next/ideas:
* Support NG2+
* Travis CI
* Gatling / Protractor / Cucumber tests
* Github
* AWS / CloudFoundry / Kubernetes deployment
* Build a docker image and publish to a docker registry
* Publish to Artifactory
* Git flow (master/develop/MR/PR/tags)
* Generator tests
* jhipster.github.io doc

Notes:
* I reused templates from generator-jhipster-ci. Kudos to @pascalgrimaud 
* I haven't tested enough Gitlab and Circle generated files

