### PR TITLE
Run `webpack:build:dev` after generating entities.

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -127,6 +127,14 @@ module.exports = EntityGenerator.extend({
             if (!this.clientFramework) {
                 this.clientFramework = 'angular1';
             }
+            this.clientPackageManager = this.config.get('clientPackageManager');
+            if (!this.clientPackageManager) {
+                if (this.yarnInstall) {
+                    this.clientPackageManager = 'yarn';
+                } else {
+                    this.clientPackageManager = 'npm';
+                }
+            }
 
             this.skipClient = this.applicationType === 'microservice' || this.config.get('skipClient') || this.options['skip-client'];
 
@@ -645,6 +653,15 @@ module.exports = EntityGenerator.extend({
         };
         if (!this.options['skip-install'] && !this.skipClient && this.clientFramework === 'angular1') {
             injectJsFilesToIndex.call(this);
+        }
+
+        // rebuild client for Angular
+        var rebuildClient = function () {
+            this.log('\n' + chalk.bold.green('Running `webpack:build:dev` to update client app\n'));
+            this.spawnCommand(this.clientPackageManager, ['run', 'webpack:build:dev']);
+        };
+        if (!this.options['skip-install'] && !this.skipClient && this.clientFramework === 'angular2') {
+            rebuildClient.call(this);
         }
     },
 

--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -34,6 +34,14 @@ module.exports = JDLGenerator.extend({
             if (!this.clientFramework) {
                 this.clientFramework = 'angular1';
             }
+            this.clientPackageManager = this.config.get('clientPackageManager');
+            if (!this.clientPackageManager) {
+                if (this.yarnInstall) {
+                    this.clientPackageManager = 'yarn';
+                } else {
+                    this.clientPackageManager = 'npm';
+                }
+            }
         }
     },
 
@@ -89,6 +97,15 @@ module.exports = JDLGenerator.extend({
         };
         if (!this.options['skip-install'] && !this.skipClient && this.clientFramework === 'angular1') {
             injectJsFilesToIndex.call(this);
+        }
+
+        // rebuild client for Angular
+        var rebuildClient = function () {
+            this.log('\n' + chalk.bold.green('Running `webpack:build:dev` to update client app\n'));
+            this.spawnCommand(this.clientPackageManager, ['run', 'webpack:build:dev']);
+        };
+        if (!this.options['skip-install'] && !this.skipClient && this.clientFramework === 'angular2') {
+            rebuildClient.call(this);
         }
     }
 


### PR DESCRIPTION
This makes it so users can refresh their UI (if they haven't run `yarn start`) after generating entities and see the entities under the Entities menu.

If they have `yarn start` running, it will likely recompile faster, but the entity post-build does not cause `yarn start` to refresh again.

Fixes #5062.