### PR TITLE
Add ResponseWrapper which can hold the parsed and converted response,…

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -366,6 +366,7 @@ const files = {
                 'shared/_shared-common.module.ts',
                 'shared/constants/_pagination.constants.ts',
                 // models
+                'shared/model/_response-wrapper.model.ts',
                 'shared/user/_account.model.ts',
                 // login
                 'shared/login/_login.component.ts',

--- a/generators/client/templates/angular/src/main/webapp/app/shared/_index.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/_index.ts
@@ -48,6 +48,7 @@ export * from './user/account.model';
 export * from './user/user.model';
 export * from './user/user.service';
 <%_ } _%>
+export * from './model/response-wrapper.model';
 <%_ if (enableSocialSignIn) { _%>
 export * from './social/social.service';
 export * from './social/social.component';

--- a/generators/client/templates/angular/src/main/webapp/app/shared/model/_response-wrapper.model.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/model/_response-wrapper.model.ts
@@ -1,0 +1,9 @@
+import { Headers } from '@angular/http';
+
+export class ResponseWrapper {
+
+    constructor(
+            public headers: Headers,
+            public json: any) {
+    }
+}

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.ts
@@ -17,14 +17,13 @@
  limitations under the License.
 -%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { Response } from '@angular/http';
 import { ActivatedRoute, Router } from '@angular/router';
 import { Subscription } from 'rxjs/Rx';
 import { EventManager, ParseLinks, PaginationUtil<% if (enableTranslation) { %>, JhiLanguageService<% } %>, AlertService<% if (fieldsContainBlob) { %>, DataUtils<% } %> } from 'ng-jhipster';
 
 import { <%= entityAngularName %> } from './<%= entityFileName %>.model';
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
-import { ITEMS_PER_PAGE, Principal } from '../../shared';
+import { ITEMS_PER_PAGE, Principal, ResponseWrapper } from '../../shared';
 import { PaginationConfig } from '../../blocks/config/uib-pagination.config';
 
 @Component({

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -74,8 +74,8 @@ _%>
                 size: this.itemsPerPage,
                 sort: this.sort()
             }).subscribe(
-                (res: Response) => this.onSuccess(res.json(), res.headers),
-                (res: Response) => this.onError(res.json())
+                (res: ResponseWrapper) => this.onSuccess(res.json, res.headers),
+                (res: ResponseWrapper) => this.onError(res.json)
             );
             return;
         }
@@ -85,8 +85,8 @@ _%>
             size: this.itemsPerPage,
             sort: this.sort()
         }).subscribe(
-            (res: Response) => this.onSuccess(res.json(), res.headers),
-            (res: Response) => this.onError(res.json())
+            (res: ResponseWrapper) => this.onSuccess(res.json, res.headers),
+            (res: ResponseWrapper) => this.onError(res.json)
         );
     }
 

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -54,20 +54,20 @@ _%>
             this.<%= entityInstance %>Service.search({
                 query: this.currentSearch,
                 }).subscribe(
-                    (res: Response) => this.<%= entityInstancePlural %> = res.json(),
-                    (res: Response) => this.onError(res.json())
+                    (res: ResponseWrapper) => this.<%= entityInstancePlural %> = res.json,
+                    (res: ResponseWrapper) => this.onError(res.json)
                 );
             return;
        }
        <%_ } _%>
         this.<%= entityInstance %>Service.query().subscribe(
-            (res: Response) => {
-                this.<%= entityInstancePlural %> = res.json();
+            (res: ResponseWrapper) => {
+                this.<%= entityInstancePlural %> = res.json;
                 <%_ if (searchEngine === 'elasticsearch') { _%>
                 this.currentSearch = '';
                 <%_ } _%>
             },
-            (res: Response) => this.onError(res.json())
+            (res: ResponseWrapper) => this.onError(res.json)
         );
     }
     <%_ if (searchEngine === 'elasticsearch') { _%>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -81,8 +81,8 @@ currentAccount: any;
                 query: this.currentSearch,
                 size: this.itemsPerPage,
                 sort: this.sort()}).subscribe(
-                    (res: Response) => this.onSuccess(res.json(), res.headers),
-                    (res: Response) => this.onError(res.json())
+                    (res: ResponseWrapper) => this.onSuccess(res.json, res.headers),
+                    (res: ResponseWrapper) => this.onError(res.json)
                 );
             return;
         }
@@ -91,8 +91,8 @@ currentAccount: any;
             page: this.page - 1,
             size: this.itemsPerPage,
             sort: this.sort()}<%_ } _%>).subscribe(
-            (res: Response) => this.onSuccess(res.json(), res.headers),
-            (res: Response) => this.onError(res.json())
+            (res: ResponseWrapper) => this.onSuccess(res.json, res.headers),
+            (res: ResponseWrapper) => this.onError(res.json)
         );
     }
     <%_ if (databaseType !== 'cassandra') { _%>


### PR DESCRIPTION
Add ResponseWrapper which can hold the parsed and converted response, and
 refactor the conversion methods, so one implementation is called in all the code
 paths: after get/create/update/search/query, for converting the server response to javascript objects. And the dubious res.json().data = jsonResponse is won't needed

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
