### PR TITLE
config i18n in test context

### DIFF
--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -68,6 +68,8 @@ spring:
             hibernate.generate_statistics: true
             hibernate.hbm2ddl.auto: validate
     <%_ } _%>
+    messages:
+        basename: i18n/messages
     <%_ if (databaseType == 'mongodb' || databaseType == 'cassandra' || applicationType == 'gateway' || searchEngine == 'elasticsearch') { _%>
     data:
     <%_ } _%>


### PR DESCRIPTION
adding the path for message*.properties when **running the tests**.

Otherwise this kind of call :
`messageSource.getMessage("error.subtitle", null, Locale.FRENCH);`

throw an exception because it can't find the key
`org.springframework.context.NoSuchMessageException: No message found under code 'error.subtitle' for locale 'fr'.`