### PR TITLE
Fix for: #7009 TokenProvider#createToken rememberMe should not be an Object

### DIFF
--- a/generators/server/templates/src/main/java/package/security/jwt/_TokenProvider.java
+++ b/generators/server/templates/src/main/java/package/security/jwt/_TokenProvider.java
@@ -65,7 +65,7 @@ public class TokenProvider {
             1000 * jHipsterProperties.getSecurity().getAuthentication().getJwt().getTokenValidityInSecondsForRememberMe();
     }
 
-    public String createToken(Authentication authentication, Boolean rememberMe) {
+    public String createToken(Authentication authentication, boolean rememberMe) {
         String authorities = authentication.getAuthorities().stream()
             .map(GrantedAuthority::getAuthority)
             .collect(Collectors.joining(","));


### PR DESCRIPTION
This pull request fixes #7009: TokenProvider#createToken rememberMe should not be an Object (Boolean), but a primitive (boolean). Trivial change: Just one variable type is adjusted. :)

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
