### PR TITLE
add grafana with pre-configured dashboard view and few refactoring updates

### DIFF
--- a/generators/docker-prompts.js
+++ b/generators/docker-prompts.js
@@ -253,7 +253,7 @@ function askForMonitoring() {
                 name: 'Yes, for metrics only with Prometheus (only compatible with JHipster >= v3.12)'
             }
         ],
-        default: 'no'
+        default: this.monitoring ? this.monitoring : 'no'
     }];
 
     this.prompt(prompts).then((props) => {

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -49,7 +49,7 @@ const DOCKER_GRAFANA = 'grafana/grafana:4.3.2';
 const DOCKER_JENKINS = 'jenkins:latest';
 const DOCKER_SWAGGER_EDITOR = 'swaggerapi/swagger-editor:latest';
 const DOCKER_COMPOSE_FORMAT_VERSION = '2';
-const DOCKER_PROMETHEUS_OPERATOR = 'quay.io/coreos/prometheus-operator:v0.15.0';
+const DOCKER_PROMETHEUS_OPERATOR = 'quay.io/coreos/prometheus-operator:v0.16.1';
 const DOCKER_GRAFANA_WATCHER = 'quay.io/coreos/grafana-watcher:v0.0.8';
 
 // Version of Java, Scala

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -49,6 +49,8 @@ const DOCKER_GRAFANA = 'grafana/grafana:4.3.2';
 const DOCKER_JENKINS = 'jenkins:latest';
 const DOCKER_SWAGGER_EDITOR = 'swaggerapi/swagger-editor:latest';
 const DOCKER_COMPOSE_FORMAT_VERSION = '2';
+const DOCKER_PROMETHEUS_OPERATOR = 'quay.io/coreos/prometheus-operator:v0.15.0';
+const DOCKER_GRAFANA_WATCHER = 'quay.io/coreos/grafana-watcher:v0.0.8';
 
 // Version of Java, Scala
 const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
@@ -212,7 +214,9 @@ const constants = {
     DOCKER_JENKINS,
     DOCKER_SWAGGER_EDITOR,
     SQL_DB_OPTIONS,
-    DOCKER_COMPOSE_FORMAT_VERSION
+    DOCKER_COMPOSE_FORMAT_VERSION,
+    DOCKER_PROMETHEUS_OPERATOR,
+    DOCKER_GRAFANA_WATCHER
 };
 
 module.exports = constants;

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -72,6 +72,7 @@ function writeFiles() {
         writePrometheusTpr() {
             if (this.prometheusOperator) {
                 this.template('monitoring/_jhipster-grafana.yml', 'monitoring/jhipster-grafana.yml');
+                this.template('monitoring/_jhipster-grafana-dashboard.yml', 'monitoring/jhipster-grafana-dashboard.yml');
                 this.template('monitoring/_jhipster-prometheus-cr.yml', 'monitoring/jhipster-prometheus-cr.yml');
                 this.template('monitoring/_jhipster-prometheus-crd.yml', 'monitoring/jhipster-prometheus-crd.yml');
             }

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -26,67 +26,72 @@ function writeFiles() {
             for (let i = 0; i < this.appConfigs.length; i++) {
                 const appName = this.appConfigs[i].baseName.toLowerCase();
                 this.app = this.appConfigs[i];
-                this.template('_deployment.yml', `${appName}/${appName}-deployment.yml`);
-                this.template('_service.yml', `${appName}/${appName}-service.yml`);
+                this.template('_deployment.yml', `${this.directoryPath}/k8s/${appName}/${appName}-deployment.yml`);
+                this.template('_service.yml', `${this.directoryPath}/k8s/${appName}/${appName}-service.yml`);
                 // If we choose microservice with no DB, it is trying to move _no.yml as prodDatabaseType is getting tagged as 'string' type
                 if (this.app.prodDatabaseType !== 'no') {
-                    this.template(`db/_${this.app.prodDatabaseType}.yml`, `${appName}/${appName}-${this.app.prodDatabaseType}.yml`);
+                    this.template(`db/_${this.app.prodDatabaseType}.yml`, `${this.directoryPath}/k8s/${appName}/${appName}-${this.app.prodDatabaseType}.yml`);
                 }
                 if (this.app.searchEngine === 'elasticsearch') {
-                    this.template('db/_elasticsearch.yml', `${appName}/${appName}-elasticsearch.yml`);
+                    this.template('db/_elasticsearch.yml', `${this.directoryPath}/k8s/${appName}/${appName}-elasticsearch.yml`);
                 }
                 if (this.app.messageBroker === 'kafka') {
-                    this.template('db/_kafka.yml', `${appName}/${appName}-kafka.yml`);
+                    this.template('db/_kafka.yml', `${this.directoryPath}/k8s/${appName}/${appName}-kafka.yml`);
                 }
                 if ((this.app.applicationType === 'gateway' || this.app.applicationType === 'monolith') && this.kubernetesServiceType === 'Ingress') {
-                    this.template('_ingress.yml', `${appName}/${appName}-ingress.yml`);
+                    this.template('_ingress.yml', `${this.directoryPath}/k8s/${appName}/${appName}-ingress.yml`);
                 }
-                if (this.prometheusOperator) {
-                    this.template('monitoring/_jhipster-prometheus-sm.yml', `${appName}/${appName}-prometheus-sm.yml`);
+                if (this.monitoring === 'prometheus') {
+                    this.template('monitoring/_jhipster-prometheus-sm.yml', `${this.directoryPath}/k8s/${appName}/${appName}-prometheus-sm.yml`);
                 }
             }
         },
 
         writeReadme() {
-            this.template('_README-KUBERNETES.md', 'README.md');
+            this.template('_README-KUBERNETES.md', `${this.directoryPath}/k8s/README.md`);
         },
 
         writeNamespace() {
             if (this.kubernetesNamespace !== 'default') {
-                this.template('_namespace.yml', 'namespace.yml');
+                this.template('_namespace.yml', `${this.directoryPath}/k8s/namespace.yml`);
             }
         },
 
         writeJhipsterConsole() {
-            if (this.jhipsterConsole) {
-                this.template('console/_jhipster-elasticsearch.yml', 'console/jhipster-elasticsearch.yml');
-                this.template('console/_jhipster-logstash.yml', 'console/jhipster-logstash.yml');
-                this.template('console/_jhipster-console.yml', 'console/jhipster-console.yml');
-                this.template('console/_jhipster-dashboard-console.yml', 'console/jhipster-dashboard-console.yml');
+            if (this.monitoring === 'elk') {
+                this.template('console/_jhipster-elasticsearch.yml', `${this.directoryPath}/k8s/console/jhipster-elasticsearch.yml`);
+                this.template('console/_jhipster-logstash.yml', `${this.directoryPath}/k8s/console/jhipster-logstash.yml`);
+                this.template('console/_jhipster-console.yml', `${this.directoryPath}/k8s/console/jhipster-console.yml`);
+                this.template('console/_jhipster-dashboard-console.yml', `${this.directoryPath}/k8s/console/jhipster-dashboard-console.yml`);
                 if (this.composeApplicationType === 'microservice') {
-                    this.template('console/_jhipster-zipkin.yml', 'console/jhipster-zipkin.yml');
+                    this.template('console/_jhipster-zipkin.yml', `${this.directoryPath}/k8s/console/jhipster-zipkin.yml`);
                 }
             }
         },
 
-        writePrometheusTpr() {
-            if (this.prometheusOperator) {
-                this.template('monitoring/_jhipster-grafana.yml', 'monitoring/jhipster-grafana.yml');
-                this.template('monitoring/_jhipster-grafana-dashboard.yml', 'monitoring/jhipster-grafana-dashboard.yml');
-                this.template('monitoring/_jhipster-prometheus-cr.yml', 'monitoring/jhipster-prometheus-cr.yml');
-                this.template('monitoring/_jhipster-prometheus-crd.yml', 'monitoring/jhipster-prometheus-crd.yml');
+        writePrometheusGrafanaFiles() {
+            if (this.monitoring === 'prometheus') {
+                this.template('monitoring/_jhipster-prometheus-crd.yml', `${this.directoryPath}/k8s/monitoring/jhipster-prometheus-crd.yml`);
+                this.template('monitoring/_jhipster-prometheus-cr.yml', `${this.directoryPath}/k8s/monitoring/jhipster-prometheus-cr.yml`);
+                this.template('monitoring/_jhipster-grafana.yml', `${this.directoryPath}/k8s/monitoring/jhipster-grafana.yml`);
+                this.template('monitoring/_jhipster-grafana-dashboard.yml', `${this.directoryPath}/k8s/monitoring/jhipster-grafana-dashboard.yml`);
             }
         },
 
         writeRegistryFiles() {
             if (this.serviceDiscoveryType === 'eureka') {
-                this.template('registry/_jhipster-registry.yml', 'registry/jhipster-registry.yml');
-                this.template('registry/_application-configmap.yml', 'registry/application-configmap.yml');
+                this.template('registry/_jhipster-registry.yml', `${this.directoryPath}/k8s/registry/jhipster-registry.yml`);
+                this.template('registry/_application-configmap.yml', `${this.directoryPath}/k8s/registry/application-configmap.yml`);
             } else if (this.serviceDiscoveryType === 'consul') {
-                this.template('registry/_consul.yml', 'registry/consul.yml');
-                this.template('registry/_consul-config-loader.yml', 'registry/consul-config-loader.yml');
-                this.template('registry/_application-configmap.yml', 'registry/application-configmap.yml');
+                this.template('registry/_consul.yml', `${this.directoryPath}/k8s/registry/consul.yml`);
+                this.template('registry/_consul-config-loader.yml', `${this.directoryPath}/k8s/registry/consul-config-loader.yml`);
+                this.template('registry/_application-configmap.yml', `${this.directoryPath}/k8s/registry/application-configmap.yml`);
             }
+        },
+
+        writeConfigRunFile() {
+            this.template('_apply.sh', `${this.directoryPath}/k8s/kubectl-apply.sh`);
         }
+
     };
 }

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -42,7 +42,7 @@ function writeFiles() {
                     this.template('_ingress.yml', `${appName}/${appName}-ingress.yml`);
                 }
                 if (this.prometheusOperator) {
-                    this.template('_prometheus.yml', `${appName}/${appName}-prometheus.yml`);
+                    this.template('monitoring/_jhipster-prometheus-sm.yml', `${appName}/${appName}-prometheus-sm.yml`);
                 }
             }
         },
@@ -71,7 +71,9 @@ function writeFiles() {
 
         writePrometheusTpr() {
             if (this.prometheusOperator) {
-                this.template('_prometheus-tpr.yml', 'prometheus-tpr.yml');
+                this.template('monitoring/_jhipster-grafana.yml', 'monitoring/jhipster-grafana.yml');
+                this.template('monitoring/_jhipster-prometheus-cr.yml', 'monitoring/jhipster-prometheus-cr.yml');
+                this.template('monitoring/_jhipster-prometheus-crd.yml', 'monitoring/jhipster-prometheus-crd.yml');
             }
         },
 

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -95,6 +95,9 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KAFKA = constants.DOCKER_KAFKA;
                 this.DOCKER_ZOOKEEPER = constants.DOCKER_ZOOKEEPER;
+                this.DOCKER_PROMETHEUS_OPERATOR = constants.DOCKER_PROMETHEUS_OPERATOR;
+                this.DOCKER_GRAFANA_WATCHER = constants.DOCKER_GRAFANA_WATCHER;
+                this.DOCKER_GRAFANA = constants.DOCKER_GRAFANA;
 
                 if (this.defaultAppsFolders !== undefined) {
                     this.log('\nFound .yo-rc.json config file...');
@@ -202,7 +205,7 @@ module.exports = class extends BaseGenerator {
             this.log(`  ${chalk.cyan('kubectl apply -f console')}`);
         }
         if (this.prometheusOperator) {
-            this.log(`  ${chalk.cyan('kubectl apply -f prometheus-tpr.yml')}`);
+            this.log(`  ${chalk.cyan('kubectl apply -f monitoring')}`);
         }
         if (this.gatewayNb >= 1 || this.microserviceNb >= 1) {
             this.log(`  ${chalk.cyan('kubectl apply -f registry')}`);

--- a/generators/kubernetes/prompts.js
+++ b/generators/kubernetes/prompts.js
@@ -21,10 +21,6 @@ const dockerPrompts = require('../docker-prompts');
 
 module.exports = _.extend({
     askForKubernetesNamespace,
-    askForDockerRepositoryName,
-    askForDockerPushCommand,
-    askForJhipsterConsole,
-    askForPrometheusOperator,
     askForKubernetesServiceType,
     askForIngressDomain
 }, dockerPrompts);
@@ -41,70 +37,6 @@ function askForKubernetesNamespace() {
 
     this.prompt(prompts).then((props) => {
         this.kubernetesNamespace = props.kubernetesNamespace;
-        done();
-    });
-}
-
-function askForDockerRepositoryName() {
-    const done = this.async();
-
-    const prompts = [{
-        type: 'input',
-        name: 'dockerRepositoryName',
-        message: 'What should we use for the base Docker repository name?',
-        default: this.dockerRepositoryName
-    }];
-
-    this.prompt(prompts).then((props) => {
-        this.dockerRepositoryName = props.dockerRepositoryName;
-        done();
-    });
-}
-
-function askForDockerPushCommand() {
-    const done = this.async();
-
-    const prompts = [{
-        type: 'input',
-        name: 'dockerPushCommand',
-        message: 'What command should we use for push Docker image to repository?',
-        default: this.dockerPushCommand ? this.dockerPushCommand : 'docker push'
-    }];
-
-    this.prompt(prompts).then((props) => {
-        this.dockerPushCommand = props.dockerPushCommand;
-        done();
-    });
-}
-
-function askForJhipsterConsole() {
-    const done = this.async();
-
-    const prompts = [{
-        type: 'confirm',
-        name: 'jhipsterConsole',
-        message: 'Do you want to use JHipster Console for log aggregation (ELK)?',
-        default: this.jhipsterConsole ? this.jhipsterConsole : true
-    }];
-
-    this.prompt(prompts).then((props) => {
-        this.jhipsterConsole = props.jhipsterConsole;
-        done();
-    });
-}
-
-function askForPrometheusOperator() {
-    const done = this.async();
-
-    const prompts = [{
-        type: 'confirm',
-        name: 'prometheusOperator',
-        message: 'Do you want to export your services for Prometheus (needs a running prometheus operator)?',
-        default: this.prometheusOperator ? this.prometheusOperator : true
-    }];
-
-    this.prompt(prompts).then((props) => {
-        this.prometheusOperator = props.prometheusOperator;
         done();
     });
 }

--- a/generators/kubernetes/templates/_apply.sh
+++ b/generators/kubernetes/templates/_apply.sh
@@ -17,7 +17,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-# Files are ordered in proper order with needed wait for the dependent crds' to get initialized
+# Files are ordered in proper order with needed wait for the dependent custom resource definitions to get initialized.
+# Usage: sh <%-directoryPath%>apply.sh
 <%_ if (kubernetesNamespace !== 'default') { _%>
 kubectl apply -f <%-directoryPath%>k8s/namespace.yml
 <%_ } _%> <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>

--- a/generators/kubernetes/templates/_apply.sh
+++ b/generators/kubernetes/templates/_apply.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env sh
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+# Files are ordered in proper order with needed wait for the dependent crds' to get initialized
+<%_ if (kubernetesNamespace !== 'default') { _%>
+kubectl apply -f <%-directoryPath%>k8s/namespace.yml
+<%_ } _%> <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
+kubectl apply -f <%-directoryPath%>k8s/registry/
+<%_ } _%> <%_ if (monitoring === 'elk') { _%>
+kubectl apply -f <%-directoryPath%>k8s/console/
+<%_ } _%> <%_ if (monitoring === 'prometheus') { _%>
+kubectl apply -f <%-directoryPath%>k8s/monitoring/jhipster-prometheus-crd.yml
+until [ $(kubectl get crd prometheuses.monitoring.coreos.com 2>>/dev/null | wc -l) -ge 2 ]; do
+    echo "Waiting for the custom resource prometheus operator to get initialised";
+    sleep 5;
+done
+kubectl apply -f <%-directoryPath%>k8s/monitoring/jhipster-prometheus-cr.yml
+kubectl apply -f <%-directoryPath%>k8s/monitoring/jhipster-grafana.yml
+kubectl apply -f <%-directoryPath%>k8s/monitoring/jhipster-grafana-dashboard.yml
+<%_ } _%> <%_ appConfigs.forEach((appConfig, index) =>  { _%>
+kubectl apply -f <%-directoryPath%>k8s/<%- appConfig.baseName.toLowerCase() %>/
+<%_ }) _%>

--- a/generators/kubernetes/templates/_deployment.yml
+++ b/generators/kubernetes/templates/_deployment.yml
@@ -28,6 +28,37 @@ spec:
       labels:
         app: <%= app.baseName.toLowerCase() %>
     spec:
+      initContainers:
+        - name: init-ds
+          image: busybox
+          command:
+            - '/bin/sh'
+            - '-c'
+            - |
+                while true
+                do
+                <%_ if (app.prodDatabaseType === 'mysql') { _%>
+                  rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-mysql 3306)
+                <%_ } _%>
+                <%_ if (app.prodDatabaseType === 'mariadb') { _%>
+                  rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-mariadb 3306)
+                <%_ } _%>
+                <%_ if (app.prodDatabaseType === 'postgresql') { _%>
+                  rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-postgresql 5432)
+                <%_ } _%>
+                <%_ if (app.prodDatabaseType === 'mongodb') { _%>
+                  rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-mongodb 27017)
+                <%_ } _%>
+                <%_ if (app.prodDatabaseType === 'couchbase') { _%>
+                  rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-couchbase 8091)
+                <%_ } _%>
+                  if [ $? -eq 0 ]; then
+                    echo "DB is UP"
+                    break
+                  fi
+                  echo "DB is not yet reachable;sleep for 10s before retry"
+                  sleep 10
+                done
       containers:
       - name: <%= app.baseName.toLowerCase() %>-app
         image: <%= app.targetImageName %>
@@ -86,7 +117,7 @@ spec:
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_ZK_NODES
           value: <%= app.baseName.toLowerCase() %>-zookeeper.<%= kubernetesNamespace %>.svc.cluster.local
         <%_ } _%>
-        <%_ if (jhipsterConsole) { _%>
+        <%_ if (monitoring === 'elk') { _%>
         - name: JHIPSTER_METRICS_LOGS_ENABLED
           value: 'true'
         - name: JHIPSTER_LOGGING_LOGSTASH_ENABLED
@@ -100,7 +131,7 @@ spec:
           value: http://jhipster-zipkin
             <%_ } _%>
         <%_ } _%>
-        <%_ if (prometheusOperator) { _%>
+        <%_ if (monitoring === 'prometheus') { _%>
         - name: JHIPSTER_METRICS_PROMETHEUS_ENABLED
           value: 'true'
         - name: JHIPSTER_METRICS_PROMETHEUS_ENDPOINT
@@ -122,9 +153,11 @@ spec:
           httpGet:
             path: /management/health
             port: web
+          initialDelaySeconds: 20
+          periodSeconds: 15
+          failureThreshold: 6
         livenessProbe:
           httpGet:
             path: /management/health
             port: web
-          initialDelaySeconds: 180
-
+          initialDelaySeconds: 120

--- a/generators/kubernetes/templates/monitoring/_jhipster-grafana-dashboard.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-grafana-dashboard.yml
@@ -2333,7 +2333,7 @@ spec:
       - name: grafana-configurer
         image: <%= DOCKER_GRAFANA_WATCHER %>
         args:
-          - '--watch-dir=/var/grafana-dashboards'
+          - '--watch-dir=/var/grafana-dashboard'
           - '--grafana-url=http://jhipster-grafana:3000'
         env:
         - name: GRAFANA_USER

--- a/generators/kubernetes/templates/monitoring/_jhipster-grafana-dashboard.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-grafana-dashboard.yml
@@ -1,0 +1,2364 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: jhipster-grafana-dashboard
+  namespace: <%= kubernetesNamespace %>
+data:
+  deployment-dashboard.json: |
+    {
+        "dashboard": {
+            "__inputs": [
+                {
+                    "name": "DS_PROMETHEUS",
+                    "label": "prometheus",
+                    "description": "",
+                    "type": "datasource",
+                    "pluginId": "prometheus",
+                    "pluginName": "Prometheus"
+                }
+            ],
+            "__requires": [
+                {
+                    "type": "grafana",
+                    "id": "grafana",
+                    "name": "Grafana",
+                    "version": "4.6.0"
+                },
+                {
+                    "type": "panel",
+                    "id": "graph",
+                    "name": "Graph",
+                    "version": ""
+                },
+                {
+                    "type": "datasource",
+                    "id": "prometheus",
+                    "name": "Prometheus",
+                    "version": "1.0.0"
+                },
+                {
+                    "type": "panel",
+                    "id": "singlestat",
+                    "name": "Singlestat",
+                    "version": ""
+                }
+            ],
+            "annotations": {
+                "list": [
+                    {
+                        "builtIn": 1,
+                        "datasource": "-- Grafana --",
+                        "enable": true,
+                        "hide": true,
+                        "iconColor": "rgba(0, 211, 255, 1)",
+                        "name": "Annotations & Alerts",
+                        "type": "dashboard"
+                    }
+                ]
+            },
+            "description": "JHipster metrics",
+            "editable": true,
+            "gnetId": 3308,
+            "graphTooltip": 0,
+            "hideControls": false,
+            "id": null,
+            "links": [],
+            "refresh": false,
+            "rows": [
+                {
+                    "collapse": false,
+                    "height": "250px",
+                    "panels": [
+                        {
+                            "cacheTimeout": null,
+                            "colorBackground": false,
+                            "colorValue": false,
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "decimals": null,
+                            "description": "Service status",
+                            "format": "none",
+                            "gauge": {
+                                "maxValue": 1,
+                                "minValue": 0,
+                                "show": true,
+                                "thresholdLabels": false,
+                                "thresholdMarkers": true
+                            },
+                            "height": "",
+                            "id": 1,
+                            "interval": null,
+                            "links": [],
+                            "mappingType": 1,
+                            "mappingTypes": [
+                                {
+                                    "name": "value to text",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "range to text",
+                                    "value": 2
+                                }
+                            ],
+                            "maxDataPoints": 100,
+                            "nullPointMode": "connected",
+                            "nullText": null,
+                            "postfix": "",
+                            "postfixFontSize": "50%",
+                            "prefix": "",
+                            "prefixFontSize": "100%",
+                            "rangeMaps": [
+                                {
+                                    "from": "null",
+                                    "text": "N/A",
+                                    "to": "null"
+                                }
+                            ],
+                            "span": 4,
+                            "sparkline": {
+                                "fillColor": "rgba(31, 118, 189, 0.18)",
+                                "full": false,
+                                "lineColor": "rgb(31, 120, 193)",
+                                "show": false
+                            },
+                            "tableColumn": "Value",
+                            "targets": [
+                                {
+                                    "expr": "up{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "table",
+                                    "intervalFactor": 2,
+                                    "refId": "A",
+                                    "step": 20,
+                                    "metric": "up",
+                                    "legendFormat": "service"
+                                }
+                            ],
+                            "thresholds": "0",
+                            "title": "Service Status Now",
+                            "type": "singlestat",
+                            "valueFontSize": "120%",
+                            "valueMaps": [
+                                {
+                                    "op": "=",
+                                    "text": "Down",
+                                    "value": "0"
+                                },
+                                {
+                                    "value": "1",
+                                    "op": "=",
+                                    "text": "Up"
+                                }
+                            ],
+                            "valueName": "current",
+                            "hideTimeOverride": false,
+                            "minSpan": null,
+                            "repeat": null,
+                            "transparent": false
+                        },
+                        {
+                            "id": 29,
+                            "title": "Service Uptime",
+                            "span": 8,
+                            "type": "graph",
+                            "targets": [
+                                {
+                                    "refId": "A",
+                                    "expr": "up{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "step": 2,
+                                    "legendFormat": "{{pod}}"
+                                }
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "renderer": "flot",
+                            "yaxes": [
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": "1",
+                                    "format": "short"
+                                },
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": "1",
+                                    "format": "short"
+                                }
+                            ],
+                            "xaxis": {
+                                "show": true,
+                                "mode": "time",
+                                "name": null,
+                                "values": [],
+                                "buckets": null
+                            },
+                            "lines": true,
+                            "fill": 1,
+                            "linewidth": 1,
+                            "dashes": false,
+                            "dashLength": 10,
+                            "spaceLength": 10,
+                            "points": true,
+                            "pointradius": 3,
+                            "bars": false,
+                            "stack": false,
+                            "percentage": false,
+                            "legend": {
+                                "show": true,
+                                "values": false,
+                                "min": false,
+                                "max": false,
+                                "current": false,
+                                "total": false,
+                                "avg": false,
+                                "alignAsTable": true
+                            },
+                            "nullPointMode": "null",
+                            "steppedLine": true,
+                            "tooltip": {
+                                "value_type": "individual",
+                                "shared": true,
+                                "sort": 0
+                            },
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "aliasColors": {},
+                            "seriesOverrides": [],
+                            "thresholds": [],
+                            "links": [],
+                            "description": "The uptime of the service"
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Uptime Metrics",
+                    "titleSize": "h6"
+                },
+                {
+                    "collapse": false,
+                    "height": 250,
+                    "panels": [
+                        {
+                            "cacheTimeout": null,
+                            "colorBackground": false,
+                            "colorValue": true,
+                            "colors": [
+                                "rgba(32, 176, 9, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Total requests count",
+                            "format": "none",
+                            "gauge": {
+                                "maxValue": 10000000000000,
+                                "minValue": 0,
+                                "show": true,
+                                "thresholdLabels": false,
+                                "thresholdMarkers": true
+                            },
+                            "id": 5,
+                            "interval": null,
+                            "links": [],
+                            "mappingType": 1,
+                            "mappingTypes": [
+                                {
+                                    "name": "value to text",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "range to text",
+                                    "value": 2
+                                }
+                            ],
+                            "maxDataPoints": 100,
+                            "nullPointMode": "connected",
+                            "nullText": null,
+                            "postfix": "",
+                            "postfixFontSize": "50%",
+                            "prefix": "",
+                            "prefixFontSize": "50%",
+                            "rangeMaps": [
+                                {
+                                    "from": "null",
+                                    "text": "N/A",
+                                    "to": "null"
+                                }
+                            ],
+                            "span": 3,
+                            "sparkline": {
+                                "fillColor": "rgba(31, 118, 189, 0.18)",
+                                "full": false,
+                                "lineColor": "rgb(31, 120, 193)",
+                                "show": false
+                            },
+                            "tableColumn": "Value",
+                            "targets": [
+                                {
+                                    "expr": "com_codahale_metrics_servlet_InstrumentedFilter_requests_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "table",
+                                    "intervalFactor": 2,
+                                    "refId": "A",
+                                    "step": 20,
+                                    "metric": "com_codahale_metrics_servlet_InstrumentedFilter_requests_count"
+                                }
+                            ],
+                            "thresholds": "",
+                            "title": "Total Requests",
+                            "type": "singlestat",
+                            "valueFontSize": "70%",
+                            "valueMaps": [
+                                {
+                                    "op": "=",
+                                    "text": "N/A",
+                                    "value": "null"
+                                }
+                            ],
+                            "valueName": "total",
+                            "transparent": false
+                        },
+                        {
+                            "cacheTimeout": null,
+                            "colorBackground": false,
+                            "colorValue": false,
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Number of 200 OK requests",
+                            "format": "none",
+                            "gauge": {
+                                "maxValue": 10000000000000000,
+                                "minValue": 0,
+                                "show": true,
+                                "thresholdLabels": false,
+                                "thresholdMarkers": true
+                            },
+                            "id": 6,
+                            "interval": null,
+                            "links": [],
+                            "mappingType": 1,
+                            "mappingTypes": [
+                                {
+                                    "name": "value to text",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "range to text",
+                                    "value": 2
+                                }
+                            ],
+                            "maxDataPoints": 100,
+                            "nullPointMode": "connected",
+                            "nullText": null,
+                            "postfix": "",
+                            "postfixFontSize": "50%",
+                            "prefix": "",
+                            "prefixFontSize": "50%",
+                            "rangeMaps": [
+                                {
+                                    "from": "null",
+                                    "text": "N/A",
+                                    "to": "null"
+                                }
+                            ],
+                            "span": 3,
+                            "sparkline": {
+                                "fillColor": "rgba(31, 118, 189, 0.78)",
+                                "full": false,
+                                "lineColor": "rgb(31, 120, 193)",
+                                "show": true
+                            },
+                            "tableColumn": "Value",
+                            "targets": [
+                                {
+                                    "expr": "com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_ok_total{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "table",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "",
+                                    "refId": "A",
+                                    "step": 20,
+                                    "metric": "com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_ok_total"
+                                }
+                            ],
+                            "thresholds": "",
+                            "title": "Total Successful hits",
+                            "type": "singlestat",
+                            "valueFontSize": "80%",
+                            "valueMaps": [
+                                {
+                                    "op": "=",
+                                    "text": "N/A",
+                                    "value": "null"
+                                }
+                            ],
+                            "valueName": "total"
+                        },
+                        {
+                            "cacheTimeout": null,
+                            "colorBackground": false,
+                            "colorValue": false,
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Number of server errors and bad requests",
+                            "format": "none",
+                            "gauge": {
+                                "maxValue": 1,
+                                "minValue": 0,
+                                "show": true,
+                                "thresholdLabels": false,
+                                "thresholdMarkers": true
+                            },
+                            "id": 7,
+                            "interval": null,
+                            "links": [],
+                            "mappingType": 1,
+                            "mappingTypes": [
+                                {
+                                    "name": "value to text",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "range to text",
+                                    "value": 2
+                                }
+                            ],
+                            "maxDataPoints": 100,
+                            "nullPointMode": "connected",
+                            "nullText": null,
+                            "postfix": "",
+                            "postfixFontSize": "50%",
+                            "prefix": "",
+                            "prefixFontSize": "50%",
+                            "rangeMaps": [
+                                {
+                                    "from": "null",
+                                    "text": "N/A",
+                                    "to": "null"
+                                }
+                            ],
+                            "span": 3,
+                            "sparkline": {
+                                "fillColor": "rgba(31, 118, 189, 0.18)",
+                                "full": false,
+                                "lineColor": "rgb(31, 120, 193)",
+                                "show": false
+                            },
+                            "tableColumn": "Value",
+                            "targets": [
+                                {
+                                    "expr": "com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_serverError_total{namespace =\"$namespace\", service =\"$service_name\"} + com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_badRequest_total{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "refId": "A",
+                                    "step": 20,
+                                    "metric": "com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_serverError_total"
+                                }
+                            ],
+                            "thresholds": "1",
+                            "title": "Total Bad hits",
+                            "type": "singlestat",
+                            "valueFontSize": "70%",
+                            "valueMaps": [
+                                {
+                                    "op": "=",
+                                    "text": "N/A",
+                                    "value": "null"
+                                }
+                            ],
+                            "valueName": "total"
+                        },
+                        {
+                            "cacheTimeout": null,
+                            "colorBackground": false,
+                            "colorValue": false,
+                            "colors": [
+                                "rgba(245, 54, 54, 0.9)",
+                                "rgba(237, 129, 40, 0.89)",
+                                "rgba(50, 172, 45, 0.97)"
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Number of 404 not found requests",
+                            "format": "none",
+                            "gauge": {
+                                "maxValue": 1,
+                                "minValue": 0,
+                                "show": true,
+                                "thresholdLabels": false,
+                                "thresholdMarkers": true
+                            },
+                            "id": 8,
+                            "interval": null,
+                            "links": [],
+                            "mappingType": 1,
+                            "mappingTypes": [
+                                {
+                                    "name": "value to text",
+                                    "value": 1
+                                },
+                                {
+                                    "name": "range to text",
+                                    "value": 2
+                                }
+                            ],
+                            "maxDataPoints": 100,
+                            "nullPointMode": "connected",
+                            "nullText": null,
+                            "postfix": "",
+                            "postfixFontSize": "50%",
+                            "prefix": "",
+                            "prefixFontSize": "50%",
+                            "rangeMaps": [
+                                {
+                                    "from": "null",
+                                    "text": "N/A",
+                                    "to": "null"
+                                }
+                            ],
+                            "span": 3,
+                            "sparkline": {
+                                "fillColor": "rgba(31, 118, 189, 0.18)",
+                                "full": false,
+                                "lineColor": "rgb(31, 120, 193)",
+                                "show": false
+                            },
+                            "tableColumn": "",
+                            "targets": [
+                                {
+                                    "expr": "com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_notFound_total{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "refId": "A",
+                                    "step": 20,
+                                    "metric": "com_codahale_metrics_servlet_InstrumentedFilter_responseCodes_notFound_total"
+                                }
+                            ],
+                            "thresholds": "1",
+                            "title": "Trace 404 hits",
+                            "type": "singlestat",
+                            "valueFontSize": "80%",
+                            "valueMaps": [
+                                {
+                                    "op": "=",
+                                    "text": "N/A",
+                                    "value": "null"
+                                }
+                            ],
+                            "valueName": "total"
+                        },
+                        {
+                            "id": 30,
+                            "title": "Active Requests",
+                            "span": 12,
+                            "type": "graph",
+                            "targets": [
+                                {
+                                    "refId": "A",
+                                    "expr": "com_codahale_metrics_servlet_InstrumentedFilter_activeRequests{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "metric": "com_codahale_metrics_servlet_InstrumentedFilter_activeRequests",
+                                    "step": 2,
+                                    "legendFormat": "{{service}}"
+                                }
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "renderer": "flot",
+                            "yaxes": [
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": null,
+                                    "max": null,
+                                    "format": "short"
+                                },
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": null,
+                                    "max": null,
+                                    "format": "short"
+                                }
+                            ],
+                            "xaxis": {
+                                "show": true,
+                                "mode": "time",
+                                "name": null,
+                                "values": [
+                                    "total"
+                                ],
+                                "buckets": null
+                            },
+                            "lines": true,
+                            "fill": 1,
+                            "linewidth": 2,
+                            "dashes": false,
+                            "dashLength": 10,
+                            "spaceLength": 10,
+                            "points": false,
+                            "pointradius": 5,
+                            "bars": false,
+                            "stack": false,
+                            "percentage": false,
+                            "legend": {
+                                "show": true,
+                                "values": true,
+                                "min": true,
+                                "max": true,
+                                "current": true,
+                                "total": false,
+                                "avg": true,
+                                "alignAsTable": true
+                            },
+                            "nullPointMode": "null",
+                            "steppedLine": false,
+                            "tooltip": {
+                                "value_type": "individual",
+                                "shared": false,
+                                "sort": 0
+                            },
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "aliasColors": {},
+                            "seriesOverrides": [],
+                            "thresholds": [],
+                            "links": []
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Requests Metrics",
+                    "titleSize": "h6"
+                },
+                {
+                    "collapse": false,
+                    "height": 250,
+                    "panels": [
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "The current number of live threads including daemon and non-daemon and runnable threads",
+                            "fill": 4,
+                            "id": 10,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true,
+                                "rightSide": false,
+                                "hideEmpty": false
+                            },
+                            "lines": true,
+                            "linewidth": 2,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": true,
+                            "targets": [
+                                {
+                                    "expr": "jvm_threads_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Total threads",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_threads_count"
+                                },
+                                {
+                                    "expr": "jvm_threads_daemon_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "jvm_threads_daemon_count",
+                                    "step": 4,
+                                    "legendFormat": "Daemon threads"
+                                },
+                                {
+                                    "expr": "jvm_threads_runnable_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "C",
+                                    "metric": "jvm_threads_runnable_count",
+                                    "step": 4,
+                                    "legendFormat": "Runnable threads"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Live Threads",
+                            "tooltip": {
+                                "shared": false,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+                                    "total"
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                }
+                            ],
+                            "transparent": false
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "The current number of blocked and deadlock threads",
+                            "fill": 1,
+                            "id": 11,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_threads_blocked_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Blocked threads",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_threads_blocked_count"
+                                },
+                                {
+                                    "expr": "jvm_threads_deadlock_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "jvm_threads_deadlock_count",
+                                    "step": 4,
+                                    "legendFormat": "Deadlock threads"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Blocked and Deadlock Threads",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "The current number of waiting threads",
+                            "fill": 1,
+                            "id": 12,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_threads_waiting_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Waiting threads",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_threads_waiting_count"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Waiting Threads",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                }
+                            ]
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Thread Metrics",
+                    "titleSize": "h6"
+                },
+                {
+                    "collapse": false,
+                    "height": 250,
+                    "panels": [
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "An estimate of the number of buffers in the pool",
+                            "fill": 1,
+                            "id": 13,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_buffers_direct_count{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{service}}",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_buffers_direct_count"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Buffer Count",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "An estimate of the memory that the Java virtual machine is using for this buffer pool",
+                            "fill": 1,
+                            "id": 14,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_buffers_direct_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{service}}",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_buffers_direct_used"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Buffer Mem Used",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "An estimate of the total capacity of the buffers in this pool",
+                            "fill": 1,
+                            "id": 15,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": false,
+                                "current": true,
+                                "max": false,
+                                "min": false,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_buffers_direct_capacity{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{service}}",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_buffers_direct_capacity"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Buffer Capacity",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "The total amount of heap memory",
+                            "fill": 1,
+                            "id": 18,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_memory_heap_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Used",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_memory_heap_used"
+                                },
+                                {
+                                    "expr": "jvm_memory_heap_max{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "jvm_memory_heap_max",
+                                    "step": 4,
+                                    "legendFormat": "Maximum"
+                                },
+                                {
+                                    "expr": "jvm_memory_heap_committed{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "C",
+                                    "metric": "jvm_memory_heap_committed",
+                                    "step": 4,
+                                    "legendFormat": "Committed"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Heap Memory",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "The amount of used, committed and max memory",
+                            "fill": 1,
+                            "id": 16,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_memory_total_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Used",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_memory_total_used"
+                                },
+                                {
+                                    "expr": "jvm_memory_total_max{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "jvm_memory_total_max",
+                                    "step": 4,
+                                    "legendFormat": "Max"
+                                },
+                                {
+                                    "expr": "jvm_memory_total_committed{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "C",
+                                    "metric": "jvm_memory_total_committed",
+                                    "step": 4,
+                                    "legendFormat": "Committed"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Total Memory",
+                            "tooltip": {
+                                "shared": false,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+                                    "total"
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "The total amount of  non heap memory",
+                            "fill": 1,
+                            "id": 17,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 4,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_memory_non_heap_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Non Heap Used",
+                                    "refId": "A",
+                                    "step": 4,
+                                    "metric": "jvm_memory_non_heap_used"
+                                },
+                                {
+                                    "expr": "jvm_memory_non_heap_committed{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "jvm_memory_non_heap_max",
+                                    "step": 4,
+                                    "legendFormat": "Non Heap Committed"
+                                },
+                                {
+                                    "expr": "jvm_memory_pools_Metaspace_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "C",
+                                    "metric": "jvm_memory_pools_Metaspace_used",
+                                    "step": 4,
+                                    "legendFormat": "Metaspace Used"
+                                },
+                                {
+                                    "expr": "jvm_memory_pools_Code_Cache_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "D",
+                                    "metric": "jvm_memory_pools_Code_Cache_used",
+                                    "step": 4,
+                                    "legendFormat": "Code Cache Used"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Other Memory",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Memory Metrics",
+                    "titleSize": "h6"
+                },
+                {
+                    "collapse": false,
+                    "height": 250,
+                    "panels": [
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Memory space of new generation",
+                            "fill": 2,
+                            "id": 19,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 2,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_memory_pools_PS_Eden_Space_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Used",
+                                    "refId": "A",
+                                    "step": 2,
+                                    "metric": "jvm_memory_pools_PS_Eden_Space_used"
+                                },
+                                {
+                                    "expr": "jvm_memory_pools_PS_Eden_Space_max{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "jvm_memory_pools_PS_Eden_Space_max",
+                                    "step": 2,
+                                    "legendFormat": "Max"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Eden Space",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Memory space of new generation",
+                            "fill": 1,
+                            "id": 20,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 6,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_memory_pools_PS_Survivor_Space_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Used",
+                                    "refId": "A",
+                                    "step": 2,
+                                    "metric": "jvm_memory_pools_PS_Old_Gen_used"
+                                },
+                                {
+                                    "expr": "jvm_memory_pools_PS_Survivor_Space_max{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "metric": "",
+                                    "step": 2,
+                                    "legendFormat": "Max"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Survivor Space",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        },
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Memory space of old generation",
+                            "fill": 1,
+                            "id": 24,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 12,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "jvm_memory_pools_PS_Old_Gen_used{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "Used",
+                                    "refId": "A",
+                                    "step": 2,
+                                    "metric": "jvm_memory_pools_PS_Old_Gen_used"
+                                },
+                                {
+                                    "expr": "jvm_memory_pools_PS_Old_Gen_max{namespace =\"$namespace\", service =\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "refId": "B",
+                                    "step": 2,
+                                    "legendFormat": "Max"
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "Old Generation",
+                            "tooltip": {
+                                "shared": true,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": []
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "decbytes",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                },
+                                {
+                                    "format": "s",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": null,
+                                    "show": true
+                                }
+                            ]
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Memory Space Metrics",
+                    "titleSize": "h6"
+                },
+                {
+                    "collapse": false,
+                    "height": 250,
+                    "panels": [
+                        {
+                            "id": 31,
+                            "title": "Cache Hits",
+                            "span": 6,
+                            "type": "graph",
+                            "targets": [
+                                {
+                                    "refId": "A",
+                                    "expr": "{__name__=~\"^jcache_statistics.*cache_hits\", namespace=\"$namespace\", service=\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "step": 2,
+                                    "legendFormat": "{{__name__}}"
+                                }
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "renderer": "flot",
+                            "yaxes": [
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "none"
+                                },
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                }
+                            ],
+                            "xaxis": {
+                                "show": true,
+                                "mode": "time",
+                                "name": null,
+                                "values": [
+                                    "total"
+                                ],
+                                "buckets": null
+                            },
+                            "lines": true,
+                            "fill": 1,
+                            "linewidth": 1,
+                            "dashes": false,
+                            "dashLength": 10,
+                            "spaceLength": 10,
+                            "points": false,
+                            "pointradius": 5,
+                            "bars": false,
+                            "stack": false,
+                            "percentage": false,
+                            "legend": {
+                                "show": true,
+                                "values": true,
+                                "min": true,
+                                "max": true,
+                                "current": true,
+                                "total": true,
+                                "avg": true,
+                                "alignAsTable": true
+                            },
+                            "nullPointMode": "null",
+                            "steppedLine": false,
+                            "tooltip": {
+                                "value_type": "individual",
+                                "shared": false,
+                                "sort": 0
+                            },
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "aliasColors": {},
+                            "seriesOverrides": [],
+                            "thresholds": [],
+                            "links": [],
+                            "description": "The total number of cache hits"
+                        },
+                        {
+                            "id": 32,
+                            "title": "Cache Misses",
+                            "span": 6,
+                            "type": "graph",
+                            "targets": [
+                                {
+                                    "refId": "A",
+                                    "expr": "{__name__=~\"^jcache_statistics.*cache_misses\", namespace=\"$namespace\", service=\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "step": 2,
+                                    "legendFormat": "{{__name__}}"
+                                }
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "renderer": "flot",
+                            "yaxes": [
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                },
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                }
+                            ],
+                            "xaxis": {
+                                "show": true,
+                                "mode": "time",
+                                "name": null,
+                                "values": [],
+                                "buckets": null
+                            },
+                            "lines": true,
+                            "fill": 1,
+                            "linewidth": 1,
+                            "dashes": false,
+                            "dashLength": 10,
+                            "spaceLength": 10,
+                            "points": false,
+                            "pointradius": 5,
+                            "bars": false,
+                            "stack": false,
+                            "percentage": false,
+                            "legend": {
+                                "show": true,
+                                "values": true,
+                                "min": true,
+                                "max": true,
+                                "current": true,
+                                "total": true,
+                                "avg": true,
+                                "alignAsTable": true
+                            },
+                            "nullPointMode": "null",
+                            "steppedLine": false,
+                            "tooltip": {
+                                "value_type": "individual",
+                                "shared": true,
+                                "sort": 0
+                            },
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "aliasColors": {},
+                            "seriesOverrides": [],
+                            "thresholds": [],
+                            "links": [],
+                            "description": "The total number of cache misses"
+                        },
+                        {
+                            "id": 33,
+                            "title": "Cache Gets",
+                            "span": 6,
+                            "type": "graph",
+                            "targets": [
+                                {
+                                    "refId": "A",
+                                    "expr": "{__name__=~\"^jcache_statistics.*cache_gets\", namespace=\"$namespace\", service=\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "step": 2,
+                                    "legendFormat": "{{__name__}}"
+                                }
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "renderer": "flot",
+                            "yaxes": [
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                },
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                }
+                            ],
+                            "xaxis": {
+                                "show": true,
+                                "mode": "time",
+                                "name": null,
+                                "values": [],
+                                "buckets": null
+                            },
+                            "lines": true,
+                            "fill": 1,
+                            "linewidth": 1,
+                            "dashes": false,
+                            "dashLength": 10,
+                            "spaceLength": 10,
+                            "points": false,
+                            "pointradius": 5,
+                            "bars": false,
+                            "stack": false,
+                            "percentage": false,
+                            "legend": {
+                                "show": true,
+                                "values": true,
+                                "min": true,
+                                "max": true,
+                                "current": true,
+                                "total": true,
+                                "avg": true,
+                                "alignAsTable": true
+                            },
+                            "nullPointMode": "null",
+                            "steppedLine": false,
+                            "tooltip": {
+                                "value_type": "individual",
+                                "shared": true,
+                                "sort": 0
+                            },
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "aliasColors": {},
+                            "seriesOverrides": [],
+                            "thresholds": [],
+                            "links": [],
+                            "description": "The total number of cache gets"
+                        },
+                        {
+                            "id": 34,
+                            "title": "Cache Puts",
+                            "span": 6,
+                            "type": "graph",
+                            "targets": [
+                                {
+                                    "refId": "A",
+                                    "expr": "{__name__=~\"^jcache_statistics.*cache_puts\", namespace=\"$namespace\", service=\"$service_name\"}",
+                                    "intervalFactor": 2,
+                                    "format": "time_series",
+                                    "step": 2,
+                                    "legendFormat": "{{__name__}}"
+                                }
+                            ],
+                            "datasource": "${DS_PROMETHEUS}",
+                            "renderer": "flot",
+                            "yaxes": [
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                },
+                                {
+                                    "label": null,
+                                    "show": true,
+                                    "logBase": 1,
+                                    "min": "0",
+                                    "max": null,
+                                    "format": "short"
+                                }
+                            ],
+                            "xaxis": {
+                                "show": true,
+                                "mode": "time",
+                                "name": null,
+                                "values": [],
+                                "buckets": null
+                            },
+                            "lines": true,
+                            "fill": 1,
+                            "linewidth": 1,
+                            "dashes": false,
+                            "dashLength": 10,
+                            "spaceLength": 10,
+                            "points": false,
+                            "pointradius": 5,
+                            "bars": false,
+                            "stack": false,
+                            "percentage": false,
+                            "legend": {
+                                "show": true,
+                                "values": true,
+                                "min": true,
+                                "max": true,
+                                "current": true,
+                                "total": true,
+                                "avg": true,
+                                "alignAsTable": true
+                            },
+                            "nullPointMode": "null",
+                            "steppedLine": false,
+                            "tooltip": {
+                                "value_type": "individual",
+                                "shared": true,
+                                "sort": 0
+                            },
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "aliasColors": {},
+                            "seriesOverrides": [],
+                            "thresholds": [],
+                            "links": [],
+                            "description": "The total number of cache puts"
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "Cache Metrics",
+                    "titleSize": "h6"
+                },
+                {
+                    "collapse": false,
+                    "height": 250,
+                    "panels": [
+                        {
+                            "aliasColors": {},
+                            "bars": false,
+                            "dashLength": 10,
+                            "dashes": false,
+                            "datasource": "${DS_PROMETHEUS}",
+                            "description": "Count of REST requests",
+                            "fill": 1,
+                            "id": 27,
+                            "legend": {
+                                "alignAsTable": true,
+                                "avg": true,
+                                "current": true,
+                                "max": true,
+                                "min": true,
+                                "show": true,
+                                "total": false,
+                                "values": true
+                            },
+                            "lines": true,
+                            "linewidth": 1,
+                            "links": [],
+                            "nullPointMode": "null",
+                            "percentage": false,
+                            "pointradius": 5,
+                            "points": false,
+                            "renderer": "flot",
+                            "seriesOverrides": [],
+                            "spaceLength": 10,
+                            "span": 12,
+                            "stack": false,
+                            "steppedLine": false,
+                            "targets": [
+                                {
+                                    "expr": "{__name__=~\".*rest.*_count\", namespace=\"$namespace\", service=\"$service_name\"} ",
+                                    "format": "time_series",
+                                    "intervalFactor": 2,
+                                    "legendFormat": "{{__name__}}",
+                                    "refId": "A",
+                                    "step": 2
+                                }
+                            ],
+                            "thresholds": [],
+                            "timeFrom": null,
+                            "timeShift": null,
+                            "title": "REST Requests Metrics",
+                            "tooltip": {
+                                "shared": false,
+                                "sort": 0,
+                                "value_type": "individual"
+                            },
+                            "type": "graph",
+                            "xaxis": {
+                                "buckets": null,
+                                "mode": "time",
+                                "name": null,
+                                "show": true,
+                                "values": [
+                                    "total"
+                                ]
+                            },
+                            "yaxes": [
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                },
+                                {
+                                    "format": "short",
+                                    "label": null,
+                                    "logBase": 1,
+                                    "max": null,
+                                    "min": "0",
+                                    "show": true
+                                }
+                            ],
+                            "decimals": 0
+                        }
+                    ],
+                    "repeat": null,
+                    "repeatIteration": null,
+                    "repeatRowId": null,
+                    "showTitle": true,
+                    "title": "REST Metrics",
+                    "titleSize": "h6"
+                }
+            ],
+            "schemaVersion": 14,
+            "style": "dark",
+            "tags": [
+                "java",
+                "jhipster",
+                "spring-boot"
+            ],
+            "templating": {
+                "list": [
+                    {
+                        "allValue": null,
+                        "current": {},
+                        "datasource": "${DS_PROMETHEUS}",
+                        "hide": 0,
+                        "includeAll": false,
+                        "label": "Namespace",
+                        "multi": false,
+                        "name": "namespace",
+                        "options": [],
+                        "query": "label_values(jvm_files, namespace)",
+                        "refresh": 2,
+                        "regex": "",
+                        "sort": 1,
+                        "tagValuesQuery": "",
+                        "tags": [],
+                        "tagsQuery": "",
+                        "type": "query",
+                        "useTags": false
+                    },
+                    {
+                        "allValue": null,
+                        "current": {},
+                        "datasource": "${DS_PROMETHEUS}",
+                        "hide": 0,
+                        "includeAll": false,
+                        "label": "Service Name",
+                        "multi": false,
+                        "name": "service_name",
+                        "options": [],
+                        "query": "label_values(jvm_files, service)",
+                        "refresh": 2,
+                        "regex": "",
+                        "sort": 1,
+                        "tagValuesQuery": "",
+                        "tags": [],
+                        "tagsQuery": "",
+                        "type": "query",
+                        "useTags": false
+                    }
+                ]
+            },
+            "time": {
+                "from": "now-15m",
+                "to": "now"
+            },
+            "timepicker": {
+                "refresh_intervals": [
+                    "5s",
+                    "10s",
+                    "30s",
+                    "1m",
+                    "5m",
+                    "15m",
+                    "30m",
+                    "1h",
+                    "2h",
+                    "1d"
+                ],
+                "time_options": [
+                    "5m",
+                    "15m",
+                    "1h",
+                    "6h",
+                    "12h",
+                    "24h",
+                    "2d",
+                    "7d",
+                    "30d"
+                ]
+            },
+            "timezone": "",
+            "title": "JHipster Metrics",
+            "version": 3
+        },
+        "inputs": [
+            {
+                "name": "DS_PROMETHEUS",
+                "pluginId": "prometheus",
+                "type": "datasource",
+                "value": "prometheus"
+            }
+        ],
+        "overwrite": true
+    }
+  prometheus-datasource.json: |
+    {
+        "access": "proxy",
+        "basicAuth": false,
+        "name": "prometheus",
+        "type": "prometheus",
+        "url": "http://jhipster-prometheus:9090"
+    }
+---
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: jhipster-grafana-dashboard
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    job: jhipster-grafana-dashboard
+spec:
+  template:
+    metadata:
+      labels:
+        job: jhipster-grafana-dashboard
+    spec:
+      initContainers:
+        - name: init-dependent-services-check
+          image: busybox
+          command:
+            - '/bin/sh'
+            - '-c'
+            - |
+                until nc -z -w 1 jhipster-prometheus 9090
+                do
+                  echo Waiting for prometheus to get initialized
+                  sleep 5
+                done
+                until nc -z -w 1 jhipster-grafana 3000
+                do
+                  echo Waiting for grafana to get initialized
+                  sleep 5
+                done
+      containers:
+      - name: grafana-configurer
+        image: <%= DOCKER_GRAFANA_WATCHER %>
+        args:
+          - '--watch-dir=/var/grafana-dashboards'
+          - '--grafana-url=http://jhipster-grafana:3000'
+        env:
+        - name: GRAFANA_USER
+          valueFrom:
+            secretKeyRef:
+              name: jhipster-grafana-credentials
+              key: username
+        - name: GRAFANA_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: jhipster-grafana-credentials
+              key: password
+        resources:
+          requests:
+            memory: "16Mi"
+            cpu: "50m"
+          limits:
+            memory: "32Mi"
+            cpu: "100m"
+        volumeMounts:
+        - name: grafana-dashboard
+          mountPath: /var/grafana-dashboard
+      volumes:
+      - name: grafana-dashboard
+        configMap:
+          name: jhipster-grafana-dashboard
+      restartPolicy: OnFailure
+

--- a/generators/kubernetes/templates/monitoring/_jhipster-grafana.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-grafana.yml
@@ -1,0 +1,110 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+apiVersion: v1
+kind: Secret
+metadata:
+  name: jhipster-grafana-credentials
+  namespace: <%= kubernetesNamespace %>
+data:
+  username: amhpcHN0ZXI=
+  password: amhpcHN0ZXI=
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: jhipster-grafana
+  namespace: <%= kubernetesNamespace %>
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        app: jhipster-grafana
+    spec:
+      containers:
+      - name: jhipster-grafana
+        image: <%= DOCKER_GRAFANA %>
+        ports:
+        - containerPort: 3000
+          name: http
+          protocol: TCP
+        env:
+        - name: GF_SECURITY_ADMIN_USER
+          valueFrom:
+            secretKeyRef:
+              name: jhipster-grafana-credentials
+              key: username
+        - name: GF_SECURITY_ADMIN_PASSWORD
+          valueFrom:
+            secretKeyRef:
+              name: jhipster-grafana-credentials
+              key: password
+        - name: GF_USERS_ALLOW_SIGN_UP
+          value: "false"
+        resources:
+          requests:
+            memory: "100Mi"
+            cpu: "100m"
+          limits:
+            memory: "250Mi"
+            cpu: "200m"
+        volumeMounts:
+        - name: grafana-storage
+          mountPath: /var/grafana-storage
+      volumes:
+      - name: grafana-storage
+        emptyDir: {}
+      restartPolicy: Always
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: jhipster-grafana
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    app: jhipster-grafana
+spec:
+  ports:
+  - name: http
+    port: 3000
+    targetPort: 3000
+  <%_ if (kubernetesServiceType !== 'Ingress') { _%>
+  type: <%= kubernetesServiceType %>
+  <%_ } else { _%>
+  type: ClusterIP
+  <%_ } _%>
+  selector:
+    app: jhipster-grafana
+---
+<%_ if (kubernetesServiceType === 'Ingress') { _%>
+apiVersion: extensions/v1beta1
+kind: Ingress
+metadata:
+  name: jhipster-grafana
+  namespace: <%= kubernetesNamespace %>
+spec:
+  rules:
+  - host: jhipster-grafana.<%= ingressDomain %>
+    http:
+      paths:
+      - path: /
+        backend:
+          serviceName: jhipster-grafana
+          servicePort: 3000
+<%_ } _%>

--- a/generators/kubernetes/templates/monitoring/_jhipster-prometheus-cr.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-prometheus-cr.yml
@@ -41,6 +41,7 @@ rules:
   verbs: ["get"]
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
+# limit to the namespace
 kind: RoleBinding
 metadata:
   name: jhipster-prometheus-rb
@@ -59,6 +60,7 @@ metadata:
   name: jhipster-prometheus
   namespace: <%= kubernetesNamespace %>
 spec:
+  replica: 1
   serviceAccountName: jhipster-prometheus-sa
   serviceMonitorSelector:
     matchLabels:

--- a/generators/kubernetes/templates/monitoring/_jhipster-prometheus-cr.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-prometheus-cr.yml
@@ -19,13 +19,13 @@
 apiVersion: v1
 kind: ServiceAccount
 metadata:
-  name: prometheus-<%= kubernetesNamespace %>
+  name: jhipster-prometheus-sa
   namespace: <%= kubernetesNamespace %>
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: Role
 metadata:
-  name: prometheus-<%= kubernetesNamespace %>
+  name: jhipster-prometheus-role
   namespace: <%= kubernetesNamespace %>
 rules:
 - apiGroups: [""]
@@ -43,25 +43,23 @@ rules:
 apiVersion: rbac.authorization.k8s.io/v1beta1
 kind: RoleBinding
 metadata:
-  name: prometheus-<%= kubernetesNamespace %>
+  name: jhipster-prometheus-rb
   namespace: <%= kubernetesNamespace %>
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
-  name: prometheus-<%= kubernetesNamespace %>
+  name: jhipster-prometheus-role
 subjects:
 - kind: ServiceAccount
-  name: prometheus-<%= kubernetesNamespace %>
-  namespace: <%= kubernetesNamespace %>
+  name: jhipster-prometheus-sa
 ---
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: Prometheus
 metadata:
-  name: <%= kubernetesNamespace %>
+  name: jhipster-prometheus
   namespace: <%= kubernetesNamespace %>
 spec:
-  version: v1.6.2
-  serviceAccountName: prometheus-<%= kubernetesNamespace %>
+  serviceAccountName: jhipster-prometheus-sa
   serviceMonitorSelector:
     matchLabels:
       team: <%= kubernetesNamespace %>
@@ -72,15 +70,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: prometheus-<%= kubernetesNamespace %>
+  name: jhipster-prometheus
   namespace: <%= kubernetesNamespace %>
 spec:
-  type: NodePort
   ports:
   - name: web
-    nodePort: 30901
     port: 9090
     protocol: TCP
     targetPort: web
   selector:
-    prometheus: <%= kubernetesNamespace %>
+    prometheus: jhipster-prometheus

--- a/generators/kubernetes/templates/monitoring/_jhipster-prometheus-crd.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-prometheus-crd.yml
@@ -1,0 +1,121 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: ClusterRole
+metadata:
+  name: jhipster-prometheus-operator-cr
+rules:
+- apiGroups:
+  - extensions
+  resources:
+  - thirdpartyresources
+  verbs:
+  - "*"
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - "*"
+- apiGroups:
+  - monitoring.coreos.com
+  resources:
+  - alertmanagers
+  - prometheuses
+  - servicemonitors
+  verbs:
+  - "*"
+- apiGroups:
+  - apps
+  resources:
+  - statefulsets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - configmaps
+  - secrets
+  verbs: ["*"]
+- apiGroups: [""]
+  resources:
+  - pods
+  verbs: ["list", "delete"]
+- apiGroups: [""]
+  resources:
+  - services
+  - endpoints
+  verbs: ["get", "create", "update"]
+- apiGroups: [""]
+  resources:
+  - nodes
+  verbs: ["list", "watch"]
+- apiGroups: [""]
+  resources:
+  - namespaces
+  verbs: ["list"]
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: jhipster-prometheus-operator-sa
+  namespace: <%= kubernetesNamespace %>
+---
+apiVersion: rbac.authorization.k8s.io/v1beta1
+kind: RoleBinding
+metadata:
+  name: jhipster-prometheus-operator-rb
+  namespace: <%= kubernetesNamespace %>
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: ClusterRole
+  name: jhipster-prometheus-operator-cr
+subjects:
+- kind: ServiceAccount
+  name: jhipster-prometheus-operator-sa
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  labels:
+    k8s-app: prometheus-operator
+  name: jhipster-prometheus-operator
+  namespace: <%= kubernetesNamespace %>
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        k8s-app: prometheus-operator
+    spec:
+      containers:
+      - args:
+        - --kubelet-service=kube-system/kubelet
+        - --config-reloader-image=quay.io/coreos/configmap-reload:v0.0.1
+        image: <%= DOCKER_PROMETHEUS_OPERATOR %>
+        name: prometheus-operator
+        ports:
+        - containerPort: 8080
+          name: http
+        resources:
+          limits:
+            cpu: 200m
+            memory: 100Mi
+          requests:
+            cpu: 100m
+            memory: 50Mi
+      serviceAccountName: jhipster-prometheus-operator-sa

--- a/generators/kubernetes/templates/monitoring/_jhipster-prometheus-crd.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-prometheus-crd.yml
@@ -76,7 +76,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 ---
 apiVersion: rbac.authorization.k8s.io/v1beta1
-kind: RoleBinding
+kind: ClusterRoleBinding
 metadata:
   name: jhipster-prometheus-operator-rb
   namespace: <%= kubernetesNamespace %>
@@ -87,6 +87,7 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: jhipster-prometheus-operator-sa
+  namespace: <%= kubernetesNamespace %>
 ---
 apiVersion: extensions/v1beta1
 kind: Deployment

--- a/generators/kubernetes/templates/monitoring/_jhipster-prometheus-sm.yml
+++ b/generators/kubernetes/templates/monitoring/_jhipster-prometheus-sm.yml
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-apiVersion: monitoring.coreos.com/v1alpha1
+apiVersion: monitoring.coreos.com/v1
 kind: ServiceMonitor
 metadata:
   name: <%= app.baseName.toLowerCase() %>-app

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -8,73 +8,73 @@ const fse = require('fs-extra');
 
 const expectedFiles = {
     eurekaregistry: [
-        'registry/jhipster-registry.yml',
-        'registry/application-configmap.yml'
+        './k8s/registry/jhipster-registry.yml',
+        './k8s/registry/application-configmap.yml'
     ],
     consulregistry: [
-        'registry/consul.yml',
-        'registry/consul-config-loader.yml',
-        'registry/application-configmap.yml'
+        './k8s/registry/consul.yml',
+        './k8s/registry/consul-config-loader.yml',
+        './k8s/registry/application-configmap.yml'
     ],
     jhgate: [
-        'jhgate/jhgate-deployment.yml',
-        'jhgate/jhgate-mysql.yml',
-        'jhgate/jhgate-service.yml'
+        './k8s/jhgate/jhgate-deployment.yml',
+        './k8s/jhgate/jhgate-mysql.yml',
+        './k8s/jhgate/jhgate-service.yml'
     ],
     jhgateingress: [
-        'jhgate/jhgate-deployment.yml',
-        'jhgate/jhgate-mysql.yml',
-        'jhgate/jhgate-service.yml',
-        'jhgate/jhgate-ingress.yml'
+        './k8s/jhgate/jhgate-deployment.yml',
+        './k8s/jhgate/jhgate-mysql.yml',
+        './k8s/jhgate/jhgate-service.yml',
+        './k8s/jhgate/jhgate-ingress.yml'
     ],
     customnamespace: [
-        'namespace.yml'
+        './k8s/namespace.yml'
     ],
     jhconsole: [
-        'console/jhipster-console.yml',
-        'console/jhipster-elasticsearch.yml',
-        'console/jhipster-logstash.yml',
-        'console/jhipster-dashboard-console.yml',
-        'console/jhipster-zipkin.yml'
+        './k8s/console/jhipster-console.yml',
+        './k8s/console/jhipster-elasticsearch.yml',
+        './k8s/console/jhipster-logstash.yml',
+        './k8s/console/jhipster-dashboard-console.yml',
+        './k8s/console/jhipster-zipkin.yml'
     ],
     msmysql: [
-        'msmysql/msmysql-deployment.yml',
-        'msmysql/msmysql-mysql.yml',
-        'msmysql/msmysql-service.yml'
+        './k8s/msmysql/msmysql-deployment.yml',
+        './k8s/msmysql/msmysql-mysql.yml',
+        './k8s/msmysql/msmysql-service.yml'
     ],
     mspsql: [
-        'mspsql/mspsql-deployment.yml',
-        'mspsql/mspsql-postgresql.yml',
-        'mspsql/mspsql-service.yml',
-        'mspsql/mspsql-elasticsearch.yml'
+        './k8s/mspsql/mspsql-deployment.yml',
+        './k8s/mspsql/mspsql-postgresql.yml',
+        './k8s/mspsql/mspsql-service.yml',
+        './k8s/mspsql/mspsql-elasticsearch.yml'
     ],
     msmongodb: [
-        'msmongodb/msmongodb-deployment.yml',
-        'msmongodb/msmongodb-mongodb.yml',
-        'msmongodb/msmongodb-service.yml'
+        './k8s/msmongodb/msmongodb-deployment.yml',
+        './k8s/msmongodb/msmongodb-mongodb.yml',
+        './k8s/msmongodb/msmongodb-service.yml'
     ],
     msmariadb: [
-        'msmariadb/msmariadb-deployment.yml',
-        'msmariadb/msmariadb-mariadb.yml',
-        'msmariadb/msmariadb-service.yml'
+        './k8s/msmariadb/msmariadb-deployment.yml',
+        './k8s/msmariadb/msmariadb-mariadb.yml',
+        './k8s/msmariadb/msmariadb-service.yml'
     ],
     monolith: [
-        'samplemysql/samplemysql-deployment.yml',
-        'samplemysql/samplemysql-mysql.yml',
-        'samplemysql/samplemysql-service.yml',
-        'samplemysql/samplemysql-elasticsearch.yml'
+        './k8s/samplemysql/samplemysql-deployment.yml',
+        './k8s/samplemysql/samplemysql-mysql.yml',
+        './k8s/samplemysql/samplemysql-service.yml',
+        './k8s/samplemysql/samplemysql-elasticsearch.yml'
     ],
     kafka: [
-        'samplekafka/samplekafka-deployment.yml',
-        'samplekafka/samplekafka-mysql.yml',
-        'samplekafka/samplekafka-service.yml',
-        'samplekafka/samplekafka-kafka.yml'
+        './k8s/samplekafka/samplekafka-deployment.yml',
+        './k8s/samplekafka/samplekafka-mysql.yml',
+        './k8s/samplekafka/samplekafka-service.yml',
+        './k8s/samplekafka/samplekafka-kafka.yml'
     ],
     prometheusmonit: [
-        'monitoring/jhipster-prometheus-crd.yml',
-        'monitoring/jhipster-prometheus-cr.yml',
-        'monitoring/jhipster-grafana.yml',
-        'monitoring/jhipster-grafana-dashboard.yml'
+        './k8s/monitoring/jhipster-prometheus-crd.yml',
+        './k8s/monitoring/jhipster-prometheus-cr.yml',
+        './k8s/monitoring/jhipster-grafana.yml',
+        './k8s/monitoring/jhipster-grafana-dashboard.yml'
     ]
 };
 
@@ -103,12 +103,12 @@ describe('JHipster Kubernetes Sub Generator', () => {
         });
         it('creates expected registry files and content', () => {
             assert.file(expectedFiles.eurekaregistry);
-            assert.fileContent('registry/jhipster-registry.yml', /# base64 encoded "meetup"/);
+            assert.fileContent('./k8s/registry/jhipster-registry.yml', /# base64 encoded "meetup"/);
         });
         it('creates expected gateway files and content', () => {
             assert.file(expectedFiles.jhgate);
-            assert.fileContent('jhgate/jhgate-deployment.yml', /image: jhipsterrepository\/jhgate/);
-            assert.fileContent('jhgate/jhgate-deployment.yml', /jhipsternamespace.svc.cluster/);
+            assert.fileContent('./k8s/jhgate/jhgate-deployment.yml', /image: jhipsterrepository\/jhgate/);
+            assert.fileContent('./k8s/jhgate/jhgate-deployment.yml', /jhipsternamespace.svc.cluster/);
         });
     });
 

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -70,6 +70,12 @@ const expectedFiles = {
         'samplekafka/samplekafka-service.yml',
         'samplekafka/samplekafka-kafka.yml'
     ],
+    prometheusmonit: [
+        'monitoring/jhipster-prometheus-crd.yml',
+        'monitoring/jhipster-prometheus-cr.yml',
+        'monitoring/jhipster-grafana.yml',
+        'monitoring/jhipster-grafana-dashboard.yml'
+    ]
 };
 
 describe('JHipster Kubernetes Sub Generator', () => {
@@ -91,7 +97,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipsterrepository',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'jhipsternamespace',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer'
                 })
                 .on('end', done);
@@ -125,7 +130,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer'
 
                 })
@@ -159,7 +163,7 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'mynamespace',
-                    jhipsterConsole: true,
+                    monitoring: 'elk',
                     kubernetesServiceType: 'LoadBalancer'
 
                 })
@@ -196,7 +200,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'Ingress',
                     ingressDomain: 'example.com'
 
@@ -232,7 +235,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer'
 
                 })
@@ -273,7 +275,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer'
 
                 })
@@ -316,7 +317,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer'
 
                 })
@@ -347,7 +347,6 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
-                    jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer'
 
                 })
@@ -358,6 +357,43 @@ describe('JHipster Kubernetes Sub Generator', () => {
         });
         it('creates expected default files', () => {
             assert.file(expectedFiles.kafka);
+        });
+    });
+
+    describe('mysql microservice with custom namespace and jhipster prometheus monitoring', () => {
+        beforeEach((done) => {
+            helpers
+                .run(require.resolve('../generators/kubernetes'))
+                .inTmpDir((dir) => {
+                    fse.copySync(path.join(__dirname, './templates/compose/'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    composeApplicationType: 'microservice',
+                    directoryPath: './',
+                    chosenApps: [
+                        '02-mysql'
+                    ],
+                    dockerRepositoryName: 'jhipster',
+                    dockerPushCommand: 'docker push',
+                    kubernetesNamespace: 'mynamespace',
+                    monitoring: 'prometheus',
+                    kubernetesServiceType: 'LoadBalancer'
+
+                })
+                .on('end', done);
+        });
+        it('creates expected registry files', () => {
+            assert.file(expectedFiles.eurekaregistry);
+        });
+        it('creates expected mysql files', () => {
+            assert.file(expectedFiles.msmysql);
+        });
+        it('creates expected prometheus files', () => {
+            assert.file(expectedFiles.prometheusmonit);
+        });
+        it('creates expected namespace file', () => {
+            assert.file(expectedFiles.customnamespace);
         });
     });
 });


### PR DESCRIPTION
- Grafana added with pre-configured dashboard view
- Prometheus operator is included (as the app specific bits like service monitor and rbac objects are dependent on the operator crd)
- Aligned some of the prompts (jhipster console and prometheus) to be in sync with docker-compose
- Added a shell script pgm to deploy all of the k8s objects at one go
- Added init-container check to deployment object to wait for dependent services initialisation
- Output file structure is been refactored
- README and test spec updated accordingly
