### PR TITLE
Migrate to Dockerfile maven plugin

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -56,6 +56,7 @@ function writeFiles() {
         writeDockerFiles() {
             // Create Docker and Docker Compose files
             this.template(`${DOCKER_DIR}_Dockerfile`, `${DOCKER_DIR}Dockerfile`);
+            this.template(`${DOCKER_DIR}.dockerignore`, `${DOCKER_DIR}.dockerignore`);
             this.template(`${DOCKER_DIR}_app.yml`, `${DOCKER_DIR}app.yml`);
             if (this.prodDatabaseType === 'mysql') {
                 this.template(`${DOCKER_DIR}_mysql.yml`, `${DOCKER_DIR}mysql.yml`);

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -61,7 +61,7 @@
         <%_ if (cucumberTests) { _%>
         <cucumber.version>1.2.4</cucumber.version>
         <%_ } _%>
-        <docker-maven-plugin.version>0.4.13</docker-maven-plugin.version>
+        <dockerfile-maven-plugin.version>1.3.4</dockerfile-maven-plugin.version>
         <!-- Overridden to get metrics-jcache -->
         <dropwizard-metrics.version>3.2.2</dropwizard-metrics.version>
         <%_ if (!skipClient) { _%>
@@ -994,6 +994,25 @@
                             </resources>
                         </configuration>
                     </execution>
+                    <execution>
+                        <id>docker-resources</id>
+                        <phase>validate</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>target/</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/docker/</directory>
+                                    <filtering>true</filtering>
+                                    <excludes>
+                                        <exclude>**/*.yml</exclude>
+                                    </excludes>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
                 </executions>
             </plugin>
             <plugin>
@@ -1120,18 +1139,24 @@
             </plugin>
             <plugin>
                 <groupId>com.spotify</groupId>
-                <artifactId>docker-maven-plugin</artifactId>
-                <version>${docker-maven-plugin.version}</version>
+                <artifactId>dockerfile-maven-plugin</artifactId>
+                <version>${dockerfile-maven-plugin.version}</version>
+                <!--
+                Uncomment the section below to build the docker image with mvn package and and push it with mvn deploy
+                <executions>
+                    <execution>
+                    <id>default</id>
+                    <goals>
+                        <goal>build</goal>
+                        <goal>push</goal>
+                    </goals>
+                    </execution>
+                </executions>
+                -->
                 <configuration>
-                    <imageName><%= baseName.toLowerCase() %></imageName>
-                    <dockerDirectory>src/main/docker</dockerDirectory>
-                    <resources>
-                        <resource>
-                            <targetPath>/</targetPath>
-                            <directory>${project.build.directory}</directory>
-                            <include>${project.build.finalName}.war</include>
-                        </resource>
-                    </resources>
+                    <repository>${project.artifactId}</repository>
+                    <tag>${project.version}</tag>
+                    <contextDirectory>${project.build.directory}</contextDirectory>
                 </configuration>
             </plugin>
             <%_ if (enableSwaggerCodegen) { _%>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -1155,7 +1155,7 @@
                 -->
                 <configuration>
                     <repository>${project.artifactId}</repository>
-                    <tag>${project.version}</tag>
+                    <tag>latest</tag>
                     <contextDirectory>${project.build.directory}</contextDirectory>
                 </configuration>
             </plugin>

--- a/generators/server/templates/gradle/_docker.gradle
+++ b/generators/server/templates/gradle/_docker.gradle
@@ -24,6 +24,10 @@ task buildDocker(type: Exec) {
             from "src/main/docker/"
             into "build/docker/"
             include "*"
+            exclude "**/*.yml"
+            filter {
+                it.replace('@project.build.finalName@', rootProject.name + '-' + version)
+            }
         }
         copy {
             from "build/libs"

--- a/generators/server/templates/src/main/docker/.dockerignore
+++ b/generators/server/templates/src/main/docker/.dockerignore
@@ -1,7 +1,7 @@
 <%#
  Copyright 2013-2017 the original author or authors from the JHipster project.
 
- This file is part of the JHipster project, see http://www.jhipster.tech/
+ This file is part of the JHipster project, see https://jhipster.github.io/
  for more information.
 
  Licensed under the Apache License, Version 2.0 (the "License");
@@ -16,15 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-FROM <%= DOCKER_JAVA_JRE %>
-
-ENV SPRING_OUTPUT_ANSI_ENABLED=ALWAYS \
-    JHIPSTER_SLEEP=0 \
-    JAVA_OPTS="<%_ if (hibernateCache === 'infinispan') { _%>-Djgroups.tcp.address=NON_LOOPBACK -Djava.net.preferIPv4Stack=true<%_ } _%>"
-
-ADD @project.build.finalName@.war /app.war
-
-EXPOSE <%= serverPort %><% if (hibernateCache === 'hazelcast') { %> 5701/udp<% } %>
-CMD echo "The application will start in ${JHIPSTER_SLEEP}s..." && \
-    sleep ${JHIPSTER_SLEEP} && \
-    java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /app.war
+# https://docs.docker.com/engine/reference/builder/#dockerignore-file
+# by default ignore everything except the jar file
+**/*
+!*.jar
+!*.war

--- a/generators/server/templates/src/main/docker/.dockerignore
+++ b/generators/server/templates/src/main/docker/.dockerignore
@@ -21,3 +21,6 @@
 **/*
 !*.jar
 !*.war
+<%_ if (prodDatabaseType === 'cassandra') { _%>
+!cassandra/
+<%_ } _%>


### PR DESCRIPTION
- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Fix #6194

I much prefer this new plugin which is more simple in its approach and more "native" to docker.
I have changed some little things, for example I set the full war file name in the dockerfile, this will prevent the issue when you were force to clean the target/ directory because there were two versions of the war file, then the `ADD *.war app.war` instruction was confused.

Also this new plugin paves the way for a new strategy for docker tagging. As it will tag the version of the docker image and store this version in maven build metadata files, I would like to exploit this in the docker-compose and k8s subgen.