### PR TITLE
add quick method for recompiling vendor part

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -119,6 +119,7 @@
     "start": "<%= clientPackageManager %> run webpack:dev",
     "webpack:build": "webpack --config webpack/webpack.vendor.js && webpack --config webpack/webpack.dev.js",
     "webpack:build:dev": "webpack --config webpack/webpack.dev.js",
+    "webpack:build:vendor": "webpack --config webpack/webpack.vendor.js",
     "webpack:dev": "webpack-dev-server --config webpack/webpack.dev.js  --progress --inline --hot --profile --port=9060",
     "webpack:prod": "<%= clientPackageManager %> test && webpack -p --config webpack/webpack.vendor.js && webpack -p --config webpack/webpack.prod.js",
     "test": "<%= clientPackageManager %> run lint && karma start src/test/javascript/karma.conf.js",

--- a/generators/client/templates/angular/src/main/webapp/app/_vendor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_vendor.ts
@@ -1,4 +1,4 @@
-/* after changing this file run '<%= clientPackageManager %> install' or '<%= clientPackageManager %> run webpack:build' */
+/* after changing this file run '<%= clientPackageManager %> run webpack:build:vendor' or '<%= clientPackageManager %> install' or '<%= clientPackageManager %> run webpack:build' */
 /* tslint:disable */
 <%_ if (useSass) { _%>
 import '../content/scss/vendor.scss';

--- a/generators/client/templates/angular/src/main/webapp/content/css/_vendor.css
+++ b/generators/client/templates/angular/src/main/webapp/content/css/_vendor.css
@@ -1,4 +1,4 @@
-/* after changing this file run '<%= clientPackageManager %> install' or '<%= clientPackageManager %> run webpack:build' */
+/* after changing this file run '<%= clientPackageManager %> run webpack:build:vendor' or '<%= clientPackageManager %> install' or '<%= clientPackageManager %> run webpack:build' */
 @import '~bootstrap/dist/css/bootstrap.min.css';
 @import '~font-awesome/css/font-awesome.css';
 

--- a/generators/client/templates/angular/src/main/webapp/content/scss/_vendor.scss
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/_vendor.scss
@@ -1,4 +1,4 @@
-/* after changing this file run '<%= clientPackageManager %> install' or '<%= clientPackageManager %> run webpack:build' */
+/* after changing this file run '<%= clientPackageManager %> run webpack:build:vendor' or '<%= clientPackageManager %> install' or '<%= clientPackageManager %> run webpack:build' */
 $fa-font-path: '~font-awesome/fonts';
 
 /***************************


### PR DESCRIPTION
`webpack:build` recompiles whole project - it's annoyingly slow if repeatedly changing-debugging some third party lib
new task `webpack:build:vendor` compiles only vendor part and is very quick