### PR TITLE
Fix AngularCli integration issues

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -15,6 +15,7 @@ const files = {
         {
             templates: [
                 '_package.json',
+                '_proxy.conf.json',
                 '_tsconfig.json',
                 '_tsconfig-aot.json',
                 '_tslint.json',

--- a/generators/client/templates/angular/_.angular-cli.json
+++ b/generators/client/templates/angular/_.angular-cli.json
@@ -1,5 +1,6 @@
 {
   "project": {
+    "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
     "name": "<%= dasherizedBaseName %>"
   },
   "apps": [
@@ -8,19 +9,26 @@
       "outDir": "<%= DIST_DIR %>app",
       "assets": [
         "content",
+        "i18n",
         "favicon.ico"
       ],
       "index": "index.html",
       "main": "app/app.main.ts",
+      "polyfills": "app/polyfills.ts",
       "test": "",
       "tsconfig": "../../../tsconfig.json",
       "prefix": "<%= jhiPrefix %>",
       "mobile": false,
       "styles": [
-        "content/css/main.css"
+        <%_ if (useSass) { _%>
+        "content/scss/vendor.scss",
+        "content/scss/global.scss"
+        <%_ } else { _%>
+        "content/css/vendor.css",
+        "content/css/global.css"
+        <%_ } _%>
       ],
-      "scripts": [],
-      "environments": {}
+      "scripts": []
     }
   ],
   "addons": [],
@@ -32,25 +40,36 @@
     }
   },
   <%_ } _%>
+  "lint": [
+    {
+      "project": "../../../tsconfig.json"
+    },
+    {
+      "project": "../../../tsconfig.-aotjson"
+    }
+  ],
   "test": {
     "karma": {
       "config": "src/test/javascript/karma.conf.js"
     }
   },
   "defaults": {
+    <%_ if (useSass) { _%>
+    "styleExt": "scss",
+    <%_ } else { _%>
     "styleExt": "css",
+    <%_ } _%>
     "prefixInterfaces": false,
     "inline": {
       "style": true,
       "template": false
     },
     "spec": {
-      "class": false,
       "component": false,
       "directive": false,
-      "module": false,
       "pipe": false,
       "service": false
     }
-  }
+  },
+  "packageManager": "yarn"
 }

--- a/generators/client/templates/angular/_.angular-cli.json
+++ b/generators/client/templates/angular/_.angular-cli.json
@@ -47,7 +47,7 @@
       "project": "../../../tsconfig.json"
     },
     {
-      "project": "../../../tsconfig.-aotjson"
+      "project": "../../../tsconfig-aotjson"
     }
   ],
   "test": {

--- a/generators/client/templates/angular/_.angular-cli.json
+++ b/generators/client/templates/angular/_.angular-cli.json
@@ -47,7 +47,7 @@
       "project": "../../../tsconfig.json"
     },
     {
-      "project": "../../../tsconfig-aotjson"
+      "project": "../../../tsconfig-aot.json"
     }
   ],
   "test": {

--- a/generators/client/templates/angular/_.angular-cli.json
+++ b/generators/client/templates/angular/_.angular-cli.json
@@ -9,7 +9,9 @@
       "outDir": "<%= DIST_DIR %>app",
       "assets": [
         "content",
+        <%_ if (enableTranslation) { _%>
         "i18n",
+        <%_ } _%>
         "favicon.ico"
       ],
       "index": "index.html",

--- a/generators/client/templates/angular/_proxy.conf.json
+++ b/generators/client/templates/angular/_proxy.conf.json
@@ -1,0 +1,7 @@
+{
+  "*": {
+    "target":"http://localhost:<%= serverPort %>",
+    "secure": false,
+    "loglevel": "debug"
+  }
+}


### PR DESCRIPTION
Fix integration issues with AngularCli regarding styling, polyfills and content loading.
Also add default proxy configuration when using ng serve instead of yarn start. User can now run `ng serve —proxy-conf proxy.conf.json` to use his backend.

Related to #5558