### PR TITLE
add the management/* endpoints to the default swagger includePattern

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -198,7 +198,7 @@ jhipster:
     mail:
         from: <%= baseName %>@localhost
     swagger:
-        default-include-pattern: /api/.*
+        default-include-pattern: /(api|management)/.*
         title: <%=baseName%> API
         description: <%=baseName%> API documentation
         version: 0.0.1


### PR DESCRIPTION
- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

![screen shot 2017-06-07 at 11 02 36](https://user-images.githubusercontent.com/513471/26937592-16289c3c-4c72-11e7-8a4b-5d19f1e19928.png)

@jdubois do you agree with this change ? I know it clutters the docs view but I think it serves its purpose.