### PR TITLE
add a validation rule to forbid entity name beginning with a number

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -180,6 +180,8 @@ module.exports = EntityGenerator.extend({
         validateEntityName() {
             if (!(/^([a-zA-Z0-9_]*)$/.test(this.name))) {
                 this.error(chalk.red('The entity name cannot contain special characters'));
+            } else if ((/^[0-9].*$/.test(this.name))) {
+                this.error(chalk.red('The entity name cannot start with a number'));
             } else if (this.name === '') {
                 this.error(chalk.red('The entity name cannot be empty'));
             } else if (this.name.indexOf('Detail', this.name.length - 'Detail'.length) !== -1) {


### PR DESCRIPTION
closes #5591

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
I didn't find any test relative to validation. I did search for `validateEntityName()` inside the test directory and checked `generator-jhipster/test/test-entity.js` without success . Such tests would be beneficial for the application but I don't have time to do that from scratch in the near future.
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Unlike the following code sample, I don't have a capture group `(the things inside parentheses are captured)`, should I ?

```javascript
validateEntityName() {
  if (!(/^([a-zA-Z0-9_]*)$/.test(this.name))) {
    this.error(chalk.red('The entity name cannot contain special characters'));
  } 
```