### PR TITLE
Clear out the stored previous url after login

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login.component.ts
@@ -89,6 +89,7 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
             // // since login is succesful, go to stored previousState and clear previousState
             const redirect = this.stateStorageService.getUrl();
             if (redirect) {
+                this.stateStorageService.storeUrl(null);
                 this.router.navigate([redirect]);
             }
         }).catch(() => {


### PR DESCRIPTION
 so it wont'get redirect on the second time on login. This could happen, with a quick logout, and login, where the user should stay on the home screen, but without clearing the field, the old value is reused.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
