### PR TITLE
Ignore JHipster package.json scripts during upgrade

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -225,7 +225,7 @@ module.exports = UpgradeGenerator.extend({
             const installJhipsterLocally = (version, callback) => {
                 this.log(`Installing JHipster ${version} locally`);
                 const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-                shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile`, { silent: this.silent }, (code, msg, err) => {
+                shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile --ignore-scripts`, { silent: this.silent }, (code, msg, err) => {
                     if (code === 0) this.log(chalk.green(`Installed ${GENERATOR_JHIPSTER}@${version}`));
                     else this.error(`Something went wrong while installing the JHipster generator! ${msg} ${err}`);
                     callback();
@@ -274,7 +274,7 @@ module.exports = UpgradeGenerator.extend({
             this.log(chalk.yellow(`Updating ${GENERATOR_JHIPSTER} to ${this.latestVersion} . This might take some time...`));
             const done = this.async();
             const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${this.latestVersion} --dev --no-lockfile`, { silent: this.silent }, (code, msg, err) => {
+            shelljs.exec(`${commandPrefix} ${GENERATOR_JHIPSTER}@${this.latestVersion} --dev --no-lockfile --ignore-scripts`, { silent: this.silent }, (code, msg, err) => {
                 if (code === 0) this.log(chalk.green(`Updated ${GENERATOR_JHIPSTER} to version ${this.latestVersion}`));
                 else this.error(`Something went wrong while updating JHipster! ${msg} ${err}`);
                 done();


### PR DESCRIPTION
Npm scripts of generator-jhipster are useful for global installation but they are not required in the context of an upgrade where the focus is on code and dependencies.

These scripts can make the upgrade fail for bad reasons like issue #6162 about tabtab. 

This change adds `--ignore-scripts` option  to `yarn add` or `npm install` during upgrade.

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
