### PR TITLE
fix check on errorHeader

### DIFF
--- a/generators/client/templates/angularjs/src/main/webapp/app/components/alert/_alert-error.directive.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/components/alert/_alert-error.directive.js
@@ -86,7 +86,7 @@
                 }).sort();
                 var errorHeader = httpResponse.headers(headers[0]);
                 var entityKey = httpResponse.headers(headers[1]);
-                if (errorHeader) {
+                if (angular.isString(errorHeader)) {
                     var entityName = <% if (enableTranslation) { %>$translate.instant('global.menu.entities.' + entityKey)<% }else{ %>entityKey<% } %>;
                     addErrorAlert(errorHeader, errorHeader, {entityName: entityName});
                 } else if (httpResponse.data && httpResponse.data.fieldErrors) {


### PR DESCRIPTION
When angular receive an error from a webservice,
There are 2 differents cases:
 1) either X-pocApp-error and X-pocApp-params are sent in the headers
 2) either httpResponse.data is populated with an ErrorVM structure

The test `if (errorHeader)` : is always 'true'.
because we have `var errorHeader=httpResponse.headers(headers[0])` and `httpResponse.headers(headers[0])` is never undefined (or null or false...). 
It's either a String in the case of 1) or an Object (the headers) in the case of 2).

And It seems the way to handle this properly is already done in notification.interceptor.js 
(https://github.com/jhipster/generator-jhipster/blob/master/generators/client/templates/angularjs/src/main/webapp/app/blocks/interceptor/_notification.interceptor.js)

(check the the same commit of the corresponding line).

Maybe @mehmet-aslan can confirm the fix ?
