### PR TITLE
only ignore gradle's 'build' folder

### DIFF
--- a/generators/server/templates/gitignore
+++ b/generators/server/templates/gitignore
@@ -75,7 +75,7 @@ target/
 # Gradle
 ######################
 .gradle/
-build/
+/build/
 
 ######################
 # Package Files
@@ -110,7 +110,6 @@ Desktop.ini
 ######################
 # Directories
 ######################
-/build/
 /bin/
 /deploy/
 


### PR DESCRIPTION
Thanks @jeffrey-anderson for narrowing down that issue to git.   This issue only affects NG1 apps after v4

`build/` ignored all directories named `build`, including those in bower_components (ngInfiniteScroll and angular-loading-bar have them).  We already ignore `/build/` so this recent addition should be removed.  Here's an [example commit](https://github.com/ruddell/git-bower-jhipster-issue/commit/4d3fcb0ca1417729c03509d46ec76ba92bb3ff8f) of what changes

Fixes #5142, #5113 and #5119