### PR TITLE
Fix protractor tests for NPM

### DIFF
--- a/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
@@ -22,16 +22,21 @@ const HtmlScreenshotReporter = require("protractor-jasmine2-screenshot-reporter"
 const JasmineReporters = require('jasmine-reporters');
 
 const prefix = '<%= TEST_SRC_DIR %>'.replace(/[^/]+/g,'..');
+<%_ if (clientPackageManager === 'npm') { _%>
+const seleniumFolder = 'node_modules/protractor/node_modules/webdriver-manager/selenium/';
+<%_ } else { _%>
+const seleniumFolder = 'node_modules/webdriver-manager/selenium/';
+<%_ } _%>
 
 var webbrowserDriver= '';
 if (os.platform() === 'win32') {
-    webbrowserDriver = prefix + 'node_modules/webdriver-manager/selenium/chromedriver_2.33.exe';
+    webbrowserDriver = prefix + seleniumFolder + 'chromedriver_2.33.exe';
 } else {
-    webbrowserDriver = prefix + 'node_modules/webdriver-manager/selenium/chromedriver_2.33';
+    webbrowserDriver = prefix + seleniumFolder + 'chromedriver_2.33';
 }
 
 exports.config = {
-    seleniumServerJar: prefix + 'node_modules/webdriver-manager/selenium/selenium-server-standalone-3.6.0.jar',
+    seleniumServerJar: prefix + seleniumFolder + 'selenium-server-standalone-3.6.0.jar',
     chromeDriver: webbrowserDriver,
     allScriptsTimeout: 20000,
 


### PR DESCRIPTION
Related to @deepu105's https://github.com/jhipster/generator-jhipster/pull/6474#issuecomment-340284102

The reason why the build failed, is because you used NPM instead of Yarn. With that, we detected this issue. As the `node_modules` folder is managed differently between Yarn and NPM, the selenium folder is not at the same place.

It should fix the build in the [generator-jhipster-entity-audit](https://github.com/hipster-labs/generator-jhipster-entity-audit)

___

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
