### PR TITLE
6668 -  fix the logstash-appender stopping working issues

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -53,11 +53,12 @@ import org.springframework.cloud.context.config.annotation.RefreshScope;
 @Configuration
 <%_ if (serviceDiscoveryType === "eureka") { _%>
 @ConditionalOnProperty("eureka.client.enabled")
+@RefreshScope
 <%_ } _%>
 <%_ if (serviceDiscoveryType === "consul") { _%>
 @ConditionalOnConsulEnabled
-<%_ } _%>
 @RefreshScope
+<%_ } _%>
 public class LoggingConfiguration {
 
     private static final String LOGSTASH_APPENDER_NAME = "LOGSTASH";

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -48,6 +48,7 @@ import org.springframework.cloud.consul.ConditionalOnConsulEnabled;
 import org.springframework.cloud.consul.serviceregistry.ConsulRegistration;
 <%_ } _%>
 import org.springframework.context.annotation.Configuration;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 
 @Configuration
 <%_ if (serviceDiscoveryType === "eureka") { _%>
@@ -56,6 +57,7 @@ import org.springframework.context.annotation.Configuration;
 <%_ if (serviceDiscoveryType === "consul") { _%>
 @ConditionalOnConsulEnabled
 <%_ } _%>
+@RefreshScope
 public class LoggingConfiguration {
 
     private static final String LOGSTASH_APPENDER_NAME = "LOGSTASH";

--- a/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_LoggingConfiguration.java
@@ -42,13 +42,15 @@ import org.springframework.beans.factory.annotation.Value;
 <%_ if (serviceDiscoveryType === "eureka") { _%>
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.cloud.netflix.eureka.EurekaInstanceConfigBean;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 <%_ } _%>
 <%_ if (serviceDiscoveryType === "consul") { _%>
 import org.springframework.cloud.consul.ConditionalOnConsulEnabled;
 import org.springframework.cloud.consul.serviceregistry.ConsulRegistration;
+import org.springframework.cloud.context.config.annotation.RefreshScope;
 <%_ } _%>
 import org.springframework.context.annotation.Configuration;
-import org.springframework.cloud.context.config.annotation.RefreshScope;
+
 
 @Configuration
 <%_ if (serviceDiscoveryType === "eureka") { _%>


### PR DESCRIPTION
In the SpringCloudConfig, Spring will refresh its configuration even the app is already running.  Spring will call the `LoggerContext` to refresh all the logger config. which will `StopAndReset` the log config. it will stop all the logappender and remove all the `LoggerContextListener`.   After that, `LoggerContext `will load the new configuration based on the configuration file (logback-spring.xml) . then, Spring will call the configuration class ...... , but here, the `LoggingConfiguration` bean is a singleton and already been created. 
In this case, the above `LoggingConfiguration`  won't be created again (even the `logstash-appender` has been stopped).

We add the `@RefreshScope` here to force Spring to recreate this bean when there is configuration refresh

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
