### PR TITLE
Add hint for how to run jhipster after linking local generator

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -203,6 +203,11 @@ Now, running the 'jhipster' command should use your specific JHipster version. Y
 ```shell
 jhipster
 ```
+Depending on which parts of the generator you have changed, do not forget to run jhipster command with the proper arguments e.g. when updating the entity template run:
+
+```shell
+jhipster --with-entities
+```
 
 You should see your changes reflected in the generated project.
 


### PR DESCRIPTION
After linking the local generator, I have problems to see the changes when running jhipster in my local app. The problem was that I need to run `jhipster --with-entities` because the changes that I have done in the generator were in the entity template.
Such a hint will save times for newbies like me.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
