### PR TITLE
fix oauth2 logout

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-oauth2.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-oauth2.service.ts
@@ -52,9 +52,10 @@ export class AuthServerProvider {
         <%_ if (websocket === 'spring-websocket') { _%>
         this.trackerService.disconnect();
         <%_ } _%>
-        return this.http.post('api/logout', {}).map((response: Response) => {
+        return new Observable(observer => {
+            this.http.post('api/logout', {});
             this.$localStorage.clear('authenticationToken');
-            return response;
+            observer.complete();
         });
     }
 }


### PR DESCRIPTION
I couldn't reproduce this until I ran protractor, then I couldn't log in as admin.  I remembered the protractor tests change the password to `newpassword` and I noticed that worked to log in the admin.

So the real issue is that when you click `Sign out` with Oauth2, it would redirect to `/` before completing the logout, making the `Sign in` element invisible.  Then every other test would fail as it expected the password to be `admin` but it was never changed back from `newpassword`.  I copied the JWT logout method and it now works as expected.

Fix #4982 
