### PR TITLE
add SERVER_API_URL to UAA apps

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -333,9 +333,7 @@ module.exports = class extends BaseGenerator {
 
                 this.styleSheetExt = this.useSass ? 'scss' : 'css';
                 this.pkType = this.getPkType(this.databaseType);
-                this.apiUrlPrefix = `${this.authenticationType === 'uaa' ? `'${this.uaaBaseName.toLowerCase()}/` : 'SERVER_API_URL + \''}`;
-                this.apiUaaUrlPrefix = `${this.authenticationType === 'uaa' ? `${this.uaaBaseName.toLowerCase()}/` : ''}`;
-                this.apiServerUrlPrefix = `${this.authenticationType !== 'uaa' ? 'SERVER_API_URL + \'' : '\''}`;
+                this.apiUaaUrlPrefix = `${this.authenticationType === 'uaa' ? `SERVER_API_URL + '${this.uaaBaseName.toLowerCase()}/` : 'SERVER_API_URL + \''}`;
                 this.DIST_DIR = this.BUILD_DIR + constants.CLIENT_DIST_DIR;
             },
 

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -333,7 +333,7 @@ module.exports = class extends BaseGenerator {
 
                 this.styleSheetExt = this.useSass ? 'scss' : 'css';
                 this.pkType = this.getPkType(this.databaseType);
-                this.apiUaaUrlPrefix = `${this.authenticationType === 'uaa' ? `SERVER_API_URL + '${this.uaaBaseName.toLowerCase()}/` : 'SERVER_API_URL + \''}`;
+                this.apiUaaPath = `${this.authenticationType === 'uaa' ? `${this.uaaBaseName.toLowerCase()}/` : ''}`;
                 this.DIST_DIR = this.BUILD_DIR + constants.CLIENT_DIST_DIR;
             },
 

--- a/generators/client/templates/angular/src/main/webapp/app/_app.constants.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_app.constants.ts
@@ -20,17 +20,11 @@
  /* tslint:disable */
 let _VERSION = '0.0.1-SNAPSHOT'; // This value will be overwritten by Webpack
 let _DEBUG_INFO_ENABLED = true; // This value will be overwritten by Webpack
-<%_ if (authenticationType !== 'uaa') { _%>
 let _SERVER_API_URL = ''; // This value will be overwritten by Webpack
-<%_ } _%>
 /* @toreplace VERSION */
 /* @toreplace DEBUG_INFO_ENABLED */
-<%_ if (authenticationType !== 'uaa') { _%>
 /* @toreplace SERVER_API_URL */
-<%_ } _%>
 /* tslint:enable */
 export const VERSION = _VERSION;
 export const DEBUG_INFO_ENABLED = _DEBUG_INFO_ENABLED;
-<%_ if (authenticationType !== 'uaa') { _%>
 export const SERVER_API_URL = _SERVER_API_URL;
-<%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.service.ts
@@ -30,7 +30,7 @@ export class ActivateService {
         const params: URLSearchParams = new URLSearchParams();
         params.set('key', key);
 
-        return this.http.get(<%- apiUaaUrlPrefix %>api/activate', {
+        return this.http.get(SERVER_API_URL + '<%- apiUaaPath %>api/activate', {
             search: params
         }).map((res: Response) => res);
     }

--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response, URLSearchParams } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class ActivateService {
@@ -32,7 +30,7 @@ export class ActivateService {
         const params: URLSearchParams = new URLSearchParams();
         params.set('key', key);
 
-        return this.http.get(<%- apiUrlPrefix %>api/activate', {
+        return this.http.get(<%- apiUaaUrlPrefix %>api/activate', {
             search: params
         }).map((res: Response) => res);
     }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class PasswordResetFinishService {
@@ -29,6 +27,6 @@ export class PasswordResetFinishService {
     constructor(private http: Http) {}
 
     save(keyAndPassword: any): Observable<any> {
-        return this.http.post(<%- apiUrlPrefix %>api/account/reset-password/finish', keyAndPassword);
+        return this.http.post(<%- apiUaaUrlPrefix %>api/account/reset-password/finish', keyAndPassword);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.service.ts
@@ -27,6 +27,6 @@ export class PasswordResetFinishService {
     constructor(private http: Http) {}
 
     save(keyAndPassword: any): Observable<any> {
-        return this.http.post(<%- apiUaaUrlPrefix %>api/account/reset-password/finish', keyAndPassword);
+        return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account/reset-password/finish', keyAndPassword);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.service.ts
@@ -27,6 +27,6 @@ export class PasswordResetInitService {
     constructor(private http: Http) {}
 
     save(mail: string): Observable<any> {
-        return this.http.post(<%- apiUaaUrlPrefix %>api/account/reset-password/init', mail);
+        return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account/reset-password/init', mail);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class PasswordResetInitService {
@@ -29,6 +27,6 @@ export class PasswordResetInitService {
     constructor(private http: Http) {}
 
     save(mail: string): Observable<any> {
-        return this.http.post(<%- apiUrlPrefix %>api/account/reset-password/init', mail);
+        return this.http.post(<%- apiUaaUrlPrefix %>api/account/reset-password/init', mail);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class PasswordService {
@@ -29,6 +27,6 @@ export class PasswordService {
     constructor(private http: Http) {}
 
     save(newPassword: string): Observable<any> {
-        return this.http.post(<%- apiUrlPrefix %>api/account/change-password', newPassword);
+        return this.http.post(<%- apiUaaUrlPrefix %>api/account/change-password', newPassword);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.service.ts
@@ -27,6 +27,6 @@ export class PasswordService {
     constructor(private http: Http) {}
 
     save(newPassword: string): Observable<any> {
-        return this.http.post(<%- apiUaaUrlPrefix %>api/account/change-password', newPassword);
+        return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account/change-password', newPassword);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/_register.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/_register.service.ts
@@ -27,6 +27,6 @@ export class Register {
     constructor(private http: Http) {}
 
     save(account: any): Observable<any> {
-        return this.http.post(<%- apiUaaUrlPrefix %>api/register', account);
+        return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/register', account);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/_register.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/_register.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class Register {
@@ -29,6 +27,6 @@ export class Register {
     constructor(private http: Http) {}
 
     save(account: any): Observable<any> {
-        return this.http.post(<%- apiUrlPrefix %>api/register', account);
+        return this.http.post(<%- apiUaaUrlPrefix %>api/register', account);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.service.ts
@@ -21,15 +21,12 @@ import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 
 import { Session } from './session.model';
-<%_ if (authenticationType !== 'uaa') { _%>
-
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class SessionsService {
 
-    private resourceUrl = <%- apiUrlPrefix %>api/account/sessions/';
+    private resourceUrl = SERVER_API_URL + 'api/account/sessions/';
     constructor(private http: Http) { }
 
     findAll(): Observable<Session[]> {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response, URLSearchParams } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class AuditsService  {
@@ -39,6 +37,6 @@ export class AuditsService  {
             search: params
         };
 
-        return this.http.get(<%- apiUrlPrefix %>management/audits', options);
+        return this.http.get(<%- apiUaaUrlPrefix %>management/audits', options);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.service.ts
@@ -37,6 +37,6 @@ export class AuditsService  {
             search: params
         };
 
-        return this.http.get(<%- apiUaaUrlPrefix %>management/audits', options);
+        return this.http.get(SERVER_API_URL + '<%- apiUaaPath %>management/audits', options);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class <%=jhiPrefixCapitalized%>ConfigurationService {
@@ -30,7 +28,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationService {
     }
 
     get(): Observable<any> {
-        return this.http.get(<%- apiServerUrlPrefix %>management/configprops').map((res: Response) => {
+        return this.http.get(SERVER_API_URL + 'management/configprops').map((res: Response) => {
             const properties: any[] = [];
 
             const propertiesObject = res.json();
@@ -49,7 +47,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationService {
     }
 
     getEnv(): Observable<any> {
-        return this.http.get(<%- apiServerUrlPrefix %>management/env').map((res: Response) => {
+        return this.http.get(SERVER_API_URL + 'management/env').map((res: Response) => {
             const properties: any = {};
 
             const propertiesObject = res.json();

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway-routes.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway-routes.service.ts
@@ -20,9 +20,7 @@ import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 import { GatewayRoute } from './gateway-route.model';
 
 @Injectable()
@@ -30,6 +28,6 @@ export class GatewayRoutesService {
     constructor(private http: Http) { }
 
     findAll(): Observable<GatewayRoute[]> {
-        return this.http.get(<% if (authenticationType === 'uaa') { %>'<% } else { %>SERVER_API_URL + '<% } %>api/gateway/routes/').map((res: Response) => res.json());
+        return this.http.get(SERVER_API_URL + 'api/gateway/routes/').map((res: Response) => res.json());
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class <%=jhiPrefixCapitalized%>HealthService {
@@ -33,7 +31,7 @@ export class <%=jhiPrefixCapitalized%>HealthService {
     }
 
     checkHealth(): Observable<any> {
-        return this.http.get(<%- apiServerUrlPrefix %>management/health').map((res: Response) => res.json());
+        return this.http.get(SERVER_API_URL + 'management/health').map((res: Response) => res.json());
     }
 
     transformHealthData(data): any {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 import { Log } from './log.model';
 
@@ -30,10 +28,10 @@ export class LogsService {
     constructor(private http: Http) { }
 
     changeLevel(log: Log): Observable<Response> {
-        return this.http.put(<%- apiServerUrlPrefix %>management/logs', log);
+        return this.http.put(SERVER_API_URL + 'management/logs', log);
     }
 
     findAll(): Observable<Log[]> {
-        return this.http.get(<%- apiServerUrlPrefix %>management/logs').map((res: Response) => res.json());
+        return this.http.get(SERVER_API_URL + 'management/logs').map((res: Response) => res.json());
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Response, Http } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class <%=jhiPrefixCapitalized%>MetricsService {
@@ -29,10 +27,10 @@ export class <%=jhiPrefixCapitalized%>MetricsService {
     constructor(private http: Http) {}
 
     getMetrics(): Observable<any> {
-        return this.http.get(<%- apiServerUrlPrefix %>management/metrics').map((res: Response) => res.json());
+        return this.http.get(SERVER_API_URL + 'management/metrics').map((res: Response) => res.json());
     }
 
     threadDump(): Observable<any> {
-        return this.http.get(<%- apiServerUrlPrefix %>management/dump').map((res: Response) => res.json());
+        return this.http.get(SERVER_API_URL + 'management/dump').map((res: Response) => res.json());
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/_profile.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/_profile.service.ts
@@ -19,15 +19,13 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 import { ProfileInfo } from './profile-info.model';
 
 @Injectable()
 export class ProfileService {
 
-    private profileInfoUrl = <% if (authenticationType === 'uaa') { %>'<% } else { %>SERVER_API_URL + '<% } %>api/profile-info';
+    private profileInfoUrl = SERVER_API_URL + 'api/profile-info';
     private profileInfo: Promise<ProfileInfo>;
 
     constructor(private http: Http) { }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
@@ -26,10 +26,10 @@ export class AccountService  {
     constructor(private http: Http) { }
 
     get(): Observable<any> {
-        return this.http.get(<%- apiUaaUrlPrefix %>api/account').map((res: Response) => res.json());
+        return this.http.get(SERVER_API_URL + '<%- apiUaaPath %>api/account').map((res: Response) => res.json());
     }
 
     save(account: any): Observable<Response> {
-        return this.http.post(<%- apiUaaUrlPrefix %>api/account', account);
+        return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account', account);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
@@ -19,19 +19,17 @@
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class AccountService  {
     constructor(private http: Http) { }
 
     get(): Observable<any> {
-        return this.http.get(<%- apiUrlPrefix %>api/account').map((res: Response) => res.json());
+        return this.http.get(<%- apiUaaUrlPrefix %>api/account').map((res: Response) => res.json());
     }
 
     save(account: any): Observable<Response> {
-        return this.http.post(<%- apiUrlPrefix %>api/account', account);
+        return this.http.post(<%- apiUaaUrlPrefix %>api/account', account);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
@@ -21,8 +21,8 @@ import { Http } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 <%_ if (authenticationType !== 'uaa') { _%>
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
-import { SERVER_API_URL } from '../../app.constants';
 <%_ } _%>
+import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()
 export class AuthServerProvider {
@@ -48,7 +48,7 @@ export class AuthServerProvider {
             password: credentials.password,
             rememberMe: credentials.rememberMe
         };
-        return this.http.post('auth/login', data, {});
+        return this.http.post(SERVER_API_URL + 'auth/login', data, {});
 <% } else { %>
         const data = {
             username: credentials.username,
@@ -89,7 +89,7 @@ export class AuthServerProvider {
 
     logout(): Observable<any> {
 <%_ if (authenticationType === 'uaa') { _%>
-        return this.http.post('auth/logout', null);
+        return this.http.post(SERVER_API_URL + 'auth/logout', null);
 <% } else { %>
         return new Observable((observer) => {
             this.$localStorage.clear('authenticationToken');

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
@@ -19,9 +19,7 @@
 import { Injectable } from '@angular/core';
 import { Http, Response<% if (authenticationType !== 'oauth2') { %>, Headers<% } %> } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 
 @Injectable()
 export class AuthServerProvider {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
@@ -20,9 +20,7 @@ import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
 import { Observable } from 'rxjs/Rx';
 
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from '../../app.constants';
-<%_ } _%>
 <%_ if (authenticationType !== 'oauth2') { _%>
 import { User } from './user.model';
 <%_ } _%>
@@ -31,7 +29,7 @@ import { createRequestOption } from '../model/request-util';
 
 @Injectable()
 export class UserService {
-    private resourceUrl = <%- apiUrlPrefix %>api/users';
+    private resourceUrl = <%- apiUaaUrlPrefix %>api/users';
 
     constructor(private http: Http) { }
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -63,7 +61,7 @@ export class UserService {
 
     authorities(): Observable<string[]> {
 <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
-        return this.http.get(<%- apiUrlPrefix %>api/users/authorities').map((res: Response) => {
+        return this.http.get(<%- apiUaaUrlPrefix %>api/users/authorities').map((res: Response) => {
             const json = res.json();
             return <string[]> json;
         });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
@@ -29,7 +29,7 @@ import { createRequestOption } from '../model/request-util';
 
 @Injectable()
 export class UserService {
-    private resourceUrl = <%- apiUaaUrlPrefix %>api/users';
+    private resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/users';
 
     constructor(private http: Http) { }
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -61,7 +61,7 @@ export class UserService {
 
     authorities(): Observable<string[]> {
 <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
-        return this.http.get(<%- apiUaaUrlPrefix %>api/users/authorities').map((res: Response) => {
+        return this.http.get(SERVER_API_URL + '<%- apiUaaPath %>api/users/authorities').map((res: Response) => {
             const json = res.json();
             return <string[]> json;
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/user/_user.service.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/user/_user.service.spec.ts
@@ -22,9 +22,7 @@ import { ConnectionBackend, RequestOptions, BaseRequestOptions, Http, Response, 
 import { JhiDateUtils } from 'ng-jhipster';
 
 import { UserService, User } from './../../../../../../main/webapp/app/shared';
-<%_ if (authenticationType !== 'uaa') { _%>
 import { SERVER_API_URL } from './../../../../../../main/webapp/app/app.constants';
-<%_ } _%>
 
 describe('Service Tests', () => {
 
@@ -59,7 +57,7 @@ describe('Service Tests', () => {
         describe('Service methods', () => {
             it('should call correct URL', () => {
                 service.find('user').subscribe(() => {});
-                const resourceUrl = <%- apiUrlPrefix %>api/users';
+                const resourceUrl = <%- apiUaaUrlPrefix %>api/users';
 
                 expect(this.lastConnection).toBeDefined();
                 expect(this.lastConnection.request.url).toEqual(`${resourceUrl}/user`);

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/user/_user.service.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/user/_user.service.spec.ts
@@ -57,7 +57,7 @@ describe('Service Tests', () => {
         describe('Service methods', () => {
             it('should call correct URL', () => {
                 service.find('user').subscribe(() => {});
-                const resourceUrl = <%- apiUaaUrlPrefix %>api/users';
+                const resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/users';
 
                 expect(this.lastConnection).toBeDefined();
                 expect(this.lastConnection.request.url).toEqual(`${resourceUrl}/user`);

--- a/generators/client/templates/angular/webpack/_webpack.common.js
+++ b/generators/client/templates/angular/webpack/_webpack.common.js
@@ -29,12 +29,12 @@ const utils = require('./utils.js');
 module.exports = (options) => {
     const DATAS = {
         VERSION: `'${utils.parseVersion()}'`,
-        DEBUG_INFO_ENABLED: options.env === 'development'<% if (authenticationType !== 'uaa') { %>,
+        DEBUG_INFO_ENABLED: options.env === 'development',
         // The root URL for API calls, ending with a '/' - for example: `"http://www.jhipster.tech:8081/myservice/"`.
         // If this URL is left empty (""), then it will be relative to the current context.
         // If you use an API server, in `prod` mode, you will need to enable CORS
         // (see the `jhipster.cors` common JHipster property in the `application-*.yml` configurations)
-        SERVER_API_URL: `""`<% } %>
+        SERVER_API_URL: `""`
     };
     return {
         resolve: {

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_account.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_account.service.js
@@ -26,7 +26,7 @@
     Account.$inject = ['$resource'];
 
     function Account ($resource) {
-        var service = $resource('<%- apiUaaUrlPrefix %>api/account', {}, {
+        var service = $resource('<%- apiUaaPath %>api/account', {}, {
             'get': { method: 'GET', params: {}, isArray: false,
                 interceptor: {
                     response: function(response) {

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_activate.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_activate.service.js
@@ -26,7 +26,7 @@
     Activate.$inject = ['$resource'];
 
     function Activate ($resource) {
-        var service = $resource('<%- apiUaaUrlPrefix %>api/activate', {}, {
+        var service = $resource('<%- apiUaaPath %>api/activate', {}, {
             'get': { method: 'GET', params: {}, isArray: false}
         });
 

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_password-reset-finish.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_password-reset-finish.service.js
@@ -26,7 +26,7 @@
     PasswordResetFinish.$inject = ['$resource'];
 
     function PasswordResetFinish($resource) {
-        var service = $resource('<%- apiUaaUrlPrefix %>api/account/reset-password/finish', {}, {});
+        var service = $resource('<%- apiUaaPath %>api/account/reset-password/finish', {}, {});
 
         return service;
     }

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_password-reset-init.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_password-reset-init.service.js
@@ -26,7 +26,7 @@
     PasswordResetInit.$inject = ['$resource'];
 
     function PasswordResetInit($resource) {
-        var service = $resource('<%- apiUaaUrlPrefix %>api/account/reset-password/init', {}, {});
+        var service = $resource('<%- apiUaaPath %>api/account/reset-password/init', {}, {});
 
         return service;
     }

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_password.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_password.service.js
@@ -26,7 +26,7 @@
     Password.$inject = ['$resource'];
 
     function Password($resource) {
-        var service = $resource('<%- apiUaaUrlPrefix %>api/account/change-password', {}, {});
+        var service = $resource('<%- apiUaaPath %>api/account/change-password', {}, {});
 
         return service;
     }

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_register.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_register.service.js
@@ -26,6 +26,6 @@
     Register.$inject = ['$resource'];
 
     function Register ($resource) {
-        return $resource('<%- apiUaaUrlPrefix %>api/register', {}, {});
+        return $resource('<%- apiUaaPath %>api/register', {}, {});
     }
 })();

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_sessions.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/auth/_sessions.service.js
@@ -26,7 +26,7 @@
     Sessions.$inject = ['$resource'];
 
     function Sessions ($resource) {
-        return $resource('<%- apiUaaUrlPrefix %>api/account/sessions/:series', {}, {
+        return $resource('api/account/sessions/:series', {}, {
             'getAll': { method: 'GET', isArray: true}
         });
     }

--- a/generators/client/templates/angularjs/src/main/webapp/app/services/user/_user.service.js
+++ b/generators/client/templates/angularjs/src/main/webapp/app/services/user/_user.service.js
@@ -26,7 +26,7 @@
     User.$inject = ['$resource'];
 
     function User ($resource) {
-        var service = $resource('<%- apiUaaUrlPrefix %>api/users/:login', {}, {
+        var service = $resource('<%- apiUaaPath %>api/users/:login', {}, {
             'query': {method: 'GET', isArray: true},
             'get': {
                 method: 'GET',


### PR DESCRIPTION
Simplified the three API url variables into one - `this.apiUaaPath` which is only used on routes that the UAA controls (user auth/management).

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
