### PR TITLE
Fixing issue on rancher-compose module for non default port on gateway

### DIFF
--- a/generators/rancher-compose/index.js
+++ b/generators/rancher-compose/index.js
@@ -206,6 +206,7 @@ module.exports = RancherGenerator.extend({
 
                     // Register gateway of monolith app name
                     this.hasFrontApp = true;
+                    this.frontAppPort = ports[0];
                     this.frontAppName = `${lowercaseBaseName}-app`;
                 }
 
@@ -213,7 +214,7 @@ module.exports = RancherGenerator.extend({
                 yamlConfig.image = this.dockerRepositoryName ? `${this.dockerRepositoryName}/${yamlConfig.image}` : yamlConfig.image;
 
                 // Add monitoring configuration for monolith directly in the docker-compose file as they can't get them from the config server
-                if (appConfig.applicationType === 'monolith' && this.monitoring === 'elk') {
+                if (this.monitoring === 'elk') {
                     yamlConfig.environment.push('JHIPSTER_LOGGING_LOGSTASH_ENABLED=true');
                     yamlConfig.environment.push('JHIPSTER_LOGGING_LOGSTASH_HOST=jhipster-logstash');
                     yamlConfig.environment.push('JHIPSTER_METRICS_LOGS_ENABLED=true');

--- a/generators/rancher-compose/templates/_docker-compose.yml
+++ b/generators/rancher-compose/templates/_docker-compose.yml
@@ -5,7 +5,7 @@ services:
       image: rancher/load-balancer-service
       ports:
         # Listen on public port 80 and direct traffic to private port 8080 of the service
-        - 80:8080
+        - 80:<%= frontAppPort %>
       links:
         # Target services in the same stack will be listed as a link
         - <%= frontAppName %>:<%= frontAppName %>


### PR DESCRIPTION
When gateway has a port different to 8080, load balancing service could not bind to it.
Also add monitoring configuration on all application not only on monolith