### PR TITLE
fix tslint semicolon config for Angular

### DIFF
--- a/generators/client/templates/angular/_tslint.json
+++ b/generators/client/templates/angular/_tslint.json
@@ -81,6 +81,7 @@
         ],
         "radix": true,
         "semicolon": [
+            true,
             "always"
         ],
         "triple-equals": [

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/_password-strength-bar.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/_password-strength-bar.component.ts
@@ -71,7 +71,7 @@ export class PasswordStrengthBarComponent {
         force = (passedMatches === 3) ? Math.min(force, 40) : force;
 
         return force;
-    };
+    }
 
     getColor(s: number): any {
         let idx = 0;
@@ -87,7 +87,7 @@ export class PasswordStrengthBarComponent {
             idx = 4;
         }
         return {idx: idx + 1, col: this.colors[idx]};
-    };
+    }
 
     @Input()
     set passwordToCheck(password: string) {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/model/_base-entity.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/model/_base-entity.ts
@@ -1,4 +1,4 @@
 export interface BaseEntity {
     // using type any to avoid methods complaining of invalid type
     id?: any;
-};
+}

--- a/generators/client/templates/angular/src/main/webapp/app/shared/model/_request-util.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/model/_request-util.ts
@@ -10,7 +10,7 @@ export const createRequestOption = (req?: any): HttpParams => {
         });
         if (req.sort) {
             req.sort.forEach((val) => {
-                options = options.append('sort', val)
+                options = options.append('sort', val);
             });
         }
     }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/_password-reset-init.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/_password-reset-init.component.spec.ts
@@ -99,7 +99,7 @@ describe('Component Tests', () => {
                 spyOn(service, 'save').and.returnValue(Observable.throw({
                     status: 400,
                     json() {
-                        return {type : EMAIL_NOT_FOUND_TYPE}
+                        return {type : EMAIL_NOT_FOUND_TYPE};
                     }
                 }));
                 comp.resetAccount.email = 'user@domain.com';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/register/_register.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/register/_register.component.spec.ts
@@ -92,7 +92,7 @@ describe('Component Tests', () => {
                     spyOn(service, 'save').and.returnValue(Observable.throw({
                         status: 400,
                         json() {
-                            return {type : LOGIN_ALREADY_USED_TYPE}
+                            return {type : LOGIN_ALREADY_USED_TYPE};
                         }
                     }));
                     comp.registerAccount.password = comp.confirmPassword = 'password';
@@ -113,7 +113,7 @@ describe('Component Tests', () => {
                     spyOn(service, 'save').and.returnValue(Observable.throw({
                         status: 400,
                         json() {
-                            return {type : EMAIL_ALREADY_USED_TYPE}
+                            return {type : EMAIL_ALREADY_USED_TYPE};
                         }
                     }));
                     comp.registerAccount.password = comp.confirmPassword = 'password';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/_audits.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/_audits.component.spec.ts
@@ -20,7 +20,7 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { NgbPaginationConfig} from '@ng-bootstrap/ng-bootstrap';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
-import { PaginationConfig } from '../../../../../../main/webapp/app/blocks/config/uib-pagination.config'
+import { PaginationConfig } from '../../../../../../main/webapp/app/blocks/config/uib-pagination.config';
 import { AuditsComponent } from '../../../../../../main/webapp/app/admin/audits/audits.component';
 import { AuditsService } from '../../../../../../main/webapp/app/admin/audits/audits.service';
 import { ITEMS_PER_PAGE } from '../../../../../../main/webapp/app/shared';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/_login.component.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/_login.component.spec.ts
@@ -77,7 +77,7 @@ describe('Component Tests', () => {
                         username: 'admin',
                         password: 'admin',
                         rememberMe: true
-                    }
+                    };
                     comp.username = 'admin';
                     comp.password = 'admin';
                     comp.rememberMe = true;
@@ -109,7 +109,7 @@ describe('Component Tests', () => {
                         username: 'admin',
                         password: 'admin',
                         rememberMe: true
-                    }
+                    };
                     comp.username = 'admin';
                     comp.password = 'admin';
                     comp.rememberMe = true;
@@ -139,13 +139,13 @@ describe('Component Tests', () => {
                 username: 'admin',
                 password: 'admin',
                 rememberMe: true
-            }
+            };
 
             const expected = {
                 username: null,
                 password: null,
                 rememberMe: true
-            }
+            };
 
             comp.credentials = credentials;
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/user/_user.service.spec.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/user/_user.service.spec.ts
@@ -46,7 +46,7 @@ describe('Service Tests', () => {
 
         afterEach(() => {
             httpMock.verify();
-        })
+        });
 
         describe('Service methods', () => {
             it('should call correct URL', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/_mock-state-storage.service.ts
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/_mock-state-storage.service.ts
@@ -22,8 +22,8 @@ import Spy = jasmine.Spy;
 
 export class MockStateStorageService extends SpyObject {
 
-    getUrlSpy: Spy
-    storeUrlSpy: Spy
+    getUrlSpy: Spy;
+    storeUrlSpy: Spy;
 
     constructor() {
         super(StateStorageService);

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/_entity.spec.ts
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/_entity.spec.ts
@@ -213,36 +213,36 @@ export class <%= entityClass %>DialogPage {
             <%_ if (fieldType === 'Boolean') { _%>
     get<%= fieldNameCapitalized %>Input = function() {
         return this.<%= fieldName %>Input;
-    }
+    };
             <%_ } else if (fieldIsEnum) { _%>
     set<%= fieldNameCapitalized %>Select = function(<%= fieldName %>) {
         this.<%= fieldName %>Select.sendKeys(<%= fieldName %>);
-    }
+    };
 
     get<%= fieldNameCapitalized %>Select = function() {
         return this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
-    }
+    };
 
     <%=fieldName %>SelectLastOption = function() {
         this.<%=fieldName %>Select.all(by.tagName('option')).last().click();
-    }
+    };
     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
     set<%= fieldNameCapitalized %>Input = function(<%= fieldName %>) {
         this.<%= fieldName %>Input.sendKeys(<%= fieldName %>);
-    }
+    };
 
     get<%= fieldNameCapitalized %>Input = function() {
         return this.<%= fieldName %>Input.getAttribute('value');
-    }
+    };
 
     <%_ } else { _%>
     set<%= fieldNameCapitalized %>Input = function(<%= fieldName %>) {
         this.<%= fieldName %>Input.sendKeys(<%= fieldName %>);
-    }
+    };
 
     get<%= fieldNameCapitalized %>Input = function() {
         return this.<%= fieldName %>Input.getAttribute('value');
-    }
+    };
 
     <%_ } _%>
     <%_ }); _%>
@@ -255,19 +255,19 @@ export class <%= entityClass %>DialogPage {
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
     <%=relationshipName %>SelectLastOption = function() {
         this.<%=relationshipName %>Select.all(by.tagName('option')).last().click();
-    }
+    };
 
     <%=relationshipName %>SelectOption = function(option) {
         this.<%=relationshipName %>Select.sendKeys(option);
-    }
+    };
 
     get<%=relationshipNameCapitalized %>Select = function() {
         return this.<%=relationshipName %>Select;
-    }
+    };
 
     get<%=relationshipNameCapitalized %>SelectedOption = function() {
         return this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
-    }
+    };
 
     <%_ } _%>
     <%_ }); _%>

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management.service.spec.ts
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/_entity-management.service.spec.ts
@@ -84,7 +84,7 @@ describe('Service Tests', () => {
 
         afterEach(() => {
             httpMock.verify();
-        })
+        });
 
     });
 


### PR DESCRIPTION
4d6bf48:
```
"semicolon": [
            "always"
]
```

should be

```
"semicolon": [
            true,
            "always"
]
```


5718bba:
fix tslint warning
