### PR TITLE
disable 'Clustered HTTP sessions using Hazelcast' option when oauth2 is selected

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -475,7 +475,8 @@ function askForOptionalItems(meta) {
         });
     }
     if ((applicationType === 'monolith' || applicationType === 'gateway') &&
-            (this.hibernateCache === 'no' || this.hibernateCache === 'hazelcast')) {
+            (this.hibernateCache === 'no' || this.hibernateCache === 'hazelcast') &&
+            this.authenticationType !== 'oauth2') {
         choices.push({
             name: 'Clustered HTTP sessions using Hazelcast',
             value: 'clusteredHttpSession:hazelcast'


### PR DESCRIPTION
‘hazelcast session clustering’ and ‘oauth2’ options are incompatible and login doesn’t work when the two options are selected. See  #6756's related comments and conclusion for more details.

Fix #6756

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
