### PR TITLE
Fix LoggingConfiguration log enriching

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -21,25 +21,27 @@ public class LoggingConfiguration {
 
     private LoggerContext context = (LoggerContext) LoggerFactory.getILoggerFactory();
 
-    @Value("${spring.application.name}")
-    private String appName;
+    private final String appName;
 
-    @Value("${server.port}")
-    private String serverPort;
-    <%_ if (serviceDiscoveryType == "eureka") { _%>
+    private final String serverPort;
+    <%_ if (serviceDiscoveryType === "eureka") { _%>
 
-    @Value("${eureka.instance.instanceId}")
-    private String instanceId;
+    private final String instanceId;
     <%_ } _%>
-    <%_ if (serviceDiscoveryType == "consul") { _%>
+    <%_ if (serviceDiscoveryType === "consul") { _%>
 
-    @Value("${spring.cloud.consul.discovery.instanceId}")
-    private String instanceId;
+    private final String instanceId;
     <%_ } _%>
 
     private final JHipsterProperties jHipsterProperties;
 
-    public LoggingConfiguration(JHipsterProperties jHipsterProperties) {
+    public LoggingConfiguration(@Value("${spring.application.name}") String appName, @Value("${server.port}") String serverPort,
+        <% if (serviceDiscoveryType === "eureka") { %>@Value("${eureka.instance.instanceId}") String instanceId,<% } %><% if (serviceDiscoveryType === "consul") { %>@Value("${spring.cloud.consul.discovery.instanceId}") String instanceId,<% } %> JHipsterProperties jHipsterProperties) {
+        this.appName = appName;
+        this.serverPort = serverPort;
+        <%_ if (serviceDiscoveryType !== false) { _%>
+        this.instanceId = instanceId;
+        <%_ } _%>
         this.jHipsterProperties = jHipsterProperties;
         if (jHipsterProperties.getLogging().getLogstash().isEnabled()) {
             addLogstashAppender(context);


### PR DESCRIPTION
Logstash log enriching with application name, port, etc was broken by the migration to constructor injection.

This caused things like this in Kibana:

![screen shot 2017-03-23 at 12 28 57](https://cloud.githubusercontent.com/assets/513471/24245795/a2f52f94-0fc4-11e7-8ccc-60cbc8cded82.png)


This PR fixes the issue.