### PR TITLE
update jacoco to latest version

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -70,7 +70,7 @@
         <!-- Spring social -->
         <httpclient.version>4.5.1</httpclient.version>
         <%_ } _%>
-        <jacoco-maven-plugin.version>0.7.7.201606060606</jacoco-maven-plugin.version>
+        <jacoco-maven-plugin.version>0.7.9</jacoco-maven-plugin.version>
         <java.version>1.<%= javaVersion %></java.version>
         <%_ if (hibernateCache === 'ehcache' || hibernateCache === 'hazelcast') { _%>
         <jcache.version>1.0.0</jcache.version>

--- a/generators/server/templates/gradle/_sonar.gradle
+++ b/generators/server/templates/gradle/_sonar.gradle
@@ -2,7 +2,7 @@ apply plugin: "org.sonarqube"
 apply plugin: 'jacoco'
 
 jacoco {
-    toolVersion = '0.7.6.201602180812'
+    toolVersion = '0.7.9'
 }
 
 jacocoTestReport {


### PR DESCRIPTION
Was there a specific reason why we didn't update jacoco for quite a long time (especially in gradle)?