### PR TITLE
Change oauth_client_details column lengths to match Oracle 11g limits

### DIFF
--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/_initial_schema.xml
@@ -254,8 +254,8 @@
             <column name="authorities" type="varchar(255)"/>
             <column name="access_token_validity" type="INT"/>
             <column name="refresh_token_validity" type="INT"/>
-            <column name="additional_information" type="VARCHAR(4096)"/>
-            <column name="autoapprove" type="VARCHAR(4096)"/>
+            <column name="additional_information" type="VARCHAR(4000)"/>
+            <column name="autoapprove" type="VARCHAR(4000)"/>
         </createTable>
 
         <createTable tableName="oauth_client_token">


### PR DESCRIPTION
The fields in question are:

* additional_information
* autoapprove