### PR TITLE
Removing throws clause to resolve "sonar" bug

### DIFF
--- a/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/social/_SocialConfiguration.java
@@ -132,7 +132,7 @@ public class SocialConfiguration implements SocialConfigurer {
     }
 
     @Bean
-    public ProviderSignInController providerSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter) throws Exception {
+    public ProviderSignInController providerSignInController(ConnectionFactoryLocator connectionFactoryLocator, UsersConnectionRepository usersConnectionRepository, SignInAdapter signInAdapter) {
         ProviderSignInController providerSignInController = new ProviderSignInController(connectionFactoryLocator, usersConnectionRepository, signInAdapter);
         providerSignInController.setSignUpUrl("/social/signup");
         providerSignInController.setApplicationUrl(environment.getProperty("spring.application.url"));


### PR DESCRIPTION
Removing unnecessary throws clause to resolve sonar reported bug(major) "Define and throw a dedicated exception instead of using a generic one".