### PR TITLE
Fix "sign in" left align when langage different from english

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.html
@@ -23,7 +23,7 @@
 </div>
 <div class="modal-body">
     <div class="row">
-        <div class="col-md-4 offset-md-4">
+        <div class="col-md-4 offset-md-2">
             <h1 jhiTranslate="login.title">Sign in</h1>
         </div>
         <div class="col-md-8 offset-md-2">


### PR DESCRIPTION
When language selected is french, "Sign in" left-align is not well displayed.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
