### PR TITLE
fix autoincrement

### DIFF
--- a/generators/entity/templates/server/src/main/resources/config/liquibase/changelog/_added_entity.xml
+++ b/generators/entity/templates/server/src/main/resources/config/liquibase/changelog/_added_entity.xml
@@ -11,7 +11,7 @@
     <property name="now" value="sysdate" dbms="oracle"/>
     <property name="now" value="GETDATE()" dbms="mssql"/>
 
-    <property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle,mssql"/>
+    <property name="autoIncrement" value="true" dbms="mysql,mariadb"/>
 
     <property name="floatType" value="float4" dbms="postgresql, h2"/>
     <property name="floatType" value="float" dbms="mysql, oracle, mssql"/>


### PR DESCRIPTION
In `_Entity.java` and in `_User.java`,
When using a database other than `mysql` and `mariadb`: the `hibernate_sequence` is used according to the following code:
`<% if (databaseType == 'sql') { %>`
`@Id`
`<%_ if (prodDatabaseType == 'mysql' || prodDatabaseType == 'mariadb') { _%>`
`@GeneratedValue(strategy = GenerationType.IDENTITY)`
`<%_ }  else { _%>`
`@GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")`
`@SequenceGenerator(name = "sequenceGenerator")`
`<%_ } _%>`

In `_added_entity.xml`, the `autoIncrement` variable is set to `true` for `postgresql` (and h2,oracle,...),
which creates a sequence (with liquibase) for this entity **which is actually not used** because of the use of sequenceGenerator described above. (This is my case and I'm using postgresql 9.6):
`<property name="autoIncrement" value="true" dbms="mysql,h2,postgresql,oracle,mssql"/>`

In _initial_schema.xml, everything is fine for the User entity and `autoincrement` is set to `true` only for `mariadb` and `mysql`, which doesn't create a sequence in database.

So I would say that `autoIncrement` should be set to `true` only for `mysql` and `mariadb` ?