### PR TITLE
Add CORS support to OAuth in microservices

### DIFF
--- a/generators/server/templates/src/main/java/package/config/_OAuth2SsoConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_OAuth2SsoConfiguration.java
@@ -28,6 +28,7 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
 import org.springframework.security.web.util.matcher.NegatedRequestMatcher;
 import org.springframework.security.web.util.matcher.RequestMatcher;
+import org.springframework.web.filter.CorsFilter;
 
 import io.github.jhipster.security.AjaxLogoutSuccessHandler;
 
@@ -37,10 +38,14 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter {
 
     private final RequestMatcher authorizationHeaderRequestMatcher;
 
-    public OAuth2SsoConfiguration(@Qualifier("authorizationHeaderRequestMatcher") RequestMatcher authorizationHeaderRequestMatcher) {
-        this.authorizationHeaderRequestMatcher = authorizationHeaderRequestMatcher;
-    }
+    private final CorsFilter corsFilter;
 
+    public OAuth2SsoConfiguration(@Qualifier("authorizationHeaderRequestMatcher")
+                                  RequestMatcher authorizationHeaderRequestMatcher, CorsFilter corsFilter) {
+        this.authorizationHeaderRequestMatcher = authorizationHeaderRequestMatcher;
+        this.corsFilter = corsFilter;
+    }
+    
     @Bean
     public AjaxLogoutSuccessHandler ajaxLogoutSuccessHandler() {
         return new AjaxLogoutSuccessHandler();
@@ -51,6 +56,7 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter {
         http
             .csrf()
             .disable()
+            .addFilterBefore(corsFilter, CsrfFilter.class)
             .headers()
             .frameOptions()
             .disable()


### PR DESCRIPTION
Seems to make sense since the `SecurityConfiguration` for OAuth with a monolith does the [same thing](https://github.com/jhipster/generator-jhipster/blob/master/generators/server/templates/src/main/java/package/config/_SecurityConfiguration.java#L190). I found this change necessary to get an Ionic app talking to a gateway in a microservices architecture.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
