### PR TITLE
to avoid conflict of grabbing websocket port

### DIFF
--- a/generators/client/templates/angular/webpack/_webpack.dev.js
+++ b/generators/client/templates/angular/webpack/_webpack.dev.js
@@ -56,7 +56,14 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         new BrowserSyncPlugin({
             host: 'localhost',
             port: 9000,
-            proxy: 'http://localhost:9060'
+            proxy: {
+                target: 'http://localhost:9060'
+                <% if (websocket === 'spring-websocket') { %>,
+                // When your app also uses web sockets
+                // NOTE: requires 2.8.1 or above
+                ws: true
+                <% } %>
+            }
         }, {
             reload: false
         }),

--- a/generators/client/templates/angular/webpack/_webpack.dev.js
+++ b/generators/client/templates/angular/webpack/_webpack.dev.js
@@ -57,12 +57,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
             host: 'localhost',
             port: 9000,
             proxy: {
-                target: 'http://localhost:9060'
-                <% if (websocket === 'spring-websocket') { %>,
-                // When your app also uses web sockets
-                // NOTE: requires 2.8.1 or above
-                ws: true
-                <% } %>
+                target: 'http://localhost:9060'<% if (websocket === 'spring-websocket') { %>,
+                ws: true<% } %>
             }
         }, {
             reload: false


### PR DESCRIPTION
both the spring-websocket and Browsersync use websocket so they will be grabbing the websocket port. the best way is to separate the Browsersync websocket port to a different one otherwise the spring-websocket will not work in the way as expected.

One typical error would refer to this ticket https://github.com/BrowserSync/browser-sync/issues/625.

this change requires BrowserSync version 2.8.1+