### PR TITLE
Fix build error with sw-workbox

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -127,7 +127,7 @@
     "webpack-notifier": "1.5.0",
     "webpack-visualizer-plugin": "0.1.11",
     "web-app-manifest-loader": "0.1.1",
-    "workbox-webpack-plugin": "2.1.2",
+    "workbox-webpack-plugin": "3.0.0-alpha.3",
     "write-file-webpack-plugin": "4.1.0"
   },
   "engines": {

--- a/generators/client/templates/angular/webpack/_webpack.prod.js
+++ b/generators/client/templates/angular/webpack/_webpack.prod.js
@@ -129,12 +129,6 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
             debug: false
         }),
         new WorkboxPlugin({
-          // to cache all under <%= BUILD_DIR %>www
-          globDirectory: utils.root('<%= BUILD_DIR %>www'),
-          // find these files and cache them
-          globPatterns: ['**/*.{html,bundle.js,css,png,svg,jpg,gif,json}'],
-          // create service worker at the <%= BUILD_DIR %>www
-          swDest: path.resolve(utils.root('<%= BUILD_DIR %>www'), 'sw.js'),
           clientsClaim: true,
           skipWaiting: true,
         })


### PR DESCRIPTION
This is a fix for a major issue that made prod builds to fail for some users.

Only solution found (thanks  @kaidohallik) was to upgrade workbox-webpack-plugin from 2.1.2 to 3.0.0-alpha.3.

Tested successfully on Ubuntu 17.10 and Windows 10 with JHipster 4.13.2 using maven where it was failing systematically.

Fix #6945

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

  