### PR TITLE
Docker-compose : don't expose jhipster-elasticsearch port 9200 on the host

### DIFF
--- a/generators/docker-compose/templates/_jhipster-console.yml
+++ b/generators/docker-compose/templates/_jhipster-console.yml
@@ -20,8 +20,6 @@ version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     jhipster-elasticsearch:
         image: <%= DOCKER_JHIPSTER_ELASTICSEARCH %>
-        ports:
-            - 9200:9200
         # Uncomment this as well as the volume section down below
         # to have elasticsearch data persisted to a volume
         # you will need to create a named volume with `docker volume create log-data`


### PR DESCRIPTION
fix #6621

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
