### PR TITLE
add each language to webpack.common.js via language subgen

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -115,7 +115,9 @@
     "webpack-merge": "4.1.0",
     "webpack-notifier": "1.5.0",
     "webpack-visualizer-plugin": "0.1.11",
+    <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.5",
+    <%_ } _%>
     "write-file-webpack-plugin": "3.4.2",
     <%_ if (buildTool == 'maven') { _%>
     "xml2js": "0.4.17",

--- a/generators/client/templates/angular/webpack/_webpack.common.js
+++ b/generators/client/templates/angular/webpack/_webpack.common.js
@@ -23,7 +23,9 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const StringReplacePlugin = require('string-replace-webpack-plugin');
 const AddAssetHtmlPlugin = require('add-asset-html-webpack-plugin');
 const WebpackNotifierPlugin = require('webpack-notifier');
+<%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin")
+<%_ } _%>
 const path = require('path');
 
 module.exports = function (options) {
@@ -125,6 +127,7 @@ module.exports = function (options) {
                 $: "jquery",
                 jQuery: "jquery"
             }),
+            <%_ if (enableTranslation) { _%>
             new MergeJsonWebpackPlugin({
                 output: {
                     groupBy: [
@@ -132,6 +135,7 @@ module.exports = function (options) {
                     ]
                 }
             }),
+            <%_ } _%>
             new HtmlWebpackPlugin({
                 template: './src/main/webapp/index.html',
                 chunksSortMode: 'dependency',

--- a/generators/client/templates/angular/webpack/_webpack.common.js
+++ b/generators/client/templates/angular/webpack/_webpack.common.js
@@ -126,11 +126,9 @@ module.exports = function (options) {
                 jQuery: "jquery"
             }),
             new MergeJsonWebpackPlugin({
-                output:{
-                    groupBy:[
-<%_ for (language in languages) { _%>
-                        { pattern:"./src/main/webapp/i18n/<%= languages[language] %>/*.json", fileName:"./<%= BUILD_DIR %>www/i18n/<%= languages[language] %>/all.json" },
-<%_ } _%>
+                output: {
+                    groupBy: [
+                        // jhipster-needle-i18n-language-webpack - JHipster will add/remove languages in this array
                     ]
                 }
             }),

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1913,6 +1913,28 @@ module.exports = class extends Generator {
         }
     }
 
+    updateLanguagesInWebpack(languages) {
+        const fullPath = 'webpack/webpack.common.js';
+        try {
+            let content = 'groupBy: [\n';
+            for (let i = 0, len = languages.length; i < len; i++) {
+                const language = languages[i];
+                content += `                        { pattern: "./src/main/webapp/i18n/${language}/*.json", fileName: "./${this.BUILD_DIR}www/i18n/${language}/all.json" }${i !== languages.length - 1 ? ',' : ''}\n`;
+            }
+            content +=
+                '                        // jhipster-needle-i18n-language-webpack - JHipster will add/remove languages in this array\n' +
+                '                 ]';
+
+            jhipsterUtils.replaceContent({
+                file: fullPath,
+                pattern: /groupBy:.*\[([^\]]*jhipster-needle-i18n-language-webpack[^\]]*)\]/g,
+                content
+            }, this);
+        } catch (e) {
+            this.log(chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required jhipster-needle. Webpack language task not updated with languages: ') + languages + chalk.yellow(' since block was not found. Check if you have enabled translation support.\n'));
+        }
+    }
+
     insight(trackingCode = 'UA-46075199-2', packageName = packagejs.name, packageVersion = packagejs.version) {
         const insight = new Insight({
             trackingCode,

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -100,6 +100,12 @@ module.exports = LanguagesGenerator.extend({
             this.enableSocialSignIn = this.config.get('enableSocialSignIn');
             this.currentLanguages = this.config.get('languages');
             this.clientFramework = this.config.get('clientFramework');
+            // Make dist dir available in templates
+            if (this.config.get('buildTool') === 'maven') {
+                this.BUILD_DIR = 'target/';
+            } else {
+                this.BUILD_DIR = 'build/';
+            }
         }
     },
 
@@ -193,6 +199,7 @@ module.exports = LanguagesGenerator.extend({
                 this.updateLanguagesInLanguageConstant(this.config.get('languages'));
             } else {
                 this.updateLanguagesInLanguageConstantNG2(this.config.get('languages'));
+                this.updateLanguagesInWebpack(this.config.get('languages'));
             }
         }
     }


### PR DESCRIPTION
This is needed for the new way of loading translations - after the initial generation if a user adds a language with `yo jhipster:languages`, it needs to be added here as well or no translations load


- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
