### PR TITLE
user validation in WS layer

### DIFF
--- a/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
+++ b/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
@@ -43,6 +43,7 @@ public class UserDTO {
         if (enableSocialSignIn) {
             columnMax = 100;
         } _%>
+    @NotNull
     @Pattern(regexp = Constants.LOGIN_REGEX)
     @Size(min = 1, max = <%=columnMax %>)
     private String login;

--- a/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
@@ -43,6 +43,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.annotation.Secured;
 import org.springframework.web.bind.annotation.*;
 
+import javax.validation.Valid;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.util.*;<% if (searchEngine == 'elasticsearch') { %>
@@ -117,7 +118,7 @@ public class UserResource {
     @PostMapping("/users")
     @Timed
     @Secured(AuthoritiesConstants.ADMIN)
-    public ResponseEntity createUser(@RequestBody ManagedUserVM managedUserVM) throws URISyntaxException {
+    public ResponseEntity createUser(@Valid @RequestBody ManagedUserVM managedUserVM) throws URISyntaxException {
         log.debug("REST request to save User : {}", managedUserVM);
 
         if (managedUserVM.getId() != null) {
@@ -153,7 +154,7 @@ public class UserResource {
     @PutMapping("/users")
     @Timed
     @Secured(AuthoritiesConstants.ADMIN)
-    public ResponseEntity<UserDTO> updateUser(@RequestBody ManagedUserVM managedUserVM) {
+    public ResponseEntity<UserDTO> updateUser(@Valid @RequestBody ManagedUserVM managedUserVM) {
         log.debug("REST request to update User : {}", managedUserVM);
         Optional<User> existingUser = userRepository.findOneByEmail(managedUserVM.getEmail());
         if (existingUser.isPresent() && (!existingUser.get().getId().equals(managedUserVM.getId()))) {


### PR DESCRIPTION
Validates the `managedUserVM` in the WS layer (like in AccountResource)

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [] Tests are added where necessary, **supplementary tests could be written when having a null or empty login for example but it might not be worth the amount of code for this.., let me know**
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
