### PR TITLE
Added --history-api-fallback

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -148,7 +148,7 @@
     "webpack:build": "<%= clientPackageManager %> run ngc && webpack --config webpack/webpack.vendor.js && webpack --config webpack/webpack.dev.js",
     "webpack:build:dev": "webpack --config webpack/webpack.dev.js",
     "webpack:build:vendor": "webpack --config webpack/webpack.vendor.js",
-    "webpack:dev": "webpack-dev-server --config webpack/webpack.dev.js  --progress --inline --hot --profile --port=9060",
+    "webpack:dev": "webpack-dev-server --config webpack/webpack.dev.js  --progress --inline --hot --profile --port=9060 --history-api-fallback",
     "webpack:test": "<%= clientPackageManager %> run ngc && <%= clientPackageManager %> run test",
     "webpack:prod": "<%= clientPackageManager %> run ngc && webpack -p --config webpack/webpack.vendor.js && webpack -p --config webpack/webpack.prod.js",
     "test": "<%= clientPackageManager %> run lint && karma start src/test/javascript/karma.conf.js",


### PR DESCRIPTION
Added param for webpack-dev-server. It prevents 404 error in development mode during browser refresh or internal redirect
