### PR TITLE
Fixed Guava version for reflections dependency

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -375,6 +375,7 @@ dependencies {
     <%_ } _%>
     <%_ if (databaseType === 'mongodb') { _%>
     compile "com.github.mongobee:mongobee:${mongobee_version}"
+    compile "com.google.guava:guava:${guava_version}"
     <%_ } _%>
     compile ("io.springfox:springfox-swagger2:${springfox_version}") {
         exclude module: 'mapstruct'

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -61,6 +61,7 @@ liquibase_slf4j_version=2.0.0
 liquibase_hibernate5_version=3.6
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
+guava_version=23.0
 mongobee_version=0.12
 <%_ } _%>
 <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -127,6 +127,7 @@
         <%_ } _%>
         <%_ if (databaseType === 'mongodb') { _%>
         <mongobee.version>0.12</mongobee.version>
+        <guava.version>23.0</guava.version>
         <%_ } _%>
         <node.version>v<%= NODE_VERSION %></node.version>
         <%_ if (clientPackageManager === 'npm') { _%>
@@ -542,6 +543,11 @@
         </dependency>
         <%_ } _%>
         <%_ if (databaseType === 'mongodb') { _%>
+        <dependency>
+            <groupId>com.google.guava</groupId>
+            <artifactId>guava</artifactId>
+            <version>${guava.version}</version>
+        </dependency>
         <dependency>
             <groupId>com.github.mongobee</groupId>
             <artifactId>mongobee</artifactId>
@@ -1136,9 +1142,9 @@
             </plugin>
             <%_ if (enableSwaggerCodegen) { _%>
             <plugin>
-                <!-- 
-                    Plugin that provides API-first development using swagger-codegen to 
-                    generate Spring-MVC endpoint stubs at compile time from a swagger definition file 
+                <!--
+                    Plugin that provides API-first development using swagger-codegen to
+                    generate Spring-MVC endpoint stubs at compile time from a swagger definition file
                 -->
                 <groupId>io.swagger</groupId>
                 <artifactId>swagger-codegen-maven-plugin</artifactId>


### PR DESCRIPTION
Fixed #6150 

The `org.reflections.reflections` dependency of `com.github.mongobee.mongobee` needs `com.google.guava:guava version` >= 20. Currently version 18 is imported automatically.

Without this fix the following error occurs:
`org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'mongobee' defined in class path resource [com/company/example/config/DatabaseConfiguration.class]: Invocation of init method failed; nested exception is java.lang.NoSuchMethodError: com.google.common.collect.Sets$SetView.iterator()Lcom/google/common/collect/UnmodifiableIterator;`


Link to the POM of the `org.reflections.reflections` dependency:
https://github.com/ronmamo/reflections/blob/0.9.11/pom.xml
