### PR TITLE
Fix for custom jhiPrefix not being assigned correctly

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -108,7 +108,7 @@ module.exports = class extends BaseGenerator {
         this.skipClient = this.configOptions.skipClient = this.options['skip-client'] || this.config.get('skipClient');
         this.skipServer = this.configOptions.skipServer = this.options['skip-server'] || this.config.get('skipServer');
         this.skipUserManagement = this.configOptions.skipUserManagement = this.options['skip-user-management'] || this.config.get('skipUserManagement');
-        this.jhiPrefix = this.configOptions.jhiPrefix || this.config.get('jhiPrefix') || this.options['jhi-prefix'];
+        this.jhiPrefix = this.configOptions.jhiPrefix = this.config.get('jhiPrefix') || this.options['jhi-prefix'];
         this.withEntities = this.options['with-entities'];
         this.skipChecks = this.options['skip-checks'];
         this.useYarn = this.configOptions.useYarn = !this.options.npm;

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -80,7 +80,7 @@ describe('JHipster generator', () => {
         describe('AngularX', () => {
             beforeEach((done) => {
                 helpers.run(path.join(__dirname, '../generators/app'))
-                    .withOptions({ skipInstall: true, skipChecks: true })
+                    .withOptions({ skipInstall: true, skipChecks: true, jhiPrefix: 'test' })
                     .withPrompts({
                         baseName: 'jhipster',
                         clientFramework: 'angularX',
@@ -121,6 +121,9 @@ describe('JHipster generator', () => {
             });
             it('contains clientFramework with angularX value', () => {
                 assert.fileContent('.yo-rc.json', /"clientFramework": "angularX"/);
+            });
+            it('contains correct custom prefix when specified', () => {
+                assert.fileContent('.angular-cli.json', /"prefix": "test"/);
             });
         });
 


### PR DESCRIPTION
Fix bug where jhiPrefix would default to 'jhi' in Angular components and .angular-cli.json because this.configOptions.jhiPrefix was never assigned a value.

Fix #6525

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
