### PR TITLE
Fix docker-compose when using new registry [ci skip]

### DIFF
--- a/generators/docker-compose/templates/_jhipster-registry.yml
+++ b/generators/docker-compose/templates/_jhipster-registry.yml
@@ -29,6 +29,7 @@ services:
         environment:
             - SPRING_PROFILES_ACTIVE=dev,native
             - SECURITY_USER_PASSWORD=<%= adminPassword %>
+            - JHIPSTER_REGISTRY_PASSWORD=<%= adminPassword %>
             <%_ if (monitoring === 'elk') { _%>
             - JHIPSTER_LOGGING_LOGSTASH_ENABLED=true
             - JHIPSTER_LOGGING_LOGSTASH_HOST=jhipster-logstash


### PR DESCRIPTION
When using the new registry, this missing config is needed.

Steps to reproduce:
- generate a gateway
- build with: `./mvnw package -Pprod docker:build`
- create a new folder: `compose`
- generate the compose file with: `yo jhipster:docker-compose` and select the previous gateway
- edit `jhipster-registry.yml` and replace `jhipster/jhipster-registry:v2.6.0` by `jhipster/jhipster-registry:develop`
- then, run with: `docker-compose up`
- you'll get this error for jhipster-registry:
```
jhipster-registry_1  | java.net.URISyntaxException: Illegal character in authority at index 7: http://admin:${jhipster.registry.password}@jhipster-registry:8761/eureka/
jhipster-registry_1  | 	at java.net.URI$Parser.fail(URI.java:2848)
jhipster-registry_1  | 	at java.net.URI$Parser.parseAuthority(URI.java:3186)
jhipster-registry_1  | 	at java.net.URI$Parser.parseHierarchical(URI.java:3097)
jhipster-registry_1  | 	at java.net.URI$Parser.parse(URI.java:3053)
jhipster-registry_1  | 	at java.net.URI.<init>(URI.java:588)
```

I skip tests because there is no Travis tests for this part.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
