### PR TITLE
Console log forwarding improvements

### DIFF
--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -69,19 +69,23 @@ processResources {
             it.replace('#logback.loglevel#', logbackLoglevel)
         }
     }
-    <%_ if (applicationType === 'monolith') { _%>
     filesMatching('**/application.yml') {
-    <%_ } _%>
-    <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
-    filesMatching('**/bootstrap.yml') {
-    <%_ } _%>
-        filter {
-            it.replace('#spring.profiles.active#', profiles)
-        }
         filter {
             it.replace('#project.version#', version)
         }
+        <%_ if (applicationType === 'monolith') { _%>
+        filter {
+            it.replace('#spring.profiles.active#', profiles)
+        }
+        <%_ } _%>
     }
+    <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
+    filesMatching('**/bootstrap.yml') {
+        filter {
+            it.replace('#spring.profiles.active#', profiles)
+        }
+    }
+    <%_ } _%>
 }
 
 <%_ if (!skipClient) { _%>

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -72,19 +72,23 @@ processResources {
             it.replace('#logback.loglevel#', logbackLoglevel)
         }
     }
-    <%_ if (applicationType === 'monolith') { _%>
     filesMatching('**/application.yml') {
-    <%_ } _%>
-    <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
-    filesMatching('**/bootstrap.yml') {
-    <%_ } _%>
-        filter {
-            it.replace('#spring.profiles.active#', profiles)
-        }
         filter {
             it.replace('#project.version#', version)
         }
+        <%_ if (applicationType === 'monolith') { _%>
+        filter {
+            it.replace('#spring.profiles.active#', profiles)
+        }
+        <%_ } _%>
     }
+    <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
+    filesMatching('**/bootstrap.yml') {
+        filter {
+            it.replace('#spring.profiles.active#', profiles)
+        }
+    }
+    <%_ } _%>
 }
 
 <%_ if (!skipClient) { _%>

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -19,14 +19,20 @@
 package <%=packageName%>.config;
 
 import java.net.InetSocketAddress;
+import java.util.Iterator;
 
 import io.github.jhipster.config.JHipsterProperties;
 
 import ch.qos.logback.classic.AsyncAppender;
 import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.LoggerContext;
+import ch.qos.logback.classic.boolex.OnMarkerEvaluator;
+import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.classic.spi.LoggerContextListener;
+import ch.qos.logback.core.Appender;
+import ch.qos.logback.core.filter.EvaluatorFilter;
 import ch.qos.logback.core.spi.ContextAwareBase;
+import ch.qos.logback.core.spi.FilterReply;
 import net.logstash.logback.appender.LogstashTcpSocketAppender;
 import net.logstash.logback.encoder.LogstashEncoder;
 import net.logstash.logback.stacktrace.ShortenedThrowableConverter;
@@ -51,6 +57,8 @@ import org.springframework.context.annotation.Configuration;
 @ConditionalOnConsulEnabled
 <%_ } _%>
 public class LoggingConfiguration {
+    private static final String LOGSTASH_APPENDER_NAME = "LOGSTASH";
+    private static final String ASYNC_LOGSTASH_APPENDER_NAME = "ASYNC_LOGSTASH";
 
     private final Logger log = LoggerFactory.getLogger(LoggingConfiguration.class);
 
@@ -86,15 +94,20 @@ public class LoggingConfiguration {
         this.version = version;
         if (jHipsterProperties.getLogging().getLogstash().isEnabled()) {
             addLogstashAppender(context);
-
-            // Add context listener
-            LogbackLoggerContextListener loggerContextListener = new LogbackLoggerContextListener();
-            loggerContextListener.setContext(context);
-            context.addListener(loggerContextListener);
+            addContextListener(context);
+        }
+        if (jHipsterProperties.getMetrics().getLogs().isEnabled()) {
+            setMetricsMarkerLogbackFilter(context);
         }
     }
 
-    public void addLogstashAppender(LoggerContext context) {
+    private void addContextListener(LoggerContext context) {
+        LogbackLoggerContextListener loggerContextListener = new LogbackLoggerContextListener();
+        loggerContextListener.setContext(context);
+        context.addListener(loggerContextListener);
+    }
+
+    private void addLogstashAppender(LoggerContext context) {
         log.info("Initializing Logstash logging");
 
         LogstashTcpSocketAppender logstashAppender = new LogstashTcpSocketAppender();
@@ -131,6 +144,32 @@ public class LoggingConfiguration {
         asyncLogstashAppender.start();
 
         context.getLogger("ROOT").addAppender(asyncLogstashAppender);
+    }
+
+    // Configure a log filter to remove "metrics" logs from all appenders except the "LOGSTASH" appender
+    private void setMetricsMarkerLogbackFilter(LoggerContext context) {
+        log.info("Filtering metrics logs from all appenders except the {} appender", LOGSTASH_APPENDER_NAME);
+        OnMarkerEvaluator onMarkerMetricsEvaluator = new OnMarkerEvaluator();
+        onMarkerMetricsEvaluator.setContext(context);
+        onMarkerMetricsEvaluator.addMarker("metrics");
+        onMarkerMetricsEvaluator.start();
+        EvaluatorFilter<ILoggingEvent> metricsFilter = new EvaluatorFilter<>();
+        metricsFilter.setContext(context);
+        metricsFilter.setEvaluator(onMarkerMetricsEvaluator);
+        metricsFilter.setOnMatch(FilterReply.DENY);
+        metricsFilter.start();
+
+        for (ch.qos.logback.classic.Logger logger : context.getLoggerList()) {
+            for (Iterator<Appender<ILoggingEvent>> it = logger.iteratorForAppenders(); it.hasNext(); ) {
+                Appender<ILoggingEvent> appender = it.next();
+                if (!appender.getName().equals(ASYNC_LOGSTASH_APPENDER_NAME)) {
+                    log.debug("Filter metrics logs from the {} appender", appender.getName());
+                    appender.setContext(context);
+                    appender.addFilter(metricsFilter);
+                    appender.start();
+                }
+            }
+        }
     }
 
     /**

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -68,10 +68,13 @@ public class LoggingConfiguration {
     private final ConsulRegistration consulRegistration;
     <%_ } _%>
 
+    private final String version;
+
     private final JHipsterProperties jHipsterProperties;
 
     public LoggingConfiguration(@Value("${spring.application.name}") String appName, @Value("${server.port}") String serverPort,
-        <% if (serviceDiscoveryType === "eureka") { %>EurekaInstanceConfigBean eurekaInstanceConfigBean,<% } %><% if (serviceDiscoveryType === "consul") { %> ConsulRegistration consulRegistration,<% } %> JHipsterProperties jHipsterProperties) {
+        <% if (serviceDiscoveryType === "eureka") { %>EurekaInstanceConfigBean eurekaInstanceConfigBean,<% } %><% if (serviceDiscoveryType === "consul") { %> ConsulRegistration consulRegistration,<% } %> JHipsterProperties jHipsterProperties, @Value("${info.project.version}")
+String version) {
         this.appName = appName;
         this.serverPort = serverPort;
         <%_ if (serviceDiscoveryType === 'eureka') { _%>
@@ -81,6 +84,7 @@ public class LoggingConfiguration {
         this.consulRegistration = consulRegistration;
         <%_ } _%>
         this.jHipsterProperties = jHipsterProperties;
+        this.version = version;
         if (jHipsterProperties.getLogging().getLogstash().isEnabled()) {
             addLogstashAppender(context);
 
@@ -99,7 +103,7 @@ public class LoggingConfiguration {
         logstashAppender.setContext(context);
         <%_ if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa')) { _%>
         String customFields = "{\"app_name\":\"" + appName + "\",\"app_port\":\"" + serverPort + "\"," +
-            "\"instance_id\":\"" + <% if (serviceDiscoveryType === "eureka") { %>eurekaInstanceConfigBean.getInstanceId()<% } %><% if (serviceDiscoveryType === "consul") { %>consulRegistration.getInstanceId()<% } %> + "\"}";
+            "\"instance_id\":\"" + <% if (serviceDiscoveryType === "eureka") { %>eurekaInstanceConfigBean.getInstanceId()<% } %><% if (serviceDiscoveryType === "consul") { %>consulRegistration.getInstanceId()<% } %> + "\"," + "\"version\":\"" + version + "\"}";
         <%_ } else { _%>
         String customFields = "{\"app_name\":\"" + appName + "\",\"app_port\":\"" + serverPort + "\"}";
         <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -73,8 +73,7 @@ public class LoggingConfiguration {
     private final JHipsterProperties jHipsterProperties;
 
     public LoggingConfiguration(@Value("${spring.application.name}") String appName, @Value("${server.port}") String serverPort,
-        <% if (serviceDiscoveryType === "eureka") { %>EurekaInstanceConfigBean eurekaInstanceConfigBean,<% } %><% if (serviceDiscoveryType === "consul") { %> ConsulRegistration consulRegistration,<% } %> JHipsterProperties jHipsterProperties, @Value("${info.project.version}")
-String version) {
+        <% if (serviceDiscoveryType === "eureka") { %>EurekaInstanceConfigBean eurekaInstanceConfigBean,<% } %><% if (serviceDiscoveryType === "consul") { %> ConsulRegistration consulRegistration,<% } %> JHipsterProperties jHipsterProperties, @Value("${info.project.version}") String version) {
         this.appName = appName;
         this.serverPort = serverPort;
         <%_ if (serviceDiscoveryType === 'eureka') { _%>

--- a/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
@@ -31,6 +31,7 @@ import org.springframework.cloud.netflix.metrics.spectator.SpectatorMetricReader
 <%_ } _%>
 
 import com.codahale.metrics.JmxReporter;
+import com.codahale.metrics.JvmAttributeGaugeSet;
 import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.Slf4jReporter;
 import com.codahale.metrics.health.HealthCheckRegistry;

--- a/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
@@ -66,7 +66,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
     private static final String PROP_METRIC_REG_JVM_THREADS = "jvm.threads";
     private static final String PROP_METRIC_REG_JVM_FILES = "jvm.files";
     private static final String PROP_METRIC_REG_JVM_BUFFERS = "jvm.buffers";
-    private static final String PROP_METRIC_REG_JVM_GAUGE_SET = "jvm.gauges";
+    private static final String PROP_METRIC_REG_JVM_ATTRIBUTE_SET = "jvm.attributes";
 <% if (hibernateCache === 'ehcache' || hibernateCache === 'infinispan') { %>
     private static final String PROP_METRIC_REG_JCACHE_STATISTICS = "jcache.statistics";
 <%_ } _%>
@@ -113,7 +113,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
         metricRegistry.register(PROP_METRIC_REG_JVM_THREADS, new ThreadStatesGaugeSet());
         metricRegistry.register(PROP_METRIC_REG_JVM_FILES, new FileDescriptorRatioGauge());
         metricRegistry.register(PROP_METRIC_REG_JVM_BUFFERS, new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
-        metricRegistry.register(PROP_METRIC_REG_JVM_GAUGE_SET, new JvmAttributeGaugeSet());
+        metricRegistry.register(PROP_METRIC_REG_JVM_ATTRIBUTE_SET, new JvmAttributeGaugeSet());
 <% if (hibernateCache === 'ehcache' || hibernateCache === 'infinispan') { %>
         metricRegistry.register(PROP_METRIC_REG_JCACHE_STATISTICS, new JCacheGaugeSet());
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
@@ -45,6 +45,7 @@ import com.zaxxer.hikari.HikariDataSource;
 <%_ } _%>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.Marker;
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.beans.factory.annotation.Autowired;
 <%_ } _%>
@@ -127,8 +128,10 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
         }
         if (jHipsterProperties.getMetrics().getLogs().isEnabled()) {
             log.info("Initializing Metrics Log reporting");
+            Marker metricsMarker = org.slf4j.MarkerFactory.getMarker("metrics");
             final Slf4jReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
                 .outputTo(LoggerFactory.getLogger("metrics"))
+                .markWith(metricsMarker)
                 .convertRatesTo(TimeUnit.SECONDS)
                 .convertDurationsTo(TimeUnit.MILLISECONDS)
                 .build();

--- a/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
@@ -63,6 +63,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
     private static final String PROP_METRIC_REG_JVM_THREADS = "jvm.threads";
     private static final String PROP_METRIC_REG_JVM_FILES = "jvm.files";
     private static final String PROP_METRIC_REG_JVM_BUFFERS = "jvm.buffers";
+    private static final String PROP_METRIC_REG_JVM_GAUGE_SET = "jvm.gauges";
 <% if (hibernateCache === 'ehcache' || hibernateCache === 'infinispan') { %>
     private static final String PROP_METRIC_REG_JCACHE_STATISTICS = "jcache.statistics";
 <%_ } _%>
@@ -109,6 +110,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
         metricRegistry.register(PROP_METRIC_REG_JVM_THREADS, new ThreadStatesGaugeSet());
         metricRegistry.register(PROP_METRIC_REG_JVM_FILES, new FileDescriptorRatioGauge());
         metricRegistry.register(PROP_METRIC_REG_JVM_BUFFERS, new BufferPoolMetricSet(ManagementFactory.getPlatformMBeanServer()));
+        metricRegistry.register(PROP_METRIC_REG_JVM_GAUGE_SET, new JvmAttributeGaugeSet());
 <% if (hibernateCache === 'ehcache' || hibernateCache === 'infinispan') { %>
         metricRegistry.register(PROP_METRIC_REG_JCACHE_STATISTICS, new JCacheGaugeSet());
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MetricsConfiguration.java
@@ -47,6 +47,7 @@ import com.zaxxer.hikari.HikariDataSource;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.slf4j.Marker;
+import org.slf4j.MarkerFactory;
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.beans.factory.annotation.Autowired;
 <%_ } _%>
@@ -129,7 +130,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
         }
         if (jHipsterProperties.getMetrics().getLogs().isEnabled()) {
             log.info("Initializing Metrics Log reporting");
-            Marker metricsMarker = org.slf4j.MarkerFactory.getMarker("metrics");
+            Marker metricsMarker = MarkerFactory.getMarker("metrics");
             final Slf4jReporter reporter = Slf4jReporter.forRegistry(metricRegistry)
                 .outputTo(LoggerFactory.getLogger("metrics"))
                 .markWith(metricsMarker)
@@ -145,7 +146,7 @@ public class MetricsConfiguration extends MetricsConfigurerAdapter {
     @Bean
     @ConditionalOnProperty("jhipster.logging.spectator-metrics.enabled")
     @ExportMetricReader
-    public SpectatorMetricReader SpectatorMetricReader(Registry registry) {
+    public SpectatorMetricReader spectatorMetricReader(Registry registry) {
         log.info("Initializing Spectator Metrics Log reporting");
         return new SpectatorMetricReader(registry);
     }

--- a/generators/server/templates/src/main/resources/_logback-spring.xml
+++ b/generators/server/templates/src/main/resources/_logback-spring.xml
@@ -112,15 +112,6 @@
         <resetJUL>true</resetJUL>
     </contextListener>
 
-        <!--
-    Filter out metrics logs, they should only be forwarded to logstash
-    (see MetricsConfiguration.java#L88)
-    -->
-    <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
-        <Marker>metrics</Marker>
-        <OnMatch>DENY</OnMatch>
-    </turboFilter>
-
     <root level="#logback.loglevel#">
         <appender-ref ref="CONSOLE"/>
 <!--

--- a/generators/server/templates/src/main/resources/_logback-spring.xml
+++ b/generators/server/templates/src/main/resources/_logback-spring.xml
@@ -112,6 +112,15 @@
         <resetJUL>true</resetJUL>
     </contextListener>
 
+        <!--
+    Filter out metrics logs, they should only be forwarded to logstash
+    (see MetricsConfiguration.java#L88)
+    -->
+    <turboFilter class="ch.qos.logback.classic.turbo.MarkerFilter">
+        <Marker>metrics</Marker>
+        <OnMatch>DENY</OnMatch>
+    </turboFilter>
+
     <root level="#logback.loglevel#">
         <appender-ref ref="CONSOLE"/>
 <!--

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -170,11 +170,9 @@ server:
         cookie:
             http-only: true
 
-<%_ if (serviceDiscoveryType === false) { _%>
 info:
     project:
         version: #project.version#
-<%_ } _%>
 
 # ===================================================================
 # JHipster specific properties

--- a/generators/server/templates/src/main/resources/config/_bootstrap.yml
+++ b/generators/server/templates/src/main/resources/config/_bootstrap.yml
@@ -55,7 +55,3 @@ spring:
             label: master # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the configuration source Git repository
         <%_ } _%>
-
-info:
-    project:
-        version: #project.version#

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -132,6 +132,12 @@ server:
     port: 10344
     address: localhost
 
+<%_ if (serviceDiscoveryType === false) { _%>
+info:
+    project:
+        version: #project.version#
+<%_ } _%>
+
 # ===================================================================
 # JHipster specific properties
 #

--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -132,11 +132,9 @@ server:
     port: 10344
     address: localhost
 
-<%_ if (serviceDiscoveryType === false) { _%>
 info:
     project:
         version: #project.version#
-<%_ } _%>
 
 # ===================================================================
 # JHipster specific properties


### PR DESCRIPTION
- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Some updates for the integration with the JHipster Console:

- Fix bad InstanceId forwarded to the Console (see https://github.com/jhipster/jhipster-console/issues/55)
- Add artifact version to logs forwarded to the console (for visibility when doing canaries)
- Add JvmAttributeGaugeSet to Dropwizard so that we can have the "uptime" metrics (planned for the registry).

And most important feature:
- When metrics logs are enabled, they are now filtered from the console and file appenders and only sent to logstash !
I'm sure this was a blocker for a lot of people.

