### PR TITLE
Modify ParameterizedErrorVM to support client-side interpolation of multiple params

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/_alert-error.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/_alert-error.component.ts
@@ -62,7 +62,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                                 'Field ' + fieldName + ' cannot be empty', 'error.' + fieldError.message, {fieldName: fieldName});
                         }
                     } else if (httpResponse.text() !== '' && httpResponse.json() && httpResponse.json().message) {
-                        this.addErrorAlert(httpResponse.json().message, httpResponse.json().message, httpResponse.json());
+                        this.addErrorAlert(httpResponse.json().message, httpResponse.json().message, httpResponse.json().params);
                     } else {
                         this.addErrorAlert(httpResponse.text());
                     }

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
@@ -11,7 +11,7 @@ package <%=packageName%>.web.rest.errors;
  * Can be translated with:
  *
  * <pre>
- * "error.myCustomError" :  "The server says {{params0}} to {{params1}}"
+ * "error.myCustomError" :  "The server says {{params.param0}} to {{params.param1}}"
  * </pre>
  */
 public class CustomParameterizedException extends RuntimeException {

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
@@ -1,5 +1,8 @@
 package <%=packageName%>.web.rest.errors;
 
+import java.util.HashMap;
+import java.util.Map;
+
 /**
  * Custom, parameterized exception, which can be translated on the client side.
  * For example:

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
@@ -11,7 +11,7 @@ package <%=packageName%>.web.rest.errors;
  * Can be translated with:
  *
  * <pre>
- * "error.myCustomError" :  "The server says {{params[0]}} to {{params[1]}}"
+ * "error.myCustomError" :  "The server says {{params0}} to {{params1}}"
  * </pre>
  */
 public class CustomParameterizedException extends RuntimeException {

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
@@ -11,7 +11,7 @@ package <%=packageName%>.web.rest.errors;
  * Can be translated with:
  *
  * <pre>
- * "error.myCustomError" :  "The server says {{params.param0}} to {{params.param1}}"
+ * "error.myCustomError" :  "The server says {{param0}} to {{param1}}"
  * </pre>
  */
 public class CustomParameterizedException extends RuntimeException {

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_CustomParameterizedException.java
@@ -18,17 +18,30 @@ public class CustomParameterizedException extends RuntimeException {
 
     private static final long serialVersionUID = 1L;
 
+    private static final String PARAM = "param";
+
     private final String message;
-    private final String[] params;
+    private Map<String, String> paramMap;
 
     public CustomParameterizedException(String message, String... params) {
         super(message);
         this.message = message;
-        this.params = params;
+        if (params != null && params.length > 0) {
+            this.paramMap = new HashMap<>();
+            for (int i = 0; i < params.length; i++) {
+                paramMap.put(PARAM + i, params[i]);
+            }
+        }
+    }
+
+    public CustomParameterizedException(String message, Map<String, String> paramMap) {
+        super(message);
+        this.message = message;
+        this.paramMap = paramMap;
     }
 
     public ParameterizedErrorVM getErrorVM() {
-        return new ParameterizedErrorVM(message, params);
+        return new ParameterizedErrorVM(message, paramMap);
     }
 
 }

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
@@ -11,7 +11,7 @@ public class ParameterizedErrorVM implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    public static final String PARAMS = "params";
+    private static final String PARAMS = "params";
 
     private final String message;
     private Map<String, String> paramMap;
@@ -35,8 +35,8 @@ public class ParameterizedErrorVM implements Serializable {
         return message;
     }
 
-    public String[] getParams() {
-        return params;
+    public Map<String, String> getParams() {
+        return paramMap;
     }
 
 }

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
@@ -11,7 +11,7 @@ public class ParameterizedErrorVM implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String PARAMS = "params";
+    private static final String PARAM = "param";
 
     private final String message;
     private Map<String, String> paramMap;
@@ -26,7 +26,7 @@ public class ParameterizedErrorVM implements Serializable {
         if (params != null && params.length > 0) {
             paramMap = new HashMap<>();
             for (int i = 0; i < params.length; i++) {
-                paramMap.put(PARAMS + i, params[i]);
+                paramMap.put(PARAM + i, params[i]);
             }
         }
     }

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
@@ -1,7 +1,6 @@
 package <%=packageName%>.web.rest.errors;
 
 import java.io.Serializable;
-import java.util.HashMap;
 import java.util.Map;
 
 /**
@@ -11,24 +10,12 @@ public class ParameterizedErrorVM implements Serializable {
 
     private static final long serialVersionUID = 1L;
 
-    private static final String PARAM = "param";
-
     private final String message;
-    private Map<String, String> paramMap;
+    private final Map<String, String> paramMap;
 
     public ParameterizedErrorVM(String message, Map<String, String> paramMap) {
         this.message = message;
         this.paramMap = paramMap;
-    }
-
-    public ParameterizedErrorVM(String message, String... params) {
-        this.message = message;
-        if (params != null && params.length > 0) {
-            paramMap = new HashMap<>();
-            for (int i = 0; i < params.length; i++) {
-                paramMap.put(PARAM + i, params[i]);
-            }
-        }
     }
 
     public String getMessage() {

--- a/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_ParameterizedErrorVM.java
@@ -1,6 +1,8 @@
 package <%=packageName%>.web.rest.errors;
 
 import java.io.Serializable;
+import java.util.HashMap;
+import java.util.Map;
 
 /**
  * View Model for sending a parameterized error message.
@@ -8,12 +10,25 @@ import java.io.Serializable;
 public class ParameterizedErrorVM implements Serializable {
 
     private static final long serialVersionUID = 1L;
+
+    public static final String PARAMS = "params";
+
     private final String message;
-    private final String[] params;
+    private Map<String, String> paramMap;
+
+    public ParameterizedErrorVM(String message, Map<String, String> paramMap) {
+        this.message = message;
+        this.paramMap = paramMap;
+    }
 
     public ParameterizedErrorVM(String message, String... params) {
         this.message = message;
-        this.params = params;
+        if (params != null && params.length > 0) {
+            paramMap = new HashMap<>();
+            for (int i = 0; i < params.length; i++) {
+                paramMap.put(PARAMS + i, params[i]);
+            }
+        }
     }
 
     public String getMessage() {

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -44,7 +44,7 @@ module.exports = UpgradeGenerator.extend({
 
     _cleanUp() {
         shelljs.ls('-A').forEach((file) => {
-            if (['.yo-rc.json', '.jhipster', 'node_modules', '.git'].indexOf(file) === -1) {
+            if (['.yo-rc.json', '.jhipster', '.git'].indexOf(file) === -1) {
                 shelljs.rm('-rf', file);
             }
         });
@@ -53,7 +53,7 @@ module.exports = UpgradeGenerator.extend({
 
     _generate(version, callback) {
         this.log(`Regenerating app with jhipster ${version}...`);
-        shelljs.exec('yo jhipster --with-entities --force --skip-install', { silent: true }, (code, msg, err) => {
+        shelljs.exec('yo jhipster --with-entities --force --skip-install', { silent: false }, (code, msg, err) => {
             if (code === 0) this.log(chalk.green(`Successfully regenerated app with jhipster ${version}`));
             else this.error(`Something went wrong while generating project! ${err}`);
             callback();
@@ -101,7 +101,7 @@ module.exports = UpgradeGenerator.extend({
             this.log(`Looking for latest ${GENERATOR_JHIPSTER} version...`);
             const done = this.async();
             const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn info' : 'npm show';
-            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER} version`, { silent: true }, (code, msg, err) => {
+            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER} version`, { silent: false }, (code, msg, err) => {
                 this.latestVersion = this.clientPackageManager === 'yarn' ? msg.split('\n')[1] : msg.replace('\n', '');
                 if (semver.lt(this.currentVersion, this.latestVersion)) {
                     this.log(chalk.green(`New ${GENERATOR_JHIPSTER} version found: ${this.latestVersion}`));
@@ -186,7 +186,7 @@ module.exports = UpgradeGenerator.extend({
             const installJhipsterLocally = (version, callback) => {
                 this.log(`Installing JHipster ${version} locally`);
                 const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-                shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile`, { silent: true }, (code, msg, err) => {
+                shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile`, { silent: false }, (code, msg, err) => {
                     if (code === 0) this.log(chalk.green(`Installed ${GENERATOR_JHIPSTER}@${version}`));
                     else this.error(`Something went wrong while installing the JHipster generator! ${msg} ${err}`);
                     callback();
@@ -230,7 +230,7 @@ module.exports = UpgradeGenerator.extend({
             this.log(chalk.yellow(`Updating ${GENERATOR_JHIPSTER} to ${this.latestVersion} . This might take some time...`));
             const done = this.async();
             const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${this.latestVersion} --dev --no-lockfile`, { silent: true }, (code, msg, err) => {
+            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${this.latestVersion} --dev --no-lockfile`, { silent: false }, (code, msg, err) => {
                 if (code === 0) this.log(chalk.green(`Updated ${GENERATOR_JHIPSTER} to version ${this.latestVersion}`));
                 else this.error(`Something went wrong while updating generator! ${msg} ${err}`);
                 done();
@@ -269,7 +269,7 @@ module.exports = UpgradeGenerator.extend({
             shelljs.rm('-rf', 'node_modules');
             this.log('Installing dependencies, please wait...');
             const installCommand = this.clientPackageManager === 'yarn' ? 'yarn' : 'npm install';
-            shelljs.exec(installCommand, { silent: true }, (code, msg, err) => {
+            shelljs.exec(installCommand, { silent: false }, (code, msg, err) => {
                 if (code !== 0) {
                     this.error(`${installCommand}failed.`);
                 }

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -44,7 +44,7 @@ module.exports = UpgradeGenerator.extend({
 
     _cleanUp() {
         shelljs.ls('-A').forEach((file) => {
-            if (['.yo-rc.json', '.jhipster', '.git'].indexOf(file) === -1) {
+            if (['.yo-rc.json', '.jhipster', 'node_modules', '.git'].indexOf(file) === -1) {
                 shelljs.rm('-rf', file);
             }
         });
@@ -53,7 +53,7 @@ module.exports = UpgradeGenerator.extend({
 
     _generate(version, callback) {
         this.log(`Regenerating app with jhipster ${version}...`);
-        shelljs.exec('yo jhipster --with-entities --force --skip-install', { silent: false }, (code, msg, err) => {
+        shelljs.exec('yo jhipster --with-entities --force --skip-install', { silent: true }, (code, msg, err) => {
             if (code === 0) this.log(chalk.green(`Successfully regenerated app with jhipster ${version}`));
             else this.error(`Something went wrong while generating project! ${err}`);
             callback();
@@ -101,7 +101,7 @@ module.exports = UpgradeGenerator.extend({
             this.log(`Looking for latest ${GENERATOR_JHIPSTER} version...`);
             const done = this.async();
             const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn info' : 'npm show';
-            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER} version`, { silent: false }, (code, msg, err) => {
+            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER} version`, { silent: true }, (code, msg, err) => {
                 this.latestVersion = this.clientPackageManager === 'yarn' ? msg.split('\n')[1] : msg.replace('\n', '');
                 if (semver.lt(this.currentVersion, this.latestVersion)) {
                     this.log(chalk.green(`New ${GENERATOR_JHIPSTER} version found: ${this.latestVersion}`));
@@ -186,7 +186,7 @@ module.exports = UpgradeGenerator.extend({
             const installJhipsterLocally = (version, callback) => {
                 this.log(`Installing JHipster ${version} locally`);
                 const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-                shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile`, { silent: false }, (code, msg, err) => {
+                shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile`, { silent: true }, (code, msg, err) => {
                     if (code === 0) this.log(chalk.green(`Installed ${GENERATOR_JHIPSTER}@${version}`));
                     else this.error(`Something went wrong while installing the JHipster generator! ${msg} ${err}`);
                     callback();
@@ -230,7 +230,7 @@ module.exports = UpgradeGenerator.extend({
             this.log(chalk.yellow(`Updating ${GENERATOR_JHIPSTER} to ${this.latestVersion} . This might take some time...`));
             const done = this.async();
             const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${this.latestVersion} --dev --no-lockfile`, { silent: false }, (code, msg, err) => {
+            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${this.latestVersion} --dev --no-lockfile`, { silent: true }, (code, msg, err) => {
                 if (code === 0) this.log(chalk.green(`Updated ${GENERATOR_JHIPSTER} to version ${this.latestVersion}`));
                 else this.error(`Something went wrong while updating generator! ${msg} ${err}`);
                 done();
@@ -269,7 +269,7 @@ module.exports = UpgradeGenerator.extend({
             shelljs.rm('-rf', 'node_modules');
             this.log('Installing dependencies, please wait...');
             const installCommand = this.clientPackageManager === 'yarn' ? 'yarn' : 'npm install';
-            shelljs.exec(installCommand, { silent: false }, (code, msg, err) => {
+            shelljs.exec(installCommand, { silent: true }, (code, msg, err) => {
                 if (code !== 0) {
                     this.error(`${installCommand}failed.`);
                 }


### PR DESCRIPTION
Modify params attribute of ParameterizedErrorVM  template to be key/value pair (Map) so that the client-side is able to perform string interpolation of multiple parameters within a message.  

See `alert-error.component.ts` and notice that calls to the function addErrorAlert, which performs  interpolation, use key/value pairs (json object) to specify interpolation parameters.  Using an array will not work for case where there are multiple placeholders (params).

Current implementation uses a "params" array which translates to json as, for example:
```
{
  "message" : "error.myCustomError",
  "params" : ["param 1 value", "param 2 value"]
  }
} 
```
A map is required to support the feature correctly:
```
{
  "message" : "error.myCustomError",
  "params" : {
    "param0" : "Program 4",
    "param1" : "another param"
  }
}
```

Custom, parameterized exception, which can be translated on the client side. For example:

`throw new CustomParameterizedException("myCustomError", "hello", "world");
   
Can be translated with:
   `"error.myCustomError" :  "The server says {{param0}} to {{param1}}"`


or

Custom, parameterized exception, which can be translated on the client side. For example:
```
final HashMap<String, String> params = new HashMap<>();
params.put("customParamName", "hi");
params.put("anotherParamName", "you");
throw new CustomParameterizedException("myCustomError", params.);

```
Can be translated with:
`"error.myCustomError" : "The server says {{customParamName}} to {{anotherParamName}}"`