### PR TITLE
Renamed mongodb port in openshift generator

### DIFF
--- a/generators/openshift/templates/db/_mongodb.yml
+++ b/generators/openshift/templates/db/_mongodb.yml
@@ -216,7 +216,7 @@ objects:
           port: 27017
           targetPort: 27017
         -
-          name: mongodb-bc
+          name: mongodb
           protocol: TCP
           port: 80
           targetPort: 27017


### PR DESCRIPTION
"mongodb-bc" port name was used twice, preventing the app to deploy in
openshift

Fix #6240

Note that I could not find tests related to the kind of file I changed

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
