### PR TITLE
Travis: remove travis_wait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -79,7 +79,7 @@ install:
 script:
   - $JHIPSTER_SCRIPTS/03-docker-compose.sh
   - $JHIPSTER_SCRIPTS/04-tests.sh
-  - travis_wait 30 $JHIPSTER_SCRIPTS/05-run.sh
+  - $JHIPSTER_SCRIPTS/05-run.sh
   - $JHIPSTER_SCRIPTS/06-sonar.sh
 notifications:
   webhooks:


### PR DESCRIPTION
Following the @deepu105's comments [here](https://github.com/jhipster/generator-jhipster/issues/6051#issuecomment-315560699)

> The build either failed or stalled but its reported as passed. Any idea?

I have the same when running in my computer. As @sendilkumarn said, it's more a WARNING than an ERROR and the build finished with 0 code. So for me, it's ok.
Looking our code [here](https://github.com/jhipster/generator-jhipster/blob/master/travis/scripts/05-run.sh#L72-L75), we should exit the build when there are error

> @pascalgrimaud not just one most of our recent prod builds are stalled at that point so technically we are never testing the prod AOT builds https://travis-ci.org/jhipster/generator-jhipster/jobs/253721138#L3322

The code [here](https://github.com/jhipster/generator-jhipster/blob/master/travis/scripts/05-run.sh#L62-L67) use profile `prod`, for 2 builds:
- [app-default-from-scratch](https://github.com/jhipster/generator-jhipster/blob/master/.travis.yml#L36)
- [app-ng2-psql-es-noi18n](https://github.com/jhipster/generator-jhipster/blob/master/.travis.yml#L38)

> @pascalgrimaud I think it might have something to do with the logging from the maven frontend plugin. The webpack part is written as ERROR instead of INFO

Indeed, the stdout is different. I think the problem comes from the use of `travis_wait`.
I removed it, as it's not necessary. The build takes less than 10min now, as you guys did so a good job :)
See https://travis-ci.org/pascalgrimaud/generator-jhipster/jobs/254089816#L6155
It should be the same output than in local computer
_____

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
