### PR TITLE
improve navbar migration from bootstrap 4 alpha to beta

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.html
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<nav class="navbar navbar-inverse navbar-expand-md jh-navbar">
+<nav class="navbar navbar-dark navbar-expand-md jh-navbar">
     <div class="jh-logo-container float-left">
         <a class="jh-navbar-toggler hidden-lg-up float-right" href="javascript:void(0);" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation" (click)="toggleNavbar()">
             <i class="fa fa-bars"></i>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.css
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.css
@@ -66,7 +66,7 @@ Navbar
     color: #fff;
 }
 
-@media screen and (min-width: 768px) { 
+@media screen and (min-width: 768px) {
     .jh-navbar-toggler {
         display: none;
     }
@@ -81,11 +81,6 @@ Navbar
 .navbar-title {
     display: inline-block;
     vertical-align: middle;
-    color: #fff;
-}
-
-.nav-link {
-    color: #fff;
 }
 
 /* ==========================================================================

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.scss
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.scss
@@ -59,7 +59,7 @@ Navbar
     }
 }
 
-@media screen and (min-width: 768px) { 
+@media screen and (min-width: 768px) {
     .jh-navbar-toggler {
         display: none;
     }
@@ -74,11 +74,6 @@ Navbar
 .navbar-title {
     display: inline-block;
     vertical-align: middle;
-    color: #fff;
-}
-
-.nav-link {
-    color: #fff;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Initial migration: https://github.com/jhipster/generator-jhipster/commit/4627a9bf0d1f6932b6a18eac2271fafb76631f65
Initial migration appplied constant link colors.
Better migration is to replace old css class `navbar-inverse` with new `navbar-dark` as this changed in Bootstrap 4 beta: https://github.com/twbs/bootstrap/commit/36e482ed2728eec37188b5ec486283334bb3034f
Among other things this change makes active menu highlighted again.