### PR TITLE
Add HTTP/2 Support and instructions for enabling TLS

### DIFF
--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -90,6 +90,7 @@ mapstruct_version=1.1.0.Final
 <%_ if (enableSocialSignIn) { _%>
 spring_social_google_version=1.0.0.RELEASE
 <%_ } _%>
+undertow_version=1.4.10.Final
 
 ## below are some of the gradle performance improvement settings that can be used as required, these are not enabled by default
 

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -164,6 +164,7 @@
         <spring-social-twitter.version>1.1.2.RELEASE</spring-social-twitter.version>
         <%_ } _%>
         <springfox.version>2.6.1</springfox.version>
+        <undertow.version>1.4.10.Final</undertow.version>
         <%_ if (clientPackageManager === 'yarn') { _%>
         <yarn.version>v0.19.1</yarn.version>
         <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
+++ b/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
@@ -15,6 +15,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.context.embedded.*;
+import org.springframework.boot.context.embedded.undertow.UndertowEmbeddedServletContainerFactory;
+import io.undertow.UndertowOptions;
 import org.springframework.boot.web.servlet.ServletContextInitializer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -128,6 +130,15 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
         // When running in an IDE or with <% if (buildTool == 'gradle') { %>./gradlew bootRun<% } else { %>./mvnw spring-boot:run<% } %>, set location of the static web assets.
         setLocationForStaticAssets(container);
         <%_ } _%>
+
+        // Enable HTTP/2 for Undertow - https://twitter.com/ankinson/status/829256167700492288
+        // NOTE: HTTP/2 requires HTTPS! HTTP requests will fallback to HTTP/1.1.
+        if (container instanceof UndertowEmbeddedServletContainerFactory) {
+            ((UndertowEmbeddedServletContainerFactory) container)
+                .addBuilderCustomizers((builder) -> {
+                    builder.setServerOption(UndertowOptions.ENABLE_HTTP2, true);
+                });
+        }
     }
     <%_ if (!skipClient) { _%>
 

--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -194,6 +194,20 @@ liquibase:
     contexts: dev
 <%_ } _%>
 
+# ===================================================================
+# To enable HTTP/2, generate a certificate using:
+# keytool -genkey -alias undertow -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 3650
+#
+# You can also use Let's Encrypt:
+# https://maximilian-boehm.com/hp2121/Create-a-Java-Keystore-JKS-from-Let-s-Encrypt-Certificates.htm
+#
+# Then, change server.port to 8443 and add the following server.ssl properties.
+#    ssl:
+#        key-store: keystore.p12
+#        key-store-password: <your-password>
+#        keyStoreType: PKCS12
+#        keyAlias: undertow
+# ===================================================================
 server:
     port: <%= serverPort %>
 


### PR DESCRIPTION
After this patch, if you enable TLS[1], HTTP/2 will be enabled for requests. If you don't enable TLS, HTTP/1.1 will still be used.

NOTE: I tried to use Apache with mod_proxy and mod_ssl (pointing to 8080), and found it doesn’t work. Deploying to Cloud Foundry or Heroku (and enabling SSL) doesn't work either.

[1] See [Wikipedia](https://en.wikipedia.org/wiki/Transport_Layer_Security) to see why I call it TLS instead of SSL.