### PR TITLE
add filter url param

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/model/_request-util.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/model/_request-util.ts
@@ -10,6 +10,7 @@ export const createRequestOption = (req?: any): BaseRequestOptions => {
             params.paramsMap.set('sort', req.sort);
         }
         params.set('query', req.query);
+        params.set('filter', req.filter);
 
         options.params = params;
     }


### PR DESCRIPTION
**filter**  url param need to be passed in the url when we use _*-is-null_ filter to get the entities not already linked.
The server use it through this template `get_all_stream_template.ejs`.

Related to https://github.com/jhipster/generator-jhipster/issues/6735


