### PR TITLE
fix generating microservice entities on a gateway

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -394,11 +394,11 @@ module.exports = class extends BaseGenerator {
                 if (context.entityAngularJSSuffix) {
                     this.data.angularJSSuffix = context.entityAngularJSSuffix;
                 }
-                if (this.applicationType === 'microservice') {
+                if (context.applicationType === 'microservice') {
                     this.data.microserviceName = context.baseName;
                     this.data.searchEngine = context.searchEngine;
                 }
-                if (this.applicationType === 'gateway' && context.useMicroserviceJson) {
+                if (context.applicationType === 'gateway' && context.useMicroserviceJson) {
                     this.data.microserviceName = context.microserviceName;
                     this.data.searchEngine = context.searchEngine;
                 }


### PR DESCRIPTION
Microservices are failing to save `microserviceName` in the entity's JSON file, which leads to a failure if manually importing it into the gateway.
```
Using JHipster version installed locally in current project's node_modules
Executing jhipster:entity Foo
Options: 

The entity Foo is being created.

? Do you want to generate this entity from an existing microservice? Yes
? Enter the path to the microservice root directory: ../ms

Found the .jhipster/Foo.json configuration file, entity can be automatically generated!

Error: ERROR! Microservice name for the entity is not found. Entity cannot be generated!
    at Environment.error (/private/tmp/jh/gway/gway/node_modules/yeoman-environment/lib/environment.js:157:40)
    at Object.error (/private/tmp/jh/gway/gway/node_modules/generator-jhipster/generators/generator-base.js:1964:18)
    at Object.loadEntityJson (/private/tmp/jh/gway/gway/node_modules/generator-jhipster/generators/generator-base.js:1764:22)
    at prompt.then (/private/tmp/jh/gway/gway/node_modules/generator-jhipster/generators/entity/prompts.js:89:18)
```

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
