### PR TITLE
Fix exception when sending social registration validation email

### DIFF
--- a/generators/server/templates/src/main/java/package/service/_MailService.java
+++ b/generators/server/templates/src/main/java/package/service/_MailService.java
@@ -133,6 +133,7 @@ public class MailService {
         Locale locale = Locale.forLanguageTag(user.getLangKey());
         Context context = new Context(locale);
         context.setVariable(USER, user);
+        context.setVariable(BASE_URL, jHipsterProperties.getMail().getBaseUrl());
         context.setVariable("provider", StringUtils.capitalize(provider));
         String content = templateEngine.process("socialRegistrationValidationEmail", context);
         String subject = messageSource.getMessage("email.social.registration.title", null, locale);


### PR DESCRIPTION
I did not find this error in the issues, I just ran into it and fixed. It can be reproduced by signing in using Spring Social in newly generated project.

Error log:
> 2017-10-22 19:50:04.427 DEBUG 20656 --- [list-Executor-2] c.a.myapp.service.MailService         : Sending social registration validation email to 'some-random-email@gmail.com'
> 2017-10-22 19:50:04.680 ERROR 20656 --- [list-Executor-2] org.thymeleaf.TemplateEngine             : [THYMELEAF][myapp-Executor-2] Exception processing template "socialRegistrationValidationEmail": Link base "null/favicon.ico" cannot be context relative (/) or page relative unless you implement the org.thymeleaf.context.IWebContext interface (context is of class: org.thymeleaf.context.Context) (socialRegistrationValidationEmail:6)
> 2017-10-22 19:50:04.682 ERROR 20656 --- [list-Executor-2] c.a.myapp.aop.logging.LoggingAspect   : Exception in com.anarsultanov.myapp.service.MailService.sendSocialRegistrationValidationEmail() with cause = 'NULL' and exception = 'Link base "null/favicon.ico" cannot be context relative (/) or page relative unless you implement the org.thymeleaf.context.IWebContext interface (context is of class: org.thymeleaf.context.Context) (socialRegistrationValidationEmail:6)'

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
