### PR TITLE
Fixed missing 'one-to-many' relationship case for required relation

### DIFF
--- a/generators/entity/templates/server/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/server/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -294,7 +294,7 @@ _%>
         <%= otherEntityNameCapitalized %> <%= relationshipFieldName %> = <%= otherEntityNameCapitalized %>ResourceIntTest.createEntity(em);
         em.persist(<%= relationshipFieldName %>);
         em.flush();
-            <%_ if (relationshipType == 'many-to-many') { _%>
+            <%_ if (relationshipType == 'many-to-many' || relationshipType == 'one-to-many') { _%>
         <%= entityInstance %>.get<%= relationshipNameCapitalizedPlural %>().add(<%= relationshipFieldName %>);
             <%_ } else { _%>
         <%= entityInstance %>.set<%= relationshipNameCapitalized %>(<%= relationshipFieldName %>);


### PR DESCRIPTION
Currently a **required**  `one-to-many` relationship yields to a compilation error in the appropriate *ResourceIntTest.java class.

```
jhipster-test/src/test/java/de/test/web/rest/AResourceIntTest.java:[82,22] incompatible types: de.test.domain.B cannot be converted to java.util.Set<de.test.domain.B>
```
It fails since a one-to-many relations is handled wrong: trying to access a `set` method which is expecting a set of b's.

Reproducible with the following JDL used in a fresh project:

```
entity A {}
entity B {}

relationship OneToMany {
  A{b required} to B
}
```

As the relation to B is many A only has a set of B's. Thus we also need to add one item to the set, similar to the many-to-many case.

Cheer's,
Marco