### PR TITLE
Truncate AuditEvent data when length exceeds 255

### DIFF
--- a/generators/server/templates/src/main/java/package/repository/_CustomAuditEventRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_CustomAuditEventRepository.java
@@ -114,11 +114,13 @@ public class CustomAuditEventRepository implements AuditEventRepository {
         if (data != null) {
             for (Map.Entry<String, String> entry : data.entrySet()) {
                 String value = entry.getValue();
-                int length = value.length();
-                if (length > EVENT_DATA_COLUMN_MAX_LENGTH) {
-                    value = value.substring(0, EVENT_DATA_COLUMN_MAX_LENGTH);
-                    log.warn("Event data for {} too long ({}) has been truncated to {}. Consider increasing column width.",
-                        entry.getKey(), length, EVENT_DATA_COLUMN_MAX_LENGTH);
+                if (value != null) {
+                    int length = value.length();
+                    if (length > EVENT_DATA_COLUMN_MAX_LENGTH) {
+                        value = value.substring(0, EVENT_DATA_COLUMN_MAX_LENGTH);
+                        log.warn("Event data for {} too long ({}) has been truncated to {}. Consider increasing column width.",
+                                 entry.getKey(), length, EVENT_DATA_COLUMN_MAX_LENGTH);
+                    }
                 }
                 results.put(entry.getKey(), value);
             }

--- a/generators/server/templates/src/main/java/package/repository/_CustomAuditEventRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_CustomAuditEventRepository.java
@@ -22,6 +22,8 @@ import <%=packageName%>.config.Constants;
 import <%=packageName%>.config.audit.AuditEventConverter;
 import <%=packageName%>.domain.PersistentAuditEvent;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.boot.actuate.audit.AuditEventRepository;
 import org.springframework.stereotype.Repository;
@@ -29,7 +31,9 @@ import org.springframework.transaction.annotation.Propagation;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Date;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * An implementation of Spring Boot's AuditEventRepository.
@@ -39,9 +43,16 @@ public class CustomAuditEventRepository implements AuditEventRepository {
 
     private static final String AUTHORIZATION_FAILURE = "AUTHORIZATION_FAILURE";
 
+    /**
+     * Should be the same as in Liquibase migration.
+     */
+    protected static final int EVENT_DATA_COLUMN_MAX_LENGTH = 255;
+
     private final PersistenceAuditEventRepository persistenceAuditEventRepository;
 
     private final AuditEventConverter auditEventConverter;
+
+    private final Logger log = LoggerFactory.getLogger(getClass());
 
     public CustomAuditEventRepository(PersistenceAuditEventRepository persistenceAuditEventRepository,
             AuditEventConverter auditEventConverter) {
@@ -88,8 +99,30 @@ public class CustomAuditEventRepository implements AuditEventRepository {
             persistentAuditEvent.setPrincipal(event.getPrincipal());
             persistentAuditEvent.setAuditEventType(event.getType());
             persistentAuditEvent.setAuditEventDate(event.getTimestamp().toInstant());
-            persistentAuditEvent.setData(auditEventConverter.convertDataToStrings(event.getData()));
+            Map<String, String> eventData = auditEventConverter.convertDataToStrings(event.getData());
+            persistentAuditEvent.setData(truncate(eventData));
             persistenceAuditEventRepository.save(persistentAuditEvent);
         }
+    }
+
+    /**
+     * Truncate event data that might exceed column length.
+     */
+    private Map<String, String> truncate(Map<String, String> data) {
+        Map<String, String> results = new HashMap<>();
+
+        if (data != null) {
+            for (Map.Entry<String, String> entry : data.entrySet()) {
+                String value = entry.getValue();
+                int length = value.length();
+                if (length > EVENT_DATA_COLUMN_MAX_LENGTH) {
+                    value = value.substring(0, EVENT_DATA_COLUMN_MAX_LENGTH);
+                    log.warn("Event data for {} too long ({}) has been truncated to {}. Consider increasing column width.",
+                        entry.getKey(), length, EVENT_DATA_COLUMN_MAX_LENGTH);
+                }
+                results.put(entry.getKey(), value);
+            }
+        }
+        return results;
     }
 }

--- a/generators/server/templates/src/test/java/package/repository/_CustomAuditEventRepositoryIntTest.java
+++ b/generators/server/templates/src/test/java/package/repository/_CustomAuditEventRepositoryIntTest.java
@@ -42,9 +42,10 @@ import java.util.List;
 import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static <%=packageName%>.repository.CustomAuditEventRepository.EVENT_DATA_COLUMN_MAX_LENGTH;
 
 /**
- * Test class for the CustomAuditEventRepository customAuditEventRepository class.
+ * Test class for the CustomAuditEventRepository class.
  *
  * @see CustomAuditEventRepository
  */
@@ -187,7 +188,30 @@ public class CustomAuditEventRepositoryIntTest {
         assertThat(persistentAuditEvent.getAuditEventDate()).isEqualTo(event.getTimestamp().toInstant());
     }
 
+ 
     @Test
+    public void addAuditEventTruncateLargeData() {
+        Map<String, Object> data = new HashMap<>();
+        StringBuilder largeData = new StringBuilder();
+        for (int i = 0; i < EVENT_DATA_COLUMN_MAX_LENGTH + 10; i++) {
+            largeData.append("a");
+        }
+        data.put("test-key", largeData);
+        AuditEvent event = new AuditEvent("test-user", "test-type", data);
+        customAuditEventRepository.add(event);
+        List<PersistentAuditEvent> persistentAuditEvents = persistenceAuditEventRepository.findAll();
+        assertThat(persistentAuditEvents).hasSize(1);
+        PersistentAuditEvent persistentAuditEvent = persistentAuditEvents.get(0);
+        assertThat(persistentAuditEvent.getPrincipal()).isEqualTo(event.getPrincipal());
+        assertThat(persistentAuditEvent.getAuditEventType()).isEqualTo(event.getType());
+        assertThat(persistentAuditEvent.getData()).containsKey("test-key");
+        String actualData = persistentAuditEvent.getData().get("test-key");
+        assertThat(actualData.length()).isEqualTo(EVENT_DATA_COLUMN_MAX_LENGTH);
+        assertThat(actualData).isSubstringOf(largeData);
+        assertThat(persistentAuditEvent.getAuditEventDate()).isEqualTo(event.getTimestamp().toInstant());
+    }
+
+   @Test
     public void testAddEventWithWebAuthenticationDetails() {
         HttpSession session = new MockHttpSession(null, "test-session-id");
         MockHttpServletRequest request = new MockHttpServletRequest();


### PR DESCRIPTION
I got the case while working on a PR for using logstash to report audit events for microservices.
It was causing an exception because the column data is a varchar(255): "JdbcSQLException: Value too long for column".

Now, data is truncated and a warning is logged:

> Event data for test-key too long (265) has been truncated to 255. Consider increasing column width.

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
