### PR TITLE
return bad request on PUT if ID is not provided in entity

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/web/rest/_EntityResource.java
+++ b/generators/entity/templates/server/src/main/java/package/web/rest/_EntityResource.java
@@ -108,7 +108,7 @@ public class <%= entityClass %>Resource {
     public ResponseEntity<<%= instanceType %>> update<%= entityClass %>(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) throws URISyntaxException {
         log.debug("REST request to update <%= entityClass %> : {}", <%= instanceName %>);
         if (<%= instanceName %>.getId() == null) {
-            return create<%= entityClass %>(<%= instanceName %>);
+            return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "noid", "An existing <%= entityInstance %> must have an ID")).body(null);
         }<%- include('../../common/save_template', {viaService: viaService}); -%>
         return ResponseEntity.ok()
             .headers(HeaderUtil.createEntityUpdateAlert(ENTITY_NAME, <%= instanceName %>.getId().toString()))


### PR DESCRIPTION
I would suggest to return a bad request when an update of an entity is performed when the ID of the entity is not provided.

Currently if the ID is null, the call is redirect to an entity creation.
I think if the client perform a PUT and does not provide an ID, that means there is a mistake somewhere and this action shouldn't be considered as an entity creation.

What do you think?

