### PR TITLE
remove tmp volume from dockerfile

### DIFF
--- a/generators/server/templates/src/main/docker/_Dockerfile
+++ b/generators/server/templates/src/main/docker/_Dockerfile
@@ -24,7 +24,6 @@ ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
 # add directly the war
 ADD *.war /app.war
 
-VOLUME /tmp
 EXPOSE <%= serverPort %><% if (hibernateCache == 'hazelcast') { %> 5701/udp<% } %>
 CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
     sleep ${JHIPSTER_SLEEP} && \


### PR DESCRIPTION
The /tmp volume doesn't serve a purpose for us (original purpose seems to be Tomcat related).  Removing it shouldn't cause any issues as users can still declare a tmp volume if they wish (which would go along with Policy 1).  This was done in the registry already https://github.com/jhipster/jhipster-registry/pull/105

Original reasoning was from https://spring.io/guides/gs/spring-boot-docker/ (same place the old `touch` command we removed came from)
>	We added a VOLUME pointing to "/tmp" because that is where a Spring Boot application creates working directories for Tomcat by default. The effect is to create a temporary file on your host under "/var/lib/docker" and link it to the container under "/tmp". This step is optional for the simple app that we wrote here, but can be necessary for other Spring Boot applications if they need to actually write in the filesystem.

I have an app that uses the filesystem heavily but no issues without the `/tmp` volume.  Another downside about the volume is that when removing the container, you must specify to remove the volume as well, even if you didn't mount it.

- [ ] Travis tests are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per [CONTRIBUTING.md](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
