### PR TITLE
Fix #6190 and #6413 - page refresh should work properly, if the user …

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_user-route-access-service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_user-route-access-service.ts
@@ -35,16 +35,19 @@ export class UserRouteAccessService implements CanActivate {
     canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): boolean | Promise<boolean> {
 
         const authorities = route.data['authorities'];
-        if (!authorities || authorities.length === 0) {
-            return true;
-        }
-
+        // We need to call the checkLogin / and so the principal.identity() function, to ensure,
+        // that the client has a principal too, if they already logged in by the server.
+        // This could happen on a page refresh.
         return this.checkLogin(authorities, state.url);
     }
 
     checkLogin(authorities: string[], url: string): Promise<boolean> {
         const principal = this.principal;
         return Promise.resolve(principal.identity().then((account) => {
+
+            if (!authorities || authorities.length === 0) {
+                return true;
+            }
 
             if (account) {
               return principal.hasAnyAuthority(authorities).then(


### PR DESCRIPTION
 page refresh should work properly, if the user is logged in, but try to access a public page

This patch ensures that the principal is fetched - in this case, so the client will know, if it's already logged in.

