### PR TITLE
Do not use build timestamp for dev

### DIFF
--- a/generators/client/templates/angularjs/_gulpfile.js
+++ b/generators/client/templates/angularjs/_gulpfile.js
@@ -139,7 +139,7 @@ gulp.task('ngconstant:dev', function () {
         constants: {
             VERSION: util.parseVersion(),
             DEBUG_INFO_ENABLED: true,
-            BUILD_TIMESTAMP: new Date().getTime()
+            BUILD_TIMESTAMP: ''
         },
         template: config.constantTemplate,
         stream: true

--- a/generators/client/templates/angularjs/src/main/webapp/app/_app.constants.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/_app.constants.js
@@ -23,5 +23,5 @@
         .module('<%=angularAppName%>')
         .constant('VERSION', '0.0.1-SNAPSHOT')
         .constant('DEBUG_INFO_ENABLED', true)
-        .constant('BUILD_TIMESTAMP', '');
+        .constant('BUILD_TIMESTAMP', "");
 })();


### PR DESCRIPTION
- Remove  build timestamp for dev build because it updates 'app.constants.js' everytime we run 'gulp' which could be annoying (and useless).

- Change to double quotes in `.constant('BUILD_TIMESTAMP', "");` as gulp produces double quote rather than simple ones...

