### PR TITLE
Added missing _enum_nl.json file for the Dutch language

### DIFF
--- a/generators/entity/templates/client/i18n/_enum_nl.json
+++ b/generators/entity/templates/client/i18n/_enum_nl.json
@@ -1,0 +1,8 @@
+{
+    "<%= angularAppName %>": {
+        "<%= enumName %>" : {
+            "null": ""<% for (enumId in enums) { %>,
+            "<%=enums[enumId]%>": "<%=enums[enumId]%>"<% } %>
+        }
+    }
+}


### PR DESCRIPTION
There is no `_enum_nl.json` file. This breaks the JDL parser (and probably also the entity generator) when adding an enum with i18n support for Dutch.