### PR TITLE
Email address check should be case insensitive - fixed only for SQL apps

### DIFF
--- a/generators/server/templates/src/main/java/package/repository/_UserRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_UserRepository.java
@@ -80,7 +80,7 @@ public interface UserRepository extends <% if (databaseType === 'sql') { %>JpaRe
 
     Optional<User> findOneByResetKey(String resetKey);
 
-    Optional<User> findOneByEmail(String email);
+    Optional<User> findOneByEmailIgnoreCase(String email);
 
     Optional<User> findOneByLogin(String login);
     <%_ if (databaseType === 'sql') { _%>
@@ -225,9 +225,9 @@ public class UserRepository {
         return findOneFromIndex(stmt);
     }
 
-    public Optional<User> findOneByEmail(String email) {
+    public Optional<User> findOneByEmailIgnoreCase(String email) {
         BoundStatement stmt = findOneByEmailStmt.bind();
-        stmt.setString("email", email);
+        stmt.setString("email", email.toLowerCase());
         return findOneFromIndex(stmt);
     }
 
@@ -257,8 +257,8 @@ public class UserRepository {
             if (!StringUtils.isEmpty(oldUser.getLogin()) && !oldUser.getLogin().equals(user.getLogin())) {
                 session.execute(deleteByLoginStmt.bind().setString("login", oldUser.getLogin()));
             }
-            if (!StringUtils.isEmpty(oldUser.getEmail()) && !oldUser.getEmail().equals(user.getEmail())) {
-                session.execute(deleteByEmailStmt.bind().setString("email", oldUser.getEmail()));
+            if (!StringUtils.isEmpty(oldUser.getEmail()) && !oldUser.getEmail().equalsIgnoreCase(user.getEmail())) {
+                session.execute(deleteByEmailStmt.bind().setString("email", oldUser.getEmail().toLowerCase()));
             }
         }
         BatchStatement batch = new BatchStatement();
@@ -277,7 +277,7 @@ public class UserRepository {
             .setString("login", user.getLogin())
             .setString("id", user.getId()));
         batch.add(insertByEmailStmt.bind()
-            .setString("email", user.getEmail())
+            .setString("email", user.getEmail().toLowerCase())
             .setString("id", user.getId()));
         session.execute(batch);
         return user;
@@ -293,7 +293,7 @@ public class UserRepository {
             batch.add(deleteByResetKeyStmt.bind().setString("reset_key", user.getResetKey()));
         }
         batch.add(deleteByLoginStmt.bind().setString("login", user.getLogin()));
-        batch.add(deleteByEmailStmt.bind().setString("email", user.getEmail()));
+        batch.add(deleteByEmailStmt.bind().setString("email", user.getEmail().toLowerCase()));
         session.execute(batch);
     }
 

--- a/generators/server/templates/src/main/java/package/service/_SocialService.java
+++ b/generators/server/templates/src/main/java/package/service/_SocialService.java
@@ -112,7 +112,7 @@ public class SocialService {
             throw new IllegalArgumentException("Email cannot be null with an existing login");
         }
         if (!StringUtils.isBlank(email)) {
-            Optional<User> user = userRepository.findOneByEmail(email);
+            Optional<User> user = userRepository.findOneByEmailIgnoreCase(email);
             if (user.isPresent()) {
                 log.info("User already exist associate the connection to this account");
                 return user.get();

--- a/generators/server/templates/src/main/java/package/service/_UserService.java
+++ b/generators/server/templates/src/main/java/package/service/_UserService.java
@@ -164,7 +164,7 @@ public class UserService {
     }
 
     public Optional<User> requestPasswordReset(String mail) {
-        return userRepository.findOneByEmail(mail)
+        return userRepository.findOneByEmailIgnoreCase(mail)
             .filter(User::getActivated)
             .map(user -> {
                 user.setResetKey(RandomUtil.generateResetKey());

--- a/generators/server/templates/src/main/java/package/web/rest/_AccountResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_AccountResource.java
@@ -103,7 +103,7 @@ public class AccountResource {
         }
         return userRepository.findOneByLogin(managedUserVM.getLogin().toLowerCase())
             .map(user -> new ResponseEntity<>("login already in use", textPlainHeaders, HttpStatus.BAD_REQUEST))
-            .orElseGet(() -> userRepository.findOneByEmail(managedUserVM.getEmail())
+            .orElseGet(() -> userRepository.findOneByEmailIgnoreCase(managedUserVM.getEmail())
                 .map(user -> new ResponseEntity<>("email address already in use", textPlainHeaders, HttpStatus.BAD_REQUEST))
                 .orElseGet(() -> {
                     User user = userService
@@ -168,7 +168,7 @@ public class AccountResource {
     @Timed
     public ResponseEntity saveAccount(@Valid @RequestBody UserDTO userDTO) {
         final String userLogin = SecurityUtils.getCurrentUserLogin();
-        Optional<User> existingUser = userRepository.findOneByEmail(userDTO.getEmail());
+        Optional<User> existingUser = userRepository.findOneByEmailIgnoreCase(userDTO.getEmail());
         if (existingUser.isPresent() && (!existingUser.get().getLogin().equalsIgnoreCase(userLogin))) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert("user-management", "emailexists", "Email already in use")).body(null);
         }

--- a/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_UserResource.java
@@ -129,7 +129,7 @@ public class UserResource {
             return ResponseEntity.badRequest()
                 .headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "userexists", "Login already in use"))
                 .body(null);
-        } else if (userRepository.findOneByEmail(managedUserVM.getEmail()).isPresent()) {
+        } else if (userRepository.findOneByEmailIgnoreCase(managedUserVM.getEmail()).isPresent()) {
             return ResponseEntity.badRequest()
                 .headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "emailexists", "Email already in use"))
                 .body(null);
@@ -155,7 +155,7 @@ public class UserResource {
     @Secured(AuthoritiesConstants.ADMIN)
     public ResponseEntity<UserDTO> updateUser(@Valid @RequestBody ManagedUserVM managedUserVM) {
         log.debug("REST request to update User : {}", managedUserVM);
-        Optional<User> existingUser = userRepository.findOneByEmail(managedUserVM.getEmail());
+        Optional<User> existingUser = userRepository.findOneByEmailIgnoreCase(managedUserVM.getEmail());
         if (existingUser.isPresent() && (!existingUser.get().getId().equals(managedUserVM.getId()))) {
             return ResponseEntity.badRequest().headers(HeaderUtil.createFailureAlert(ENTITY_NAME, "emailexists", "Email already in use")).body(null);
         }

--- a/generators/server/templates/src/test/java/package/service/_SocialServiceIntTest.java
+++ b/generators/server/templates/src/test/java/package/service/_SocialServiceIntTest.java
@@ -168,7 +168,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         // Verify
-        final Optional<User> user = userRepository.findOneByEmail("mail@mail.com");
+        final Optional<User> user = userRepository.findOneByEmailIgnoreCase("mail@mail.com");
         assertThat(user).isPresent();
 
         // Teardown
@@ -189,7 +189,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         //Verify
-        User user = userRepository.findOneByEmail("mail@mail.com").get();
+        User user = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         assertThat(user.getFirstName()).isEqualTo("FIRST_NAME");
         assertThat(user.getLastName()).isEqualTo("LAST_NAME");
         assertThat(user.getImageUrl()).isEqualTo("IMAGE_URL");
@@ -212,7 +212,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         //Verify
-        User user = userRepository.findOneByEmail("mail@mail.com").get();
+        User user = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         assertThat(user.getActivated()).isEqualTo(true);
         assertThat(user.getPassword()).isNotEmpty();
         Authority userAuthority = authorityRepository.findOne("ROLE_USER");
@@ -236,7 +236,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         //Verify
-        final User user = userRepository.findOneByEmail("mail@mail.com").get();
+        final User user = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         assertThat(user.getLangKey()).isEqualTo("fr");
 
         // Teardown
@@ -257,7 +257,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         //Verify
-        User user = userRepository.findOneByEmail("mail@mail.com").get();
+        User user = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         assertThat(user.getLogin()).isEqualTo("mail@mail.com");
 
         // Teardown
@@ -278,7 +278,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         //Verify
-        User user = userRepository.findOneByEmail("mail@mail.com").get();
+        User user = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         assertThat(user.getLogin()).isEqualToIgnoringCase("@LOGIN");
 
         // Teardown
@@ -302,7 +302,7 @@ public class SocialServiceIntTest {
         verify(mockConnectionRepository, times(1)).addConnection(connection);
 
         // Teardown
-        User userToDelete = userRepository.findOneByEmail("mail@mail.com").get();
+        User userToDelete = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         userRepository.delete(userToDelete);
     }
 
@@ -329,7 +329,7 @@ public class SocialServiceIntTest {
         assertThat(userRepository.count()).isEqualTo(initialUserCount);
 
         // Teardown
-        User userToDelete = userRepository.findOneByEmail("mail@mail.com").get();
+        User userToDelete = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         userRepository.delete(userToDelete);
     }
 
@@ -352,7 +352,7 @@ public class SocialServiceIntTest {
         socialService.createSocialUser(connection, "fr");
 
         //Verify
-        User userToVerify = userRepository.findOneByEmail("mail@mail.com").get();
+        User userToVerify = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         assertThat(userToVerify.getLogin()).isEqualTo("@other_login");
         assertThat(userToVerify.getFirstName()).isEqualTo("OTHER_FIRST_NAME");
         assertThat(userToVerify.getLastName()).isEqualTo("OTHER_LAST_NAME");
@@ -378,7 +378,7 @@ public class SocialServiceIntTest {
         verify(mockMailService, times(1)).sendSocialRegistrationValidationEmail(anyObject(), anyString());
 
         // Teardown
-        User userToDelete = userRepository.findOneByEmail("mail@mail.com").get();
+        User userToDelete = userRepository.findOneByEmailIgnoreCase("mail@mail.com").get();
         userRepository.delete(userToDelete);
     }
 


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Currently it is possible to register twice with the same email address, but different case - example@Example.com and example@example.com - which is confusing. And when you ask for a password remainder, currently the user needs to enter with the same case. AFAIK the host names are case-insensitives by some RFC, and the user names by conventions (I haven't seen an email provider, which allowed to register duplicate accounts with different cases.

 This patch fixes the problem only for relational dbs, where it can be fixed easily by query. 

