### PR TITLE
Fix Backslashes in validation patterns are not escaped in 'translateValues'

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
@@ -144,7 +144,7 @@
           <%_ } _%>
           <%_ if (fields[idx].fieldValidateRules.indexOf('pattern') != -1) { _%>
           <small class="form-text text-danger"
-           [hidden]="!editForm.controls.<%= fieldName %>?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{ pattern: '<%= fields[idx].fieldValidateRulesPattern.replace(/"/g, '&#34;') %>' }">
+           [hidden]="!editForm.controls.<%= fieldName %>?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{ pattern: '<%= fields[idx].fieldValidateRulesPattern.replace(/"/g, '&#34;').replace(/\\/g, '\\\\') %>' }">
             This field should follow pattern "<%- fields[idx].fieldValidateRulesPattern.replace(/&/g, '&amp;').replace(/\{/g, '&#123;').replace(/\}/g, '&#125;') %>".
           </small>
             <%_ } _%>


### PR DESCRIPTION
Fix #4966