### PR TITLE
Exclude cloudfoundry and heroku connectors until needed

### DIFF
--- a/generators/cloudfoundry/USAGE
+++ b/generators/cloudfoundry/USAGE
@@ -1,5 +1,6 @@
 Description:
-    Generates a `deploy/cloudfoundry` folder with a specific manifest.yml to deploy to Cloud Foundry
+    Generates a `deploy/cloudfoundry` folder with a specific manifest.yml to deploy to Cloud Foundry.
+    Adds the spring-cloud-cloudfoundry-connector dependency to Maven / Gradle as appropriate.
 
 Example:
     jhipster cloudfoundry

--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -60,6 +60,16 @@ module.exports = class extends BaseGenerator {
                 this.template('_application-cloudfoundry.yml', `${constants.SERVER_MAIN_RES_DIR}config/application-cloudfoundry.yml`);
             },
 
+            addCloudFoundryDependencies() {
+                if (this.buildTool === 'maven') {
+                    this.addMavenDependency('org.springframework.cloud', 'spring-cloud-localconfig-connector');
+                    this.addMavenDependency('org.springframework.cloud', 'spring-cloud-cloudfoundry-connector');
+                } else if (this.buildTool === 'gradle') {
+                    this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-localconfig-connector');
+                    this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-cloudfoundry-connector');
+                }
+            },
+
             checkInstallation() {
                 if (this.abort) return;
                 const done = this.async();

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1192,8 +1192,8 @@ module.exports = class extends PrivateBase {
      *
      * @param {string} groupId - dependency groupId
      * @param {string} artifactId - dependency artifactId
-     * @param {string} version - explicit dependency version number
-     * @param {string} other - explicit other thing: scope, exclusions...
+     * @param {string} version - (optional) explicit dependency version number
+     * @param {string} other - (optional) explicit other thing: scope, exclusions...
      */
     addMavenDependency(groupId, artifactId, version, other) {
         const fullPath = 'pom.xml';
@@ -1284,16 +1284,20 @@ module.exports = class extends PrivateBase {
      * @param {string} scope - scope of the new dependency, e.g. compile
      * @param {string} group - maven GroupId
      * @param {string} name - maven ArtifactId
-     * @param {string} version - explicit version number
+     * @param {string} version - (optional) explicit dependency version number
      */
     addGradleDependency(scope, group, name, version) {
         const fullPath = 'build.gradle';
+        let dependency = `${group}:${name}`;
+        if (version) {
+            dependency += `:${version}`;
+        }
         try {
             jhipsterUtils.rewriteFile({
                 file: fullPath,
                 needle: 'jhipster-needle-gradle-dependency',
                 splicable: [
-                    `${scope} '${group}:${name}:${version}'`
+                    `${scope} "${dependency}"`
                 ]
             }, this);
         } catch (e) {

--- a/generators/heroku/USAGE
+++ b/generators/heroku/USAGE
@@ -1,5 +1,6 @@
 Description:
     Initializes a Heroku app and generates a WAR file that is ready to push to Heroku.
+    Adds the spring-cloud-heroku-connector dependency to Maven / Gradle as appropriate.
 
 Example:
     jhipster heroku

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -322,6 +322,16 @@ module.exports = class extends BaseGenerator {
                 });
             },
 
+            addHerokuDependencies() {
+                if (this.buildTool === 'maven') {
+                    this.addMavenDependency('org.springframework.cloud', 'spring-cloud-localconfig-connector');
+                    this.addMavenDependency('org.springframework.cloud', 'spring-cloud-heroku-connector');
+                } else if (this.buildTool === 'gradle') {
+                    this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-localconfig-connector');
+                    this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-heroku-connector');
+                }
+            },
+
             addHerokuBuildPlugin() {
                 if (this.buildTool !== 'gradle') return;
                 this.addGradlePlugin('gradle.plugin.com.heroku.sdk', 'heroku-gradle', '0.2.0');

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -355,7 +355,7 @@ dependencies {
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
     compile "org.springframework.cloud:spring-cloud-starter-feign"
     <%_ } _%>
-    compile "org.springframework.boot:spring-boot-starter-cloud-connectors"
+    compile "org.springframework.cloud:spring-cloud-spring-service-connector"
     compile "org.springframework:spring-context-support"
     compile "org.springframework.security:spring-security-config"
     compile "org.springframework.security:spring-security-data"

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -546,6 +546,11 @@
             <artifactId>liquibase-core</artifactId>
         </dependency>
         <%_ } _%>
+        <dependency>
+            <groupId>net.logstash.logback</groupId>
+            <artifactId>logstash-logback-encoder</artifactId>
+            <version>${logstash-logback-encoder.version}</version>
+        </dependency>
         <%_ if (databaseType === 'mongodb') { _%>
         <dependency>
             <groupId>com.google.guava</groupId>
@@ -827,13 +832,8 @@
         </dependency>
         <%_ } _%>
         <dependency>
-            <groupId>net.logstash.logback</groupId>
-            <artifactId>logstash-logback-encoder</artifactId>
-            <version>${logstash-logback-encoder.version}</version>
-        </dependency>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-cloud-connectors</artifactId>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-spring-service-connector</artifactId>
         </dependency>
         <!-- security -->
         <dependency>


### PR DESCRIPTION
Sorry for all these PRs guys, I'm trying to keep my proposals small and topical.

As you probably guessed by now, I am attempting to reduce the size of my WAR and submitting changes I make that I think might be generally useful here.

In this case I would like to exclude the provider-specific cloud connectors from the build, until the user indicates s/he wants them by running the relevant subgenerator.

This makes a largish difference, particularly because the jar for the CloudFoundry connector is pretty huge -- it includes most of Jackson, for some reason.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
