### PR TITLE
Kubernetes logstash config: added TCP listener

### DIFF
--- a/generators/kubernetes/templates/console/_logstash-config.yml
+++ b/generators/kubernetes/templates/console/_logstash-config.yml
@@ -29,6 +29,11 @@ data:
             type => syslog
             codec => json
         }
+        tcp {
+            port => 5000
+            type => syslog
+            codec => json
+        }
     }
 
     filter {


### PR DESCRIPTION
The Kubernetes generator did not include the TCP listener in the Logstash config.

Would love to add some tests, but not sure how to test this.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
