### PR TITLE
Made the #toString method use the right getter names

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/domain/_Entity.java
+++ b/generators/entity/templates/server/src/main/java/package/domain/_Entity.java
@@ -403,8 +403,8 @@ public class <%= entityClass %> implements Serializable {
                 const fieldType = fields[idx].fieldType;
                 const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
                 const fieldName = fields[idx].fieldName;
-                const fieldNameCapitalized = fieldName.charAt(0).toUpperCase() + fieldName.slice(1) _%>
-            ", <%= fieldName %>='" + <% if (fieldType.toLowerCase() === 'boolean') { %>is<% } else { %>get<%_ } _%><%= fieldNameCapitalized %>() + "'" +
+                const fieldInJavaBeanMethod = fields[idx].fieldInJavaBeanMethod; _%>
+            ", <%= fieldName %>='" + <% if (fieldType.toLowerCase() === 'boolean') { %>is<% } else { %>get<%_ } _%><%= fieldInJavaBeanMethod %>() + "'" +
                 <%_ if ((fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent !== 'text') { _%>
             ", <%= fieldName %>ContentType='" + <%= fieldName %>ContentType + "'" +
                 <%_ } _%>


### PR DESCRIPTION
Should hopefully close [#130 from the JHCore project](https://github.com/jhipster/jhipster-core/issues/130) and the related #5969. 
The variable `fieldInJavaBeanMethod` was used for the accessors, and `fieldNameCapitalized` was built for the `#toString` method, and only used once.

- [] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed