### PR TITLE
fix blocking of uaa app regeneration

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2065,6 +2065,7 @@ module.exports = class extends PrivateBase {
         const keyStoreFile = `${SERVER_MAIN_RES_DIR}keystore.jks`;
         if (this.fs.exists(keyStoreFile)) {
             this.log(chalk.cyan(`\nKeyStore '${keyStoreFile}' already exists. Leaving unchanged.\n`));
+            done();
         } else {
             shelljs.mkdir('-p', SERVER_MAIN_RES_DIR);
             const javaHome = shelljs.env.JAVA_HOME;


### PR DESCRIPTION
When you run `jhipster` in an existing UAA application, the regeneration is blocked because `done()` is never called when a keystore.jks already exists. This PR lets regeneration continue.  

<details>
<summary>Example output showing the issue, jhipster exits here</summary>

<pre>

Executing jhipster:app
Options: 


        ██╗ ██╗   ██╗ ████████╗ ███████╗   ██████╗ ████████╗ ████████╗ ███████╗
        ██║ ██║   ██║ ╚══██╔══╝ ██╔═══██╗ ██╔════╝ ╚══██╔══╝ ██╔═════╝ ██╔═══██╗
        ██║ ████████║    ██║    ███████╔╝ ╚█████╗     ██║    ██████╗   ███████╔╝
  ██╗   ██║ ██╔═══██║    ██║    ██╔════╝   ╚═══██╗    ██║    ██╔═══╝   ██╔══██║
  ╚██████╔╝ ██║   ██║ ████████╗ ██║       ██████╔╝    ██║    ████████╗ ██║  ╚██╗
   ╚═════╝  ╚═╝   ╚═╝ ╚═══════╝ ╚═╝       ╚═════╝     ╚═╝    ╚═══════╝ ╚═╝   ╚═╝

                            http://www.jhipster.tech

Welcome to the JHipster Generator v4.13.3
 _______________________________________________________________________________________________________________

  If you find JHipster useful consider supporting our collective https://opencollective.com/generator-jhipster
  Documentation for creating an application: http://www.jhipster.tech/creating-an-app/
 _______________________________________________________________________________________________________________

Application files will be generated in folder: /private/tmp/jh/uaa-stack/uaa
This is an existing project, using the configuration from your .yo-rc.json file 
to re-generate the project...


Installing languages: en for server

KeyStore 'src/main/resources/keystore.jks' already exists. Leaving unchanged.


</pre>
</details>


- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
