### PR TITLE
Main Component Padding 

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/css/_global.css
+++ b/generators/client/templates/angular/src/main/webapp/content/css/_global.css
@@ -32,7 +32,7 @@ Generic styles
 /* other generic styles */
 
 .card {
-    padding: 30px;
+    padding: 1.5%;
     margin-top: 20px;
     border: none;
 }

--- a/generators/client/templates/angular/src/main/webapp/content/scss/_global.scss
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/_global.scss
@@ -34,7 +34,7 @@ Generic styles
 /* other generic styles */
 
 .card {
-    padding: 30px;
+    padding: 1.5%;
     margin-top: 20px;
     border: none;
 }


### PR DESCRIPTION
In the main.component that wraps the entire site, there is a css property "card" that sets the padding for the content.  This is set to 30px prior to my change.  However, on small screens, say 400 pixels width, 30 left and 30 right padding is too much.  This change makes the padding a percentage of screen size.  I set it to 1.5%, which looks good to me but is subjective.  This translates to:

400w px : ~6px padding
800w px: ~12px padding
1200w px: ~18px padding 