### PR TITLE
enable 'no database' option for uaa+gateway combination, polish prompts

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
@@ -42,10 +42,12 @@
                     <div *ngFor="let authority of user.authorities">
                         <span class="tag tag-info">{{ authority }}</span>
                     </div>
-                </td><% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+                </td>
+                <%_ if (databaseType !== 'cassandra') { _%>
                 <td>{{user.createdDate | date:'dd/MM/yy HH:mm'}}</td>
                 <td>{{user.lastModifiedBy}}</td>
-                <td>{{user.lastModifiedDate | date:'dd/MM/yy HH:mm'}}</td><% } %>
+                <td>{{user.lastModifiedDate | date:'dd/MM/yy HH:mm'}}</td>
+                <%_ } _%>
                 <td class="text-xs-right">
                     <div class="btn-group flex-btn-group-container">
                         <button type="submit"

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -145,7 +145,7 @@ module.exports = EntityGenerator.extend({
         },
 
         validateDbExistence: function () {
-            if(this.databaseType === 'no') {
+            if(this.databaseType === 'no' && !(this.authenticationType === 'uaa' && this.applicationType === 'gateway')) {
                 this.error(chalk.red('The entity cannot be generated as the application does not have a database configured!'));
             }
         },

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -25,9 +25,13 @@ function askForMicroserviceJson() {
     }
 
     var done = this.async();
+    var databaseType = this.databaseType;
 
     var prompts = [
         {
+            when: function () {
+                return databaseType !== 'no';
+            },
             type: 'confirm',
             name: 'useMicroserviceJson',
             message: 'Do you want to generate this entity from an existing microservice?',
@@ -35,7 +39,7 @@ function askForMicroserviceJson() {
         },
         {
             when: function(response) {
-                return response.useMicroserviceJson === true;
+                return response.useMicroserviceJson === true || databaseType === 'no';
             },
             type: 'input',
             name: 'microservicePath',
@@ -59,7 +63,7 @@ function askForMicroserviceJson() {
     ];
 
     this.prompt(prompts).then(function(props) {
-        if (props.useMicroserviceJson) {
+        if (props.microservicePath) {
             this.log(chalk.green('\nFound the ' + this.filename + ' configuration file, entity can be automatically generated!\n'));
             if(path.isAbsolute(props.microservicePath)) {
                 this.microservicePath = props.microservicePath;

--- a/generators/entity/templates/client/angular/src/test/javascript/spec/app/entities/_entity-management-detail.component.spec.ts
+++ b/generators/entity/templates/client/angular/src/test/javascript/spec/app/entities/_entity-management-detail.component.spec.ts
@@ -68,7 +68,7 @@ describe('Component Tests', () => {
             it('Should call load all on init', () => {
             // GIVEN
             spyOn(service, 'find').and.returnValue(Observable.of(new <%= entityClass %>(<%_
-            if (databaseType == 'sql') { %>10<% } else if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>'aaa'<% } %>)));
+            if (databaseType === 'sql' || databaseType === 'no') { %>10<% } else if (databaseType === 'mongodb' || databaseType === 'cassandra') { %>'aaa'<% } %>)));
 
             // WHEN
             comp.ngOnInit();
@@ -76,7 +76,7 @@ describe('Component Tests', () => {
             // THEN
             expect(service.find).toHaveBeenCalledWith(123);
             expect(comp.<%= entityInstance %>).toEqual(jasmine.objectContaining({id: <%_
-            if (databaseType == 'sql') { %>10<% } else if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>'aaa'<% } %>}));
+            if (databaseType === 'sql' || databaseType === 'no') { %>10<% } else if (databaseType === 'mongodb' || databaseType === 'cassandra') { %>'aaa'<% } %>}));
             });
         });
     });

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -146,12 +146,12 @@ function askForServerSideOpts() {
         },
         {
             when: function (response) {
-                return applicationType === 'microservice';
+                return applicationType === 'microservice' || (response.authenticationType === 'uaa' && applicationType === 'gateway');
             },
             type: 'list',
             name: 'databaseType',
             message: function (response) {
-                return getNumberedQuestion('Which *type* of database would you like to use?', applicationType === 'microservice');
+                return getNumberedQuestion('Which *type* of database would you like to use?', applicationType === 'microservice' || (response.authenticationType === 'uaa' && applicationType === 'gateway'));
             },
             choices: [
                 {
@@ -175,12 +175,12 @@ function askForServerSideOpts() {
         },
         {
             when: function (response) {
-                return response.enableSocialSignIn;
+                return response.authenticationType === 'oauth2' && !response.databaseType;
             },
             type: 'list',
             name: 'databaseType',
             message: function (response) {
-                return getNumberedQuestion('Which *type* of database would you like to use?', response.enableSocialSignIn);
+                return getNumberedQuestion('Which *type* of database would you like to use?', response.authenticationType === 'oauth2' && !response.databaseType);
             },
             choices: [
                 {
@@ -196,33 +196,12 @@ function askForServerSideOpts() {
         },
         {
             when: function (response) {
-                return response.authenticationType === 'oauth2' && !response.enableSocialSignIn && applicationType !== 'microservice';
+                return !response.databaseType;
             },
             type: 'list',
             name: 'databaseType',
             message: function (response) {
-                return getNumberedQuestion('Which *type* of database would you like to use?', response.authenticationType === 'oauth2' && !response.enableSocialSignIn && applicationType !== 'microservice');
-            },
-            choices: [
-                {
-                    value: 'sql',
-                    name: 'SQL (H2, MySQL, MariaDB, PostgreSQL, Oracle)'
-                },
-                {
-                    value: 'mongodb',
-                    name: 'MongoDB'
-                }
-            ],
-            default: 0
-        },
-        {
-            when: function (response) {
-                return response.authenticationType !== 'oauth2' && !response.enableSocialSignIn && applicationType !== 'microservice';
-            },
-            type: 'list',
-            name: 'databaseType',
-            message: function (response) {
-                return getNumberedQuestion('Which *type* of database would you like to use?', response.authenticationType !== 'oauth2' && !response.enableSocialSignIn && applicationType !== 'microservice');
+                return getNumberedQuestion('Which *type* of database would you like to use?', !response.databaseType);
             },
             choices: [
                 {


### PR DESCRIPTION
Gateways that use UAA don't require a database.

Also, I simplified some of the conditions for databaseType prompt:
 - Don't prompt if a databaseType is already selected
 - Removed database prompt that appear when social login is enabled because that can't be selected until afterwards.