### PR TITLE
Fix yarn failure when upgrading microservices

### DIFF
--- a/generators/app/templates/_skipClientApp.package.json
+++ b/generators/app/templates/_skipClientApp.package.json
@@ -17,6 +17,7 @@
  limitations under the License.
 -%>
 {
+  "private": true,
   "devDependencies": {
     <%_ otherModules.forEach(function(module) { _%>
     "<%= module.name %>": "<%= module.version %>",


### PR DESCRIPTION
When generating an app without client code, upgrade generator fails because yarn complains about no licence. Adding `"private": true` to `package.json` avoids this error and makes a lot of sense as there's no npm module to publish anyway.

See https://github.com/yarnpkg/yarn/issues/3821

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
