### PR TITLE
Check node version when using the generator. Need at least 6.9.0+

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -108,6 +108,24 @@ module.exports = JhipsterGenerator.extend({
             }.bind(this));
         },
 
+        checkNode: function () {
+            if (this.skipChecks || this.skipServer) return;
+            var done = this.async();
+            exec('node -v', function (err, stdout, stderr) {
+                if (err) {
+                    this.warning('Node is not found on your computer.');
+                } else {
+                    var nodeVersionMajor = stdout.split('.')[0].replace(/v/g, '');
+                    var nodeVersionMinor = stdout.split('.')[1];
+                    var nodeVersion = stdout.replace(/\n/g, '');
+                    if (nodeVersionMajor < 6 || (nodeVersionMajor >= 6 && nodeVersionMinor < 9)) {
+                        this.warning('Your node version is too old (' + nodeVersion + '). You should use at least Node ' + chalk.bold('v6.9.0+'));
+                    }
+                }
+                done();
+            }.bind(this));
+        },
+
         checkGit: function () {
             if (this.skipChecks || this.skipClient) return;
             var done = this.async();


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/5065
I don't put `fix` or `close` as @gmarziou suggested another solution too

```
Welcome to the JHipster Generator v4.0.0
Documentation for creating an application: https://jhipster.github.io/creating-an-app/
Application files will be generated in folder: /home/pgrimaud/tmp/23-toto
WARNING! Your node version is too old (v4.5.0). You should use at least Node v6.9.0+
? (1/15) Which *type* of application would you like to create? (Use arrow keys)
❯ Monolithic application (recommended for simple projects) 
  Microservice application 
  Microservice gateway 
  [BETA] JHipster UAA server (for microservice OAuth2 authentication) 
```