### PR TITLE
Remove redundant and broken error handling when saving entities

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -148,7 +148,7 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
 
     private subscribeToSaveResponse(result: Observable<<%= entityAngularName %>>) {
         result.subscribe((res: <%= entityAngularName %>) =>
-            this.onSaveSuccess(res), (res: Response) => this.onSaveError(res));
+            this.onSaveSuccess(res), (res: Response) => this.onSaveError());
     }
 
     private onSaveSuccess(result: <%= entityAngularName %>) {
@@ -157,17 +157,11 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
         this.activeModal.dismiss(result);
     }
 
-    private onSaveError(error) {
-        try {
-            error.json();
-        } catch (exception) {
-            error.message = error.text();
-        }
+    private onSaveError() {
         this.isSaving = false;
-        this.onError(error);
     }
 
-    private onError(error) {
+    private onError(error: any) {
         this.alertService.error(error.message, null, null);
     }
     <%_


### PR DESCRIPTION
Error handling seems to be unnecessary at this point:
1. There is a global HTTP error handling routine in alert-error.component.ts
2. The local error handling seems to be broken because if the error response contains json (which is the regular case), response.message stays undefined, so there is no message to show
If there is no specific reason for save error handling in the dialog component, I would propose to remove the code for now.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
