### PR TITLE
allow Authorization header to the specified SERVER_API_URL

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth.interceptor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/_auth.interceptor.ts
@@ -20,6 +20,7 @@ import { Observable } from 'rxjs/Observable';
 import { RequestOptionsArgs, Response } from '@angular/http';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { JhiHttpInterceptor } from 'ng-jhipster';
+import { SERVER_API_URL } from '../../app.constants';
 
 export class AuthInterceptor extends JhiHttpInterceptor {
 
@@ -31,7 +32,7 @@ export class AuthInterceptor extends JhiHttpInterceptor {
     }
 
     requestIntercept(options?: RequestOptionsArgs): RequestOptionsArgs {
-        if (!options || !options.url || /^http/.test(options.url)) {
+        if (!options || !options.url || (/^http/.test(options.url) && !(SERVER_API_URL && options.url.startsWith(SERVER_API_URL)))) {
             return options;
         }
 


### PR DESCRIPTION
If a developer specifies a separate backend server as the SERVER_API_URL, we should allow the Authorization header to go to that server.  The current behavior when authenticating in a separated client/server is that the login modal closes with successful call to `/api/authenticate` but then a 401 is received from `/api/account` due to no Authorization header.

This still prevents any URLs containing `http` other than the SERVER_API_URL

Fix #6798

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
