### PR TITLE
remove Reflect.ts warnings from console also in Windows

### DIFF
--- a/generators/client/templates/angular/webpack/_webpack.dev.js
+++ b/generators/client/templates/angular/webpack/_webpack.dev.js
@@ -49,7 +49,7 @@ module.exports = webpackMerge(commonConfig({env: ENV}), {
             loaders: [
                 'tslint-loader'
             ],
-            exclude: ['node_modules', /reflect-metadata\/Reflect\.ts/]
+            exclude: ['node_modules', new RegExp('reflect-metadata\\' + path.sep + 'Reflect\\.ts')]
         }]
     },
     plugins: [


### PR DESCRIPTION
Without this change 144 warnings from `Reflect.ts` are shown in Windows:
* in command line window on dev server start and on every HMR
* also in web browser console on load and on every HMR
