### PR TITLE
Reduce code duplication on entity save response handling

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -28,6 +28,7 @@ import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 import { Response } from '@angular/http';
 
+import { Observable } from 'rxjs/Rx';
 import { NgbActiveModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { EventManager, AlertService<% if (enableTranslation) { %>, JhiLanguageService<% } %><% if (fieldsContainBlob) { %>, DataUtils<% } %> } from 'ng-jhipster';
 
@@ -160,14 +161,17 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
     save() {
         this.isSaving = true;
         if (this.<%= entityInstance %>.id !== undefined) {
-            this.<%= entityInstance %>Service.update(this.<%= entityInstance %>)
-                .subscribe((res: <%= entityAngularName %>) =>
-                    this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
+            this.subscribeToSaveResponse(
+                this.<%= entityInstance %>Service.update(this.<%= entityInstance %>));
         } else {
-            this.<%= entityInstance %>Service.create(this.<%= entityInstance %>)
-                .subscribe((res: <%= entityAngularName %>) =>
-                    this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
+            this.subscribeToSaveResponse(
+                this.<%= entityInstance %>Service.create(this.<%= entityInstance %>));
         }
+    }
+
+    private subscribeToSaveResponse(result: Observable<<%= entityAngularName %>>) {
+        result.subscribe((res: <%= entityAngularName %>) =>
+            this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
     }
 
     private onSaveSuccess(result: <%= entityAngularName %>) {

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity.service.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity.service.ts
@@ -48,13 +48,7 @@ export class <%= entityAngularName %>Service {
     create(<%= entityInstance %>: <%= entityAngularName %>):
         Observable<<%= entityAngularName %>> {
     <%_ } _%>
-        const copy: <%= entityAngularName %> = Object.assign({}, <%= entityInstance %>);
-        <%_ for (idx in fields){ if (fields[idx].fieldType == 'LocalDate') { _%>
-        copy.<%=fields[idx].fieldName%> = this.dateUtils
-            .convertLocalDateToServer(<%= entityInstance %>.<%=fields[idx].fieldName%>);
-        <%_ } if (fields[idx].fieldType == 'ZonedDateTime') { _%>
-        copy.<%=fields[idx].fieldName%> = this.dateUtils.toDate(<%= entityInstance %>.<%=fields[idx].fieldName%>);
-        <%_ } } _%>
+        const copy = this.convert(<%= entityInstance %>);
         return this.http.post(this.resourceUrl, copy).map((res: Response) => {
             return res.json();
         });
@@ -67,13 +61,7 @@ export class <%= entityAngularName %>Service {
     update(<%= entityInstance %>: <%= entityAngularName %>):
         Observable<<%= entityAngularName %>> {
     <%_ } _%>
-        const copy: <%= entityAngularName %> = Object.assign({}, <%= entityInstance %>);
-        <%_ for (idx in fields){ if (fields[idx].fieldType == 'LocalDate') { _%>
-        copy.<%=fields[idx].fieldName%> = this.dateUtils
-            .convertLocalDateToServer(<%= entityInstance %>.<%=fields[idx].fieldName%>);
-        <%_ } if (fields[idx].fieldType == 'ZonedDateTime') { %>
-        copy.<%=fields[idx].fieldName%> = this.dateUtils.toDate(<%= entityInstance %>.<%=fields[idx].fieldName%>);
-        <%_ } } _%>
+        const copy = this.convert(<%= entityInstance %>);
         return this.http.put(this.resourceUrl, copy).map((res: Response) => {
             return res.json();
         });
@@ -156,5 +144,16 @@ export class <%= entityAngularName %>Service {
             options.search = params;
         }
         return options;
+    }
+
+    private convert(<%= entityInstance %>: <%= entityAngularName %>): <%= entityAngularName %> {
+        const copy: <%= entityAngularName %> = Object.assign({}, <%= entityInstance %>);
+        <%_ for (idx in fields){ if (fields[idx].fieldType == 'LocalDate') { _%>
+        copy.<%=fields[idx].fieldName%> = this.dateUtils
+            .convertLocalDateToServer(<%= entityInstance %>.<%=fields[idx].fieldName%>);
+        <%_ } if (fields[idx].fieldType == 'ZonedDateTime') { %>
+        copy.<%=fields[idx].fieldName%> = this.dateUtils.toDate(<%= entityInstance %>.<%=fields[idx].fieldName%>);
+        <%_ } } _%>
+        return copy;
     }
 }


### PR DESCRIPTION
The same code is repeated twice for updating and inserting entity - this can be refactored to a separate function