### PR TITLE
Replace directive with translate pipe to fix IE rendering issue

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
@@ -62,7 +62,7 @@ _%>
                 const values = fields[idx].fieldValues.replace(/\s/g, '').split(',');
                 for (key in values) {
                     const value = values[key]; _%>
-                <option value="<%= value %>">{{'<%=enumPrefix%>.<%=value%>' | translate}}</option>
+                <option value="<%= value %>"><% if (enableTranslation) { %>{{'<%=enumPrefix%>.<%=value%>' | translate}}<% } else { %><%=value%><% } %></option>
                 <%_ } _%>
             </select>
             <%_ } else { _%>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.html
@@ -62,7 +62,7 @@ _%>
                 const values = fields[idx].fieldValues.replace(/\s/g, '').split(',');
                 for (key in values) {
                     const value = values[key]; _%>
-                <option value="<%= value %>" jhiTranslate="<%=enumPrefix%>.<%=value%>"><%= value %></option>
+                <option value="<%= value %>">{{'<%=enumPrefix%>.<%=value%>' | translate}}</option>
                 <%_ } _%>
             </select>
             <%_ } else { _%>


### PR DESCRIPTION
Internet Explorer 11 seems to have a problem with dynamically filled select boxes. The jhiTranslate directive seems to be evaluated too late in the lifecycle, so IE shows only blank options. It works with Angular's translate pipe, though.

Fixes #6147

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
