### PR TITLE
Fix Travis protractor builds by fixing yarn version to pre 1.X

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -64,7 +64,7 @@ before_install:
   - export DISPLAY=:99.0
   - sh -e /etc/init.d/xvfb start
   # Repo for Yarn
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
   - export PATH=$HOME/.yarn/bin:$PATH
   - yarn global add yo bower gulp-cli
 install:


### PR DESCRIPTION
Yarn 1.X introduces breaking changes: https://github.com/yarnpkg/yarn/releases/tag/v1.0.0

I have some ideas in how to fix those problems and upgrade to yarn 1.X but it can be done later as it's not straightforward.