### PR TITLE
Generate criteria class and backend for filtering

### DIFF
--- a/generators/entity/files.js
+++ b/generators/entity/files.js
@@ -88,6 +88,20 @@ const serverFiles = {
             ]
         },
         {
+            condition: generator => generator.jpaMetamodelFiltering,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/service/dto/_EntityCriteria.java',
+                    renameTo: generator => `${generator.packageFolder}/service/dto/${generator.entityClass}Criteria.java`
+                },
+                {
+                    file: 'package/service/_EntityQueryService.java',
+                    renameTo: generator => `${generator.packageFolder}/service/${generator.entityClass}QueryService.java`
+                },
+            ]
+        },
+        {
             condition: generator => generator.searchEngine === 'elasticsearch',
             path: SERVER_MAIN_SRC_DIR,
             templates: [{

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -213,6 +213,7 @@ module.exports = EntityGenerator.extend({
                 this.validation = false;
                 this.dto = 'no';
                 this.service = 'no';
+                this.jpaMetamodelFiltering = false;
             } else {
                 // existing entity reading values from file
                 this.log(`\nThe entity ${this.name} is being updated.\n`);
@@ -256,6 +257,7 @@ module.exports = EntityGenerator.extend({
         this.searchEngine = this.fileData.searchEngine || this.searchEngine;
         this.javadoc = this.fileData.javadoc;
         this.entityTableName = this.fileData.entityTableName;
+        this.copyFilteringFlag(this.fileData, this);
         if (_.isUndefined(this.entityTableName)) {
             this.warning(`entityTableName is missing in .jhipster/${this.name}.json, using entity name as fallback`);
             this.entityTableName = this.getTableName(this.name);
@@ -302,6 +304,7 @@ module.exports = EntityGenerator.extend({
         askForTableName: prompts.askForTableName,
         askForDTO: prompts.askForDTO,
         askForService: prompts.askForService,
+        askForFiltering: prompts.askForFiltering,
         askForPagination: prompts.askForPagination
     },
 
@@ -401,6 +404,10 @@ module.exports = EntityGenerator.extend({
                 this.warning(`service is missing in .jhipster/${this.name}.json, using no as fallback`);
                 this.service = 'no';
             }
+            if (_.isUndefined(this.jpaMetamodelFiltering)) {
+                this.warning(`jpaMetamodelFiltering is missing in .jhipster/${this.name}.json, using 'no' as fallback`);
+                this.jpaMetamodelFiltering = false;
+            }
             if (_.isUndefined(this.pagination)) {
                 if (this.databaseType === 'sql' || this.databaseType === 'mongodb') {
                     this.warning(`pagination is missing in .jhipster/${this.name}.json, using no as fallback`);
@@ -427,6 +434,7 @@ module.exports = EntityGenerator.extend({
             this.data.dto = this.dto;
             this.data.service = this.service;
             this.data.entityTableName = this.entityTableName;
+            this.copyFilteringFlag(this, this.data);
             if (this.databaseType === 'sql' || this.databaseType === 'mongodb') {
                 this.data.pagination = this.pagination;
             } else {
@@ -744,6 +752,7 @@ module.exports = EntityGenerator.extend({
                         fieldsContainBigDecimal: this.fieldsContainBigDecimal,
                         fieldsContainBlob: this.fieldsContainBlob,
                         fieldsContainImageBlob: this.fieldsContainImageBlob,
+                        jpaMetamodelFiltering: this.jpaMetamodelFiltering,
                         pkType: this.pkType,
                         entityApiUrl: this.entityApiUrl,
                         entityClass: this.entityClass,

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -32,6 +32,7 @@ module.exports = {
     askForTableName,
     askForDTO,
     askForService,
+    askForFiltering,
     askForPagination
 };
 
@@ -272,6 +273,36 @@ function askForTableName() {
         if (props.entityTableName !== this.entityTableName) {
             this.entityTableName = _.snakeCase(props.entityTableName).toLowerCase();
         }
+        done();
+    });
+}
+
+function askForFiltering() {
+    // don't prompt if server is skipped, or the backend is not sql, or no service requested
+    if (this.useConfigurationFile || this.skipServer || this.databaseType !== 'sql' || this.service === 'no') {
+        return;
+    }
+    const done = this.async();
+    const prompts = [
+        {
+            type: 'list',
+            name: 'filtering',
+            message: 'Do you want to add filtering?',
+            choices: [
+                {
+                    value: 'no',
+                    name: 'Not needed'
+                },
+                {
+                    name: 'Dynamic filtering for the entities with JPA Static metamodel',
+                    value: 'jpaMetamodel'
+                }
+            ],
+            default: 0
+        }
+    ];
+    this.prompt(prompts).then((props) => {
+        this.jpaMetamodelFiltering = props.filtering === 'jpaMetamodel';
         done();
     });
 }

--- a/generators/entity/templates/server/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/get_all_template.ejs
@@ -21,7 +21,21 @@
     const instanceName = (dto === 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
     const mapper = entityInstance + 'Mapper';
     const entityListToDtoListReference = mapper + '.' + 'toDto';
-    if (pagination === 'no') { %>
+    if (jpaMetamodelFiltering) {  %>
+    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(<%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>,@ApiParam Pageable pageable<% } %>) {
+        log.debug("REST request to get <%= entityClassPlural %> by criteria: {}", criteria);
+    <%_ if (pagination === 'no') { _%>
+        List<<%= instanceType %>> entityList = <%= entityInstance %>QueryService.findByCriteria(criteria);
+        return ResponseEntity.ok().body(entityList);
+    <%_ } else { _%>
+        Page<<%= instanceType %>> page = <%= entityInstance %>QueryService.findByCriteria(criteria, pageable);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityApiUrl %>");
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
+    <%_ } _%>
+    }
+<%
+    } else {
+        if (pagination === 'no') { %>
     public List<<%= instanceType %>> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get all <%= entityClassPlural %>");<% if (viaService) { %>
         return <%= entityInstance %>Service.findAll();<% } else if (dto === 'mapstruct') { %>
@@ -35,5 +49,6 @@
         Page<<%= entityClass %>> page = <%= entityInstance %>Repository.findAll(pageable);<% } %>
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityApiUrl %>");
         return new ResponseEntity<>(<% if (!viaService && dto === 'mapstruct') { %><%= entityListToDtoListReference %>(page.getContent())<% } else { %>page.getContent()<% } %>, headers, HttpStatus.OK);
-    <% } -%>
-}
+    <%_ } _%>
+    }
+<%_ } _%>

--- a/generators/entity/templates/server/src/main/java/package/common/inject_template.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/inject_template.ejs
@@ -30,9 +30,12 @@
 <%_  } else { _%>
 
     private final <%= entityClass %>Service <%= entityInstance %>Service;
+<%_ if (queryService) {  _%>
+    private final <%= entityClass %>QueryService <%= entityInstance %>QueryService;
 <%_ } _%>
 
-    public <%= constructorName %>(<% if (!viaService) { %><%= entityClass %>Repository <%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityClass %>Mapper <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository<% } %><%  } else { %><%= entityClass %>Service <%= entityInstance %>Service<% } %>) {
+<%_ } _%>
+    public <%= constructorName %>(<% if (!viaService) { %><%= entityClass %>Repository <%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityClass %>Mapper <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository<% } %><%  } else { %><%= entityClass %>Service <%= entityInstance %>Service<% } %><% if (queryService && viaService) { %>, <%= entityClass %>QueryService <%= entityInstance %>QueryService<% } %>) {
         <%_ if (!viaService) { _%>
         this.<%= entityInstance %>Repository = <%= entityInstance %>Repository;
             <%_ if (dto === 'mapstruct') { _%>
@@ -43,5 +46,8 @@
             <%_ } _%>
         <%_  } else { _%>
         this.<%= entityInstance %>Service = <%= entityInstance %>Service;
+            <%_ if (queryService) {  _%>
+        this.<%= entityInstance %>QueryService = <%= entityInstance %>QueryService;
+            <%_ } _%>
         <%_ } _%>
     }

--- a/generators/entity/templates/server/src/main/java/package/repository/_EntityRepository.java
+++ b/generators/entity/templates/server/src/main/java/package/repository/_EntityRepository.java
@@ -64,7 +64,7 @@ import java.util.UUID;<% } %>
 <%_ } if (databaseType === 'sql' || databaseType === 'mongodb') { _%>
 @SuppressWarnings("unused")
 @Repository
-public interface <%=entityClass%>Repository extends <% if (databaseType === 'sql') { %>JpaRepository<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<% } %><<%=entityClass%>,<%= pkType %>> {
+public interface <%=entityClass%>Repository extends <% if (databaseType === 'sql') { %>JpaRepository<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<% } %><<%=entityClass%>,<%= pkType %>><% if (jpaMetamodelFiltering) { %>, JpaSpecificationExecutor<<%=entityClass%>><% } %> {
     <%_ for (idx in relationships) {
         if (relationships[idx].relationshipType === 'many-to-one' && relationships[idx].otherEntityName === 'user') { _%>
 

--- a/generators/entity/templates/server/src/main/java/package/service/_EntityQueryService.java
+++ b/generators/entity/templates/server/src/main/java/package/service/_EntityQueryService.java
@@ -1,0 +1,139 @@
+<%#
+ Copyright 2013-2017 the original author or authors.
+
+ This file is part of the JHipster project, see https://jhipster.github.io/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.service;
+<%_ const serviceClassName = entityClass + 'QueryService';
+    const instanceType = (dto === 'mapstruct') ? entityClass + 'DTO' : entityClass;
+    const instanceName = (dto === 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
+    const mapper = entityInstance  + 'Mapper';
+    const dtoToEntity = mapper + '.'+ 'toEntity';
+    const entityToDto = mapper + '.'+ 'toDto';
+    const entityListToDto = mapper + '.' + 'toDto';
+    const entityToDtoReference = mapper + '::'+ 'toDto';
+    const repository = entityInstance  + 'Repository';
+    const criteria = entityClass + 'Criteria';
+
+    if (fieldsContainLocalDate === true) { _%>
+import java.time.LocalDate;<% } %><% if (fieldsContainZonedDateTime === true) { %>
+import java.time.ZonedDateTime;<% } if (fieldsContainBigDecimal === true) { %>
+import java.math.BigDecimal;<% } %>
+
+import java.util.List;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.domain.Specifications;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import io.github.jhipster.service.QueryService;
+
+import <%=packageName%>.domain.<%= entityClass %>;
+import <%=packageName%>.domain.*; // for static metamodels
+import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine === 'elasticsearch') { %>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } %>
+import <%=packageName%>.service.dto.<%= entityClass %>Criteria;
+<% if (dto === 'mapstruct') { %>
+import <%=packageName%>.service.dto.<%= entityClass %>DTO;
+import <%=packageName%>.service.mapper.<%= entityClass %>Mapper;<% } %>
+<%_ for (idx in fields) { if (fields[idx].fieldIsEnum === true) { _%>
+import <%=packageName%>.domain.enumeration.<%= fields[idx].fieldType %>;
+<%_ } } _%>
+
+/**
+ * Service for executing complex queries for <%= entityClass %> entities in the database.
+ * The main input is a {@link <%= entityClass %>Criteria} which get's converted to {@link Specifications},
+ * in a way that all the filters must apply.
+ * It returns a {@link List} of {%link <%= instanceType %>} or a {@link Page} of {%link <%= instanceType %>} which fullfills the criterias
+ */
+@Service<% if (databaseType === 'sql') { %>
+@Transactional(readOnly = true)<% } %>
+public class <%= serviceClassName %> extends QueryService<<%= entityClass %>> {
+
+    private final Logger log = LoggerFactory.getLogger(<%= serviceClassName %>.class);
+
+<%- include('../common/inject_template', {viaService: false, constructorName: serviceClassName, queryService: false}); -%>
+
+    /**
+     * Return a {@link List} of {%link <%= instanceType %>} which matches the criteria from the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @return the matching entities.
+     */
+    @Transactional(readOnly = true)
+    public List<<%= instanceType %>> findByCriteria(<%= criteria %> criteria) {
+        log.debug("find by criteria : {}", criteria);
+        final Specifications<<%= entityClass %>> specification = createSpecification(criteria);
+    <%_ if (dto === 'mapstruct') { _%>
+        return <%= entityListToDto %>(<%= repository %>.findAll(specification));
+    <%_ } else { _%>
+        return <%= repository %>.findAll(specification);
+    <%_ } _%>
+    }
+
+    /**
+     * Return a {@link Page} of {%link <%= instanceType %>} which matches the criteria from the database
+     * @param criteria The object which holds all the filters, which the entities should match.
+     * @param page The page, which should be returned.
+     * @return the matching entities.
+     */
+    @Transactional(readOnly = true)
+    public Page<<%= instanceType %>> findByCriteria(<%= criteria %> criteria, Pageable page) {
+        log.debug("find by criteria : {}, page: {}", criteria, page);
+        final Specifications<<%= entityClass %>> specification = createSpecification(criteria);
+    <%_ if (dto === 'mapstruct') { _%>
+        final Page<<%= entityClass %>> result = <%= repository %>.findAll(specification, page);
+        return result.map(<%= entityToDtoReference %>);
+    <%_ } else { _%>
+        return <%= repository %>.findAll(specification, page);
+    <%_ } _%>
+    }
+
+    /**
+     * Function to convert <%= criteria %> to a {@link Specifications}
+     */
+    private Specifications<<%= entityClass %>> createSpecification(<%= criteria %> criteria) {
+        Specifications<<%= entityClass %>> specification = Specifications.where(null);
+        if (criteria != null) {
+            if (criteria.getId() != null) {
+                specification = specification.and(buildSpecification(criteria.getId(), <%= entityClass %>_.id));
+            }
+            <%_
+            fields.forEach((field) => {
+                if (isFilterableType(field.fieldType)) { _%>
+            if (criteria.get<%= field.fieldInJavaBeanMethod %>() != null) {
+                specification = specification.and(<%= getSpecificationBuilder(field.fieldType) %>(criteria.get<%= field.fieldInJavaBeanMethod %>(), <%= entityClass %>_.<%= field.fieldName %>));
+            }
+            <%_ }
+            });
+
+            relationships.forEach((relationship) => {
+                const relationshipType = relationship.relationshipType;
+                if (relationshipType == 'many-to-one' || relationshipType == 'one-to-one') { _%>
+            if (criteria.get<%= relationship.relationshipNameCapitalized %>Id() != null) {
+                specification = specification.and(buildReferringEntitySpecification(criteria.get<%= relationship.relationshipNameCapitalized %>Id(), <%= entityClass %>_.<%= relationship.relationshipFieldName %>, <%= relationship.otherEntityNameCapitalized %>_.id));
+            }
+            <%_    } // if relationshipType=...
+            }); // forEach
+        _%>
+        }
+        return specification;
+    }
+
+}

--- a/generators/entity/templates/server/src/main/java/package/service/dto/_EntityCriteria.java
+++ b/generators/entity/templates/server/src/main/java/package/service/dto/_EntityCriteria.java
@@ -1,0 +1,102 @@
+package <%= packageName %>.service.dto;
+
+import java.io.Serializable;<% if (fieldsContainBigDecimal === true) { %>
+import java.math.BigDecimal;<% } %>
+<%_ for (idx in fields) { if (fields[idx].fieldIsEnum === true) { _%>
+import <%= packageName %>.domain.enumeration.<%= fields[idx].fieldType %>;
+<%_ } } _%>
+import io.github.jhipster.service.filter.Filter;
+import io.github.jhipster.service.filter.IntegerFilter;
+import io.github.jhipster.service.filter.LongFilter;
+import io.github.jhipster.service.filter.StringFilter;
+import io.github.jhipster.service.filter.RangeFilter;
+<%_ if (fieldsContainInstant === true) { _%>
+import io.github.jhipster.service.filter.InstantFilter;<% } %>
+<%_ if (fieldsContainLocalDate === true) { _%>
+import io.github.jhipster.service.filter.LocalDateFilter;<% } %>
+<%_ if (fieldsContainZonedDateTime === true) { _%>
+import io.github.jhipster.service.filter.ZonedDateTimeFilter;<% } %>
+
+<%_
+  const referenceFilterType = '' + pkType + 'Filter';
+  var filterVariables = [{name:'id', type: pkType, filterType:referenceFilterType,fieldInJavaBeanMethod:'Id' } ];
+  var extraFilters = {};
+  fields.forEach((field) => {
+    const fieldType = field.fieldType;
+    if (isFilterableType(fieldType)) {
+      var filterType;
+      if (field.fieldIsEnum == true) {
+        filterType = fieldType + 'Filter';
+        extraFilters[fieldType] = {type : filterType, superType: 'Filter<' + fieldType + '>', fieldType:fieldType};
+      } else if (['LocalDate', 'ZonedDateTime', 'Instant', 'String', 'Long', 'Integer'].includes(fieldType)) {
+        filterType = fieldType + 'Filter';
+      } else if (['Float', 'Double', 'BigDecimal'].includes(fieldType)) {
+        filterType = 'RangeFilter<' + fieldType + '>';
+      } else {
+        filterType = 'Filter<' + fieldType + '>';
+      }
+      filterVariables.push( { filterType : filterType,
+            name: field.fieldName,
+            type: fieldType,
+            fieldInJavaBeanMethod: field.fieldInJavaBeanMethod });
+    }
+  });
+  relationships.forEach((relationship) => {
+    const relationshipType = relationship.relationshipType;
+    if (relationshipType === 'many-to-one' || relationshipType === 'one-to-one') {
+      filterVariables.push({ filterType : referenceFilterType,
+            name: relationship.relationshipFieldName + 'Id',
+            type: relationshipType,
+            fieldInJavaBeanMethod: relationship.relationshipNameCapitalized + 'Id' });
+    }
+  });
+_%>
+
+/**
+ * Criteria class for the <%= entityClass %> entity. This class is used in <%= entityClass %>Resource to
+ * receive all the possible filtering options from the Http GET request parameters.
+ * For example the following could be a valid requests:
+ * <code> /<%= entityApiUrl %>?id.greaterThan=5&amp;attr1.contains=something&amp;attr2.specified=false</code>
+ * As Spring is unable to properly convert the types, unless specific {@link Filter} class are used, we need to use
+ * fix type specific filters.
+ */
+public class <%= entityClass %>Criteria implements Serializable {
+<%_ Object.keys(extraFilters).forEach((key) => {
+        extraFilter = extraFilters[key]; _%>
+    /**
+     * Class for filtering <%= key %>
+     */
+    public static class <%= extraFilter.type %> extends <%- extraFilter.superType %> {
+    }
+
+<%_ }); _%>
+    private static final long serialVersionUID = 1L;
+
+<%_ filterVariables.forEach((filterVariable) => { _%>
+
+    private <%- filterVariable.filterType %> <%= filterVariable.name %>;
+<%_ }); _%>
+
+    public <%= entityClass %>Criteria() {
+    }
+
+<%_ filterVariables.forEach((filterVariable) => { _%>
+    public <%- filterVariable.filterType %> get<%= filterVariable.fieldInJavaBeanMethod %>() {
+        return <%= filterVariable.name %>;
+    }
+
+    public void set<%= filterVariable.fieldInJavaBeanMethod %>(<%- filterVariable.filterType %> <%= filterVariable.name %>) {
+        this.<%= filterVariable.name %> = <%= filterVariable.name %>;
+    }
+
+<%_ }); _%>
+    @Override
+    public String toString() {
+        return "<%= entityClass %>Criteria{" +
+<%_ filterVariables.forEach((field) => { _%>
+                (<%= field.name %> != null ? "<%= field.name %>=" + <%= field.name %> + ", " : "") +
+<%_ }); _%>
+            "}";
+    }
+
+}

--- a/generators/entity/templates/server/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/generators/entity/templates/server/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -61,7 +61,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
 public class <%= serviceClassName %> <% if (service === 'serviceImpl') { %>implements <%= entityClass %>Service<% } %>{
 
     private final Logger log = LoggerFactory.getLogger(<%= serviceClassName %>.class);
-<%- include('../../common/inject_template', {viaService: viaService, constructorName: serviceClassName}); -%>
+<%- include('../../common/inject_template', {viaService: viaService, constructorName: serviceClassName, queryService: false}); -%>
 
     /**
      * Save a <%= entityInstance %>.

--- a/generators/entity/templates/server/src/main/java/package/web/rest/_EntityResource.java
+++ b/generators/entity/templates/server/src/main/java/package/web/rest/_EntityResource.java
@@ -33,6 +33,10 @@ import <%=packageName%>.service.dto.<%= entityClass %>DTO;
 <%_ if (service === 'no') { _%>
 import <%=packageName%>.service.mapper.<%= entityClass %>Mapper;
 <%_ } } _%>
+<%_ if (jpaMetamodelFiltering) {  _%>
+import <%=packageName%>.service.dto.<%= entityClass %>Criteria;
+import <%=packageName%>.service.<%= entityClass %>QueryService;
+<%_ } _%>
 <%_ if (pagination !== 'no') { _%>
 import io.swagger.annotations.ApiParam;
 <%_ } _%>
@@ -75,7 +79,7 @@ public class <%= entityClass %>Resource {
     <%_
     const instanceType = (dto === 'mapstruct') ? entityClass + 'DTO' : entityClass;
     const instanceName = (dto === 'mapstruct') ? entityInstance + 'DTO' : entityInstance;
-    _%><%- include('../../common/inject_template', {viaService: viaService, constructorName: entityClass + 'Resource'}); -%>
+    _%><%- include('../../common/inject_template', {viaService: viaService, constructorName: entityClass + 'Resource', queryService: jpaMetamodelFiltering}); -%>
 
     /**
      * POST  /<%= entityApiUrl %> : Create a new <%= entityInstance %>.
@@ -120,7 +124,8 @@ public class <%= entityClass %>Resource {
     /**
      * GET  /<%= entityApiUrl %> : get all the <%= entityInstancePlural %>.
      *<% if (pagination !== 'no') { %>
-     * @param pageable the pagination information<% } if (fieldsContainNoOwnerOneToOne) { %>
+     * @param pageable the pagination information<% } if (jpaMetamodelFiltering) { %>
+     * @param criteria the criterias which the requested entities should match<% } else if (fieldsContainNoOwnerOneToOne) { %>
      * @param filter the filter of the request<% } %>
      * @return the ResponseEntity with status 200 (OK) and the list of <%= entityInstancePlural %> in body
      */

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -614,4 +614,31 @@ module.exports = class extends Generator {
         }
         return false;
     }
+
+    /**
+     * Return the method name which converts the filter to specification
+     * @param {string} fieldType
+     */
+    getSpecificationBuilder(fieldType) {
+        if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal', 'LocalDate', 'ZonedDateTime', 'Instant'].includes(fieldType)) {
+            return 'buildRangeSpecification';
+        }
+        if (fieldType === 'String') {
+            return 'buildStringSpecification';
+        }
+        return 'buildSpecification';
+    }
+
+    isFilterableType(fieldType) {
+        // Float, Double, BigDecimal and Boolean should work - new server library release needed
+        return !(['byte[]', 'ByteBuffer', 'Float', 'Double', 'BigDecimal', 'Boolean'].includes(fieldType));
+    }
+
+    copyFilteringFlag(from, to) {
+        if (this.databaseType === 'sql' && this.service !== 'no') {
+            to.jpaMetamodelFiltering = from.jpaMetamodelFiltering;
+        } else {
+            to.jpaMetamodelFiltering = false;
+        }
+    }
 };

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -924,6 +924,14 @@
                             <artifactId>mapstruct-processor</artifactId>
                             <version>${mapstruct.version}</version>
                         </path>
+<%_ if (databaseType === 'sql') { _%>
+                        <!-- For JPA static metamodel generation -->
+                        <path>
+                            <groupId>org.hibernate</groupId>
+                            <artifactId>hibernate-jpamodelgen</artifactId>
+                            <version>${hibernate.version}</version>
+                        </path>
+<% } %>
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>

--- a/generators/server/templates/gradle/_mapstruct.gradle
+++ b/generators/server/templates/gradle/_mapstruct.gradle
@@ -20,4 +20,7 @@ apply plugin: "net.ltgt.apt"
 
 dependencies {
     apt "org.mapstruct:mapstruct-processor:${mapstruct_version}"
+<%_ if (databaseType === 'sql') { _%>
+    apt "org.hibernate:hibernate-jpamodelgen:${hibernate_version}"
+<%_ } _%>
 }

--- a/travis/samples/.jhipster/BankAccount.json
+++ b/travis/samples/.jhipster/BankAccount.json
@@ -76,5 +76,6 @@
     "changelogDate": "20150805124838",
     "dto": "mapstruct",
     "pagination": "no",
+    "jpaMetamodelFiltering": true,
     "service": "serviceImpl"
 }

--- a/travis/samples/.jhipster/CassTestServiceClassEntity.json
+++ b/travis/samples/.jhipster/CassTestServiceClassEntity.json
@@ -214,5 +214,6 @@
     "changelogDate": "20160208184031",
     "dto": "no",
     "service": "serviceClass",
+    "jpaMetamodelFiltering": true,
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/CassTestServiceImplEntity.json
+++ b/travis/samples/.jhipster/CassTestServiceImplEntity.json
@@ -214,5 +214,6 @@
     "changelogDate": "20160208184031",
     "dto": "no",
     "service": "serviceImpl",
+    "jpaMetamodelFiltering": true,
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/FieldTestServiceClassEntity.json
+++ b/travis/samples/.jhipster/FieldTestServiceClassEntity.json
@@ -319,5 +319,6 @@
     "changelogDate": "20160208184031",
     "dto": "no",
     "service": "serviceClass",
+    "jpaMetamodelFiltering": true,
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/MicroserviceBankAccount.json
+++ b/travis/samples/.jhipster/MicroserviceBankAccount.json
@@ -70,5 +70,6 @@
     "changelogDate": "20150805124838",
     "dto": "mapstruct",
     "pagination": "no",
+    "jpaMetamodelFiltering": true,
     "service": "serviceImpl"
 }

--- a/travis/samples/.jhipster/MicroserviceLabel.json
+++ b/travis/samples/.jhipster/MicroserviceLabel.json
@@ -23,5 +23,6 @@
     "changelogDate": "20150805124936",
     "dto": "no",
     "pagination": "pagination",
+    "jpaMetamodelFiltering": true,
     "service": "serviceClass"
 }

--- a/travis/samples/.jhipster/TestEntity.json
+++ b/travis/samples/.jhipster/TestEntity.json
@@ -54,5 +54,6 @@
     "changelogDate": "20160208210109",
     "dto": "no",
     "service": "no",
+    "jpaMetamodelFiltering": true,
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/TestServiceClass.json
+++ b/travis/samples/.jhipster/TestServiceClass.json
@@ -47,5 +47,6 @@
     "changelogDate": "20160208210109",
     "dto": "no",
     "service": "serviceClass",
+    "jpaMetamodelFiltering": true,
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/TestServiceImpl.json
+++ b/travis/samples/.jhipster/TestServiceImpl.json
@@ -47,5 +47,6 @@
     "changelogDate": "20160208210109",
     "dto": "no",
     "service": "serviceImpl",
+    "jpaMetamodelFiltering": true,
     "pagination": "no"
 }


### PR DESCRIPTION
Add automatically the static metamodel generation/JPASpecificationExecution, and generate criteria classes and filtering code for JPA (with spring's JPA Specifications)

This is a first version, only SQL is checked, and with 'service' class generation. And the REST controller is not modified yet.

What do you think?