### PR TITLE
Travis: new install script for jhipster-dependency and jhipster lib

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ services:
   - docker
 language: node_js
 node_js:
-  - "8.9.3"
+  - "8.9.4"
 jdk:
   - oraclejdk8
 addons:
@@ -30,6 +30,17 @@ env:
     # environment properties
     - SPRING_OUTPUT_ANSI_ENABLED=ALWAYS
     - SPRING_JPA_SHOW_SQL=false
+
+    # if JHIPSTER_DEPENDENCIES_BRANCH value is release, use the release from Maven
+    - JHIPSTER_DEPENDENCIES_REPO=https://github.com/jhipster/jhipster-dependencies.git
+    - JHIPSTER_DEPENDENCIES_BRANCH=release
+    # if JHIPSTER_LIB_BRANCH value is release, use the release from Maven
+    - JHIPSTER_LIB_REPO=https://github.com/jhipster/jhipster.git
+    - JHIPSTER_LIB_BRANCH=release
+    # if JHIPSTER_BRANCH value is release, use the release from NPM
+    - JHIPSTER_REPO=https://github.com/generator-jhipster/jhipster.git
+    - JHIPSTER_BRANCH=release
+
   matrix:
     - JHIPSTER=ngx-default PROFILE=prod PROTRACTOR=1
     - JHIPSTER=ngx-psql-es-noi18n PROFILE=prod PROTRACTOR=1
@@ -63,12 +74,7 @@ before_install:
   - yarn -v
   - yarn global add yo bower gulp-cli
 install:
-  - cd "$TRAVIS_BUILD_DIR"/
-  - yarn install
-  - yarn global add file:"$TRAVIS_BUILD_DIR"
-  - if [ "$JHIPSTER" == "ngx-default" ]; then
-        yarn test;
-    fi
+  - $JHIPSTER_SCRIPTS/00-install-jhipster.sh
   - $JHIPSTER_SCRIPTS/01-generate-entities.sh
   - $JHIPSTER_SCRIPTS/02-generate-project.sh
 script:

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -55,7 +55,7 @@ const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the var
 const SCALA_VERSION = '2.12.1';
 
 // version of Node, Yarn, NPM
-const NODE_VERSION = '8.9.3';
+const NODE_VERSION = '8.9.4';
 const YARN_VERSION = '1.3.2';
 const NPM_VERSION = '5.6.0';
 

--- a/travis/scripts/00-install-jhipster.sh
+++ b/travis/scripts/00-install-jhipster.sh
@@ -1,0 +1,103 @@
+#!/bin/bash
+set -e
+
+#-------------------------------------------------------------------------------
+# List HOME
+#-------------------------------------------------------------------------------
+ls -al "$HOME"
+
+#-------------------------------------------------------------------------------
+# Install JHipster Dependencies
+#-------------------------------------------------------------------------------
+cd "$HOME"
+if [[ "$TRAVIS_REPO_SLUG" == *"/jhipster-dependencies" ]]; then
+    echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG"
+    echo "No need to clone jhipster-dependencies: use local version"
+
+    cd "$TRAVIS_BUILD_DIR"
+    ./mvnw clean install -Dgpg.skip=true
+
+elif [[ "$JHIPSTER_DEPENDENCIES_BRANCH" == "release" ]]; then
+    echo "No need to clone jhipster-dependencies: use release version"
+
+else
+    git clone "$JHIPSTER_DEPENDENCIES_REPO" jhipster-dependencies
+    cd jhipster-dependencies
+    if [ "$JHIPSTER_DEPENDENCIES_BRANCH" == "latest" ]; then
+        LATEST=$(git describe --abbrev=0)
+        git checkout -b "$LATEST" "$LATEST"
+    elif [ "$JHIPSTER_DEPENDENCIES_BRANCH" != "master" ]; then
+        git checkout -b "$JHIPSTER_DEPENDENCIES_BRANCH" origin/"$JHIPSTER_DEPENDENCIES_BRANCH"
+    fi
+    git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+
+    ./mvnw clean install -Dgpg.skip=true
+    ls -al ~/.m2/repository/io/github/jhipster/jhipster-dependencies/
+fi
+
+#-------------------------------------------------------------------------------
+# Install JHipster lib
+#-------------------------------------------------------------------------------
+cd "$HOME"
+if [[ "$TRAVIS_REPO_SLUG" == *"/jhipster" ]]; then
+    echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG"
+    echo "No need to clone jhipster: use local version"
+
+    cd "$TRAVIS_BUILD_DIR"
+    ./mvnw clean install -Dgpg.skip=true
+
+elif [[ "$JHIPSTER_LIB_BRANCH" == "release" ]]; then
+    echo "No need to clone jhipster: use release version"
+
+else
+    git clone "$JHIPSTER_LIB_REPO" jhipster
+    cd jhipster
+    if [ "$JHIPSTER_LIB_BRANCH" == "latest" ]; then
+        LATEST=$(git describe --abbrev=0)
+        git checkout -b "$LATEST" "$LATEST"
+    elif [ "$JHIPSTER_LIB_BRANCH" != "master" ]; then
+        git checkout -b "$JHIPSTER_LIB_BRANCH" origin/"$JHIPSTER_LIB_BRANCH"
+    fi
+    git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+
+    ./mvnw clean install -Dgpg.skip=true
+    ls -al ~/.m2/repository/io/github/jhipster/jhipster/
+fi
+
+#-------------------------------------------------------------------------------
+# Install JHipster Generator
+#-------------------------------------------------------------------------------
+cd "$HOME"
+if [[ "$TRAVIS_REPO_SLUG" == *"/generator-jhipster" ]]; then
+    echo "TRAVIS_REPO_SLUG=$TRAVIS_REPO_SLUG"
+    echo "No need to clone generator-jhipster: use local version"
+
+    cd "$TRAVIS_BUILD_DIR"/
+    yarn install
+    yarn global add file:"$TRAVIS_BUILD_DIR"
+    if [[ "$JHIPSTER" == "" || "$JHIPSTER" == "ngx-default" ]]; then
+        yarn test
+    fi
+
+elif [[ "$JHIPSTER_BRANCH" == "release" ]]; then
+    yarn global add generator-jhipster
+
+else
+    git clone "$JHIPSTER_REPO" generator-jhipster
+    cd generator-jhipster
+    if [ "$JHIPSTER_BRANCH" == "latest" ]; then
+        LATEST=$(git describe --abbrev=0)
+        git checkout -b "$LATEST" "$LATEST"
+    elif [ "$JHIPSTER_BRANCH" != "master" ]; then
+        git checkout -b "$JHIPSTER_BRANCH" origin/"$JHIPSTER_BRANCH"
+    fi
+    git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
+
+    yarn install
+    yarn global add file:"$TRAVIS_BUILD_DIR"/generator-jhipster
+fi
+
+#-------------------------------------------------------------------------------
+# List HOME
+#-------------------------------------------------------------------------------
+ls -al "$HOME"


### PR DESCRIPTION
Improve the installation:
- it will help jhipster-dependency, jhipster (lib) projects, as it will use the same scripts to install the full stack
- the branch spring-boot-2 won't need to wait new release because this new installation can use specific distant branch

By default, the current Travis won't use any branch or master, but official release instead.
_____

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
