### PR TITLE
Fix version of selenium chromedriver to 2_34 for AngularJS

### DIFF
--- a/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
+++ b/generators/client/templates/angularjs/src/test/javascript/_protractor.conf.js
@@ -30,13 +30,13 @@ const seleniumFolder = 'node_modules/webdriver-manager/selenium/';
 
 var webbrowserDriver= '';
 if (os.platform() === 'win32') {
-    webbrowserDriver = prefix + seleniumFolder + 'chromedriver_2.33.exe';
+    webbrowserDriver = prefix + seleniumFolder + 'chromedriver_2.34.exe';
 } else {
-    webbrowserDriver = prefix + seleniumFolder + 'chromedriver_2.33';
+    webbrowserDriver = prefix + seleniumFolder + 'chromedriver_2.34';
 }
 
 exports.config = {
-    seleniumServerJar: prefix + seleniumFolder + 'selenium-server-standalone-3.6.0.jar',
+    seleniumServerJar: prefix + seleniumFolder + 'selenium-server-standalone-3.8.1.jar',
     chromeDriver: webbrowserDriver,
     allScriptsTimeout: 20000,
 


### PR DESCRIPTION
Fix protractor builds for ng1 application:
See https://travis-ci.org/jhipster/generator-jhipster/jobs/314358422 :
```
[03:39:50] E/direct - Error message: Could not find chromedriver at /home/travis/app/node_modules/webdriver-manager/selenium/chromedriver_2.33. Run 'webdriver-manager update' to download binaries.
[03:39:50] E/direct - Error: Could not find chromedriver at /home/travis/app/node_modules/webdriver-manager/selenium/chromedriver_2.33. Run 'webdriver-manager update' to download binaries.
    at Direct.getNewDriver (/home/travis/app/node_modules/gulp-protractor/node_modules/protractor/built/driverProviders/direct.js:68:27)
    at Runner.createBrowser (/home/travis/app/node_modules/gulp-protractor/node_modules/protractor/built/runner.js:195:43)
    at q.then.then (/home/travis/app/node_modules/gulp-protractor/node_modules/protractor/built/runner.js:339:29)
    at _fulfilled (/home/travis/app/node_modules/q/q.js:834:54)
    at self.promiseDispatch.done (/home/travis/app/node_modules/q/q.js:863:30)
    at Promise.promise.promiseDispatch (/home/travis/app/node_modules/q/q.js:796:13)
    at /home/travis/app/node_modules/q/q.js:556:49
    at runSingle (/home/travis/app/node_modules/q/q.js:137:13)
    at flush (/home/travis/app/node_modules/q/q.js:125:13)
    at _combinedTickCallback (internal/process/next_tick.js:131:7)
[03:39:50] E/launcher - Process exited with error code 135
```

Similar PR https://github.com/jhipster/generator-jhipster/pull/6474

_____


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
