### PR TITLE
adds oauth2 filter order also for uaa server

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -127,7 +127,7 @@ spring:
 security:
     basic:
         enabled: false
-    <%_ if (authenticationType == 'oauth2') { _%>
+    <%_ if (authenticationType == 'oauth2' || authenticationType == 'uaa') { _%>
     oauth2:
         resource:
             filter-order: 3


### PR DESCRIPTION
for the same reason as there, with spring boot 1.5.1 the filter order changed.

we should do a 4.0.7 release very soon do make oauth2 grea..aah working again :smile: 


fix #5285 