### PR TITLE
fix csrf + cors filter chain order

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_MicroserviceSecurityConfiguration.java
@@ -99,9 +99,6 @@ import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.cloud.client.loadbalancer.RestTemplateCustomizer;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.http.HttpEntity;
-import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpMethod;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
@@ -111,6 +108,10 @@ import org.springframework.security.oauth2.provider.token.TokenStore;
 import org.springframework.security.oauth2.provider.token.store.JwtAccessTokenConverter;
 import org.springframework.security.oauth2.provider.token.store.JwtTokenStore;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+<%_ if (applicationType === 'gateway') { _%>
+import org.springframework.security.web.csrf.CsrfFilter;
+import org.springframework.web.filter.CorsFilter;
+<%_ } _%>
 import org.springframework.web.client.RestTemplate;
 
 @Configuration
@@ -119,8 +120,15 @@ import org.springframework.web.client.RestTemplate;
 public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerAdapter {
     private final OAuth2Properties oAuth2Properties;
 
-    public MicroserviceSecurityConfiguration(OAuth2Properties oAuth2Properties) {
+    <%_ if (applicationType === 'gateway') { _%>
+    private final CorsFilter corsFilter;
+
+    <%_ } _%>
+    public MicroserviceSecurityConfiguration(OAuth2Properties oAuth2Properties<%_ if (applicationType === 'gateway') { _%>, CorsFilter corsFilter<%_ } _%>) {
         this.oAuth2Properties = oAuth2Properties;
+        <%_ if (applicationType === 'gateway') { _%>
+        this.corsFilter = corsFilter;
+        <%_ } _%>
     }
 
     @Override
@@ -131,6 +139,7 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
             .ignoringAntMatchers("/h2-console/**")
             .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
         .and()
+            .addFilterBefore(corsFilter, CsrfFilter.class)
 		<%_ } else { _%>
             .disable()
 		<%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java
@@ -50,10 +50,13 @@ import org.springframework.security.data.repository.query.SecurityEvaluationCont
 <%_ if (authenticationType === 'session') { _%>
 import org.springframework.security.web.authentication.RememberMeServices;
 import org.springframework.security.web.csrf.CookieCsrfTokenRepository;
+import org.springframework.security.web.csrf.CsrfFilter;
 <%_ } _%>
 <%_ if (authenticationType !== 'oauth2') { _%>
-import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import org.springframework.web.filter.CorsFilter;
+<%_ } _%>
+<%_ if (authenticationType === 'jwt') { _%>
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 <%_ } _%>
 
 import javax.annotation.PostConstruct;
@@ -178,8 +181,10 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .csrfTokenRepository(CookieCsrfTokenRepository.withHttpOnlyFalse())
         .and()
             <%_ } _%>
-            <%_ if (authenticationType !== 'oauth2') { _%>
+            <%_ if (authenticationType === 'jwt') { _%>
             .addFilterBefore(corsFilter, UsernamePasswordAuthenticationFilter.class)
+            <% } else if (authenticationType === 'session') { %>
+            .addFilterBefore(corsFilter, CsrfFilter.class)
             <%_ } _%>
             .exceptionHandling()
             .authenticationEntryPoint(http401UnauthorizedEntryPoint())<% if (authenticationType === 'session') { %>


### PR DESCRIPTION
CorsFilter needs to be before CsrfFilter or else a CSRF issue blocks the CORS headers from being applied.  Very similar to https://github.com/jhipster/generator-jhipster/issues/4704, related [StackOverflow answer](https://stackoverflow.com/a/46269353/3737815) with more explanation.

This affects Session apps and UAA gateways (now using CSRF) receiving requests from a client that requires CORS headers.

Instructions to reproduce:
 - Generate an app with session auth
 - Start it in `dev` at localhost:8080, `dev` has CORS on by default
 - Go to http://jruddell.com/examples/test.html and open the console.  It's the example from the StackOverflow linked above, hosted so that it requires CORS headers.   It makes a POST request to localhost:8080/api/authenticate to login as user (you can view the source). 
 - The request fails from CSRF, but the console complains `No 'Access-Control-Allow-Origin' header is present`.  If you try to view the response to the request in the network tab, it is blank.

Solution:
 - Add the CorsFilter before the CsrfFilter like in this PR and restart the app
 - You can now view the response in the network tab and see the real error message which is CSRF related.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
