### PR TITLE
upgrade mysql and add flag for explicit defaults for timestamp

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -20,7 +20,7 @@
 // version of docker images
 const DOCKER_JHIPSTER_REGISTRY = 'jhipster/jhipster-registry:v3.0.0';
 const DOCKER_JAVA_JRE = 'openjdk:8-jre-alpine';
-const DOCKER_MYSQL = 'mysql:5.7.13'; // mysql.5.7.14+ doesn't work well with zoned date time, see https://github.com/jhipster/generator-jhipster/pull/4038
+const DOCKER_MYSQL = 'mysql:5.7.18';
 const DOCKER_MARIADB = 'mariadb:10.1.17';
 const DOCKER_POSTGRESQL = 'postgres:9.6.2';
 const DOCKER_MONGODB = 'mongo:3.2.10';

--- a/generators/server/templates/src/main/docker/_mysql.yml
+++ b/generators/server/templates/src/main/docker/_mysql.yml
@@ -28,4 +28,4 @@ services:
             - MYSQL_DATABASE=<%=baseName.toLowerCase()%>
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8 --explicit_defaults_for_timestamp

--- a/test/templates/compose/01-gateway/src/main/docker/mysql.yml
+++ b/test/templates/compose/01-gateway/src/main/docker/mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     jhgate-mysql:
-        image: mysql:5.7.11
+        image: mysql:5.7.18
         # volumes:
         #     - ~/volumes/jhipster/jhgate/mysql/:/var/lib/mysql/
         environment:
@@ -10,4 +10,4 @@ services:
             - MYSQL_DATABASE=jhgate
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8 --explicit_defaults_for_timestamp

--- a/test/templates/compose/02-mysql/src/main/docker/mysql.yml
+++ b/test/templates/compose/02-mysql/src/main/docker/mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     msmysql-mysql:
-        image: mysql:5.7.11
+        image: mysql:5.7.18
         # volumes:
         #     - ~/volumes/jhipster/msmysql/mysql/:/var/lib/mysql/
         environment:
@@ -10,4 +10,4 @@ services:
             - MYSQL_DATABASE=msmysql
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8 --explicit_defaults_for_timestamp

--- a/test/templates/compose/06-uaa/src/main/docker/mysql.yml
+++ b/test/templates/compose/06-uaa/src/main/docker/mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     uaaserver-mysql:
-        image: mysql:5.7.11
+        image: mysql:5.7.18
         # volumes:
         #     - ~/volumes/jhipster/uaaserver/mysql/:/var/lib/mysql/
         environment:
@@ -10,4 +10,4 @@ services:
             - MYSQL_DATABASE=uaaserver
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8 --explicit_defaults_for_timestamp

--- a/test/templates/compose/08-monolith/src/main/docker/mysql.yml
+++ b/test/templates/compose/08-monolith/src/main/docker/mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     samplemysql-mysql:
-        image: mysql:5.7.13
+        image: mysql:5.7.18
         # volumes:
         #     - ~/volumes/jhipster/sampleMysql/mysql/:/var/lib/mysql/
         environment:
@@ -10,4 +10,4 @@ services:
             - MYSQL_DATABASE=samplemysql
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8 --explicit_defaults_for_timestamp

--- a/test/templates/compose/09-kafka/src/main/docker/mysql.yml
+++ b/test/templates/compose/09-kafka/src/main/docker/mysql.yml
@@ -1,7 +1,7 @@
 version: '2'
 services:
     samplekafka-mysql:
-        image: mysql:5.7.13
+        image: mysql:5.7.18
         # volumes:
         #     - ~/volumes/jhipster/sampleKafka/mysql/:/var/lib/mysql/
         environment:
@@ -10,4 +10,4 @@ services:
             - MYSQL_DATABASE=samplekafka
         ports:
             - 3306:3306
-        command: mysqld --lower_case_table_names=1 --skip-ssl
+        command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8 --explicit_defaults_for_timestamp


### PR DESCRIPTION
Fix #5743

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary (FieldTestEntity.json covers this)
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
