### PR TITLE
add a default locale provider

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/_shared-common.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/_shared-common.module.ts
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule } from '@angular/core';
+import { NgModule, LOCALE_ID } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 
 <%_ if (websocket === 'spring-websocket') { _%>
@@ -51,7 +51,11 @@ import {
         <%_ } if (websocket === 'spring-websocket') { _%>
         WindowRef,
         <%_ } _%>
-        Title
+        Title,
+        {
+            provide: LOCALE_ID,
+            useValue: '<%= nativeLanguage %>'
+        },
     ],
     exports: [
         <%=angularXAppName%>SharedLibsModule,


### PR DESCRIPTION
By adding a default local provider, the Date/Number string will format and display as local style not US style.

already answered by this link:
https://stackoverflow.com/questions/34904683/how-to-set-locale-in-datepipe-in-angular2

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
