### PR TITLE
AWS also supports mariadb.

### DIFF
--- a/generators/aws/index.js
+++ b/generators/aws/index.js
@@ -54,6 +54,9 @@ module.exports = class extends BaseGenerator {
                 const prodDatabaseType = this.config.get('prodDatabaseType');
 
                 switch (prodDatabaseType.toLowerCase()) {
+                case 'mariadb':
+                    this.dbEngine = 'mariadb';
+                    break;
                 case 'mysql':
                     this.dbEngine = 'mysql';
                     break;


### PR DESCRIPTION
I will update the docs in the next days - just to mention that mariadb is supported. The aws generator also needs some better error checks, but that's another issue.
I need to go back and try docker-compose - I think this would be simpler for my user-case.
