### PR TITLE
Fix lint script for Windows

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -135,7 +135,7 @@
     "node": ">=6.9.0"
   },
   "scripts": {
-    "lint": "tslint --project './tsconfig.json' -e 'node_modules/**'",
+    "lint": "tslint --project 'tsconfig.json' -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "ngc": "ngc -p tsconfig-aot.json",
     "cleanup": "rimraf <%= BUILD_DIR %>{aot,www}",


### PR DESCRIPTION
`tslint --project './tsconfig.json' -e 'node_modules/**'`

failed on Windows due to `./` path

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
