### PR TITLE
prevent deactivate himself, ng1

### DIFF
--- a/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management.html
+++ b/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management.html
@@ -30,10 +30,10 @@
                 <td>{{user.login}}</td>
                 <td>{{user.email}}</td>
                 <td>
-                    <span class="label label-danger hand" ng-click="vm.setActive(user, true)" ng-show="!user.activated"
-                          data-translate="userManagement.deactivated">Deactivated</span>
-                    <span class="label label-success hand" ng-click="vm.setActive(user, false)" ng-show="user.activated"
-                          data-translate="userManagement.activated">Activated</span>
+                    <button class="btn btn-danger btn-xs" ng-click="vm.setActive(user, true)" ng-show="!user.activated"
+                            data-translate="userManagement.deactivated">Deactivated</button>
+                    <button class="btn btn-success btn-xs" ng-click="vm.setActive(user, false)" ng-show="user.activated"
+                            ng-disabled="vm.currentAccount.login==user.login" data-translate="userManagement.activated">Activated</button>
                 </td>
                 <% if (enableTranslation) { %><td>{{user.langKey}}</td><% } %>
                 <td>


### PR DESCRIPTION
Like for the user deletion, we can not deactivate our own account in the user management page.
If this is accepted, I can apply it on ng2.

We still can edit our own account with the dialog and deactivate it but it 'requires more clicks'.
or should we disable the deactivation in the user edition as well ?
or nothing of all of this ?
