### PR TITLE
Remove unused dependencies: awaitility and thymeleaf-layout-dialect

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -320,7 +320,9 @@ dependencies {
     <%_ if (websocket === 'spring-websocket') { _%>
     compile "org.springframework.boot:spring-boot-starter-websocket"
     <%_ } _%>
-    compile "org.springframework.boot:spring-boot-starter-thymeleaf"
+    compile ("org.springframework.boot:spring-boot-starter-thymeleaf") {
+        exclude module: 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
+    }
     compile "org.zalando:problem-spring-web:${problem_spring_web_version}"
     <%_ if (databaseType === 'cassandra') { _%>
     compile "com.google.guava:guava:18.0"

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -406,7 +406,6 @@ dependencies {
     compile "org.springframework.social:spring-social-facebook"
     compile "org.springframework.social:spring-social-twitter"
     <%_ } _%>
-    testCompile "org.awaitility:awaitility:${awaitility_version}"
     testCompile "com.jayway.jsonpath:json-path"
     <%_ if (databaseType === 'cassandra') { _%>
     testCompile ("org.cassandraunit:cassandra-unit-spring:${cassandra_unit_spring_version}") {

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -19,7 +19,6 @@
 rootProject.name=<%= dasherizedBaseName %>
 profile=dev
 assertj_version=3.6.2
-awaitility_version=2.0.0
 <%_ if (applicationType === 'gateway') { _%>
 bucket4j_version=3.0.1
 <%_ } _%>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -52,7 +52,6 @@
     <properties>
         <argLine>-Djava.security.egd=file:/dev/./urandom -Xmx256m</argLine>
         <assertj.version>3.6.2</assertj.version>
-        <awaitility.version>2.0.0</awaitility.version>
         <%_ if (applicationType === 'gateway') { _%>
         <bucket4j.version>3.0.1</bucket4j.version>
         <%_ } _%>
@@ -378,12 +377,6 @@
             </exclusions>
         </dependency>
         <%_ } _%>
-        <dependency>
-            <groupId>org.awaitility</groupId>
-            <artifactId>awaitility</artifactId>
-            <version>${awaitility.version}</version>
-            <scope>test</scope>
-        </dependency>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -674,6 +674,12 @@
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-thymeleaf</artifactId>
+            <exclusions>
+                <exclusion>
+                    <groupId>nz.net.ultraq.thymeleaf</groupId>
+                    <artifactId>thymeleaf-layout-dialect</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
         <dependency>
             <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
This removes two dependencies that aren't used by the generated app, one of which (thymeleaf-layout-dialect) was transitively pulling in all of groovy (at a whopping 4.5 MB!).

Of course if people want to use the thymeleaf dialect after all it's easy enough for them to remove the exclusion.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
