### PR TITLE
use the real fs when reading entity JSON files

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -29,6 +29,7 @@ const exec = require('child_process').exec;
 const os = require('os');
 const https = require('https');
 const pluralize = require('pluralize');
+const jhiCore = require('jhipster-core');
 const packagejs = require('../package.json');
 const jhipsterUtils = require('./util');
 const constants = require('./generator-constants');
@@ -1438,14 +1439,21 @@ module.exports = class extends Generator {
             return e1.definition.changelogDate - e2.definition.changelogDate;
         }
 
-        if (shelljs.test('-d', JHIPSTER_CONFIG_DIR)) {
-            shelljs.ls(path.join(JHIPSTER_CONFIG_DIR, '*.json')).forEach((file) => {
-                const definition = this.fs.readJSON(file);
-                entities.push({ name: path.basename(file, '.json'), definition });
-            });
+        if (!shelljs.test('-d', JHIPSTER_CONFIG_DIR)) {
+            return entities;
         }
 
-        return entities.sort(isBefore);
+        return shelljs.ls(
+            path.join(JHIPSTER_CONFIG_DIR, '*.json')
+        ).reduce((acc, file) => {
+            try {
+                const definition = jhiCore.readEntityJSON(file);
+                acc.push({ name: path.basename(file, '.json'), definition });
+            } catch (error) {
+                // not an entity file / malformed?
+            }
+            return acc;
+        }, entities).sort(isBefore);
     }
 
     /**

--- a/test/test-generator-base.js
+++ b/test/test-generator-base.js
@@ -63,7 +63,8 @@ describe('Generator Base', () => {
             });
             it('returns an up-to-date state', () => {
                 assert.deepEqual(
-                    BaseGenerator.prototype.getExistingEntities()[0]
+                    BaseGenerator.prototype.getExistingEntities()
+                        .find(it => it.name === 'Region')
                         .definition.fields[1],
                     { fieldName: 'regionDesc', fieldType: 'String' }
                 );

--- a/test/test-generator-base.js
+++ b/test/test-generator-base.js
@@ -1,6 +1,7 @@
-/* global describe, it*/
+/* global describe, before, it*/
 
 const assert = require('assert');
+const jhiCore = require('jhipster-core');
 const expectedFiles = require('./test-expected-files');
 const BaseGenerator = require('../generators/generator-base');
 
@@ -30,6 +31,42 @@ describe('Generator Base', () => {
         describe('when called', () => {
             it('returns an array', () => {
                 assert.notEqual(BaseGenerator.prototype.getAllSupportedLanguages().length, 0);
+            });
+        });
+    });
+    describe('getExistingEntities', () => {
+        describe('when entities change on-disk', () => {
+            before(() => {
+                const entities = {
+                    Region: {
+                        fluentMethods: true,
+                        relationships: [],
+                        fields: [
+                            {
+                                fieldName: 'regionName',
+                                fieldType: 'String'
+                            }
+                        ],
+                        changelogDate: '20170623093902',
+                        entityTableName: 'region',
+                        dto: 'mapstruct',
+                        pagination: 'no',
+                        service: 'serviceImpl',
+                        angularJSSuffix: 'mySuffix'
+                    }
+                };
+                jhiCore.exportToJSON(entities, true);
+                BaseGenerator.prototype.getExistingEntities();
+                entities.Region.fields.push(
+                    { fieldName: 'regionDesc', fieldType: 'String' });
+                jhiCore.exportToJSON(entities, true);
+            });
+            it('returns an up-to-date state', () => {
+                assert.deepEqual(
+                    BaseGenerator.prototype.getExistingEntities()[0]
+                        .definition.fields[1],
+                    { fieldName: 'regionDesc', fieldType: 'String' }
+                );
             });
         });
     });


### PR DESCRIPTION
Normally `this.fs` is yeoman's in-memory filesystem (mem-fs) so once
file is read from disk it's not re-read.

Using jhipster-core function `readEntityJSON` means we always read from
disk and have most up to date and consistent state.

This came up when implementing a change in `import-jdl` generator where
entities needed to be re-read after they've been changed by the import.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
