### PR TITLE
Add spring-cloud-dependencies to pom.xml

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -8,6 +8,18 @@
         <version>1.4.4.RELEASE</version>
         <relativePath />
     </parent>
+    
+        <dependencyManagement>
+        <dependencies>
+            <dependency>
+                <groupId>org.springframework.cloud</groupId>
+                <artifactId>spring-cloud-dependencies</artifactId>
+                <version>Camden.SR5</version>
+                <type>pom</type>
+                <scope>import</scope>
+            </dependency>
+        </dependencies>
+    </dependencyManagement>
 
     <groupId><%= packageName %></groupId>
     <artifactId><%= dasherizedBaseName %></artifactId>


### PR DESCRIPTION
JHipster Generator 4.0.5 fails to compile a microservice project due to missing pom configuration for spring-cloud-starter dependencies.  This is required to pull in the proper spring-cloud-starter version information. Closes #5253.