### PR TITLE
only import rxjs modules that are used

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/_vendor.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_vendor.ts
@@ -23,4 +23,6 @@ import '../content/scss/vendor.scss';
 <%_} else { _%>
 import '../content/css/vendor.css';
 <%_ } _%>
+import 'rxjs/add/operator/map';
+import 'rxjs/add/operator/catch';
 // jhipster-needle-add-element-to-vendor - JHipster will add new menu items here

--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/_activate.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response, URLSearchParams } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/_password-reset-finish.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/_password-reset-init.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/_register.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/_register.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/_sessions.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { Session } from './session.model';
 import { SERVER_API_URL } from '../../app.constants';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/_audits.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response, URLSearchParams } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/_configuration.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway-routes.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/_gateway-routes.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { SERVER_API_URL } from '../../app.constants';
 import { GatewayRoute } from './gateway-route.model';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/_logs.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 import { Log } from './log.model';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/_metrics.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Response, Http } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-detail.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/_user-management-detail.component.ts
@@ -18,7 +18,7 @@
 -%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 
 import { User, UserService } from '../../shared';
 

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/_alert-error.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/_alert-error.component.ts
@@ -21,7 +21,7 @@ import { Component, OnDestroy } from '@angular/core';
 import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
 import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-alert-error',

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_account.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-jwt.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 <%_ if (authenticationType !== 'uaa') { _%>
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/_auth-session.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response<% if (authenticationType !== 'oauth2') { %>, Headers<% } %> } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 
 @Injectable()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/user/_user.service.ts
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { SERVER_API_URL } from '../../app.constants';
 <%_ if (authenticationType !== 'oauth2') { _%>

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/activate/_activate.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/activate/_activate.component.spec.ts
@@ -18,7 +18,7 @@
 -%>
 import { TestBed, async, tick, fakeAsync, inject } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { MockActivatedRoute } from '../../../helpers/mock-route.service';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/_password-reset-finish.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/_password-reset-finish.component.spec.ts
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { Renderer, ElementRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/_password-reset-init.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/_password-reset-init.component.spec.ts
@@ -18,7 +18,7 @@
 -%>
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { Renderer, ElementRef } from '@angular/core';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../../test.module';
 import { PasswordResetInitComponent } from '../../../../../../../main/webapp/app/account/password-reset/init/password-reset-init.component';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/_password.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/_password.component.spec.ts
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { PasswordComponent } from '../../../../../../main/webapp/app/account/password/password.component';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/register/_register.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/register/_register.component.spec.ts
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async, inject, tick, fakeAsync } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/sessions/_sessions.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/sessions/_sessions.component.spec.ts
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { Session } from '../../../../../../main/webapp/app/account/sessions/session.model';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/_settings.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/_settings.component.spec.ts
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { Principal, AccountService } from '../../../../../../main/webapp/app/shared';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management-delete-dialog.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management-delete-dialog.component.spec.ts
@@ -18,7 +18,7 @@
 -%>
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management-detail.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management-detail.component.spec.ts
@@ -1,6 +1,6 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { MockActivatedRoute } from '../../../helpers/mock-route.service';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management-dialog.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management-dialog.component.spec.ts
@@ -21,7 +21,7 @@ const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/_user-management.component.spec.ts
@@ -20,7 +20,7 @@
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { Headers } from '@angular/http';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/client/templates/angular/webpack/_webpack.common.js
+++ b/generators/client/templates/angular/webpack/_webpack.common.js
@@ -20,6 +20,7 @@ const webpack = require('webpack');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const StringReplacePlugin = require('string-replace-webpack-plugin');
+const rxPaths = require('rxjs/_esm5/path-mapping');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
 <%_ } _%>
@@ -39,7 +40,8 @@ module.exports = (options) => {
     return {
         resolve: {
             extensions: ['.ts', '.js'],
-            modules: ['node_modules']
+            modules: ['node_modules'],
+            alias: rxPaths()
         },
         stats: {
             children: false

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity-management-detail.component.ts
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity-management-detail.component.ts
@@ -26,7 +26,7 @@ for (const idx in fields) {
 _%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 import { JhiEventManager<% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
 
 import { <%= entityAngularName %> } from './<%= entityFileName %>.model';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity-management-dialog.component.ts
@@ -32,7 +32,7 @@ import { Component, OnInit, OnDestroy<% if (fieldsContainImageBlob) { %>, Elemen
 import { ActivatedRoute } from '@angular/router';
 import { Response } from '@angular/http';
 
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { JhiEventManager<% if (queries && queries.length > 0) { %>, JhiAlertService<% } %><% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity-management.component.ts
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity-management.component.ts
@@ -22,7 +22,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 <%_ } else if (searchEngine === 'elasticsearch') { _%>
 import { ActivatedRoute } from '@angular/router';
 <%_ } _%>
-import { Subscription } from 'rxjs/Rx';
+import { Subscription } from 'rxjs/Subscription';
 import { JhiEventManager, <% if (pagination !== 'no') { %>JhiParseLinks, <% } %>JhiAlertService<% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
 
 import { <%= entityAngularName %> } from './<%= entityFileName %>.model';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity.service.ts
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/_entity.service.ts
@@ -24,7 +24,7 @@
 _%>
 import { Injectable } from '@angular/core';
 import { Http, Response } from '@angular/http';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { SERVER_API_URL } from '../../app.constants';
 <%_ if (hasDate) { _%>
 

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management-delete-dialog.component.spec.ts
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management-delete-dialog.component.spec.ts
@@ -22,7 +22,7 @@ _%>
 /* tslint:disable max-line-length */
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management-detail.component.spec.ts
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management-detail.component.spec.ts
@@ -21,7 +21,7 @@ const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
 /* tslint:disable max-line-length */
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { <%= entityAngularName %>DetailComponent } from '../../../../../../main/webapp/app/entities/<%= entityFolderName %>/<%= entityFileName %>-detail.component';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management-dialog.component.spec.ts
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management-dialog.component.spec.ts
@@ -22,7 +22,7 @@ _%>
 /* tslint:disable max-line-length */
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management.component.spec.ts
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management.component.spec.ts
@@ -21,7 +21,7 @@ const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
 /* tslint:disable max-line-length */
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { Observable } from 'rxjs/Rx';
+import { Observable } from 'rxjs/Observable';
 import { Headers } from '@angular/http';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';


### PR DESCRIPTION
##### **Overview of the issue**
For size-sensitive apps, rxjs can be imported differently as mentioned in the [rxjs readme](https://github.com/ReactiveX/rxjs).  We can reduce the size of the vendor bundle (default app, no entities) from 946 KB -> 818 KB (gzipped 209 KB -> 178 KB).  This is the [same method](https://github.com/angular/angular-cli/blob/a5edc12ee83264c6a691a688970d5c3deeada717/packages/%40angular/cli/tasks/eject.ts#L273-L279) that the angular-cli uses to optimize rxjs imports when you run `ng eject`.

Related PR in ng-jhipster: https://github.com/jhipster/ng-jhipster/pull/59

Webpack Visualizer RXJS size screenshots: [Before](https://user-images.githubusercontent.com/4294623/34221966-e56988ae-e587-11e7-86d3-fc3a458a611b.png) + [After](https://user-images.githubusercontent.com/4294623/34221967-e58a9b3e-e587-11e7-8892-a5927f27cce6.png)

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
