### PR TITLE
Fix tests for Clustered HTTP Session with Hazelcast

### DIFF
--- a/generators/server/templates/src/test/java/package/config/_WebConfigurerTest.java
+++ b/generators/server/templates/src/test/java/package/config/_WebConfigurerTest.java
@@ -22,6 +22,16 @@ import com.codahale.metrics.MetricRegistry;
 import com.codahale.metrics.servlet.InstrumentedFilter;
 import com.codahale.metrics.servlets.MetricsServlet;
 <%_ if (clusteredHttpSession === 'hazelcast') { _%>
+import com.hazelcast.cardinality.CardinalityEstimator;
+import com.hazelcast.config.Config;
+import com.hazelcast.core.*;
+import com.hazelcast.durableexecutor.DurableExecutorService;
+import com.hazelcast.logging.LoggingService;
+import com.hazelcast.mapreduce.JobTracker;
+import com.hazelcast.quorum.QuorumService;
+import com.hazelcast.ringbuffer.Ringbuffer;
+import com.hazelcast.scheduledexecutor.IScheduledExecutorService;
+import com.hazelcast.transaction.*;
 import com.hazelcast.web.spring.SpringAwareWebFilter;
 <%_ } _%>
 import io.github.jhipster.config.JHipsterConstants;
@@ -49,6 +59,9 @@ import org.xnio.OptionMap;
 
 import javax.servlet.*;
 import java.util.*;
+<%_ if (clusteredHttpSession === 'hazelcast') { _%>
+import java.util.concurrent.ConcurrentMap;
+<%_ } _%>
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.any;
@@ -91,9 +104,10 @@ public class WebConfigurerTest {
         env = new MockEnvironment();
         props = new JHipsterProperties();
 
-        <%_ if (clusteredHttpSession === 'hazelcast' || cacheProvider === 'hazelcast') { _%>
-        webConfigurer = new WebConfigurer(env, props,
-            null);
+        <%_ if (clusteredHttpSession === 'hazelcast') { _%>
+        webConfigurer = new WebConfigurer(env, props, new MockHazelcastInstance());
+        <%_ } else if (cacheProvider === 'hazelcast') { _%>
+        webConfigurer = new WebConfigurer(env, props, null);
         <%_ } else { _%>
         webConfigurer = new WebConfigurer(env, props);
         <%_ } _%>
@@ -398,4 +412,214 @@ public class WebConfigurerTest {
             return null;
         }
     }
+    <%_ if (clusteredHttpSession === 'hazelcast') { _%>
+
+    public static class MockHazelcastInstance implements HazelcastInstance {
+
+        @Override
+        public String getName() {
+            return "HazelcastInstance";
+        }
+
+        @Override
+        public <E> IQueue<E> getQueue(String s) {
+            return null;
+        }
+
+        @Override
+        public <E> ITopic<E> getTopic(String s) {
+            return null;
+        }
+
+        @Override
+        public <E> ISet<E> getSet(String s) {
+            return null;
+        }
+
+        @Override
+        public <E> IList<E> getList(String s) {
+            return null;
+        }
+
+        @Override
+        public <K, V> IMap<K, V> getMap(String s) {
+            return null;
+        }
+
+        @Override
+        public <K, V> ReplicatedMap<K, V> getReplicatedMap(String s) {
+            return null;
+        }
+
+        @Override
+        public JobTracker getJobTracker(String s) {
+            return null;
+        }
+
+        @Override
+        public <K, V> MultiMap<K, V> getMultiMap(String s) {
+            return null;
+        }
+
+        @Override
+        public ILock getLock(String s) {
+            return null;
+        }
+
+        @Override
+        public <E> Ringbuffer<E> getRingbuffer(String s) {
+            return null;
+        }
+
+        @Override
+        public <E> ITopic<E> getReliableTopic(String s) {
+            return null;
+        }
+
+        @Override
+        public Cluster getCluster() {
+            return null;
+        }
+
+        @Override
+        public Endpoint getLocalEndpoint() {
+            return null;
+        }
+
+        @Override
+        public IExecutorService getExecutorService(String s) {
+            return null;
+        }
+
+        @Override
+        public DurableExecutorService getDurableExecutorService(String s) {
+            return null;
+        }
+
+        @Override
+        public <T> T executeTransaction(TransactionalTask<T> transactionalTask) throws TransactionException {
+            return null;
+        }
+
+        @Override
+        public <T> T executeTransaction(TransactionOptions transactionOptions, TransactionalTask<T> transactionalTask) throws TransactionException {
+            return null;
+        }
+
+        @Override
+        public TransactionContext newTransactionContext() {
+            return null;
+        }
+
+        @Override
+        public TransactionContext newTransactionContext(TransactionOptions transactionOptions) {
+            return null;
+        }
+
+        @Override
+        public IdGenerator getIdGenerator(String s) {
+            return null;
+        }
+
+        @Override
+        public IAtomicLong getAtomicLong(String s) {
+            return null;
+        }
+
+        @Override
+        public <E> IAtomicReference<E> getAtomicReference(String s) {
+            return null;
+        }
+
+        @Override
+        public ICountDownLatch getCountDownLatch(String s) {
+            return null;
+        }
+
+        @Override
+        public ISemaphore getSemaphore(String s) {
+            return null;
+        }
+
+        @Override
+        public Collection<DistributedObject> getDistributedObjects() {
+            return null;
+        }
+
+        @Override
+        public String addDistributedObjectListener(DistributedObjectListener distributedObjectListener) {
+            return null;
+        }
+
+        @Override
+        public boolean removeDistributedObjectListener(String s) {
+            return false;
+        }
+
+        @Override
+        public Config getConfig() {
+            return null;
+        }
+
+        @Override
+        public PartitionService getPartitionService() {
+            return null;
+        }
+
+        @Override
+        public QuorumService getQuorumService() {
+            return null;
+        }
+
+        @Override
+        public ClientService getClientService() {
+            return null;
+        }
+
+        @Override
+        public LoggingService getLoggingService() {
+            return null;
+        }
+
+        @Override
+        public LifecycleService getLifecycleService() {
+            return null;
+        }
+
+        @Override
+        public <T extends DistributedObject> T getDistributedObject(String s, String s1) {
+            return null;
+        }
+
+        @Override
+        public ConcurrentMap<String, Object> getUserContext() {
+            return null;
+        }
+
+        @Override
+        public HazelcastXAResource getXAResource() {
+            return null;
+        }
+
+        @Override
+        public ICacheManager getCacheManager() {
+            return null;
+        }
+
+        @Override
+        public CardinalityEstimator getCardinalityEstimator(String s) {
+            return null;
+        }
+
+        @Override
+        public IScheduledExecutorService getScheduledExecutorService(String s) {
+            return null;
+        }
+
+        @Override
+        public void shutdown() {
+
+        }
+    }
+    <%_ } _%>
 }


### PR DESCRIPTION
On Master, the tests failed when choosing Clustered HTTP Session with Hazelcast:
```
{
  "generator-jhipster": {
    "promptValues": {
      "packageName": "io.github.pascalgrimaud",
      "nativeLanguage": "en"
    },
    "jhipsterVersion": "4.13.0",
    "baseName": "jhipster",
    "packageName": "io.github.pascalgrimaud",
    "packageFolder": "io/github/pascalgrimaud",
    "serverPort": "8080",
    "authenticationType": "jwt",
    "cacheProvider": "hazelcast",
    "enableHibernateCache": true,
    "clusteredHttpSession": "hazelcast",
    "websocket": false,
    "databaseType": "sql",
    "devDatabaseType": "h2Disk",
    "prodDatabaseType": "mysql",
    "searchEngine": false,
    "messageBroker": false,
    "serviceDiscoveryType": false,
    "buildTool": "maven",
    "enableSocialSignIn": false,
    "enableSwaggerCodegen": false,
    "jwtSecretKey": "b8f09707d3a857f364927a4fa87aeb3f3ff66726",
    "clientFramework": "angularX",
    "useSass": false,
    "clientPackageManager": "yarn",
    "applicationType": "monolith",
    "testFrameworks": [],
    "jhiPrefix": "jhi",
    "enableTranslation": true,
    "nativeLanguage": "en",
    "languages": [
      "en"
    ]
  }
}
```

There is a missing tests in our Travis build.
I added it back in this commit: https://github.com/jhipster/generator-jhipster/pull/6878#discussion_r158390560

_____

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
