### PR TITLE
remove unnecessary throws clause

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/get_all_template.ejs
@@ -10,8 +10,7 @@
         List<<%= entityClass %>> <%= entityInstancePlural %> = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>();
         return <% if (dto == 'mapstruct') { %><%= entityListToDtoListReference %>(<%= entityInstancePlural %>)<% } else { %><%= entityInstancePlural %><% } %>;<% } %>
     <% } if (pagination != 'no') { %>
-    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(@ApiParam Pageable pageable<% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %>)
-        throws URISyntaxException {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(@ApiParam Pageable pageable<% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get a page of <%= entityClassPlural %>");<% if (viaService) { %>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.findAll(pageable);<% } else { %>
         Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(pageable);<% } %>

--- a/generators/entity/templates/server/src/main/java/package/common/search_template.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/search_template.ejs
@@ -8,8 +8,7 @@
     public List<<%= instanceType %>> search<%= entityClassPlural %>(@RequestParam String query) {
         log.debug("REST request to search <%= entityClassPlural %> for query {}", query);<%- include('search_stream_template', {viaService: viaService}); -%>
     <% } if (pagination != 'no') { %>
-    public ResponseEntity<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, @ApiParam Pageable pageable)
-        throws URISyntaxException {
+    public ResponseEntity<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, @ApiParam Pageable pageable) {
         log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
         Page<<%= entityClass %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>

--- a/generators/server/templates/src/main/java/package/web/rest/_AuditResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_AuditResource.java
@@ -35,10 +35,9 @@ public class AuditResource {
      *
      * @param pageable the pagination information
      * @return the ResponseEntity with status 200 (OK) and the list of AuditEvents in body
-     * @throws URISyntaxException if there is an error to generate the pagination HTTP headers
      */
     @GetMapping
-    public ResponseEntity<List<AuditEvent>> getAll(@ApiParam Pageable pageable) throws URISyntaxException {
+    public ResponseEntity<List<AuditEvent>> getAll(@ApiParam Pageable pageable) {
         Page<AuditEvent> page = auditEventService.findAll(pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/management/audits");
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
@@ -51,14 +50,13 @@ public class AuditResource {
      * @param toDate the end of the time period of AuditEvents to get
      * @param pageable the pagination information
      * @return the ResponseEntity with status 200 (OK) and the list of AuditEvents in body
-     * @throws URISyntaxException if there is an error to generate the pagination HTTP headers
      */
 
     @GetMapping(params = {"fromDate", "toDate"})
     public ResponseEntity<List<AuditEvent>> getByDates(
         @RequestParam(value = "fromDate") LocalDate fromDate,
         @RequestParam(value = "toDate") LocalDate toDate,
-        @ApiParam Pageable pageable) throws URISyntaxException {
+        @ApiParam Pageable pageable) {
 
         Page<AuditEvent> page = auditEventService.findByDates(fromDate.atTime(0, 0), toDate.atTime(23, 59), pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/management/audits");

--- a/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
@@ -152,18 +152,15 @@ public class UserResource {
      *<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
      * @param pageable the pagination information<% } %>
      * @return the ResponseEntity with status 200 (OK) and with body all users
-     * @throws URISyntaxException if the pagination headers couldn't be generated
      */
     @GetMapping("/users")
     @Timed<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
-    public ResponseEntity<List<UserDTO>> getAllUsers(@ApiParam Pageable pageable)
-        throws URISyntaxException {
+    public ResponseEntity<List<UserDTO>> getAllUsers(@ApiParam Pageable pageable) {
         final Page<UserDTO> page = userService.getAllManagedUsers(pageable);
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/users");
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }<% } else { // Cassandra %>
-    public ResponseEntity<List<UserDTO>> getAllUsers()
-        throws URISyntaxException {
+    public ResponseEntity<List<UserDTO>> getAllUsers() {
         final List<UserDTO> userDTOs = userService.getAllManagedUsers();
         return new ResponseEntity<>(userDTOs, HttpStatus.OK);
     }<% } %>

--- a/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_PaginationUtil.java
@@ -18,8 +18,7 @@ public final class PaginationUtil {
     private PaginationUtil() {
     }
 
-    public static HttpHeaders generatePaginationHttpHeaders(Page page, String baseUrl)
-        throws URISyntaxException {
+    public static HttpHeaders generatePaginationHttpHeaders(Page page, String baseUrl) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("X-Total-Count", "" + Long.toString(page.getTotalElements()));
@@ -42,13 +41,12 @@ public final class PaginationUtil {
         return headers;
     }
 
-    private static String generateUri(String baseUrl, int page, int size) throws URISyntaxException {
+    private static String generateUri(String baseUrl, int page, int size) {
         return UriComponentsBuilder.fromUriString(baseUrl).queryParam("page", page).queryParam("size", size).toUriString();
     }
     <%_ if (searchEngine === 'elasticsearch') { _%>
 
-    public static HttpHeaders generateSearchPaginationHttpHeaders(String query, Page page, String baseUrl)
-        throws URISyntaxException {
+    public static HttpHeaders generateSearchPaginationHttpHeaders(String query, Page page, String baseUrl) {
 
         HttpHeaders headers = new HttpHeaders();
         headers.add("X-Total-Count", "" + page.getTotalElements());


### PR DESCRIPTION
Actually those functions throw the URISyntaxException no more, so the throws clause is unnecessary