### PR TITLE
Remove ProfileInfoResource and improve info endpoint

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -37,7 +37,7 @@ export class ProfileService {
                     const data = res.body;
                     const pi = new ProfileInfo();
                     pi.activeProfiles = data['activeProfiles'];
-                    const displayRibbonOnProfiles = data['displayRibbonOnProfiles'].split(',');
+                    const displayRibbonOnProfiles = data['display-ribbon-on-profiles'].split(',');
                     const ribbonProfiles = displayRibbonOnProfiles.filter((profile) => pi.activeProfiles.includes(profile));
                     if (ribbonProfiles.length !== 0) {
                         pi.ribbonEnv = ribbonProfiles[0];

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -36,8 +36,8 @@ export class ProfileService {
                 .map((res: HttpResponse<ProfileInfo>) => {
                     const data = res.body;
                     const pi = new ProfileInfo();
-                    pi.activeProfiles = data['active-profiles'];
-                    const displayRibbonOnProfiles = data['display-ribbon-on-profiles'].split(',');
+                    pi.activeProfiles = data['activeProfiles'];
+                    const displayRibbonOnProfiles = data['displayRibbonOnProfiles'].split(',');
 
                     const ribbonProfiles = displayRibbonOnProfiles.filter(function(profile) {
                         return pi.activeProfiles.includes(profile);

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -38,11 +38,7 @@ export class ProfileService {
                     const pi = new ProfileInfo();
                     pi.activeProfiles = data['activeProfiles'];
                     const displayRibbonOnProfiles = data['displayRibbonOnProfiles'].split(',');
-
-                    const ribbonProfiles = displayRibbonOnProfiles.filter(function(profile) {
-                        return pi.activeProfiles.includes(profile);
-                    });
-
+                    const ribbonProfiles = displayRibbonOnProfiles.filter((profile) => pi.activeProfiles.includes(profile));
                     if (ribbonProfiles.length !== 0) {
                         pi.ribbonEnv = ribbonProfiles[0];
                     }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -25,21 +25,29 @@ import { ProfileInfo } from './profile-info.model';
 @Injectable()
 export class ProfileService {
 
-    private profileInfoUrl = SERVER_API_URL + 'api/profile-info';
+    private infoUrl = SERVER_API_URL + 'management/info';
     private profileInfo: Promise<ProfileInfo>;
 
     constructor(private http: HttpClient) { }
 
     getProfileInfo(): Promise<ProfileInfo> {
         if (!this.profileInfo) {
-            this.profileInfo = this.http.get<ProfileInfo>(this.profileInfoUrl, { observe: 'response' })
+            this.profileInfo = this.http.get<ProfileInfo>(this.infoUrl, { observe: 'response' })
                 .map((res: HttpResponse<ProfileInfo>) => {
                     const data = res.body;
                     const pi = new ProfileInfo();
-                    pi.activeProfiles = data.activeProfiles;
-                    pi.ribbonEnv = data.ribbonEnv;
-                    pi.inProduction = data.activeProfiles.includes('prod') ;
-                    pi.swaggerEnabled = data.activeProfiles.includes('swagger');
+                    pi.activeProfiles = data['active-profiles'];
+                    const displayRibbonOnProfiles = data['display-ribbon-on-profiles'].split(',');
+
+                    const ribbonProfiles = displayRibbonOnProfiles.filter(function(profile) {
+                        return pi.activeProfiles.includes(profile);
+                    });
+
+                    if (ribbonProfiles.length !== 0) {
+                        pi.ribbonEnv = ribbonProfiles[0];
+                    }
+                    pi.inProduction = pi.activeProfiles.includes('prod');
+                    pi.swaggerEnabled = pi.activeProfiles.includes('swagger');
                     return pi;
                 }).toPromise();
         }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -38,12 +38,14 @@ export class ProfileService {
                     const pi = new ProfileInfo();
                     pi.activeProfiles = data['activeProfiles'];
                     const displayRibbonOnProfiles = data['display-ribbon-on-profiles'].split(',');
-                    const ribbonProfiles = displayRibbonOnProfiles.filter((profile) => pi.activeProfiles.includes(profile));
-                    if (ribbonProfiles.length !== 0) {
-                        pi.ribbonEnv = ribbonProfiles[0];
+                    if (pi.activeProfiles) {
+                        const ribbonProfiles = displayRibbonOnProfiles.filter((profile) => pi.activeProfiles.includes(profile));
+                        if (ribbonProfiles.length !== 0) {
+                            pi.ribbonEnv = ribbonProfiles[0];
+                        }
+                        pi.inProduction = pi.activeProfiles.includes('prod');
+                        pi.swaggerEnabled = pi.activeProfiles.includes('swagger');
                     }
-                    pi.inProduction = pi.activeProfiles.includes('prod');
-                    pi.swaggerEnabled = pi.activeProfiles.includes('swagger');
                     return pi;
                 }).toPromise();
         }

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -590,17 +590,6 @@ const serverFiles = {
                 { file: 'package/client/TokenRelayRequestInterceptor.java', renameTo: generator => `${generator.javaDir}client/TokenRelayRequestInterceptor.java` }
             ]
         },
-
-        writeServerJavaWebFiles() {
-            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/vm/package-info.java.ejs`, `${javaDir}web/rest/vm/package-info.java`);
-            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/vm/LoggerVM.java.ejs`, `${javaDir}web/rest/vm/LoggerVM.java`);
-
-            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/HeaderUtil.java.ejs`, `${javaDir}web/rest/util/HeaderUtil.java`);
-            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/PaginationUtil.java.ejs`, `${javaDir}web/rest/util/PaginationUtil.java`);
-            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/package-info.java.ejs`, `${javaDir}web/rest/package-info.java`);
-
-            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/LogsResource.java.ejs`, `${javaDir}web/rest/LogsResource.java`);
-        },
         {
             condition: generator => !(generator.applicationType !== 'microservice' && !(generator.applicationType === 'gateway' && (generator.authenticationType === 'uaa' || generator.authenticationType === 'oauth2')))
                 && (generator.applicationType === 'microservice'),
@@ -647,75 +636,6 @@ const serverFiles = {
                 { file: 'package/config/MetricsConfiguration.java', renameTo: generator => `${generator.javaDir}config/MetricsConfiguration.java` },
                 { file: 'package/config/WebConfigurer.java', renameTo: generator => `${generator.javaDir}config/WebConfigurer.java` }
             ]
-        },
-
-        writeServerTestFwFiles() {
-            // Create Test Java files
-            const testDir = this.testDir;
-
-            mkdirp(testDir);
-
-            if (this.databaseType === 'cassandra') {
-                this.template(`${SERVER_TEST_SRC_DIR}package/CassandraKeyspaceUnitTest.java.ejs`, `${testDir}CassandraKeyspaceUnitTest.java`);
-                this.template(`${SERVER_TEST_SRC_DIR}package/AbstractCassandraTest.java.ejs`, `${testDir}AbstractCassandraTest.java`);
-                this.template(`${SERVER_TEST_SRC_DIR}package/config/CassandraTestConfiguration.java.ejs`, `${testDir}config/CassandraTestConfiguration.java`);
-                this.template(`${SERVER_TEST_RES_DIR}cassandra-random-port.yml.ejs`, `${SERVER_TEST_RES_DIR}cassandra-random-port.yml`);
-            }
-
-            if (this.databaseType === 'couchbase') {
-                this.template(`${SERVER_TEST_SRC_DIR}package/config/DatabaseTestConfiguration.java.ejs`, `${testDir}config/DatabaseTestConfiguration.java`);
-            }
-
-            this.template(`${SERVER_TEST_SRC_DIR}package/config/WebConfigurerTest.java.ejs`, `${testDir}config/WebConfigurerTest.java`);
-            this.template(`${SERVER_TEST_SRC_DIR}package/config/WebConfigurerTestController.java.ejs`, `${testDir}config/WebConfigurerTestController.java`);
-            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/TestUtil.java.ejs`, `${testDir}web/rest/TestUtil.java`);
-            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/LogsResourceIntTest.java.ejs`, `${testDir}web/rest/LogsResourceIntTest.java`);
-            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/errors/ExceptionTranslatorIntTest.java.ejs`, `${testDir}web/rest/errors/ExceptionTranslatorIntTest.java`);
-            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/errors/ExceptionTranslatorTestController.java.ejs`, `${testDir}web/rest/errors/ExceptionTranslatorTestController.java`);
-            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/util/PaginationUtilUnitTest.java.ejs`, `${testDir}web/rest/util/PaginationUtilUnitTest.java`);
-
-            this.template(`${SERVER_TEST_RES_DIR}config/application.yml.ejs`, `${SERVER_TEST_RES_DIR}config/application.yml`);
-            this.template(`${SERVER_TEST_RES_DIR}logback.xml.ejs`, `${SERVER_TEST_RES_DIR}logback.xml`);
-
-            // Create Gateway tests files
-            if (this.applicationType === 'gateway') {
-                this.template(`${SERVER_TEST_SRC_DIR}package/gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java.ejs`, `${testDir}gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java`);
-            }
-            if (this.serviceDiscoveryType) {
-                this.template(`${SERVER_TEST_RES_DIR}config/bootstrap.yml.ejs`, `${SERVER_TEST_RES_DIR}config/bootstrap.yml`);
-            }
-
-            if (this.authenticationType === 'uaa') {
-                this.template(`${SERVER_TEST_SRC_DIR}package/security/OAuth2TokenMockUtil.java.ejs`, `${testDir}security/OAuth2TokenMockUtil.java`);
-                this.template(`${SERVER_TEST_SRC_DIR}package/config/SecurityBeanOverrideConfiguration.java.ejs`, `${testDir}config/SecurityBeanOverrideConfiguration.java`);
-                if (this.applicationType === 'gateway') {
-                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/OAuth2CookieHelperTest.java.ejs`, `${testDir}security/oauth2/OAuth2CookieHelperTest.java`);
-                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/OAuth2AuthenticationServiceTest.java.ejs`, `${testDir}security/oauth2/OAuth2AuthenticationServiceTest.java`);
-                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/CookieTokenExtractorTest.java.ejs`, `${testDir}security/oauth2/CookieTokenExtractorTest.java`);
-                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/CookieCollectionTest.java.ejs`, `${testDir}security/oauth2/CookieCollectionTest.java`);
-                }
-            }
-
-            // Create Gatling test files
-            if (this.gatlingTests) {
-                this.copy(`${TEST_DIR}gatling/conf/gatling.conf.ejs`, `${TEST_DIR}gatling/conf/gatling.conf`);
-                this.copy(`${TEST_DIR}gatling/conf/logback.xml.ejs`, `${TEST_DIR}gatling/conf/logback.xml`);
-                mkdirp(`${TEST_DIR}gatling/user-files/data`);
-                mkdirp(`${TEST_DIR}gatling/user-files/bodies`);
-                mkdirp(`${TEST_DIR}gatling/user-files/simulations`);
-            }
-
-            // Create Cucumber test files
-            if (this.cucumberTests) {
-                this.template(`${SERVER_TEST_SRC_DIR}package/cucumber/CucumberTest.java.ejs`, `${testDir}cucumber/CucumberTest.java`);
-                this.template(`${SERVER_TEST_SRC_DIR}package/cucumber/stepdefs/StepDefs.java.ejs`, `${testDir}cucumber/stepdefs/StepDefs.java`);
-                this.copy(`${TEST_DIR}features/gitkeep`, `${TEST_DIR}features/.gitkeep`);
-            }
-
-            // Create auth config test files
-            if (this.applicationType === 'monolith' && this.authenticationType !== 'oauth2') {
-                this.template(`${SERVER_TEST_SRC_DIR}package/security/DomainUserDetailsServiceIntTest.java.ejs`, `${testDir}security/DomainUserDetailsServiceIntTest.java`);
-            }
         },
         {
             condition: generator => generator.cacheProvider === 'infinispan',
@@ -860,8 +780,6 @@ const serverFiles = {
                 { file: 'package/web/rest/package-info.java', renameTo: generator => `${generator.javaDir}web/rest/package-info.java` },
 
                 { file: 'package/web/rest/LogsResource.java', renameTo: generator => `${generator.javaDir}web/rest/LogsResource.java` },
-                { file: 'package/web/rest/ProfileInfoResource.java', renameTo: generator => `${generator.javaDir}web/rest/ProfileInfoResource.java` },
-
             ]
         },
 
@@ -910,7 +828,6 @@ const serverFiles = {
                 { file: 'package/config/WebConfigurerTestController.java', renameTo: generator => `${generator.testDir}config/WebConfigurerTestController.java` },
                 { file: 'package/web/rest/TestUtil.java', renameTo: generator => `${generator.testDir}web/rest/TestUtil.java` },
                 { file: 'package/web/rest/LogsResourceIntTest.java', renameTo: generator => `${generator.testDir}web/rest/LogsResourceIntTest.java` },
-                { file: 'package/web/rest/ProfileInfoResourceIntTest.java', renameTo: generator => `${generator.testDir}web/rest/ProfileInfoResourceIntTest.java` },
                 { file: 'package/web/rest/errors/ExceptionTranslatorIntTest.java', renameTo: generator => `${generator.testDir}web/rest/errors/ExceptionTranslatorIntTest.java` },
                 { file: 'package/web/rest/errors/ExceptionTranslatorTestController.java', renameTo: generator => `${generator.testDir}web/rest/errors/ExceptionTranslatorTestController.java` },
                 { file: 'package/web/rest/util/PaginationUtilUnitTest.java', renameTo: generator => `${generator.testDir}web/rest/util/PaginationUtilUnitTest.java` },

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -592,6 +592,14 @@ const serverFiles = {
         },
         {
             condition: generator => !(generator.applicationType !== 'microservice' && !(generator.applicationType === 'gateway' && (generator.authenticationType === 'uaa' || generator.authenticationType === 'oauth2')))
+                && (generator.authenticationType === 'oauth2' && generator.applicationType === 'gateway'),
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                { file: 'package/config/OAuth2SsoConfiguration.java', renameTo: generator => `${generator.javaDir}config/OAuth2SsoConfiguration.java` }
+            ]
+        },
+        {
+            condition: generator => !(generator.applicationType !== 'microservice' && !(generator.applicationType === 'gateway' && (generator.authenticationType === 'uaa' || generator.authenticationType === 'oauth2')))
                 && (generator.applicationType === 'microservice'),
             path: SERVER_MAIN_RES_DIR,
             templates: [
@@ -635,6 +643,13 @@ const serverFiles = {
                 { file: 'package/config/LoggingAspectConfiguration.java', renameTo: generator => `${generator.javaDir}config/LoggingAspectConfiguration.java` },
                 { file: 'package/config/MetricsConfiguration.java', renameTo: generator => `${generator.javaDir}config/MetricsConfiguration.java` },
                 { file: 'package/config/WebConfigurer.java', renameTo: generator => `${generator.javaDir}config/WebConfigurer.java` }
+            ]
+        },
+        {
+            condition: generator => ['ehcache', 'hazelcast', 'infinispan'].includes(generator.cacheProvider) || generator.applicationType === 'gateway',
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                { file: 'package/config/CacheConfiguration.java', renameTo: generator => `${generator.javaDir}config/CacheConfiguration.java` }
             ]
         },
         {

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -590,13 +590,16 @@ const serverFiles = {
                 { file: 'package/client/TokenRelayRequestInterceptor.java', renameTo: generator => `${generator.javaDir}client/TokenRelayRequestInterceptor.java` }
             ]
         },
-        {
-            condition: generator => !(generator.applicationType !== 'microservice' && !(generator.applicationType === 'gateway' && (generator.authenticationType === 'uaa' || generator.authenticationType === 'oauth2')))
-                && (generator.authenticationType === 'oauth2' && generator.applicationType === 'gateway'),
-            path: SERVER_MAIN_SRC_DIR,
-            templates: [
-                { file: 'package/config/OAuth2SsoConfiguration.java', renameTo: generator => `${generator.javaDir}config/OAuth2SsoConfiguration.java` }
-            ]
+
+        writeServerJavaWebFiles() {
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/vm/package-info.java.ejs`, `${javaDir}web/rest/vm/package-info.java`);
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/vm/LoggerVM.java.ejs`, `${javaDir}web/rest/vm/LoggerVM.java`);
+
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/HeaderUtil.java.ejs`, `${javaDir}web/rest/util/HeaderUtil.java`);
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/util/PaginationUtil.java.ejs`, `${javaDir}web/rest/util/PaginationUtil.java`);
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/package-info.java.ejs`, `${javaDir}web/rest/package-info.java`);
+
+            this.template(`${SERVER_MAIN_SRC_DIR}package/web/rest/LogsResource.java.ejs`, `${javaDir}web/rest/LogsResource.java`);
         },
         {
             condition: generator => !(generator.applicationType !== 'microservice' && !(generator.applicationType === 'gateway' && (generator.authenticationType === 'uaa' || generator.authenticationType === 'oauth2')))
@@ -645,12 +648,74 @@ const serverFiles = {
                 { file: 'package/config/WebConfigurer.java', renameTo: generator => `${generator.javaDir}config/WebConfigurer.java` }
             ]
         },
-        {
-            condition: generator => ['ehcache', 'hazelcast', 'infinispan'].includes(generator.cacheProvider) || generator.applicationType === 'gateway',
-            path: SERVER_MAIN_SRC_DIR,
-            templates: [
-                { file: 'package/config/CacheConfiguration.java', renameTo: generator => `${generator.javaDir}config/CacheConfiguration.java` }
-            ]
+
+        writeServerTestFwFiles() {
+            // Create Test Java files
+            const testDir = this.testDir;
+
+            mkdirp(testDir);
+
+            if (this.databaseType === 'cassandra') {
+                this.template(`${SERVER_TEST_SRC_DIR}package/CassandraKeyspaceUnitTest.java.ejs`, `${testDir}CassandraKeyspaceUnitTest.java`);
+                this.template(`${SERVER_TEST_SRC_DIR}package/AbstractCassandraTest.java.ejs`, `${testDir}AbstractCassandraTest.java`);
+                this.template(`${SERVER_TEST_SRC_DIR}package/config/CassandraTestConfiguration.java.ejs`, `${testDir}config/CassandraTestConfiguration.java`);
+                this.template(`${SERVER_TEST_RES_DIR}cassandra-random-port.yml.ejs`, `${SERVER_TEST_RES_DIR}cassandra-random-port.yml`);
+            }
+
+            if (this.databaseType === 'couchbase') {
+                this.template(`${SERVER_TEST_SRC_DIR}package/config/DatabaseTestConfiguration.java.ejs`, `${testDir}config/DatabaseTestConfiguration.java`);
+            }
+
+            this.template(`${SERVER_TEST_SRC_DIR}package/config/WebConfigurerTest.java.ejs`, `${testDir}config/WebConfigurerTest.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/config/WebConfigurerTestController.java.ejs`, `${testDir}config/WebConfigurerTestController.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/TestUtil.java.ejs`, `${testDir}web/rest/TestUtil.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/LogsResourceIntTest.java.ejs`, `${testDir}web/rest/LogsResourceIntTest.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/errors/ExceptionTranslatorIntTest.java.ejs`, `${testDir}web/rest/errors/ExceptionTranslatorIntTest.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/errors/ExceptionTranslatorTestController.java.ejs`, `${testDir}web/rest/errors/ExceptionTranslatorTestController.java`);
+            this.template(`${SERVER_TEST_SRC_DIR}package/web/rest/util/PaginationUtilUnitTest.java.ejs`, `${testDir}web/rest/util/PaginationUtilUnitTest.java`);
+
+            this.template(`${SERVER_TEST_RES_DIR}config/application.yml.ejs`, `${SERVER_TEST_RES_DIR}config/application.yml`);
+            this.template(`${SERVER_TEST_RES_DIR}logback.xml.ejs`, `${SERVER_TEST_RES_DIR}logback.xml`);
+
+            // Create Gateway tests files
+            if (this.applicationType === 'gateway') {
+                this.template(`${SERVER_TEST_SRC_DIR}package/gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java.ejs`, `${testDir}gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java`);
+            }
+            if (this.serviceDiscoveryType) {
+                this.template(`${SERVER_TEST_RES_DIR}config/bootstrap.yml.ejs`, `${SERVER_TEST_RES_DIR}config/bootstrap.yml`);
+            }
+
+            if (this.authenticationType === 'uaa') {
+                this.template(`${SERVER_TEST_SRC_DIR}package/security/OAuth2TokenMockUtil.java.ejs`, `${testDir}security/OAuth2TokenMockUtil.java`);
+                this.template(`${SERVER_TEST_SRC_DIR}package/config/SecurityBeanOverrideConfiguration.java.ejs`, `${testDir}config/SecurityBeanOverrideConfiguration.java`);
+                if (this.applicationType === 'gateway') {
+                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/OAuth2CookieHelperTest.java.ejs`, `${testDir}security/oauth2/OAuth2CookieHelperTest.java`);
+                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/OAuth2AuthenticationServiceTest.java.ejs`, `${testDir}security/oauth2/OAuth2AuthenticationServiceTest.java`);
+                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/CookieTokenExtractorTest.java.ejs`, `${testDir}security/oauth2/CookieTokenExtractorTest.java`);
+                    this.template(`${SERVER_TEST_SRC_DIR}package/security/oauth2/CookieCollectionTest.java.ejs`, `${testDir}security/oauth2/CookieCollectionTest.java`);
+                }
+            }
+
+            // Create Gatling test files
+            if (this.gatlingTests) {
+                this.copy(`${TEST_DIR}gatling/conf/gatling.conf.ejs`, `${TEST_DIR}gatling/conf/gatling.conf`);
+                this.copy(`${TEST_DIR}gatling/conf/logback.xml.ejs`, `${TEST_DIR}gatling/conf/logback.xml`);
+                mkdirp(`${TEST_DIR}gatling/user-files/data`);
+                mkdirp(`${TEST_DIR}gatling/user-files/bodies`);
+                mkdirp(`${TEST_DIR}gatling/user-files/simulations`);
+            }
+
+            // Create Cucumber test files
+            if (this.cucumberTests) {
+                this.template(`${SERVER_TEST_SRC_DIR}package/cucumber/CucumberTest.java.ejs`, `${testDir}cucumber/CucumberTest.java`);
+                this.template(`${SERVER_TEST_SRC_DIR}package/cucumber/stepdefs/StepDefs.java.ejs`, `${testDir}cucumber/stepdefs/StepDefs.java`);
+                this.copy(`${TEST_DIR}features/gitkeep`, `${TEST_DIR}features/.gitkeep`);
+            }
+
+            // Create auth config test files
+            if (this.applicationType === 'monolith' && this.authenticationType !== 'oauth2') {
+                this.template(`${SERVER_TEST_SRC_DIR}package/security/DomainUserDetailsServiceIntTest.java.ejs`, `${testDir}security/DomainUserDetailsServiceIntTest.java`);
+            }
         },
         {
             condition: generator => generator.cacheProvider === 'infinispan',

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -73,6 +73,12 @@ processResources {
     <%_ } _%>
 }
 
+generateGitProperties {
+    onlyIf {
+        !source.isEmpty()
+    }
+}
+
 gitProperties {
     keys = ['git.branch', 'git.commit.id.abbrev', 'git.commit.id.describe']
 }

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -73,14 +73,8 @@ processResources {
     <%_ } _%>
 }
 
-generateGitProperties {
-    onlyIf {
-        !source.isEmpty()
-    }
-}
-
 gitProperties {
-    keys = ['git.branch', 'git.commit.id.abbrev']
+    keys = ['git.branch', 'git.commit.id.abbrev', 'git.commit.id.describe']
 }
 
 <%_ if (!skipClient) { _%>

--- a/generators/server/templates/src/main/java/package/config/LoggingConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/LoggingConfiguration.java.ejs
@@ -82,7 +82,7 @@ public class LoggingConfiguration {
     private final JHipsterProperties jHipsterProperties;
 
     public LoggingConfiguration(@Value("${spring.application.name}") String appName, @Value("${server.port}") String serverPort,
-        <% if (serviceDiscoveryType === "consul") { %> ConsulRegistration consulRegistration,<% } %><% if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa')) { %> @Value("${info.project.version}") String version,<% } %> JHipsterProperties jHipsterProperties) {
+        <% if (serviceDiscoveryType === "consul") { %> ConsulRegistration consulRegistration,<% } %><% if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa')) { %> @Value("${info.project.version:}") String version,<% } %> JHipsterProperties jHipsterProperties) {
         this.appName = appName;
         this.serverPort = serverPort;
         <%_ if (serviceDiscoveryType === 'consul') { _%>

--- a/generators/server/templates/src/main/java/package/config/MicroserviceSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/MicroserviceSecurityConfiguration.java.ejs
@@ -80,6 +80,7 @@ public class MicroserviceSecurityConfiguration extends WebSecurityConfigurerAdap
             .authorizeRequests()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/info").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/swagger-resources/configuration/ui").permitAll()
         .and()
@@ -153,9 +154,9 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
             .authorizeRequests()
-            .antMatchers("/api/profile-info").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/info").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/swagger-resources/configuration/ui").permitAll();
     }
@@ -269,9 +270,9 @@ public class MicroserviceSecurityConfiguration extends ResourceServerConfigurerA
         .and()
             .requestMatcher(authorizationHeaderRequestMatcher())
             .authorizeRequests()
-            .antMatchers("/api/profile-info").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/info").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN);
     }
 }

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -236,11 +236,11 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/api/account/reset-password/init").permitAll()
             .antMatchers("/api/account/reset-password/finish").permitAll()
             <%_ } _%>
-            .antMatchers("/api/profile-info").permitAll()
             .antMatchers("/api/**").authenticated()<% if (websocket === 'spring-websocket') { %>
             .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/websocket/**").permitAll()<% } %>
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/info").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/v2/api-docs/**").permitAll()
             .antMatchers("/swagger-resources/configuration/ui").permitAll()

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -53,6 +53,9 @@ eureka:
             zone: primary # This is needed for the load balancer
             profile: ${spring.profiles.active}
             version: ${info.project.version}
+            git-version: ${git.commit.id.describe:}
+            git-commit: ${git.commit.id.abbrev:}
+            git-branch: ${git.branch:}
 ribbon:
     eureka:
         enabled: true
@@ -211,9 +214,10 @@ server:
             cookie:
                 http-only: true
 
+# Properties to be exposed on the /info management endpoint
 info:
-    project:
-        version: #project.version#
+    # Comma separated list of profiles that will trigger the ribbon to show
+    display-ribbon-on-profiles: "dev"
 
 # ===================================================================
 # JHipster specific properties
@@ -251,8 +255,6 @@ jhipster:
         contact-email:
         license:
         license-url:
-    ribbon:
-        display-on-active-profiles: dev
 
 # ===================================================================
 # Application specific properties

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -52,7 +52,7 @@ eureka:
         metadata-map:
             zone: primary # This is needed for the load balancer
             profile: ${spring.profiles.active}
-            version: ${info.project.version}
+            version: ${info.project.version:}
             git-version: ${git.commit.id.describe:}
             git-commit: ${git.commit.id.abbrev:}
             git-branch: ${git.branch:}

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -217,7 +217,7 @@ server:
 # Properties to be exposed on the /info management endpoint
 info:
     # Comma separated list of profiles that will trigger the ribbon to show
-    display-ribbon-on-profiles: "dev"
+    displayRibbonOnProfiles: "dev"
 
 # ===================================================================
 # JHipster specific properties

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -217,7 +217,7 @@ server:
 # Properties to be exposed on the /info management endpoint
 info:
     # Comma separated list of profiles that will trigger the ribbon to show
-    displayRibbonOnProfiles: "dev"
+    display-ribbon-on-profiles: "dev"
 
 # ===================================================================
 # JHipster specific properties

--- a/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
@@ -43,7 +43,7 @@ spring:
                 format: yaml
                 profile-separator: "-"
             discovery:
-                tags: profile=${spring.profiles.active}, version=${info.project.version}
+                tags: profile=${spring.profiles.active}, version=${info.project.version:}
             host: localhost
             port: 8500
         <%_ } _%>


### PR DESCRIPTION
Linked to https://github.com/jhipster/jhipster/pull/53

- Migrate the ProfileInfoResource to standard spring boot configuration.
- Migrate the development ribbon mechanism to the front-end
- Display build data in  `/management/info` endpoint as such:

```
{
  "display-ribbon-on-profiles" : "dev",
  "git" : {
    "commit" : {
      "id" : {
        "abbrev" : "92e2d29",
        "describe" : "92e2d29-dirty"
      }
    },
    "branch" : "master"
  },
  "build" : {
    "version" : "0.0.1-SNAPSHOT",
    "artifact" : "sb-2-t-2",
    "name" : "Sb 2 T 2",
    "group" : "com.mycompany.myapp",
    "time" : "2018-01-26T16:59:48Z"
  },
  "active-profiles" : [ "swagger", "dev" ]
}
```

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
