### PR TITLE
open health endpoint for all apps

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
@@ -54,9 +54,7 @@ public class MicroserviceSecurityConfiguration extends WebSecurityConfigurerAdap
         .and()
             .authorizeRequests()
             .antMatchers("/api/**").authenticated()
-            <%_ if (serviceDiscoveryType == 'consul') { _%>
             .antMatchers("/management/health").permitAll()
-            <%_ } _%>
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/swagger-resources/configuration/ui").permitAll()
         .and()
@@ -129,9 +127,7 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
             .authorizeRequests()
             .antMatchers("/api/profile-info").permitAll()
             .antMatchers("/api/**").authenticated()
-            <%_ if (serviceDiscoveryType == 'consul') { _%>
             .antMatchers("/management/health").permitAll()
-            <%_ } _%>
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/swagger-resources/configuration/ui").permitAll();
     }

--- a/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -202,9 +202,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/**").authenticated()<% if (websocket == 'spring-websocket') { %>
             .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/websocket/**").permitAll()<% } %>
-            <%_ if (serviceDiscoveryType == 'consul') { _%>
             .antMatchers("/management/health").permitAll()
-            <%_ } _%>
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/v2/api-docs/**").permitAll()
             .antMatchers("/swagger-resources/configuration/ui").permitAll()

--- a/generators/server/templates/src/main/java/package/config/_UaaConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_UaaConfiguration.java
@@ -75,9 +75,7 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter {
                 .antMatchers("/api/**").authenticated()<% if (websocket == 'spring-websocket') { %>
                 .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
                 .antMatchers("/websocket/**").permitAll()<% } %>
-                <%_ if (serviceDiscoveryType == 'consul') { _%>
                 .antMatchers("/management/health").permitAll()
-                <%_ } _%>
                 .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
                 .antMatchers("/v2/api-docs/**").permitAll()
                 .antMatchers("/swagger-resources/configuration/ui").permitAll()


### PR DESCRIPTION
This lets developers set up simple unauthenticated health checks (I wanted it for Rancher). We already open it up for Consul.

While admins get a full report, users and anonymous users get:
```
curl 'http://localhost:8080/management/health' 
{
  "description" : "Spring Cloud Eureka Discovery Client",    # Not there for monoliths
  "status" : "UP"
}
```
> Shows application health information (when the application is secure, a simple ‘status’ when accessed over an unauthenticated connection or full message details when authenticated).
http://docs.spring.io/spring-boot/docs/current/reference/html/production-ready-endpoints.html
