### PR TITLE
This stops generating js & js.map in the same folder

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -119,7 +119,7 @@
     "tsc": "tsc",
     "tsc:w": "tsc -w",
     "ngc": "ngc -p tsconfig-aot.json",
-    "cleanup": "rimraf '<%= MAIN_SRC_DIR%>app/**/*.js' '<%= MAIN_SRC_DIR%>app/**/*.js.map' <%= BUILD_DIR %>",
+    "cleanup": "rimraf <%= BUILD_DIR %>",
     "start": "<%= clientPackageManager %> run webpack:dev",
     "webpack:build": "<%= clientPackageManager %> run ngc && webpack --config webpack/webpack.vendor.js && webpack --config webpack/webpack.dev.js",
     "webpack:build:dev": "webpack --config webpack/webpack.dev.js",

--- a/generators/client/templates/angular/_tsconfig-aot.json
+++ b/generators/client/templates/angular/_tsconfig-aot.json
@@ -7,7 +7,8 @@
     "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "lib": ["es2015", "dom"],
-    "suppressImplicitAnyIndexErrors": true
+    "suppressImplicitAnyIndexErrors": true,
+    "outDir": "<%= DIST_DIR %>app"
   },
 
   "files": [


### PR DESCRIPTION
It took a while to figure this out, since we already specify a path below. 

It fixes [this](https://github.com/jhipster/generator-jhipster/pull/5495#issuecomment-291016939)

@jdubois @pascalgrimaud 