### PR TITLE
fix social sign in redirect in Angular 2

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -191,7 +191,7 @@ jhipster:
         <%_ if (authenticationType == 'jwt') { _%>
         redirect-after-sign-in: "/#/social-auth"
         <%_ } else { _%>
-        redirect-after-sign-in: "/#/home"
+        redirect-after-sign-in: "/#/"
         <%_ } _%>
 <%_ } _%>
     ribbon:


### PR DESCRIPTION
in AngularJs 1 both `/#/home` and `/#/` are working (route `home` is defined with path `/`)
in Angular 2 (4) only `/#/` is working (no route `home` exists, home component path is empty string)
so changing redirect to `/#/` which works both in AngularJs 1 and Angular 2 (4)