### PR TITLE
Don't put two database drivers in a single package

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -381,9 +381,6 @@ dependencies {
     <%_ if (devDatabaseType === 'mariadb' || prodDatabaseType === 'mariadb') { _%>
     compile "org.mariadb.jdbc:mariadb-java-client"
     <%_ } _%>
-    <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
-    compile "com.h2database:h2"
-    <%_ } _%>
     <%_ if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { _%>
     compile "com.microsoft.sqlserver:mssql-jdbc"
     compile "com.github.sabomichal:liquibase-mssql"

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -215,9 +215,7 @@
         <dependency>
             <groupId>com.h2database</groupId>
             <artifactId>h2</artifactId>
-            <%_ if (devDatabaseType !== 'h2Disk' && devDatabaseType !== 'h2Memory') { _%>
             <scope>test</scope>
-            <%_ } _%>
         </dependency>
         <%_ if (hibernateCache === 'hazelcast' || clusteredHttpSession === 'hazelcast' || applicationType === 'gateway') { _%>
         <dependency>
@@ -1192,6 +1190,12 @@
                     <artifactId>spring-boot-devtools</artifactId>
                     <optional>true</optional>
                 </dependency>
+                <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
+                <dependency>
+                    <groupId>com.h2database</groupId>
+                    <artifactId>h2</artifactId>
+                </dependency>
+                <%_ } _%>
             </dependencies>
             <build>
                 <plugins>

--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -32,6 +32,9 @@ ext {
 
 dependencies {
     compile "org.springframework.boot:spring-boot-devtools"
+    <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
+    compile "com.h2database:h2"
+    <%_ } _%>
 }
 
 def profiles = 'dev'


### PR DESCRIPTION
When users select different databases for development and production (as when following the default choices) they will end up with two drivers in their package. This PR will make sure that they only get the appropriate one for the profile they're packaging.

It slightly increases the complexity of the generator(*) -- I wanted to keep the dependency in the general section in case dev and prod are the same database -- will have no effect on the complexity on the generated maven/gradle build, and will make the packaged artifact simpler.

Hope this makes sense!

(*) Alternatively, if you prefer, I could just put the driver in the profiles even when they're the same for dev and prod, which would not increase the generator complexity at all.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
