### PR TITLE
added 'eu-west-2' to supported deployment regions

### DIFF
--- a/generators/aws/prompts.js
+++ b/generators/aws/prompts.js
@@ -96,7 +96,7 @@ function prompting() {
             type: 'list',
             name: 'awsRegion',
             message: 'On which region do you want to deploy?',
-            choices: ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'sa-east-1',
+            choices: ['ap-northeast-1', 'ap-southeast-1', 'ap-southeast-2', 'eu-central-1', 'eu-west-1', 'eu-west-2', 'sa-east-1',
                 'us-east-1', 'us-west-1', 'us-west-2'],
             default: 3
         }];


### PR DESCRIPTION
Added support for deploying JHipster projects on AWS `eu-west-2` (London) region