### PR TITLE
set oauth2 resource filter-order to the old default

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -127,6 +127,11 @@ spring:
 security:
     basic:
         enabled: false
+    <%_ if (authenticationType == 'oauth2') { _%>
+    oauth2:
+        resource:
+            filter-order: 3
+    <%_ } _%>
 
 server:
     session:


### PR DESCRIPTION
>The default order of the OAuth2 resource filter has changed from 3 to SecurityProperties.ACCESS_OVERRIDE_ORDER - 1. This places it after the actuator endpoints but before the basic authentication filter chain. The default can be restored by setting security.oauth2.resource.filter-order = 3



Fix #5298 
