### PR TITLE
change heroku deployment to deploy as standalone application

### DIFF
--- a/generators/ci-cd/templates/_.gitlab-ci.yml
+++ b/generators/ci-cd/templates/_.gitlab-ci.yml
@@ -169,7 +169,7 @@ gatling-test:
 maven-deploy:
     stage: deploy
      script:
-        - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+        - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
     <%_ } else { _%>
 maven-package:
     stage: package

--- a/generators/ci-cd/templates/_circle.yml
+++ b/generators/ci-cd/templates/_circle.yml
@@ -63,7 +63,7 @@ test:
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
     <%_ if (heroku.includes('circle')) { _%>
-        - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+        - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
     <%_ } else { _%>
         - ./mvnw package -Pprod -DskipTests
     <%_ } _%>

--- a/generators/ci-cd/templates/_travis.yml
+++ b/generators/ci-cd/templates/_travis.yml
@@ -79,7 +79,7 @@ script:
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
   <%_ if (heroku.includes('travis')) { _%>
-  - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+  - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
   <%_ } else { _%>
   - ./mvnw package -Pprod -DskipTests
   <%_ } _%>

--- a/generators/ci-cd/templates/jenkins/_Jenkinsfile
+++ b/generators/ci-cd/templates/jenkins/_Jenkinsfile
@@ -74,7 +74,7 @@ node {
     <%_ } _%>
     <%_ if (heroku.includes('jenkins')) { _%>
 <%= indent %>    stage('package and deploy') {
-<%= indent %>        sh "./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy-war -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
+<%= indent %>        sh "./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
     <%_ } else { _%>
 <%= indent %>    stage('packaging') {
 <%= indent %>        sh "./mvnw package -Pprod -DskipTests"


### PR DESCRIPTION
change the deployment type because WebSockets don't work with the webapp-runner.jar used by heroku-maven-plugin but work when deployed as a Spring Boot standalone application

close #5507