### PR TITLE
Correction of name of JWT Token in Swagger

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
@@ -99,7 +99,7 @@
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <% } %>
                 <% if (authenticationType === 'jwt' || authenticationType === 'uaa') { %>
-                    var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken") || sessionStorage.getItem("jhi-authenticationToken"));
+                    var authToken = JSON.parse(localStorage.getItem("jhi-authenticationtoken") || sessionStorage.getItem("jhi-authenticationtoken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
                 <% } %>


### PR DESCRIPTION
Correction of name of JWT Token in Swagger (only for Angular2)
caused by ng2-webstorage (lowercase)