### PR TITLE
Fix Align Left Account Menu

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.scss
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.scss
@@ -57,6 +57,9 @@ Navbar
             color: #fff;
         }
     }
+	.dropdown-menu-right {
+        left: auto !important;
+    }
 }
 
 @media screen and (min-width: 768px) {


### PR DESCRIPTION
In the Bootstrap update, the login screen, account and password for example are getting off the screen. A scroll bar is generated below.

This improvement leaves everything correct. I ran the tests on the new generator and it worked perfectly.

