### PR TITLE
remove webpack for ng1

### DIFF
--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -102,9 +102,9 @@ gulpBuildWithOpts.dependsOn npm_install
 gulpBuildWithOpts.dependsOn bower
 processResources.dependsOn gulpBuildWithOpts
 test.dependsOn gulp_test
-test.dependsOn webpack_test
 bootRun.dependsOn gulp_test
     <%_ } else { _%>
+test.dependsOn webpack_test
 processResources.dependsOn webpack
     <%_ } _%>
 <%_ } _%>


### PR DESCRIPTION
Currently frontend test when using ng1 also contains webpack, which doesn't work :)
When merging this PR webpack is only used when angular is used and gulp only when ng1 is selected.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
