### PR TITLE
Tezcane edits and fixes

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
@@ -15,7 +15,7 @@
                 <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="email"<% } %>><span jhiTranslate="userManagement.email">Email</span><% if (databaseType !== 'cassandra') { %> <span class="fa fa-sort"></span><% } %></th>
                 <th></th>
                 <%_ if (enableTranslation) { _%>
-                <th <% if (databaseType !== 'cassandra') { %> jhiSortBy="langKey"<% } %>> <span jhiTranslate="userManagement.langKey">Lang Key</span><% if (databaseType !== 'cassandra') { %> <span class="fa fa-sort"></span><% } %></th>
+                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="langKey"<% } %>> <span jhiTranslate="userManagement.langKey">Lang Key</span><% if (databaseType !== 'cassandra') { %> <span class="fa fa-sort"></span><% } %></th>
                 <%_ } _%>
                 <th><span jhiTranslate="userManagement.profiles">Profiles</span></th>
                 <%_ if (databaseType !== 'cassandra') { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.ts
@@ -34,7 +34,8 @@ export class UserMgmtComponent implements OnInit, OnDestroy {
         private parseLinks: ParseLinks,
         private alertService: AlertService,
         private principal: Principal,
-        private eventManager: EventManager,<%_ if (databaseType !== 'cassandra') { _%>
+        private eventManager: EventManager,
+        <%_ if (databaseType !== 'cassandra') { _%>
         private paginationUtil: PaginationUtil,
         private paginationConfig: PaginationConfig,
         <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
@@ -3,7 +3,7 @@ import { Router } from '@angular/router';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { JhiLanguageService } from 'ng-jhipster';
 
-import { ProfileService } from '../profiles/profile.service'; // FIXME barrel doesnt work here
+import { ProfileService } from '../profiles/profile.service'; // FIXME barrel doesn't work here
 import { <% if (enableTranslation) { %>JhiLanguageHelper, <% } %>Principal, LoginModalService, LoginService } from '../../shared';
 
 import { VERSION, DEBUG_INFO_ENABLED } from '../../app.constants';

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_principal.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_principal.service.ts
@@ -3,7 +3,7 @@ import { Observable } from 'rxjs/Observable';
 import { Subject } from 'rxjs/Subject';
 import { AccountService } from './account.service';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service'; // Barrel doesnt work here. No idea why!
+import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service'; // Barrel doesn't work here. No idea why!
 <%_ } _%>
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
@@ -77,7 +77,7 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements OnInit, Aft
             });
 
             // // previousState was set in the authExpiredInterceptor before being redirected to login modal.
-            // // since login is succesful, go to stored previousState and clear previousState
+            // // since login is successful, go to stored previousState and clear previousState
             let previousState = this.stateStorageService.getPreviousState();
             if (previousState) {
                 this.stateStorageService.resetPreviousState();

--- a/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/tracker/_tracker.service.ts
@@ -42,7 +42,7 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
         if (this.connectedPromise === null) {
           this.connection = this.createConnection();
         }
-        // building absolute path so that websocket doesnt fail when deploying with a context path
+        // building absolute path so that websocket doesn't fail when deploying with a context path
         const loc = this.$window.location;
         let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
         <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa' || authenticationType === 'oauth2') { _%>

--- a/generators/client/templates/angularjs/src/main/webapp/app/admin/tracker/_tracker.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/admin/tracker/_tracker.service.js
@@ -27,7 +27,7 @@
         return service;
 
         function connect () {
-            //building absolute path so that websocket doesnt fail when deploying with a context path
+            //building absolute path so that websocket doesn't fail when deploying with a context path
             var loc = $window.location;
             var url = '//' + loc.host + loc.pathname + 'websocket/tracker';<% if (authenticationType === 'oauth2') { %>
             /*jshint camelcase: false */

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1511,7 +1511,7 @@ module.exports = class extends Generator {
                 done();
             });
         } catch (err) {
-            // fail silently as this function doesnt affect normal generator flow
+            // fail silently as this function doesn't affect normal generator flow
         }
     }
 

--- a/generators/languages/templates/src/main/webapp/i18n/en/_activate.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/_activate.json
@@ -3,9 +3,9 @@
         "title": "Activation",
         "messages": {
             <%_ if (clientFramework === 'angular1') { _%>
-            "success": "<strong>Your user has been activated.</strong> Please <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">sign in</a>.",
+            "success": "<strong>Your user account has been activated.</strong> Please <a class=\"alert-link\" href=\"\" ng-click=\"vm.login()\">sign in</a>.",
             <%_ } else { _%>
-            "success": "<strong>Your user has been activated.</strong> Please ",
+            "success": "<strong>Your user account has been activated.</strong> Please sign in.",
             <%_ } _%>
             "error": "<strong>Your user could not be activated.</strong> Please use the registration form to sign up."
         }

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1150,7 +1150,7 @@
                         </lifecycleMappingMetadata>
                     </configuration>
                 </plugin>
-             </plugins>
+            </plugins>
         </pluginManagement>
     </build>
     <profiles>

--- a/generators/server/templates/src/main/java/package/domain/_User.java
+++ b/generators/server/templates/src/main/java/package/domain/_User.java
@@ -85,7 +85,7 @@ public class User<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
     private String lastName;
 
     @Email
-    @Size(max = 100)<% if (databaseType == 'sql') { %>
+    @Size(min = 5, max = 100)<% if (databaseType == 'sql') { %>
     @Column(length = 100, unique = true)<% } %><% if (databaseType == 'mongodb') { %>
     @Indexed<% } %>
     private String email;
@@ -279,11 +279,7 @@ public class User<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
 
         User user = (User) o;
 
-        if (!login.equals(user.login)) {
-            return false;
-        }
-
-        return true;
+        return login.equals(user.login);
     }
 
     @Override

--- a/generators/server/templates/src/main/java/package/gateway/ratelimiting/_RateLimitingFilter.java
+++ b/generators/server/templates/src/main/java/package/gateway/ratelimiting/_RateLimitingFilter.java
@@ -7,7 +7,6 @@ import io.github.jhipster.config.JHipsterProperties;
 import java.util.Calendar;
 import java.util.Date;
 import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/generators/server/templates/src/main/java/package/service/_UserService.java
+++ b/generators/server/templates/src/main/java/package/service/_UserService.java
@@ -215,13 +215,19 @@ public class UserService {
      * @param lastName last name of user
      * @param email email id of user
      * @param langKey language key
+     <%_ if (databaseType == 'mongodb' || databaseType == 'sql') { _%>
+     * @param imageUrl image URL of user
+     <%_ } _%>
      */
-    public void updateUser(String firstName, String lastName, String email, String langKey) {
+    public void updateUser(String firstName, String lastName, String email, String langKey<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, String imageUrl<% } %>) {
         userRepository.findOneByLogin(SecurityUtils.getCurrentUserLogin()).ifPresent(user -> {
             user.setFirstName(firstName);
             user.setLastName(lastName);
             user.setEmail(email);
             user.setLangKey(langKey);
+            <%_ if (databaseType == 'mongodb' || databaseType == 'sql') { _%>
+            user.setImageUrl(imageUrl);
+            <%_ } _%>
             <%_ if (databaseType == 'mongodb' || databaseType == 'cassandra') { _%>
             userRepository.save(user);
             <%_ } _%>
@@ -263,6 +269,9 @@ public class UserService {
                 <%_ if (databaseType == 'mongodb' || databaseType == 'cassandra') { _%>
                 userRepository.save(user);
                 <%_ } _%>
+                <%_ if (searchEngine == 'elasticsearch') { _%>
+                userSearchRepository.save(user);
+                <%_ } _%>
                 log.debug("Changed Information for User: {}", user);
                 return user;
             })
@@ -298,8 +307,9 @@ public class UserService {
     }
 
     <%_ if (databaseType == 'sql') { _%>
-    @Transactional(readOnly = true)<%_ } _%>
-    <% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+    @Transactional(readOnly = true)
+    <%_ } _%>
+    <%_ if (databaseType == 'sql' || databaseType == 'mongodb') { _%>
     public Page<UserDTO> getAllManagedUsers(Pageable pageable) {
         return userRepository.findAllByLoginNot(pageable, Constants.ANONYMOUS_USER).map(UserDTO::new);
     }<% } else { // Cassandra %>

--- a/generators/server/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -152,7 +152,7 @@ public class AccountResource {
             .findOneByLogin(SecurityUtils.getCurrentUserLogin())
             .map(u -> {
                 userService.updateUser(userDTO.getFirstName(), userDTO.getLastName(), userDTO.getEmail(),
-                    userDTO.getLangKey());
+                    userDTO.getLangKey()<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, userDTO.getImageUrl()<% } %>);
                 return new ResponseEntity(HttpStatus.OK);
             })
             .orElseGet(() -> new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR));

--- a/generators/server/templates/src/main/java/package/web/rest/vm/_ManagedUserVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/vm/_ManagedUserVM.java
@@ -29,7 +29,7 @@ public class ManagedUserVM extends UserDTO {
                          <% if (databaseType == 'mongodb' || databaseType == 'sql') { %>String createdBy, ZonedDateTime createdDate, String lastModifiedBy, ZonedDateTime lastModifiedDate,
                         <% } %>Set<String> authorities) {
 
-        super(id, login, firstName, lastName, email, activated<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>,  imageUrl<% } %>, langKey,
+        super(id, login, firstName, lastName, email, activated<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, imageUrl<% } %>, langKey,
             <% if (databaseType == 'mongodb' || databaseType == 'sql') { %>createdBy, createdDate, lastModifiedBy, lastModifiedDate,  <% } %>authorities);
 
         this.password = password;

--- a/generators/server/templates/src/main/resources/mails/creationEmail.html
+++ b/generators/server/templates/src/main/resources/mails/creationEmail.html
@@ -12,8 +12,8 @@
             Your JHipster account has been created, please click on the URL below to access it:
         </p>
         <p>
-          <a th:href="@{|${baseUrl}/#/reset/finish?key=${user.resetKey}|}"
-             th:text="|${user.login}|">login</a>
+            <a th:href="@{|${baseUrl}/#/activate?key=${user.activationKey}|}"
+               th:text="|${user.login}|">login</a>
         </p>
         <p>
             <span th:text="#{email.activation.text2}">Regards, </span>

--- a/generators/server/templates/src/test/java/package/web/rest/_AccountResourceIntTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_AccountResourceIntTest.java
@@ -124,6 +124,7 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
         <%_ if (databaseType == 'mongodb' || databaseType == 'sql') { _%>
         user.setImageUrl("http://placehold.it/50x50");
         <%_ } _%>
+        user.setLangKey("en");
         user.setAuthorities(authorities);
         when(mockUserService.getUserWithAuthorities()).thenReturn(user);
 
@@ -138,6 +139,7 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
             <%_ if (databaseType == 'mongodb' || databaseType == 'sql') { _%>
             .andExpect(jsonPath("$.imageUrl").value("http://placehold.it/50x50"))
             <%_ } _%>
+            .andExpect(jsonPath("$.langKey").value("en"))
             .andExpect(jsonPath("$.authorities").value(AuthoritiesConstants.ADMIN));
     }
 
@@ -307,7 +309,7 @@ public class AccountResourceIntTest <% if (databaseType == 'cassandra') { %>exte
             new HashSet<>(Arrays.asList(AuthoritiesConstants.USER)));
 
         // Duplicate login, different e-mail
-        ManagedUserVM duplicatedUser = new ManagedUserVM(validUser.getId(), validUser.getLogin(), validUser.getPassword(), validUser.getLogin(), validUser.getLastName(),
+        ManagedUserVM duplicatedUser = new ManagedUserVM(validUser.getId(), validUser.getLogin(), validUser.getPassword(), validUser.getFirstName(), validUser.getLastName(),
             "alicejr@example.com", true<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, validUser.getImageUrl()<% } %>, validUser.getLangKey()<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, validUser.getCreatedBy(), validUser.getCreatedDate(), validUser.getLastModifiedBy(), validUser.getLastModifiedDate()<% } %>, validUser.getAuthorities());
 
         // Good user

--- a/generators/server/templates/src/test/java/package/web/rest/_ProfileInfoResourceIntTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_ProfileInfoResourceIntTest.java
@@ -10,7 +10,6 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.core.env.Environment;
 import org.springframework.http.MediaType;

--- a/generators/server/templates/src/test/java/package/web/rest/_UserResourceIntTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_UserResourceIntTest.java
@@ -167,8 +167,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
         // Create the User
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             null,
             DEFAULT_LOGIN,
@@ -187,7 +187,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             null,
             null,
             <%_ } _%>
-            autorities);
+            authorities);
 
         restUserMockMvc.perform(post("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -215,8 +215,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
     public void createUserWithExistingId() throws Exception {
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             <%_ if (databaseType === 'cassandra') { _%>
             UUID.randomUUID().toString(),
@@ -241,7 +241,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             null,
             null,
             <%_ } _%>
-            autorities);
+            authorities);
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restUserMockMvc.perform(post("/api/users")
@@ -266,8 +266,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         <%_ } _%>
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             null,
             DEFAULT_LOGIN, // this login should already be used
@@ -286,7 +286,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             null,
             null,
             <%_ } _%>
-            autorities);
+            authorities);
 
         // Create the User
         restUserMockMvc.perform(post("/api/users")
@@ -311,8 +311,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         <%_ } _%>
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             null,
             "anotherlogin",
@@ -331,7 +331,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             null,
             null,
             <%_ } _%>
-            autorities);
+            authorities);
 
         // Create the User
         restUserMockMvc.perform(post("/api/users")
@@ -419,8 +419,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             updatedUser.getId(),
             updatedUser.getLogin(),
@@ -439,7 +439,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             updatedUser.getLastModifiedBy(),
             updatedUser.getLastModifiedDate(),
             <%_ } _%>
-            autorities);
+            authorities);
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -474,8 +474,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             updatedUser.getId(),
             UPDATED_LOGIN,
@@ -494,7 +494,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             updatedUser.getLastModifiedBy(),
             updatedUser.getLastModifiedDate(),
             <%_ } _%>
-            autorities);
+            authorities);
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -545,13 +545,11 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         userSearchRepository.save(anotherUser);
         <%_ } _%>
 
-        int databaseSizeBeforeUpdate = userRepository.findAll().size();
-
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             updatedUser.getId(),
             updatedUser.getLogin(),
@@ -570,7 +568,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             updatedUser.getLastModifiedBy(),
             updatedUser.getLastModifiedDate(),
             <%_ } _%>
-            autorities);
+            authorities);
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -607,13 +605,12 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         <%_ if (searchEngine === 'elasticsearch') { _%>
         userSearchRepository.save(anotherUser);
         <%_ } _%>
-        int databaseSizeBeforeUpdate = userRepository.findAll().size();
 
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> autorities = new HashSet<>();
-        autorities.add("ROLE_USER");
+        Set<String> authorities = new HashSet<>();
+        authorities.add("ROLE_USER");
         ManagedUserVM managedUserVM = new ManagedUserVM(
             updatedUser.getId(),
             "jhipster", // this login should already be used by anotherUser
@@ -632,7 +629,7 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
             updatedUser.getLastModifiedBy(),
             updatedUser.getLastModifiedDate(),
             <%_ } _%>
-            autorities);
+            authorities);
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "devDependencies": {
     "eslint": "3.17.1",
     "eslint-config-airbnb-base": "11.1.1",
-    "eslint-plugin-import": "2.2.0",
+    "eslint-plugin-import": "^2.2.0",
     "fs-extra": "2.1.0",
     "mocha": "3.2.0",
     "yeoman-assert": "3.0.0",


### PR DESCRIPTION
Not sure if my commit message came out right, here it is again:

Fix missing imageUrl and elasticsearch saves, unit test fixes and various code cleanup


 Bugs Fixes

UserService.updateUser()+AccountResource.saveAccount(): Add imageUrl update ability to mongo and sql
    - There was no way for imageUrl to be updated by user.
UserService.updateUser(UserDTO userDTO): elasticsearch save so "User management" items can refresh
    - Without this, UI data is stale since "User managment" main page does elasticsearch query
creationEmail.html: Fix link from password reset key to account activation key
User.java: Add email Size min = 5 annotation restriction
AccountResourceIntTest.testRegisterDuplicateLogin(): Fix "getLogin()" to "getLastName()"
AccountResourceIntTest.testGetExistingAccount(): add missing langKey insertion and check

Code Cleanup

User.equals(): replace if else block with "return login.equals(user.login)"
activate.json: "Your user has been activated." to "Your user account has been activated."
activate.json: "Please" to "Please sign in."
comment updates: "succesful" to "successful" and "doesnt" to "doesn't"
ManagedUserVM.java: ",  imageUrl" to ", imageUrl"
pom.xml: " </plugins" to "</plugins" (one extra space above </pluginManagement) 
ProfileInfoResourceIntTest.java: remove unused import ...beans.factory.annotation.Autowired;
RateLimiting.java:  remove unused import ... javax.servlet.http.HttpServletResponse;
user-management.components.ts: constructor alignment fixed
user-management.components.html: "<th  " to "<th "
UserResourceIntTest.java: rename "autorities" to "authorities" across file
UserResourceIntTest.updateUserExistingEmail(): remove unused variable "databaseSizeBeforeUpdate"
UserResourceIntTest.updateUserExistingLogin(): remove unused variable "databaseSizeBeforeUpdate"
UserService.java: "@Transactional(readOnly = true)    " to "@Transactional(readOnly = true)"

Fix new issues only