### PR TITLE
Tuning tsc

### DIFF
--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -15,7 +15,8 @@
             "node_modules/@types"
         ]
     },
-    "exclude": [
-        "node_modules"
+    "include": [
+        "src/main/webapp",
+        "src/test/javascript"
     ]
 }

--- a/generators/client/templates/angular/_tsconfig.json
+++ b/generators/client/templates/angular/_tsconfig.json
@@ -16,7 +16,7 @@
         ]
     },
     "include": [
-        "src/main/webapp",
+        "src/main/webapp/app",
         "src/test/javascript"
     ]
 }


### PR DESCRIPTION
By default, tsc includes **/* and our tsconfig.json excludes node_modules, I found it's better to include source folders explicitly (white list versus black list approach).

By defining includes explicitly, compilation time went from 12.80s to 11.15s with some variations of course.