### PR TITLE
fixes bootstrap templating in gradle for microservices

### DIFF
--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -55,6 +55,8 @@ processResources {
     <%_ } _%>
         filter {
             it.replace('#spring.profiles.active#', profiles)
+        }
+        filter {
             it.replace('#project.version#', version)
         }
     }

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -57,6 +57,8 @@ processResources {
     <%_ } _%>
         filter {
             it.replace('#spring.profiles.active#', profiles)
+        }
+        filter {
             it.replace('#project.version#', version)
         }
     }


### PR DESCRIPTION
it seems you can't define more than one `it.replace(..)` per `filter` in `processResources` in gradle

fix #5240 
