### PR TITLE
add no-sandbox to chromium options

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/angular/src/test/javascript/_karma.conf.js
@@ -90,7 +90,14 @@ module.exports = (config) => {
 
         // start these browsers
         // available browser launchers: https://npmjs.org/browse/keyword/karma-launcher
-        browsers: ['ChromiumHeadless'],
+        browsers: ['ChromiumHeadlessNoSandbox'],
+
+        customLaunchers: {
+            ChromiumHeadlessNoSandbox: {
+                base: 'ChromiumHeadless',
+                    flags: ['--no-sandbox']
+            }
+        },
 
         // Ensure all browsers can run tests written in .ts files
         mime: {

--- a/generators/client/templates/angularjs/src/test/javascript/_karma.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_karma.conf.js
@@ -91,7 +91,14 @@ module.exports = function (config) {
         // - Opera
         // - Safari (only Mac)
         // - IE (only Windows)
-        browsers: ['ChromiumHeadless'],
+        browsers: ['ChromiumHeadlessNoSandbox'],
+
+        customLaunchers: {
+            ChromiumHeadlessNoSandbox: {
+                base: 'ChromiumHeadless',
+                    flags: ['--no-sandbox']
+            }
+        },
 
         // Continuous Integration mode
         // if true, it capture browsers, run tests and exit


### PR DESCRIPTION
add no-sandbox to chromium options

option allows chromium tests to be run as root, typically in a docker context

Fix #6545

- Please make sure the below checklist is followed for Pull Requests.

- [X ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X ] Tests are added where necessary
- [ X] Documentation is added/updated where necessary
- [ X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
