### PR TITLE
Improve output of jhipster upgrade

### DIFF
--- a/cli/jhipster.js
+++ b/cli/jhipster.js
@@ -17,7 +17,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-
 const semver = require('semver');
 const packageJson = require('../package.json');
 const logger = require('./utils').logger;
@@ -35,21 +34,23 @@ if (!semver.satisfies(currentNodeVersion, minimumNodeVersion)) {
     process.exit(1);
 }
 
-let preferGlobal = false;
-if (process.argv.length >= 3) {
-    if (process.argv[2] === 'upgrade') {
-        // Prefer global version for `jhipster upgrade` to get most recent code
-        preferGlobal = true;
-    }
+let preferLocal = true;
+
+// Don't use commander for parsing command line to avoid polluting it in cli.js 
+// --prefer-local: Always resolve node modules locally (useful when using linked module)
+if (process.argv.includes('upgrade') && !process.argv.includes('--prefer-local')) {
+    // Prefer global version for `jhipster upgrade` to get most recent code
+    preferLocal = false;
 }
-requireCLI(preferGlobal);
+
+requireCLI(preferLocal);
 
 /*
  * Require cli.js giving priority to local version over global one if it exists.
  */
-function requireCLI(preferGlobal) {
+function requireCLI(preferLocal) {
     /* eslint-disable global-require */
-    if (!preferGlobal) {
+    if (preferLocal) {
         try {
             const localCLI = require.resolve(path.join(process.cwd(), 'node_modules', 'generator-jhipster', 'cli', 'cli.js'));
             if (__dirname !== path.dirname(localCLI)) {

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -297,7 +297,7 @@ module.exports = class extends Generator {
     }
 
     isGitInstalled(callback) {
-        this.gitExec('--version', (code) => {
+        this.gitExec('--version', { trace: false }, (code) => {
             if (code !== 0) {
                 this.warning('git is not found on your computer.\n',
                     ` Install git: ${chalk.yellow('https://git-scm.com/')}`

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1575,12 +1575,15 @@ module.exports = class extends PrivateBase {
         }
         if (options.async === undefined) options.async = true;
         if (options.silent === undefined) options.silent = true;
+        if (options.trace === undefined) options.trace = true;
 
         if (!Array.isArray(args)) {
             args = [args];
         }
         const command = `git ${args.join(' ')}`;
-        this.info(command);
+        if (options.trace) {
+            this.info(command);
+        }
         shelljs.exec(command, options, callback);
     }
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1573,13 +1573,14 @@ module.exports = class extends PrivateBase {
         if (arguments.length < 3) {
             options = {};
         }
-        options.async = true;
-        options.silent = true;
+        if (options.async === undefined) options.async = true;
+        if (options.silent === undefined) options.silent = true;
 
         if (!Array.isArray(args)) {
             args = [args];
         }
         const command = `git ${args.join(' ')}`;
+        this.info(command);
         shelljs.exec(command, options, callback);
     }
 
@@ -1689,6 +1690,24 @@ module.exports = class extends PrivateBase {
      */
     warning(msg) {
         this.log(`${chalk.yellow.bold('WARNING!')} ${msg}`);
+    }
+
+    /**
+     * Print an info message.
+     *
+     * @param {string} value - message to print
+     */
+    info(msg) {
+        this.log.info(msg);
+    }
+
+    /**
+     * Print a success message.
+     *
+     * @param {string} value - message to print
+     */
+    success(msg) {
+        this.log.ok(msg);
     }
 
     /**


### PR DESCRIPTION
This will ease debugging `jhipster upgrade` issues.

- Use log.ok() standard method in success() logging method
- Skip install if there are conflicts in `package.json` file
- List the conflicting files  at the end if any
- Set verbose output by default
- Add a `--silent`option

Fix #6237

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
