### PR TITLE
JHipster CLI now runs project local module

### DIFF
--- a/cli/jhipster.js
+++ b/cli/jhipster.js
@@ -21,6 +21,7 @@
 const semver = require('semver');
 const packageJson = require('../package.json');
 const logger = require('./utils').logger;
+const path = require('path');
 
 const currentNodeVersion = process.versions.node;
 const minimumNodeVersion = packageJson.engines.node;
@@ -33,4 +34,28 @@ if (!semver.satisfies(currentNodeVersion, minimumNodeVersion)) {
     /* eslint-enable  */
     process.exit(1);
 }
-require('./cli');
+
+requireCLI();
+
+/*
+ * Require cli.js giving priority to local version over global one if it exists.
+ */
+function requireCLI() {
+    /* eslint-disable global-require */
+    try {
+        const localCLI = require.resolve(path.join(process.cwd(), 'node_modules', 'generator-jhipster', 'cli', 'cli.js'));
+        if (__dirname !== path.dirname(localCLI)) {
+            // load local version
+            /* eslint-disable import/no-dynamic-require */
+            logger.info('Using JHipster locally installed in current project\'s node_modules');
+            require(localCLI);
+            return;
+        }
+    } catch (e) {
+        // Unable to find local version, so global one will be loaded anyway
+    }
+    // load global version
+    logger.info('Using JHipster globally installed');
+    require('./cli');
+    /* eslint-enable  */
+}


### PR DESCRIPTION
`cli/jhipster.js` now detects whether there's a project local version of `cli/cli.js`so that it is loaded in priority over globally installed version.

Fix #6208

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
