### PR TITLE
docker prompts - accept paths not ending with a slash

### DIFF
--- a/generators/docker-prompts.js
+++ b/generators/docker-prompts.js
@@ -297,15 +297,16 @@ function askForAdminPassword() {
 }
 
 function getAppFolders(input, composeApplicationType) {
-    const files = shelljs.ls('-l', this.destinationPath(input));
+    const destinationPath = this.destinationPath(input);
+    const files = shelljs.ls('-l', destinationPath);
     const appsFolders = [];
 
     files.forEach((file) => {
         if (file.isDirectory()) {
-            if ((shelljs.test('-f', `${input + file.name}/.yo-rc.json`))
-                && (shelljs.test('-f', `${input + file.name}/src/main/docker/app.yml`))) {
+            if ((shelljs.test('-f', `${destinationPath}/${file.name}/.yo-rc.json`))
+                && (shelljs.test('-f', `${destinationPath}/${file.name}/src/main/docker/app.yml`))) {
                 try {
-                    const fileData = this.fs.readJSON(`${input + file.name}/.yo-rc.json`);
+                    const fileData = this.fs.readJSON(`${destinationPath}/${file.name}/.yo-rc.json`);
                     if ((fileData['generator-jhipster'].baseName !== undefined)
                         && ((composeApplicationType === undefined)
                             || (composeApplicationType === fileData['generator-jhipster'].applicationType)


### PR DESCRIPTION
Currently, if the path entered into the `jhipster docker-compose` does not end in a `/`, the generator will not find any apps.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
