### PR TITLE
[ci skip] fix pom.xml whitespace off for cucumber line

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -971,7 +971,7 @@
                         </goals>
                         <configuration>
                             <includes>
-                              <include>**/*Cucumber*.java</include>
+                                <include>**/*Cucumber*.java</include>
                             </includes>
                         </configuration>
                     </execution>


### PR DESCRIPTION
[ci skip] fix pom.xml whitespace off for cucumber line

fix for issue #5491