### PR TITLE
Fixed reload on i18n file changes

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -90,7 +90,7 @@
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.4",
     <%_ if (enableTranslation) { _%>
-    "merge-jsons-webpack-plugin": "1.0.8",
+    "merge-jsons-webpack-plugin": "1.0.11",
     <%_ } _%>
     "ngc-webpack": "3.1.1",
     "phantomjs-prebuilt": "2.1.14",
@@ -144,7 +144,7 @@
     "build": "<%= clientPackageManager %> run webpack:prod",
     "test": "karma start src/test/javascript/karma.conf.js",
     "test:watch": "<%= clientPackageManager %> test -- --watch",
-    "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress --inline --hot --profile --port=9060",
+    "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress --inline --hot --profile --port=9060 --watch-content-base",
     "webpack:build:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --progress --profile",
     "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:main",
     "webpack:prod:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --progress --profile",


### PR DESCRIPTION
Update the merge-jsons-webpack-plugin to 1.0.11 where the .json file change detection is fixed,
see: https://github.com/tettusud/merge-jsons-webpack-plugin/issues/21
Add --watch-content-base to the start script of the webpack-dev-server.

Fix #6308

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
