### PR TITLE
Remove duplicate security configuration

### DIFF
--- a/generators/server/templates/src/test/resources/config/_application.yml
+++ b/generators/server/templates/src/test/resources/config/_application.yml
@@ -121,50 +121,6 @@ spring:
 liquibase:
     contexts: test
 
-<%_ if (authenticationType === 'oauth2') { _%>
-# ===================================================================
-# OpenID Connect Settings. Default settings are for Keycloak in Docker.
-# Start Keycloak using `docker-compose -f src/main/docker/keycloak.yml up`.
-#
-# To use Okta, your settings should resemble the following:
-#
-# accessTokenUri: https://{yourOktaDomain}.com/oauth2/default/v1/token
-# userAuthorizationUri: https://{yourOktaDomain}.com/oauth2/default/v1/authorize
-# clientId: {copy after creating an OIDC app}
-# clientSecret: {copy after creating an OIDC app}
-# userInfoUri: https://{yourOktaDomain}.com/oauth2/default/v1/userinfo
-# tokenInfoUri: https://{yourOktaDomain}.com/oauth2/default/v1/introspect
-#
-# You can also override these properties using environment variables.
-# For example:
-#
-# export SECURITY_OAUTH2_CLIENT_CLIENT_ID="jhipster"
-# export SECURITY_OAUTH2_CLIENT_CLIENT_SECRET="38561a05"
-# ===================================================================
-<%_ } _%>
-security:
-    basic:
-        enabled: false
-    <%_ if (authenticationType === 'uaa') { _%>
-    oauth2:
-        resource:
-            filter-order: 3
-    <%_ } else if (authenticationType === 'oauth2') { _%>
-    oauth2:
-        client:
-            access-token-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/token
-            user-authorization-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/auth
-            client-id: web_app
-            client-secret: web_app
-            client-authentication-scheme: form
-            scope: openid profile email
-        resource:
-            filter-order: 3
-            user-info-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/userinfo
-            token-info-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/token/introspect
-            prefer-token-info: false
-    <%_ } _%>
-
 server:
     port: 10344
     address: localhost


### PR DESCRIPTION
When I was refactoring the OIDC / OAuth integration, I found I needed to have the security settings duplicated in the test directory's `application.yml`. This seemed strange, especially since the property values are the same as the ones in the main directory's `application.yml`. Now, it seems this is no longer necessary.

I tested this by making this modification in the generator-jhipster project and then running `npm link`. 

Then I generated three different projects with OAuth 2.0, Session Auth, and JWT. I ran `./mvnw test` in each to confirm everything worked. I did not test UAA, but I'm guessing the behavior should be the same.