### PR TITLE
move popup router navigation to popup service

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-delete-dialog.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-delete-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { EventManager, JhiLanguageService } from 'ng-jhipster';
 
@@ -18,15 +18,13 @@ export class UserMgmtDeleteDialogComponent {
         private jhiLanguageService: JhiLanguageService,
         private userService: UserService,
         public activeModal: NgbActiveModal,
-        private eventManager: EventManager,
-        private router: Router
+        private eventManager: EventManager
     ) {
         this.jhiLanguageService.setLocations(['user-management']);
     }
 
     clear () {
         this.activeModal.dismiss('cancel');
-        this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
     }
 
     confirmDelete (login) {
@@ -34,7 +32,6 @@ export class UserMgmtDeleteDialogComponent {
             this.eventManager.broadcast({ name: 'userListModification',
                 content: 'Deleted a user'});
             this.activeModal.dismiss(true);
-            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
         });
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.ts
@@ -1,5 +1,5 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { EventManager, JhiLanguageService } from 'ng-jhipster';
@@ -25,8 +25,7 @@ export class UserMgmtDialogComponent implements OnInit {
         private jhiLanguageService: JhiLanguageService,
         <%_ } _%>
         private userService: UserService,
-        private eventManager: EventManager,
-        private router: Router
+        private eventManager: EventManager
     ) {}
 
     ngOnInit() {
@@ -42,7 +41,6 @@ export class UserMgmtDialogComponent implements OnInit {
 
     clear() {
         this.activeModal.dismiss('cancel');
-        this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
     }
 
     save() {
@@ -59,7 +57,6 @@ export class UserMgmtDialogComponent implements OnInit {
         this.eventManager.broadcast({ name: 'userListModification', content: 'OK' });
         this.isSaving = false;
         this.activeModal.dismiss(result);
-        this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
     }
 
     private onSaveError() {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-modal.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-modal.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
 import { UserMgmtDialogComponent } from './user-management-dialog.component';
@@ -9,6 +10,7 @@ export class UserModalService {
     private isOpen = false;
     constructor (
         private modalService: NgbModal,
+        private router: Router,
         private userService: UserService
     ) {}
 
@@ -30,9 +32,11 @@ export class UserModalService {
         modalRef.componentInstance.user = user;
         modalRef.result.then(result => {
             console.log(`Closed with: ${result}`);
+            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
             this.isOpen = false;
         }, (reason) => {
             console.log(`Dismissed ${reason}`);
+            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
             this.isOpen = false;
         });
         return modalRef;

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-delete-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-delete-dialog.component.ts
@@ -7,7 +7,7 @@ for (var idx in fields) {
 }
 _%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { EventManager<% if (enableTranslation) { %>, JhiLanguageService<% } %> } from 'ng-jhipster';
@@ -30,8 +30,7 @@ export class <%= entityAngularJSName %>DeleteDialogComponent {
         <%_ } _%>
         private <%= entityInstance %>Service: <%= entityClass %>Service,
         public activeModal: NgbActiveModal,
-        private eventManager: EventManager,
-        private router: Router
+        private eventManager: EventManager
     ) {
         <%_ if (enableTranslation) { _%>
         this.jhiLanguageService.setLocations(<%- toArrayString(i18nToLoad) %>);
@@ -40,7 +39,6 @@ export class <%= entityAngularJSName %>DeleteDialogComponent {
 
     clear () {
         this.activeModal.dismiss('cancel');
-        this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
     }
 
     confirmDelete (id: number) {
@@ -49,7 +47,6 @@ export class <%= entityAngularJSName %>DeleteDialogComponent {
                 name: '<%= entityInstance %>ListModification',
                 content: 'Deleted an <%= entityInstance %>'
             });
-            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
             this.activeModal.dismiss(true);
         });
     }

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -7,7 +7,7 @@ for (var idx in fields) {
 }
 _%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute } from '@angular/router';
 import { Response } from '@angular/http';
 
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
@@ -80,8 +80,7 @@ export class <%= entityAngularJSName %>DialogComponent implements OnInit {
         private alertService: AlertService,
         private <%= entityInstance %>Service: <%= entityClass %>Service,<% for (idx in differentRelationships) {%>
         private <%= differentRelationships[idx].otherEntityName %>Service: <%= differentRelationships[idx].otherEntityNameCapitalized %>Service,<% } %>
-        private eventManager: EventManager,
-        private router: Router
+        private eventManager: EventManager
     ) {
         <%_ if (enableTranslation) { _%>
         this.jhiLanguageService.setLocations(<%- toArrayString(i18nToLoad) %>);
@@ -119,7 +118,6 @@ export class <%= entityAngularJSName %>DialogComponent implements OnInit {
    <%_ } _%>
     clear () {
         this.activeModal.dismiss('cancel');
-        this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
     }
 
     save () {
@@ -137,7 +135,6 @@ export class <%= entityAngularJSName %>DialogComponent implements OnInit {
         this.eventManager.broadcast({ name: '<%= entityInstance %>ListModification', content: 'OK'});
         this.isSaving = false;
         this.activeModal.dismiss(result);
-        this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
     }
 
     private onSaveError (error) {

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-popup.service.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-popup.service.ts
@@ -1,4 +1,5 @@
 import { Injectable, Component } from '@angular/core';
+import { Router } from '@angular/router';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 <%_ if (fieldsContainZonedDateTime) { _%>
 import { DatePipe } from '@angular/common';
@@ -19,6 +20,7 @@ export class <%= entityClass %>PopupService {
         private datePipe: DatePipe,
         <%_ } _%>
         private modalService: NgbModal,
+        private router: Router,
         private <%= entityInstance %>Service: <%= entityClass %>Service
     ) {}
 
@@ -63,9 +65,11 @@ export class <%= entityClass %>PopupService {
         modalRef.componentInstance.<%= entityInstance %> = <%= entityInstance %>;
         modalRef.result.then(result => {
             console.log(`Closed with: ${result}`);
+            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
             this.isOpen = false;
         }, (reason) => {
             console.log(`Dismissed ${reason}`);
+            this.router.navigate([{ outlets: { popup: null }}], { replaceUrl: true });
             this.isOpen = false;
         });
         return modalRef;


### PR DESCRIPTION
The router should navigate away from the popup route on close, and the escape key didn't call clear or save (which handled the routing).  This is the same as how it handled it in NG1

Fix #5100