### PR TITLE
Replace PhantomJS by chromiumHeadless and puppeteer

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -78,14 +78,13 @@
     <%_ if (protractorTests) { _%>
     "jasmine-reporters": "2.2.1",
     <%_ } _%>
-    "karma": "1.7.0",
+    "karma": "1.7.1",
     "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "1.1.1",
     "karma-intl-shim": "1.0.3",
     "karma-jasmine": "1.1.0",
     "karma-junit-reporter": "1.2.0",
     "karma-notify-reporter": "1.0.1",
-    "karma-phantomjs-launcher": "1.0.4",
     "karma-remap-istanbul": "0.6.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.4",
@@ -93,12 +92,12 @@
     "merge-jsons-webpack-plugin": "1.0.11",
     <%_ } _%>
     "ngc-webpack": "3.2.2",
-    "phantomjs-prebuilt": "2.1.14",
     <%_ if (protractorTests) { _%>
     "protractor": "5.1.2",
     "protractor-jasmine2-screenshot-reporter": "0.4.0",
     <%_ } _%>
     "proxy-middleware": "0.15.0",
+    "puppeteer": "0.10.2",
     "rimraf": "2.6.1",
     "sourcemap-istanbul-instrumenter-loader": "0.2.0",
     "string-replace-webpack-plugin": "0.1.3",
@@ -151,12 +150,8 @@
     "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:prod:main && <%= clientPackageManager %> run clean-www",
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
-    "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js",
-    <%_ if (protractorTests) { _%>
+    "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"<% if (protractorTests) { %>,
     "e2e": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
-    "postinstall": "webdriver-manager update && node node_modules/phantomjs-prebuilt/install.js"
-    <%_ } else { _%>
-    "postinstall": "node node_modules/phantomjs-prebuilt/install.js"
-    <%_ } _%>
+    "postinstall": "webdriver-manager update"<% } %>
   }
 }

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -150,8 +150,10 @@
     "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:prod:main && <%= clientPackageManager %> run clean-www",
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
-    "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"<% if (protractorTests) { %>,
+    "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"
+    <%_ if (protractorTests) { _%>,
     "e2e": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
-    "postinstall": "webdriver-manager update"<% } %>
+    "postinstall": "webdriver-manager update"
+    <%_ } _%>
   }
 }

--- a/generators/client/templates/angular/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/angular/src/test/javascript/_karma.conf.js
@@ -18,9 +18,9 @@
 -%>
 const webpackConfig = require('../../../webpack/webpack.test.js');
 
-var ChromiumRevision = require('puppeteer/package.json').puppeteer.chromium_revision;
-var Downloader = require('puppeteer/utils/ChromiumDownloader');
-var revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
+const ChromiumRevision = require('puppeteer/package.json').puppeteer.chromium_revision;
+const Downloader = require('puppeteer/utils/ChromiumDownloader');
+const revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
 process.env.CHROMIUM_BIN = revisionInfo.executablePath;
 
 const WATCH = process.argv.indexOf('--watch') > -1;

--- a/generators/client/templates/angular/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/angular/src/test/javascript/_karma.conf.js
@@ -18,6 +18,11 @@
 -%>
 const webpackConfig = require('../../../webpack/webpack.test.js');
 
+var ChromiumRevision = require('puppeteer/package.json').puppeteer.chromium_revision;
+var Downloader = require('puppeteer/utils/ChromiumDownloader');
+var revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
+process.env.CHROMIUM_BIN = revisionInfo.executablePath;
+
 const WATCH = process.argv.indexOf('--watch') > -1;
 
 module.exports = (config) => {
@@ -85,7 +90,7 @@ module.exports = (config) => {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['PhantomJS'],
+        browsers: ['ChromiumHeadless'],
 
         // Ensure all browsers can run tests written in .ts files
         mime: {

--- a/generators/client/templates/angular/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angular/src/test/javascript/_protractor.conf.js
@@ -31,8 +31,10 @@ exports.config = {
 
     capabilities: {
         'browserName': 'chrome',
-        'phantomjs.binary.path': require('phantomjs-prebuilt').path,
-        'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG']
+
+        chromeOptions: {
+            args: [ "--headless", "--disable-gpu", "--window-size=800,600" ]
+          }
     },
 
     directConnect: true,

--- a/generators/client/templates/angular/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angular/src/test/javascript/_protractor.conf.js
@@ -31,10 +31,9 @@ exports.config = {
 
     capabilities: {
         'browserName': 'chrome',
-
         chromeOptions: {
             args: [ "--headless", "--disable-gpu", "--window-size=800,600" ]
-          }
+        }
     },
 
     directConnect: true,

--- a/generators/client/templates/angularjs/_package.json
+++ b/generators/client/templates/angularjs/_package.json
@@ -58,7 +58,7 @@
     "gulp-rename": "1.2.2",
     "gulp-replace": "0.5.4",
     <%_ if (protractorTests) { _%>
-    "gulp-protractor": "3.0.0",
+    "gulp-protractor": "4.1.0",
     "gulp-util": "3.0.7",
     <%_ } _%>
     "gulp-rev": "7.1.2",
@@ -73,23 +73,22 @@
     <%_ if (protractorTests) { _%>
     "jasmine-reporters": "2.2.0",
     <%_ } _%>
-    "karma": "1.2.0",
-    "karma-chrome-launcher": "2.0.0",
+    "karma": "1.7.1",
+    "karma-chrome-launcher": "2.2.0",
     "karma-coverage": "1.1.1",
-    "karma-jasmine": "1.0.2",
-    "karma-junit-reporter": "1.1.0",
-    "karma-phantomjs-launcher": "1.0.2",
+    "karma-jasmine": "1.1.0",
+    "karma-junit-reporter": "1.2.0",
     "karma-script-launcher": "1.0.0",
     "lazypipe": "1.0.1",
     "lodash": "4.15.0",
     "main-bower-files": "2.13.1",
     "map-stream": "0.0.6",
-    "phantomjs-prebuilt": "2.1.12",
     <%_ if (protractorTests) { _%>
-    "protractor": "4.0.4",
-    "protractor-jasmine2-screenshot-reporter": "0.3.2",
+    "protractor": "5.1.2",
+    "protractor-jasmine2-screenshot-reporter": "0.4.1",
     <%_ } _%>
     "proxy-middleware": "0.15.0",
+    "puppeteer": "0.10.2",    
     "run-sequence": "1.2.2",
     <%_ if (buildTool === 'maven') { _%>
     "xml2js": "0.4.17",

--- a/generators/client/templates/angularjs/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_karma.conf.js
@@ -19,6 +19,11 @@
 // Karma configuration
 // http://karma-runner.github.io/0.13/config/configuration-file.html
 
+var ChromiumRevision = require('puppeteer/package.json').puppeteer.chromium_revision;
+var Downloader = require('puppeteer/utils/ChromiumDownloader');
+var revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);
+process.env.CHROMIUM_BIN = revisionInfo.executablePath;
+
 var sourcePreprocessors = ['coverage'];
 
 function isDebug() {
@@ -88,9 +93,8 @@ module.exports = function (config) {
         // - Firefox
         // - Opera
         // - Safari (only Mac)
-        // - PhantomJS
         // - IE (only Windows)
-        browsers: ['PhantomJS'],
+        browsers: ['ChromiumHeadless'],
 
         // Continuous Integration mode
         // if true, it capture browsers, run tests and exit

--- a/generators/client/templates/angularjs/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_karma.conf.js
@@ -16,9 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-// Karma configuration
-// http://karma-runner.github.io/0.13/config/configuration-file.html
-
 var ChromiumRevision = require('puppeteer/package.json').puppeteer.chromium_revision;
 var Downloader = require('puppeteer/utils/ChromiumDownloader');
 var revisionInfo = Downloader.revisionInfo(Downloader.currentPlatform(), ChromiumRevision);

--- a/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
@@ -25,13 +25,13 @@ const prefix = '<%= TEST_SRC_DIR %>'.replace(/[^/]+/g,'..');
 
 var webbrowserDriver= '';
 if (os.platform() === 'win32') {
-    webbrowserDriver = prefix + 'node_modules/webdriver-manager/selenium/chromedriver_2.26.exe';
+    webbrowserDriver = prefix + 'node_modules/webdriver-manager/selenium/chromedriver_2.32.exe';
 } else {
-    webbrowserDriver = prefix + 'node_modules/webdriver-manager/selenium/chromedriver_2.26';
+    webbrowserDriver = prefix + 'node_modules/webdriver-manager/selenium/chromedriver_2.32';
 }
 
 exports.config = {
-    seleniumServerJar: prefix + 'node_modules/webdriver-manager/selenium/selenium-server-standalone-2.53.1.jar',
+    seleniumServerJar: prefix + 'node_modules/webdriver-manager/selenium/selenium-server-standalone-3.5.3.jar',
     chromeDriver: webbrowserDriver,
     allScriptsTimeout: 20000,
 
@@ -43,8 +43,10 @@ exports.config = {
 
     capabilities: {
         'browserName': 'chrome',
-        'phantomjs.binary.path': require('phantomjs-prebuilt').path,
-        'phantomjs.ghostdriver.cli.args': ['--loglevel=DEBUG']
+
+        chromeOptions: {
+            args: ["--headless", "--disable-gpu"]
+        }
     },
 
     directConnect: true,

--- a/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
@@ -43,7 +43,6 @@ exports.config = {
 
     capabilities: {
         'browserName': 'chrome',
-
         chromeOptions: {
             args: ["--headless", "--disable-gpu"]
         }

--- a/generators/server/templates/gitignore
+++ b/generators/server/templates/gitignore
@@ -4,7 +4,6 @@
 /<%= CLIENT_MAIN_SRC_DIR %>content/css/main.css<% } %>
 /<%= CLIENT_DIST_DIR %>**
 /<%= TEST_DIR %>javascript/coverage/
-/<%= TEST_DIR %>javascript/PhantomJS*/
 
 ######################
 # Node


### PR DESCRIPTION
PhantomJS deprecation announcement: https://groups.google.com/forum/m/#!topic/phantomjs/9aI5d-LDuNE
Last release of PhantomJS: v2.1.1 Jan 24, 2016

This is working great in my tests, hopefully we will even notice performance improvements in Travis

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed