### PR TITLE
Fix infinite loop of 401 exceptions in AuthExpiredInterceptor...

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/_login-modal.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/_login-modal.service.ts
@@ -33,9 +33,7 @@ export class LoginModalService {
             return;
         }
         this.isOpen = true;
-        const modalRef = this.modalService.open(<%=jhiPrefixCapitalized%>LoginModalComponent, {
-            container: 'nav'
-        });
+        const modalRef = this.modalService.open(<%=jhiPrefixCapitalized%>LoginModalComponent);
         modalRef.result.then((result) => {
             this.isOpen = false;
         }, (reason) => {


### PR DESCRIPTION
…when using UAA and Angular

- shows LoginModal, when user was authenticated, but lost credentials
- moved LoginModal from nav container to default, so it can be showed before recently active modal

fix #6882

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
