### PR TITLE
Fix spring profile yml substitution for apps using service discovery

### DIFF
--- a/generators/server/templates/_pom.xml
+++ b/generators/server/templates/_pom.xml
@@ -847,7 +847,11 @@
                                     <directory><%= SERVER_MAIN_RES_DIR %></directory>
                                     <filtering>true</filtering>
                                     <includes>
+<%_ if (!serviceDiscoveryType) { _%>
                                         <include>config/application.yml</include>
+<%_ } else { _%>
+                                        <include>config/bootstrap.yml</include>
+<%_ } _%>
                                     </includes>
                                 </resource>
                                 <resource>

--- a/generators/server/templates/gradle/_profile_dev.gradle
+++ b/generators/server/templates/gradle/_profile_dev.gradle
@@ -67,13 +67,13 @@ processResources {
         filter {
             it.replace('#project.version#', version)
         }
-        <%_ if (applicationType === 'monolith') { _%>
+        <%_ if (!serviceDiscoveryType) { _%>
         filter {
             it.replace('#spring.profiles.active#', profiles)
         }
         <%_ } _%>
     }
-    <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
+    <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
     filesMatching('**/bootstrap.yml') {
         filter {
             it.replace('#spring.profiles.active#', profiles)

--- a/generators/server/templates/gradle/_profile_prod.gradle
+++ b/generators/server/templates/gradle/_profile_prod.gradle
@@ -68,13 +68,13 @@ processResources {
         filter {
             it.replace('#project.version#', version)
         }
-        <%_ if (applicationType === 'monolith') { _%>
+        <%_ if (!serviceDiscoveryType) { _%>
         filter {
             it.replace('#spring.profiles.active#', profiles)
         }
         <%_ } _%>
     }
-    <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
+    <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
     filesMatching('**/bootstrap.yml') {
         filter {
             it.replace('#spring.profiles.active#', profiles)

--- a/generators/server/templates/src/main/resources/config/_application.yml
+++ b/generators/server/templates/src/main/resources/config/_application.yml
@@ -121,7 +121,7 @@ spring:
                 healthCheckPath: /management/health
                 instanceId: ${spring.application.name}:${spring.application.instance-id:${random.value}}
     <%_ } _%>
-    <%_ if (applicationType === 'monolith') { _%>
+    <%_ if (!serviceDiscoveryType) { _%>
     profiles:
         # The commented value for `active` can be replaced with valid Spring profiles to load.
         # Otherwise, it will be filled in by <%= buildTool %> when building the WAR file


### PR DESCRIPTION
Fix profile substitutions for all configurations that were broken :
- microservice, gateway, uaa with maven
- monolith + service discovery, it was actually working partially as the profile was correctly set in application.yml. However this is subtly wrong as it prevent from retrieving the right profile specific configuration from the config server.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
