### PR TITLE
fix swagger for UAA apps

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
@@ -104,7 +104,18 @@
                 <%_ if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-XSRF-TOKEN", getCSRF(), "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
-                <%_ } else if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+                <%_ } else if (authenticationType === 'uaa') { _%>
+                    var interceptor = {
+                        requestInterceptor: {
+                            apply: function (requestObj) {
+                                var headers = requestObj.headers || {};
+                                headers['X-XSRF-TOKEN'] = getCSRF();
+                                return requestObj;
+                            }
+                        }
+                    };
+                    window.swaggerUi.options.requestInterceptor = interceptor.requestInterceptor
+                <%_ } else if (authenticationType === 'jwt') { _%>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationtoken") || sessionStorage.getItem("jhi-authenticationtoken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);

--- a/generators/client/templates/angularjs/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/angularjs/src/main/webapp/swagger-ui/_index.html
@@ -105,6 +105,18 @@
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-XSRF-TOKEN", getCSRF(), "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <%_ } _%>
+                <%_ if (authenticationType === 'uaa') { _%>
+                    var interceptor = {
+                        requestInterceptor: {
+                            apply: function (requestObj) {
+                                var headers = requestObj.headers || {};
+                                headers['X-XSRF-TOKEN'] = getCSRF();
+                                return requestObj;
+                            }
+                        }
+                    };
+                    window.swaggerUi.options.requestInterceptor = interceptor.requestInterceptor
+                <%_ } _%>
                 <%_ if (authenticationType === 'oauth2') { _%>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken")).access_token;
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization",
@@ -116,7 +128,7 @@
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("X-Auth-Token", authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("key", apiKeyAuth);
                 <%_ } _%>
-                <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+                <%_ if (authenticationType === 'jwt') { _%>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken") || sessionStorage.getItem("jhi-authenticationToken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);


### PR DESCRIPTION
UAA apps now use an XSRF Token and expect the token to change on every request. UAA apps also no longer use a token header for authentication (switched to cookies in v4.9.0).

This doesn't seem to affect the other auth types so I left them as is.

Fix #6657

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
