### PR TITLE
Keep the "authorization" ignored header with OIDC

### DIFF
--- a/generators/server/templates/src/main/java/package/gateway/_TokenRelayFilter.java
+++ b/generators/server/templates/src/main/java/package/gateway/_TokenRelayFilter.java
@@ -25,8 +25,10 @@ import <%=packageName%>.security.oauth2.AuthorizationHeaderUtil;
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 import org.springframework.stereotype.Component;
+<%_ if (authenticationType === 'jwt') { _%>
 
 import java.util.Set;
+<%_ } _%>
 
 @Component
 public class TokenRelayFilter extends ZuulFilter {
@@ -38,9 +40,11 @@ public class TokenRelayFilter extends ZuulFilter {
     @Override
     public Object run() {
         RequestContext ctx = RequestContext.getCurrentContext();
+        <%_ if (authenticationType === 'jwt') { _%>
         Set<String> headers = (Set<String>) ctx.get("ignoredHeaders");
         // JWT tokens should be relayed to the resource servers
         headers.remove("authorization");
+        <%_ } _%>
         <%_ if (authenticationType === 'oauth2') { _%>
         // Add specific authorization headers for OAuth2
         ctx.addZuulRequestHeader(AUTHORIZATION_HEADER,


### PR DESCRIPTION
Some people could use it to abuse the system, as you could have 2 "authorization" headers. It's better not to trust the one from the browser.

See #6519

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
