### PR TITLE
#6114 prevent NPE in Audit Event

### DIFF
--- a/generators/server/templates/src/main/java/package/config/audit/_AuditEventConverter.java
+++ b/generators/server/templates/src/main/java/package/config/audit/_AuditEventConverter.java
@@ -53,6 +53,9 @@ public class AuditEventConverter {
      * @return the converted list.
      */
     public AuditEvent convertToAuditEvent(PersistentAuditEvent persistentAuditEvent) {
+        if(persistentAuditEvent == null){
+            return null;
+        }
         return new AuditEvent(Date.from(persistentAuditEvent.getAuditEventDate()), persistentAuditEvent.getPrincipal(),
             persistentAuditEvent.getAuditEventType(), convertDataToObjects(persistentAuditEvent.getData()));
     }


### PR DESCRIPTION
#6114 NPE from `null` resultset when expected AuditEvent is single object

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
