### PR TITLE
Fix to not call unnecessarily the /api/profile-info method multiple times

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/_navbar.component.ts
@@ -73,7 +73,7 @@ export class NavbarComponent implements OnInit {
         });
 
         <%_ } _%>
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
+        this.profileService.getProfileInfo().then((profileInfo) => {
             this.inProduction = profileInfo.inProduction;
             this.swaggerEnabled = profileInfo.swaggerEnabled;
         });

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/_page-ribbon.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/_page-ribbon.component.ts
@@ -39,7 +39,7 @@ export class PageRibbonComponent implements OnInit {
     constructor(private profileService: ProfileService) {}
 
     ngOnInit() {
-        this.profileService.getProfileInfo().subscribe((profileInfo) => {
+        this.profileService.getProfileInfo().then((profileInfo) => {
             this.profileInfo = profileInfo;
             this.ribbonEnv = profileInfo.ribbonEnv;
         });

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/_profile.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/_profile.service.ts
@@ -18,7 +18,6 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
 
 <%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
@@ -29,19 +28,23 @@ import { ProfileInfo } from './profile-info.model';
 export class ProfileService {
 
     private profileInfoUrl = <% if (authenticationType === 'uaa') { %>'<% } else { %>SERVER_API_URL + '<% } %>api/profile-info';
+    private profileInfo: Promise<ProfileInfo>;
 
     constructor(private http: Http) { }
 
-    getProfileInfo(): Observable<ProfileInfo> {
-        return this.http.get(this.profileInfoUrl)
-            .map((res: Response) => {
-                const data = res.json();
-                const pi = new ProfileInfo();
-                pi.activeProfiles = data.activeProfiles;
-                pi.ribbonEnv = data.ribbonEnv;
-                pi.inProduction = data.activeProfiles.indexOf('prod') !== -1;
-                pi.swaggerEnabled = data.activeProfiles.indexOf('swagger') !== -1;
-                return pi;
-            });
+    getProfileInfo(): Promise<ProfileInfo> {
+        if (!this.profileInfo) {
+            this.profileInfo = this.http.get(this.profileInfoUrl)
+                .map((res: Response) => {
+                    const data = res.json();
+                    const pi = new ProfileInfo();
+                    pi.activeProfiles = data.activeProfiles;
+                    pi.ribbonEnv = data.ribbonEnv;
+                    pi.inProduction = data.activeProfiles.indexOf('prod') !== -1;
+                    pi.swaggerEnabled = data.activeProfiles.indexOf('swagger') !== -1;
+                    return pi;
+            }).toPromise();
+        }
+        return this.profileInfo;
     }
 }


### PR DESCRIPTION
Twice for opening the home page, one call is from the navbar.component.ts, the second is from the page-ribbon.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
