### PR TITLE
make swagger input spec environment aware

### DIFF
--- a/generators/server/templates/gradle/_swagger.gradle
+++ b/generators/server/templates/gradle/_swagger.gradle
@@ -20,11 +20,11 @@
  * Plugin that provides API-first development using swagger-codegen to
  * generate Spring-MVC endpoint stubs at compile time from a swagger definition file
  */
- 
+
 apply plugin: "org.detoeuf.swagger-codegen"
 
 swagger {
-    inputSpec = '<%= SERVER_MAIN_RES_DIR %>swagger/api.yml'
+    inputSpec = file('<%= SERVER_MAIN_RES_DIR %>swagger/api.yml').absolutePath
     outputDir = file('build/swagger')
     lang = 'spring'
 


### PR DESCRIPTION
close #6447 by let the file eobject handle win/unix path seperators.
