### PR TITLE
Fixing the auth-interceptor

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 import { JhiHttpInterceptor } from 'ng-jhipster';
-<%_ if (authenticationType === 'oauth2' || authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
 import { Injector } from '@angular/core';
-<%_ } _%>
 import { RequestOptionsArgs, Response } from '@angular/http';
 import { Observable } from 'rxjs/Observable';
 <%_ if (authenticationType === 'oauth2' || authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
@@ -43,8 +41,8 @@ export class AuthExpiredInterceptor extends JhiHttpInterceptor {
 <%_ } _%>
 <%_ if (authenticationType === 'session') { _%>
     constructor(
+        private injector: Injector,
         private stateStorageService: StateStorageService,
-        private authServerProvider: AuthServerProvider,
         private loginServiceModal: LoginModalService) {
         super();
     }
@@ -83,7 +81,8 @@ export class AuthExpiredInterceptor extends JhiHttpInterceptor {
                 } else {
                     this.stateStorageService.storeUrl('/');
                 }
-                this.authServerProvider.logout();
+                const authServer: AuthServerProvider = this.injector.get(AuthServerProvider);
+                authServer.logout();
                 this.loginServiceModal.open();
             }
             return Observable.throw(error);

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
@@ -47,7 +47,6 @@ export function interceptableFactory(
     <%_ } if (authenticationType === 'session') { _%>
     injector: Injector,
     stateStorageService: StateStorageService,
-    authServerProvider: AuthServerProvider,
     loginServiceModal: LoginModalService,
     <%_ } _%>
     eventManager: JhiEventManager
@@ -62,8 +61,8 @@ export function interceptableFactory(
         <%_ } _%>
             new AuthExpiredInterceptor(injector),
         <%_ } if (authenticationType === 'session') { _%>
-            new AuthExpiredInterceptor(stateStorageService,
-                authServerProvider, loginServiceModal),
+            new AuthExpiredInterceptor(injector, stateStorageService,
+                loginServiceModal),
         <%_ } _%>
             // Other interceptors can be added here
             new ErrorHandlerInterceptor(eventManager),
@@ -86,6 +85,7 @@ export function customHttpProvider() {
             <%_ } if (authenticationType === 'session') { _%>
             Injector,
             StateStorageService,
+            LoginModalService,
             <%_ } _%>
             JhiEventManager
         ]


### PR DESCRIPTION
Fixing the js problem "ERROR TypeError: _this.authServerProvider.logout is not a function
    at CatchSubscriber.eval [as selector] (VM8171 auth-expired.interceptor.ts:42)
    at CatchSubscriber.error (VM7476 catch.js:104)..."

Which caused by wrong dependency declarations - which cause that in AuthExpiredInterceptor
 the loginServiceModal is null, and authServerProvider is actually a JhiEventManager.
Unfortunately injecting the AuthServerProvider would cause a cyclic dependency, so the Injector is used,
and the AuthServerProvider is acquired lazily

