### PR TITLE
Disable angular-cli webpack commands

### DIFF
--- a/generators/client/templates/angular/_.angular-cli.json
+++ b/generators/client/templates/angular/_.angular-cli.json
@@ -17,9 +17,10 @@
  limitations under the License.
 -%>
 {
+    "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
     "project": {
-        "$schema": "./node_modules/@angular/cli/lib/config/schema.json",
-        "name": "<%= dasherizedBaseName %>"
+        "name": "<%= dasherizedBaseName %>",
+        "ejected": true
     },
     "apps": [{
         "root": "<%= MAIN_SRC_DIR %>",


### PR DESCRIPTION
Currently in generated project, users can still run "ng build", "ng serve" and "ng test" which can bring confusion as these commands do nt have the required options for JHipster (api proxy, ...).

This change adds `"ejected": true` in `.angular-cli.json` so that users can no longer use angular-cli build process but still use other commands like "ng generate".

If a user tries "ng build" on an ejected project, an error is thrown: "An ejected project cannot use the build command anymore."

See https://github.com/angular/angular-cli/wiki/eject#ng-eject

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
