### PR TITLE
removes redundant kubectl in k8s readme [ci skip]

### DIFF
--- a/generators/kubernetes/templates/_README-KUBERNETES.md
+++ b/generators/kubernetes/templates/_README-KUBERNETES.md
@@ -108,7 +108,7 @@ $ kubectl get svc prometheus-<%= kubernetesNamespace %><%= kubernetesNamespace =
 The registry is deployed using a headless service in kubernetes, so the primary service has no IP address, and cannot get a node port. You can create a secondary service for any type, using:
 
 ```
-$ kubectl kubectl expose service jhipster-registry --type=NodePort --name=exposed-registry<%= kubernetesNamespace === 'default' ? '' : ` -n ${kubernetesNamespace}` %>
+$ kubectl expose service jhipster-registry --type=NodePort --name=exposed-registry<%= kubernetesNamespace === 'default' ? '' : ` -n ${kubernetesNamespace}` %>
 ```
 
 and explore the details using


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
