### PR TITLE
Fix yaml files generated by docker-compose sub generator [ci skip]

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -266,8 +266,8 @@ module.exports = DockerComposeGenerator.extend({
                     yamlArray[j] = yamlArray[j].replace(/'/g, '');
                 }
                 yamlString = yamlArray.join('\n');
-                yamlString = yamlString.replace('>-\n                ', '');
-                yamlString = yamlString.replace('>-\n                ', '');
+                yamlString = yamlString.replace(/>-\n/g, '');
+                yamlString = yamlString.replace(/-\s\s+/g, '- ');
                 this.appsYaml.push(yamlString);
             });
         },


### PR DESCRIPTION
When using the sub generator docker-compose, the generated docker-compose.yml is incorrect, because of this: `- >-` :

```yaml
version: '2'
services:
    gateway-app:
        image: gateway
        environment:
            - SPRING_PROFILES_ACTIVE=prod,swagger
            - EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
            - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
            - >-
                SPRING_DATASOURCE_URL=jdbc:mysql://gateway-mysql:3306/gateway?useUnicode=true&characterEncoding=utf8&useSSL=false
            - SPRING_DATA_CASSANDRA_CONTACTPOINTS=gateway-cassandra
            - JHIPSTER_SLEEP=30
            - JHIPSTER_REGISTRY_PASSWORD=admin
        ports:
            - 8080:8080
    gateway-mysql:
        image: mysql:5.7.13
        environment:
            - MYSQL_USER=root
            - MYSQL_ALLOW_EMPTY_PASSWORD=yes
            - MYSQL_DATABASE=gateway
        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8
    
    jhipster-registry:
        extends:
            file: jhipster-registry.yml
            service: jhipster-registry
```

With this fix, the result is:
```yaml
version: '2'
services:
    gateway-app:
        image: gateway
        environment:
            - SPRING_PROFILES_ACTIVE=prod,swagger
            - EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
            - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
            - SPRING_DATASOURCE_URL=jdbc:mysql://gateway-mysql:3306/gateway?useUnicode=true&characterEncoding=utf8&useSSL=false
            - SPRING_DATA_CASSANDRA_CONTACTPOINTS=gateway-cassandra
            - JHIPSTER_SLEEP=30
            - JHIPSTER_REGISTRY_PASSWORD=admin
        ports:
            - 8080:8080
    gateway-mysql:
        image: mysql:5.7.13
        environment:
            - MYSQL_USER=root
            - MYSQL_ALLOW_EMPTY_PASSWORD=yes
            - MYSQL_DATABASE=gateway
        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8
    
    jhipster-registry:
        extends:
            file: jhipster-registry.yml
            service: jhipster-registry
```