### PR TITLE
fix gradle nodeInstall

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -423,9 +423,9 @@ task stage(dependsOn: 'bootRepackage') {
 
 if (project.hasProperty('nodeInstall')) {
     node {
-        version = '${node_version}'
-        npmVersion = '${npm_version}'
-        yarnVersion = '${yarn_version}'
+        version = "${node_version}"
+        npmVersion = "${npm_version}"
+        yarnVersion = "${yarn_version}"
         download = true
     }
 }


### PR DESCRIPTION
interpolation in groovy takes place in double quote strings, not in single quote strings  
this problem was introduced in https://github.com/jhipster/generator-jhipster/commit/7e72dc66e698a1eed03c5f893af74c712289d5d2