### PR TITLE
[5471] options are now passed when importing JDL files

### DIFF
--- a/generators/import-jdl/index.js
+++ b/generators/import-jdl/index.js
@@ -75,7 +75,11 @@ module.exports = JDLGenerator.extend({
                     this.composeWith(require.resolve('../entity'), {
                         regenerate: true,
                         'skip-install': true,
-                        arguments: [entity.name]
+                        'skip-client': entity.definition.skipClient,
+                        'skip-server': entity.definition.skipServer,
+                        'no-fluent-methods': entity.definition.noFluentMethod,
+                        'skip-user-management': entity.definition.skipUserManagement,
+                        arguments: [entity.name],
                     });
                 });
             } catch (e) {


### PR DESCRIPTION
@jdubois @deepu105 A warning: the trick I used to make it work consists in actually writing the options in the JSON files. If you're not okay with this, I'll try to tweak the `index.js` a bit more so as not to do this, but I'd rather not to.