### PR TITLE
remove problematic character from greek global.json

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/el/_global.json
+++ b/generators/languages/templates/src/main/webapp/i18n/el/_global.json
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-﻿{
+{
     "global": {
         "title": "<%= capitalizedBaseName %>",
         "browsehappy": "Χρησιμοποείται ένα <strong>απαρχαιωμένο</strong> πρόγραμμα περιήγησης. Παρακαλώ <a href=\"http://browsehappy.com/?locale=en\">αναβαθμίστε το πρόγραμμα περιήγησης σας</a> να βελτιωθεί η εμπειρία σας.",


### PR DESCRIPTION
In case of selecting greek language to the application, the webpack build is broken. eg

{
  "generator-jhipster": {
    "promptValues": {
      "packageName": "com.mycompany.company",
      "nativeLanguage": "en"
    }, 
    "jhipsterVersion": "4.6.2",
    "baseName": "company",
    "packageName": "com.mycompany.company",
    "packageFolder": "com/mycompany/company",
    "serverPort": "8080",
    "authenticationType": "jwt",
    "hibernateCache": "ehcache",
    "clusteredHttpSession": false,
    "websocket": "spring-websocket",
    "databaseType": "sql",
    "devDatabaseType": "h2Disk",
    "prodDatabaseType": "mysql",
    "searchEngine": "elasticsearch",
    "messageBroker": false,
    "serviceDiscoveryType": false,
    "buildTool": "maven",
    "enableSocialSignIn": false,
    "jwtSecretKey": "5e51fc29a7e22c1b7ac3aa3a00476c0f25b98221",
    "clientFramework": "angularX",
    "useSass": true,
    "clientPackageManager": "yarn",
    "applicationType": "monolith",
    "testFrameworks": [
      "gatling",
      "cucumber",
      "protractor"
    ],
    "jhiPrefix": "jhi",
    "enableTranslation": true,
    "nativeLanguage": "en",
    "languages": [
      "en",
      "el"
    ]
  }
}

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X ] Tests are added where necessary
- [X ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
