### PR TITLE
Angular-oidc support

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -150,6 +150,14 @@ const files = {
             templates: [
                 'blocks/interceptor/_auth.interceptor.ts'
             ]
+        },
+        {
+            condition: generator => generator.authenticationType === 'oauth2',
+            path: ANGULAR_DIR,
+            templates: [
+                'blocks/interceptor/_auth.interceptor.ts',
+                'blocks/config/_auth.config.ts'
+            ]
         }
     ],
     angularMain: [

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -35,6 +35,9 @@
     "@angular/platform-browser-dynamic": "4.3.2",
     "@angular/router": "4.3.2",
     "@ng-bootstrap/ng-bootstrap": "1.0.0-beta.5",
+    <%_ if (authenticationType === 'oauth2') { _%>
+    "angular-oauth2-oidc": "^2.1.8",
+    <%_ } _%>
     "bootstrap": "4.0.0-beta",
     "core-js": "2.4.1",
     "font-awesome": "4.7.0",

--- a/generators/client/templates/angular/src/main/webapp/app/_app-routing.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_app-routing.module.ts
@@ -27,7 +27,8 @@ const LAYOUT_ROUTES = [
 
 @NgModule({
     imports: [
-        RouterModule.forRoot(LAYOUT_ROUTES, { useHash: true })
+        RouterModule.forRoot(LAYOUT_ROUTES, { useHash: true <%_ if (authenticationType === 'oauth2') { _%>, initialNavigation: false<%_ } _%> })
+
     ],
     exports: [
         RouterModule

--- a/generators/client/templates/angular/src/main/webapp/app/_app.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_app.module.ts
@@ -21,6 +21,9 @@ import './vendor.ts';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { Ng2Webstorage } from 'ng2-webstorage';
+<%_ if (authenticationType === 'oauth2') { _%>
+import { OAuthModule } from 'angular-oauth2-oidc';
+<%_ } _%>
 
 import { <%=angularXAppName%>SharedModule, UserRouteAccessService } from './shared';
 import { <%=angularXAppName%>AppRoutingModule} from './app-routing.module';
@@ -50,6 +53,9 @@ import {
 @NgModule({
     imports: [
         BrowserModule,
+        <%_ if (authenticationType === 'oauth2') { _%>
+        OAuthModule.forRoot(),
+        <%_ } _%>
         <%=angularXAppName%>AppRoutingModule,
         Ng2Webstorage.forRoot({ prefix: 'jhi', separator: '-'}),
         <%=angularXAppName%>SharedModule,

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/_auth.config.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/_auth.config.ts
@@ -1,0 +1,34 @@
+<%#
+Copyright 2013-2017 the original author or authors from the JHipster project.
+
+This file is part of the JHipster project, see http://www.jhipster.tech/
+for more information.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-%>
+import { AuthConfig } from 'angular-oauth2-oidc';
+
+export const authConfig: AuthConfig = {
+
+    // Url of the Identity Provider
+    issuer: 'http://localhost:9080/auth/realms/jhipster',
+
+    // URL of the SPA to redirect the user to after login
+    redirectUri: window.location.origin + '/index.html',
+
+    // The SPA's id. The SPA is registerd with this id at the auth-server
+    clientId: 'web_app',
+
+    // set the scope for the permissions the client should request
+    scope: 'openid profile email',
+};

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth-expired.interceptor.ts
@@ -26,7 +26,7 @@ import { LoginService } from '../../shared/login/login.service';
 import { Router } from '@angular/router';
     <%_ } _%>
 <%_ } _%>
-<%_ if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
+<%_ if (authenticationType === 'session') { _%>
 import { AuthServerProvider } from '../../shared/auth/auth-session.service';
 import { StateStorageService } from '../../shared/auth/state-storage.service';
     <%_ if (authenticationType === 'session') { _%>
@@ -48,8 +48,7 @@ export class AuthExpiredInterceptor extends JhiHttpInterceptor {
         super();
     }
 <%_ } else if (authenticationType === 'oauth2') { _%>
-    constructor(private injector: Injector,
-        private stateStorageService: StateStorageService) {
+    constructor(private injector: Injector) {
         super();
     }
 <%_ } _%>
@@ -72,7 +71,7 @@ export class AuthExpiredInterceptor extends JhiHttpInterceptor {
             return Observable.throw(error);
         });
     }
-<%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
+<%_ } else if (authenticationType === 'session') { _%>
 
     responseIntercept(observable: Observable<Response>): Observable<Response> {
         return <Observable<Response>> observable.catch((error) => {
@@ -99,5 +98,17 @@ export class AuthExpiredInterceptor extends JhiHttpInterceptor {
             return Observable.throw(error);
         });
     }
+<%_ } else if (authenticationType === 'oauth2') { _%>
+
+    responseIntercept(observable: Observable<Response>): Observable<Response> {
+        return <Observable<Response>> observable.catch((error) => {
+            if (error.status === 401) {
+                const loginService: LoginService = this.injector.get(LoginService);
+                loginService.logout();
+            }
+            return Observable.throw(error);
+        });
+    }
 <%_ } _%>
+
 }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth.interceptor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth.interceptor.ts
@@ -18,24 +18,40 @@
 -%>
 import { Observable } from 'rxjs/Observable';
 import { RequestOptionsArgs, Response } from '@angular/http';
+<%_ if (authenticationType === 'oauth2') { _%>
+import { OAuthService } from 'angular-oauth2-oidc';
+import { Injector } from '@angular/core';
+<%_ } else { _%>
 import { LocalStorageService, SessionStorageService } from 'ng2-webstorage';
+<%_ } _%>
 import { JhiHttpInterceptor } from 'ng-jhipster';
 
 export class AuthInterceptor extends JhiHttpInterceptor {
 
+    <%_ if (authenticationType === 'oauth2') { _%>
+    constructor(private injector: Injector) {
+        super();
+    }
+    <%_ } else { _%>
     constructor(
         private localStorage: LocalStorageService,
         private sessionStorage: SessionStorageService
     ) {
         super();
     }
+    <%_ } _%>
 
     requestIntercept(options?: RequestOptionsArgs): RequestOptionsArgs {
         if (!options || !options.url || /^http/.test(options.url)) {
             return options;
         }
 
+        <%_ if (authenticationType === 'oauth2') { _%>
+        const oauthService: OAuthService = this.injector.get(OAuthService);
+        const token = oauthService.getAccessToken();
+        <%_ } else { _%>
         const token = this.localStorage.retrieve('authenticationToken') || this.sessionStorage.retrieve('authenticationToken');
+        <%_ } _%>
         if (!!token) {
             options.headers.append('Authorization', 'Bearer ' + token);
         }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_http.provider.ts
@@ -20,13 +20,15 @@ import { JhiEventManager, JhiInterceptableHttp } from 'ng-jhipster';
 import { Injector } from '@angular/core';
 import { Http, XHRBackend, RequestOptions } from '@angular/http';
 
-<%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+<%_ if (authenticationType === 'jwt' || authenticationType === 'uaa' || authenticationType === 'oauth2') { _%>
     <%_ if (authenticationType !== 'uaa') { _%>
 import { AuthInterceptor } from './auth.interceptor';
     <%_ } _%>
+    <%_ if (authenticationType !== 'oauth2') { _%>
 import { LocalStorageService, SessionStorageService } from 'ng2-webstorage';
+    <%_ } _%>
 <%_ } _%>
-<%_ if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
+<%_ if (authenticationType === 'session') { _%>
     <%_ if (authenticationType === 'session') { _%>
 import { AuthServerProvider } from '../../shared/auth/auth-session.service';
 import { LoginModalService } from '../../shared/login/login-modal.service';
@@ -50,7 +52,6 @@ export function interceptableFactory(
     loginServiceModal: LoginModalService,
     <%_ } else if (authenticationType === 'oauth2') { _%>
     injector: Injector,
-    stateStorageService: StateStorageService,
     <%_ } _%>
     eventManager: JhiEventManager
 ) {
@@ -67,7 +68,8 @@ export function interceptableFactory(
             new AuthExpiredInterceptor(injector, stateStorageService,
                 loginServiceModal),
         <%_ } else if (authenticationType === 'oauth2') { _%>
-        new AuthExpiredInterceptor(injector, stateStorageService),
+        new AuthInterceptor(injector),
+        new AuthExpiredInterceptor(injector),
         <%_ } _%>
             // Other interceptors can be added here
             new ErrorHandlerInterceptor(eventManager),
@@ -89,7 +91,9 @@ export function customHttpProvider() {
             Injector,
             <%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
             Injector,
+            <%_ if (authenticationType !== 'oauth2') { _%>
             StateStorageService,
+            <%_ } _%>
                 <%_ if (authenticationType === 'session') { _%>
             LoginModalService,
                 <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
@@ -17,21 +17,50 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
+<%_ if (authenticationType === 'oauth2') { _%>
+import {OAuthService} from 'angular-oauth2-oidc';
+import {Account} from '../user/account.model';
+<%_ } _%>
+<%_ if (authenticationType !== 'oauth2') { _%>
 import { Http, Response } from '@angular/http';
+<%_ } _%>
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
+<%_ if (authenticationType !== 'uaa' || authenticationType !== 'oauth2') { _%>
 import { SERVER_API_URL } from '../../app.constants';
 <%_ } _%>
 
 @Injectable()
 export class AccountService  {
+    <%_ if (authenticationType === 'oauth2') { _%>
+    constructor(private oauthService: OAuthService) { }
+    <%_ } else  { _%>
     constructor(private http: Http) { }
+    <%_ } _%>
 
+    <%_ if (authenticationType === 'oauth2') { _%>
+    get(): Observable<Account> {
+        return Observable.fromPromise(this.oauthService.loadUserProfile().then((account: any) => {
+            return new Account(
+                account.email_verified,
+                account.roles,
+                account.email,
+                account.given_name,
+                account.lang_key,
+                account.family_name,
+                account.preferred_username,
+                account.image_url
+            );
+        }));
+    }
+    <%_ } else { _%>
     get(): Observable<any> {
         return this.http.get(<% if (authenticationType === 'uaa') { %>'<%= uaaBaseName.toLowerCase() %>/<% } else { %>SERVER_API_URL + '<% } %>api/account').map((res: Response) => res.json());
     }
+    <%_ } _%>
 
+    <%_ if (authenticationType !== 'oauth2') { _%>
     save(account: any): Observable<Response> {
         return this.http.post(<% if (authenticationType === 'uaa') { %>'<%= uaaBaseName.toLowerCase() %>/<% } else { %>SERVER_API_URL + '<% } %>api/account', account);
     }
+    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
@@ -101,11 +101,16 @@
                 });
 
                 function addApiKeyAuthorization() {
-                <%_ if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
+                <%_ if (authenticationType === 'session') { _%>
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-XSRF-TOKEN", getCSRF(), "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-                <%_ } else if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+                <%_ } else { _%>
+                    <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa' ) { _%>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationtoken") || sessionStorage.getItem("jhi-authenticationtoken"));
+                    <%_ } _%>
+                    <%_ if (authenticationType === 'oauth2' ) { _%>
+                    var authToken = localStorage.getItem("access_token") || sessionStorage.getItem("access_token");
+                    <%_ } _%>
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
                 <%_ } _%>

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -190,18 +190,10 @@ security:
         client:
             access-token-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/token
             user-authorization-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/auth
-            <%_ if (applicationType === 'gateway' || applicationType === 'monolith') { _%>
-            client-id: web_app
-            client-secret: web_app
-            client-authentication-scheme: form
-            scope: openid profile email
-            <%_ } _%>
-            <%_ if (applicationType === 'microservice') { _%>
             client-id: internal
             client-secret: internal
             authentication-scheme: header
             client-authentication-scheme: header
-            <%_ } _%>
         resource:
             filter-order: 3
             user-info-uri: http://localhost:9080/auth/realms/jhipster/protocol/openid-connect/userinfo


### PR DESCRIPTION
The current implementation of JHipster OIDC delegates the authentication to the backend application. The aim of this PR is to let the client do the authentication and pass the Bearer to the token removing de facto the transitive dependency (client -> backend -> IdP). I used [angular-oauth2-oidc](https://github.com/manfredsteyer/angular-oauth2-oidc) for this PR

The support should work either on microservices and monoliths. 

Once of the motivation of this PR is to help to decouple the front and backend in order to be able to develop both components separately. 

- Please make sure the below checklist is followed for Pull Requests.

- [x] [angular-oidc]() installation
- [x] Configuration for authentication
- [x] Map IdP user with Jhipster representation
- [x] Update `oauth2` `clientId` and `clientSecret` to use `internal` only in backend
- [x] Make Swagger-UI works
- [ ] Make the IdP URL configurable like `SERVER_API_URL`
- [ ] Provide the new Keycloak configuration
- [x] Test with mciroservices
- [ ] Test with monoliths  
- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

