### PR TITLE
Check that upgrade is run from a JHipster project directory

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -126,9 +126,8 @@ module.exports = class extends BaseGenerator {
 
             assertJHipsterProject() {
                 const done = this.async();
-                if (!(shelljs.test('-f', '.yo-rc.json'))
-                    && !(shelljs.test('-d', '.jhipster'))) {
-                    this.error('Current directory is not a JHipster project.');
+                if (!this.getJhipsterAppConfig()) {
+                    this.error('Current directory does not contain a JHipster project.');
                 }
                 done();
             },

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -123,6 +123,16 @@ module.exports = class extends BaseGenerator {
 
     get configuring() {
         return {
+
+            assertJHipsterProject() {
+                const done = this.async();
+                if (!(shelljs.test('-f', '.yo-rc.json'))
+                    && !(shelljs.test('-d', '.jhipster'))) {
+                    this.error('Current directory is not a JHipster project.');
+                }
+                done();
+            },
+
             assertGitPresent() {
                 const done = this.async();
                 this.isGitInstalled((code) => {


### PR DESCRIPTION
Provide user with a helpful message when jhipster upgrade is run from a directory that is not a JHipster project.

Fix #6596

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
