### PR TITLE
cacheBuster with build timestamp for translation json files

### DIFF
--- a/generators/client/templates/angularjs/_gulpfile.js
+++ b/generators/client/templates/angularjs/_gulpfile.js
@@ -138,7 +138,8 @@ gulp.task('ngconstant:dev', function () {
         name: '<%= angularAppName %>',
         constants: {
             VERSION: util.parseVersion(),
-            DEBUG_INFO_ENABLED: true
+            DEBUG_INFO_ENABLED: true,
+            BUILD_TIMESTAMP: new Date().getTime()
         },
         template: config.constantTemplate,
         stream: true
@@ -152,7 +153,8 @@ gulp.task('ngconstant:prod', function () {
         name: '<%= angularAppName %>',
         constants: {
             VERSION: util.parseVersion(),
-            DEBUG_INFO_ENABLED: false
+            DEBUG_INFO_ENABLED: false,
+            BUILD_TIMESTAMP: new Date().getTime()
         },
         template: config.constantTemplate,
         stream: true

--- a/generators/client/templates/angularjs/src/main/webapp/app/_app.constants.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/_app.constants.js
@@ -22,5 +22,6 @@
     angular
         .module('<%=angularAppName%>')
         .constant('VERSION', '0.0.1-SNAPSHOT')
-        .constant('DEBUG_INFO_ENABLED', true);
+        .constant('DEBUG_INFO_ENABLED', true)
+        .constant('BUILD_TIMESTAMP', '')
 })();

--- a/generators/client/templates/angularjs/src/main/webapp/app/blocks/config/_translation.config.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/blocks/config/_translation.config.js
@@ -23,12 +23,12 @@
         .module('<%=angularAppName%>')
         .config(translationConfig);
 
-    translationConfig.$inject = ['$translateProvider', 'tmhDynamicLocaleProvider'];
+    translationConfig.$inject = ['$translateProvider', 'tmhDynamicLocaleProvider', 'BUILD_TIMESTAMP'];
 
-    function translationConfig($translateProvider, tmhDynamicLocaleProvider) {
+    function translationConfig($translateProvider, tmhDynamicLocaleProvider, BUILD_TIMESTAMP) {
         // Initialize angular-translate
         $translateProvider.useLoader('$translatePartialLoader', {
-            urlTemplate: 'i18n/{lang}/{part}.json'
+            urlTemplate: 'i18n/{lang}/{part}.json' + (BUILD_TIMESTAMP ? '?build=' + BUILD_TIMESTAMP : '')
         });
 
         $translateProvider.preferredLanguage('<%= nativeLanguage %>');


### PR DESCRIPTION
When I deploy the app with a war file to tomcat or using the jhipster deployment script to heroku,

the translation json files (e.g. global.json, home.json, ...) are not necessarily reloaded by $translateProvider. This causes that the updated translations are not loaded and I have to manually delete the browser cache..

I have most of the time a `200  (from disk cache)` with chrome or a `200 cached` with firefox. 

I firstly investigate in `WebConfigurer` through `initCachingHttpHeadersFilter` and add `cachingHttpHeadersFilter.addMappingForUrlPatterns(disps, true, "/i18n/*");`, thinking that the caching rules are not applied to i18n url => but I still have the same problem..

Then I tried `$translateProvider.useLoaderCache(false);` => same problem..

So through this PR, I added a "cacheBuster" using the build timestamp (a new constant) on the `urlTemplate`,

so the urls look like this having necessarily a `200` with the new files the first time and then `from cache` on next requests: 
- global.json?build=1499106805822
- home.json?build=1499106805822

I didn't try on Angular 4 yet, but for me this mechanism fixes those caching browser issues in a general way.

WDYT



