### PR TITLE
Show error message when pom.xml parsing failed

### DIFF
--- a/generators/client/templates/angular/webpack/_utils.js
+++ b/generators/client/templates/angular/webpack/_utils.js
@@ -32,6 +32,9 @@ function parseVersion() {
     let version = null;
     const pomXml = fs.readFileSync('pom.xml', 'utf8');
     parseString(pomXml, (err, result) => {
+        if (err) {
+            throw new Error('Failed to parse pom.xml: ' + err);
+        }
         if (result.project.version && result.project.version[0]) {
             version = result.project.version[0];
         } else if (result.project.parent && result.project.parent[0] && result.project.parent[0].version && result.project.parent[0].version[0]) {

--- a/generators/client/templates/angularjs/gulp/_utils.js
+++ b/generators/client/templates/angularjs/gulp/_utils.js
@@ -36,6 +36,9 @@ function parseVersion() {
     var version = null;
     var pomXml = fs.readFileSync('pom.xml', 'utf8');
     parseString(pomXml, function (err, result) {
+        if (err) {
+            throw new Error('Failed to parse pom.xml: ' + err);
+        }
         if (result.project.version && result.project.version[0]) {
             version = result.project.version[0];
         } else if (result.project.parent && result.project.parent[0] && result.project.parent[0].version && result.project.parent[0].version[0]) {


### PR DESCRIPTION
After `jhipster upgrade`, pom.xml was not fully merged and so contained `>>>`markers and frontend build failed without any helpful message.

Now it fails with a message indicating the line number of the problem.

I made the change for angularjs and angular.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
