### PR TITLE
fix "event" entity name

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -120,15 +120,15 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
         return this.dataUtils.openFile(contentType, field);
     }
 
-    setFileData(event, <%= entityInstance %>, field, isImage) {
+    setFileData(event, entity, field, isImage) {
         if (event && event.target.files && event.target.files[0]) {
             const file = event.target.files[0];
             if (isImage && !/^image\//.test(file.type)) {
                 return;
             }
             this.dataUtils.toBase64(file, (base64Data) => {
-                <%= entityInstance %>[field] = base64Data;
-                <%= entityInstance %>[`${field}ContentType`] = file.type;
+                entity[field] = base64Data;
+                entity[`${field}ContentType`] = file.type;
             });
         }
     }


### PR DESCRIPTION
If the entity's name was `event` (or `field`) and the entity contained a blob field, a TS error would occur because two variables in the function have the same name.  This makes it so the entity name doesn't matter

Fix #6198

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
