### PR TITLE
Use jhi-prefix option instead of default jhi

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/_app.module.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/_app.module.ts
@@ -51,7 +51,7 @@ import {
     imports: [
         BrowserModule,
         <%=angularXAppName%>AppRoutingModule,
-        Ng2Webstorage.forRoot({ prefix: 'jhi', separator: '-'}),
+        Ng2Webstorage.forRoot({ prefix: '<%=jhiPrefixDashed %>', separator: '-'}),
         <%=angularXAppName%>SharedModule,
         <%=angularXAppName%>HomeModule,
         <%=angularXAppName%>AdminModule,

--- a/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
+++ b/generators/client/templates/angular/src/main/webapp/swagger-ui/_index.html
@@ -116,7 +116,7 @@
                     };
                     window.swaggerUi.options.requestInterceptor = interceptor.requestInterceptor
                 <%_ } else if (authenticationType === 'jwt') { _%>
-                    var authToken = JSON.parse(localStorage.getItem("jhi-authenticationtoken") || sessionStorage.getItem("jhi-authenticationtoken"));
+                    var authToken = JSON.parse(localStorage.getItem("<%=jhiPrefixDashed %>-authenticationtoken") || sessionStorage.getItem("<%=jhiPrefixDashed %>-authenticationtoken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
                     window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
                 <%_ } _%>


### PR DESCRIPTION
In scenario where jhi-prefix option is provided to override default, use same as storage prefix as well as in swagger ui while retrieving token

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
