### PR TITLE
log exception with stacktrace

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/errors/_ExceptionTranslator.java
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/_ExceptionTranslator.java
@@ -20,6 +20,8 @@ package <%=packageName%>.web.rest.errors;
 
 import java.util.List;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.annotation.AnnotationUtils;
 <%_ if (databaseType != 'no' && databaseType != 'cassandra') { _%>
 import org.springframework.dao.ConcurrencyFailureException;
@@ -39,6 +41,8 @@ import org.springframework.web.bind.annotation.*;
  */
 @ControllerAdvice
 public class ExceptionTranslator {
+
+    private final Logger log = LoggerFactory.getLogger(ExceptionTranslator.class);
 <%_ if (databaseType != 'no' && databaseType != 'cassandra') { _%>
 
     @ExceptionHandler(ConcurrencyFailureException.class)
@@ -84,7 +88,8 @@ public class ExceptionTranslator {
     }
 
     @ExceptionHandler(Exception.class)
-    public ResponseEntity<ErrorVM> processRuntimeException(Exception ex) {
+    public ResponseEntity<ErrorVM> processException(Exception ex) {
+        log.error(ex.getMessage(), ex);
         BodyBuilder builder;
         ErrorVM errorVM;
         ResponseStatus responseStatus = AnnotationUtils.findAnnotation(ex.getClass(), ResponseStatus.class);


### PR DESCRIPTION
Logs the exception with the stacktrace when exception is handled by `@ExceptionHandler(Exception.class)`.

In production, a RuntimeException that leads for the client to a `ErrorConstants.ERR_INTERNAL_SERVER_ERROR` should be logged server side (message and stacktrace) to know what is wrong

WDYT?