### PR TITLE
fixes ID links for entity and user-management components

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
@@ -28,7 +28,7 @@
             </thead>
             <tbody *ngIf ="users">
             <tr *ngFor="let user of users; trackBy: trackIdentity">
-                <td><a [routerLink]="['../user', user.login]">{{user.id}}</a></td>
+                <td><a [routerLink]="['../user-management', user.login]">{{user.id}}</a></td>
                 <td>{{user.login}}</td>
                 <td>{{user.email}}</td>
                 <td>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.html
@@ -14,9 +14,9 @@
             <%_ if (searchEngine == 'elasticsearch') { _%>
             <div class="col-xs-8 no-padding-right">
                 <form name="searchForm" class="form-inline">
-                    <div class="input-group pull-right" >
+                    <div class="input-group pull-right">
                         <input type="text" class="form-control" [(ngModel)]="currentSearch" id="currentSearch" name="currentSearch" placeholder="<% if (enableTranslation) { %>{{ '<%= keyPrefix %>home.search' | translate }}<% } else { %>Query<% } %>">
-                        <span  class="input-group-btn width-min" >
+                        <span  class="input-group-btn width-min">
                             <button class="btn btn-info" (click)="search(currentSearch)">
                                 <span class="fa fa-search"></span>
                             </button>
@@ -54,7 +54,7 @@
             </thead>
             <tbody<% if (pagination == 'infinite-scroll') { %> infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']" [infiniteScrollDistance]="0"<% } %>>
             <tr *ngFor="let <%=entityInstance %> of <%=entityInstancePlural %> ;trackBy: trackId">
-                <td><a [routerLink]="['../<%= entityInstance %>', <%= entityInstance %>.id ]" >{{<%=entityInstance %>.id}}</a></td>
+                <td><a [routerLink]="['../<%= entityUrl %>', <%= entityInstance %>.id ]">{{<%=entityInstance %>.id}}</a></td>
                 <%_ for (idx in fields) {
                 var fieldName = fields[idx].fieldName;
                 var fieldNameCapitalized = fields[idx].fieldNameCapitalized;
@@ -110,13 +110,13 @@
                     <%_ } else { _%>
                         <%_ if (relationshipType == 'many-to-many') { _%>
                     <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>">
-                            <a class="form-control-static" [routerLink]="['../<%= otherEntityStateName %>', <%= relationshipFieldName %>?.id ]" >{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{last ? '' : ', '}}
+                            <a class="form-control-static" [routerLink]="['../<%= otherEntityStateName %>', <%= relationshipFieldName %>?.id ]">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{last ? '' : ', '}}
                         </span>
                         <%_ } else { _%>
                             <%_ if (dto == 'no') { _%>
-                    <a [routerLink]="['../<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "?.id" %> ]" >{{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}</a>
+                    <a [routerLink]="['../<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "?.id" %> ]">{{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}</a>
                             <%_ } else { _%>
-                    <a [routerLink]="['../<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "Id" %> %> ]" >{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
+                    <a [routerLink]="['../<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "Id" %> %> ]">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
                             <%_ } _%>
                         <%_ } _%>
                     <%_ } _%>


### PR DESCRIPTION
When an entity contains more than one word, the link on the ID in the entity table was broken.  For example: `logEntry` should be `log-entry`

User management ID also pointed to the wrong place