### PR TITLE
Configure sh files with LF as default EOL

### DIFF
--- a/generators/server/templates/gitattributes
+++ b/generators/server/templates/gitattributes
@@ -21,7 +21,7 @@
 *.properties    text
 *.sass          text
 *.scss          text
-*.sh            text
+*.sh            text eol=lf
 *.sql           text
 *.txt           text
 *.ts            text


### PR DESCRIPTION
Without this parameter, you can have an issue using Docker on Windows
for project on Git environment:

- when you clone an existing JHipster project, the EOL of sh files could
be updated to CRLF on Windows OS (depending on local Git configuration)

- when you run Docker with these sh files (for instance Couchbase, see #6327),
Docker can't execute them as they are not recognized.

It is the same thing with bat files on Windows, and it is already forced
as CRLF in the same file. On the sample repo you chose, you can notine it defines this rule as
well for Web profiles:
https://github.com/alexkaratarakis/gitattributes/blob/master/Web.gitattributes

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
