### PR TITLE
Travis: remove ignore engines when launching yarn install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -69,7 +69,7 @@ before_install:
   - yarn global add yo bower gulp-cli
 install:
   - cd "$TRAVIS_BUILD_DIR"/
-  - yarn install --ignore-engines
+  - yarn install
   - yarn link
   - yarn run test
   - $JHIPSTER_SCRIPTS/01-generate-entities.sh


### PR DESCRIPTION
Related to JHipster CLI (https://github.com/jhipster/generator-jhipster/pull/5726 and https://github.com/jhipster/generator-jhipster/issues/5747), the flag `--ignore-engines` when launching `yarn install` should not be necessary

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
