### PR TITLE
Refactorization of the 2 digits date part code in audit component tests

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/_audits.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/_audits.component.spec.ts
@@ -26,7 +26,7 @@ import { AuditsService } from '../../../../../../main/webapp/app/admin/audits/au
 import { ITEMS_PER_PAGE } from '../../../../../../main/webapp/app/shared';
 
 function build2DigitsDatePart(datePart: number) {
-    return ('0' + datePart).slice(-2);
+    return `0${datePart}`.slice(-2);
 }
 
 function getDate(isToday= true) {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/_audits.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/_audits.component.spec.ts
@@ -25,6 +25,10 @@ import { AuditsComponent } from '../../../../../../main/webapp/app/admin/audits/
 import { AuditsService } from '../../../../../../main/webapp/app/admin/audits/audits.service';
 import { ITEMS_PER_PAGE } from '../../../../../../main/webapp/app/shared';
 
+function build2DigitsDatePart(datePart: number) {
+    return ('0' + datePart).slice(-2);
+}
+
 function getDate(isToday= true) {
     let date: Date = new Date();
     if (isToday) {
@@ -38,8 +42,9 @@ function getDate(isToday= true) {
         date = new Date(date.getFullYear(), date.getMonth() - 1, date.getDate());
       }
     }
-    const dateString = date.getDate() < 10 ? '0' + date.getDate() : '' + date.getDate();
-    return `${date.getFullYear()}-${('0' + (date.getMonth() + 1)).slice(-2)}-${dateString}`;
+    const monthString = build2DigitsDatePart(date.getMonth() + 1);
+    const dateString = build2DigitsDatePart(date.getDate());
+    return `${date.getFullYear()}-${monthString}-${dateString}`;
 }
 
 describe('Component Tests', () => {


### PR DESCRIPTION
Fix #6926

just a little refactorization to remove the duplicate code that builds 2 digits date parts in the function getDate of the audits component tests
