### PR TITLE
Fixing "Ambiguous mapping methods found for mapping property" error w…

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/service/mapper/_EntityMapper.java
+++ b/generators/entity/templates/server/src/main/java/package/service/mapper/_EntityMapper.java
@@ -47,7 +47,7 @@ for (idx in relationships) {
     List<<%= entityClass %>> <%= entityInstance %>DTOsTo<%= entityClassPlural %>(List<<%= entityClass %>DTO> <%= entityInstance %>DTOs);
     /**
      * generating the fromId for all mappers if the databaseType is sql, as the class has relationship to it might need it, instead of
-     * creating a new attribute to know if the enitity has any relationship from someother entity
+     * creating a new attribute to know if the entity has any relationship from some other entity
      */
      <%if(databaseType === 'sql') { %>
     default <%= entityClass %> <%= entityInstance %>FromId(Long id) {

--- a/generators/entity/templates/server/src/main/java/package/service/mapper/_EntityMapper.java
+++ b/generators/entity/templates/server/src/main/java/package/service/mapper/_EntityMapper.java
@@ -47,9 +47,10 @@ for (idx in relationships) {
     List<<%= entityClass %>> <%= entityInstance %>DTOsTo<%= entityClassPlural %>(List<<%= entityClass %>DTO> <%= entityInstance %>DTOs);
 
     /**
-     * generating the fromId for all mappers, as the class has relationship to it might need it, instead of
+     * generating the fromId for all mappers if the databaseType is sql, as the class has relationship to it might need it, instead of
      * creating a new attribute to know if the enitity has any relationship from someother entity
      */
+     <%if(databaseType === 'sql') { %>
     default <%= entityClass %> <%= entityInstance %>FromId(Long id) {
         if (id == null) {
             return null;
@@ -58,5 +59,6 @@ for (idx in relationships) {
         <%= entityInstance %>.setId(id);
         return <%= entityInstance %>;
     }
+    <%}%>
 
 }

--- a/generators/entity/templates/server/src/main/java/package/service/mapper/_EntityMapper.java
+++ b/generators/entity/templates/server/src/main/java/package/service/mapper/_EntityMapper.java
@@ -9,8 +9,13 @@ import java.util.List;
 /**
  * Mapper for the entity <%= entityClass %> and its DTO <%= entityClass %>DTO.
  */
-@Mapper(componentModel = "spring", uses = {<% for (idx in relationships) {
-    if ((relationships[idx].relationshipType == 'many-to-many' && relationships[idx].ownerSide == true) || relationships[idx].otherEntityNameCapitalized == 'User') { %><%= relationships[idx].otherEntityNameCapitalized %>Mapper.class, <% } } %>})
+@Mapper(componentModel = "spring", uses = {<% var existingMappings = [];
+  for (idx in relationships) {
+    if ((relationships[idx].relationshipType == 'many-to-many' && relationships[idx].ownerSide == true)|| relationships[idx].relationshipType == 'many-to-one' ||(relationships[idx].relationshipType == 'one-to-one' && relationships[idx].ownerSide == true)){
+      // if the entity is mapped twice, we should implement the mapping once
+      if (existingMappings.indexOf(relationships[idx].otherEntityNameCapitalized) == -1 && relationships[idx].otherEntityNameCapitalized !== entityClass) {
+          existingMappings.push(relationships[idx].otherEntityNameCapitalized);
+      %><%= relationships[idx].otherEntityNameCapitalized %>Mapper.class, <% } } } %>})
 public interface <%= entityClass %>Mapper {
 <%
 // entity -> DTO mapping
@@ -39,27 +44,19 @@ for (idx in relationships) {
     @Mapping(target = "<%= relationshipName %>", ignore = true)<% } } %>
     <%= entityClass %> <%= entityInstance %>DTOTo<%= entityClass %>(<%= entityClass %>DTO <%= entityInstance %>DTO);
 
-    List<<%= entityClass %>> <%= entityInstance %>DTOsTo<%= entityClassPlural %>(List<<%= entityClass %>DTO> <%= entityInstance %>DTOs);<%
+    List<<%= entityClass %>> <%= entityInstance %>DTOsTo<%= entityClassPlural %>(List<<%= entityClass %>DTO> <%= entityInstance %>DTOs);
 
-// the user mapping is imported in the @Mapper annotation
-var existingMappings = ['user'];
-for (idx in relationships) {
-    var relationshipType = relationships[idx].relationshipType;
-    var otherEntityName = relationships[idx].otherEntityName;
-    var otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-    var ownerSide = relationships[idx].ownerSide;
-    if (relationshipType == 'many-to-one' || (relationshipType == 'one-to-one' && ownerSide == true) || (relationshipType == 'many-to-many' && ownerSide == true)) {
-        // if the entity is mapped twice, we should implement the mapping once
-        if (existingMappings.indexOf(otherEntityName) == -1) {
-            existingMappings.push(otherEntityName);
-    %>
-
-    default <%= otherEntityNameCapitalized %> <%= otherEntityName %>FromId(Long id) {
+    /**
+     * generating the fromId for all mappers, as the class has relationship to it might need it, instead of
+     * creating a new attribute to know if the enitity has any relationship from someother entity
+     */
+    default <%= entityClass %> <%= entityInstance %>FromId(Long id) {
         if (id == null) {
             return null;
         }
-        <%= otherEntityNameCapitalized %> <%= otherEntityName %> = new <%= otherEntityNameCapitalized %>();
-        <%= otherEntityName %>.setId(id);
-        return <%= otherEntityName %>;
-    }<% } } } %>
+        <%= entityClass %> <%= entityInstance %> = new <%= entityClass %>();
+        <%= entityInstance %>.setId(id);
+        return <%= entityInstance %>;
+    }
+
 }

--- a/test/templates/import-jdl/jdl-ambiguous.jdl
+++ b/test/templates/import-jdl/jdl-ambiguous.jdl
@@ -1,0 +1,54 @@
+
+entity WishList {
+    name String,
+    description String
+}
+
+relationship OneToMany {
+    Profile {
+        wishList
+    }
+    to WishList
+}
+
+relationship ManyToMany {
+    WishList {
+        listing
+    }
+    to Listing
+}
+
+
+entity Profile {
+    name String,
+    description String
+}
+
+relationship OneToOne {
+    Profile {
+        user
+    }
+    to User
+}
+
+relationship ManyToOne {
+    Listing {
+        host(name)
+    }
+    to Profile
+}
+
+
+entity Listing {
+    name String,
+    description String
+}
+
+
+
+dto * with mapstruct
+
+// Set service options to all except few
+service all with serviceImpl 
+// Set an angular suffix
+angularSuffix * with mySuffix

--- a/test/test-import-jdl.js
+++ b/test/test-import-jdl.js
@@ -37,7 +37,7 @@ describe('JHipster generator import jdl', function () {
                 .inTmpDir(function (dir) {
                     fse.copySync(path.join(__dirname, '../test/templates/import-jdl'), dir);
                 })
-                .withArguments(['jdl.jdl', 'jdl2.jdl'])
+                .withArguments(['jdl.jdl', 'jdl2.jdl', 'jdl-ambiguous.jdl'])
                 .on('end', done);
         });
 
@@ -52,7 +52,11 @@ describe('JHipster generator import jdl', function () {
                 '.jhipster/Country.json',
                 '.jhipster/Region.json',
                 '.jhipster/DepartmentAlt.json',
-                '.jhipster/JobHistoryAlt.json'
+                '.jhipster/JobHistoryAlt.json',
+                '.jhipster/Listing.json',
+                '.jhipster/Profile.json',
+                '.jhipster/WishList.json'
+
             ]);
         });
     });


### PR DESCRIPTION
…hile compiling the mappers of DTOs created using mapstruct

Changed EntityMapper generation to create the source mapper than creating in target mapper class and
 add the appropriate mappers in the maptstruct @Uses.This will eliminate the ambiguous methods in target mapper class

Fix #5403