### PR TITLE
Added explicit name for heroku db creation to prevent duplicates

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -257,7 +257,7 @@ module.exports = HerokuGenerator.extend({
             }
 
             this.log(chalk.bold('\nProvisioning addons'));
-            exec(`heroku addons:create ${dbAddOn} --app ${this.herokuAppName}`, {}, (err, stdout, stderr) => {
+            exec(`heroku addons:create ${dbAddOn} --as DATABASE --app ${this.herokuAppName}`, {}, (err, stdout, stderr) => {
                 if (err) {
                     const verifyAccountUrl = 'https://heroku.com/verify';
                     if (_.includes(err, verifyAccountUrl)) {


### PR DESCRIPTION
This change prevents a duplicate DB addon from being created if a user has manually added an addon of another type. For example, if a user has manually added a ClearDB addon, this will not add a JawsDB addon. Fixes #6284