### PR TITLE
Fix upgrade subgen

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -176,9 +176,9 @@ module.exports = JhipsterGenerator.extend({
                 this.applicationType = 'monolith';
             }
             this.baseName = this.config.get('baseName');
-            this.jhipsterVersion = this.config.get('jhipsterVersion');
+            this.jhipsterVersion = packagejs.version;
             if (this.jhipsterVersion === undefined) {
-                this.jhipsterVersion = packagejs.version;
+                this.jhipsterVersion = this.config.get('jhipsterVersion');
             }
             this.otherModules = this.config.get('otherModules');
             this.testFrameworks = this.config.get('testFrameworks');

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -164,9 +164,9 @@ module.exports = JhipsterServerGenerator.extend({
             }
             this.buildTool = this.config.get('buildTool');
             this.enableSocialSignIn = this.config.get('enableSocialSignIn');
-            this.jhipsterVersion = this.config.get('jhipsterVersion');
+            this.jhipsterVersion = packagejs.version;
             if (this.jhipsterVersion === undefined) {
-                this.jhipsterVersion = packagejs.version;
+                this.jhipsterVersion = this.config.get('jhipsterVersion');
             }
             this.authenticationType = this.config.get('authenticationType');
             if (this.authenticationType === 'session') {

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -23,7 +23,7 @@ module.exports = UpgradeGenerator.extend({
 
     initializing: {
         displayLogo: function () {
-            this.log(chalk.green('Welcome to the JHipster Upgrade Sub-Generator '));
+            this.log(chalk.green('Welcome to the JHipster Upgrade Sub-Generator'));
             this.log(chalk.green('This will upgrade your current application codebase to the latest JHipster version'));
         },
 
@@ -224,7 +224,7 @@ module.exports = UpgradeGenerator.extend({
         updateJhipster: function() {
             this.log(chalk.yellow('Updating ' + GENERATOR_JHIPSTER + '. This might take some time...'));
             var done = this.async();
-            shelljs.exec('npm install ' + GENERATOR_JHIPSTER, {silent:true}, function (code, msg, err) {
+            shelljs.exec('npm install ' + GENERATOR_JHIPSTER + '@' + this.latestVersion, {silent:true}, function (code, msg, err) {
                 if (code === 0) this.log(chalk.green('Updated ' + GENERATOR_JHIPSTER + ' to version ' + this.latestVersion));
                 else this.error('Something went wrong while updating generator! ' + msg + ' ' + err);
                 done();


### PR DESCRIPTION
I have something working well, but with two minor downsides:
 - For NG1, `bower install` always needs to run afterwards (and during the upgrade process, to get any updates because we check them in).
 - yarn.lock was giving me issues when the upgrade switches git branches, so I use  `--no-lockfile` during the upgrade process. This means that at the end of an upgrade, yarn.lock is changed

To test, delete node_modules/generator-jhipster after generating an older project and use your linked generator-jhipster to run `yo jhipster:upgrade`.  The upgrade process installs a local version matching the package.json and upgrades the project correctly.

Sample apps showing the commits from the generator from v4.0.2 to v4.0.3:
NG1 Example: https://github.com/ruddell/upgrade-ng1/commits/master
NG2 Example: https://github.com/ruddell/upgrade-ng2/commits/master
Fix #5116