### PR TITLE
adds $JAVA_OPTS to Dockerfile

### DIFF
--- a/generators/server/templates/src/main/docker/_Dockerfile
+++ b/generators/server/templates/src/main/docker/_Dockerfile
@@ -20,6 +20,8 @@ FROM <%= DOCKER_JAVA_JRE %>
 
 ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
     JHIPSTER_SLEEP=0
+ENV JAVA_OPTS=""
+
 
 # add directly the war
 ADD *.war /app.war
@@ -27,4 +29,5 @@ ADD *.war /app.war
 EXPOSE <%= serverPort %><% if (hibernateCache == 'hazelcast') { %> 5701/udp<% } %>
 CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
     sleep ${JHIPSTER_SLEEP} && \
-    java -Djava.security.egd=file:/dev/./urandom -jar /app.war
+    java $JAVA_OPTS -Djava.security.egd=file:/dev/./urandom -jar /app.war
+


### PR DESCRIPTION
this allows the user to specify options like memory limit by
providing environment variables.


## Motivation

after running a workload of ~10 services (with replicas on top) in kubernetes, I run into heavy memory issues, were entire nodes were crashing as running Java in docker with default settings allocates nearly all the memory. This PR **does not change that**!! But now the user can provide 

```
ENV JAVA_OPTS = " -Xmx300m -Xms300m" 
```

in any way, like from CMD, in docker-compose, rancher-compose or kubernetes deployment, to **really** limit the JVM memory usage.

I can add docs to this for kubernetes

I decided not do set any options, in favor of not breaking change existing setups. I personally run my containers with 300m limits and have noticed no performance issues in any way.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
