### PR TITLE
Suppress false positive Sonar warning

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/vm/_LoginVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/vm/_LoginVM.java
@@ -46,6 +46,7 @@ public class LoginVM {
     }
 
     @Override
+    @SuppressWarnings("squid:S2068") // The hard-coded password is actually hidden here...
     public String toString() {
         return "LoginVM{" +
             "username='" + username + '\'' +


### PR DESCRIPTION
Sonar considers it as a blocker vulnerability and gives you a "E" mark which is quite unfair...