### PR TITLE
sync gradle dev profile with maven dev profile in Angular 2

### DIFF
--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -31,7 +31,7 @@ task gulpConstantDev(type: GulpTask) {
     args = ["ngconstant:dev", "--no-notification"]
 }
     <%_ } else { _%>
-task webpack(type: <%= clientPackageManager.charAt(0).toUpperCase() + clientPackageManager.slice(1) %>Task, dependsOn: '<%= clientPackageManager %>_install') {
+task webpackBuildDev(type: <%= clientPackageManager.charAt(0).toUpperCase() + clientPackageManager.slice(1) %>Task) {
     args = ["run", "webpack:build:dev"]
 }
     <%_ } _%>
@@ -63,7 +63,7 @@ processResources {
     <%_ if (clientFramework === 'angular1') { _%>
 processResources.dependsOn gulpConstantDev
     <%_ } else { _%>
-processResources.dependsOn webpack
-webpack.onlyIf { project.hasProperty('webpack') }
+processResources.dependsOn webpackBuildDev
+webpackBuildDev.onlyIf { project.hasProperty('webpack') }
     <%_ } _%>
 <%_ } _%>


### PR DESCRIPTION
Currently in gradle there are 2 quite inconvenient differences from maven:
1. In `dev` profile maven doesn't execute any frontend tasks but gradle executes `yarn/npm install` (it also triggers `webpack` from `postInstall` in `package.json`) and `webpack` second time. It makes every app startup with gradle very slow.
As a side note: in code https://github.com/jhipster/generator-jhipster/blob/master/generators/server/templates/gradle/_profile_dev.gradle#L67 I can see that there is tried to achieve the same behaviour as with maven but in gradle all tasks are also project properties, so `webpack.onlyIf { project.hasProperty('webpack') }` always returns true.
2. In `webpack` profile maven doesn't execute `npm/yarn install` but gradle executes. Beside install steps it causes double `webpack` compilation when using gradle (`postInstall` command from `package.json` runs also `webpack`).

This PR removes these differences, makes gradle behave similarily with maven.

After this change:  
`gradlew` is starting app with dev profile without any frontend task  
`gradlew -Pwebpack` runs webpack and after that starts app (no need to specify `-Pdev -Pwebpack` profiles like is needed with maven: `-Pdev,webpack`)
