### PR TITLE
Fix to use the proper entity class on the client side

### DIFF
--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity.service.ts
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity.service.ts
@@ -55,13 +55,8 @@ export class <%= entityAngularName %>Service {
     <%_ } _%>
         const copy = this.convert(<%= entityInstance %>);
         return this.http.post(this.resourceUrl, copy).map((res: Response) => {
-            <%_ if(hasDate) { _%>
             const jsonResponse = res.json();
-            this.convertItemFromServer(jsonResponse);
-            return jsonResponse;
-            <%_ } else { _%>
-            return res.json();
-            <%_ } _%>
+            return this.convertItemFromServer(jsonResponse);
         });
     }
     <%_ if (entityAngularName.length <= 30) { _%>
@@ -74,25 +69,15 @@ export class <%= entityAngularName %>Service {
     <%_ } _%>
         const copy = this.convert(<%= entityInstance %>);
         return this.http.put(this.resourceUrl, copy).map((res: Response) => {
-            <%_ if(hasDate) { _%>
             const jsonResponse = res.json();
-            this.convertItemFromServer(jsonResponse);
-            return jsonResponse;
-            <%_ } else { _%>
-            return res.json();
-            <%_ } _%>
+            return this.convertItemFromServer(jsonResponse);
         });
     }
 
     find(id: <% if (pkType === 'String') { %>string<% } else { %>number<% } %>): Observable<<%= entityAngularName %>> {
         return this.http.get(`${this.resourceUrl}/${id}`).map((res: Response) => {
-            <%_ if(hasDate) { _%>
             const jsonResponse = res.json();
-            this.convertItemFromServer(jsonResponse);
-            return jsonResponse;
-            <%_ } else { _%>
-            return res.json();
-            <%_ } _%>
+            return this.convertItemFromServer(jsonResponse);
         });
     }
 
@@ -116,29 +101,34 @@ export class <%= entityAngularName %>Service {
 
     private convertResponse(res: Response): ResponseWrapper {
         const jsonResponse = res.json();
-    <%_ if(hasDate) { _%>
+        const result = [];
         for (let i = 0; i < jsonResponse.length; i++) {
-            this.convertItemFromServer(jsonResponse[i]);
+            result.push(this.convertItemFromServer(jsonResponse[i]));
         }
-    <%_ } _%>
-        return new ResponseWrapper(res.headers, jsonResponse, res.status);
+        return new ResponseWrapper(res.headers, result, res.status);
     }
-    <%_ if(hasDate) { _%>
 
-    private convertItemFromServer(entity: any) {
+    /**
+     * Convert a returned JSON object to <%= entityAngularName %>.
+     */
+    private convertItemFromServer(json: any): <%= entityAngularName %> {
+        const entity: <%= entityAngularName %> = Object.assign(new <%= entityAngularName %>(), json);
         <%_ for (idx in fields) { _%>
             <%_ if (fields[idx].fieldType === 'LocalDate') { _%>
         entity.<%=fields[idx].fieldName%> = this.dateUtils
-            .convertLocalDateFromServer(entity.<%=fields[idx].fieldName%>);
+            .convertLocalDateFromServer(json.<%=fields[idx].fieldName%>);
             <%_ } _%>
             <%_ if (['Instant', 'ZonedDateTime'].includes(fields[idx].fieldType)) { _%>
         entity.<%=fields[idx].fieldName%> = this.dateUtils
-            .convertDateTimeFromServer(entity.<%=fields[idx].fieldName%>);
+            .convertDateTimeFromServer(json.<%=fields[idx].fieldName%>);
             <%_ } _%>
         <%_ } _%>
+        return entity;
     }
-    <%_ } _%>
 
+    /**
+     * Convert a <%= entityAngularName %> to a JSON which can be sent to the server.
+     */
     private convert(<%= entityInstance %>: <%= entityAngularName %>): <%= entityAngularName %> {
         const copy: <%= entityAngularName %> = Object.assign({}, <%= entityInstance %>);
         <%_ for (idx in fields){ if (fields[idx].fieldType === 'LocalDate') { _%>


### PR DESCRIPTION
not just a fake object, which has similar structure.

 This is useful, if the user adds methods to the entity class later.
The current implementation is confusing, because the user expects, that if he adds some code to the entity.model, then he can use it from the various components

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
