### PR TITLE
[WIP] Spring Boot 1.5.1

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -44,9 +44,7 @@ dependencyManagement {
     mavenBom 'org.springframework.cloud:spring-cloud-stream-dependencies:' + spring_cloud_stream_version
     <%_ } _%>
     <%_ if (serviceDiscoveryType) { _%>
-    mavenBom 'org.springframework.cloud:spring-cloud-dependencies:' + spring_cloud_version {
-        bomProperty 'spring-cloud-netflix-core.version' '1.2.5.RELEASE'
-    }
+    mavenBom 'org.springframework.cloud:spring-cloud-dependencies:' + spring_cloud_version
     <%_ } _%>
   }
 }

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -246,7 +246,7 @@ dependencies {
     <%_ } _%>
     <%_ if (databaseType === 'sql') { _%>
     compile "org.hibernate:hibernate-envers"
-    compile "org.hibernate:hibernate-validator:${hibernate_validator_version}"
+    compile "org.hibernate:hibernate-validator"
     compile ("org.liquibase:liquibase-core") {
         exclude(module: 'jetty-servlet')
     }

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -392,9 +392,6 @@ dependencies {
     testCompile "org.hamcrest:hamcrest-library"
     <%_ if (gatlingTests) { _%>
     testCompile "io.gatling.highcharts:gatling-charts-highcharts:${gatling_version}"
-    <%_ if (databaseType === 'cassandra') { _%>
-    compile "io.netty:netty-handler:${netty_handler_version}"
-    <%_ } _%>
     <%_ } _%>
     <%_ if (devDatabaseType != 'h2Disk' && devDatabaseType != 'h2Memory') { _%>
     testCompile "com.h2database:h2"

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -44,7 +44,9 @@ dependencyManagement {
     mavenBom 'org.springframework.cloud:spring-cloud-stream-dependencies:' + spring_cloud_stream_version
     <%_ } _%>
     <%_ if (serviceDiscoveryType) { _%>
-    mavenBom 'org.springframework.cloud:spring-cloud-dependencies:' + spring_cloud_version
+    mavenBom 'org.springframework.cloud:spring-cloud-dependencies:' + spring_cloud_version {
+        bomProperty 'spring-cloud-netflix-core.version' '1.2.5.RELEASE'
+    }
     <%_ } _%>
   }
 }
@@ -190,42 +192,39 @@ repositories {
 dependencies {
     compile "io.github.jhipster:jhipster:${jhipster_server_version}"
     compile "io.dropwizard.metrics:metrics-core"
-    compile "io.dropwizard.metrics:metrics-healthchecks:${dropwizard_metrics_version}"
-    compile "io.dropwizard.metrics:metrics-jvm:${dropwizard_metrics_version}"
-    compile "io.dropwizard.metrics:metrics-servlet:${dropwizard_metrics_version}"
-    compile "io.dropwizard.metrics:metrics-json:${dropwizard_metrics_version}"
-    compile ("io.dropwizard.metrics:metrics-servlets:${dropwizard_metrics_version}") {
-        exclude(module: 'metrics-healthchecks')
-    }
+    compile "io.dropwizard.metrics:metrics-jvm:" + dependencyManagement.managedVersions["io.dropwizard.metrics:metrics-core"]
+    compile "io.dropwizard.metrics:metrics-servlet:" + dependencyManagement.managedVersions["io.dropwizard.metrics:metrics-core"]
+    compile "io.dropwizard.metrics:metrics-json:" + dependencyManagement.managedVersions["io.dropwizard.metrics:metrics-core"]
+    compile ("io.dropwizard.metrics:metrics-servlets")
     compile ("net.logstash.logback:logstash-logback-encoder:${logstash_logback_encoder_version}") {
         exclude(module: 'ch.qos.logback')
     }
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-json-org:${jackson_version}"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-hppc:${jackson_version}"
-    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310:${jackson_version}"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-json-org"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-hppc"
+    compile "com.fasterxml.jackson.datatype:jackson-datatype-jsr310"
     <%_ if (databaseType === 'sql') { _%>
     compile "com.fasterxml.jackson.datatype:jackson-datatype-hibernate5"
     <%_ } _%>
-    compile "com.fasterxml.jackson.core:jackson-annotations:${jackson_version}"
-    compile "com.fasterxml.jackson.core:jackson-databind:${jackson_version}"
+    compile "com.fasterxml.jackson.core:jackson-annotations"
+    compile "com.fasterxml.jackson.core:jackson-databind"
     compile ("com.ryantenney.metrics:metrics-spring:${metrics_spring_version}") {
         exclude(module: 'metrics-core')
         exclude(module: 'metrics-healthchecks')
     }
     <%_ if (hibernateCache === 'hazelcast') { _%>
-    compile "com.hazelcast:hazelcast:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast"
     compile "com.hazelcast:hazelcast-hibernate52:${hazelcast_hibernate_version}"
-    compile "com.hazelcast:hazelcast-spring:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast-spring"
     <%_ } _%>
     <%_ if (clusteredHttpSession === 'hazelcast' && hibernateCache != 'hazelcast') { _%>
-    compile "com.hazelcast:hazelcast:${hazelcast_version}"
-    compile "com.hazelcast:hazelcast-spring:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast"
+    compile "com.hazelcast:hazelcast-spring"
     <%_ } _%>
     <%_ if (clusteredHttpSession === 'hazelcast') { _%>
-    compile "com.hazelcast:hazelcast-wm:${hazelcast_version}"
+    compile "com.hazelcast:hazelcast-wm:${hazelcast_wm_version}"
     <%_ } _%>
     <%_ if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { _%>
-    compile "javax.cache:cache-api:${jcache_version}"
+    compile "javax.cache:cache-api"
     <%_ } _%>
     <%_ if (databaseType === 'sql') { _%>
     compile "org.hibernate:hibernate-core:${hibernate_version}"
@@ -250,7 +249,7 @@ dependencies {
     <%_ if (databaseType === 'sql') { _%>
     compile "org.hibernate:hibernate-envers"
     compile "org.hibernate:hibernate-validator:${hibernate_validator_version}"
-    compile ("org.liquibase:liquibase-core:${liquibase_core_version}") {
+    compile ("org.liquibase:liquibase-core") {
         exclude(module: 'jetty-servlet')
     }
     compile "com.mattbertolini:liquibase-slf4j:${liquibase_slf4j_version}"
@@ -286,11 +285,11 @@ dependencies {
     <%_ } _%>
     compile "org.springframework.boot:spring-boot-starter-thymeleaf"
     <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
-    compile ("com.datastax.cassandra:cassandra-driver-core:${datastax_driver_version}") {
+    compile ("com.datastax.cassandra:cassandra-driver-core") {
         exclude module: 'com.codahale.metrics'
     }
-    compile "com.datastax.cassandra:cassandra-driver-extras:${datastax_driver_version}"
-    compile "com.datastax.cassandra:cassandra-driver-mapping:${datastax_driver_version}"
+    compile "com.datastax.cassandra:cassandra-driver-extras:" + dependencyManagement.managedVersions["com.datastax.cassandra:cassandra-driver-core"]
+    compile "com.datastax.cassandra:cassandra-driver-mapping"
     <%_ } _%>
     <%_ if (applicationType === 'gateway') { _%>
     compile "org.springframework.cloud:spring-cloud-starter-zuul"
@@ -350,13 +349,13 @@ dependencies {
     compile "org.postgresql:postgresql"
     <%_ } _%>
     <%_ if (devDatabaseType === 'mariadb' || prodDatabaseType === 'mariadb') { _%>
-    compile "org.mariadb.jdbc:mariadb-java-client:${mariadb_java_client_version}"
+    compile "org.mariadb.jdbc:mariadb-java-client"
     <%_ } _%>
     <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
     compile "com.h2database:h2"
     <%_ } _%>
     <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
-    compile "com.microsoft.sqlserver:mssql-jdbc:${mssql_jdbc_driver_version}"
+    compile "com.microsoft.sqlserver:mssql-jdbc:${mssql_jdbc_version}"
     compile "com.github.sabomichal:liquibase-mssql:${liquibase_mssql_version}"
     <%_ } _%>
     compile "org.mapstruct:mapstruct-jdk8:${mapstruct_version}"
@@ -367,7 +366,7 @@ dependencies {
     compile "org.springframework.social:spring-social-facebook"
     compile "org.springframework.social:spring-social-twitter"
     <%_ } _%>
-    testCompile "com.jayway.awaitility:awaitility:${awaility_version}"
+    testCompile "org.awaitility:awaitility:${awaitility_version}"
     testCompile "com.jayway.jsonpath:json-path"
     <%_ if (databaseType === 'cassandra') { _%>
     testCompile ("org.cassandraunit:cassandra-unit-spring:${cassandra_unit_spring_version}") {
@@ -381,7 +380,7 @@ dependencies {
     testCompile "org.springframework.boot:spring-boot-starter-test"
     testCompile "org.springframework.security:spring-security-test"
     testCompile "org.springframework.boot:spring-boot-test"
-    testCompile "org.assertj:assertj-core:${assertj_core_version}"
+    testCompile "org.assertj:assertj-core:${assertj_version}"
     testCompile "junit:junit"
     testCompile "org.mockito:mockito-core"
     <%_ if (databaseType === 'sql') { _%>
@@ -393,16 +392,16 @@ dependencies {
     testCompile "org.hamcrest:hamcrest-library"
     <%_ if (gatlingTests) { _%>
     testCompile "io.gatling.highcharts:gatling-charts-highcharts:${gatling_version}"
-        <%_ if (databaseType === 'cassandra') { _%>
-    compile "io.netty:netty-handler:4.0.36.Final"
-        <%_ } _%>
+    <%_ if (databaseType === 'cassandra') { _%>
+    compile "io.netty:netty-handler:${netty_handler_version}"
+    <%_ } _%>
     <%_ } _%>
     <%_ if (devDatabaseType != 'h2Disk' && devDatabaseType != 'h2Memory') { _%>
     testCompile "com.h2database:h2"
     <%_ } _%>
     <%_ if (devDatabaseType === 'oracle' || prodDatabaseType === 'oracle') { _%>
     // more information at https://blogs.oracle.com/dev2dev/entry/how_to_get_oracle_jdbc
-    compile "com.oracle.jdbc:ojdbc7:${oracle_driver_java_version}"
+    compile "com.oracle.jdbc:ojdbc7:${oracle_version}"
     <%_ } _%>
     <%_ if (messageBroker === 'kafka') { _%>
     testCompile "org.springframework.cloud:spring-cloud-stream-test-support"
@@ -429,8 +428,8 @@ task stage(dependsOn: 'bootRepackage') {
 
 if (project.hasProperty('nodeInstall')) {
     node {
-        version = '6.9.5'
-        npmVersion = '4.1.2'
+        version = '${node_version}'
+        npmVersion = '${npm_version}'
         download = true
     }
 

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -44,9 +44,6 @@ hibernate_validator_version=5.3.4.Final
 lz4_version=1.3.0
 <%_ } _%>
 metrics_spring_version=3.1.3
-<%_ if (databaseType === 'cassandra') { _%>
-netty_handler_version=4.0.44.Final
-<%_ } _%>
 node_version=6.9.5
 npm_version=4.1.2
 prometheus_simpleclient_version=0.0.20

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -37,9 +37,6 @@ liquibase_hibernate5_version=3.6
 <%_ if (databaseType === 'mongodb') { _%>
 mongobee_version=0.10
 <%_ } _%>
-<%_ if (databaseType === 'sql') { _%>
-hibernate_validator_version=5.3.4.Final
-<%_ } _%>
 <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
 lz4_version=1.3.0
 <%_ } _%>

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -1,60 +1,55 @@
 rootProject.name=<%= dasherizedBaseName %>
 profile=dev
-assertj_core_version=3.5.2
-awaility_version=1.7.0
+assertj_version=3.6.2
+awaitility_version=2.0.0
 <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
 commons_codec_version=1.10
 <%_ } _%>
-commons_lang_version=3.4
+commons_lang_version=3.5
 commons_io_version=2.5
 <%_ if (databaseType === 'cassandra') { _%>
-cassandra_unit_spring_version=3.0.0.1
+cassandra_unit_spring_version=3.1.1.0
 <%_ } _%>
 <%_ if (cucumberTests) { _%>
-cucumber_version=1.2.4
+cucumber_version=1.2.5
 <%_ } _%>
-dropwizard_metrics_version=3.1.2
-logstash_logback_encoder_version=4.7
-<%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
-datastax_driver_version=3.0.1
-<%_ } _%>
-javax_transaction_version=1.2
-json_path_version=0.9.1
-jackson_version=2.7.3
+logstash_logback_encoder_version=4.8
 jhipster_server_version=1.0.1
 <%_ if (authenticationType === 'jwt') { _%>
 jjwt_version=0.7.0
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
-jna_version=4.2.2
+jna_version=4.3.0
 <%_ } _%>
 geronimo_javamail_1_4_mail_version=1.8.4
 <%_ if (clusteredHttpSession === 'hazelcast' || hibernateCache === 'hazelcast') { _%>
-hazelcast_version=3.7
+hazelcast_version=3.7.5
+hazelcast_wm_version=3.8
 <%_ } _%>
 <%_ if (hibernateCache === 'hazelcast') { _%>
-hazelcast_hibernate_version=1.1.1
+hazelcast_hibernate_version=1.2
 <%_ } _%>
-<%_ if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { _%>
-jcache_version=1.0.0
-<%_ } _%>
-hibernate_version=5.2.4.Final
+hibernate_version=5.2.7.Final
 <%_ if (databaseType === 'sql') { _%>
 liquibase_slf4j_version=2.0.0
-liquibase_core_version=3.5.3
 liquibase_hibernate5_version=3.6
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
 mongobee_version=0.10
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>
-hibernate_validator_version=5.3.3.Final
+hibernate_validator_version=5.3.4.Final
 <%_ } _%>
 <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
 lz4_version=1.3.0
 <%_ } _%>
-metrics_spring_version=3.1.2
-prometheus_simpleclient_version=0.0.18
+metrics_spring_version=3.1.3
+<%_ if (databaseType === 'cassandra') { _%>
+netty_handler_version=4.0.44.Final
+<%_ } _%>
+node_version=6.9.5
+npm_version=4.1.2
+prometheus_simpleclient_version=0.0.20
 <%_ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
 postgresql_version=9.4.1212
 <%_ } _%>
@@ -62,29 +57,22 @@ postgresql_version=9.4.1212
 spring_security_oauth2_version=2.0.12.RELEASE
 <%_ } _%>
 springfox_version=2.6.1
-spring_boot_version=1.4.4.RELEASE
+spring_boot_version=1.5.1.RELEASE
 <%_ if (serviceDiscoveryType) { _%>
-spring_cloud_version=Brixton.SR7
+spring_cloud_version=Camden.SR4
 <%_ } _%>
 <%_ if (messageBroker === 'kafka') { _%>
-spring_cloud_stream_version=Brooklyn.RELEASE
-<%_ } _%>
-<%_ if (devDatabaseType === 'mysql' || prodDatabaseType === 'mysql') { _%>
-mysql_connector_java_version=5.1.36
-<%_ } _%>
-<%_ if (devDatabaseType === 'mariadb' || prodDatabaseType === 'mariadb') { _%>
-mariadb_java_client_version=1.4.4
+spring_cloud_stream_version=Brooklyn.SR2
 <%_ } _%>
 <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
-mssql_jdbc_driver_version=6.1.0.jre8
+mssql_jdbc_version=6.1.0.jre8
 liquibase_mssql_version=1.5
 <%_ } _%>
 <%_ if (devDatabaseType === 'oracle' || prodDatabaseType === 'oracle') { _%>
-oracle_driver_java_version=12.1.0.2
+oracle_version=12.1.0.2.0
 <%_ } _%>
-h2_version=1.4.188
 <%_ if (gatlingTests) { _%>
-gatling_version=2.2.0
+gatling_version=2.2.3
 <%_ } _%>
 mapstruct_version=1.1.0.Final
 <%_ if (enableSocialSignIn) { _%>

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -56,7 +56,7 @@ spring_security_oauth2_version=2.0.12.RELEASE
 springfox_version=2.6.1
 spring_boot_version=1.5.1.RELEASE
 <%_ if (serviceDiscoveryType) { _%>
-spring_cloud_version=Camden.SR4
+spring_cloud_version=Camden.SR5
 <%_ } _%>
 <%_ if (messageBroker === 'kafka') { _%>
 spring_cloud_stream_version=Brooklyn.SR2

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -171,8 +171,7 @@
         <spring-cloud-stream.version>Brooklyn.SR2</spring-cloud-stream.version>
         <%_ } _%>
         <%_ if (serviceDiscoveryType) { _%>
-        <spring-cloud.version>Camden.SR4</spring-cloud.version>
-        <spring-cloud-netflix.version>1.2.5.RELEASE</spring-cloud-netflix.version>
+        <spring-cloud.version>Camden.SR5</spring-cloud.version>
         <%_ } _%>
         <%_ if (authenticationType === 'oauth2' || authenticationType === 'uaa') { _%>
         <spring-security-oauth.version>2.0.12.RELEASE</spring-security-oauth.version>
@@ -203,11 +202,6 @@
             </dependency>
             <%_ } _%>
             <%_ if (serviceDiscoveryType) { _%>
-            <dependency>
-                <groupId>org.springframework.cloud</groupId>
-                <artifactId>spring-cloud-netflix-core</artifactId>
-                <version>${spring-cloud-netflix.version}</version>
-            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>spring-boot-starter-parent</artifactId>
         <groupId>org.springframework.boot</groupId>
-        <version>1.4.4.RELEASE</version>
+        <version>1.5.1.RELEASE</version>
         <relativePath />
     </parent>
 
@@ -32,79 +32,99 @@
     <%_ } _%>
 
     <prerequisites>
-        <maven>3.0.0</maven>
+        <maven>${maven.version}</maven>
     </prerequisites>
 
     <properties>
         <argLine>-Djava.security.egd=file:/dev/./urandom -Xmx256m</argLine>
-        <assertj-core.version>3.5.2</assertj-core.version>
-        <awaitility.version>1.7.0</awaitility.version>
+        <assertj.version>3.6.2</assertj.version>
+        <awaitility.version>2.0.0</awaitility.version>
+        <%_ if (databaseType === 'cassandra') { _%>
+        <cassandra-unit-spring.version>3.1.1.0</cassandra-unit-spring.version>
+        <%_ } _%>
+        <%_ if (databaseType === 'sql') { _%>
+        <cdi-api.version>1.2</cdi-api.version>
+        <%_ } _%>
         <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
         <commons-codec.version>1.10</commons-codec.version>
         <%_ } _%>
         <commons-io.version>2.5</commons-io.version>
-        <commons-lang.version>3.4</commons-lang.version>
+        <commons-lang.version>3.5</commons-lang.version>
         <%_ if (cucumberTests) { _%>
-        <cucumber.version>1.2.4</cucumber.version>
+        <cucumber.version>1.2.5</cucumber.version>
         <%_ } _%>
-        <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
-        <datastax-driver.version>3.0.1</datastax-driver.version>
-        <%_ } _%>
+        <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>
         <%_ if (!skipClient) { _%>
         <frontend-maven-plugin.version>1.3</frontend-maven-plugin.version>
         <%_ } _%>
         <%_ if (gatlingTests) { _%>
-        <gatling-maven-plugin.version>2.2.0</gatling-maven-plugin.version>
-        <gatling.version>2.2.0</gatling.version>
+        <gatling.version>2.2.3</gatling.version>
+        <gatling-maven-plugin.version>2.2.1</gatling-maven-plugin.version>
         <%_ } _%>
         <%_ if (clusteredHttpSession === 'hazelcast' || hibernateCache === 'hazelcast') { _%>
-        <hazelcast.version>3.7</hazelcast.version>
-        <hazelcast-hibernate.version>1.1.1</hazelcast-hibernate.version>
+        <hazelcast-hibernate52.version>1.2</hazelcast-hibernate52.version>
+        <hazelcast-wm.version>3.8</hazelcast-wm.version>
         <%_ } _%>
         <%_ if (databaseType === 'sql') { _%>
-        <hibernate-validator.version>5.3.3.Final</hibernate-validator.version>
-        <hibernate.version>5.2.4.Final</hibernate.version>
-        <hikaricp.version>2.4.6</hikaricp.version>
+        <hibernate.version>5.2.7.Final</hibernate.version>
+        <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
+        <hikaricp.version>2.6.0</hikaricp.version>
         <%_ } _%>
         <%_ if (enableSocialSignIn) { _%>
         <!-- Spring social -->
-        <httpclient.version>4.5.1</httpclient.version>
+        <httpclient.version>4.5.3</httpclient.version>
         <%_ } _%>
         <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <java.version>1.<%= javaVersion %></java.version>
-        <%_ if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { _%>
-        <jcache.version>1.0.0</jcache.version>
+        <%_ if (databaseType === 'sql') { _%>
+        <javassist.version>3.21.0-GA</javassist.version>
+        <%_ } _%>
+        <%_ if (gatlingTests) { _%>
+        <jzlib.version>1.1.3</jzlib.version>
         <%_ } _%>
         <jhipster.server.version>1.0.1</jhipster.server.version>
         <%_ if (authenticationType === 'jwt') { _%>
         <jjwt.version>0.7.0</jjwt.version>
         <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
-        <jna.version>4.2.2</jna.version>
+        <jna.version>4.3.0</jna.version>
         <%_ } _%>
         <%_ if (databaseType === 'sql') { _%>
         <liquibase-hibernate5.version>3.6</liquibase-hibernate5.version>
-        <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
-        <liquibase.version>3.5.3</liquibase.version>
+        <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
+        <liquibase-mssql.version>1.5</liquibase-mssql.version>
         <%_ } _%>
-        <logstash-logback-encoder.version>4.7</logstash-logback-encoder.version>
+        <liquibase-slf4j.version>2.0.0</liquibase-slf4j.version>
+        <%_ } _%>
+        <logstash-logback-encoder.version>4.8</logstash-logback-encoder.version>
         <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
         <lz4.version>1.3.0</lz4.version>
         <%_ } _%>
-        <%_ if (devDatabaseType === 'mariadb' || prodDatabaseType === 'mariadb') { _%>
-        <mariadb.version>1.4.4</mariadb.version>
-        <%_ } _%>
         <m2e.apt.activation>jdt_apt</m2e.apt.activation>
         <mapstruct.version>1.1.0.Final</mapstruct.version>
+        <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
         <maven-enforcer-plugin.version>1.4.1</maven-enforcer-plugin.version>
         <maven-resources-plugin.version>3.0.1</maven-resources-plugin.version>
         <maven.build.timestamp.format>yyyyMMddHHmmss</maven.build.timestamp.format>
         <maven.compiler.source>${java.version}</maven.compiler.source>
         <maven.compiler.target>${java.version}</maven.compiler.target>
+        <maven.version>3.0.0</maven.version>
         <metrics-spring.version>3.1.3</metrics-spring.version>
+        <%_ if (databaseType === 'mongodb') { _%>
+        <mongobee.version>0.10</mongobee.version>
+        <%_ } _%>
+        <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
+        <mssql-jdbc.version>6.1.0.jre8</mssql-jdbc.version>
+        <%_ } _%>
+        <%_ if (databaseType === 'cassandra') { _%>
+        <netty-handler.version>4.0.44.Final</netty-handler.version>
+        <%_ } _%>
         <node.version>v6.9.5</node.version>
         <%_ if (clientPackageManager === 'npm') { _%>
         <npm.version>4.1.2</npm.version>
+        <%_ } _%>
+        <%_ if (devDatabaseType === 'oracle' || prodDatabaseType === 'oracle') { _%>
+        <oracle.version>12.1.0.2.0</oracle.version>
         <%_ } _%>
         <%_ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
         <postgresql.version>9.4.1212</postgresql.version>
@@ -112,9 +132,12 @@
         <!-- These remain empty unless the corresponding profile is active -->
         <profile.no-liquibase />
         <profile.swagger />
+        <prometheus-simpleclient.version>0.0.20</prometheus-simpleclient.version>
         <!-- Sonar properties -->
         <project.testresult.directory>${project.build.directory}/test-results</project.testresult.directory>
         <run.addResources>false</run.addResources>
+        <scala-maven-plugin.version>3.2.2</scala-maven-plugin.version>
+        <scala.version>2.12.1</scala.version>
         <sonar-maven-plugin.version>3.2</sonar-maven-plugin.version>
 
         <sonar.exclusions><%= CLIENT_MAIN_SRC_DIR %>content/**/*.*, <%= CLIENT_MAIN_SRC_DIR %>bower_components/**/*.*, <%= CLIENT_MAIN_SRC_DIR %>i18n/*.js, <%= CLIENT_DIST_DIR %>**/*.*</sonar.exclusions>
@@ -148,22 +171,23 @@
         <sortpom-maven-plugin.version>2.5.0</sortpom-maven-plugin.version>
         <!-- Spring properties -->
         <%_ if (messageBroker === 'kafka') { _%>
-        <spring-cloud-stream.version>Brooklyn.RELEASE</spring-cloud-stream.version>
+        <spring-cloud-stream.version>Brooklyn.SR2</spring-cloud-stream.version>
         <%_ } _%>
         <%_ if (serviceDiscoveryType) { _%>
-        <spring-cloud.version>Brixton.SR7</spring-cloud.version>
+        <spring-cloud.version>Camden.SR4</spring-cloud.version>
+        <spring-cloud-netflix.version>1.2.5.RELEASE</spring-cloud-netflix.version>
         <%_ } _%>
         <%_ if (authenticationType === 'oauth2' || authenticationType === 'uaa') { _%>
-        <spring-security-oauth2.version>2.0.12.RELEASE</spring-security-oauth2.version>
+        <spring-security-oauth.version>2.0.12.RELEASE</spring-security-oauth.version>
         <%_ } _%>
         <%_ if (enableSocialSignIn) { _%>
         <!-- Spring social -->
-        <spring-social-facebook.version>2.0.3.RELEASE</spring-social-facebook.version>
         <spring-social-google.version>1.0.0.RELEASE</spring-social-google.version>
-        <spring-social-security.version>1.1.2.RELEASE</spring-social-security.version>
-        <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>
         <%_ } _%>
         <springfox.version>2.6.1</springfox.version>
+        <%_ if (databaseType === 'sql') { _%>
+        <validation-api.version>1.1.0.Final</validation-api.version>
+        <%_ } _%>
         <%_ if (clientPackageManager === 'yarn') { _%>
         <yarn.version>v0.19.1</yarn.version>
         <%_ } _%>
@@ -182,6 +206,11 @@
             </dependency>
             <%_ } _%>
             <%_ if (serviceDiscoveryType) { _%>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-netflix-core</artifactId>
+                <version>${spring-cloud-netflix.version}</version>
+            </dependency>
             <dependency>
                 <groupId>org.springframework.cloud</groupId>
                 <artifactId>spring-cloud-dependencies</artifactId>
@@ -211,11 +240,6 @@
         </dependency>
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
-            <artifactId>metrics-healthchecks</artifactId>
-            <version>${dropwizard-metrics.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-json</artifactId>
             <version>${dropwizard-metrics.version}</version>
         </dependency>
@@ -232,12 +256,6 @@
         <dependency>
             <groupId>io.dropwizard.metrics</groupId>
             <artifactId>metrics-servlets</artifactId>
-            <exclusions>
-                <exclusion>
-                    <artifactId>metrics-healthchecks</artifactId>
-                    <groupId>io.dropwizard.metrics</groupId>
-                </exclusion>
-            </exclusions>
         </dependency>
         <%_ if (databaseType === 'sql') { _%>
         <dependency>
@@ -248,7 +266,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hppc</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -257,7 +274,6 @@
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-json-org</artifactId>
-            <version>${jackson.version}</version>
         </dependency>
         <dependency>
             <groupId>com.h2database</groupId>
@@ -270,32 +286,30 @@
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast</artifactId>
-            <version>${hazelcast.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (hibernateCache === 'hazelcast') { _%>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-hibernate52</artifactId>
-            <version>${hazelcast-hibernate.version}</version>
+            <version>${hazelcast-hibernate52.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (hibernateCache === 'hazelcast' || clusteredHttpSession === 'hazelcast') { _%>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-spring</artifactId>
-            <version>${hazelcast.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (clusteredHttpSession === 'hazelcast') { _%>
         <dependency>
             <groupId>com.hazelcast</groupId>
             <artifactId>hazelcast-wm</artifactId>
-            <version>${hazelcast.version}</version>
+            <version>${hazelcast-wm.version}</version>
         </dependency>
         <%_ } _%>
         <dependency>
-            <groupId>com.jayway.awaitility</groupId>
+            <groupId>org.awaitility</groupId>
             <artifactId>awaitility</artifactId>
             <version>${awaitility.version}</version>
             <scope>test</scope>
@@ -394,14 +408,14 @@
         <dependency>
             <groupId>com.jcraft</groupId>
             <artifactId>jzlib</artifactId>
-            <version>1.1.2</version>
+            <version>${jzlib.version}</version>
         </dependency>
         <%_ if (databaseType === 'cassandra') { _%>
         <!-- include netty handler explicitly to overcome dependency mismatch when using Cassandra -->
         <dependency>
             <groupId>io.netty</groupId>
             <artifactId>netty-handler</artifactId>
-            <version>4.0.36.Final</version>
+            <version>${netty-handler.version}</version>
         </dependency>
         <%_ } _%>
         <%_ } _%>
@@ -409,7 +423,13 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-            <version>${jcache.version}</version>
+        </dependency>
+        <%_ } _%>
+        <%_ if (databaseType === 'sql') { _%>
+        <dependency>
+            <groupId>javax.enterprise</groupId>
+            <artifactId>cdi-api</artifactId>
+            <version>${cdi-api.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (devDatabaseType === 'mysql' || prodDatabaseType === 'mysql') { _%>
@@ -422,7 +442,6 @@
         <dependency>
             <groupId>org.mariadb.jdbc</groupId>
             <artifactId>mariadb-java-client</artifactId>
-            <version>${mariadb.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
@@ -437,32 +456,31 @@
         <dependency>
             <groupId>com.oracle.jdbc</groupId>
             <artifactId>ojdbc7</artifactId>
-            <version>12.1.0.2</version>
+            <version>${oracle.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
         <dependency>
             <groupId>com.microsoft.sqlserver</groupId>
             <artifactId>mssql-jdbc</artifactId>
-            <version>6.1.0.jre8</version>
+            <version>${mssql-jdbc.version}</version>
         </dependency>
         <dependency>
             <groupId>com.github.sabomichal</groupId>
             <artifactId>liquibase-mssql</artifactId>
-            <version>1.5</version>
+            <version>${liquibase-mssql.version}</version>
         </dependency>
         <%_ } _%>
         <dependency>
             <groupId>org.assertj</groupId>
             <artifactId>assertj-core</artifactId>
-            <version>${assertj-core.version}</version>
             <scope>test</scope>
         </dependency>
         <%_ if (databaseType === 'cassandra') { _%>
         <dependency>
             <groupId>org.cassandraunit</groupId>
             <artifactId>cassandra-unit-spring</artifactId>
-            <version>3.0.0.1</version>
+            <version>${cassandra-unit-spring.version}</version>
             <scope>test</scope>
             <exclusions>
                 <exclusion>
@@ -491,7 +509,6 @@
         <dependency>
             <groupId>org.hibernate</groupId>
             <artifactId>hibernate-validator</artifactId>
-            <version>${hibernate-validator.version}</version>
         </dependency>
         <dependency>
             <groupId>org.liquibase</groupId>
@@ -508,7 +525,7 @@
         <dependency>
             <groupId>com.github.mongobee</groupId>
             <artifactId>mongobee</artifactId>
-            <version>0.10</version>
+            <version>${mongobee.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
@@ -606,6 +623,7 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
+            <version>${spring-security.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -637,7 +655,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>${spring-security-oauth2.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (authenticationType === 'jwt') { _%>
@@ -651,7 +668,6 @@
         <dependency>
             <groupId>org.springframework.security.oauth</groupId>
             <artifactId>spring-security-oauth2</artifactId>
-            <version>${spring-security-oauth2.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.security</groupId>
@@ -663,7 +679,6 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-core</artifactId>
-            <version>${datastax-driver.version}</version>
             <exclusions>
                 <exclusion>
                     <groupId>com.codahale.metrics</groupId>
@@ -674,12 +689,11 @@
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-extras</artifactId>
-            <version>${datastax-driver.version}</version>
+            <version>${cassandra-driver.version}</version>
         </dependency>
         <dependency>
             <groupId>com.datastax.cassandra</groupId>
             <artifactId>cassandra-driver-mapping</artifactId>
-            <version>${datastax-driver.version}</version>
         </dependency>
         <%_ } _%>
         <!-- Spring Cloud -->
@@ -791,12 +805,10 @@
         <dependency>
             <groupId>org.apache.httpcomponents</groupId>
             <artifactId>httpclient</artifactId>
-            <version>${httpclient.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.social</groupId>
             <artifactId>spring-social-security</artifactId>
-            <version>${spring-social-security.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.social</groupId>
@@ -806,12 +818,10 @@
         <dependency>
             <groupId>org.springframework.social</groupId>
             <artifactId>spring-social-facebook</artifactId>
-            <version>${spring-social-facebook.version}</version>
         </dependency>
         <dependency>
             <groupId>org.springframework.social</groupId>
             <artifactId>spring-social-twitter</artifactId>
-            <version>${spring-social-twitter.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (cucumberTests) { _%>
@@ -888,7 +898,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>${maven-compiler-plugin.version}</version>
                 <configuration>
                     <annotationProcessorPaths>
                         <path>
@@ -922,8 +932,8 @@
                 <configuration>
                     <rules>
                         <requireMavenVersion>
-                            <message>You are running an older version of Maven. JHipster requires at least Maven 3.0</message>
-                            <version>[3.0.0,)</version>
+                            <message>You are running an older version of Maven. JHipster requires at least Maven ${maven.version}</message>
+                            <version>[${maven.version},)</version>
                         </requireMavenVersion>
                         <requireJavaVersion>
                             <message>You are running an older version of Java. JHipster requires at least JDK ${java.version}</message>
@@ -1061,7 +1071,7 @@
                     <dependency>
                         <groupId>org.javassist</groupId>
                         <artifactId>javassist</artifactId>
-                        <version>3.18.2-GA</version>
+                        <version>${javassist.version}</version>
                     </dependency>
                     <dependency>
                         <groupId>org.liquibase.ext</groupId>
@@ -1076,7 +1086,7 @@
                     <dependency>
                         <groupId>javax.validation</groupId>
                         <artifactId>validation-api</artifactId>
-                        <version>1.1.0.Final</version>
+                        <version>${validation-api.version}</version>
                     </dependency>
                 </dependencies>
             </plugin>
@@ -1096,7 +1106,7 @@
             <plugin>
                 <groupId>com.spotify</groupId>
                 <artifactId>docker-maven-plugin</artifactId>
-                <version>0.4.10</version>
+                <version>${docker-maven-plugin.version}</version>
                 <configuration>
                     <imageName><%= baseName.toLowerCase() %></imageName>
                     <dockerDirectory>src/main/docker</dockerDirectory>
@@ -1284,7 +1294,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-clean-plugin</artifactId>
-                        <version>2.5</version>
                         <configuration>
                             <filesets>
                                 <fileset>
@@ -1493,7 +1502,7 @@
                     <plugin>
                         <groupId>net.alchim31.maven</groupId>
                         <artifactId>scala-maven-plugin</artifactId>
-                        <version>3.2.2</version>
+                        <version>${scala-maven-plugin.version}</version>
                         <executions>
                             <execution>
                                 <id>compile</id>
@@ -1515,7 +1524,7 @@
                         <configuration>
                             <recompileMode>incremental</recompileMode>
                             <verbose>true</verbose>
-                            <scalaVersion>2.11.7</scalaVersion>
+                            <scalaVersion>${scala.version}</scalaVersion>
                         </configuration>
                     </plugin>
                 </plugins>
@@ -1544,9 +1553,6 @@
                 Profile for monitoring the application with Prometheus.
             -->
             <id>prometheus</id>
-            <properties>
-                <prometheus-simpleclient.version>0.0.18</prometheus-simpleclient.version>
-            </properties>
             <dependencies>
                 <dependency>
                     <groupId>io.prometheus</groupId>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -42,9 +42,6 @@
         <%_ if (databaseType === 'cassandra') { _%>
         <cassandra-unit-spring.version>3.1.1.0</cassandra-unit-spring.version>
         <%_ } _%>
-        <%_ if (databaseType === 'sql') { _%>
-        <cdi-api.version>1.2</cdi-api.version>
-        <%_ } _%>
         <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
         <commons-codec.version>1.10</commons-codec.version>
         <%_ } _%>
@@ -406,13 +403,6 @@
         <dependency>
             <groupId>javax.cache</groupId>
             <artifactId>cache-api</artifactId>
-        </dependency>
-        <%_ } _%>
-        <%_ if (databaseType === 'sql') { _%>
-        <dependency>
-            <groupId>javax.enterprise</groupId>
-            <artifactId>cdi-api</artifactId>
-            <version>${cdi-api.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (devDatabaseType === 'mysql' || prodDatabaseType === 'mysql') { _%>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -64,7 +64,6 @@
         <%_ } _%>
         <%_ if (databaseType === 'sql') { _%>
         <hibernate.version>5.2.7.Final</hibernate.version>
-        <hibernate-validator.version>5.3.4.Final</hibernate-validator.version>
         <hikaricp.version>2.6.0</hikaricp.version>
         <%_ } _%>
         <%_ if (enableSocialSignIn) { _%>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -606,7 +606,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-test</artifactId>
-            <version>${spring-security.version}</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -780,7 +779,6 @@
         <dependency>
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-messaging</artifactId>
-            <version>${spring-security.version}</version>
         </dependency>
         <%_ } _%>
         <%_ if (enableSocialSignIn) { _%>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -116,9 +116,6 @@
         <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
         <mssql-jdbc.version>6.1.0.jre8</mssql-jdbc.version>
         <%_ } _%>
-        <%_ if (databaseType === 'cassandra') { _%>
-        <netty-handler.version>4.0.44.Final</netty-handler.version>
-        <%_ } _%>
         <node.version>v6.9.5</node.version>
         <%_ if (clientPackageManager === 'npm') { _%>
         <npm.version>4.1.2</npm.version>
@@ -410,14 +407,6 @@
             <artifactId>jzlib</artifactId>
             <version>${jzlib.version}</version>
         </dependency>
-        <%_ if (databaseType === 'cassandra') { _%>
-        <!-- include netty handler explicitly to overcome dependency mismatch when using Cassandra -->
-        <dependency>
-            <groupId>io.netty</groupId>
-            <artifactId>netty-handler</artifactId>
-            <version>${netty-handler.version}</version>
-        </dependency>
-        <%_ } _%>
         <%_ } _%>
         <%_ if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { _%>
         <dependency>

--- a/generators/server/templates/gradle/_graphite.gradle
+++ b/generators/server/templates/gradle/_graphite.gradle
@@ -1,3 +1,3 @@
 dependencies {
-    compile "io.dropwizard.metrics:metrics-graphite:${dropwizard_metrics_version}"
+    compile "io.dropwizard.metrics:metrics-graphite"
 }

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -56,6 +56,8 @@ hystrix:
 
 <%_ } _%>
 management:
+    security:
+        roles: ADMIN
     context-path: /management
     health:
         mail:

--- a/generators/server/templates/src/test/gatling/conf/gatling.conf
+++ b/generators/server/templates/src/test/gatling/conf/gatling.conf
@@ -10,8 +10,10 @@ gatling {
         #runDescription = ""          # The description for this simulation run, displayed in each report
         #encoding = "utf-8"           # Encoding to use throughout Gatling for file and string manipulation
         #simulationClass = ""         # The FQCN of the simulation to run (when used in conjunction with noReports, the simulation for which assertions will be validated)
-        #disableCompiler = false      # When set to true, skip compiling and load an already compiled simulation (used in conjunction with simulationClass)
         #mute = false                 # When set to true, don't ask for simulation name nor run description (currently only used by Gatling SBT plugin)
+        #elFileBodiesCacheMaxCapacity = 200        # Cache size for request body EL templates, set to 0 to disable
+        #rawFileBodiesCacheMaxCapacity = 200       # Cache size for request body Raw templates, set to 0 to disable
+        #rawFileBodiesInMemoryMaxSize = 1000       # Below this limit, raw file bodies will be cached in memory
 
         extract {
             regex {
@@ -23,131 +25,107 @@ gatling {
             jsonPath {
                 #cacheMaxCapacity = 200 # Cache size for the compiled jsonPath queries, set to 0 to disable caching
                 #preferJackson = false  # When set to true, prefer Jackson over Boon for JSON-related operations
-                jackson {
-                    #allowComments = false           # Allow comments in JSON files
-                    #allowUnquotedFieldNames = false # Allow unquoted JSON fields names
-                    #allowSingleQuotes = false       # Allow single quoted JSON field names
-                }
-
             }
             css {
                 #cacheMaxCapacity = 200 # Cache size for the compiled CSS selectors queries,  set to 0 to disable caching
             }
         }
-
-        timeOut {
-            #simulation = 8640000 # Absolute timeout, in seconds, of a simulation
-        }
         directory {
-            #data = user-files/data                    # Folder where user's data (e.g. files used by Feeders) is located
-            #requestBodies = user-files/request-bodies # Folder where request bodies are located
-            #simulations = user-files/simulations      # Folder where the bundle's simulations are located
-            #reportsOnly = ""                          # If set, name of report folder to look for in order to generate its report
-            #binaries = ""                             # If set, name of the folder where compiles classes are located
-            #results = results                         # Name of the folder where all reports folder are located
-        }
-        zinc {
-            #jvmArgs = "-Xss10M" # JVM args passed to Zinc (in charge of compiling Gatling Simulations)
+            #data = user-files/data               # Folder where user's data (e.g. files used by Feeders) is located
+            #bodies = user-files/bodies           # Folder where bodies are located
+            #simulations = user-files/simulations # Folder where the bundle's simulations are located
+            #reportsOnly = ""                     # If set, name of report folder to look for in order to generate its report
+            #binaries = ""                        # If set, name of the folder where compiles classes are located: Defaults to GATLING_HOME/target.
+            #results = results                    # Name of the folder where all reports folder are located
         }
     }
     charting {
         #noReports = false       # When set to true, don't generate HTML reports
         #maxPlotPerSeries = 1000 # Number of points per graph in Gatling reports
-        #accuracy = 10           # Accuracy, in milliseconds, of the report's stats
+        #useGroupDurationMetric = false  # Switch group timings from cumulated response time to group duration.
         indicators {
             #lowerBound = 800      # Lower bound for the requests' response time to track in the reports and the console summary
             #higherBound = 1200    # Higher bound for the requests' response time to track in the reports and the console summary
-            #percentile1 = 95      # Value for the first percentile to track in the reports, the console summary and GraphiteDataWriter
-            #percentile2 = 99      # Value for the second percentile to track in the reports, the console summary and GraphiteDataWriter
+            #percentile1 = 50      # Value for the 1st percentile to track in the reports, the console summary and Graphite
+            #percentile2 = 75      # Value for the 2nd percentile to track in the reports, the console summary and Graphite
+            #percentile3 = 95      # Value for the 3rd percentile to track in the reports, the console summary and Graphite
+            #percentile4 = 99      # Value for the 4th percentile to track in the reports, the console summary and Graphite
         }
     }
     http {
-        #elFileBodiesCacheMaxCapacity = 200        # Cache size for request body EL templates, set to 0 to disable
-        #rawFileBodiesCacheMaxCapacity = 200       # Cache size for request body Raw templates, set to 0 to disable
         #fetchedCssCacheMaxCapacity = 200          # Cache size for CSS parsed content, set to 0 to disable
         #fetchedHtmlCacheMaxCapacity = 200         # Cache size for HTML parsed content, set to 0 to disable
-        #redirectPerUserCacheMaxCapacity = 200     # Per virtual user cache size for permanent redirects, set to 0 to disable
-        #expirePerUserCacheMaxCapacity = 200       # Per virtual user cache size for permanent 'Expire' headers, set to 0 to disable
-        #lastModifiedPerUserCacheMaxCapacity = 200 # Per virtual user cache size for permanent 'Last-Modified' headers, set to 0 to disable
-        #etagPerUserCacheMaxCapacity = 200         # Per virtual user cache size for permanent ETag headers, set to 0 to disable
-        #warmUpUrl = "http://goo.gl/pq1Xwu"        # The URL to use to warm-up the HTTP stack (blank means disabled)
+        #perUserCacheMaxCapacity = 200             # Per virtual user cache size, set to 0 to disable
+        #warmUpUrl = "http://gatling.io"           # The URL to use to warm-up the HTTP stack (blank means disabled)
+        #enableGA = true                           # Very light Google Analytics, please support
         ssl {
-            trustStore {
-                #type = ""      # Type of SSLContext's TrustManagers store
-                #file = ""      # Location of SSLContext's TrustManagers store
-                #password = ""  # Password for SSLContext's TrustManagers store
-                #algorithm = "" # Algorithm used by SSLContext's TrustManagers store
-            }
             keyStore {
                 #type = ""      # Type of SSLContext's KeyManagers store
                 #file = ""      # Location of SSLContext's KeyManagers store
                 #password = ""  # Password for SSLContext's KeyManagers store
                 #algorithm = "" # Algorithm used SSLContext's KeyManagers store
             }
+            trustStore {
+                #type = ""      # Type of SSLContext's TrustManagers store
+                #file = ""      # Location of SSLContext's TrustManagers store
+                #password = ""  # Password for SSLContext's TrustManagers store
+                #algorithm = "" # Algorithm used by SSLContext's TrustManagers store
+            }
         }
         ahc {
-            #allowPoolingConnections = true             # Allow pooling HTTP connections (keep-alive header automatically added)
-            #allowPoolingSslConnections = true          # Allow pooling HTTPS connections (keep-alive header automatically added)
-            #compressionEnforced = false                # Enforce gzip/deflate when Accept-Encoding header is not defined
-            #connectTimeout = 60000                     # Timeout when establishing a connection
-            #pooledConnectionIdleTimeout = 60000        # Timeout when a connection stays unused in the pool
-            #readTimeout = 60000                        # Timeout when a used connection stays idle
-            #connectionTTL = -1                         # Max duration a connection can stay open (-1 means no limit)
-            #ioThreadMultiplier = 2                     # Number of Netty worker threads per core
-            #maxConnectionsPerHost = -1                 # Max number of connections per host (-1 means no limit)
-            #maxConnections = -1                        # Max number of connections (-1 means no limit)
-            #maxRetry = 0                               # Number of times that a request should be tried again
-            #requestTimeout = 60000                     # Timeout of the requests
-            #useProxyProperties = false                 # When set to true, supports standard Proxy System properties
-            #webSocketTimeout = 60000                   # Timeout when a used websocket connection stays idle
-            #useRelativeURIsWithConnectProxies = true   # When set to true, use relative URIs when talking with an SSL proxy or a WebSocket proxy
-            #acceptAnyCertificate = true                # When set to true, doesn't validate SSL certificates
-            #httpClientCodecMaxInitialLineLength = 4096 # Maximum length of the initial line of the response (e.g. "HTTP/1.0 200 OK")
-            #httpClientCodecMaxHeaderSize = 8192        # Maximum size, in bytes, of each request's headers
-            #httpClientCodecMaxChunkSize = 8192         # Maximum length of the content or each chunk
-            #keepEncodingHeader = true                  # Don't drop Encoding response header after decoding
-            #webSocketMaxFrameSize = 10240              # Maximum frame payload size
+            #keepAlive = true                                # Allow pooling HTTP connections (keep-alive header automatically added)
+            #connectTimeout = 10000                          # Timeout when establishing a connection
+            #handshakeTimeout = 10000                        # Timeout when performing TLS hashshake
+            #pooledConnectionIdleTimeout = 60000             # Timeout when a connection stays unused in the pool
+            #readTimeout = 60000                             # Timeout when a used connection stays idle
+            #maxRetry = 2                                    # Number of times that a request should be tried again
+            #requestTimeout = 60000                          # Timeout of the requests
+            #acceptAnyCertificate = true                     # When set to true, doesn't validate SSL certificates
+            #httpClientCodecMaxInitialLineLength = 4096      # Maximum length of the initial line of the response (e.g. "HTTP/1.0 200 OK")
+            #httpClientCodecMaxHeaderSize = 8192             # Maximum size, in bytes, of each request's headers
+            #httpClientCodecMaxChunkSize = 8192              # Maximum length of the content or each chunk
+            #webSocketMaxFrameSize = 10240000                # Maximum frame payload size
+            #sslEnabledProtocols = [TLSv1.2, TLSv1.1, TLSv1] # Array of enabled protocols for HTTPS, if empty use the JDK defaults
+            #sslEnabledCipherSuites = []                     # Array of enabled cipher suites for HTTPS, if empty use the AHC defaults
+            #sslSessionCacheSize = 0                         # SSLSession cache size, set to 0 to use JDK's default
+            #sslSessionTimeout = 0                           # SSLSession timeout in seconds, set to 0 to use JDK's default (24h)
+            #useOpenSsl = false                              # if OpenSSL should be used instead of JSSE (requires tcnative jar)
+            #useNativeTransport = false                      # if native transport should be used instead of Java NIO (requires netty-transport-native-epoll, currently Linux only)
+            #tcpNoDelay = true
+            #soReuseAddress = false
+            #soLinger = -1
+            #soSndBuf = -1
+            #soRcvBuf = -1
+            #allocator = "pooled"                            # switch to unpooled for unpooled ByteBufAllocator
+            #maxThreadLocalCharBufferSize = 200000           # Netty's default is 16k
+        }
+        dns {
+            #queryTimeout = 5000                             # Timeout of each DNS query in millis
+            #maxQueriesPerResolve = 6                        # Maximum allowed number of DNS queries for a given name resolution
         }
     }
+    jms {
+       #acknowledgedMessagesBufferSize = 5000             # size of the buffer used to tracked acknowledged messages and protect against duplicate receives
+    }
     data {
-        #writers = "console, file" # The lists of DataWriters to which Gatling write simulation data (currently supported : "console", "file", "graphite", "jdbc")
-        #reader = file             # The DataReader used by the charting engine for reading simulation results
+        #writers = [console, file]      # The list of DataWriters to which Gatling write simulation data (currently supported : console, file, graphite, jdbc)
         console {
-            #light = false           # When set to true, displays a light version without detailed request stats
+           #light = false                # When set to true, displays a light version without detailed request stats
         }
         file {
-            #bufferSize = 8192       # FileDataWriter's internal data buffer size, in bytes
+            #bufferSize = 8192            # FileDataWriter's internal data buffer size, in bytes
         }
         leak {
             #noActivityTimeout = 30  # Period, in seconds, for which Gatling may have no activity before considering a leak may be happening
         }
-        jdbc {
-            db {
-                #url = "jdbc:mysql://localhost:3306/temp" # The JDBC URL used by the JDBC DataWriter
-                #username = "root"                        # The database user used by the JDBC DataWriter
-                #password = "123123q"                     # The password for the specified user
-            }
-            #bufferSize = 20                            # The size for each batch of SQL inserts to send to the database
-            create {
-                #createRunRecordTable = "CREATE TABLE IF NOT EXISTS `RunRecords` ( `id` INT NOT NULL AUTO_INCREMENT , `runDate` DATETIME NULL , `simulationId` VARCHAR(45) NULL , `runDescription` VARCHAR(45) NULL , PRIMARY KEY (`id`) )"
-                #createRequestRecordTable = "CREATE TABLE IF NOT EXISTS `RequestRecords` (`id` int(11) NOT NULL AUTO_INCREMENT, `runId` int DEFAULT NULL, `scenario` varchar(45) DEFAULT NULL, `userId` VARCHAR(20) NULL, `name` varchar(50) DEFAULT NULL, `requestStartDate` bigint DEFAULT NULL, `requestEndDate` bigint DEFAULT NULL, `responseStartDate` bigint DEFAULT NULL, `responseEndDate` bigint DEFAULT NULL, `status` varchar(2) DEFAULT NULL, `message` varchar(4500) DEFAULT NULL, `responseTime` bigint DEFAULT NULL, PRIMARY KEY (`id`) )"
-                #createScenarioRecordTable = "CREATE TABLE IF NOT EXISTS `ScenarioRecords` (`id` int(11) NOT NULL AUTO_INCREMENT, `runId` int DEFAULT NULL, `scenarioName` varchar(45) DEFAULT NULL, `userId` VARCHAR(20) NULL, `event` varchar(50) DEFAULT NULL, `startDate` bigint DEFAULT NULL, `endDate` bigint DEFAULT NULL, PRIMARY KEY (`id`) )"
-                #createGroupRecordTable = "CREATE TABLE IF NOT EXISTS `GroupRecords` (`id` int(11) NOT NULL AUTO_INCREMENT, `runId` int DEFAULT NULL, `scenarioName` varchar(45) DEFAULT NULL, `userId` VARCHAR(20) NULL, `entryDate` bigint DEFAULT NULL, `exitDate` bigint DEFAULT NULL, `status` varchar(2) DEFAULT NULL, PRIMARY KEY (`id`) )"
-            }
-            insert {
-                #insertRunRecord = "INSERT INTO RunRecords (runDate, simulationId, runDescription) VALUES (?,?,?)"
-                #insertRequestRecord = "INSERT INTO RequestRecords (runId, scenario, userId, name, requestStartDate, requestEndDate, responseStartDate, responseEndDate, status, message, responseTime) VALUES (?,?,?,?,?,?,?,?,?,?,?)"
-                #insertScenarioRecord = "INSERT INTO ScenarioRecords (runId, scenarioName, userId, event, startDate, endDate) VALUES (?,?,?,?,?,?)"
-                #insertGroupRecord = "INSERT INTO GroupRecords (runId, scenarioName, userId, entryDate, exitDate, status) VALUES (?,?,?,?,?,?)"
-            }
-        }
         graphite {
             #light = false              # only send the all* stats
             #host = "localhost"         # The host where the Carbon server is located
-            #port = 2003                # The port to which the Carbon server listens to
+            #port = 2003                # The port to which the Carbon server listens to (2003 is default for plaintext, 2004 is default for pickle)
             #protocol = "tcp"           # The protocol used to send data to Carbon (currently supported : "tcp", "udp")
             #rootPathPrefix = "gatling" # The common prefix of all metrics sent to Graphite
             #bufferSize = 8192          # GraphiteDataWriter's internal data buffer size, in bytes
+            #writeInterval = 1          # GraphiteDataWriter's write interval, in seconds
         }
     }
 }

--- a/generators/server/templates/src/test/java/package/cucumber/stepdefs/_StepDefs.java
+++ b/generators/server/templates/src/test/java/package/cucumber/stepdefs/_StepDefs.java
@@ -2,13 +2,15 @@ package <%=packageName%>.cucumber.stepdefs;
 
 import <%=packageName%>.<%= mainClass %>;
 
-import org.springframework.boot.test.SpringApplicationContextLoader;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 import org.springframework.test.web.servlet.ResultActions;
 
+import org.springframework.boot.test.context.SpringBootTest;
+
 @WebAppConfiguration
-@ContextConfiguration(classes = <%= mainClass %>.class, loader = SpringApplicationContextLoader.class)
+@SpringBootTest
+@ContextConfiguration(classes = <%= mainClass %>.class)
 public abstract class StepDefs {
 
     protected ResultActions actions;

--- a/generators/server/templates/src/test/resources/_cassandra-random-port.yml
+++ b/generators/server/templates/src/test/resources/_cassandra-random-port.yml
@@ -586,3 +586,7 @@ encryption_options:
     # algorithm: SunX509
     # store_type: JKS
     # cipher_suites: [TLS_RSA_WITH_AES_128_CBC_SHA,TLS_RSA_WITH_AES_256_CBC_SHA]
+
+# Workaround for bug in cassandra-unit 3.1.1.0
+# https://github.com/jsevellec/cassandra-unit/issues/212
+cdc_raw_directory: target/embeddedCassandra/cdc


### PR DESCRIPTION
As per https://github.com/jhipster/generator-jhipster/issues/5045#issuecomment-278023167 -- please see questions/remarks in that thread also.

Some additions:

- There is a counterpart to this PR over at the serverside JHipster lib, [here](https://github.com/jhipster/jhipster/pull/7). I was wondering if it might make sense to deduplicate some currently redundant stuff between the generator and the lib, for instance by having the lib as parent of the generated project. But I'm not completely sure how that might work with gradle; I suppose one might look into the spring-boot-gradle plugin, which [advertises](https://github.com/spring-gradle-plugins/dependency-management-plugin) that it can import POMs (of course that's how it interacts with `spring-boot-dependencies` too!). If something like that works out, I guess it might even be possible to have all version properties in a single place, instead of duplicated for gradle and maven.

- I was able to get rid of the awkward dependency override that I mentioned earlier, on `spring-cloud-netflix`, by going forward and including `spring-cloud` Camden SR5. It's probably a good idea to keep an eye on `spring-cloud-stream` Chelsea, which is currently at M1.

- Thanks to @cbornet who pointed me to an earlier complication with `netty-handler` which I was now able to remove.

- I found kind of a cute [trick](https://github.com/jhipster/generator-jhipster/pull/5146/files#diff-5595eed51dd01e38e024547a86042a81R199) to effectively import version strings from the `spring-boot-dependencies` POM into the gradle build. But after discovering that I didn't double back to see if it could be applied more widely.

- In general I was able to remove some version strings from JH code. Mostly this is to align with `spring-boot-dependencies` implicitly, but also I found out that -- provided we use the same property names --  it is sufficient to override the version property and we don't have to include the version with the dependency itself. As an example, see what I did with `assertj` [here](https://github.com/jhipster/generator-jhipster/pull/5146/files#diff-4ac12e0abae2ba3bd72788629c00c4abR40) and [here](https://github.com/jhipster/generator-jhipster/pull/5146/files#diff-4ac12e0abae2ba3bd72788629c00c4abL458).

Still to do:

- [ ] There's a failing test (app-ng2-jwt)  that I wasn't able to quickly fix (or spend a lot of time on).
- [ ] SB1.5 has autoconfiguration for Kafka, but I don't know much about it and haven't looked into it now.