### PR TITLE
Define a module for home

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -126,6 +126,7 @@ const files = {
                 'entities/_entity.module.ts',
                 // home module
                 'home/_index.ts',
+                { file: 'home/_home.module.ts', method: 'copyJs' },
                 { file: 'home/_home.route.ts', method: 'copyJs' },
                 { file: 'home/_home.component.ts', method: 'copyJs' },
                 { file: 'home/_home.component.html', method: 'copyHtml' },

--- a/generators/client/templates/angular/src/main/webapp/app/_app.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_app.module.ts
@@ -8,12 +8,12 @@ import { BrowserModule } from '@angular/platform-browser';
 import { Ng2Webstorage } from 'ng2-webstorage';
 
 import { <%=angular2AppName%>SharedModule, UserRouteAccessService } from './shared';
+import { <%=angular2AppName%>HomeModule } from './home/home.module';
 import { <%=angular2AppName%>AdminModule } from './admin/admin.module';
 import { <%=angular2AppName%>AccountModule } from './account/account.module';
 import { <%=angular2AppName%>EntityModule } from './entities/entity.module';
 
 import { LayoutRoutingModule } from './layouts';
-import { HomeComponent } from './home';
 import { customHttpProvider } from './blocks/interceptor/http.provider';
 import { PaginationConfig } from './blocks/config/uib-pagination.config';
 
@@ -36,13 +36,13 @@ import {
         LayoutRoutingModule,
         Ng2Webstorage.forRoot({ prefix: 'jhi', separator: '-'}),
         <%=angular2AppName%>SharedModule,
+        <%=angular2AppName%>HomeModule,
         <%=angular2AppName%>AdminModule,
         <%=angular2AppName%>AccountModule,
         <%=angular2AppName%>EntityModule
     ],
     declarations: [
         <%=jhiPrefixCapitalized%>MainComponent,
-        HomeComponent,
         NavbarComponent,
         ErrorComponent,
         PageRibbonComponent,

--- a/generators/client/templates/angular/src/main/webapp/app/home/_home.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_home.module.ts
@@ -1,0 +1,24 @@
+import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { ParseLinks } from 'ng-jhipster';
+
+import { ParattSharedModule } from '../shared';
+
+import { HOME_ROUTES, HomeComponent } from './';
+
+
+@NgModule({
+    imports: [
+        ParattSharedModule,
+        RouterModule.forRoot(HOME_ROUTES, { useHash: true })
+    ],
+    declarations: [
+        HomeComponent,
+    ],
+    entryComponents: [
+    ],
+    providers: [
+    ],
+    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+})
+export class <%=angular2AppName%>HomeModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/home/_home.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_home.module.ts
@@ -2,14 +2,14 @@ import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { ParseLinks } from 'ng-jhipster';
 
-import { ParattSharedModule } from '../shared';
+import { <%=angular2AppName%>SharedModule } from '../shared';
 
 import { HOME_ROUTES, HomeComponent } from './';
 
 
 @NgModule({
     imports: [
-        ParattSharedModule,
+        <%=angular2AppName%>SharedModule,
         RouterModule.forRoot(HOME_ROUTES, { useHash: true })
     ],
     declarations: [

--- a/generators/client/templates/angular/src/main/webapp/app/home/_home.route.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_home.route.ts
@@ -1,14 +1,16 @@
-import { Route } from '@angular/router';
+import { Routes } from '@angular/router';
 
 import { UserRouteAccessService } from '../shared';
 import { HomeComponent } from './';
 
-export const homeRoute: Route = {
-  path: '',
-  component: HomeComponent,
-  data: {
-    authorities: [],
-    pageTitle: 'home.title'
-  },
-  canActivate: [UserRouteAccessService]
-};
+export const HOME_ROUTES: Routes = [
+  {
+    path: '',
+    component: HomeComponent,
+    data: {
+      authorities: [],
+      pageTitle: 'home.title'
+    },
+    canActivate: [UserRouteAccessService]
+  }
+];

--- a/generators/client/templates/angular/src/main/webapp/app/home/_index.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/home/_index.ts
@@ -1,2 +1,3 @@
 export * from './home.component';
 export * from './home.route';
+export * from './home.module';

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/_layout-routing.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/_layout-routing.module.ts
@@ -1,12 +1,10 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes, Resolve } from '@angular/router';
 
-import { homeRoute } from '../home';
 import { navbarRoute } from '../app.route';
 import { errorRoute } from './';
 
 let LAYOUT_ROUTES = [
-    homeRoute,
     navbarRoute,
     ...errorRoute
 ];


### PR DESCRIPTION
Home page should have its own module to keep app.module simple and high level and because it gives some structure to users for modifying it.

Remove layout block dependency on home route as it deals only with layout not content.