### PR TITLE
Change Eureka Environment variable to valid character

### DIFF
--- a/generators/server/templates/src/main/docker/_app.yml
+++ b/generators/server/templates/src/main/docker/_app.yml
@@ -27,7 +27,7 @@ services:
             - SPRING_CLOUD_CONSUL_PORT=8500
             <%_ } _%>
             <%_ if (serviceDiscoveryType == 'eureka') { _%>
-            - EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
+            - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
             - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
             <%_ } _%>
             <%_ if (prodDatabaseType == 'mysql') { _%>


### PR DESCRIPTION
The “EUREKA_CLIENT_SERVICE-URL_DEFAULTZONE” environment variable specified in the _app.yml file contains an invalid hyphen(-) character. When the container is started, this variable is not set. This change replaces the hyphen with an underscore, which Spring Boot can still read due to its relaxed binding rules. This change aligns the _app.xml file it to the Kubernetes+Openshift versions of this template.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
