### PR TITLE
Redirect to home page after logging in from password reset page

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
@@ -75,8 +75,8 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
         }).then(() => {
             this.authenticationError = false;
             this.activeModal.dismiss('login success');
-            if (this.router.url === '/register' || (/activate/.test(this.router.url)) ||
-                this.router.url === '/finishReset' || this.router.url === '/requestReset') {
+            if (this.router.url === '/register' || (/^\/activate\//.test(this.router.url)) ||
+                (/^\/reset\//.test(this.router.url))) {
                 this.router.navigate(['']);
             }
 


### PR DESCRIPTION
The paths used in comparison did not match the actual routes. Also, it makes sense to limit the regular expression to match only if the path *begins* with the string - we do not want to lose a valid deep link like /customer/order/activate.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary (login component currently has no tests)
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
