### PR TITLE
Fix favicon link in the email template

### DIFF
--- a/generators/server/templates/src/main/resources/mails/activationEmail.html
+++ b/generators/server/templates/src/main/resources/mails/activationEmail.html
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.activation.title}">JHipster activation</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" href="${baseUrl}/favicon.ico" />
+        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.activation.greeting(${user.login})}">

--- a/generators/server/templates/src/main/resources/mails/creationEmail.html
+++ b/generators/server/templates/src/main/resources/mails/creationEmail.html
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.activation.title}">JHipster creation</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" href="${baseUrl}/favicon.ico" />
+        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.activation.greeting(${user.login})}">

--- a/generators/server/templates/src/main/resources/mails/passwordResetEmail.html
+++ b/generators/server/templates/src/main/resources/mails/passwordResetEmail.html
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.reset.title}">JHipster password reset</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" href="${baseUrl}/favicon.ico" />
+        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.reset.greeting(${user.login})}">

--- a/generators/server/templates/src/main/resources/mails/socialRegistrationValidationEmail.html
+++ b/generators/server/templates/src/main/resources/mails/socialRegistrationValidationEmail.html
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.social.registration.title}">JHipster activation</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" href="${baseUrl}/favicon.ico" />
+        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.social.registration.greeting(${user.firstName})}">


### PR DESCRIPTION
The baseUrl is not correctly used in thymeleaf template, so the favicon url is not resolved. Not sure which email client use this, but it seemed wrong.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

