### PR TITLE
Fix shared folder for ng2+social+websocket

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/social/_social-register.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/social/_social-register.component.ts
@@ -3,7 +3,7 @@ import { JhiLanguageService } from 'ng-jhipster';
 import { ActivatedRoute } from '@angular/router';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
-import { LoginModalService } from '../shared';
+import { LoginModalService } from '../../shared';
 
 @Component({
     selector: '<%=jhiPrefix%>-register',


### PR DESCRIPTION
Fix Travis build ng2+social+websocket:
> ERROR in [at-loader] src/main/webapp/app/account/social/social-register.component.ts:6:35 
    TS2307: Cannot find module '../shared'.
webpack: Failed to compile.