### PR TITLE
Upgrade chalk to fix warning

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test": "mocha --timeout 20000 --slow 0 --reporter spec test/*.spec.js"
   },
   "dependencies": {
-    "chalk": "2.0.1",
+    "chalk": "2.1.0",
     "cheerio": "0.22.0",
     "commander": "2.10.0",
     "didyoumean": "1.2.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -226,9 +226,9 @@ chai@4.1.0:
     pathval "^1.0.0"
     type-detect "^4.0.0"
 
-chalk@2.0.1:
-  version "2.0.1"
-  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.0.1.tgz#dbec49436d2ae15f536114e76d14656cdbc0f44d"
+chalk@2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/chalk/-/chalk-2.1.0.tgz#ac5becf14fa21b99c6c92ca7a7d7cfd5b17e743e"
   dependencies:
     ansi-styles "^3.1.0"
     escape-string-regexp "^1.0.5"


### PR DESCRIPTION
warning generator-jhipster > chalk@2.0.1: Please upgrade to Chalk 2.1.0 - template literals in this version (2.0.1) are quite buggy.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
