### PR TITLE
Correct a unit test failure on windows OS

### DIFF
--- a/generators/server/templates/src/test/java/package/config/_WebConfigurerTest.java
+++ b/generators/server/templates/src/test/java/package/config/_WebConfigurerTest.java
@@ -42,6 +42,7 @@ import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
 import io.undertow.Undertow;
 import io.undertow.Undertow.Builder;
 import io.undertow.UndertowOptions;
+import org.apache.commons.io.FilenameUtils;
 <%_ if (devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory') { _%>
 import org.h2.server.web.WebServlet;
 <%_ } _%>
@@ -159,7 +160,7 @@ public class WebConfigurerTest {
         assertThat(container.getMimeMappings().get("json")).isEqualTo("text/html;charset=utf-8");
         <%_ if (!skipClient) { _%>
         if (container.getDocumentRoot() != null) {
-            assertThat(container.getDocumentRoot().getPath()).isEqualTo("<%= BUILD_DIR %>www");
+            assertThat(container.getDocumentRoot().getPath()).isEqualTo(FilenameUtils.separatorsToSystem("<%= BUILD_DIR %>www"));
         }
         <%_ } _%>
 
@@ -177,7 +178,7 @@ public class WebConfigurerTest {
         assertThat(container.getMimeMappings().get("abs")).isEqualTo("audio/x-mpeg");
         assertThat(container.getMimeMappings().get("html")).isEqualTo("text/html;charset=utf-8");
         assertThat(container.getMimeMappings().get("json")).isEqualTo("text/html;charset=utf-8");
-        assertThat(container.getDocumentRoot().getPath()).isEqualTo("src/main/webapp");
+        assertThat(container.getDocumentRoot().getPath()).isEqualTo(FilenameUtils.separatorsToSystem("src/main/webapp"));
 
         Builder builder = Undertow.builder();
         container.getBuilderCustomizers().forEach(c -> c.customize(builder));


### PR DESCRIPTION
Unix Path are misinterpreted on windows system. Using FilenameUtils.separatorsToSystem from apache commons to make the path system independent.

Fix #5805
