### PR TITLE
Change registry volume mount for Consul Registry sidekick

### DIFF
--- a/generators/rancher-compose/templates/_docker-compose.yml
+++ b/generators/rancher-compose/templates/_docker-compose.yml
@@ -97,9 +97,9 @@ services:
         volumes:
           - /config
         volumes_from:
-          - consul-config-sidekick
+          - registry-config-sidekick
         labels:
-          io.rancher.sidekicks: consul-config-sidekick
+          io.rancher.sidekicks: registry-config-sidekick
 <%_ } _%>
 <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
     registry-config-sidekick:


### PR DESCRIPTION
Change to registry volume mount for Consul Registry sidekick in Rancher. Allows the configuration to be deployed to Rancher correctly when Consul has been selected.

Fix for #5778

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
