### PR TITLE
add null check to entity generation

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -582,7 +582,7 @@ module.exports = EntityGenerator.extend({
 
                 if (_.isUndefined(relationship.otherEntityAngularName)) {
                     if (relationship.otherEntityNameCapitalized !== 'User') {
-                        var otherEntityAngularSuffix = otherEntityData.angularJSSuffix || '';
+                        var otherEntityAngularSuffix = otherEntityData ? otherEntityData.angularJSSuffix || '' : '';
                         relationship.otherEntityAngularName = _.upperFirst(relationship.otherEntityName) + _.upperFirst(_.camelCase(otherEntityAngularSuffix));
                     } else {
                         relationship.otherEntityAngularName = 'User';


### PR DESCRIPTION
add null check for otherEntityData so entity generation will still work if the related entity does not exist yet -- note, an error will still appear on the console but generation will work

Fix #5265