### PR TITLE
properly template oauth_client_details.csv

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -474,7 +474,7 @@ function writeFiles() {
                 this.copy(`${SERVER_MAIN_RES_DIR}config/liquibase/authorities.csv`, `${SERVER_MAIN_RES_DIR}config/liquibase/authorities.csv`);
                 this.copy(`${SERVER_MAIN_RES_DIR}config/liquibase/users_authorities.csv`, `${SERVER_MAIN_RES_DIR}config/liquibase/users_authorities.csv`);
                 if (this.authenticationType === 'oauth2') {
-                    this.copy(`${SERVER_MAIN_RES_DIR}config/liquibase/oauth_client_details.csv`, `${SERVER_MAIN_RES_DIR}config/liquibase/oauth_client_details.csv`);
+                    this.template(`${SERVER_MAIN_RES_DIR}config/liquibase/oauth_client_details.csv`, `${SERVER_MAIN_RES_DIR}config/liquibase/oauth_client_details.csv`);
                 }
             }
 


### PR DESCRIPTION
Oauth2 apps are currently broken as the database has `<%= baseName %>` instead of the actual baseName.  This started happening in v4.1.0 (it's fine in v4.0.8)