### PR TITLE
fix test comment generator _EntityResourceIntTest.java

### DIFF
--- a/generators/entity/templates/server/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/server/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -397,7 +397,7 @@ _%>
             .content(TestUtil.convertObjectToJsonBytes(<%= entityInstance %><% if (dto === 'mapstruct') { %>DTO<% } %>)))
             .andExpect(status().isBadRequest());
 
-        // Validate the Alice in the database
+        // Validate the <%= entityClass %> in the database
         List<<%= entityClass %>> <%= entityInstance %>List = <%= entityInstance %>Repository.findAll();
         assertThat(<%= entityInstance %>List).hasSize(databaseSizeBeforeCreate);
     }


### PR DESCRIPTION
change 'Alice' to entityClass using EJS synthax.

the integration test generator was hardcoded to produce the following comment: 'Validate the Alice in the database'