### PR TITLE
Optimize webpack file loader pattern for woff and woff2 files

### DIFF
--- a/generators/client/templates/angular/webpack/_webpack.common.js
+++ b/generators/client/templates/angular/webpack/_webpack.common.js
@@ -70,7 +70,7 @@ module.exports = function (options) {
                     loaders: ['style-loader', 'css-loader']
                 },
                 {
-                    test: /\.(jpe?g|png|gif|svg|woff|woff2|ttf|eot)$/i,
+                    test: /\.(jpe?g|png|gif|svg|woff2?|ttf|eot)$/i,
                     loaders: [
                         'file-loader?hash=sha512&digest=hex&name=[hash].[ext]', {
                             loader: 'image-webpack-loader',

--- a/generators/client/templates/angular/webpack/_webpack.vendor.js
+++ b/generators/client/templates/angular/webpack/_webpack.vendor.js
@@ -43,7 +43,7 @@ module.exports = {
             },
             <%_ } _%>
             {
-                test: /\.(jpe?g|png|gif|svg|woff|woff2|ttf|eot)$/i,
+                test: /\.(jpe?g|png|gif|svg|woff2?|ttf|eot)$/i,
                 loaders: [
                     'file-loader?hash=sha512&digest=hex&name=[hash].[ext]', {
                         loader: 'image-webpack-loader',


### PR DESCRIPTION
use `woff2?` instead `woff|woff2`