### PR TITLE
Use invisble class name for hiding elements in has-auth

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
@@ -22,11 +22,11 @@ export class HasAnyAuthorityDirective implements OnInit {
     }
 
     private setVisible () {
-        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', false);
+        this.renderer.setElementClass(this.el.nativeElement, 'invisible', false);
     }
 
     private setHidden () {
-        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', true);
+        this.renderer.setElementClass(this.el.nativeElement, 'invisible', true);
     }
 
     private setVisibilitySync () {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-authority.directive.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-authority.directive.ts
@@ -30,11 +30,11 @@ export class HasAuthorityDirective implements OnInit {
     }
 
     private setVisible () {
-        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', false);
+        this.renderer.setElementClass(this.el.nativeElement, 'invisible', false);
     }
 
     private setHidden () {
-        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', true);
+        this.renderer.setElementClass(this.el.nativeElement, 'invisible', true);
     }
 
     private setVisibilityAsync () {


### PR DESCRIPTION
Use a more semantic BS4 class name (`invisible`) for hiding elements in has-auth rather than `hidden-xs-up`