### PR TITLE
Pin spring security version

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -336,8 +336,8 @@ dependencies {
     compile "io.jsonwebtoken:jjwt:${jjwt_version}"
     <%_ } _%>
     <%_ if (authenticationType === 'uaa') { _%>
-    compile group: 'org.springframework.security.oauth', name: 'spring-security-oauth2'
-    compile group: 'org.springframework.security', name: 'spring-security-jwt'
+    compile "org.springframework.security.oauth:spring-security-oauth2:${spring_security_oauth2_version}"
+    compile "org.springframework.security:spring-security-jwt"
     <%_ } _%>
     <%_ if (databaseType === 'mongodb') { _%>
     compile "com.github.mongobee:mongobee:${mongobee_version}"
@@ -382,7 +382,7 @@ dependencies {
     testCompile "info.cukes:cucumber-spring:${cucumber_version}"
     <%_ } _%>
     testCompile "org.springframework.boot:spring-boot-starter-test"
-    testCompile "org.springframework.security:spring-security-test"
+    testCompile "org.springframework.security:spring-security-test:${spring_security_version}"
     testCompile "org.springframework.boot:spring-boot-test"
     testCompile "org.assertj:assertj-core:${assertj_core_version}"
     testCompile "junit:junit"

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -58,7 +58,7 @@ prometheus_simpleclient_version=0.0.18
 <%_ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
 postgresql_version=9.4.1212
 <%_ } _%>
-<%_ if (authenticationType === 'oauth2') { _%>
+<%_ if (authenticationType === 'oauth2' || authenticationType === 'uaa') { _%>
 spring_security_oauth2_version=2.0.12.RELEASE
 <%_ } _%>
 spring_security_version=4.2.1.RELEASE


### PR DESCRIPTION
The `spring-security` version is pinned to `4.2.1` (like in maven).

close #4975