### PR TITLE
make generateKeyStore synchronous to finish before git init

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1713,6 +1713,7 @@ module.exports = class extends PrivateBase {
      * Generate a KeyStore for uaa authorization server.
      */
     generateKeyStore() {
+        const done = this.async();
         const keyStoreFile = `${SERVER_MAIN_RES_DIR}keystore.jks`;
         if (this.fs.exists(keyStoreFile)) {
             this.log(chalk.cyan(`\nKeyStore '${keyStoreFile}' already exists. Leaving unchanged.\n`));
@@ -1738,6 +1739,7 @@ module.exports = class extends PrivateBase {
                     } else {
                         this.log(chalk.green(`\nKeyStore '${keyStoreFile}' generated successfully.\n`));
                     }
+                    done();
                 }
             );
         }


### PR DESCRIPTION
Small change - generates the key store for UAA apps synchronously instead of async.  This lets the project fully generate before committing to git

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
