### PR TITLE
expose link and x-total-count headers when using CORS

### DIFF
--- a/generators/server/templates/src/main/resources/config/_application-dev.yml
+++ b/generators/server/templates/src/main/resources/config/_application-dev.yml
@@ -304,8 +304,10 @@ jhipster:
         allowed-origins: "*"
         allowed-methods: "*"
         allowed-headers: "*"
-        <%_ if (authenticationType !== 'session') { _%>
-        exposed-headers: "Authorization"
+        <%_ if (authenticationType === 'session') { _%>
+        exposed-headers: "Link,X-Total-Count"
+        <%_ } else { _%>
+        exposed-headers: "Authorization,Link,X-Total-Count"
         <%_ } _%>
         allow-credentials: true
         max-age: 1800
@@ -316,7 +318,7 @@ jhipster:
         # allowed-origins: "*"
         # allowed-methods: "*"
         # allowed-headers: "*"
-        # exposed-headers: "Authorization"
+        # exposed-headers: "Authorization,Link,X-Total-Count"
         # allow-credentials: true
         # max-age: 1800
     <%_ } _%>

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -243,9 +243,13 @@ jhipster:
     # By default CORS is disabled. Uncomment to enable.
     #cors:
         #allowed-origins: "*"
-        #allowed-methods: GET, PUT, POST, DELETE, OPTIONS
+        #allowed-methods: "*"
         #allowed-headers: "*"
-        #exposed-headers:
+        <%_ if (authenticationType === 'session') { _%>
+        #exposed-headers: "Link,X-Total-Count"
+        <%_ } else { _%>
+        #exposed-headers: "Authorization,Link,X-Total-Count"
+        <%_ } _%>
         #allow-credentials: true
         #max-age: 1800
     mail:


### PR DESCRIPTION
If you try to access the user-management page or any entity page from an app using a separated client/server, the call to `this.links = this.parseLinks.parse(headers.get('link'));` fails because the `link` header is not exposed to the client.  Same situation for the `X-Total-Count` header.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
