### PR TITLE
fix oauth ws and always disconnect ws when logging out

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-oauth2.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-oauth2.service.ts
@@ -4,18 +4,12 @@ import { Observable } from 'rxjs/Rx';
 import { LocalStorageService } from 'ng2-webstorage';
 
 import { Base64 } from 'ng-jhipster';
-<%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';
-<%_ } _%>
 
 @Injectable()
 export class AuthServerProvider {
 
     constructor(
         private http: Http,
-        <%_ if (websocket === 'spring-websocket') { _%>
-        private trackerService: <%=jhiPrefixCapitalized%>TrackerService,
-        <%_ } _%>
         private base64: Base64,
         private $localStorage: LocalStorageService
     ) {}
@@ -49,9 +43,6 @@ export class AuthServerProvider {
     }
 
     logout (): Observable<any> {
-        <%_ if (websocket === 'spring-websocket') { _%>
-        this.trackerService.disconnect();
-        <%_ } _%>
         return new Observable(observer => {
             this.http.post('api/logout', {});
             this.$localStorage.clear('authenticationToken');

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
@@ -1,30 +1,13 @@
 import { Injectable } from '@angular/core';
 import { Http, Response, Headers } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-import { LocalStorageService } from 'ng2-webstorage';
-<%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';
-<%_ } _%>
 
 @Injectable()
 export class AuthServerProvider {
 
     constructor(
-        private http: Http,
-        <%_ if (websocket === 'spring-websocket') { _%>
-        private trackerService: <%=jhiPrefixCapitalized%>TrackerService,
-        <%_ } _%>
-        private $localStorage: LocalStorageService
-
+        private http: Http
     ) {}
-
-    getToken () {
-        return this.$localStorage.retrieve('authenticationToken');
-    }
-
-    hasValidToken () {
-        return !!this.getToken();
-    }
 
     login (credentials): Observable<any> {
         let data = 'j_username=' + encodeURIComponent(credentials.username) +
@@ -40,20 +23,11 @@ export class AuthServerProvider {
     }
 
     logout (): Observable<any> {
-        <%_ if (websocket === 'spring-websocket') { _%>
-        this.trackerService.disconnect();
-        <%_ } _%>
-        <%_ if (authenticationType === 'uaa') { _%>
-        this.$localStorage.clear('authenticationToken');
-        <%_ } else { _%>
         // logout from the server
         return this.http.post('api/logout', {}).map((response: Response) => {
-
-            this.$localStorage.clear('authenticationToken');
             // to get a new csrf token call the api
             this.http.get('api/account').subscribe(() => {}, () => {});
             return response;
         });
-        <%_ } _%>
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_principal.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_principal.service.ts
@@ -74,6 +74,11 @@ export class Principal {
             this.authenticationState.next(this._identity);
             return this._identity;
         }).catch(err => {
+            <%_ if (websocket === 'spring-websocket') { _%>
+            if (this.trackerService.stompClient && this.trackerService.stompClient.connected) {
+                this.trackerService.disconnect();
+            }
+            <%_ } _%>
             this._identity = null;
             this.authenticated = false;
             this.authenticationState.next(this._identity);

--- a/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
@@ -1,13 +1,13 @@
 import { Injectable, Inject } from '@angular/core';
 import { Router, NavigationEnd } from '@angular/router';
 import { Observable, Observer, Subscription } from 'rxjs/Rx';
-<%_ if (authenticationType === 'oauth2') { _%>
-import { LocalStorageService } from 'ng2-webstorage';
-<%_ } _%>
 
 import { CSRFService } from '../auth/csrf.service';
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
 import { AuthServerProvider } from '../auth/auth-jwt.service';
+<%_ } _%>
+<%_ if (authenticationType === 'oauth2') { _%>
+import { AuthServerProvider } from '../auth/auth-oauth2.service';
 <%_ } _%>
 
 // TODO find a better way to import these libs here
@@ -27,10 +27,8 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
 
     constructor(
         private router: Router,
-        <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+        <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa' || authenticationType === 'oauth2') { _%>
         private authServerProvider: AuthServerProvider,
-        <%_ } if (authenticationType === 'oauth2') { _%>
-        private $localStorage: LocalStorageService,
         <%_ } _%>
         private $document: Document,
         private $window: Window,
@@ -47,12 +45,8 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
         // building absolute path so that websocket doesnt fail when deploying with a context path
         const loc = this.$window.location;
         let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
-        <%_ if (authenticationType === 'oauth2') { _%>
-        /*jshint camelcase: false */
-        const authToken = this.$json.stringify(this.$localStorage.retrieve('authenticationToken')).access_token;
-        url += '?access_token=' + authToken;
-        <%_ } if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
-        const authToken = this.authServerProvider.getToken();
+        <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa' || authenticationType === 'oauth2') { _%>
+        const authToken = this.authServerProvider.getToken()<% if (authenticationType === 'oauth2') { %>.access_token<% } %>;
         if (authToken) {
             url += '?access_token=' + authToken;
         }


### PR DESCRIPTION
Some session/oauth were disconnecting websockets on logout, but jwt/uaa were not.  This means that logged out users incorrectly show up in the tracker.

Because `auth-oauth2.service.ts` injected `tracker.service.ts` to disconnect on logout, I couldn't inject `tracker.service.ts` into `auth-oauth2.service.ts` to get the token like expected (circular reference).

I moved the disconnection to the same method where it connects - if the user logs out while connected, the first route change will disconnect them.

Fix #5050