### PR TITLE
enable management endpoints CORS when using the dev profile

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -213,6 +213,15 @@ liquibase:
     contexts: dev
 <%_ } _%>
 
+# CORS is only enabled with the "dev" profile for endpoints, so BrowserSync can access the Management API
+endpoints:
+    cors:
+        allowed-origins: "*"
+        allowed-methods: GET, PUT, POST, DELETE, OPTIONS
+        allowed-headers: "*"
+        allow-credentials: true
+        max-age: 1800
+
 # ===================================================================
 # To enable SSL, generate a certificate using:
 # keytool -genkey -alias <%= baseName %> -storetype PKCS12 -keyalg RSA -keysize 2048 -keystore keystore.p12 -validity 3650


### PR DESCRIPTION
- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

This is needed to make call from Swagger UI to the management endpoints work when proxying from browsersync.
Linked to https://github.com/jhipster/jhipster/pull/19  