### PR TITLE
Add missing entity translates for serbian [ci skip]

### DIFF
--- a/generators/entity/templates/client/i18n/_entity_sr.json
+++ b/generators/entity/templates/client/i18n/_entity_sr.json
@@ -1,0 +1,30 @@
+{
+    "<%= angularAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "home": {
+                "title": "<%= entityClassPluralHumanized %>",
+                "createLabel": "Kreiraj novi <%= entityClassHumanized %>",
+                "createOrEditLabel": "Kreirajte ili izmenite <%= entityClassHumanized %>",
+                "search": "Potražite <%= entityClassHumanized %>"
+            },<% if (!microserviceAppName) { %>
+            "created": "Kreiran je novi <%= entityClassHumanized %> pod nazivom {{ param }}",
+            "updated": "<%= entityClassHumanized %> pod nazivom {{ param }} je ažuriran",
+            "deleted": "<%= entityClassHumanized %> pod nazivom {{ param }} je obrisan",<% } %>
+            "delete": {
+                "question": "Da li ste sigurni da želite da obrišete <%= entityClassHumanized %> pod nazivom {{ id }}?"
+            },
+            "detail": {
+                "title": "<%= entityClassHumanized %>"
+            }<% for (idx in fields) { %>,
+            "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } %>
+        }
+    }<% if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Kreiran je novi <%= entityClassHumanized %> pod nazivom  {{ param }}",
+            "updated": "<%= entityClassHumanized %> pod nazivom {{ param }} je ažuriran",
+            "deleted": "<%= entityClassHumanized %> pod nazivom {{ param }} je obrisan"
+        }
+    }<% } %>
+}

--- a/generators/entity/templates/client/i18n/_enum_sr.json
+++ b/generators/entity/templates/client/i18n/_enum_sr.json
@@ -1,0 +1,8 @@
+{
+    "<%= angularAppName %>": {
+        "<%= enumName %>" : {
+            "null": ""<% for (enumId in enums) { %>,
+            "<%=enums[enumId]%>": "<%=enums[enumId]%>"<% } %>
+        }
+    }
+}


### PR DESCRIPTION
When submiting support for sr I was following this https://github.com/jhipster/generator-jhipster/pull/4486 This means that Vietnamese language also lack support for entities. 

@tientq can you follow this PR and do the same for Vietnamese language after review ?