### PR TITLE
fix duplicate key issue in Korean health.json

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/ko/_health.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/_health.json
@@ -20,13 +20,13 @@
     "health": {
         "title": "상태 확인",
         "refresh.button": "새로고침",
-        "stacktrace": "Stack trace",
+        "stacktrace": "스택트레이스",
         "details": {
-            "details": "Details",
-            "properties": "Properties",
-            "name": "Name",
-            "value": "Value",
-            "error": "Error"
+            "details": "세부사항",
+            "properties": "정보",
+            "name": "이름",
+            "value": "값",
+            "error": "오류"
         },
         "indicator": {
             <%_ if (messageBroker === 'kafka') { _%>
@@ -45,7 +45,6 @@
             "mongo": "MongoDB"<% } %><% if (databaseType === 'cassandra') { %>,
             "cassandra": "Cassandra"<% } %>
         },
-        "stacktrace": "스택트레이스",
         "table": {
             "service": "서비스 이름",
             "status": "상태"


### PR DESCRIPTION
fix duplicate key "Stacktrace" in Ko health.json and add missing translations

noticed most translation files in jHipster kept "Stacktrace" in English -- not sure if there is a reason for that? I left the Korean transliteration, I also added a few missing translations (to the best of my ability)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
