### PR TITLE
skip docker-compose registry config for monoliths without service discovery

### DIFF
--- a/generators/docker-compose/prompts.js
+++ b/generators/docker-compose/prompts.js
@@ -204,18 +204,19 @@ function askForMonitoring() {
 }
 
 function askForServiceDiscovery() {
-    if (this.regenerate || this.composeApplicationType === 'monolith') return;
+    if (this.regenerate) return;
 
     var done = this.async();
 
     var serviceDiscoveryEnabledApps = [];
     this.appConfigs.forEach(function (appConfig, index) {
-        if(appConfig.serviceDiscoveryType && (appConfig.applicationType === 'microservice' || appConfig.applicationType === 'gateway')) {
+        if(appConfig.serviceDiscoveryType) {
             serviceDiscoveryEnabledApps.push({baseName: appConfig.baseName, serviceDiscoveryType: appConfig.serviceDiscoveryType});
         }
     }, this);
 
     if(serviceDiscoveryEnabledApps.length === 0) {
+        this.serviceDiscoveryType = false;
         done();
         return;
     }
@@ -251,7 +252,7 @@ function askForServiceDiscovery() {
                     name: 'Consul'
                 },
                 {
-                    value: 'no',
+                    value: false,
                     name: 'No Service Discovery and Configuration'
                 }
             ],


### PR DESCRIPTION
When a monolith's serviceDiscoveryType was false or missing, the docker-compose generator would assume you needed a registry.  This fixes it for the kubernetes subgen as well since it uses the same prompts.

This is the issue discussed at the bottom in https://github.com/jhipster/generator-jhipster/issues/4955#issuecomment-278998120 @PierreBesson @jdubois 