### PR TITLE
Auto-complete fields for the entities

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -405,7 +405,9 @@ const files = {
                 'shared/alert/alert.component.ts',
                 'shared/alert/alert-error.component.ts',
                 // dates
-                'shared/util/datepicker-adapter.ts'
+                'shared/util/datepicker-adapter.ts',
+                // fields
+                'shared/fields/base-form-field.component.ts'
             ]
         },
         {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/fields/base-autocomplete.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/fields/base-autocomplete.component.ts.ejs
@@ -1,0 +1,52 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+
+export class BaseAutocompleteField<T> extends BaseFormField<T> {
+    searching = false;
+    searchFailed = false;
+    selected: T;
+    hideSearchingWhenUnsubscribed = new Observable(() => () => this.searching = false);
+
+    constructor(
+            config: NgbTypeaheadConfig
+        ) {
+            super();
+            config.showHint = true;
+        }
+
+    search = (text$: Observable<string>) =>
+        text$
+            .debounceTime(300)
+            .distinctUntilChanged()
+            .do(() => this.searching = true)
+            .switchMap((term) =>
+                this.<%= entityInstance %>Service.query({'<%= autocompleteField %>.contains': term})
+                    .do(() => this.searchFailed = false)
+                    .map((r: HttpResponse<I<%= entityAngularName %>[]>) => {
+                        this.searchFailed = (r.body.length === 0);
+                        return r.body;
+                    })
+                    .catch(() => {
+                        this.searchFailed = true;
+                        return Observable.of([]);
+                    }))
+                .do(() => this.searching = false)
+                .merge(this.hideSearchingWhenUnsubscribed)
+    
+    

--- a/generators/client/templates/angular/src/main/webapp/app/shared/fields/base-form-field.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/fields/base-form-field.component.ts.ejs
@@ -1,0 +1,62 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { ControlValueAccessor } from '@angular/forms';
+
+export class BaseFormField<T> implements ControlValueAccessor {
+    private innerValue: T;
+    protected disabled: boolean;
+
+    private changed = new Array<(value: T) => void>();
+    private touched = new Array<() => void>();
+
+    public getValue(): T {
+        return this.innerValue;
+    }
+
+    protected setValue(value: T) {
+        if (this.innerValue !== value) {
+            this.innerValue = value;
+            this.changed.forEach((f) => f(value));
+        }
+    }
+
+    protected forceOnChange() {
+        this.changed.forEach((f) => f(this.innerValue));
+    }
+
+    touch() {
+        this.touched.forEach((f) => f());
+    }
+
+    writeValue(value: T) {
+        this.innerValue = value;
+    }
+
+    registerOnChange(fn: (value: T) => void) {
+        this.changed.push(fn);
+    }
+
+    registerOnTouched(fn: () => void) {
+        this.touched.push(fn);
+    }
+
+    setDisabledState(isDisabled: boolean) {
+        this.disabled = isDisabled;
+    }
+}

--- a/generators/client/templates/angular/src/main/webapp/app/shared/index.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/index.ts.ejs
@@ -20,6 +20,7 @@ export * from './constants/input.constants';
 export * from './alert/alert.component';
 export * from './alert/alert-error.component';
 export * from './auth/has-any-authority.directive';
+export * from './fields/base-form-field.component';
 <%_ if (enableTranslation) { _%>
 export * from './language/find-language-from-key.pipe';
 <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
@@ -23,6 +23,13 @@ import '../content/scss/vendor.scss';
 <%_} else { _%>
 import '../content/css/vendor.css';
 <%_ } _%>
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
+import 'rxjs/add/operator/debounceTime';
+import 'rxjs/add/operator/do';
+import 'rxjs/add/operator/distinctUntilChanged';
+import 'rxjs/add/observable/of';
+import 'rxjs/add/observable/throw';
 
 // Imports all fontawesome core and solid icons
 

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -62,6 +62,18 @@ const angularFiles = {
                     renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}-delete-dialog.component.html`
                 },
                 {
+                    file: 'entities/entity-multi-selection.component.html',
+                    method: 'processHtml',
+                    template: true,
+                    renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}-multi-selection.component.html`
+                },
+                {
+                    file: 'entities/entity-selection.component.html',
+                    method: 'processHtml',
+                    template: true,
+                    renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}-selection.component.html`
+                },
+                {
                     file: 'entities/index.ts',
                     renameTo: generator => `entities/${generator.entityFolderName}/index.ts`
                 },
@@ -81,6 +93,14 @@ const angularFiles = {
                 {
                     file: 'entities/entity-management.component.ts',
                     renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}.component.ts`
+                },
+                {
+                    file: 'entities/entity-multi-selection.component.ts',
+                    renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}-multi-selection.component.ts`
+                },
+                {
+                    file: 'entities/entity-selection.component.ts',
+                    renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}-selection.component.ts`
                 },
                 {
                     file: 'entities/entity-management-update.component.ts',

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -189,59 +189,24 @@
                 const otherEntityField = relationships[idx].otherEntityField;
                 const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
                 const relationshipRequired = relationships[idx].relationshipRequired;
+                const multiSelection = (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true);
+                const uiFieldType = relationships[idx].uiFieldType + (multiSelection ? '-multi-selection' : '-selection');
+                const fieldToSave = entityInstance + '.' + (multiSelection ? relationshipFieldNamePlural : relationshipFieldName) + (dto === 'no' ? '' : 'Id');
                 const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
                 <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true && otherEntityName === 'user')) { _%>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
-                    <%_ if (dto === 'no') { _%>
-                    <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= entityInstance %>.<%=relationshipFieldName %>" <% if (relationshipRequired) { %> required<% } %>>
-                        <%_ if (!relationshipRequired) { _%>
-                        <option [ngValue]="null"></option>
-                        <%_ } else { _%>
-                        <option *ngIf="!editForm.value.<%= relationshipName %>" [ngValue]="null" selected></option>
-                        <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === <%= entityInstance %>.<%=relationshipFieldName %>?.id ? <%= entityInstance %>.<%=relationshipFieldName %> : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: track<%=otherEntityNameCapitalized %>ById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
-                    </select>
-                    <%_ } else { _%>
-                    <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= entityInstance %>.<%=relationshipFieldName %>Id" <% if (relationshipRequired) { %> required<% } %>>
-                        <%_ if (!relationshipRequired) { _%>
-                        <option [ngValue]="null"></option>
-                        <%_ } else { _%>
-                        <option *ngIf="!editForm.value.<%= relationshipName %>" [ngValue]="null" selected></option>
-                        <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: track<%=otherEntityNameCapitalized %>ById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
-                    </select>
-                    <%_ } _%>
+                    <<%= uiFieldType %> id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= fieldToSave %>" <% if (relationshipRequired) { %> required<% } %>></<%= uiFieldType %>>
                 </div>
                 <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true) { _%>
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
-                    <%_ if (dto === 'no') { _%>
-                    <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= entityInstance %>.<%=relationshipFieldName %>"<% if (relationshipRequired) { %> required<% } %>>
-                        <%_ if (!relationshipRequired) { _%>
-                        <option [ngValue]="null"></option>
-                        <%_ } else { _%>
-                        <option *ngIf="!editForm.value.<%= relationshipName %>" [ngValue]="null" selected></option>
-                        <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === <%= entityInstance %>.<%=relationshipFieldName %>?.id ? <%= entityInstance %>.<%=relationshipFieldName %> : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: track<%=otherEntityNameCapitalized %>ById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
-                    </select>
-                    <%_ } else { _%>
-                    <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= entityInstance %>.<%=relationshipFieldName %>Id"<% if (relationshipRequired) { %> required<% } %>>
-                        <%_ if (!relationshipRequired) { _%>
-                        <option [ngValue]="null"></option>
-                        <%_ } else { _%>
-                        <option *ngIf="!editForm.value.<%= relationshipName %>" [ngValue]="null" selected></option>
-                        <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: track<%=otherEntityNameCapitalized %>ById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
-                    </select>
-                    <%_ } _%>
+                    <<%= uiFieldType %> id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= fieldToSave %>" <% if (relationshipRequired) { %> required<% } %>></<%= uiFieldType %>>
                 </div>
-                <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
+                <%_ } else if (relationshipType === 'many-to-many' && ownerSide === true) { _%>
                 <div class="form-group">
                     <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
-                    <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" [(ngModel)]="<%=entityInstance %>.<%=relationshipFieldNamePlural %>"<% if (relationshipRequired) { %> required<% } %>>
-                        <option [ngValue]="getSelected(<%=entityInstance %>.<%=relationshipFieldNamePlural %>, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: track<%=otherEntityNameCapitalized %>ById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
-                    </select>
+                    <<%= uiFieldType %> id="field_<%= relationshipName %>" name="<%= relationshipName %>" [(ngModel)]="<%= fieldToSave %>" <% if (relationshipRequired) { %> required<% } %>></<%= uiFieldType %>>
                 </div>
                 <%_ } _%>
                 <%_ if (relationships[idx].relationshipValidate === true) { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -30,35 +30,10 @@ import { Observable } from 'rxjs';
 import * as moment from 'moment';
 import { DATE_TIME_FORMAT } from 'app/shared/constants/input.constants';
 <%_ } _%>
-<%_ if (queries && queries.length > 0 || fieldsContainBlob) { _%>
-import { <% if (queries && queries.length > 0) { %>JhiAlertService, <% } %><% if (fieldsContainBlob) { %>JhiDataUtils<% } %> } from 'ng-jhipster';
-<%_ } _%>
+import { <% if (fieldsContainBlob) { %>JhiDataUtils<% } %> } from 'ng-jhipster';
 
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
-<%_
-let hasRelationshipQuery = false;
-Object.keys(differentRelationships).forEach(key => {
-    const hasAnyRelationshipQuery = differentRelationships[key].some(rel =>
-        (rel.relationshipType === 'one-to-one' && rel.ownerSide === true && rel.otherEntityName !== 'user')
-            || rel.relationshipType !== 'one-to-many'
-    );
-    if (hasAnyRelationshipQuery) {
-        hasRelationshipQuery = true;
-    }
-    if (differentRelationships[key].some(rel => rel.relationshipType !== 'one-to-many')) {
-        const uniqueRel = differentRelationships[key][0];
-        if (uniqueRel.otherEntityAngularName !== entityAngularName) {
-            if (uniqueRel.otherEntityAngularName === 'User') {
-_%>
-import { I<%= uniqueRel.otherEntityAngularName %>, <%= uniqueRel.otherEntityAngularName%>Service } from 'app/core';
-<%_         } else { _%>
-import { I<%= uniqueRel.otherEntityAngularName %> } from 'app/shared/model/<%= uniqueRel.otherEntityModelName %>.model';
-import { <%= uniqueRel.otherEntityAngularName%>Service } from 'app/entities/<%= uniqueRel.otherEntityPath %>';
-<%_         }
-        }
-    }
-}); _%>
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>-update',
@@ -68,10 +43,6 @@ export class <%= entityAngularName %>UpdateComponent implements OnInit {
 
     private _<%= entityInstance %>: I<%= entityAngularName %>;
     isSaving: boolean;
-    <%_
-    for ( const idx in variables ) { %>
-    <%- variables[idx] %>
-    <%_ } _%>
     <%_ for ( idx in fields ) {
         const fieldName = fields[idx].fieldName;
         const fieldType = fields[idx].fieldType;
@@ -86,19 +57,7 @@ export class <%= entityAngularName %>UpdateComponent implements OnInit {
         <%_ if (fieldsContainBlob) { _%>
         private dataUtils: JhiDataUtils,
         <%_ } _%>
-        <%_ if (queries && queries.length > 0) { _%>
-        private jhiAlertService: JhiAlertService,
-        <%_ } _%>
         private <%= entityInstance %>Service: <%= entityAngularName %>Service,
-        <%_ Object.keys(differentRelationships).forEach(key => {
-            if (differentRelationships[key].some(rel => rel.relationshipType !== 'one-to-many')) {
-                const uniqueRel = differentRelationships[key][0];
-                if (uniqueRel.otherEntityAngularName !== entityAngularName) { _%>
-        private <%= uniqueRel.otherEntityName %>Service: <%= uniqueRel.otherEntityAngularName %>Service,
-        <%_
-                }
-            }
-        }); _%>
         <%_ if (fieldsContainImageBlob) { _%>
         private elementRef: ElementRef,
         <%_ } _%>
@@ -111,9 +70,6 @@ export class <%= entityAngularName %>UpdateComponent implements OnInit {
         this.activatedRoute.data.subscribe(({<%= entityInstance %>}) => {
             this.<%= entityInstance %> = <%= entityInstance %>;
         });
-        <%_ for (idx in queries) { _%>
-        <%- queries[idx] %>
-        <%_ } _%>
     }
 
     <%_ if (fieldsContainBlob) { _%>
@@ -171,36 +127,7 @@ export class <%= entityAngularName %>UpdateComponent implements OnInit {
     private onSaveError() {
         this.isSaving = false;
     }
-    <%_ if (queries && queries.length > 0) { _%>
 
-    private onError(errorMessage: string) {
-        this.jhiAlertService.error(errorMessage, null, null);
-    }
-    <%_ } _%>
-    <%_
-    const entitiesSeen = [];
-    for (idx in relationships) {
-        const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-        if (relationships[idx].relationshipType !== 'one-to-many' && !entitiesSeen.includes(otherEntityNameCapitalized)) {
-    _%>
-
-    track<%= otherEntityNameCapitalized %>ById(index: number, item: I<%= relationships[idx].otherEntityAngularName %>) {
-        return item.id;
-    }
-    <%_ entitiesSeen.push(otherEntityNameCapitalized); } } _%>
-    <%_ if (hasManyToMany) { _%>
-
-    getSelected(selectedVals: Array<any>, option: any) {
-        if (selectedVals) {
-            for (let i = 0; i < selectedVals.length; i++) {
-                if (option.id === selectedVals[i].id) {
-                    return selectedVals[i];
-                }
-            }
-        }
-        return option;
-    }
-    <%_ } _%>
     get <%= entityInstance %>() {
         return this._<%= entityInstance %>;
     }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -23,13 +23,23 @@ import { <%= angularXAppName %>SharedModule } from 'app/shared';
 <%_ Object.keys(differentRelationships).forEach(key => {
        if (key === 'User') { _%>
 import { <%= angularXAppName %>AdminModule } from 'app/admin/admin.module';
-<%_ }}); _%>
+<%_ } else {
+    const needOther = differentRelationships[key].some(rel => (rel.relationshipType === 'many-to-one' || rel.ownerSide === true));
+    const firstRel = differentRelationships[key][0];
+    if (needOther && firstRel.otherEntityAngularName !== entityAngularName) {
+_%>
+import { <%= firstRel.otherEntityModuleName %> } from '../<%= firstRel.otherEntityModulePath %>/<%= firstRel.otherEntityModulePath %>.module';
+<%_
+    }
+}}); _%>
 import {
     <%= entityAngularName %>Component,
     <%= entityAngularName %>DetailComponent,
     <%= entityAngularName %>UpdateComponent,
     <%= entityAngularName %>DeletePopupComponent,
     <%= entityAngularName %>DeleteDialogComponent,
+    <%= entityAngularName %>SelectionComponent,
+    <%= entityAngularName %>MultiSelectionComponent,
     <%= entityInstance %>Route,
     <%= entityInstance %>PopupRoute
 } from './';
@@ -45,7 +55,14 @@ const ENTITY_STATES = [
         <%_ Object.keys(differentRelationships).forEach(key => {
               if (key === 'User') { _%>
         <%= angularXAppName %>AdminModule,
-        <%_ }}); _%>
+        <%_ } else {
+            const needOther = differentRelationships[key].some(rel => (rel.relationshipType === 'many-to-one' || rel.ownerSide === true));
+            const firstRel = differentRelationships[key][0];
+            if (needOther && firstRel.otherEntityAngularName !== entityAngularName) { _%>
+        <%= firstRel.otherEntityModuleName %>,
+        <%_
+            }
+        }}); _%>
         RouterModule.forChild(ENTITY_STATES)
     ],
     declarations: [
@@ -54,6 +71,8 @@ const ENTITY_STATES = [
         <%= entityAngularName %>UpdateComponent,
         <%= entityAngularName %>DeleteDialogComponent,
         <%= entityAngularName %>DeletePopupComponent,
+        <%= entityAngularName %>SelectionComponent,
+        <%= entityAngularName %>MultiSelectionComponent,
     ],
     entryComponents: [
         <%= entityAngularName %>Component,
@@ -61,6 +80,10 @@ const ENTITY_STATES = [
         <%= entityAngularName %>DeleteDialogComponent,
         <%= entityAngularName %>DeletePopupComponent,
     ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    schemas: [CUSTOM_ELEMENTS_SCHEMA],
+    exports: [
+        <%= entityAngularName %>SelectionComponent,
+        <%= entityAngularName %>MultiSelectionComponent,
+    ]
 })
 export class <%= angularXAppName %><%= entityAngularName %>Module {}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-multi-selection.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-multi-selection.component.html.ejs
@@ -1,0 +1,45 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<%_
+const keyPrefix = angularAppName + '.'+ entityTranslationKey + '.searchfield.';
+_%>
+<i class="fa fa-search" aria-hidden="true"></i>
+
+<input type="text" class="form-control <%= entityFileName %>-multi-selection"
+  #input
+  [class.is-invalid]="searchFailed" 
+  [(ngModel)]="selected"
+  [ngbTypeahead]="search"
+  (selectItem)="onSelect($event, input)"
+  [inputFormatter]="formatter"
+  [resultTemplate]="resTemplate"
+  placeholder="{{ '<%= keyPrefix %>placeholder' | translate }}" />
+<br>
+<span *ngFor="let item of getValue();let idx = index">
+  <button type="button" (click)="onRemoveItem(idx)" class="btn btn-primary btn-sm">
+    <i class="fa fa-minus-square" aria-hidden="true"></i>
+    {{item.<%= autocompleteField %>}}
+  </button>
+</span>
+<span *ngIf="searching" jhiTranslate="<%= keyPrefix %>searching">Searching...</span>
+<div class="invalid-feedback" *ngIf="searchFailed" jhiTranslate="<%= keyPrefix %>notFound">Sorry, not found.</div>
+
+<ng-template #resTemplate let-item="result" let-tm="term">
+  {{item.<%= autocompleteField %>}}
+</ng-template>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-multi-selection.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-multi-selection.component.ts.ejs
@@ -1,0 +1,91 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { Component } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Observable } from 'rxjs/Observable';
+import { NgbTypeaheadConfig } from '@ng-bootstrap/ng-bootstrap';
+
+import { BaseFormField } from 'app/shared';
+
+import { I<%= entityAngularName %>, <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
+import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
+
+@Component({
+  selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>-multi-selection',
+  templateUrl: './<%= entityFileName %>-multi-selection.component.html',
+  providers: [
+      {provide: NG_VALUE_ACCESSOR, useExisting: <%= entityAngularName %>MultiSelectionComponent, multi: true},
+      NgbTypeaheadConfig
+    ],
+})
+export class <%= entityAngularName %>MultiSelectionComponent extends BaseFormField<Array<<%= entityAngularName %>>> {
+    searching = false;
+    searchFailed = false;
+    selected: <%= entityAngularName %>;
+    hideSearchingWhenUnsubscribed = new Observable(() => () => this.searching = false);
+
+    constructor(
+        config: NgbTypeaheadConfig,
+        private <%= entityInstance %>Service: <%= entityAngularName %>Service
+    ) {
+        super();
+        config.showHint = true;
+    }
+
+    search = (text$: Observable<string>) =>
+        text$
+          .debounceTime(300)
+          .distinctUntilChanged()
+          .do(() => this.searching = true)
+          .switchMap((term) =>
+              this.<%= entityInstance %>Service.query({'<%= autocompleteField %>.contains': term})
+                  .do(() => this.searchFailed = false)
+                  .map((r: HttpResponse<I<%= entityAngularName %>[]>) => {
+                      this.searchFailed = (r.body.length === 0);
+                      return r.body;
+                  })
+                  .catch(() => {
+                      this.searchFailed = true;
+                      return Observable.of([]);
+                  }))
+           .do(() => this.searching = false)
+           .merge(this.hideSearchingWhenUnsubscribed)
+
+    formatter = (modelObject: {<%= autocompleteField %>: string}) => modelObject.<%= autocompleteField %>;
+
+    onSelect($event, input) {
+        const item = $event.item;
+        const itemlist = this.getValue();
+        if (itemlist) {
+            itemlist.push(item);
+            this.forceOnChange();
+        } else {
+            this.setValue([item]);
+        }
+        $event.preventDefault();
+        input.value = '';
+    }
+
+    onRemoveItem(idx: number) {
+        super.getValue().splice(idx, 1);
+        this.forceOnChange();
+    }
+
+}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-selection.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-selection.component.html.ejs
@@ -1,0 +1,39 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<%_
+const keyPrefix = angularAppName + '.'+ entityTranslationKey + '.searchfield.';
+_%>
+<i class="fa fa-search" aria-hidden="true"></i>
+
+<input type="text" class="form-control <%= entityFileName %>-selection"
+  #input
+  [class.is-invalid]="searchFailed" 
+  [(ngModel)]="selected"
+  [ngbTypeahead]="search"
+  (selectItem)="onSelect($event, input)"
+  [inputFormatter]="formatter"
+  [resultTemplate]="resTemplate"
+  placeholder="{{ '<%= keyPrefix %>placeholder' | translate }}" />
+<br>
+<span *ngIf="searching" jhiTranslate="<%= keyPrefix %>searching">Searching...</span>
+<div class="invalid-feedback" *ngIf="searchFailed" jhiTranslate="<%= keyPrefix %>notFound">Sorry, not found.</div>
+
+<ng-template #resTemplate let-item="result" let-tm="term">
+  {{item.<%= autocompleteField %>}}
+</ng-template>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-selection.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-selection.component.ts.ejs
@@ -1,0 +1,86 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { Component } from '@angular/core';
+import { HttpResponse } from '@angular/common/http';
+import { NG_VALUE_ACCESSOR } from '@angular/forms';
+import { Observable } from 'rxjs/Observable';
+import { NgbTypeaheadConfig } from '@ng-bootstrap/ng-bootstrap';
+
+import { BaseFormField } from 'app/shared';
+
+import { I<%= entityAngularName %>, <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
+import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
+
+@Component({
+  selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>-selection',
+  templateUrl: './<%= entityFileName %>-selection.component.html',
+  providers: [
+      {provide: NG_VALUE_ACCESSOR, useExisting: <%= entityAngularName %>SelectionComponent, multi: true},
+      NgbTypeaheadConfig
+    ],
+})
+export class <%= entityAngularName %>SelectionComponent extends BaseFormField<<%= entityAngularName %>> {
+    searching = false;
+    searchFailed = false;
+    selected: <%= entityAngularName %>;
+    hideSearchingWhenUnsubscribed = new Observable(() => () => this.searching = false);
+
+    constructor(
+        config: NgbTypeaheadConfig,
+        private <%= entityInstance %>Service: <%= entityAngularName %>Service
+    ) {
+        super();
+        config.showHint = true;
+    }
+
+    search = (text$: Observable<string>) =>
+        text$
+          .debounceTime(300)
+          .distinctUntilChanged()
+          .do(() => this.searching = true)
+          .switchMap((term) =>
+              this.<%= entityInstance %>Service.query({'<%= autocompleteField %>.contains': term})
+                  .do(() => this.searchFailed = false)
+                  .map((r: HttpResponse<I<%= entityAngularName %>[]>) => {
+                      this.searchFailed = (r.body.length === 0);
+                      return r.body;
+                  })
+                  .catch(() => {
+                      this.searchFailed = true;
+                      return Observable.of([]);
+                  }))
+           .do(() => this.searching = false)
+           .merge(this.hideSearchingWhenUnsubscribed)
+
+    formatter = (modelObject: {<%= autocompleteField %>: string}) => modelObject.<%= autocompleteField %>;
+
+    onSelect($event, input) {
+        const item = $event.item;
+        this.setValue(item);
+        this.selected = item;
+        $event.preventDefault();
+        input.value = item.<%= autocompleteField %>;
+    }
+
+    writeValue(value) {
+        super.writeValue(value);
+        this.selected = value;
+    }
+
+}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/index.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/index.ts.ejs
@@ -20,5 +20,7 @@ export * from './<%= entityFileName %>.service';
 export * from './<%= entityFileName %>-update.component';
 export * from './<%= entityFileName %>-delete-dialog.component';
 export * from './<%= entityFileName %>-detail.component';
+export * from './<%= entityFileName %>-selection.component';
+export * from './<%= entityFileName %>-multi-selection.component';
 export * from './<%= entityFileName %>.component';
 export * from './<%= entityFileName %>.route';

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -145,7 +145,7 @@ export class <%= entityClass %>UpdatePage {
     }
 
     get<%=relationshipNameCapitalized %>SelectedOption() {
-        return this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
+        return this.<%=relationshipName %>Select.getAttribute('value');
     }
 
     <%_ } _%>

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -134,9 +134,9 @@ describe('<%= entityClass %> e2e test', () => {
             const relationshipName = relationship.relationshipName;
             const relationshipFieldName = relationship.relationshipFieldName; _%>
         <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-        <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
+        <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectOption('a');
         <%_ } else if ((relationshipType === 'many-to-many' && ownerSide === true)) { _%>
-        // <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
+        // <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectOption('a');
         <%_ } _%>
         <%_ }); _%>
         <%= entityInstance %>UpdatePage.save();

--- a/generators/entity-i18n/templates/i18n/entity_en.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_en.json.ejs
@@ -32,6 +32,11 @@ let helpBlocks = 0; %>
             "delete": {
                 "question": "Are you sure you want to delete <%= entityClassHumanized %> {{ id }}?"
             },
+            "searchfield": {
+                "placeholder": "Select <%= entityClassHumanized %>",
+                "searching": "Searching <%= entityClassHumanized %>...",
+                "notFound": "No matching <%= entityClassHumanized %> found!"
+            },
             "detail": {
                 "title": "<%= entityClassHumanized %>"
             }<% for (idx in fields) {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -522,6 +522,10 @@ module.exports = class extends BaseGenerator {
                         context.fieldsIsReactAvField = true;
                     }
 
+                    if (fieldType === 'String' && !context.autocompleteField) {
+                        // mark the first String as autocomplete field
+                        context.autocompleteField = field.fieldName;
+                    }
                     const nonEnumType = [
                         'String', 'Integer', 'Long', 'Float', 'Double', 'BigDecimal',
                         'LocalDate', 'Instant', 'ZonedDateTime', 'Boolean', 'byte[]', 'ByteBuffer'
@@ -608,6 +612,12 @@ module.exports = class extends BaseGenerator {
                     }
                 });
                 context.hasUserField = context.saveUserSnapshot = false;
+
+                if (!context.autocompleteField) {
+                    // if no string field found for autocompletion, use the id
+                    context.autocompleteField = 'id';
+                }
+
                 // Load in-memory data for relationships
                 context.relationships.forEach((relationship) => {
                     if (_.isUndefined(relationship.relationshipNameCapitalized)) {
@@ -725,7 +735,7 @@ module.exports = class extends BaseGenerator {
                     }
                     if (_.isUndefined(relationship.otherEntityModuleName)) {
                         if (relationship.otherEntityNameCapitalized !== 'User') {
-                            relationship.otherEntityModuleName = `${context.angularXAppName + relationship.otherEntityNameCapitalized}Module`;
+                            relationship.otherEntityModuleName = `${context.angularXAppName + relationship.otherEntityAngularName}Module`;
                             relationship.otherEntityFileName = _.kebabCase(relationship.otherEntityAngularName);
                             if (context.skipUiGrouping || otherEntityData === undefined || otherEntityData.clientRootFolder === undefined) {
                                 relationship.otherEntityClientRootFolder = '';
@@ -750,6 +760,8 @@ module.exports = class extends BaseGenerator {
                             relationship.otherEntityModulePath = 'app/core';
                         }
                     }
+                    relationship.uiFieldType = `${_.kebabCase(jhiTablePrefix)}-${_.kebabCase(relationship.otherEntityAngularName)}`;
+
                     // Load in-memory data for root
                     if (relationship.relationshipType === 'many-to-many' && relationship.ownerSide) {
                         context.fieldsContainOwnerManyToMany = true;

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -309,6 +309,7 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}app/shared/constants/error.constants.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/constants/input.constants.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/constants/pagination.constants.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/shared/fields/base-form-field.component.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/index.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/language/find-language-from-key.pipe.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/language/language.constants.ts`,


### PR DESCRIPTION
As discussed in #6339 - a possible solution is to create auto-complete fields for entity selection, instead of the current drop-down.

Currently it's not finished yet, the followings are missing:
- [ ] localization values
- [ ] it only works for entities, where filtering is enabled. It wouldn't be too hard to extend it to use ES if available, and fallback to load all the entities, and filter on the client side.
- [ ] currently it expects a string attribute named as 'name', it needs to be customized
- [ ] it's not added to any of the dialogs yet. This is where I've found the more complicated issue : these auto-complete fields are added into their respective 'entity' module, which needs to be imported in other entity modules, where these fields are needed, which will create a big spaghetti of entity inter-dependency, which is a bit scary. 
Probably we could separate the entity modules, for example the bank-account module, 
* _bank-account-base_ : bank-account.model.ts and bank-account.service.ts
* _bank-account-fields_ : the two new auto complete fields
* _bank-account-management_ : the dialogs, and listing components.

What do you think? 
 