### PR TITLE
Kubernetes: display correctly the folder name to lowercase [ci skip]

### DIFF
--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -240,14 +240,14 @@ module.exports = KubernetesGenerator.extend({
             this.log(`  ${chalk.cyan('kubectl apply -f registry')}`);
         }
         for (let i = 0; i < this.appsFolders.length; i++) {
-            this.log(`  ${chalk.cyan(`kubectl apply -f ${this.appConfigs[i].baseName}`)}`);
+            this.log(`  ${chalk.cyan(`kubectl apply -f ${this.appConfigs[i].baseName.toLowerCase()}`)}`);
         }
 
         if (this.gatewayNb + this.monolithicNb >= 1) {
             this.log('\nUse these commands to find your application\'s IP addresses:');
             for (let i = 0; i < this.appsFolders.length; i++) {
                 if (this.appConfigs[i].applicationType === 'gateway' || this.appConfigs[i].applicationType === 'monolith') {
-                    this.log(`  ${chalk.cyan(`kubectl get svc ${this.appConfigs[i].baseName}`)}`);
+                    this.log(`  ${chalk.cyan(`kubectl get svc ${this.appConfigs[i].baseName.toLowerCase()}`)}`);
                 }
             }
             this.log();


### PR DESCRIPTION
When generating Kubernetes configuration, the instructions are not correct, because the displayed folder must be in lowercase

___


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
