### PR TITLE
Fix error running the filtering tests on locales

### DIFF
--- a/generators/entity/templates/server/src/test/java/package/web/rest/_EntityResourceIntTest.java
+++ b/generators/entity/templates/server/src/test/java/package/web/rest/_EntityResourceIntTest.java
@@ -69,6 +69,7 @@ import java.util.List;<% if (databaseType === 'cassandra') { %>
 import java.util.UUID;<% } %>
 <% if (fieldsContainZonedDateTime === true) { %>
 import static <%=packageName%>.web.rest.TestUtil.sameInstant;<% } %>
+import static <%=packageName%>.web.rest.TestUtil.createFormattingConversionService;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasItem;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
@@ -291,6 +292,7 @@ _%>
         this.rest<%= entityClass %>MockMvc = MockMvcBuilders.standaloneSetup(<%= entityInstance %>Resource)
             .setCustomArgumentResolvers(pageableArgumentResolver)
             .setControllerAdvice(exceptionTranslator)
+            .setConversionService(createFormattingConversionService())
             .setMessageConverters(jacksonMessageConverter).build();
     }
 

--- a/generators/server/templates/src/test/java/package/web/rest/_TestUtil.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_TestUtil.java
@@ -23,6 +23,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeDiagnosingMatcher;
+import org.springframework.format.datetime.standard.DateTimeFormatterRegistrar;
+import org.springframework.format.support.DefaultFormattingConversionService;
+import org.springframework.format.support.FormattingConversionService;
 import org.springframework.http.MediaType;
 
 import java.io.IOException;
@@ -138,4 +141,17 @@ public class TestUtil {
         assertThat(domainObject1.hashCode()).isEqualTo(domainObject2.hashCode());
         <%_ } _%>
     }
+
+    /**
+     * Create a FormattingConversionService which use ISO date format, instead of the localized one.
+     * @return the FormattingConversionService
+     */
+    public static FormattingConversionService createFormattingConversionService() {
+        DefaultFormattingConversionService dfcs = new DefaultFormattingConversionService ();
+        DateTimeFormatterRegistrar registrar = new DateTimeFormatterRegistrar();
+        registrar.setUseIsoFormat(true);
+        registrar.registerFormatters(dfcs);
+        return dfcs;
+    }
+
 }


### PR DESCRIPTION
 where the date is not formatted as ISO

In this case, we pass the LocalDate as a string in the URL, for example as /api/bank-accounts?openingDay.equals=1970-01-01 , but in the test context, the date formatter is not configured properly, so it is expecting the date formatted as 1970/01/01 or some other locale specif way. Fortunately this works in dev/prod mode, where the {packageName}/config/DateTimeFormatConfiguration takes care of the DateTimeFormatterRegistrar's configuration

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
