### PR TITLE
only copy Cassandra files for apps that use Cassandra

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -78,7 +78,7 @@ function writeFiles() {
             if (this.prodDatabaseType === 'oracle') {
                 this.template(`${DOCKER_DIR}_oracle.yml`, `${DOCKER_DIR}oracle.yml`);
             }
-            if (this.applicationType === 'gateway' || this.prodDatabaseType === 'cassandra') {
+            if (this.prodDatabaseType === 'cassandra') {
                 // docker-compose files
                 this.template(`${DOCKER_DIR}_cassandra.yml`, `${DOCKER_DIR}cassandra.yml`);
                 this.template(`${DOCKER_DIR}_cassandra-cluster.yml`, `${DOCKER_DIR}cassandra-cluster.yml`);
@@ -182,7 +182,7 @@ function writeFiles() {
                 }
             }
 
-            if (this.databaseType === 'cassandra' || this.applicationType === 'gateway') {
+            if (this.databaseType === 'cassandra') {
                 this.template(`${SERVER_MAIN_RES_DIR}config/cql/_create-keyspace-prod.cql`, `${SERVER_MAIN_RES_DIR}config/cql/create-keyspace-prod.cql`);
                 this.template(`${SERVER_MAIN_RES_DIR}config/cql/_create-keyspace.cql`, `${SERVER_MAIN_RES_DIR}config/cql/create-keyspace.cql`);
                 this.template(`${SERVER_MAIN_RES_DIR}config/cql/_drop-keyspace.cql`, `${SERVER_MAIN_RES_DIR}config/cql/drop-keyspace.cql`);

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -43,10 +43,6 @@ eureka:
 spring:
     application:
         name: <%= baseName %>
-    <%_ if (applicationType == 'gateway' && databaseType != 'cassandra') { _%>
-    autoconfigure:
-        exclude: org.springframework.boot.autoconfigure.data.cassandra.CassandraDataAutoConfiguration, org.springframework.boot.autoconfigure.cassandra.CassandraAutoConfiguration
-    <%_ } _%>
     jackson:
         serialization.write_dates_as_timestamps: false
     cache:
@@ -95,7 +91,7 @@ spring:
             port: 27117
             database: <%= baseName %>
     <%_ } _%>
-    <%_ if (applicationType == 'gateway' || databaseType == 'cassandra') { _%>
+    <%_ if (databaseType === 'cassandra') { _%>
         cassandra:
             contactPoints: localhost
             port: 0


### PR DESCRIPTION
We were still copying Cassandra yml files for gateways after removing it for rate-limiting

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
