### PR TITLE
add jhi prefix to alertService variables in entity pages

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -86,7 +86,7 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
         <%_ if (fieldsContainBlob) { _%>
         private dataUtils: JhiDataUtils,
         <%_ } _%>
-        private alertService: JhiAlertService,
+        private jhiAlertService: JhiAlertService,
         private <%= entityInstance %>Service: <%= entityAngularName %>Service,
         <%_ Object.keys(differentRelationships).forEach(key => {
             if (differentRelationships[key].some(rel => rel.relationshipType !== 'one-to-many')) {
@@ -162,7 +162,7 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
     }
 
     private onError(error: any) {
-        this.alertService.error(error.message, null, null);
+        this.jhiAlertService.error(error.message, null, null);
     }
     <%_
     const entitiesSeen = [];

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.ts
@@ -104,6 +104,6 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
 
     <%_ }} _%>
     private onError(error) {
-        this.alertService.error(error.message, null, null);
+        this.jhiAlertService.error(error.message, null, null);
     }
 }

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -41,7 +41,7 @@ _%>
 
     constructor(
         private <%= entityInstance %>Service: <%= entityAngularName %>Service,
-        private alertService: JhiAlertService,
+        private jhiAlertService: JhiAlertService,
         <%_ if (fieldsContainBlob) { _%>
         private dataUtils: JhiDataUtils,
         <%_ } _%>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -33,7 +33,7 @@ _%>
 
     constructor(
         private <%= entityInstance %>Service: <%= entityAngularName %>Service,
-        private alertService: JhiAlertService,
+        private jhiAlertService: JhiAlertService,
         <%_ if (fieldsContainBlob) { _%>
         private dataUtils: JhiDataUtils,
         <%_ } _%>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -48,7 +48,7 @@ currentAccount: any;
     constructor(
         private <%= entityInstance %>Service: <%= entityAngularName %>Service,
         private parseLinks: JhiParseLinks,
-        private alertService: JhiAlertService,
+        private jhiAlertService: JhiAlertService,
         private principal: Principal,
         private activatedRoute: ActivatedRoute,
         <%_ if (fieldsContainBlob) { _%>


### PR DESCRIPTION
This prevents conflicts from an entity named `Alert` injecting `AlertService`.  This issue does not affect NG1 apps as the entity service is named `Alert`.

Fix #6257

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
