### PR TITLE
restrict aspect logging to Service, Repository and Resource beans

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/repository/_EntityRepository.java
+++ b/generators/entity/templates/server/src/main/java/package/repository/_EntityRepository.java
@@ -19,6 +19,7 @@
 package <%=packageName%>.repository;
 
 import <%=packageName%>.domain.<%=entityClass%>;
+import org.springframework.stereotype.Repository;
 <% if (databaseType == 'cassandra') { %>
 import com.datastax.driver.core.*;
 import com.datastax.driver.mapping.Mapper;
@@ -26,7 +27,6 @@ import com.datastax.driver.mapping.MappingManager;<% } %><% if (databaseType=='s
 import org.springframework.data.jpa.repository.*;<% if (fieldsContainOwnerManyToMany==true) { %>
 import org.springframework.data.repository.query.Param;<% } %>
 
-import org.springframework.stereotype.Repository;
 import java.util.List;<% } %><% if (databaseType=='mongodb') { %>
 import org.springframework.data.mongodb.repository.MongoRepository;<% } %><% if (databaseType == 'cassandra') { %>
 

--- a/generators/entity/templates/server/src/main/java/package/repository/_EntityRepository.java
+++ b/generators/entity/templates/server/src/main/java/package/repository/_EntityRepository.java
@@ -26,9 +26,9 @@ import com.datastax.driver.mapping.MappingManager;<% } %><% if (databaseType=='s
 import org.springframework.data.jpa.repository.*;<% if (fieldsContainOwnerManyToMany==true) { %>
 import org.springframework.data.repository.query.Param;<% } %>
 
+import org.springframework.stereotype.Repository;
 import java.util.List;<% } %><% if (databaseType=='mongodb') { %>
 import org.springframework.data.mongodb.repository.MongoRepository;<% } %><% if (databaseType == 'cassandra') { %>
-import org.springframework.stereotype.Repository;
 
 import javax.validation.ConstraintViolation;
 import javax.validation.ConstraintViolationException;
@@ -50,6 +50,7 @@ import java.util.UUID;<% } %>
  * Cassandra repository for the <%= entityClass %> entity.
  */<% } %><% if (databaseType=='sql' || databaseType=='mongodb') { %>
 @SuppressWarnings("unused")
+@Repository
 public interface <%=entityClass%>Repository extends <% if (databaseType=='sql') { %>JpaRepository<% } %><% if (databaseType=='mongodb') { %>MongoRepository<% } %><<%=entityClass%>,<%= pkType %>> {<% for (idx in relationships) { %><% if (relationships[idx].relationshipType == 'many-to-one' && relationships[idx].otherEntityName == 'user') { %>
 
     @Query("select <%= entityInstance %> from <%= entityClass %> <%= entityInstance %> where <%= entityInstance %>.<%= relationships[idx].relationshipFieldName %>.login = ?#{principal.username}")

--- a/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -51,9 +51,9 @@ public class LoggingAspect {
     /**
      * Pointcut that matches all repositories, services and Web REST endpoints.
      */
-    @Pointcut("(within(io.github.jhipster.travis.repository..*) && @annotation(org.springframework.stereotype.Repository))"+
-                  " || (within(io.github.jhipster.travis.service..*) && @annotation(org.springframework.stereotype.Service))"+
-                  " || (within(io.github.jhipster.travis.web.rest..*) && @annotation(org.springframework.web.bind.annotation.RestController))")
+    @Pointcut("(within(<%=packageName%>.repository..*) && @annotation(org.springframework.stereotype.Repository))"+
+                  " || (within(<%=packageName%>.service..*) && @annotation(org.springframework.stereotype.Service))"+
+                  " || (within(<%=packageName%>.web.rest..*) && @annotation(org.springframework.web.bind.annotation.RestController))")
     public void loggingPointcut() {
         // Method is empty as this is just a Pointcut, the implementations are in the advices.
     }

--- a/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -51,7 +51,9 @@ public class LoggingAspect {
     /**
      * Pointcut that matches all repositories, services and Web REST endpoints.
      */
-    @Pointcut("within(<%=packageName%>.repository..*) || within(<%=packageName%>.service..*) || within(<%=packageName%>.web.rest..*)")
+    @Pointcut("(within(<%=packageName%>.repository..*) && bean(*Repository))"+
+                  " || (within(<%=packageName%>.service..*) && bean(*Service))"+
+                  " || (within(<%=packageName%>.web.rest..*) && bean(*Resource))")
     public void loggingPointcut() {
         // Method is empty as this is just a Pointcut, the implementations are in the advices.
     }

--- a/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
+++ b/generators/server/templates/src/main/java/package/aop/logging/_LoggingAspect.java
@@ -51,9 +51,9 @@ public class LoggingAspect {
     /**
      * Pointcut that matches all repositories, services and Web REST endpoints.
      */
-    @Pointcut("(within(<%=packageName%>.repository..*) && bean(*Repository))"+
-                  " || (within(<%=packageName%>.service..*) && bean(*Service))"+
-                  " || (within(<%=packageName%>.web.rest..*) && bean(*Resource))")
+    @Pointcut("(within(io.github.jhipster.travis.repository..*) && @annotation(org.springframework.stereotype.Repository))"+
+                  " || (within(io.github.jhipster.travis.service..*) && @annotation(org.springframework.stereotype.Service))"+
+                  " || (within(io.github.jhipster.travis.web.rest..*) && @annotation(org.springframework.web.bind.annotation.RestController))")
     public void loggingPointcut() {
         // Method is empty as this is just a Pointcut, the implementations are in the advices.
     }


### PR DESCRIPTION
LoggingAspect no longer logs every single bean in the affect packages but only those complying with the naming convention.

Fixes #5715
