### PR TITLE
add missing spaces in french translation

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/fr/home.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/home.json
@@ -5,7 +5,7 @@
         "logged": {
             "message": "Vous êtes connecté en tant que \"{{username}}\"."
         },
-        "question": "Si vous avez des questions à propos de JHipster:",
+        "question": "Si vous avez des questions à propos de JHipster :",
         "link": {
             "homepage": "Page d'accueil de JHipster",
             "stackoverflow": "JHipster sur Stack Overflow",
@@ -14,6 +14,6 @@
             "follow": "Suivez @java_hipster sur Twitter"
         },
         "like": "Si vous aimez JHipster, donnez nous une étoile sur",
-        "github": "GitHub"
+        "github": "GitHub "
     }
 }

--- a/generators/languages/templates/src/main/webapp/i18n/fr/login.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/login.json
@@ -9,7 +9,7 @@
         },
         "messages": {
             "error": {
-                "authentication": "<strong>Erreur d'authentification!</strong> Veuillez vérifier vos identifiants de connexion."
+                "authentication": "<strong>Erreur d'authentification !</strong> Veuillez vérifier vos identifiants de connexion."
             }
         },
         "password" : {


### PR DESCRIPTION
Respectons notre belle langue :)

Not optimal for `Github` because the href link has got an extra space even if the typo is respected.