### PR TITLE
Update field_validators.ejs

### DIFF
--- a/generators/entity/templates/server/src/main/java/package/common/field_validators.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/field_validators.ejs
@@ -51,14 +51,15 @@ if (field.fieldValidate === true) {
         if (field.fieldType === 'Float' || field.fieldType === 'Double' || field.fieldType === 'BigDecimal') {
             validators.push('@DecimalMin(value = "' + field.fieldValidateRulesMin + '")');
         } else {
+            const isLong = (field.fieldValidateRulesMin > MAX_VALUE || field.fieldType == 'Long') ? 'L' : '';
             validators.push('@Min(value = ' + field.fieldValidateRulesMin + ')');
         }
     }
     if (rules.indexOf('max') !== -1) {
-        const isLong = (field.fieldValidateRulesMax > MAX_VALUE) ? 'L' : '';
         if (field.fieldType === 'Float' || field.fieldType === 'Double' || field.fieldType === 'BigDecimal') {
             validators.push('@DecimalMax(value = "' + field.fieldValidateRulesMax + '")');
         } else {
+            const isLong = (field.fieldValidateRulesMax > MAX_VALUE || field.fieldType == 'Long') ? 'L' : '';
             validators.push('@Max(value = ' + field.fieldValidateRulesMax + isLong + ')');
         }
     }

--- a/generators/entity/templates/server/src/main/java/package/common/field_validators.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/field_validators.ejs
@@ -52,7 +52,7 @@ if (field.fieldValidate === true) {
             validators.push('@DecimalMin(value = "' + field.fieldValidateRulesMin + '")');
         } else {
             const isLong = (field.fieldValidateRulesMin > MAX_VALUE || field.fieldType == 'Long') ? 'L' : '';
-            validators.push('@Min(value = ' + field.fieldValidateRulesMin + ')');
+            validators.push('@Min(value = ' + field.fieldValidateRulesMin + isLong + ')');
         }
     }
     if (rules.indexOf('max') !== -1) {


### PR DESCRIPTION
Entity generation  (from JDL)
number Long required min(70000000000) max(79999999999)

 produces
```
@Min(value = 70000000000)
@Max(value = 79999999999L)
private Long number;
```
This change will add 'L' to both limits for type Long, I don't sure about old comparison, saved for now.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
