### PR TITLE
Replace ZonedDateTime by Instant where possible

### DIFF
--- a/generators/server/templates/src/main/java/package/config/dbmigrations/_InitialSetupMigration.java
+++ b/generators/server/templates/src/main/java/package/config/dbmigrations/_InitialSetupMigration.java
@@ -32,7 +32,7 @@ import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 <%_ } _%>
 
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import java.util.Arrays;
 import java.util.Collections;
 
@@ -69,7 +69,7 @@ public class InitialSetupMigration {
         systemUser.setActivated(true);
         systemUser.setLangKey("en");
         systemUser.setCreatedBy(systemUser.getLogin());
-        systemUser.setCreatedDate(ZonedDateTime.now());
+        systemUser.setCreatedDate(Instant.now());
         systemUser.getAuthorities().add(adminAuthority);
         systemUser.getAuthorities().add(userAuthority);
         mongoTemplate.save(systemUser);
@@ -84,7 +84,7 @@ public class InitialSetupMigration {
         anonymousUser.setActivated(true);
         anonymousUser.setLangKey("en");
         anonymousUser.setCreatedBy(systemUser.getLogin());
-        anonymousUser.setCreatedDate(ZonedDateTime.now());
+        anonymousUser.setCreatedDate(Instant.now());
         mongoTemplate.save(anonymousUser);
 
         User adminUser = new User();
@@ -97,7 +97,7 @@ public class InitialSetupMigration {
         adminUser.setActivated(true);
         adminUser.setLangKey("en");
         adminUser.setCreatedBy(systemUser.getLogin());
-        adminUser.setCreatedDate(ZonedDateTime.now());
+        adminUser.setCreatedDate(Instant.now());
         adminUser.getAuthorities().add(adminAuthority);
         adminUser.getAuthorities().add(userAuthority);
         mongoTemplate.save(adminUser);
@@ -112,7 +112,7 @@ public class InitialSetupMigration {
         userUser.setActivated(true);
         userUser.setLangKey("en");
         userUser.setCreatedBy(systemUser.getLogin());
-        userUser.setCreatedDate(ZonedDateTime.now());
+        userUser.setCreatedDate(Instant.now());
         userUser.getAuthorities().add(userAuthority);
         mongoTemplate.save(userUser);
     }

--- a/generators/server/templates/src/main/java/package/domain/_AbstractAuditingEntity.java
+++ b/generators/server/templates/src/main/java/package/domain/_AbstractAuditingEntity.java
@@ -25,12 +25,12 @@ import org.hibernate.envers.Audited;<% } %>
 import org.springframework.data.annotation.CreatedBy;
 import org.springframework.data.annotation.CreatedDate;
 import org.springframework.data.annotation.LastModifiedBy;
-import org.springframework.data.annotation.LastModifiedDate;
-<% if (databaseType == 'mongodb') { %>import org.springframework.data.mongodb.core.mapping.Field;
-import java.time.ZonedDateTime;
+import org.springframework.data.annotation.LastModifiedDate;<% if (databaseType == 'mongodb') { %>
+import org.springframework.data.mongodb.core.mapping.Field;
+import java.time.Instant;
 <% } %><% if (databaseType == 'sql') { %>
 import org.springframework.data.jpa.domain.support.AuditingEntityListener;
-import java.time.ZonedDateTime;
+import java.time.Instant;
 import javax.persistence.Column;
 import javax.persistence.EntityListeners;
 import javax.persistence.MappedSuperclass;<% } %>
@@ -56,7 +56,7 @@ public abstract class AbstractAuditingEntity implements Serializable {
     @Column(name = "created_date", nullable = false)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("created_date")<% } %>
     @JsonIgnore
-    private ZonedDateTime createdDate = ZonedDateTime.now();
+    private Instant createdDate = Instant.now();
 
     @LastModifiedBy<% if (databaseType == 'sql') { %>
     @Column(name = "last_modified_by", length = 50)<% } %><% if (databaseType == 'mongodb') { %>
@@ -68,7 +68,7 @@ public abstract class AbstractAuditingEntity implements Serializable {
     @Column(name = "last_modified_date")<% } %><% if (databaseType == 'mongodb') { %>
     @Field("last_modified_date")<% } %>
     @JsonIgnore
-    private ZonedDateTime lastModifiedDate = ZonedDateTime.now();
+    private Instant lastModifiedDate = Instant.now();
 
     public String getCreatedBy() {
         return createdBy;
@@ -78,11 +78,11 @@ public abstract class AbstractAuditingEntity implements Serializable {
         this.createdBy = createdBy;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 
-    public void setCreatedDate(ZonedDateTime createdDate) {
+    public void setCreatedDate(Instant createdDate) {
         this.createdDate = createdDate;
     }
 
@@ -94,11 +94,11 @@ public abstract class AbstractAuditingEntity implements Serializable {
         this.lastModifiedBy = lastModifiedBy;
     }
 
-    public ZonedDateTime getLastModifiedDate() {
+    public Instant getLastModifiedDate() {
         return lastModifiedDate;
     }
 
-    public void setLastModifiedDate(ZonedDateTime lastModifiedDate) {
+    public void setLastModifiedDate(Instant lastModifiedDate) {
         this.lastModifiedDate = lastModifiedDate;
     }
 }

--- a/generators/server/templates/src/main/java/package/domain/_User.java
+++ b/generators/server/templates/src/main/java/package/domain/_User.java
@@ -20,7 +20,6 @@ package <%=packageName%>.domain;
 
 import <%=packageName%>.config.Constants;
 <% if (databaseType == 'cassandra') { %>
-import java.util.Date;
 import com.datastax.driver.mapping.annotations.*;<% } %>
 import com.fasterxml.jackson.annotation.JsonIgnore;<% if (databaseType == 'sql') { %>
 import org.hibernate.annotations.BatchSize;<% } %><% if (hibernateCache != 'no' && databaseType == 'sql') { %>
@@ -46,8 +45,8 @@ import javax.validation.constraints.Size;
 import java.io.Serializable;
 import java.util.HashSet;
 import java.util.Locale;
-import java.util.Set;<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
-import java.time.ZonedDateTime;<% } %>
+import java.util.Set;
+import java.time.Instant;
 
 /**
  * A user.
@@ -136,16 +135,12 @@ public class User<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
     @Column(name = "reset_key", length = 20)<% } %><% if (databaseType == 'mongodb') { %>
     @Field("reset_key")<% } %><% if (databaseType == 'cassandra') { %>
     @Column(name = "reset_key")<% } %>
-    private String resetKey;<%if (databaseType == 'sql') {%>
+    private String resetKey;
 
-    @Column(name = "reset_date")
-    private ZonedDateTime resetDate = null;<% }%><%if (databaseType == 'mongodb') {%>
-
-    @Field("reset_date")
-    private ZonedDateTime resetDate = null;<% }%><% if (databaseType == 'cassandra') { %>
-
-    @Column(name = "reset_date")
-    private Date resetDate;<% }%>
+    <%_ if (databaseType == 'sql' || databaseType == 'cassandra') { _%>
+    @Column(name = "reset_date")<% } else if (databaseType == 'mongodb') {%>
+    @Field("reset_date")<% }%>
+    private Instant resetDate = null;
 
     @JsonIgnore<% if (databaseType == 'sql') { %>
     @ManyToMany
@@ -244,24 +239,15 @@ public class User<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
 
     public void setResetKey(String resetKey) {
         this.resetKey = resetKey;
-    }<% if (databaseType == 'sql' || databaseType == 'mongodb') {%>
+    }
 
-    public ZonedDateTime getResetDate() {
+    public Instant getResetDate() {
        return resetDate;
     }
 
-    public void setResetDate(ZonedDateTime resetDate) {
+    public void setResetDate(Instant resetDate) {
        this.resetDate = resetDate;
-    }<% }%><% if (databaseType == 'cassandra') { %>
-
-    public Date getResetDate() {
-        return resetDate;
     }
-
-    public void setResetDate(Date resetDate) {
-        this.resetDate = resetDate;
-    }<% }%>
-
     public String getLangKey() {
         return langKey;
     }

--- a/generators/server/templates/src/main/java/package/repository/_UserRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_UserRepository.java
@@ -24,11 +24,6 @@ import com.datastax.driver.mapping.Mapper;
 import com.datastax.driver.mapping.MappingManager;
 <%_ } _%>
 import <%=packageName%>.domain.User;
-<%_ if (databaseType !== 'cassandra') { _%>
-
-import java.time.ZonedDateTime;
-
-<%_ } _%>
 <%_ if (databaseType === 'sql' || databaseType === 'mongodb') { _%>
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -53,6 +48,9 @@ import java.util.Optional;
 <%_ if (databaseType == 'cassandra') { _%>
 import java.util.Set;
 <%_ } _%>
+<%_ if (databaseType !== 'cassandra') { _%>
+import java.time.Instant;
+<%_ } _%>
 
 <%_ if (databaseType === 'sql') { _%>
 /**
@@ -74,7 +72,7 @@ public interface UserRepository extends <% if (databaseType == 'sql') { %>JpaRep
 
     Optional<User> findOneByActivationKey(String activationKey);
 
-    List<User> findAllByActivatedIsFalseAndCreatedDateBefore(ZonedDateTime dateTime);
+    List<User> findAllByActivatedIsFalseAndCreatedDateBefore(Instant dateTime);
 
     Optional<User> findOneByResetKey(String resetKey);
 

--- a/generators/server/templates/src/main/java/package/service/_UserService.java
+++ b/generators/server/templates/src/main/java/package/service/_UserService.java
@@ -45,7 +45,10 @@ import org.springframework.transaction.annotation.Transactional;<% } %>
 <%_ if ((databaseType == 'sql' || databaseType == 'mongodb') && authenticationType == 'session') { _%>
 import java.time.LocalDate;
 <%_ } _%>
-import java.time.ZonedDateTime;
+import java.time.Instant;
+<%_ if (databaseType == 'sql' || databaseType == 'mongodb') { _%>
+import java.time.temporal.ChronoUnit;
+<%_ } _%>
 import java.util.*;
 import java.util.stream.Collectors;
 
@@ -124,10 +127,7 @@ public class UserService {
        log.debug("Reset user password for reset key {}", key);
 
        return userRepository.findOneByResetKey(key)
-            .filter(user -> {
-                ZonedDateTime oneDayAgo = ZonedDateTime.now().minusHours(24);
-                return user.getResetDate()<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>.isAfter(oneDayAgo);<% } %><% if (databaseType == 'cassandra') { %>.after(Date.from(oneDayAgo.toInstant()));<% } %>
-           })
+           .filter(user -> user.getResetDate().isAfter(Instant.now().minusSeconds(86400)))
            .map(user -> {
                 user.setPassword(passwordEncoder.encode(newPassword));
                 user.setResetKey(null);
@@ -144,7 +144,7 @@ public class UserService {
             .filter(User::getActivated)
             .map(user -> {
                 user.setResetKey(RandomUtil.generateResetKey());
-                user.<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>setResetDate(ZonedDateTime.now());<% } %><% if (databaseType == 'cassandra') { %>setResetDate(new Date());<% } %>
+                user.setResetDate(Instant.now());
                 <%_ if (databaseType == 'mongodb' || databaseType == 'cassandra') { _%>
                 userRepository.save(user);
                 <%_ } _%>
@@ -218,7 +218,7 @@ public class UserService {
         String encryptedPassword = passwordEncoder.encode(RandomUtil.generatePassword());
         user.setPassword(encryptedPassword);
         user.setResetKey(RandomUtil.generateResetKey());
-        user.<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>setResetDate(ZonedDateTime.now());<% } %><% if (databaseType == 'cassandra') { %>setResetDate(new Date());<% } %>
+        user.setResetDate(Instant.now());
         user.setActivated(true);
         userRepository.save(user);<% if (searchEngine == 'elasticsearch') { %>
         userSearchRepository.save(user);<% } %>
@@ -395,8 +395,7 @@ public class UserService {
      */
     @Scheduled(cron = "0 0 1 * * ?")
     public void removeNotActivatedUsers() {
-        ZonedDateTime now = ZonedDateTime.now();
-        List<User> users = userRepository.findAllByActivatedIsFalseAndCreatedDateBefore(now.minusDays(3));
+        List<User> users = userRepository.findAllByActivatedIsFalseAndCreatedDateBefore(Instant.now().minus(3, ChronoUnit.DAYS));
         for (User user : users) {
             log.debug("Deleting not activated user {}", user.getLogin());
             userRepository.delete(user);<% if (searchEngine == 'elasticsearch') { %>

--- a/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
+++ b/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
@@ -28,7 +28,7 @@ import org.hibernate.validator.constraints.NotBlank;
 
 import javax.validation.constraints.*;
 <%_ if (databaseType == 'mongodb' || databaseType == 'sql') { _%>
-import java.time.ZonedDateTime;
+import java.time.Instant;
 <%_ } _%>
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -72,11 +72,11 @@ public class UserDTO {
 
     private String createdBy;
 
-    private ZonedDateTime createdDate;
+    private Instant createdDate;
 
     private String lastModifiedBy;
 
-    private ZonedDateTime lastModifiedDate;
+    private Instant lastModifiedDate;
     <%_ } _%>
 
     private Set<String> authorities;
@@ -96,7 +96,7 @@ public class UserDTO {
 
     public UserDTO(<% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } else { %>Long<% } %> id, String login, String firstName, String lastName,
         String email, boolean activated,<% if (databaseType == 'sql' || databaseType == 'mongodb') { %> String imageUrl, <% } %>String langKey,<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>
-        String createdBy, ZonedDateTime createdDate, String lastModifiedBy, ZonedDateTime lastModifiedDate,
+        String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate,
         <% } %>Set<String> authorities) {
 
         this.id = id;
@@ -165,7 +165,7 @@ public class UserDTO {
         return createdBy;
     }
 
-    public ZonedDateTime getCreatedDate() {
+    public Instant getCreatedDate() {
         return createdDate;
     }
 
@@ -173,11 +173,11 @@ public class UserDTO {
         return lastModifiedBy;
     }
 
-    public ZonedDateTime getLastModifiedDate() {
+    public Instant getLastModifiedDate() {
         return lastModifiedDate;
     }
 
-    public void setLastModifiedDate(ZonedDateTime lastModifiedDate) {
+    public void setLastModifiedDate(Instant lastModifiedDate) {
         this.lastModifiedDate = lastModifiedDate;
     }
     <%_ } _%>

--- a/generators/server/templates/src/main/java/package/web/rest/vm/_ManagedUserVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/vm/_ManagedUserVM.java
@@ -22,7 +22,7 @@ import <%=packageName%>.service.dto.UserDTO;
 import javax.validation.constraints.Size;
 
 <%_ if (databaseType == 'mongodb' || databaseType == 'sql') { _%>
-import java.time.ZonedDateTime;
+import java.time.Instant;
 <%_ } _%>
 import java.util.Set;
 
@@ -44,7 +44,7 @@ public class ManagedUserVM extends UserDTO {
 
     public ManagedUserVM(<% if (databaseType == 'mongodb' || databaseType == 'cassandra') { %>String<% } else { %>Long<% } %> id, String login, String password, String firstName, String lastName,
                          String email, boolean activated<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, String imageUrl<% } %>, String langKey,
-                         <% if (databaseType == 'mongodb' || databaseType == 'sql') { %>String createdBy, ZonedDateTime createdDate, String lastModifiedBy, ZonedDateTime lastModifiedDate,
+                         <% if (databaseType == 'mongodb' || databaseType == 'sql') { %>String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate,
                         <% } %>Set<String> authorities) {
 
         super(id, login, firstName, lastName, email, activated<% if (databaseType == 'mongodb' || databaseType == 'sql') { %>, imageUrl<% } %>, langKey,

--- a/generators/server/templates/src/test/java/package/service/_UserServiceIntTest.java
+++ b/generators/server/templates/src/test/java/package/service/_UserServiceIntTest.java
@@ -25,10 +25,8 @@ import <%=packageName%>.domain.User;<% if ((databaseType == 'sql' || databaseTyp
 import <%=packageName%>.repository.PersistentTokenRepository;<% } %>
 import <%=packageName%>.config.Constants;
 import <%=packageName%>.repository.UserRepository;
-import <%=packageName%>.service.dto.UserDTO;
-import java.time.ZonedDateTime;<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
-import <%=packageName%>.service.util.RandomUtil;<% } %><% if ((databaseType == 'sql' || databaseType == 'mongodb') && authenticationType == 'session') { %>
-import java.time.LocalDate;<% } %>
+import <%=packageName%>.service.dto.UserDTO;<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+import <%=packageName%>.service.util.RandomUtil;<% } %>
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -37,8 +35,12 @@ import org.springframework.transaction.annotation.Transactional;<% } %>
 import org.springframework.test.context.junit4.SpringRunner;
 <% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.PageRequest;
-import java.util.Optional;<%}%>
+import org.springframework.data.domain.PageRequest;<%}%>
+<% if ((databaseType == 'sql' || databaseType == 'mongodb') && authenticationType == 'session') { %>
+import java.time.LocalDate;<% } %>
+import java.time.Instant;<% if (databaseType == 'sql' || databaseType == 'mongodb') { %>
+import java.time.temporal.ChronoUnit;
+import java.util.Optional;<% } %>
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
@@ -99,7 +101,7 @@ public class UserServiceIntTest <% if (databaseType == 'cassandra') { %>extends 
     public void assertThatResetKeyMustNotBeOlderThan24Hours() {
         User user = userService.createUser("johndoe", "johndoe", "John", "Doe", "john.doe@localhost", "http://placehold.it/50x50", "en-US");
 
-        ZonedDateTime daysAgo = ZonedDateTime.now().minusHours(25);
+        Instant daysAgo = Instant.now().minus(25, ChronoUnit.HOURS);
         String resetKey = RandomUtil.generateResetKey();
         user.setActivated(true);
         user.setResetDate(daysAgo);
@@ -118,7 +120,7 @@ public class UserServiceIntTest <% if (databaseType == 'cassandra') { %>extends 
     public void assertThatResetKeyMustBeValid() {
         User user = userService.createUser("johndoe", "johndoe", "John", "Doe", "john.doe@localhost", "http://placehold.it/50x50", "en-US");
 
-        ZonedDateTime daysAgo = ZonedDateTime.now().minusHours(25);
+        Instant daysAgo = Instant.now().minus(25, ChronoUnit.HOURS);
         user.setActivated(true);
         user.setResetDate(daysAgo);
         user.setResetKey("1234");
@@ -132,7 +134,7 @@ public class UserServiceIntTest <% if (databaseType == 'cassandra') { %>extends 
     public void assertThatUserCanResetPassword() {
         User user = userService.createUser("johndoe", "johndoe", "John", "Doe", "john.doe@localhost", "http://placehold.it/50x50", "en-US");
         String oldPassword = user.getPassword();
-        ZonedDateTime daysAgo = ZonedDateTime.now().minusHours(2);
+        Instant daysAgo = Instant.now().minus(2, ChronoUnit.HOURS);
         String resetKey = RandomUtil.generateResetKey();
         user.setActivated(true);
         user.setResetDate(daysAgo);
@@ -150,8 +152,8 @@ public class UserServiceIntTest <% if (databaseType == 'cassandra') { %>extends 
     @Test
     public void testFindNotActivatedUsersByCreationDateBefore() {
         userService.removeNotActivatedUsers();
-        ZonedDateTime now = ZonedDateTime.now();
-        List<User> users = userRepository.findAllByActivatedIsFalseAndCreatedDateBefore(now.minusDays(3));
+        Instant now = Instant.now();
+        List<User> users = userRepository.findAllByActivatedIsFalseAndCreatedDateBefore(now.minus(3, ChronoUnit.DAYS));
         assertThat(users).isEmpty();
     }<% } %><% if ((databaseType == 'sql' || databaseType == 'mongodb') && authenticationType == 'session') { %>
 


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Note that the default Jackson Instant deserializer is less permissive than the ZonedDateTime one as it only accepts strings ending by "Z" or "+0000" and doesn't accept timezone offsets. The Instant deserializer can easily be modified with a Jackson2ObjectMapperBuilderCustomizer bean if necessary.
The fields modified here are read/serialize only so it doesn't break anything.