### PR TITLE
Revert "Use invisble class name for hiding elements in has-auth"

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
@@ -22,11 +22,11 @@ export class HasAnyAuthorityDirective implements OnInit {
     }
 
     private setVisible () {
-        this.renderer.setElementClass(this.el.nativeElement, 'invisible', false);
+        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', false);
     }
 
     private setHidden () {
-        this.renderer.setElementClass(this.el.nativeElement, 'invisible', true);
+        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', true);
     }
 
     private setVisibilitySync () {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-authority.directive.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-authority.directive.ts
@@ -30,11 +30,11 @@ export class HasAuthorityDirective implements OnInit {
     }
 
     private setVisible () {
-        this.renderer.setElementClass(this.el.nativeElement, 'invisible', false);
+        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', false);
     }
 
     private setHidden () {
-        this.renderer.setElementClass(this.el.nativeElement, 'invisible', true);
+        this.renderer.setElementClass(this.el.nativeElement, 'hidden-xs-up', true);
     }
 
     private setVisibilityAsync () {


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#5054 because it creates a gap in menu

Ref #5063 