### PR TITLE
use relative base instead of absolute path for context paths and proxies

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/_index.html
+++ b/generators/client/templates/angular/src/main/webapp/_index.html
@@ -19,7 +19,7 @@
 <!doctype html>
 <html class="no-js">
 <head>
-    <base href="/" />
+    <base href="./" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
@@ -121,7 +121,7 @@
                     <!-- jhipster-needle-add-element-to-admin-menu - JHipster will add entities to the admin menu here -->
                     <%_ if (devDatabaseType == 'h2Disk' || devDatabaseType == 'h2Memory') { _%>
                     <li *ngIf="!inProduction">
-                        <a class="dropdown-item" href='/h2-console' target="_tab" (click)="collapseNavbar()">
+                        <a class="dropdown-item" href='./h2-console' target="_tab" (click)="collapseNavbar()">
                             <i class="fa fa-fw fa-hdd-o" aria-hidden="true"></i>
                             <span jhiTranslate="global.menu.admin.database">Database</span>
                         </a>


### PR DESCRIPTION
Related to #5620, this allows a user to deploy the app to any context path without needing to change the base href.  When deploying to the root path, it works the same as in the past.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
