### PR TITLE
add pageSize (or items-per-page) on pagination directive

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management.component.html
@@ -100,7 +100,7 @@
             <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
         <div class="row justify-content-center">
-            <ngb-pagination [collectionSize]="totalItems" [(page)]="page" (pageChange)="loadPage(page)"></ngb-pagination>
+            <ngb-pagination [collectionSize]="totalItems" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="loadPage(page)"></ngb-pagination>
         </div>
     </div>
     <%_ } _%>

--- a/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management.html
+++ b/generators/client/templates/angularjs/src/main/webapp/app/admin/user-management/_user-management.html
@@ -91,7 +91,7 @@
     <%_ if (databaseType !== 'cassandra') { _%>
     <div class="text-center">
         <jhi-item-count page="vm.page" total="vm.queryCount" items-per-page="vm.itemsPerPage"></jhi-item-count>
-        <uib-pagination class="pagination-sm" total-items="vm.totalItems" ng-model="vm.page" ng-change="vm.transition()"></uib-pagination>
+        <uib-pagination class="pagination-sm" total-items="vm.totalItems" items-per-page="vm.itemsPerPage" ng-model="vm.page" ng-change="vm.transition()"></uib-pagination>
     </div>
     <%_ } _%>
 </div>

--- a/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.html
+++ b/generators/entity/templates/client/angular/src/main/webapp/app/entities/_entity-management.component.html
@@ -185,7 +185,7 @@
                 <jhi-item-count [page]="page" [total]="queryCount" [itemsPerPage]="itemsPerPage"></jhi-item-count>
             </div>
             <div class="row justify-content-center">
-                <ngb-pagination [collectionSize]="totalItems" [(page)]="page" (pageChange)="loadPage(page)"></ngb-pagination>
+                <ngb-pagination [collectionSize]="totalItems" [pageSize]="itemsPerPage" [(page)]="page" (pageChange)="loadPage(page)"></ngb-pagination>
             </div>
         </div>
         <%_ } _%>


### PR DESCRIPTION
Apply this fix https://github.com/jhipster/generator-jhipster/issues/4347 on:
Angular 4: Entity and User
AngularJS: User

(This is to be able to override `this.itemsPerPage = ITEMS_PER_PAGE;` by something like `this.itemsPerPage = 8;` and have the directive working. Otherwise itemsPerPage is assigned to ITEMS_PER_PAGE (20), `uib-pagination.config.ts`)
