### PR TITLE
Changed role strings in angular 2 client to typed properties of a new AuthoritiesConstants class

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -406,6 +406,7 @@ const files = {
         {
             path: ANGULAR_DIR,
             templates: [
+                'shared/auth/_authorities-constants.ts',
                 'shared/auth/_csrf.service.ts',
                 'shared/auth/_state-storage.service.ts',
                 'shared/auth/_principal.service.ts',

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.route.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.route.ts
@@ -18,14 +18,14 @@
 -%>
 import { Route } from '@angular/router';
 
-import { UserRouteAccessService } from '../../shared';
+import { UserRouteAccessService, AuthoritiesConstants } from '../../shared';
 import { PasswordComponent } from './password.component';
 
 export const passwordRoute: Route = {
     path: 'password',
     component: PasswordComponent,
     data: {
-        authorities: ['ROLE_USER'],
+        authorities: [AuthoritiesConstants.USER],
         pageTitle: 'global.menu.account.password'
     },
     canActivate: [UserRouteAccessService]

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.route.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.route.ts
@@ -18,14 +18,14 @@
 -%>
 import { Route } from '@angular/router';
 
-import { UserRouteAccessService } from '../../shared';
+import { UserRouteAccessService, AuthoritiesConstants } from '../../shared';
 import { SessionsComponent } from './sessions.component';
 
 export const sessionsRoute: Route = {
     path: 'sessions',
     component: SessionsComponent,
     data: {
-        authorities: ['ROLE_USER'],
+        authorities: [AuthoritiesConstants.USER],
         pageTitle: 'global.menu.account.sessions'
     },
     canActivate: [UserRouteAccessService]

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.route.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/_settings.route.ts
@@ -18,14 +18,14 @@
 -%>
 import { Route } from '@angular/router';
 
-import { UserRouteAccessService } from '../../shared';
+import { UserRouteAccessService, AuthoritiesConstants } from '../../shared';
 import { SettingsComponent } from './settings.component';
 
 export const settingsRoute: Route = {
     path: 'settings',
     component: SettingsComponent,
     data: {
-        authorities: ['ROLE_USER'],
+        authorities: [AuthoritiesConstants.USER],
         pageTitle: 'global.menu.account.settings'
     },
     canActivate: [UserRouteAccessService]

--- a/generators/client/templates/angular/src/main/webapp/app/admin/_admin.route.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/_admin.route.ts
@@ -17,6 +17,7 @@
  limitations under the License.
 -%>
 import { Routes } from '@angular/router';
+import { AuthoritiesConstants } from '../shared';
 
 import {
     <%_ if (devDatabaseType !== 'cassandra') { _%>
@@ -64,7 +65,7 @@ const ADMIN_ROUTES = [
 export const adminState: Routes = [{
     path: '',
     data: {
-        authorities: ['ROLE_ADMIN']
+        authorities: [AuthoritiesConstants.ADMIN]
     },
     canActivate: [UserRouteAccessService],
     children: ADMIN_ROUTES

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.route.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.route.ts
@@ -26,7 +26,7 @@ import { UserMgmtDetailComponent } from './user-management-detail.component';
 import { UserDialogComponent } from './user-management-dialog.component';
 import { UserDeleteDialogComponent } from './user-management-delete-dialog.component';
 
-import { Principal } from '../../shared';
+import { Principal, AuthoritiesConstants } from '../../shared';
 
 @Injectable()
 export class UserResolve implements CanActivate {
@@ -34,7 +34,7 @@ export class UserResolve implements CanActivate {
     constructor(private principal: Principal) { }
 
     canActivate() {
-        return this.principal.identity().then((account) => this.principal.hasAnyAuthority(['ROLE_ADMIN']));
+        return this.principal.identity().then((account) => this.principal.hasAnyAuthority([AuthoritiesConstants.ADMIN]));
     }
 }
 

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
@@ -49,7 +49,7 @@
                     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
                 </ul>
             </li>
-            <li *<%=jhiPrefix%>HasAnyAuthority="AuthoritiesConstants.ADMIN" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            <li *<%=jhiPrefix%>HasAnyAuthority="authoritiesConstants.ADMIN" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="admin-menu">
                     <span>
                         <i class="fa fa-user-plus" aria-hidden="true"></i>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
@@ -49,7 +49,7 @@
                     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
                 </ul>
             </li>
-            <li *<%=jhiPrefix%>HasAnyAuthority="'ROLE_ADMIN'" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            <li *<%=jhiPrefix%>HasAnyAuthority="AuthoritiesConstants.ADMIN" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="admin-menu">
                     <span>
                         <i class="fa fa-user-plus" aria-hidden="true"></i>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
@@ -21,6 +21,7 @@ import { Router } from '@angular/router';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { JhiLanguageService } from 'ng-jhipster';
 
+import { AuthoritiesConstants } from '../../shared';
 import { ProfileService } from '../profiles/profile.service';
 import { <% if (enableTranslation) { %>JhiLanguageHelper, <% } %>Principal, LoginModalService, LoginService } from '../../shared';
 
@@ -39,6 +40,7 @@ import { VERSION, DEBUG_INFO_ENABLED } from '../../app.constants';
 })
 export class NavbarComponent implements OnInit {
 
+    AuthoritiesConstants = AuthoritiesConstants;
     inProduction: boolean;
     isNavbarCollapsed: boolean;
     languages: any[];

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
@@ -40,7 +40,7 @@ import { VERSION, DEBUG_INFO_ENABLED } from '../../app.constants';
 })
 export class NavbarComponent implements OnInit {
 
-    AuthoritiesConstants = AuthoritiesConstants;
+    authoritiesConstants = AuthoritiesConstants;
     inProduction: boolean;
     isNavbarCollapsed: boolean;
     languages: any[];

--- a/generators/client/templates/angular/src/main/webapp/app/shared/_index.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/_index.ts
@@ -19,6 +19,7 @@
 export * from './constants/pagination.constants';
 export * from './alert/alert.component';
 export * from './alert/alert-error.component';
+export * from './auth/authorities-constants';
 export * from './auth/csrf.service';
 export * from './auth/state-storage.service';
 export * from './auth/account.service';

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_authorities-constants.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_authorities-constants.ts
@@ -1,0 +1,7 @@
+export class AuthoritiesConstants {
+    public static readonly ADMIN = 'ROLE_ADMIN';
+
+    public static readonly USER = 'ROLE_USER';
+
+    public static readonly ANONYMOUS = 'ROLE_ANONYMOUS';
+}

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
@@ -25,9 +25,15 @@ import { Principal } from './principal.service';
  *
  * @howToUse
  * ```
- *     <some-element *jhiHasAnyAuthority="'ROLE_ADMIN'">...</some-element>
+ *     <some-element *jhiHasAnyAuthority="AuthoritiesConstants.ADMIN">...</some-element>
  *
- *     <some-element *jhiHasAnyAuthority="['ROLE_ADMIN', 'ROLE_USER']">...</some-element>
+ *     <some-element *jhiHasAnyAuthority="[AuthoritiesConstants.ADMIN, AuthoritiesConstants.USER]">...</some-element>
+ * ```
+ * AuthoritiesConstants needs to be exposed in the component properties accesible from view, add in component:
+ * ```
+ * import { AuthoritiesConstants } from '../../shared';
+ * ...
+ * AuthoritiesConstants = AuthoritiesConstants;
  * ```
  */
 @Directive({

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_has-any-authority.directive.ts
@@ -33,7 +33,7 @@ import { Principal } from './principal.service';
  * ```
  * import { AuthoritiesConstants } from '../../shared';
  * ...
- * AuthoritiesConstants = AuthoritiesConstants;
+ * authoritiesConstants = AuthoritiesConstants;
  * ```
  */
 @Directive({

--- a/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
@@ -21,6 +21,7 @@ import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 
 import { User } from './user.model';
+import { AuthoritiesConstants } from '../auth/authorities-constants';
 import { ResponseWrapper } from '../model/response-wrapper.model';
 import { createRequestOption } from '../model/request-util';
 
@@ -61,7 +62,7 @@ export class UserService {
             return <string[]> json;
         });
 <%_ } else { _%>
-        return Observable.of(['ROLE_USER', 'ROLE_ADMIN']);
+        return Observable.of([AuthoritiesConstants.USER, AuthoritiesConstants.ADMIN]);
 <%_ } _%>
     }
 

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -62,7 +62,6 @@ import { ResponseWrapper } from '../../shared';
 export class <%= entityAngularName %>DialogComponent implements OnInit {
 
     <%= entityInstance %>: <%= entityAngularName %>;
-    authorities: any[];
     isSaving: boolean;
     <%_
     const query = generateEntityQueries(relationships, entityInstance, dto);
@@ -100,7 +99,6 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
 
     ngOnInit() {
         this.isSaving = false;
-        this.authorities = ['ROLE_USER', 'ROLE_ADMIN'];
         <%_ for (idx in queries) { _%>
         <%- queries[idx] %>
         <%_ } _%>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.route.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.route.ts
@@ -33,7 +33,7 @@ _%>
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Routes, CanActivate } from '@angular/router';
 
-import { UserRouteAccessService } from '../../shared';
+import { UserRouteAccessService, AuthoritiesConstants, Principal } from '../../shared';
 import { JhiPaginationUtil } from 'ng-jhipster';
 
 import { <%= entityAngularName %>Component } from './<%= entityFileName %>.component';
@@ -46,8 +46,6 @@ import {
     <%= entityAngularName %>DeletePopupComponent
 } from './<%= entityFileName %>-delete-dialog.component';
 <%_ } _%>
-
-import { Principal } from '../../shared';
 
 <%_ if (pagination === 'pagination' || pagination === 'pager') { _%>
 @Injectable()
@@ -77,7 +75,7 @@ export const <%= entityInstance %>Route: Routes = [
         },
         <%_ } _%>
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [AuthoritiesConstants.USER],
             pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
@@ -85,7 +83,7 @@ export const <%= entityInstance %>Route: Routes = [
         path: '<%= entityUrl %>/:id',
         component: <%= entityAngularName %>DetailComponent,
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [AuthoritiesConstants.USER],
             pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
@@ -97,7 +95,7 @@ export const <%= entityInstance %>PopupRoute: Routes = [
         path: '<%= entityUrl %>-new',
         component: <%= entityAngularName %>PopupComponent,
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [AuthoritiesConstants.USER],
             pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService],
@@ -107,7 +105,7 @@ export const <%= entityInstance %>PopupRoute: Routes = [
         path: '<%= entityUrl %>/:id/edit',
         component: <%= entityAngularName %>PopupComponent,
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [AuthoritiesConstants.USER],
             pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService],
@@ -117,7 +115,7 @@ export const <%= entityInstance %>PopupRoute: Routes = [
         path: '<%= entityUrl %>/:id/delete',
         component: <%= entityAngularName %>DeletePopupComponent,
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [AuthoritiesConstants.USER],
             pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService],


### PR DESCRIPTION
Added a new AuthoritiesConstants class on angular 2 client side in auth folder, similar with the java server one.
All "hard-coded" references of form 'ROLE_ADMIN', 'ROLE_USER' are now changed to AuthoritiesConstants.ADMIN, AuthoritiesConstants.USER.
Please note that I also removed an unused 'authorities' property in _entity-management-dialog.component.ts
