### PR TITLE
Fix /audit query date format

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.component.ts
@@ -38,16 +38,17 @@ export class AuditsComponent implements OnInit {
     reverse: boolean;
     toDate: string;
     totalItems: number;
+    datePipe: DatePipe;
 
     constructor(
         private auditsService: AuditsService,
-        private parseLinks: JhiParseLinks,
-        private datePipe: DatePipe
+        private parseLinks: JhiParseLinks
     ) {
         this.itemsPerPage = ITEMS_PER_PAGE;
         this.page = 1;
         this.reverse = false;
         this.orderProp = 'timestamp';
+        this.datePipe = new DatePipe('en');
     }
 
     getAudits() {


### PR DESCRIPTION
Original Fix /audit query date generated with datepipe which under default locale. 
It make a mistake when default locale is not `en` ,for example it may be 2017年-10月-3日

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
