### PR TITLE
Use simple cache and small TLD library (instead of Guava)

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -268,6 +268,7 @@ function writeFiles() {
             this.template(`${SERVER_MAIN_SRC_DIR}package/security/_package-info.java`, `${javaDir}security/package-info.java`);
 
             if (this.authenticationType === 'session') {
+                this.template(`${SERVER_MAIN_SRC_DIR}package/security/_TokenCache.java`, `${javaDir}security/TokenCache.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/security/_PersistentTokenRememberMeServices.java`, `${javaDir}security/PersistentTokenRememberMeServices.java`);
             }
 
@@ -301,6 +302,7 @@ function writeFiles() {
                 this.template(`${SERVER_MAIN_SRC_DIR}package/web/filter/_RefreshTokenFilter.java`, `${javaDir}web/filter/RefreshTokenFilter.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/web/filter/_RefreshTokenFilterConfigurer.java`, `${javaDir}web/filter/RefreshTokenFilterConfigurer.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/config/oauth2/_OAuth2AuthenticationConfiguration.java`, `${javaDir}config/oauth2/OAuth2AuthenticationConfiguration.java`);
+                this.template(`${SERVER_MAIN_SRC_DIR}package/security/_TokenCache.java`, `${javaDir}security/TokenCache.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/security/oauth2/_CookieCollection.java`, `${javaDir}security/oauth2/CookieCollection.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/security/oauth2/_CookiesHttpServletRequestWrapper.java`, `${javaDir}security/oauth2/CookiesHttpServletRequestWrapper.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/security/oauth2/_CookieTokenExtractor.java`, `${javaDir}security/oauth2/CookieTokenExtractor.java`);

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -503,6 +503,10 @@ function writeFiles() {
             this.template(`${SERVER_TEST_RES_DIR}config/_application.yml`, `${SERVER_TEST_RES_DIR}config/application.yml`);
             this.template(`${SERVER_TEST_RES_DIR}_logback.xml`, `${SERVER_TEST_RES_DIR}logback.xml`);
 
+            if (this.authenticationType === 'session') {
+                this.template(`${SERVER_TEST_SRC_DIR}package/security/_TokenCacheTest.java`, `${testDir}security/TokenCacheTest.java`);
+            }
+
             // Create Gateway tests files
             if (this.applicationType === 'gateway') {
                 this.template(`${SERVER_TEST_SRC_DIR}package/gateway/responserewriting/_SwaggerBasePathRewritingFilterTest.java`, `${testDir}gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java`);
@@ -515,6 +519,7 @@ function writeFiles() {
                 this.template(`${SERVER_TEST_SRC_DIR}package/security/_OAuth2TokenMockUtil.java`, `${testDir}security/OAuth2TokenMockUtil.java`);
                 this.template(`${SERVER_TEST_SRC_DIR}package/config/_SecurityBeanOverrideConfiguration.java`, `${testDir}config/SecurityBeanOverrideConfiguration.java`);
                 if (this.applicationType === 'gateway') {
+                    this.template(`${SERVER_TEST_SRC_DIR}package/security/_TokenCacheTest.java`, `${testDir}security/TokenCacheTest.java`);
                     this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/_OAuth2CookieHelperTest.java`, `${testDir}security/oauth2/OAuth2CookieHelperTest.java`);
                     this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/_OAuth2AuthenticationServiceTest.java`, `${testDir}security/oauth2/OAuth2AuthenticationServiceTest.java`);
                     this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/_CookieTokenExtractorTest.java`, `${testDir}security/oauth2/CookieTokenExtractorTest.java`);

--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -312,6 +312,9 @@ dependencies {
         exclude module: 'nz.net.ultraq.thymeleaf:thymeleaf-layout-dialect'
     }
     compile "org.zalando:problem-spring-web"
+    <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
+    compile "de.malkusch.whois-server-list:public-suffix-list:${public_suffix_list_version}"
+    <%_ } _%>
     <%_ if (databaseType === 'cassandra') { _%>
     compile "com.google.guava:guava:18.0"
     compile "com.datastax.cassandra:cassandra-driver-extras"

--- a/generators/server/templates/_gradle.properties
+++ b/generators/server/templates/_gradle.properties
@@ -34,6 +34,12 @@ spring_boot_version=1.5.7.RELEASE
 hibernate_version=5.2.10.Final
 mapstruct_version=1.1.0.Final
 
+# TODO put this in jhipster-dependencies if adopted
+<%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
+public_suffix_list_version=2.2.0
+<%_ } _%>
+
+
 ## below are some of the gradle performance improvement settings that can be used as required, these are not enabled by default
 
 ## The Gradle daemon aims to improve the startup and execution time of Gradle.

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -87,6 +87,11 @@
         <%_ } _%>
         <mapstruct.version>1.1.0.Final</mapstruct.version>
 
+        <!-- TODO put this in jhipster-dependencies if adopted -->
+        <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
+        <public-suffix-list.version>2.2.0</public-suffix-list.version>
+        <%_ } _%>
+
         <!-- Plugin versions -->
         <maven-clean-plugin.version>2.6.1</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.7.0</maven-compiler-plugin.version>
@@ -431,6 +436,13 @@
             <artifactId>mapstruct-jdk8</artifactId>
             <version>${mapstruct.version}</version>
         </dependency>
+        <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
+        <dependency>
+            <groupId>de.malkusch.whois-server-list</groupId>
+            <artifactId>public-suffix-list</artifactId>
+            <version>${public-suffix-list.version}</version>
+        </dependency>
+        <%_ } _%>
         <dependency>
             <groupId>org.springframework</groupId>
             <artifactId>spring-context-support</artifactId>

--- a/generators/server/templates/src/main/java/package/config/_CacheConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_CacheConfiguration.java
@@ -127,9 +127,7 @@ public class CacheConfiguration {
     private final javax.cache.configuration.Configuration<Object, Object> jcacheConfiguration;
 
     public CacheConfiguration(JHipsterProperties jHipsterProperties) {
-        JHipsterProperties.Cache.Ehcache ehcache =
-            jHipsterProperties.getCache().getEhcache();
-
+        JHipsterProperties.Cache.Ehcache ehcache = jHipsterProperties.getCache().getEhcache();
         jcacheConfiguration = Eh107Configuration.fromEhcacheCacheConfiguration(
             CacheConfigurationBuilder.newCacheConfigurationBuilder(Object.class, Object.class,
                 ResourcePoolsBuilder.heap(ehcache.getMaxEntries()))

--- a/generators/server/templates/src/main/java/package/security/_TokenCache.java
+++ b/generators/server/templates/src/main/java/package/security/_TokenCache.java
@@ -1,0 +1,155 @@
+<%#
+ Copyright 2013-2017 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://jhipster.github.io/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.security;
+
+import java.util.Iterator;
+import java.util.LinkedHashMap;
+
+/**
+ * Simple time-limited cache for login tokens, necessary to avoid concurrent
+ * requests invalidating one another. It uses a {@link java.util.LinkedHashMap}
+ * to keep the tokens in order of expiration, and a dedicated low-priority purger
+ * thread which periodically removes expired tokens from the map.
+ */
+public class TokenCache<T> {
+<%_ /* TODO Should this class be in the server lib instead? */ _%>
+
+    private final long expireMillis;
+    private final long purgeMillis;
+
+    private final LinkedHashMap<String, Value> map;
+    private final Thread purger;
+    private long latestWriteTime;
+
+    /**
+     * Construct a new TokenCache.
+     * 
+     * @param expireMillis Delay until tokens expire, in millis.
+     * @param purgeMillis  Period of the purger thread, in millis. If this is
+     *                     zero or negative, no automatic purging will be done. 
+     * @throws IllegalArgumentException if expireMillis is non-positive.
+     */
+    public TokenCache(long expireMillis, long purgeMillis) {
+        if (expireMillis <= 0l) {
+            throw new IllegalArgumentException();
+        }
+        this.expireMillis = expireMillis;
+        this.purgeMillis = purgeMillis;
+
+        map = new LinkedHashMap<>(64, 0.75f);
+        latestWriteTime = System.currentTimeMillis();
+
+        if (purgeMillis <= 0l) {
+            purger = null;
+        } else {
+            purger = new Thread(new Runnable() {
+                @Override
+                public void run() {
+                    try {
+                        while (!purger.isInterrupted()) {
+                            Thread.sleep(TokenCache.this.purgeMillis);
+                            purge();
+                        }
+                    } catch (InterruptedException x) {
+                        // done
+                    }
+                }
+            });
+            purger.setName("tokenCachePurge");
+            purger.setDaemon(true);
+            purger.setPriority(Thread.MIN_PRIORITY);
+            purger.start();
+        }
+    }
+
+    /**
+     * Get a token from the cache.
+     * 
+     * @param key The key to look for.
+     * @return The token, if present and not yet expired, or null otherwise.
+     */
+    public synchronized T get(String key) {
+        final Value val = map.get(key);
+        final long time = System.currentTimeMillis();
+        return val != null && time < val.expire ? val.token : null;
+    }
+
+    /**
+     * Put a token in the cache.
+     * If a token already exists for the given key, it is replaced.
+     * 
+     * @param key   The key to insert for.
+     * @param token The token to insert.
+     */
+    public synchronized void put(String key, T token) {
+        if (map.containsKey(key)) {
+            map.remove(key);
+        }
+        final long time = System.currentTimeMillis();
+        map.put(key, new Value(token, time + expireMillis));
+        latestWriteTime = time;
+    }
+
+    /**
+     * Get the number of tokens in the cache. Note, this may include expired
+     * tokens, unless {@link #purge()} is invoked first.
+     * 
+     * @return The size of the cache.
+     */
+    public synchronized int size() {
+        return map.size();
+    }
+
+    /**
+     * Remove expired entried from the map. This will be called periodically
+     * by the purger thread, but could be manually invoked if desired.
+     */
+    public synchronized void purge() {
+        if (map.size() > 0) {
+            long time = System.currentTimeMillis();
+            if (time - latestWriteTime > expireMillis) {
+                // Everything in the map is expired, clear all at once
+                map.clear();
+            } else {
+                // Iterate and remove until the first non-expired token
+                Iterator<Value> values = map.values().iterator();
+                do {
+                    if (time >= values.next().expire) {
+                        values.remove();
+                    } else {
+                        break;
+                    }
+                } while (values.hasNext());
+            }
+        }
+    }
+
+
+    private class Value {
+
+        private final T token;
+        private final long expire;
+
+        Value(T token, long expire) {
+            this.token = token;
+            this.expire = expire;
+        }
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/security/oauth2/_OAuth2AuthenticationService.java
+++ b/generators/server/templates/src/main/java/package/security/oauth2/_OAuth2AuthenticationService.java
@@ -28,7 +28,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Manages authentication cases for OAuth2 updating the cookies holding access and refresh tokens accordingly.

--- a/generators/server/templates/src/test/java/package/security/_TokenCacheTest.java
+++ b/generators/server/templates/src/test/java/package/security/_TokenCacheTest.java
@@ -1,0 +1,127 @@
+<%#
+ Copyright 2013-2017 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.security;
+
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+public class TokenCacheTest {
+
+    @Test
+    public void testConstructorThrows() {
+        Throwable caught = catchThrowable(() -> new TokenCache<String>(-1l, 0l));
+        assertThat(caught).isInstanceOf(IllegalArgumentException.class);
+    }
+
+    @Test
+    public void testAbsent() {
+        TokenCache<String> cache = new TokenCache<>(100l, 0l);
+        assertThat(cache.get("key")).isNull();
+    }
+
+    @Test
+    public void testAccess() {
+        TokenCache<String> cache = new TokenCache<>(100l, 0l);
+        cache.put("key", "val");
+        assertThat(cache.size()).isEqualTo(1);
+        assertThat(cache.get("key")).isEqualTo("val");
+    }
+
+    @Test
+    public void testReplace() {
+        TokenCache<String> cache = new TokenCache<>(100l, 0l);
+        cache.put("key", "val");
+        cache.put("key", "foo");
+        assertThat(cache.get("key")).isEqualTo("foo");
+    }
+
+    @Test
+    public void testExpires() {
+        TokenCache<String> cache = new TokenCache<>(1l, 0l);
+        cache.put("key", "val");
+        try {
+            Thread.sleep(5l);
+        } catch (InterruptedException x) {
+            // This should not happen
+            throw new Error(x);
+        }
+        assertThat(cache.get("key")).isNull();
+    }
+
+    @Test
+    public void testFullPurge() {
+        TokenCache<String> cache = new TokenCache<>(1l, 0l);
+        cache.put("key", "val");
+        try {
+            Thread.sleep(5l);
+        } catch (InterruptedException x) {
+            // This should not happen
+            throw new Error(x);
+        }
+        assertThat(cache.size()).isEqualTo(1);
+        cache.purge();
+        assertThat(cache.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testPartialPurge() {
+        TokenCache<String> cache = new TokenCache<>(5l, 0l);
+        cache.put("key", "val");
+        try {
+            Thread.sleep(5l);
+        } catch (InterruptedException x) {
+            // This should not happen
+            throw new Error(x);
+        }
+        cache.put("foo", "bar");
+        assertThat(cache.size()).isEqualTo(2);
+        cache.purge();
+        assertThat(cache.size()).isEqualTo(1);
+    }
+
+    @Test
+    public void testFullAutoPurge() {
+        TokenCache<String> cache = new TokenCache<>(1l, 5l);
+        cache.put("key", "val");
+        try {
+            Thread.sleep(10l);
+        } catch (InterruptedException x) {
+            // This should not happen
+            throw new Error(x);
+        }
+        assertThat(cache.size()).isEqualTo(0);
+    }
+
+    @Test
+    public void testPartialAutoPurge() {
+        TokenCache<String> cache = new TokenCache<>(10l, 5l);
+        cache.put("key", "val");
+        try {
+            Thread.sleep(10l);
+            cache.put("foo", "bar");
+            Thread.sleep(5l);
+        } catch (InterruptedException x) {
+            // This should not happen
+            throw new Error(x);
+        }
+        assertThat(cache.size()).isEqualTo(1);
+    }
+}


### PR DESCRIPTION
Ref. https://github.com/jhipster/generator-jhipster/issues/6648

Unfortunately I haven't found time to make this work with Spring caches, or Caffeine. But I'm not going to have a lot of time the next couple of days, so I wanted to put this out there for now.

If anyone wants to take a look at adding onto this, that would be great. Otherwise, this is also a fully functional (although pretty minimal) alternative to what was here before...

Note: I've added a dependency on a small public-suffix-list library to replace another little call we did to a Guava component. If this, or something like this, were adopted that would have to go into jhipster-dependencies.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
