### PR TITLE
Remove new keystore

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -33,7 +33,7 @@ util.inherits(UpgradeGenerator, BaseGenerator);
 const GENERATOR_JHIPSTER = 'generator-jhipster';
 const UPGRADE_BRANCH = 'jhipster_upgrade';
 const GIT_VERSION_NOT_ALLOW_MERGE_UNRELATED_HISTORIES = '2.9.0';
-const GENERATOR_JHIPSTER_CLI_VERSION = '4.5.1';
+const FIRST_CLI_SUPPORTED_VERSION = '4.5.1'; // The first version in which CLI support was added
 const SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
 
 module.exports = UpgradeGenerator.extend({
@@ -78,7 +78,7 @@ module.exports = UpgradeGenerator.extend({
     _generate(version, callback) {
         this.log(`Regenerating application with JHipster ${version}...`);
         let generatorCommand = 'yo jhipster';
-        if (semver.gte(version, GENERATOR_JHIPSTER_CLI_VERSION)) {
+        if (semver.gte(version, FIRST_CLI_SUPPORTED_VERSION)) {
             generatorCommand = this.clientPackageManager === 'yarn' ? '$(yarn bin)/jhipster' : '$(npm bin)/jhipster';
         }
         shelljs.exec(`${generatorCommand} --with-entities --force --skip-install`, { silent: this.silent }, (code, msg, err) => {

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -33,6 +33,7 @@ util.inherits(UpgradeGenerator, BaseGenerator);
 const GENERATOR_JHIPSTER = 'generator-jhipster';
 const UPGRADE_BRANCH = 'jhipster_upgrade';
 const GIT_VERSION_NOT_ALLOW_MERGE_UNRELATED_HISTORIES = '2.9.0';
+const GENERATOR_JHIPSTER_CLI_VERSION = '4.5.1';
 const SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
 
 module.exports = UpgradeGenerator.extend({
@@ -76,7 +77,10 @@ module.exports = UpgradeGenerator.extend({
 
     _generate(version, callback) {
         this.log(`Regenerating application with JHipster ${version}...`);
-        const generatorCommand = 'yo jhipster';
+        let generatorCommand = 'yo jhipster';
+        if (semver.gte(version, GENERATOR_JHIPSTER_CLI_VERSION)) {
+            generatorCommand = this.clientPackageManager === 'yarn' ? '$(yarn bin)/jhipster' : '$(npm bin)/jhipster';
+        }
         shelljs.exec(`${generatorCommand} --with-entities --force --skip-install`, { silent: this.silent }, (code, msg, err) => {
             if (code === 0) this.log(chalk.green(`Successfully regenerated application with JHipster ${version}`));
             else this.error(`Something went wrong while generating project! ${err}`);

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -23,6 +23,7 @@ const chalk = require('chalk');
 const BaseGenerator = require('../generator-base');
 const shelljs = require('shelljs');
 const semver = require('semver');
+const constants = require('../generator-constants');
 
 const UpgradeGenerator = generator.extend({});
 
@@ -32,7 +33,7 @@ util.inherits(UpgradeGenerator, BaseGenerator);
 const GENERATOR_JHIPSTER = 'generator-jhipster';
 const UPGRADE_BRANCH = 'jhipster_upgrade';
 const GIT_VERSION_NOT_ALLOW_MERGE_UNRELATED_HISTORIES = '2.9.0';
-const GENERATOR_JHIPSTER_CLI_VERSION = '4.5.1';
+const SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
 
 module.exports = UpgradeGenerator.extend({
     constructor: function (...args) { // eslint-disable-line object-shorthand
@@ -75,10 +76,7 @@ module.exports = UpgradeGenerator.extend({
 
     _generate(version, callback) {
         this.log(`Regenerating application with JHipster ${version}...`);
-        let generatorCommand = 'yo jhipster';
-        if (semver.gte(version, GENERATOR_JHIPSTER_CLI_VERSION)) {
-            generatorCommand = this.clientPackageManager === 'yarn' ? '$(yarn bin)/jhipster' : '$(npm bin)/jhipster';
-        }
+        const generatorCommand = 'yo jhipster';
         shelljs.exec(`${generatorCommand} --with-entities --force --skip-install`, { silent: this.silent }, (code, msg, err) => {
             if (code === 0) this.log(chalk.green(`Successfully regenerated application with JHipster ${version}`));
             else this.error(`Something went wrong while generating project! ${err}`);
@@ -108,6 +106,7 @@ module.exports = UpgradeGenerator.extend({
                     this.error('bower install failed.');
                 }
             }
+            shelljs.rm('-Rf', `${SERVER_MAIN_RES_DIR}keystore.jks`);
             this._gitCommitAll(`Generated with JHipster ${version}`, () => {
                 callback();
             });


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

This PR has two changes
1. Stop using jhipster cli when regenerate project. Because it's reason for many related issues 
I tried to use jhipster cli in new versions. Ref https://github.com/jhipster/generator-jhipster/pull/5966
An other issuse `jhipster --force` not working: Ref: https://github.com/jhipster/generator-jhipster/commit/0b9767307f33797d1384ef445fa1c792390ee45d

2. Use exist generated keystore instead of generate new keystore. Less confict, tested on generating uaa project.