### PR TITLE
increase exec max buffer

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1913,7 +1913,7 @@ module.exports = class extends PrivateBase {
         }
         buildCmd += ` -P${profile}`;
         const child = {};
-        child.stdout = exec(buildCmd, { maxBuffer: 1024 * 500 }, cb).stdout;
+        child.stdout = exec(buildCmd, { maxBuffer: 1024 * 10000 }, cb).stdout;
         child.buildCmd = buildCmd;
 
         return child;

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -97,7 +97,7 @@ module.exports = UpgradeGenerator.extend({
                 callback();
             });
         };
-        this.gitExec(['add', '-A'], { maxBuffer: 1024 * 500 }, (code, msg, err) => {
+        this.gitExec(['add', '-A'], { maxBuffer: 1024 * 10000 }, (code, msg, err) => {
             if (code !== 0) this.error(`Unable to add resources in git:\n${err}`);
             commit();
         });


### PR DESCRIPTION
As a user's project grows, the build process can fail due to the same issue as in #6059, a specific example is @dancancro's [Great Big Example Application](https://github.com/dancancro/great-big-example-application). The only way for a developer to work around this is to modify `generator-jhipster` code.

I took the default value from `execa` which [uses 10MB](https://github.com/nodejs/node/issues/9829#issuecomment-263492464).  NodeJS was going to use 1024*1024 but the PR was closed for inactivity (https://github.com/nodejs/node/pull/11196) and this doesn't seem to be enough (see @dancancro's [comment here](https://github.com/jhipster/generator-jhipster/pull/6060#issuecomment-321712546)).

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
