### PR TITLE
Fix for invalid characters when searching with non ASCII text #6052 

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/model/_request-util.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/model/_request-util.ts
@@ -9,7 +9,7 @@ export const createRequestOption = (req?: any): BaseRequestOptions => {
         if (req.sort) {
             params.paramsMap.set('sort', req.sort);
         }
-        params.set('query', req.query);
+        params.set('query', encodeURIComponent(req.query));
 
         options.params = params;
     }

--- a/generators/entity/templates/server/src/main/java/package/common/search_stream_template.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/search_stream_template.ejs
@@ -21,7 +21,7 @@ const mapper = entityInstance  + 'Mapper';
 const entityToDtoReference = mapper + '::' + 'toDto'; %>
         <%_ if (!viaService) { _%>
         return StreamSupport
-            .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto === 'mapstruct') { %>
+            .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(decodeQuery(query))).spliterator(), false)<% if (dto === 'mapstruct') { %>
             .map(<%= entityToDtoReference %>)<% } %>
             .collect(Collectors.toList());
         <%_ } else { _%>

--- a/generators/entity/templates/server/src/main/java/package/common/search_template.ejs
+++ b/generators/entity/templates/server/src/main/java/package/common/search_template.ejs
@@ -29,7 +29,7 @@
     public ResponseEntity<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, @ApiParam Pageable pageable) {
         log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
-        Page<<%= entityClass %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>
+        Page<<%= entityClass %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(decodeQuery(query)), pageable);<% } %>
         HttpHeaders headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, "/api/_search/<%= entityApiUrl %>");
         return new ResponseEntity<>(<% if (!viaService && dto === 'mapstruct') { %><%= entityListToDtoListReference %>(page.getContent())<% } else { %>page.getContent()<% } %>, headers, HttpStatus.OK);
     <% } -%>

--- a/generators/entity/templates/server/src/main/java/package/service/impl/_EntityServiceImpl.java
+++ b/generators/entity/templates/server/src/main/java/package/service/impl/_EntityServiceImpl.java
@@ -51,7 +51,8 @@ import java.util.UUID;<% } %><% if (fieldsContainNoOwnerOneToOne === true || (pa
 import java.util.stream.Collectors;<% } %><% if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && searchEngine === 'elasticsearch' && !viaService)) { %>
 import java.util.stream.StreamSupport;<% } %><% if (searchEngine === 'elasticsearch') { %>
 
-import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static <%=packageName%>.web.rest.util.QueryUtil.decodeQuery;<% } %>
 
 /**
  * Service Implementation for managing <%= entityClass %>.
@@ -147,7 +148,7 @@ public class <%= serviceClassName %> <% if (service === 'serviceImpl') { %>imple
         log.debug("Request to search <%= entityClassPlural %> for query {}", query);<%- include('../../common/search_stream_template', {viaService: viaService}); -%>
         <%_ } else { _%>
         log.debug("Request to search for a page of <%= entityClassPlural %> for query {}", query);
-        Page<<%= entityClass %>> result = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);
+        Page<<%= entityClass %>> result = <%= entityInstance %>SearchRepository.search(queryStringQuery(decodeQuery(query)), pageable);
             <%_ if (dto === 'mapstruct') { _%>
         return result.map(<%= entityToDtoReference %>);
             <%_ } else { _%>

--- a/generators/entity/templates/server/src/main/java/package/web/rest/_EntityResource.java
+++ b/generators/entity/templates/server/src/main/java/package/web/rest/_EntityResource.java
@@ -60,7 +60,8 @@ import java.util.UUID;<% } %><% if (!viaService && (searchEngine === 'elasticsea
 import java.util.stream.Collectors;<% } %><% if (searchEngine === 'elasticsearch' || fieldsContainNoOwnerOneToOne === true) { %>
 import java.util.stream.StreamSupport;<% } %><% if (searchEngine === 'elasticsearch') { %>
 
-import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static <%=packageName%>.web.rest.util.QueryUtil.decodeQuery;<% } %>
 
 /**
  * REST controller for managing <%= entityClass %>.

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -417,6 +417,7 @@ function writeFiles() {
 
             this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/_HeaderUtil.java`, `${javaDir}web/rest/util/HeaderUtil.java`);
             this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/_PaginationUtil.java`, `${javaDir}web/rest/util/PaginationUtil.java`);
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/_QueryUtil.java`, `${javaDir}web/rest/util/QueryUtil.java`);
             this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/_package-info.java`, `${javaDir}web/rest/package-info.java`);
 
             this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/_LogsResource.java`, `${javaDir}web/rest/LogsResource.java`);
@@ -453,6 +454,7 @@ function writeFiles() {
             this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/errors/_ExceptionTranslatorIntTest.java`, `${testDir}web/rest/errors/ExceptionTranslatorIntTest.java`);
             this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/errors/_ExceptionTranslatorTestController.java`, `${testDir}web/rest/errors/ExceptionTranslatorTestController.java`);
             this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/util/_PaginationUtilUnitTest.java`, `${testDir}web/rest/util/PaginationUtilUnitTest.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/util/_QueryUtilUnitTest.java`, `${testDir}web/rest/util/QueryUtilUnitTest.java`);
 
             this.template(`${SERVER_TEST_RES_DIR}config/_application.yml`, `${SERVER_TEST_RES_DIR}config/application.yml`);
             this.template(`${SERVER_TEST_RES_DIR}_logback.xml`, `${SERVER_TEST_RES_DIR}logback.xml`);

--- a/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
@@ -50,7 +50,8 @@ import java.util.*;<% if (searchEngine === 'elasticsearch') { %>
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
-import static org.elasticsearch.index.query.QueryBuilders.*;<% } %>
+import static org.elasticsearch.index.query.QueryBuilders.*;
+import static <%=packageName%>.web.rest.util.QueryUtil.decodeQuery;<% } %>
 
 /**
  * REST controller for managing users.
@@ -238,7 +239,7 @@ public class UserResource {
     @Timed
     public List<User> search(@PathVariable String query) {
         return StreamSupport
-            .stream(userSearchRepository.search(queryStringQuery(query)).spliterator(), false)
+            .stream(userSearchRepository.search(queryStringQuery(decodeQuery(query))).spliterator(), false)
             .collect(Collectors.toList());
     }<% } %>
 }

--- a/generators/server/templates/src/main/java/package/web/rest/util/_QueryUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_QueryUtil.java
@@ -1,0 +1,43 @@
+<%#
+ Copyright 2013-2017 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://jhipster.github.io/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.rest.util;
+
+import java.io.UnsupportedEncodingException;
+import java.net.URLDecoder;
+
+/**
+ * Utility class for query manipulation.
+ */
+public class QueryUtil {
+    /**
+     * Decodes the query string as encoded on client side using <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent">encodeURIComponent</a>.
+     * @param query the client encoded query string
+     * @return the decoded query string
+     * @throws {IllegalArgumentException} the query string must be correctly encoded
+     */
+    public static String decodeQuery(final String query) {
+        final String decodedQuery;
+        try {
+            decodedQuery = URLDecoder.decode(query, "UTF-8");
+        } catch (final UnsupportedEncodingException ex) {
+            throw new IllegalArgumentException("Invalid encoded query string", ex);
+        }
+        return decodedQuery;
+    }
+}

--- a/generators/server/templates/src/main/java/package/web/rest/util/_QueryUtil.java
+++ b/generators/server/templates/src/main/java/package/web/rest/util/_QueryUtil.java
@@ -29,13 +29,17 @@ public class QueryUtil {
      * Decodes the query string as encoded on client side using <a href="https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent">encodeURIComponent</a>.
      * @param query the client encoded query string
      * @return the decoded query string
-     * @throws {IllegalArgumentException} the query string must be correctly encoded
+     * @throws IllegalArgumentException if the query string is not correctly encoded
      */
     public static String decodeQuery(final String query) {
         final String decodedQuery;
         try {
-            decodedQuery = URLDecoder.decode(query, "UTF-8");
-        } catch (final UnsupportedEncodingException ex) {
+            if (query.isEmpty()) {
+                decodedQuery = "";
+            } else {
+                decodedQuery = URLDecoder.decode(query, "UTF-8");
+            }
+        } catch (final UnsupportedEncodingException|IllegalArgumentException ex) {
             throw new IllegalArgumentException("Invalid encoded query string", ex);
         }
         return decodedQuery;

--- a/generators/server/templates/src/test/java/package/web/rest/util/_QueryUtilUnitTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/util/_QueryUtilUnitTest.java
@@ -50,4 +50,9 @@ public class QueryUtilUnitTest {
     public void decodeQueryInvalidArgument() throws Exception {
         QueryUtil.decodeQuery("%+");
     }
+
+    @Test()
+    public void decodeQueryEmpty() throws Exception {
+        assertThat(QueryUtil.decodeQuery("")).isEqualTo("");
+    }
 }

--- a/generators/server/templates/src/test/java/package/web/rest/util/_QueryUtilUnitTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/util/_QueryUtilUnitTest.java
@@ -1,0 +1,53 @@
+<%#
+ Copyright 2013-2017 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://jhipster.github.io/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.rest.util;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * @see QueryUtil
+ */
+public class QueryUtilUnitTest {
+    @Test
+    public void decodeQuerySimple() throws Exception {
+        assertThat(QueryUtil.decodeQuery("abcABC%20123")).isEqualTo("abcABC 123");
+    }
+
+    @Test
+    public void decodeQueryWithNonAscii() throws Exception {
+        assertThat(QueryUtil.decodeQuery("%C3%AEnf%C4%83%C5%A3i%C5%9F%C3%A2nd%20%C3%8EMBR%C4%82%C5%A2I%C5%9E%C3%82ND")).isEqualTo("înfăţişând ÎMBRĂŢIŞÂND");
+    }
+
+    @Test
+    public void decodeQueryWithEscapes() throws Exception {
+        assertThat(QueryUtil.decodeQuery("%22A'B%20%C2%B1")).isEqualTo("\"A\'B ±");
+    }
+
+    @Test
+    public void decodeQueryWithNonAsciiVarious() throws Exception {
+        assertThat(QueryUtil.decodeQuery("%C3%9F%C3%A6%C5%82%C9%B0%E2%81%87%E2%9D%B7%E2%81%B6")).isEqualTo("ßæłɰ⁇❷⁶");
+    }
+
+    @Test(expected = IllegalArgumentException.class)
+    public void decodeQueryInvalidArgument() throws Exception {
+        QueryUtil.decodeQuery("%+");
+    }
+}


### PR DESCRIPTION
Fix for "TypeError: The header content contains invalid characters" when searching with non ASCII text, see #6052.
