### PR TITLE
Upgrade Angular to 5.1.0 / TypeScript to 2.5.3

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -54,7 +54,7 @@
     "zone.js": "0.8.16"
   },
   "devDependencies": {
-    "@angular/cli": "1.5.5",
+    "@angular/cli": "1.6.0",
     "@angular/compiler-cli": "5.1.0",
     "@ngtools/webpack": "1.8.5",
     "@types/jasmine": "2.5.53",

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -26,14 +26,14 @@
     "node_modules"
   ],
   "dependencies": {
-    "@angular/common": "5.0.5",
-    "@angular/compiler": "5.0.5",
-    "@angular/core": "5.0.5",
-    "@angular/forms": "5.0.5",
-    "@angular/http": "5.0.5",
-    "@angular/platform-browser": "5.0.5",
-    "@angular/platform-browser-dynamic": "5.0.5",
-    "@angular/router": "5.0.5",
+    "@angular/common": "5.1.0",
+    "@angular/compiler": "5.1.0",
+    "@angular/core": "5.1.0",
+    "@angular/forms": "5.1.0",
+    "@angular/http": "5.1.0",
+    "@angular/platform-browser": "5.1.0",
+    "@angular/platform-browser-dynamic": "5.1.0",
+    "@angular/router": "5.1.0",
     "@ng-bootstrap/ng-bootstrap": "1.0.0-beta.6",
     "bootstrap": "4.0.0-beta.2",
     "core-js": "2.4.1",
@@ -55,7 +55,7 @@
   },
   "devDependencies": {
     "@angular/cli": "1.5.5",
-    "@angular/compiler-cli": "5.0.5",
+    "@angular/compiler-cli": "5.1.0",
     "@ngtools/webpack": "1.8.5",
     "@types/jasmine": "2.5.53",
     "@types/node": "8.0.18",
@@ -109,7 +109,7 @@
     <%_ } _%>
     "tslint": "5.5.0",
     "tslint-loader": "3.5.3",
-    "typescript": "2.4.2",
+    "typescript": "2.5.3",
     <%_ if (useSass) { _%>
     "sass-loader": "6.0.6",
     "node-sass": "4.5.3",

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -44,7 +44,7 @@
     "ngx-infinite-scroll": "0.5.1",
     "ngx-webstorage": "2.0.1",
     "reflect-metadata": "0.1.10",
-    "rxjs": "5.5.0",
+    "rxjs": "5.5.5",
     "swagger-ui": "2.2.10",
     <%_ if (websocket === 'spring-websocket') { _%>
     "sockjs-client": "1.1.4",
@@ -67,11 +67,11 @@
     "browser-sync": "2.18.13",
     "browser-sync-webpack-plugin": "1.2.0",
     "codelyzer": "4.0.1",
-    "copy-webpack-plugin": "4.0.1",
+    "copy-webpack-plugin": "4.2.3",
     "css-loader": "0.28.4",
     "exports-loader": "0.6.4",
-    "extract-text-webpack-plugin": "3.0.0",
-    "file-loader": "0.11.2",
+    "extract-text-webpack-plugin": "3.0.2",
+    "file-loader": "1.1.5",
     "generator-jhipster": "<%= packagejs.version %>",
     "html-loader": "0.5.0",
     "html-webpack-plugin": "2.30.1",
@@ -113,7 +113,7 @@
     <%_ if (useSass) { _%>
     "sass-loader": "6.0.6",
     "node-sass": "4.5.3",
-    "postcss-loader": "2.0.6",
+    "postcss-loader": "2.0.9",
     <%_ } _%>
     <%_ if (buildTool === 'maven') { _%>
     "xml2js": "0.4.17",
@@ -121,7 +121,7 @@
     <%_ otherModules.forEach(module => { _%>
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
-    "uglifyjs-webpack-plugin": "1.0.0-beta.2",
+    "uglifyjs-webpack-plugin": "1.1.2",
     "webpack": "3.10.0",
     "webpack-dev-server": "2.9.5",
     "webpack-merge": "4.1.1",

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -122,7 +122,7 @@
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
     "uglifyjs-webpack-plugin": "1.0.0-beta.2",
-    "webpack": "3.9.1",
+    "webpack": "3.10.0",
     "webpack-dev-server": "2.9.5",
     "webpack-merge": "4.1.1",
     "webpack-notifier": "1.5.0",

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -34,7 +34,7 @@
     "@angular/platform-browser": "5.1.0",
     "@angular/platform-browser-dynamic": "5.1.0",
     "@angular/router": "5.1.0",
-    "@ng-bootstrap/ng-bootstrap": "1.0.0-beta.6",
+    "@ng-bootstrap/ng-bootstrap": "1.0.0-beta.7",
     "bootstrap": "4.0.0-beta.2",
     "core-js": "2.4.1",
     "font-awesome": "4.7.0",


### PR DESCRIPTION
Angular 5.1.0 officially supports TypeScript 2.5.x

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
