### PR TITLE
Update _UserServiceIntTest.java

### DIFF
--- a/generators/server/templates/src/test/java/package/service/_UserServiceIntTest.java
+++ b/generators/server/templates/src/test/java/package/service/_UserServiceIntTest.java
@@ -30,7 +30,8 @@ import <%=packageName%>.service.util.RandomUtil;<% } %>
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;<% if (databaseType === 'sql') { %>
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;<% if (databaseType === 'sql') { %>
 import org.springframework.transaction.annotation.Transactional;<% } %>
 import org.springframework.test.context.junit4.SpringRunner;
 <% if (databaseType === 'sql' || databaseType === 'mongodb') { %>
@@ -53,6 +54,7 @@ import static org.assertj.core.api.Assertions.*;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)<% if (databaseType === 'sql') { %>
 @Transactional<% } %>
+@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_CLASS)
 public class UserServiceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{<% if ((databaseType === 'sql' || databaseType === 'mongodb') && authenticationType === 'session') { %>
 
     @Autowired


### PR DESCRIPTION
Vanilla jHipster installation is failing integration test when you run whole integration tests package. 
The reason is that another test class (AccountResourceIntTest) is running before and deleting the data that this test relies on.
Proposed solution - load whole new context for this test.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
