### PR TITLE
fix email validation in user-management dialog for angular 4

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-dialog.component.html
@@ -79,7 +79,7 @@
         <div class="form-group">
             <label class="form-control-label" jhiTranslate="userManagement.email">Email</label>
             <input type="email" class="form-control" name="email" #emailInput="ngModel"
-                   [(ngModel)]="user.email" minlength="5" required maxlength="100">
+                   [(ngModel)]="user.email" minlength="5" required maxlength="100" email>
 
             <div *ngIf="emailInput.dirty && emailInput.invalid">
                 <small class="form-text text-danger"


### PR DESCRIPTION
Added the missing email validator for the email input.

Angular supports validating emails, but it needs to actively enabled by adding the `email` directive to an `input[type=email]`. More detail can be found [here](https://github.com/angular/angular/issues/13706).
