### PR TITLE
ngbDatepicker icon now toggles rather than opens

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
@@ -71,7 +71,7 @@
                 <input id="field_<%= fieldName %>" type="text" class="form-control" name="<%= fieldName %>" ngbDatepicker  #<%= fieldName %>Dp="ngbDatepicker" [(ngModel)]="<%= entityInstance %>.<%= fieldName %>"
                 <%- include ng_validators %>/>
                 <span class="input-group-btn">
-                    <button type="button" class="btn btn-default" (click)="<%= fieldName %>Dp.open()"><i class="fa fa-calendar"></i></button>
+                    <button type="button" class="btn btn-default" (click)="<%= fieldName %>Dp.toggle()"><i class="fa fa-calendar"></i></button>
                 </span>
             </div>
             <%_ } else if (fieldType == 'ZonedDateTime') { _%>


### PR DESCRIPTION
Toggling is more untuitive because it means that when you click first time on icon, the datepicker popup opens and when you click a second time it closes.

With previous behavior using open(), you could not close the datepicker popup by clicking on its icon.