### PR TITLE
add pngquant and phatomjs rebuild to postinstall

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -123,7 +123,7 @@
     "e2e": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
     "postinstall": "webdriver-manager update && <%= clientPackageManager %> run webpack:build"
     <%_ } else { _%>
-    "postinstall": "<%= clientPackageManager %> run webpack:build"
+    "postinstall": "node node_modules/pngquant-bin/lib/install.js && node node_modules/phantomjs-prebuilt/install.js && <%= clientPackageManager %> run webpack:build"
     <%_ } _%>
   }
 }


### PR DESCRIPTION
Related to  #5225 https://github.com/jhipster/generator-jhipster/issues/5188#issuecomment-280256476

```
ERROR in ./src/main/webapp/content/images/hipster.png
Module build failed: Error: spawn /home/vagrant/projects/jhipster-gradle/node_modules/pngquant-bin/vendor/pngquant ENOENT
    at exports._errnoException (util.js:1022:11)
    at Process.ChildProcess._handle.onexit (internal/child_process.js:193:32)
    at onErrorNT (internal/child_process.js:359:16)
    at _combinedTickCallback (internal/process/next_tick.js:74:11)
    at process._tickCallback (internal/process/next_tick.js:98:9)
 @ ./~/css-loader!./src/main/webapp/app/home/home.css 6:307-350
 @ ./src/main/webapp/app/home/home.css
 @ ./src/main/webapp/app/home/home.component.ts
 @ ./src/main/webapp/app/home/index.ts
 @ ./src/main/webapp/app/app.module.ts
 @ ./src/main/webapp/app/app.main.ts
```