### PR TITLE
modify interaction with Heroku CLI for plugin install and new Heroku account

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -145,7 +145,7 @@ module.exports = HerokuGenerator.extend({
             const cliPlugin = 'heroku-cli-deploy';
 
             exec('heroku plugins', (err, stdout) => {
-                if (stdout.indexOf(cliPlugin) > -1) {
+                if (_.includes(stdout, cliPlugin)) {
                     this.log('\nHeroku CLI deployment plugin already installed');
                     done();
                 } else {
@@ -260,7 +260,7 @@ module.exports = HerokuGenerator.extend({
             exec(`heroku addons:create ${dbAddOn} --app ${this.herokuAppName}`, {}, (err, stdout, stderr) => {
                 if (err) {
                     const verifyAccountUrl = 'https://heroku.com/verify';
-                    if (err.indexOf(verifyAccountUrl) > -1) {
+                    if (_.includes(err, verifyAccountUrl)) {
                         this.abort = true;
                         this.log.error(`Account must be verified to use addons. Please go to: ${verifyAccountUrl}`);
                         this.log.error(err);

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -142,17 +142,27 @@ module.exports = HerokuGenerator.extend({
         installHerokuDeployPlugin() {
             if (this.abort) return;
             const done = this.async();
-            this.log(chalk.bold('\nInstalling Heroku CLI deployment plugin'));
-            const child = exec('heroku plugins:install heroku-cli-deploy', (err, stdout) => {
-                if (err) {
-                    this.abort = true;
-                    this.log.error(err);
-                }
-                done();
-            });
+            const cliPlugin = 'heroku-cli-deploy';
 
-            child.stdout.on('data', (data) => {
-                this.log(data.toString());
+            exec('heroku plugins', (err, stdout) => {
+                if (stdout.indexOf(cliPlugin) > -1) {
+                    this.log('\nHeroku CLI deployment plugin already installed');
+                    done();
+                } else {
+                    this.log(chalk.bold('\nInstalling Heroku CLI deployment plugin'));
+                    const child = exec(`heroku plugins:install ${cliPlugin}`, (err, stdout) => {
+                        if (err) {
+                            this.abort = true;
+                            this.log.error(err);
+                        }
+
+                        done();
+                    });
+
+                    child.stdout.on('data', (data) => {
+                        this.log(data.toString());
+                    });
+                }
             });
         },
 
@@ -249,7 +259,14 @@ module.exports = HerokuGenerator.extend({
             this.log(chalk.bold('\nProvisioning addons'));
             exec(`heroku addons:create ${dbAddOn} --app ${this.herokuAppName}`, {}, (err, stdout, stderr) => {
                 if (err) {
-                    this.log('No new addons created');
+                    const verifyAccountUrl = 'https://heroku.com/verify';
+                    if (err.indexOf(verifyAccountUrl) > -1) {
+                        this.abort = true;
+                        this.log.error(`Account must be verified to use addons. Please go to: ${verifyAccountUrl}`);
+                        this.log.error(err);
+                    } else {
+                        this.log('No new addons created');
+                    }
                 } else {
                     this.log(`Created ${dbAddOn}`);
                 }


### PR DESCRIPTION
Fixes two issues with the Heroku CLI invocation on MacOS (10.12.5)
- Heroku generator fails if the plugin has already been installed; the install command returns a -1 error code, causing the program to abort. This fix checks to see if the plugin is already available. If it is, do not install it again.
- If your Heroku account has not been verified, then you cannot install AddOns (such as the Database AddOn). Previous behaviour silently swallows error.

@jkutner would you mind having a look at this?

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
