### PR TITLE
fix duplicate key and add translations to Korean

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/ko/_health.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/_health.json
@@ -20,13 +20,13 @@
     "health": {
         "title": "상태 확인",
         "refresh.button": "새로고침",
-        "stacktrace": "Stack trace",
+        "stacktrace": "스택트레이스",
         "details": {
-            "details": "Details",
-            "properties": "Properties",
-            "name": "Name",
-            "value": "Value",
-            "error": "Error"
+            "details": "세부사항",
+            "properties": "정보",
+            "name": "이름",
+            "value": "값",
+            "error": "오류"
         },
         "indicator": {
             <%_ if (messageBroker === 'kafka') { _%>
@@ -45,7 +45,6 @@
             "mongo": "MongoDB"<% } %><% if (databaseType === 'cassandra') { %>,
             "cassandra": "Cassandra"<% } %>
         },
-        "stacktrace": "스택트레이스",
         "table": {
             "service": "서비스 이름",
             "status": "상태"


### PR DESCRIPTION
fix duplicate key for "stacktrace" and add missing translations in i18n/ko/_health.json

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
