### PR TITLE
Same level for io.github.jhipster than the packageName

### DIFF
--- a/generators/server/templates/src/main/resources/_logback-spring.xml
+++ b/generators/server/templates/src/main/resources/_logback-spring.xml
@@ -42,7 +42,7 @@
 
     <logger name="<%=packageName%>" level="#logback.loglevel#"/>
 
-    <logger name="io.github.jhipster" level="DEBUG"/>
+    <logger name="io.github.jhipster" level="#logback.loglevel#"/>
 <% if (databaseType == 'cassandra') { %>
     <logger name="io.netty" level="WARN"/><% } %>
     <logger name="javax.activation" level="WARN"/>
@@ -101,6 +101,9 @@
 
     <root level="#logback.loglevel#">
         <appender-ref ref="CONSOLE"/>
+<!--
+        <appender-ref ref="FILE"/>
+-->
     </root>
 
 </configuration>


### PR DESCRIPTION
Some minor change in the logback configuration:
1) `io.github.jhipster` at same level than `packageName`, specially when building for prod
2) add in comment the appender-ref to `FILE`, so the logfile won't be empty when uncomment the first part

_____



- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green -> https://travis-ci.org/pascalgrimaud/generator-jhipster/builds/237258092
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
