### PR TITLE
move setFileData to ng-jhipster's data-utils

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -39,7 +39,7 @@
     "core-js": "2.4.1",
     "font-awesome": "4.7.0",
     "jquery": "3.2.1",
-    "ng-jhipster": "0.2.7",
+    "ng-jhipster": "0.2.8",
     "ng2-webstorage": "1.8.0",
     "ngx-cookie": "1.0.0",
     "ngx-infinite-scroll": "0.5.1",

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -121,16 +121,7 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
     }
 
     setFileData(event, entity, field, isImage) {
-        if (event && event.target.files && event.target.files[0]) {
-            const file = event.target.files[0];
-            if (isImage && !/^image\//.test(file.type)) {
-                return;
-            }
-            this.dataUtils.toBase64(file, (base64Data) => {
-                entity[field] = base64Data;
-                entity[`${field}ContentType`] = file.type;
-            });
-        }
+        this.dataUtils.setFileData(event, entity, field, isImage);
     }
 
     <%_ if (fieldsContainImageBlob) { _%>


### PR DESCRIPTION
Dependent on my [pull request](https://github.com/jhipster/ng-jhipster/pull/44) in ng-jhipster and a new release of that library.  Travis will fail until then

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
