### PR TITLE
configure CORS for the management path

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
+++ b/generators/server/templates/src/main/java/package/config/_WebConfigurer.java
@@ -246,9 +246,11 @@ public class WebConfigurer implements ServletContextInitializer, EmbeddedServlet
         if (config.getAllowedOrigins() != null && !config.getAllowedOrigins().isEmpty()) {
             log.debug("Registering CORS filter");
             source.registerCorsConfiguration("/api/**", config);
+            source.registerCorsConfiguration("/management/**", config);
             source.registerCorsConfiguration("/v2/api-docs", config);
             <%_ if (applicationType === 'gateway') { _%>
             source.registerCorsConfiguration("/*/api/**", config);
+            source.registerCorsConfiguration("/*/management/**", config);
             <%_ if (authenticationType === 'uaa') { _%>
             source.registerCorsConfiguration("/*/oauth/**", config);
             <%_ } _%>


### PR DESCRIPTION
Separate client/server apps need CORS configured on `/management/**` or several of the admin pages don't fetch data properly

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
