### PR TITLE
fix sonar links in readme [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,11 +43,11 @@ Please read our [guidelines](/CONTRIBUTING.md#submitting-an-issue) before submit
 [image-microservices]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=microservices
 [image-react]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=react
 
-[sonar-url]: https://sonarqube.com/dashboard?id=io.github.jhipster.sample%3Ajhipster-sample-application
-[sonar-quality-gate]: https://sonarqube.com/api/badges/gate?key=io.github.jhipster.sample%3Ajhipster-sample-application
-[sonar-coverage]: https://sonarqube.com/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=coverage
-[sonar-bugs]: https://sonarqube.com/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=bugs
-[sonar-vulnerabilities]: https://sonarqube.com/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=vulnerabilities
+[sonar-url]: https://sonarcloud.io/dashboard?id=io.github.jhipster.sample%3Ajhipster-sample-application
+[sonar-quality-gate]: https://sonarcloud.io/api/badges/gate?key=io.github.jhipster.sample%3Ajhipster-sample-application
+[sonar-coverage]: https://sonarcloud.io/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=coverage
+[sonar-bugs]: https://sonarcloud.io/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=bugs
+[sonar-vulnerabilities]: https://sonarcloud.io/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=vulnerabilities
 
 [jhipster-image]: https://raw.githubusercontent.com/jhipster/jhipster.github.io/master/images/logo/logo-jhipster2x.png
 [jhipster-url]: http://www.jhipster.tech/


### PR DESCRIPTION
URL changed from sonarqube.com to sonarcloud.io.  Currently the links take you to the Sonar home page.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
