### PR TITLE
install aws-sdk locally instead of in generator-jhipster folder

### DIFF
--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -12,13 +12,13 @@ const AwsFactory = module.exports = function AwsFactory(generatorRef, cb) {
         Aws = require('aws-sdk'); // eslint-disable-line
         cb();
     } catch (e) {
-        generator.log('Installing AWS dependencies into your JHipster folder');
-        let installCommand = 'yarn add aws-sdk progress uuid --modules-folder node_modules/generator-jhipster/node_modules';
+        generator.log('Installing AWS dependencies');
+        let installCommand = 'yarn add aws-sdk progress uuid';
         if (generator.config.get('clientPackageManager') === 'npm') {
-            installCommand = 'npm install aws-sdk progress uuid --prefix node_modules/generator-jhipster';
+            installCommand = 'npm install aws-sdk progress uuid --save';
         }
-        shelljs.exec(installCommand, { silent: false }, (code, msg, err) => {
-            if (code !== 0) generator.error(`Something went wrong while installing:\n${err}`);
+        shelljs.exec(installCommand, { silent: false }, (code) => {
+            if (code !== 0) generator.error('Something went wrong while installing the aws-sdk\n');
             Aws = require('aws-sdk'); // eslint-disable-line
             cb();
         });


### PR DESCRIPTION
The main difference with this change is that if you are developing with a locally linked generator-jhipster (mostly just the team), you will need to install the dependencies in that folder.  I can add this to the docs if needed.

Fix #6316

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
