### PR TITLE
Prepare for AOT

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
@@ -14,21 +14,20 @@ import { AuthExpiredInterceptor } from './auth-expired.interceptor';
 import { ErrorHandlerInterceptor } from './errorhandler.interceptor';
 import { NotificationInterceptor } from './notification.interceptor';
 
-export const customHttpProvider = () => ({
-    provide: Http,
-    useFactory: (
-        backend: XHRBackend,
-        defaultOptions: RequestOptions,
-        <%_ if (authenticationType === 'oauth2' || authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
-        localStorage: LocalStorageService,
-        sessionStorage: SessionStorageService,
-        injector: Injector,
-        <%_ } if (authenticationType === 'session') { _%>
-        injector: Injector,
-        stateStorageService: StateStorageService,
-        <%_ } _%>
-        eventManager: EventManager
-    ) => new InterceptableHttp(
+export function interceptableFactory(
+    backend: XHRBackend,
+    defaultOptions: RequestOptions,
+    <%_ if (authenticationType === 'oauth2' || authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+    localStorage: LocalStorageService,
+    sessionStorage: SessionStorageService,
+    injector: Injector,
+    <%_ } if (authenticationType === 'session') { _%>
+    injector: Injector,
+    stateStorageService: StateStorageService,
+    <%_ } _%>
+    eventManager: EventManager
+) {
+    return new InterceptableHttp(
         backend,
         defaultOptions,
         [
@@ -42,7 +41,13 @@ export const customHttpProvider = () => ({
             new ErrorHandlerInterceptor(eventManager),
             new NotificationInterceptor()
         ]
-    ),
+    )
+};
+
+export function customHttpProvider() {
+    return {
+        provide: Http,
+        useFactory: interceptableFactory,
     deps: [
         XHRBackend,
         RequestOptions,
@@ -56,4 +61,4 @@ export const customHttpProvider = () => ({
         <%_ } _%>
         EventManager
     ]
-});
+}};


### PR DESCRIPTION
When using angular-cli on a JHipster project, the AOT compilation fails on `http.provider.ts` because of `useFactory` property  using a lambda rather than a named function.

See https://medium.com/@isaacplmann/making-your-angular-2-library-statically-analyzable-for-aot-e1c6f3ebedd5#.hylx41wiy