### PR TITLE
ng2: fix the type of byteSize

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -20,7 +20,7 @@ _%>
     currentSearch: string;
     <%_ } _%>
     <%_ if (fieldsContainBlob) { _%>
-    byteSize: number;
+    byteSize: any;
     openFile: any;
     <%_ } _%>
 


### PR DESCRIPTION
fix this error (when using blob):

```
ERROR in [at-loader] src/main/webapp/app/entities/field-test-infinite-scroll-entity/field-test-infinite-scroll-entity.component.ts:48:9 
    Type '(base64String: string) => string' is not assignable to type 'number'.
Child html-webpack-plugin for "index.html":
    [./node_modules/html-webpack-plugin/lib/loader.js!./src/main/webapp/index.ejs] ./~/html-webpack-plugin/lib/loader.js!./src/main/webapp/index.ejs 1.82 kB {0} [built]
    [./node_modules/lodash/lodash.js] ./~/lodash/lodash.js 540 kB {0} [built]
    [./node_modules/webpack/buildin/global.js] (webpack)/buildin/global.js 509 bytes {0} [built]
    [./node_modules/webpack/buildin/module.js] (webpack)/buildin/module.js 517 bytes {0} [built]
error Command failed with exit code 2.
```