### PR TITLE
Fix for signout when using uaa and traefik

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
@@ -89,7 +89,7 @@ export class AuthServerProvider {
 
     logout(): Observable<any> {
 <%_ if (authenticationType === 'uaa') { _%>
-        return this.http.post('/auth/logout', null);
+        return this.http.post('auth/logout', null);
 <% } else { %>
         return new Observable((observer) => {
             this.$localStorage.clear('authenticationToken');

--- a/generators/client/templates/angularjs/src/test/javascript/spec/app/services/auth/_auth.services.spec.js
+++ b/generators/client/templates/angularjs/src/test/javascript/spec/app/services/auth/_auth.services.spec.js
@@ -51,7 +51,7 @@ describe('Service Tests', function () {
 
             //WHEN
             <%_ if (authenticationType === 'uaa') { _%>
-            $httpBackend.expectPOST('/auth/logout').respond();
+            $httpBackend.expectPOST('auth/logout').respond();
             <%_ } _%>
             authService.logout();
             //flush the backend to "execute" the request to do the expectedGET assertion.


### PR DESCRIPTION
When using traefik, signout should go to gateway : /gateway/auth/logout and not root /auth/logout

I verified with angular4.

Fix #6652

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
