### PR TITLE
Missing class="form-control-label" on select <label> components

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
@@ -198,7 +198,7 @@ _%>
         const translationKey = keyPrefix + relationshipName; _%>
         <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true && otherEntityName === 'user')) { _%>
         <div class="form-group">
-            <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
+            <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
             <%_ if (dto === 'no') { _%>
             <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= entityInstance %>.<%=relationshipFieldName %>" <% if (relationshipRequired) { %> required<% } %>>
                 <%_ if (!relationshipRequired) { _%>
@@ -217,7 +217,7 @@ _%>
         </div>
         <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true) { _%>
         <div class="form-group">
-            <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
+            <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
             <%_ if (dto === 'no') { _%>
             <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= entityInstance %>.<%=relationshipFieldName %>"<% if (relationshipRequired) { %> required<% } %>>
                 <%_ if (!relationshipRequired) { _%>


### PR DESCRIPTION
On line [58](https://github.com/jhipster/generator-jhipster/blob/master/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html#L58) the <label> component of the select has a class attribute (`class="form-control-label"`), but not on those two.
