### PR TITLE
use setters instead of constructor for UserDTO and ManagedUserVM

### DIFF
--- a/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
+++ b/generators/server/templates/src/main/java/package/service/dto/_UserDTO.java
@@ -86,36 +86,27 @@ public class UserDTO {
     }
 
     public UserDTO(User user) {
-        this(user.getId(), user.getLogin(), user.getFirstName(), user.getLastName(),
-            user.getEmail(), user.getActivated(),<% if (databaseType === 'sql' || databaseType === 'mongodb') { %> user.getImageUrl(), <% } %>user.getLangKey(),<% if (databaseType === 'sql' || databaseType === 'mongodb') { %>
-            user.getCreatedBy(), user.getCreatedDate(), user.getLastModifiedBy(), user.getLastModifiedDate(),
-            user.getAuthorities().stream().map(Authority::getName)
-                .collect(Collectors.toSet()));<% } else { %>
-            user.getAuthorities());<% } %>
-    }
-
-    public UserDTO(<% if (databaseType === 'mongodb' || databaseType === 'cassandra') { %>String<% } else { %>Long<% } %> id, String login, String firstName, String lastName,
-        String email, boolean activated,<% if (databaseType === 'sql' || databaseType === 'mongodb') { %> String imageUrl, <% } %>String langKey,<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>
-        String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate,
-        <% } %>Set<String> authorities) {
-
-        this.id = id;
-        this.login = login;
-        this.firstName = firstName;
-        this.lastName = lastName;
-        this.email = email;
-        this.activated = activated;
+        this.id = user.getId();
+        this.login = user.getLogin();
+        this.firstName = user.getFirstName();
+        this.lastName = user.getLastName();
+        this.email = user.getEmail();
+        this.activated = user.getActivated();
         <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-        this.imageUrl = imageUrl;
+        this.imageUrl = user.getImageUrl();
         <%_ } _%>
-        this.langKey = langKey;
+        this.langKey = user.getLangKey();
         <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-        this.createdBy = createdBy;
-        this.createdDate = createdDate;
-        this.lastModifiedBy = lastModifiedBy;
-        this.lastModifiedDate = lastModifiedDate;
+        this.createdBy = user.getCreatedBy();
+        this.createdDate = user.getCreatedDate();
+        this.lastModifiedBy = user.getLastModifiedBy();
+        this.lastModifiedDate = user.getLastModifiedDate();
+        this.authorities = user.getAuthorities().stream()
+            .map(Authority::getName)
+            .collect(Collectors.toSet());
+        <%_ } else { _%>
+        this.authorities = user.getAuthorities();
         <%_ } _%>
-        this.authorities = authorities;
     }
 
     public <% if (databaseType === 'mongodb' || databaseType === 'cassandra') { %>String<% } else { %>Long<% } %> getId() {
@@ -138,17 +129,33 @@ public class UserDTO {
         return firstName;
     }
 
+    public void setFirstName(String firstName) {
+        this.firstName = firstName;
+    }
+
     public String getLastName() {
         return lastName;
+    }
+
+    public void setLastName(String lastName) {
+        this.lastName = lastName;
     }
 
     public String getEmail() {
         return email;
     }
+
+    public void setEmail(String email) {
+        this.email = email;
+    }
     <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
 
     public String getImageUrl() {
         return imageUrl;
+    }
+
+    public void setImageUrl(String imageUrl) {
+        this.imageUrl = imageUrl;
     }
     <%_ } _%>
 
@@ -156,8 +163,16 @@ public class UserDTO {
         return activated;
     }
 
+    public void setActivated(boolean activated) {
+        this.activated = activated;
+    }
+
     public String getLangKey() {
         return langKey;
+    }
+
+    public void setLangKey(String langKey) {
+        this.langKey = langKey;
     }
     <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
 
@@ -165,12 +180,24 @@ public class UserDTO {
         return createdBy;
     }
 
+    public void setCreatedBy(String createdBy) {
+        this.createdBy = createdBy;
+    }
+
     public Instant getCreatedDate() {
         return createdDate;
     }
 
+    public void setCreatedDate(Instant createdDate) {
+        this.createdDate = createdDate;
+    }
+
     public String getLastModifiedBy() {
         return lastModifiedBy;
+    }
+
+    public void setLastModifiedBy(String lastModifiedBy) {
+        this.lastModifiedBy = lastModifiedBy;
     }
 
     public Instant getLastModifiedDate() {
@@ -184,6 +211,10 @@ public class UserDTO {
 
     public Set<String> getAuthorities() {
         return authorities;
+    }
+
+    public void setAuthorities(Set<String> authorities) {
+        this.authorities = authorities;
     }
 
     @Override

--- a/generators/server/templates/src/main/java/package/web/rest/vm/_ManagedUserVM.java
+++ b/generators/server/templates/src/main/java/package/web/rest/vm/_ManagedUserVM.java
@@ -21,11 +21,6 @@ package <%=packageName%>.web.rest.vm;
 import <%=packageName%>.service.dto.UserDTO;
 import javax.validation.constraints.Size;
 
-<%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-import java.time.Instant;
-<%_ } _%>
-import java.util.Set;
-
 /**
  * View Model extending the UserDTO, which is meant to be used in the user management UI.
  */
@@ -43,22 +38,14 @@ public class ManagedUserVM extends UserDTO {
     public ManagedUserVM() {
         // Empty constructor needed for Jackson.
     }
-
-    public ManagedUserVM(<% if (databaseType === 'mongodb' || databaseType === 'cassandra') { %>String<% } else { %>Long<% } %> id, String login, <% if (authenticationType !== 'oauth2') { %>String password, <% } %>String firstName, String lastName,
-                         String email, boolean activated<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, String imageUrl<% } %>, String langKey,
-                         <% if (databaseType === 'mongodb' || databaseType === 'sql') { %>String createdBy, Instant createdDate, String lastModifiedBy, Instant lastModifiedDate,
-                        <% } %>Set<String> authorities) {
-
-        super(id, login, firstName, lastName, email, activated<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, imageUrl<% } %>, langKey,
-            <% if (databaseType === 'mongodb' || databaseType === 'sql') { %>createdBy, createdDate, lastModifiedBy, lastModifiedDate,  <% } %>authorities);
-    <%_ if (authenticationType !== 'oauth2') { _%>
-        this.password = password;
-    <%_ } _%>
-    }
     <%_ if (authenticationType !== 'oauth2') { _%>
 
     public String getPassword() {
         return password;
+    }
+
+    public void setPassword(String password) {
+        this.password = password;
     }
     <%_ } _%>
 

--- a/generators/server/templates/src/test/java/package/web/rest/_AccountResourceIntTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_AccountResourceIntTest.java
@@ -354,25 +354,18 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void testRegisterValid() throws Exception {
-        ManagedUserVM validUser = new ManagedUserVM(
-            null,                   // id
-            "joe",                  // login
-            "password",             // password
-            "Joe",                  // firstName
-            "Shmoe",                // lastName
-            "joe@example.com",      // email
-            true,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM validUser = new ManagedUserVM();
+        validUser.setLogin("joe");
+        validUser.setPassword("password");
+        validUser.setFirstName("Joe");
+        validUser.setLastName("Shmoe");
+        validUser.setEmail("joe@example.com");
+        validUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        validUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        validUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        validUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restMvc.perform(
             post("/api/register")
@@ -387,25 +380,18 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void testRegisterInvalidLogin() throws Exception {
-        ManagedUserVM invalidUser = new ManagedUserVM(
-            null,                   // id
-            "funky-log!n",          // login <-- invalid
-            "password",             // password
-            "Funky",                // firstName
-            "One",                  // lastName
-            "funky@example.com",    // email
-            true,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM invalidUser = new ManagedUserVM();
+        invalidUser.setLogin("funky-log!n");// <-- invalid
+        invalidUser.setPassword("password");
+        invalidUser.setFirstName("Funky");
+        invalidUser.setLastName("One");
+        invalidUser.setEmail("funky@example.com");
+        invalidUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        invalidUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        invalidUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        invalidUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(
             post("/api/register")
@@ -420,25 +406,18 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void testRegisterInvalidEmail() throws Exception {
-        ManagedUserVM invalidUser = new ManagedUserVM(
-            null,               // id
-            "bob",              // login
-            "password",         // password
-            "Bob",              // firstName
-            "Green",            // lastName
-            "invalid",          // email <-- invalid
-            true,               // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM invalidUser = new ManagedUserVM();
+        invalidUser.setLogin("bob");
+        invalidUser.setPassword("password");
+        invalidUser.setFirstName("Bob");
+        invalidUser.setLastName("Green");
+        invalidUser.setEmail("invalid");// <-- invalid
+        invalidUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        invalidUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        invalidUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        invalidUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(
             post("/api/register")
@@ -453,25 +432,18 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void testRegisterInvalidPassword() throws Exception {
-        ManagedUserVM invalidUser = new ManagedUserVM(
-            null,               // id
-            "bob",              // login
-            "123",              // password with only 3 digits
-            "Bob",              // firstName
-            "Green",            // lastName
-            "bob@example.com",  // email
-            true,               // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM invalidUser = new ManagedUserVM();
+        invalidUser.setLogin("bob");
+        invalidUser.setPassword("123");// password with only 3 digits
+        invalidUser.setFirstName("Bob");
+        invalidUser.setLastName("Green");
+        invalidUser.setEmail("bob@example.com");
+        invalidUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        invalidUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        invalidUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        invalidUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(
             post("/api/register")
@@ -486,25 +458,18 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void testRegisterNullPassword() throws Exception {
-        ManagedUserVM invalidUser = new ManagedUserVM(
-            null,               // id
-            "bob",              // login
-            null,               // invalid null password
-            "Bob",              // firstName
-            "Green",            // lastName
-            "bob@example.com",  // email
-            true,               // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM invalidUser = new ManagedUserVM();
+        invalidUser.setLogin("bob");
+        invalidUser.setPassword(null);// invalid null password
+        invalidUser.setFirstName("Bob");
+        invalidUser.setLastName("Green");
+        invalidUser.setEmail("bob@example.com");
+        invalidUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        invalidUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        invalidUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        invalidUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(
             post("/api/register")
@@ -520,29 +485,38 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Transactional<% } %>
     public void testRegisterDuplicateLogin() throws Exception {
         // Good
-        ManagedUserVM validUser = new ManagedUserVM(
-            null,                   // id
-            "alice",                // login
-            "password",             // password
-            "Alice",                // firstName
-            "Something",            // lastName
-            "alice@example.com",    // email
-            true,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM validUser = new ManagedUserVM();
+        validUser.setLogin("alice");
+        validUser.setPassword("password");
+        validUser.setFirstName("Alice");
+        validUser.setLastName("Something");
+        validUser.setEmail("alice@example.com");
+        validUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        validUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        validUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        validUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         // Duplicate login, different email
-        ManagedUserVM duplicatedUser = new ManagedUserVM(validUser.getId(), validUser.getLogin(), validUser.getPassword(), validUser.getFirstName(), validUser.getLastName(),
-            "alicejr@example.com", true<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, validUser.getImageUrl()<% } %>, validUser.getLangKey()<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, validUser.getCreatedBy(), validUser.getCreatedDate(), validUser.getLastModifiedBy(), validUser.getLastModifiedDate()<% } %>, validUser.getAuthorities());
+        ManagedUserVM duplicatedUser = new ManagedUserVM();
+        duplicatedUser.setLogin(validUser.getLogin());
+        duplicatedUser.setPassword(validUser.getPassword());
+        duplicatedUser.setFirstName(validUser.getFirstName());
+        duplicatedUser.setLastName(validUser.getLastName());
+        duplicatedUser.setEmail("alicejr@example.com");
+        duplicatedUser.setActivated(validUser.isActivated());
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        duplicatedUser.setImageUrl(validUser.getImageUrl());
+        <%_ } _%>
+        duplicatedUser.setLangKey(validUser.getLangKey());
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        duplicatedUser.setCreatedBy(validUser.getCreatedBy());
+        duplicatedUser.setCreatedDate(validUser.getCreatedDate());
+        duplicatedUser.setLastModifiedBy(validUser.getLastModifiedBy());
+        duplicatedUser.setLastModifiedDate(validUser.getLastModifiedDate());
+        <%_ } _%>
+        duplicatedUser.setAuthorities(new HashSet<>(validUser.getAuthorities()));
 
         // Good user
         restMvc.perform(
@@ -566,29 +540,38 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Transactional<% } %>
     public void testRegisterDuplicateEmail() throws Exception {
         // Good
-        ManagedUserVM validUser = new ManagedUserVM(
-            null,                   // id
-            "john",                 // login
-            "password",             // password
-            "John",                 // firstName
-            "Doe",                  // lastName
-            "john@example.com",     // email
-            true,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.USER)));
+        ManagedUserVM validUser = new ManagedUserVM();
+        validUser.setLogin("john");
+        validUser.setPassword("password");
+        validUser.setFirstName("John");
+        validUser.setLastName("Doe");
+        validUser.setEmail("john@example.com");
+        validUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        validUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        validUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        validUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         // Duplicate email, different login
-        ManagedUserVM duplicatedUser = new ManagedUserVM(validUser.getId(), "johnjr", validUser.getPassword(), validUser.getLogin(), validUser.getLastName(),
-            validUser.getEmail(), true<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, validUser.getImageUrl()<% } %>, validUser.getLangKey()<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, validUser.getCreatedBy(), validUser.getCreatedDate(), validUser.getLastModifiedBy(), validUser.getLastModifiedDate()<% } %>, validUser.getAuthorities());
+        ManagedUserVM duplicatedUser = new ManagedUserVM();
+        duplicatedUser.setLogin("johnjr");
+        duplicatedUser.setPassword(validUser.getPassword());
+        duplicatedUser.setFirstName(validUser.getFirstName());
+        duplicatedUser.setLastName(validUser.getLastName());
+        duplicatedUser.setEmail(validUser.getEmail());
+        duplicatedUser.setActivated(validUser.isActivated());
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        duplicatedUser.setImageUrl(validUser.getImageUrl());
+        <%_ } _%>
+        duplicatedUser.setLangKey(validUser.getLangKey());
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        duplicatedUser.setCreatedBy(validUser.getCreatedBy());
+        duplicatedUser.setCreatedDate(validUser.getCreatedDate());
+        duplicatedUser.setLastModifiedBy(validUser.getLastModifiedBy());
+        duplicatedUser.setLastModifiedDate(validUser.getLastModifiedDate());
+        <%_ } _%>
+        duplicatedUser.setAuthorities(new HashSet<>(validUser.getAuthorities()));
 
         // Good user
         restMvc.perform(
@@ -605,8 +588,25 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
             .andExpect(status().is4xxClientError());
 
         // Duplicate email - with uppercase email address
-        final ManagedUserVM userWithUpperCaseEmail = new ManagedUserVM(validUser.getId(), "johnjr", validUser.getPassword(), validUser.getLogin(), validUser.getLastName(),
-                validUser.getEmail().toUpperCase(), true<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, validUser.getImageUrl()<% } %>, validUser.getLangKey()<% if (databaseType === 'mongodb' || databaseType === 'sql') { %>, validUser.getCreatedBy(), validUser.getCreatedDate(), validUser.getLastModifiedBy(), validUser.getLastModifiedDate()<% } %>, validUser.getAuthorities());
+        ManagedUserVM userWithUpperCaseEmail = new ManagedUserVM();
+        userWithUpperCaseEmail.setId(validUser.getId());
+        userWithUpperCaseEmail.setLogin("johnjr");
+        userWithUpperCaseEmail.setPassword(validUser.getPassword());
+        userWithUpperCaseEmail.setFirstName(validUser.getFirstName());
+        userWithUpperCaseEmail.setLastName(validUser.getLastName());
+        userWithUpperCaseEmail.setEmail(validUser.getEmail().toUpperCase());
+        userWithUpperCaseEmail.setActivated(validUser.isActivated());
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        userWithUpperCaseEmail.setImageUrl(validUser.getImageUrl());
+        <%_ } _%>
+        userWithUpperCaseEmail.setLangKey(validUser.getLangKey());
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        userWithUpperCaseEmail.setCreatedBy(validUser.getCreatedBy());
+        userWithUpperCaseEmail.setCreatedDate(validUser.getCreatedDate());
+        userWithUpperCaseEmail.setLastModifiedBy(validUser.getLastModifiedBy());
+        userWithUpperCaseEmail.setLastModifiedDate(validUser.getLastModifiedDate());
+        <%_ } _%>
+        userWithUpperCaseEmail.setAuthorities(new HashSet<>(validUser.getAuthorities()));
 
         restMvc.perform(
             post("/api/register")
@@ -621,25 +621,18 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void testRegisterAdminIsIgnored() throws Exception {
-        ManagedUserVM validUser = new ManagedUserVM(
-            null,                   // id
-            "badguy",               // login
-            "password",             // password
-            "Bad",                  // firstName
-            "Guy",                  // lastName
-            "badguy@example.com",   // email
-            true,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.ADMIN)));
+        ManagedUserVM validUser = new ManagedUserVM();
+        validUser.setLogin("badguy");
+        validUser.setPassword("password");
+        validUser.setFirstName("Bad");
+        validUser.setLastName("Guy");
+        validUser.setEmail("badguy@example.com");
+        validUser.setActivated(true);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        validUser.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        validUser.setLangKey(Constants.DEFAULT_LANGUAGE);
+        validUser.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restMvc.perform(
             post("/api/register")
@@ -698,25 +691,17 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
 
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user);
 
-        UserDTO userDTO = new UserDTO(
-            null,                   // id
-            "not-used",          // login
-            "firstname",                // firstName
-            "lastname",                  // lastName
-            "save-account@example.com",    // email
-            false,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.ADMIN))
-        );
+        UserDTO userDTO = new UserDTO();
+        userDTO.setLogin("not-used");
+        userDTO.setFirstName("firstname");
+        userDTO.setLastName("lastname");
+        userDTO.setEmail("save-account@example.com");
+        userDTO.setActivated(false);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        userDTO.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
 
         restMvc.perform(
             post("/api/account")
@@ -750,25 +735,17 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
 
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user);
 
-        UserDTO userDTO = new UserDTO(
-            null,                   // id
-            "not-used",          // login
-            "firstname",                // firstName
-            "lastname",                  // lastName
-            "invalid email",    // email
-            false,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.ADMIN))
-        );
+        UserDTO userDTO = new UserDTO();
+        userDTO.setLogin("not-used");
+        userDTO.setFirstName("firstname");
+        userDTO.setLastName("lastname");
+        userDTO.setEmail("invalid email");
+        userDTO.setActivated(false);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        userDTO.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
 
         restMvc.perform(
             post("/api/account")
@@ -805,25 +782,17 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
 
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(anotherUser);
 
-        UserDTO userDTO = new UserDTO(
-            null,                   // id
-            "not-used",          // login
-            "firstname",                // firstName
-            "lastname",                  // lastName
-            "save-existing-email2@example.com",    // email
-            false,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.ADMIN))
-        );
+        UserDTO userDTO = new UserDTO();
+        userDTO.setLogin("not-used");
+        userDTO.setFirstName("firstname");
+        userDTO.setLastName("lastname");
+        userDTO.setEmail("save-existing-email2@example.com");
+        userDTO.setActivated(false);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        userDTO.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
 
         restMvc.perform(
             post("/api/account")
@@ -850,25 +819,17 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
 
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user);
 
-        UserDTO userDTO = new UserDTO(
-            null,                   // id
-            "not-used",          // login
-            "firstname",                // firstName
-            "lastname",                  // lastName
-            "save-existing-email-and-login@example.com",    // email
-            false,                   // activated
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            "http://placehold.it/50x50", //imageUrl
-            <%_ } _%>
-            Constants.DEFAULT_LANGUAGE,// langKey
-            <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
-            null,                   // createdBy
-            null,                   // createdDate
-            null,                   // lastModifiedBy
-            null,                   // lastModifiedDate
-            <%_ } _%>
-            new HashSet<>(Collections.singletonList(AuthoritiesConstants.ADMIN))
-        );
+        UserDTO userDTO = new UserDTO();
+        userDTO.setLogin("not-used");
+        userDTO.setFirstName("firstname");
+        userDTO.setLastName("lastname");
+        userDTO.setEmail("save-existing-email-and-login@example.com");
+        userDTO.setActivated(false);
+        <%_ if (databaseType === 'mongodb' || databaseType === 'sql') { _%>
+        userDTO.setImageUrl("http://placehold.it/50x50");
+        <%_ } _%>
+        userDTO.setLangKey(Constants.DEFAULT_LANGUAGE);
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
 
         restMvc.perform(
             post("/api/account")

--- a/generators/server/templates/src/test/java/package/web/rest/_UserResourceIntTest.java
+++ b/generators/server/templates/src/test/java/package/web/rest/_UserResourceIntTest.java
@@ -214,27 +214,18 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
         // Create the User
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            null,
-            DEFAULT_LOGIN,
-            DEFAULT_PASSWORD,
-            DEFAULT_FIRSTNAME,
-            DEFAULT_LASTNAME,
-            DEFAULT_EMAIL,
-            true,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            DEFAULT_IMAGEURL,
-            <%_ } _%>
-            DEFAULT_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            null,
-            null,
-            null,
-            null,
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin(DEFAULT_LOGIN);
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail(DEFAULT_EMAIL);
+        managedUserVM.setActivated(true);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        <%_ } _%>
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(post("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -262,33 +253,25 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
     public void createUserWithExistingId() throws Exception {
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            <%_ if (databaseType === 'cassandra') { _%>
-            UUID.randomUUID().toString(),
-            <%_ } else if (databaseType === 'mongodb') { _%>
-            "1L",
-            <%_ } else { _%>
-            1L,
-            <%_ } _%>
-            DEFAULT_LOGIN,
-            DEFAULT_PASSWORD,
-            DEFAULT_FIRSTNAME,
-            DEFAULT_LASTNAME,
-            DEFAULT_EMAIL,
-            true,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            DEFAULT_IMAGEURL,
-            <%_ } _%>
-            DEFAULT_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            null,
-            null,
-            null,
-            null,
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        <%_ if (databaseType === 'cassandra') { _%>
+        managedUserVM.setId(UUID.randomUUID().toString());
+        <%_ } else if (databaseType === 'mongodb') { _%>
+        managedUserVM.setId("1L");
+        <%_ } else { _%>
+        managedUserVM.setId(1L);
+        <%_ } _%>
+        managedUserVM.setLogin(DEFAULT_LOGIN);
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail(DEFAULT_EMAIL);
+        managedUserVM.setActivated(true);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        <%_ } _%>
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         // An entity with an existing ID cannot be created, so this API call must fail
         restUserMockMvc.perform(post("/api/users")
@@ -313,27 +296,18 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         <%_ } _%>
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            null,
-            DEFAULT_LOGIN, // this login should already be used
-            DEFAULT_PASSWORD,
-            DEFAULT_FIRSTNAME,
-            DEFAULT_LASTNAME,
-            "anothermail@localhost",
-            true,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            DEFAULT_IMAGEURL,
-            <%_ } _%>
-            DEFAULT_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            null,
-            null,
-            null,
-            null,
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin(DEFAULT_LOGIN);// this login should already be used
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail("anothermail@localhost");
+        managedUserVM.setActivated(true);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        <%_ } _%>
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         // Create the User
         restUserMockMvc.perform(post("/api/users")
@@ -358,27 +332,18 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         <%_ } _%>
         int databaseSizeBeforeCreate = userRepository.findAll().size();
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            null,
-            "anotherlogin",
-            DEFAULT_PASSWORD,
-            DEFAULT_FIRSTNAME,
-            DEFAULT_LASTNAME,
-            DEFAULT_EMAIL, // this email should already be used
-            true,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            DEFAULT_IMAGEURL,
-            <%_ } _%>
-            DEFAULT_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            null,
-            null,
-            null,
-            null,
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setLogin("anotherlogin");
+        managedUserVM.setPassword(DEFAULT_PASSWORD);
+        managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
+        managedUserVM.setLastName(DEFAULT_LASTNAME);
+        managedUserVM.setEmail(DEFAULT_EMAIL);// this email should already be used
+        managedUserVM.setActivated(true);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
+        <%_ } _%>
+        managedUserVM.setLangKey(DEFAULT_LANGKEY);
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         // Create the User
         restUserMockMvc.perform(post("/api/users")
@@ -468,27 +433,25 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            updatedUser.getId(),
-            updatedUser.getLogin(),
-            UPDATED_PASSWORD,
-            UPDATED_FIRSTNAME,
-            UPDATED_LASTNAME,
-            UPDATED_EMAIL,
-            updatedUser.getActivated(),
-            <%_ if (databaseType !== 'cassandra') { _%>
-            UPDATED_IMAGEURL,
-            <%_ } _%>
-            UPDATED_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            updatedUser.getCreatedBy(),
-            updatedUser.getCreatedDate(),
-            updatedUser.getLastModifiedBy(),
-            updatedUser.getLastModifiedDate(),
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setId(updatedUser.getId());
+        managedUserVM.setLogin(updatedUser.getLogin());
+        managedUserVM.setPassword(UPDATED_PASSWORD);
+        managedUserVM.setFirstName(UPDATED_FIRSTNAME);
+        managedUserVM.setLastName(UPDATED_LASTNAME);
+        managedUserVM.setEmail(UPDATED_EMAIL);
+        managedUserVM.setActivated(updatedUser.getActivated());
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(UPDATED_IMAGEURL);
+        <%_ } _%>
+        managedUserVM.setLangKey(UPDATED_LANGKEY);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setCreatedBy(updatedUser.getCreatedBy());
+        managedUserVM.setCreatedDate(updatedUser.getCreatedDate());
+        managedUserVM.setLastModifiedBy(updatedUser.getLastModifiedBy());
+        managedUserVM.setLastModifiedDate(updatedUser.getLastModifiedDate());
+        <%_ } _%>
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -523,27 +486,25 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            updatedUser.getId(),
-            UPDATED_LOGIN,
-            UPDATED_PASSWORD,
-            UPDATED_FIRSTNAME,
-            UPDATED_LASTNAME,
-            UPDATED_EMAIL,
-            updatedUser.getActivated(),
-            <%_ if (databaseType !== 'cassandra') { _%>
-            UPDATED_IMAGEURL,
-            <%_ } _%>
-            UPDATED_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            updatedUser.getCreatedBy(),
-            updatedUser.getCreatedDate(),
-            updatedUser.getLastModifiedBy(),
-            updatedUser.getLastModifiedDate(),
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setId(updatedUser.getId());
+        managedUserVM.setLogin(UPDATED_LOGIN);
+        managedUserVM.setPassword(UPDATED_PASSWORD);
+        managedUserVM.setFirstName(UPDATED_FIRSTNAME);
+        managedUserVM.setLastName(UPDATED_LASTNAME);
+        managedUserVM.setEmail(UPDATED_EMAIL);
+        managedUserVM.setActivated(updatedUser.getActivated());
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(UPDATED_IMAGEURL);
+        <%_ } _%>
+        managedUserVM.setLangKey(UPDATED_LANGKEY);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setCreatedBy(updatedUser.getCreatedBy());
+        managedUserVM.setCreatedDate(updatedUser.getCreatedDate());
+        managedUserVM.setLastModifiedBy(updatedUser.getLastModifiedBy());
+        managedUserVM.setLastModifiedDate(updatedUser.getLastModifiedDate());
+        <%_ } _%>
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -597,27 +558,25 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            updatedUser.getId(),
-            updatedUser.getLogin(),
-            updatedUser.getPassword(),
-            updatedUser.getFirstName(),
-            updatedUser.getLastName(),
-            "jhipster@localhost",  // this email should already be used by anotherUser
-            updatedUser.getActivated(),
-            <%_ if (databaseType !== 'cassandra') { _%>
-            updatedUser.getImageUrl(),
-            <%_ } _%>
-            updatedUser.getLangKey(),
-            <%_ if (databaseType !== 'cassandra') { _%>
-            updatedUser.getCreatedBy(),
-            updatedUser.getCreatedDate(),
-            updatedUser.getLastModifiedBy(),
-            updatedUser.getLastModifiedDate(),
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setId(updatedUser.getId());
+        managedUserVM.setLogin(updatedUser.getLogin());
+        managedUserVM.setPassword(updatedUser.getPassword());
+        managedUserVM.setFirstName(updatedUser.getFirstName());
+        managedUserVM.setLastName(updatedUser.getLastName());
+        managedUserVM.setEmail("jhipster@localhost");// this email should already be used by anotherUser
+        managedUserVM.setActivated(updatedUser.getActivated());
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(updatedUser.getImageUrl());
+        <%_ } _%>
+        managedUserVM.setLangKey(updatedUser.getLangKey());
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setCreatedBy(updatedUser.getCreatedBy());
+        managedUserVM.setCreatedDate(updatedUser.getCreatedDate());
+        managedUserVM.setLastModifiedBy(updatedUser.getLastModifiedBy());
+        managedUserVM.setLastModifiedDate(updatedUser.getLastModifiedDate());
+        <%_ } _%>
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -658,27 +617,25 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         // Update the user
         User updatedUser = userRepository.findOne(user.getId());
 
-        Set<String> authorities = new HashSet<>();
-        authorities.add(AuthoritiesConstants.USER);
-        ManagedUserVM managedUserVM = new ManagedUserVM(
-            updatedUser.getId(),
-            "jhipster", // this login should already be used by anotherUser
-            updatedUser.getPassword(),
-            updatedUser.getFirstName(),
-            updatedUser.getLastName(),
-            updatedUser.getEmail(),
-            updatedUser.getActivated(),
-            <%_ if (databaseType !== 'cassandra') { _%>
-            updatedUser.getImageUrl(),
-            <%_ } _%>
-            updatedUser.getLangKey(),
-            <%_ if (databaseType !== 'cassandra') { _%>
-            updatedUser.getCreatedBy(),
-            updatedUser.getCreatedDate(),
-            updatedUser.getLastModifiedBy(),
-            updatedUser.getLastModifiedDate(),
-            <%_ } _%>
-            authorities);
+        ManagedUserVM managedUserVM = new ManagedUserVM();
+        managedUserVM.setId(updatedUser.getId());
+        managedUserVM.setLogin("jhipster");// this login should already be used by anotherUser
+        managedUserVM.setPassword(updatedUser.getPassword());
+        managedUserVM.setFirstName(updatedUser.getFirstName());
+        managedUserVM.setLastName(updatedUser.getLastName());
+        managedUserVM.setEmail(updatedUser.getEmail());
+        managedUserVM.setActivated(updatedUser.getActivated());
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setImageUrl(updatedUser.getImageUrl());
+        <%_ } _%>
+        managedUserVM.setLangKey(updatedUser.getLangKey());
+        <%_ if (databaseType !== 'cassandra') { _%>
+        managedUserVM.setCreatedBy(updatedUser.getCreatedBy());
+        managedUserVM.setCreatedDate(updatedUser.getCreatedDate());
+        managedUserVM.setLastModifiedBy(updatedUser.getLastModifiedBy());
+        managedUserVM.setLastModifiedDate(updatedUser.getLastModifiedDate());
+        <%_ } _%>
+        managedUserVM.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
 
         restUserMockMvc.perform(put("/api/users")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
@@ -750,24 +707,23 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
 
     @Test
     public void testUserDTOtoUser() {
-        UserDTO userDTO = new UserDTO(
-            DEFAULT_ID,
-            DEFAULT_LOGIN,
-            DEFAULT_FIRSTNAME,
-            DEFAULT_LASTNAME,
-            DEFAULT_EMAIL,
-            true,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            DEFAULT_IMAGEURL,
-            <%_ } _%>
-            DEFAULT_LANGKEY,
-            <%_ if (databaseType !== 'cassandra') { _%>
-            DEFAULT_LOGIN,
-            null,
-            DEFAULT_LOGIN,
-            null,
-            <%_ } _%>
-            Stream.of(AuthoritiesConstants.USER).collect(Collectors.toSet()));
+        UserDTO userDTO = new UserDTO();
+        userDTO.setId(DEFAULT_ID);
+        userDTO.setLogin(DEFAULT_LOGIN);
+        userDTO.setFirstName(DEFAULT_FIRSTNAME);
+        userDTO.setLastName(DEFAULT_LASTNAME);
+        userDTO.setEmail(DEFAULT_EMAIL);
+        userDTO.setActivated(true);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        userDTO.setImageUrl(DEFAULT_IMAGEURL);
+        <%_ } _%>
+        userDTO.setLangKey(DEFAULT_LANGKEY);
+        <%_ if (databaseType !== 'cassandra') { _%>
+        userDTO.setCreatedBy(DEFAULT_LOGIN);
+        userDTO.setLastModifiedBy(DEFAULT_LOGIN);
+        <%_ } _%>
+        userDTO.setAuthorities(Collections.singleton(AuthoritiesConstants.USER));
+
         User user = userMapper.userDTOToUser(userDTO);
         assertThat(user.getId()).isEqualTo(DEFAULT_ID);
         assertThat(user.getLogin()).isEqualTo(DEFAULT_LOGIN);


### PR DESCRIPTION
- Define setters in UserDTO and ManagedUserVM
- Avoid to have a constructor with "too" many arguments..
- Knowing what fields are set, (vs comments in the constructor call)
- Avoid pass `null` for several fields in Tests (`createdBy`, `createdDate`, `lastModifiedBy`, `lastModifiedDate`)
- having UserDTO and ManagedUserVM looking the same that EntityDTO (getters + setters)

It is mostly about readability (big constructor vs setters) and people taste as well (?), so feel free to close it if the added value is not worth or if I missed something. thx.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
