### PR TITLE
change url from /user/{login} to /{login} avoiding url conflict when …

### DIFF
--- a/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management.state.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management.state.js
@@ -113,7 +113,7 @@
         })
         .state('user-management-detail', {
             parent: 'user-management',
-            url: '/user/{login}',
+            url: '/{login}',
             data: {
                 authorities: ['ROLE_ADMIN'],
                 pageTitle: 'user-management.detail.title'


### PR DESCRIPTION
…login='user'

Similar that the url used for ng2.

Otherwise when login='user' there is a url conflict:
url: 'user/{login}' 
url: '/{login}/delete'

You can click on 'Supprimer' for the user 'user' to see the problem.
