### PR TITLE
Pool max size not set correctly

### DIFF
--- a/generators/heroku/templates/_application-heroku.yml
+++ b/generators/heroku/templates/_application-heroku.yml
@@ -42,11 +42,12 @@ eureka:
 spring:
 <%_ if (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb') { _%>
     datasource:
-        type: com.zaxxer.hikari.HikariDataSource
-        maximumPoolSize: 10
+        type: com.zaxxer.hikari.HikariDataSource        
         url: ${JDBC_DATABASE_URL}
         username: ${JDBC_DATABASE_USERNAME}
         password: ${JDBC_DATABASE_PASSWORD}
+        hikari:
+            maximumPoolSize: 8
 <%_ } else if (prodDatabaseType === 'mongodb') { _%>
     data:
         mongodb:


### PR DESCRIPTION
It needs to be under `hikari` to work. I've also reduce it to 8 because the maximum allowed (at least for JawsDB) is 10. So, when the app in launched, it is impossible to connect with any other client to the database. Which is super annoying. 8 seems to be a good compromise.