### PR TITLE
add zipkin to rancher-compose subgen

### DIFF
--- a/generators/rancher-compose/index.js
+++ b/generators/rancher-compose/index.js
@@ -68,6 +68,7 @@ module.exports = RancherGenerator.extend({
             this.DOCKER_PROMETHEUS = constants.DOCKER_PROMETHEUS;
             this.DOCKER_PROMETHEUS_ALERTMANAGER = constants.DOCKER_PROMETHEUS_ALERTMANAGER;
             this.DOCKER_GRAFANA = constants.DOCKER_GRAFANA;
+            this.DOCKER_JHIPSTER_ZIPKIN = constants.DOCKER_JHIPSTER_ZIPKIN;
         },
 
         checkDocker() {

--- a/generators/rancher-compose/templates/_docker-compose.yml
+++ b/generators/rancher-compose/templates/_docker-compose.yml
@@ -134,4 +134,13 @@ services:
         image: <%= DOCKER_JHIPSTER_CONSOLE %>
         ports:
             - 5601:5601
+    <%_ if (composeApplicationType === 'microservice') { _%>
+    jhipster-zipkin:
+        image: <%= DOCKER_JHIPSTER_ZIPKIN %>
+        ports:
+            - 9411:9411
+        environment:
+            - ES_HOSTS=http://jhipster-elasticsearch:9200
+            - ZIPKIN_UI_LOGS_URL=http://localhost:5601/app/kibana#/dashboard/logs-dashboard?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(filters:!(),options:(darkTheme:!f),panels:!((col:1,id:logs-levels,panelIndex:2,row:1,size_x:6,size_y:3,type:visualization),(col:7,columns:!(stack_trace),id:Stacktraces,panelIndex:7,row:1,size_x:4,size_y:3,sort:!('@timestamp',desc),type:search),(col:11,id:Log-forwarding-instructions,panelIndex:8,row:1,size_x:2,size_y:3,type:visualization),(col:1,columns:!(app_name,level,message),id:All-logs,panelIndex:9,row:4,size_x:12,size_y:7,sort:!('@timestamp',asc),type:search)),query:(query_string:(analyze_wildcard:!t,query:'{traceId}')),title:logs-dashboard,uiState:())
+    <%_ } _%>
 <%_ } _%>

--- a/generators/rancher-compose/templates/_docker-compose.yml
+++ b/generators/rancher-compose/templates/_docker-compose.yml
@@ -135,12 +135,13 @@ services:
         ports:
             - 5601:5601
     <%_ if (composeApplicationType === 'microservice') { _%>
-    jhipster-zipkin:
-        image: <%= DOCKER_JHIPSTER_ZIPKIN %>
-        ports:
-            - 9411:9411
-        environment:
-            - ES_HOSTS=http://jhipster-elasticsearch:9200
-            - ZIPKIN_UI_LOGS_URL=http://localhost:5601/app/kibana#/dashboard/logs-dashboard?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(filters:!(),options:(darkTheme:!f),panels:!((col:1,id:logs-levels,panelIndex:2,row:1,size_x:6,size_y:3,type:visualization),(col:7,columns:!(stack_trace),id:Stacktraces,panelIndex:7,row:1,size_x:4,size_y:3,sort:!('@timestamp',desc),type:search),(col:11,id:Log-forwarding-instructions,panelIndex:8,row:1,size_x:2,size_y:3,type:visualization),(col:1,columns:!(app_name,level,message),id:All-logs,panelIndex:9,row:4,size_x:12,size_y:7,sort:!('@timestamp',asc),type:search)),query:(query_string:(analyze_wildcard:!t,query:'{traceId}')),title:logs-dashboard,uiState:())
+    # Uncomment this section to enable Zipkin
+    #jhipster-zipkin:
+    #    image: <%= DOCKER_JHIPSTER_ZIPKIN %>
+    #    ports:
+    #        - 9411:9411
+    #    environment:
+    #        - ES_HOSTS=http://jhipster-elasticsearch:9200
+    #        - ZIPKIN_UI_LOGS_URL=http://localhost:5601/app/kibana#/dashboard/logs-dashboard?_g=(refreshInterval:(display:Off,pause:!f,value:0),time:(from:now-1h,mode:quick,to:now))&_a=(filters:!(),options:(darkTheme:!f),panels:!((col:1,id:logs-levels,panelIndex:2,row:1,size_x:6,size_y:3,type:visualization),(col:7,columns:!(stack_trace),id:Stacktraces,panelIndex:7,row:1,size_x:4,size_y:3,sort:!('@timestamp',desc),type:search),(col:11,id:Log-forwarding-instructions,panelIndex:8,row:1,size_x:2,size_y:3,type:visualization),(col:1,columns:!(app_name,level,message),id:All-logs,panelIndex:9,row:4,size_x:12,size_y:7,sort:!('@timestamp',asc),type:search)),query:(query_string:(analyze_wildcard:!t,query:'{traceId}')),title:logs-dashboard,uiState:())
     <%_ } _%>
 <%_ } _%>

--- a/generators/rancher-compose/templates/_rancher-compose.yml
+++ b/generators/rancher-compose/templates/_rancher-compose.yml
@@ -61,7 +61,8 @@ services:
     jhipster-console:
         scale: 1
     <%_ if (composeApplicationType === 'microservice') { _%>
-    jhipster-zipkin:
-        scale: 1
+    # Uncomment this section to enable Zipkin
+    #jhipster-zipkin:
+    #    scale: 1
     <%_ } _%>
 <%_ } _%>

--- a/generators/rancher-compose/templates/_rancher-compose.yml
+++ b/generators/rancher-compose/templates/_rancher-compose.yml
@@ -60,4 +60,8 @@ services:
         scale: 1
     jhipster-console:
         scale: 1
+    <%_ if (composeApplicationType === 'microservice') { _%>
+    jhipster-zipkin:
+        scale: 1
+    <%_ } _%>
 <%_ } _%>


### PR DESCRIPTION
This adds Zipkin to the rancher-compose subgen when it's chosen.  I copied the config from the docker-compose subgen.  

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
