### PR TITLE
do not use form-control class for checkbox

### DIFF
--- a/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management-dialog.html
+++ b/generators/entity/templates/client/angularjs/src/main/webapp/app/entities/_entity-management-dialog.html
@@ -87,6 +87,9 @@ var ngValidators = './ng_validators';
                         <button type="button" class="btn btn-default" ng-click="vm.openCalendar('<%=fieldName %>')"><i class="glyphicon glyphicon-calendar"></i></button>
                     </span>
                 </div>
+                <%_ } else if(fieldType == 'Boolean') { _%>
+                <input type="<%= fieldInputType %>" name="<%= fieldName %>" id="field_<%= fieldName %>"
+                          ng-model="vm.<%= entityInstance %>.<%= fieldName %>"/>
                 <%_ } else if(fieldTypeBlobContent == 'text') { _%>
                 <textarea class="form-control" name="<%= fieldName %>" id="field_<%= fieldName %>"
                     ng-model="vm.<%= entityInstance %>.<%= fieldName %>" <%- include(ngValidators) %>></textarea>


### PR DESCRIPTION
it fixes having a big checkbox in the middle using firefox (or chrome not on a mac..)

When using Boolean type in the entity generator

it seems that form-control class is just for textual input:
https://www.w3schools.com/bootstrap/bootstrap_forms.asp