### PR TITLE
Up-to-date Gatling

### DIFF
--- a/generators/entity/files.js
+++ b/generators/entity/files.js
@@ -149,9 +149,9 @@ const serverFiles = {
             condition: generator => generator.gatlingTests,
             path: TEST_DIR,
             templates: [{
-                file: 'gatling/simulations/_EntityGatlingTest.scala',
+                file: 'gatling/user-files/simulations/_EntityGatlingTest.scala',
                 options: { interpolate: INTERPOLATE_REGEX },
-                renameTo: generator => `gatling/simulations/${generator.entityClass}GatlingTest.scala`
+                renameTo: generator => `gatling/user-files/simulations/${generator.entityClass}GatlingTest.scala`
             }]
         }
     ]

--- a/generators/entity/templates/server/src/test/gatling/user-files/simulations/_EntityGatlingTest.scala
+++ b/generators/entity/templates/server/src/test/gatling/user-files/simulations/_EntityGatlingTest.scala
@@ -135,7 +135,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
             .exec(http("Create new <%= entityInstance %>")
             .post("<% if (applicationType === 'microservice') {%>/<%= baseName.toLowerCase() %><% } %>/api/<%= entityApiUrl %>")
             .headers(headers_http_authenticated)
-            .body(StringBody("""{"id":null<% for (idx in fields) { %>, "<%= fields[idx].fieldName %>":<% if (fields[idx].fieldType === 'String') { %>"SAMPLE_TEXT"<% } else if (fields[idx].fieldType === 'Integer' || fields[idx].fieldType === 'BigDecimal') { %>"0"<% } else if (fields[idx].fieldType === 'Instant' || fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'LocalDate') { %>"2020-01-01T00:00:00.000Z"<% } else { %>null<% } } %>}""")).asJSON
+            .body(StringBody("""{"id":null<% for (idx in fields) { %>, "<%= fields[idx].fieldName %>":<% if (fields[idx].fieldType === 'String') { %>"SAMPLE_TEXT"<% } else if (['Integer', 'BigDecimal'].includes(fields[idx].fieldType)) { %>"0"<% } else if (['Instant', 'ZonedDateTime', 'LocalDate'].includes(fields[idx].fieldType)) { %>"2020-01-01T00:00:00.000Z"<% } else { %>null<% } } %>}""")).asJSON
             .check(status.is(201))
             .check(headerRegex("Location", "(.*)").saveAs("new_<%= entityInstance %>_url"))).exitHereIfFailed
             .pause(10)

--- a/generators/entity/templates/server/src/test/gatling/user-files/simulations/_EntityGatlingTest.scala
+++ b/generators/entity/templates/server/src/test/gatling/user-files/simulations/_EntityGatlingTest.scala
@@ -135,7 +135,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
             .exec(http("Create new <%= entityInstance %>")
             .post("<% if (applicationType === 'microservice') {%>/<%= baseName.toLowerCase() %><% } %>/api/<%= entityApiUrl %>")
             .headers(headers_http_authenticated)
-            .body(StringBody("""{"id":null<% for (idx in fields) { %>, "<%= fields[idx].fieldName %>":<% if (fields[idx].fieldType === 'String') { %>"SAMPLE_TEXT"<% } else if (fields[idx].fieldType === 'Integer') { %>"0"<% } else if (fields[idx].fieldType === 'Instant' || fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'LocalDate') { %>"2020-01-01T00:00:00.000Z"<% } else { %>null<% } } %>}""")).asJSON
+            .body(StringBody("""{"id":null<% for (idx in fields) { %>, "<%= fields[idx].fieldName %>":<% if (fields[idx].fieldType === 'String') { %>"SAMPLE_TEXT"<% } else if (fields[idx].fieldType === 'Integer' || fields[idx].fieldType === 'BigDecimal') { %>"0"<% } else if (fields[idx].fieldType === 'Instant' || fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'LocalDate') { %>"2020-01-01T00:00:00.000Z"<% } else { %>null<% } } %>}""")).asJSON
             .check(status.is(201))
             .check(headerRegex("Location", "(.*)").saveAs("new_<%= entityInstance %>_url"))).exitHereIfFailed
             .pause(10)
@@ -154,6 +154,6 @@ class <%= entityClass %>GatlingTest extends Simulation {
     val users = scenario("Users").exec(scn)
 
     setUp(
-        users.inject(rampUsers(100) over (1 minutes))
+        users.inject(rampUsers(Integer.getInteger("users", 100)) over (Integer.getInteger("ramp", 1) minutes))
     ).protocols(httpConf)
 }

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -474,9 +474,9 @@ function writeFiles() {
             if (this.gatlingTests) {
                 this.copy(`${TEST_DIR}gatling/conf/gatling.conf`, `${TEST_DIR}gatling/conf/gatling.conf`);
                 this.copy(`${TEST_DIR}gatling/conf/logback.xml`, `${TEST_DIR}gatling/conf/logback.xml`);
-                mkdirp(`${TEST_DIR}gatling/data`);
-                mkdirp(`${TEST_DIR}gatling/bodies`);
-                mkdirp(`${TEST_DIR}gatling/simulations`);
+                mkdirp(`${TEST_DIR}gatling/user-files/data`);
+                mkdirp(`${TEST_DIR}gatling/user-files/bodies`);
+                mkdirp(`${TEST_DIR}gatling/user-files/simulations`);
             }
 
             // Create Cucumber test files

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -68,8 +68,8 @@
         <frontend-maven-plugin.version>1.4</frontend-maven-plugin.version>
         <%_ } _%>
         <%_ if (gatlingTests) { _%>
-        <gatling.version>2.2.3</gatling.version>
-        <gatling-maven-plugin.version>2.2.1</gatling-maven-plugin.version>
+        <gatling.version>2.2.5</gatling.version>
+        <gatling-maven-plugin.version>2.2.4</gatling-maven-plugin.version>
         <%_ } _%>
         <%_ if (hibernateCache === 'hazelcast') { _%>
         <hazelcast-hibernate52.version>1.2</hazelcast-hibernate52.version>
@@ -891,10 +891,15 @@
                 <version>${gatling-maven-plugin.version}</version>
                 <configuration>
                     <configFolder><%= TEST_DIR %>gatling/conf</configFolder>
-                    <dataFolder><%= TEST_DIR %>gatling/data</dataFolder>
-                    <resultsFolder>target/gatling/results</resultsFolder>
-                    <bodiesFolder><%= TEST_DIR %>gatling/bodies</bodiesFolder>
-                    <simulationsFolder><%= TEST_DIR %>gatling/simulations</simulationsFolder>
+                    <dataFolder><%= TEST_DIR %>gatling/user-files/data</dataFolder>
+                    <resultsFolder>target/gatling/results/${maven.build.timestamp}/</resultsFolder>
+                    <bodiesFolder><%= TEST_DIR %>gatling/user-files/bodies</bodiesFolder>
+                    <simulationsFolder><%= TEST_DIR %>gatling/user-files/simulations</simulationsFolder>
+                    <!-- If uncommented, these arguments below will be applied to all your gatling tests -->
+                    <!--<jvmArgs>
+                        <jvmArg>-Dusers=100</jvmArg>
+                        <jvmArg>-Dramp=1</jvmArg>
+                    </jvmArgs>-->
                     <!--
                     This will run multiple simulations one by one. Useful when doing Gatling
                     tests in CI.

--- a/generators/server/templates/gradle/_gatling.gradle
+++ b/generators/server/templates/gradle/_gatling.gradle
@@ -21,7 +21,7 @@ apply plugin: 'scala'
 sourceSets {
     test {
         scala {
-            srcDirs = ['<%= TEST_DIR %>gatling/simulations']
+            srcDirs = ['<%= TEST_DIR %>gatling/user-files/simulations']
             output.classesDir = '<%= BUILD_DIR %>test-classes'
         }
     }
@@ -57,7 +57,7 @@ task gatlingRunAll(dependsOn: 'manifestJar') {
     description = 'Run all available Gatling simulations.'
 
     doLast {
-        FileTree tree = fileTree(dir: './src/test/gatling/simulations')
+        FileTree tree = fileTree(dir: './src/test/gatling/user-files/simulations')
         tree.include '**/*.scala'
         tree.each {File file ->
             def simulationClassName = file.name.replaceFirst(".scala", "")
@@ -73,10 +73,10 @@ def createGatlingRunTask(def gatlingSimulationClassName) {
 
         final def sourceSet = sourceSets.test
 
-        def String gatlingDataFolder = "$project.rootDir.absolutePath/src/test/gatling/data"
+        def String gatlingDataFolder = "$project.rootDir.absolutePath/src/test/gatling/user-files/data"
         def String gatlingReportsFolder = "$project.buildDir.absolutePath/reports/gatling"
-        def String gatlingBodiesFolder = "$project.rootDir.absolutePath/src/test/gatling/bodies"
-        def String gatlingSimulationsFolder = "$project.rootDir.absolutePath/src/test/gatling/simulations"
+        def String gatlingBodiesFolder = "$project.rootDir.absolutePath/src/test/user-files/gatling/bodies"
+        def String gatlingSimulationsFolder = "$project.rootDir.absolutePath/src/test/user-files/gatling/simulations"
 
         classpath sourceSet.output + files(manifestJar.archivePath) + files("src/test/gatling/conf")
         main = "io.gatling.app.Gatling"

--- a/test/test-creation.js
+++ b/test/test-creation.js
@@ -60,8 +60,8 @@ describe('JHipster generator', () => {
                 testFrameworks: []
             }));
             assert.noFile([
-                `${TEST_DIR}gatling/gatling.conf`,
-                `${TEST_DIR}gatling/logback.xml`
+                `${TEST_DIR}gatling/conf/gatling.conf`,
+                `${TEST_DIR}gatling/conf/logback.xml`
             ]);
         });
         it('contains clientFramework with angular1 value', () => {
@@ -925,8 +925,8 @@ describe('JHipster generator', () => {
                 ]
             }));
             assert.noFile([
-                `${TEST_DIR}gatling/gatling.conf`,
-                `${TEST_DIR}gatling/logback.xml`
+                `${TEST_DIR}gatling/conf/gatling.conf`,
+                `${TEST_DIR}gatling/conf/logback.xml`
             ]);
         });
     });
@@ -973,8 +973,8 @@ describe('JHipster generator', () => {
                 `${TEST_DIR}features/user/user.feature`
             ]);
             assert.noFile([
-                `${TEST_DIR}gatling/gatling.conf`,
-                `${TEST_DIR}gatling/logback.xml`
+                `${TEST_DIR}gatling/conf/gatling.conf`,
+                `${TEST_DIR}gatling/conf/logback.xml`
             ]);
         });
     });

--- a/test/test-entity.js
+++ b/test/test-entity.js
@@ -59,7 +59,7 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`,
         // SERVER_MAIN_RES_DIR + 'config/liquibase/changelog/20160120213555_added_entity_Foo.xml',
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIntTest.java`,
-        `${TEST_DIR}gatling/simulations/FooGatlingTest.scala`
+        `${TEST_DIR}gatling/user-files/simulations/FooGatlingTest.scala`
     ]
 };
 describe('JHipster generator entity for angular1', () => {


### PR DESCRIPTION
This PR is intended to update Gatling (versions, structure, ...).

Concerning the structure, in particular the new "user-files" dir, I've follow the official documentation (http://gatling.io/docs/current/general/bundle_structure/)

In the pom.xml, we can use default args to give to all gatling tests (http://gatling.io/docs/current/cookbook/passing_parameters/).
I also added a dir, "target/gatling/results/${maven.build.timestamp}/" in pom.xml, to have different folders each time you launch Gatling tests.

In addition, if a BigDecimal field of an entity is required, when gatling tries to create the entity, the call fails.
So I added a case when an entity field is a BigDecimal. 

Maven and Yarn tests are OK.

---------------------------------------------------

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
