### PR TITLE
Prevent from using JDK 9

### DIFF
--- a/generators/server/templates/_build.gradle
+++ b/generators/server/templates/_build.gradle
@@ -51,6 +51,9 @@ plugins {
 apply plugin: 'java'
 sourceCompatibility=<%= JAVA_VERSION %>
 targetCompatibility=<%= JAVA_VERSION %>
+// Until JHipster supports JDK 9
+assert System.properties['java.specification.version'] == '1.8'
+
 apply plugin: 'maven'
 apply plugin: 'org.springframework.boot'
 apply plugin: 'war'

--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -810,8 +810,9 @@
                             <version>[${maven.version},)</version>
                         </requireMavenVersion>
                         <requireJavaVersion>
-                            <message>You are running an older version of Java. JHipster requires at least JDK ${java.version}</message>
-                            <version>[${java.version}.0,)</version>
+                            <!-- Until JHipster supports JDK 9 -->
+                            <message>You are running an incompatible version of Java. JHipster requires JDK ${java.version}</message>
+                            <version>[1.8,1.9)</version>
                         </requireJavaVersion>
                     </rules>
                 </configuration>

--- a/travis/scripts/04-tests.sh
+++ b/travis/scripts/04-tests.sh
@@ -2,9 +2,18 @@
 set -e
 
 #-------------------------------------------------------------------------------
-# Check Javadoc generation
+# Display environment information like JDK version
 #-------------------------------------------------------------------------------
 cd "$APP_FOLDER"
+if [ -f "mvnw" ]; then
+    ./mvnw enforcer:display-info
+elif [ -f "gradlew" ]; then
+    ./gradlew -v
+fi
+
+#-------------------------------------------------------------------------------
+# Check Javadoc generation
+#-------------------------------------------------------------------------------
 if [ -f "mvnw" ]; then
     ./mvnw javadoc:javadoc
 elif [ -f "gradlew" ]; then


### PR DESCRIPTION
Recently we have seen several questions or issues due to users using JDK 9. This commit makes maven and gradle fail in this case.

Display env info at start of Travis build

Ref  #6391

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
