### PR TITLE
Allow multiple liquibase commands in Gradle, similar to Maven

### DIFF
--- a/generators/server/templates/gradle/_liquibase.gradle
+++ b/generators/server/templates/gradle/_liquibase.gradle
@@ -77,7 +77,7 @@ task liquibase(dependsOn: compileJava, type: JavaExec) {
 }
 
 // for compatibility to former task
-task liquibaseClearChecksums() {
+task liquibaseDiffChangelog() {
 	liquibaseCommand = "diffChangeLog"
 	liquibase.execute()
 }

--- a/generators/server/templates/gradle/_liquibase.gradle
+++ b/generators/server/templates/gradle/_liquibase.gradle
@@ -73,12 +73,16 @@ def liquibaseCommand(command) {
     }
 }
 
-task liquibaseDiffChangeLog(dependsOn: initPaths) << {
-	liquibaseCommand("diffChangeLog")
+task liquibaseDiffChangeLog(dependsOn: initPaths) {
+    doLast {
+	    liquibaseCommand("diffChangeLog")
+    }
 }
 
-task liquibaseClearChecksums(dependsOn: initPaths) << {
-	liquibaseCommand("clearChecksums")
+task liquibaseClearChecksums(dependsOn: initPaths) {
+    doLast {
+        liquibaseCommand("clearChecksums")
+    }
 }
 
 def buildTimestamp() {

--- a/generators/server/templates/gradle/_liquibase.gradle
+++ b/generators/server/templates/gradle/_liquibase.gradle
@@ -18,6 +18,13 @@
 -%>
 import org.gradle.internal.os.OperatingSystem
 
+if (!hasProperty('liquibaseCommand')) {
+	ext.liquibaseCommand = 'diffChangeLog'
+	logger.warn('HINT: Using default liquibaseCommand "diffChangeLog" - specify others with -PliquibaseCommand, e.g. "gradlew liquibase -PliquibaseCommand=clearChecksums"')
+} else {
+	logger.warn('Using liquibaseCommand: ' + liquibaseCommand)
+}
+
 configurations {
     liquibase
 }
@@ -43,7 +50,7 @@ if (OperatingSystem.current().isWindows()) {
     }
 }
 
-task liquibaseDiffChangelog(dependsOn: compileJava, type: JavaExec) {
+task liquibase(dependsOn: compileJava, type: JavaExec) {
     group = "liquibase"
 
     if (OperatingSystem.current().isWindows()) {
@@ -63,10 +70,16 @@ task liquibaseDiffChangelog(dependsOn: compileJava, type: JavaExec) {
     args "--password="
     args "--url=<% if (devDatabaseType === 'mysql') { %>jdbc:mysql://localhost:3306/<%= baseName %><% } else if (devDatabaseType === 'mariadb') { %>jdbc:mariadb://localhost:3306/<%= baseName %><% } else if (devDatabaseType === 'postgresql') { %>jdbc:postgresql://localhost:5432/<%= baseName %><% } else if (devDatabaseType === 'h2Disk') { %>jdbc:h2:file:./<%= BUILD_DIR %>h2db/db/<%= lowercaseBaseName %><% } else if (devDatabaseType === 'oracle') { %>jdbc:oracle:thin:@localhost:1521:<%= baseName %><% } %>"
     args "--driver=<% if (devDatabaseType === 'mysql') { %>com.mysql.jdbc.Driver<% } else if (devDatabaseType === 'mariadb') { %>org.mariadb.jdbc.Driver<% } else if (devDatabaseType === 'postgresql') { %>org.postgresql.Driver<% } else if (devDatabaseType === 'h2Disk') { %>org.h2.Driver<% } else if (devDatabaseType === 'oracle') { %>oracle.jdbc.OracleDriver<% } %>"
-    args "diffChangeLog"
+    args liquibaseCommand
     <%_ if (authenticationType === 'oauth2') { _%>
     args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details, oauth_client_token, oauth_code, oauth_refresh_token"
     <%_ } _%>
+}
+
+// for compatibility to former task
+task liquibaseClearChecksums() {
+	liquibaseCommand = "diffChangeLog"
+	liquibase.execute()
 }
 
 def buildTimestamp() {

--- a/generators/server/templates/gradle/_liquibase.gradle
+++ b/generators/server/templates/gradle/_liquibase.gradle
@@ -18,13 +18,6 @@
 -%>
 import org.gradle.internal.os.OperatingSystem
 
-if (!hasProperty('liquibaseCommand')) {
-	ext.liquibaseCommand = 'diffChangeLog'
-	logger.warn('HINT: Using default liquibaseCommand "diffChangeLog" - specify others with -PliquibaseCommand, e.g. "gradlew liquibase -PliquibaseCommand=clearChecksums"')
-} else {
-	logger.warn('Using liquibaseCommand: ' + liquibaseCommand)
-}
-
 configurations {
     liquibase
 }
@@ -50,36 +43,42 @@ if (OperatingSystem.current().isWindows()) {
     }
 }
 
-task liquibase(dependsOn: compileJava, type: JavaExec) {
+task initPaths(dependsOn: compileJava) {
     group = "liquibase"
-
     if (OperatingSystem.current().isWindows()) {
         dependsOn pathingLiquibaseJar
-        doFirst {
-            classpath = files(pathingLiquibaseJar.archivePath)
-        }
-    } else {
-        classpath sourceSets.main.runtimeClasspath
-        classpath configurations.liquibase
-    }
-    main = "liquibase.integration.commandline.Main"
-
-    args "--changeLogFile=<%= SERVER_MAIN_RES_DIR %>config/liquibase/changelog/" + buildTimestamp() +"_changelog.xml"
-    args "--referenceUrl=hibernate:spring:<%= packageName %>.domain?dialect=<% if (devDatabaseType === 'mysql' || devDatabaseType === 'mariadb') { %>org.hibernate.dialect.MySQL5InnoDBDialect<% } else if (devDatabaseType === 'postgresql') { %>org.hibernate.dialect.PostgreSQL82Dialect<% } else if (devDatabaseType === 'h2Disk') { %>org.hibernate.dialect.H2Dialect<% } else if (devDatabaseType === 'oracle') { %>org.hibernate.dialect.Oracle12cDialect<% } %>&hibernate.physical_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy&hibernate.implicit_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy"
-    args "--username=<% if (devDatabaseType === 'mysql' || devDatabaseType === 'mariadb') { %>root<% } else if (devDatabaseType === 'postgresql' || devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %><%= baseName %><% } %>"
-    args "--password="
-    args "--url=<% if (devDatabaseType === 'mysql') { %>jdbc:mysql://localhost:3306/<%= baseName %><% } else if (devDatabaseType === 'mariadb') { %>jdbc:mariadb://localhost:3306/<%= baseName %><% } else if (devDatabaseType === 'postgresql') { %>jdbc:postgresql://localhost:5432/<%= baseName %><% } else if (devDatabaseType === 'h2Disk') { %>jdbc:h2:file:./<%= BUILD_DIR %>h2db/db/<%= lowercaseBaseName %><% } else if (devDatabaseType === 'oracle') { %>jdbc:oracle:thin:@localhost:1521:<%= baseName %><% } %>"
-    args "--driver=<% if (devDatabaseType === 'mysql') { %>com.mysql.jdbc.Driver<% } else if (devDatabaseType === 'mariadb') { %>org.mariadb.jdbc.Driver<% } else if (devDatabaseType === 'postgresql') { %>org.postgresql.Driver<% } else if (devDatabaseType === 'h2Disk') { %>org.h2.Driver<% } else if (devDatabaseType === 'oracle') { %>oracle.jdbc.OracleDriver<% } %>"
-    args liquibaseCommand
-    <%_ if (authenticationType === 'oauth2') { _%>
-    args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details, oauth_client_token, oauth_code, oauth_refresh_token"
-    <%_ } _%>
+	}
 }
 
-// for compatibility to former task
-task liquibaseDiffChangelog() {
-	liquibaseCommand = "diffChangeLog"
-	liquibase.execute()
+def liquibaseCommand(command) {
+	javaexec {	
+		if (OperatingSystem.current().isWindows()) {
+			classpath files(pathingLiquibaseJar.archivePath)
+		} else {
+			classpath sourceSets.main.runtimeClasspath
+			classpath configurations.liquibase
+		}
+		main = "liquibase.integration.commandline.Main"
+        
+        args "--changeLogFile=<%= SERVER_MAIN_RES_DIR %>config/liquibase/changelog/" + buildTimestamp() +"_changelog.xml"
+        args "--referenceUrl=hibernate:spring:<%= packageName %>.domain?dialect=<% if (devDatabaseType === 'mysql' || devDatabaseType === 'mariadb') { %>org.hibernate.dialect.MySQL5InnoDBDialect<% } else if (devDatabaseType === 'postgresql') { %>org.hibernate.dialect.PostgreSQL82Dialect<% } else if (devDatabaseType === 'h2Disk') { %>org.hibernate.dialect.H2Dialect<% } else if (devDatabaseType === 'oracle') { %>org.hibernate.dialect.Oracle12cDialect<% } %>&hibernate.physical_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy&hibernate.implicit_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy"
+        args "--username=<% if (devDatabaseType === 'mysql' || devDatabaseType === 'mariadb') { %>root<% } else if (devDatabaseType === 'postgresql' || devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %><%= baseName %><% } %>"
+        args "--password="
+        args "--url=<% if (devDatabaseType === 'mysql') { %>jdbc:mysql://localhost:3306/<%= baseName %><% } else if (devDatabaseType === 'mariadb') { %>jdbc:mariadb://localhost:3306/<%= baseName %><% } else if (devDatabaseType === 'postgresql') { %>jdbc:postgresql://localhost:5432/<%= baseName %><% } else if (devDatabaseType === 'h2Disk') { %>jdbc:h2:file:./<%= BUILD_DIR %>h2db/db/<%= lowercaseBaseName %><% } else if (devDatabaseType === 'oracle') { %>jdbc:oracle:thin:@localhost:1521:<%= baseName %><% } %>"
+        args "--driver=<% if (devDatabaseType === 'mysql') { %>com.mysql.jdbc.Driver<% } else if (devDatabaseType === 'mariadb') { %>org.mariadb.jdbc.Driver<% } else if (devDatabaseType === 'postgresql') { %>org.postgresql.Driver<% } else if (devDatabaseType === 'h2Disk') { %>org.h2.Driver<% } else if (devDatabaseType === 'oracle') { %>oracle.jdbc.OracleDriver<% } %>"
+        args liquibaseCommand
+        <%_ if (authenticationType === 'oauth2') { _%>
+        args "--excludeObjects=oauth_access_token, oauth_approvals, oauth_client_details, oauth_client_token, oauth_code, oauth_refresh_token"
+        <%_ } _%>
+    }
+}
+
+task liquibaseDiffChangeLog(dependsOn: initPaths) << {
+	liquibaseCommand("diffChangeLog")
+}
+
+task liquibaseClearChecksums(dependsOn: initPaths) << {
+	liquibaseCommand("clearChecksums")
 }
 
 def buildTimestamp() {


### PR DESCRIPTION
Gradle and liquibase allows only diffChangeLog command.
With this change, you can specify others with task liquibase and -PliquibaseCommand, e.g. 
   gradlew liquibase -PliquibaseCommand=clearChecksums
This is similar to Maven liquibase:clearChecksums
The existing task liquibaseClearChecksums is retained for compatibility.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
