### PR TITLE
Cache evict and email login

### DIFF
--- a/generators/server/templates/src/main/java/package/repository/_UserRepository.java
+++ b/generators/server/templates/src/main/java/package/repository/_UserRepository.java
@@ -94,16 +94,16 @@ public interface UserRepository extends <% if (databaseType === 'sql') { %>JpaRe
 
     String USERS_BY_EMAIL_CACHE = "usersByEmail";
     <%_ } _%>
-<%_ if (authenticationType !== 'oauth2') { _%>
+    <%_ if (authenticationType !== 'oauth2') { _%>
 
     Optional<User> findOneByActivationKey(String activationKey);
-<%_ } _%>
+    <%_ } _%>
 
     List<User> findAllByActivatedIsFalseAndCreatedDateBefore(Instant dateTime);
-<%_ if (authenticationType !== 'oauth2') { _%>
+    <%_ if (authenticationType !== 'oauth2') { _%>
 
     Optional<User> findOneByResetKey(String resetKey);
-<%_ } _%>
+    <%_ } _%>
 
     <%_ if (databaseType === 'couchbase' || databaseType === 'mongodb') { _%>
         <%_ if (cacheManagerIsAvailable === true) { _%>
@@ -143,7 +143,7 @@ public interface UserRepository extends <% if (databaseType === 'sql') { %>JpaRe
     @Cacheable(cacheNames = USERS_BY_EMAIL_CACHE)
     <%_ } _%>
     Optional<User> findOneWithAuthoritiesByEmail(String email);
-<%_ } _%>
+    <%_ } _%>
 
     Page<User> findAllByLoginNot(Pageable pageable, String login);
 }
@@ -281,18 +281,18 @@ public class UserRepository {
         return findOneFromIndex(stmt);
     }
 
-<%_ if (cacheManagerIsAvailable === true) { _%>
+    <%_ if (cacheManagerIsAvailable === true) { _%>
     @Cacheable(cacheNames = USERS_BY_EMAIL_CACHE)
-<%_ } _%>
+    <%_ } _%>
     public Optional<User> findOneByEmailIgnoreCase(String email) {
         BoundStatement stmt = findOneByEmailStmt.bind();
         stmt.setString("email", email.toLowerCase());
         return findOneFromIndex(stmt);
     }
 
-<%_ if (cacheManagerIsAvailable === true) { _%>
+    <%_ if (cacheManagerIsAvailable === true) { _%>
     @Cacheable(cacheNames = USERS_BY_LOGIN_CACHE)
-<%_ } _%>
+    <%_ } _%>
     public Optional<User> findOneByLogin(String login) {
         BoundStatement stmt = findOneByLoginStmt.bind();
         stmt.setString("login", login);

--- a/generators/server/templates/src/main/java/package/service/_UserService.java
+++ b/generators/server/templates/src/main/java/package/service/_UserService.java
@@ -298,6 +298,9 @@ public class UserService {
         SecurityUtils.getCurrentUserLogin()
             .flatMap(userRepository::findOneByLogin)
             .ifPresent(user -> {
+                <%_ if (cacheManagerIsAvailable === true) { _%>
+                cacheManager.getCache(UserRepository.USERS_BY_EMAIL_CACHE).evict(user.getEmail());
+                <%_ } _%>
                 user.setFirstName(firstName);
                 user.setLastName(lastName);
                 user.setEmail(email);

--- a/generators/server/templates/src/main/java/package/service/_UserService.java
+++ b/generators/server/templates/src/main/java/package/service/_UserService.java
@@ -337,6 +337,10 @@ public class UserService {
                     userRepository.delete(userDTO.getId());
                 }
                 <%_ } _%>
+                <%_ if (cacheManagerIsAvailable === true) { _%>
+                cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).evict(user.getLogin());
+                cacheManager.getCache(UserRepository.USERS_BY_EMAIL_CACHE).evict(user.getEmail());
+                <%_ } _%>
                 user.setLogin(userDTO.getLogin());
                 user.setFirstName(userDTO.getFirstName());
                 user.setLastName(userDTO.getLastName());

--- a/generators/server/templates/src/test/java/package/security/_DomainUserDetailsServiceIntTest.java
+++ b/generators/server/templates/src/test/java/package/security/_DomainUserDetailsServiceIntTest.java
@@ -33,6 +33,9 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
+<%_ if (databaseType === 'sql') { _%>
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+<%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
 import org.springframework.security.test.context.support.WithMockUser;
 <%_ } _%>
@@ -156,22 +159,27 @@ public class DomainUserDetailsServiceIntTest <% if (databaseType === 'cassandra'
         assertThat(userDetails.getUsername()).isEqualTo(USER_TWO_LOGIN);
     }
 
-    @Test
     <%_ if (databaseType === 'sql') { _%>
+    @Test(expected = UsernameNotFoundException.class)
     @Transactional
-    <%_ } _%>
+    public void assertThatUserCanNotBeFoundByEmailIgnoreCase() {
+    domainUserDetailsService.loadUserByUsername(USER_TWO_EMAIL.toUpperCase(Locale.ENGLISH));
+    }
+    <%_ } else { // MongoDB and Cassandra _%>
+    @Test
     public void assertThatUserCanBeFoundByEmailIgnoreCase() {
         UserDetails userDetails = domainUserDetailsService.loadUserByUsername(USER_TWO_EMAIL.toUpperCase(Locale.ENGLISH));
         assertThat(userDetails).isNotNull();
         assertThat(userDetails.getUsername()).isEqualTo(USER_TWO_LOGIN);
     }
+    <%_ } _%>
 
     @Test
     <%_ if (databaseType === 'sql') { _%>
     @Transactional
     <%_ } _%>
     public void assertThatEmailIsPrioritizedOverLogin() {
-        UserDetails userDetails = domainUserDetailsService.loadUserByUsername(USER_ONE_EMAIL.toUpperCase(Locale.ENGLISH));
+        UserDetails userDetails = domainUserDetailsService.loadUserByUsername(USER_ONE_EMAIL);
         assertThat(userDetails).isNotNull();
         assertThat(userDetails.getUsername()).isEqualTo(USER_ONE_LOGIN);
     }


### PR DESCRIPTION
Greetings JHipsters!

Fixes for issue #6987

This PR closes the cache evict bugs, the "email can not signIn with email containing upperCase" and unnecessary email db lookup issue.

This PR does not store email toLowerCase always, as i suggested premature as a fix.

Reason:
Although it is quite common to identify the locale-part of email-addresses containing upper-case letters and the equivalent lowerCase as the same email-address locale-part, RFC5321 and RFC5322 are allowing email providers to distinguish strict between lowerCase and upperCase within locale-parts.
Due to this, converting/storing the email always toLowerCase could prevent users from receiving mails/the activation mail,  in case they have an email containing upperCase chars and their email-provider handles this strict.

Although JHipster stores emails not altered, JHipster does not support strict distinguishing (due to lookup via findOneByEmailIgnoreCase on signUp). 
There are several possible solutions to deal with the standards, but each comes with pros and cons, and the standards are widely considered to be broke at that part.
This PR however uses the approach JHipsters used before (cached findOneWithAuthoritiesByEmail on signIn, but ignoreCase on signUp) and just fixes the "not able to signIn with upperCase emails" for sql dbs resulting in the following behavior:
- users must type in their email-addresses on signIn using the exact matching case as stated on signUp/account/admin panel (for sql dbs).
- users from providers with strict email-address handling could be prevented from signUp, if they are not the first with an unique ignoreCase email.
- Note that this approach is relying at signUp on ignoreCase (and for nosql dbs also on signIn) and therefore relies on the used db-engine and locale/field type/utf-8 mb db settings configuration. This might or might not work as expected on email-addresses containing special chars as idn2008 domain part.

Possible alternative implementations:

1.
Similar to the current but refactor findOneWithAuthoritiesByEmail (cached) to findOneWithAuthoritiesByEmailIgnoreCase (must be non cached than)
- This would trade the cache benefits for a perhaps better user-experience (for ignoreCase on signIn - signUp/account/admin panel still depends on email-provider)
- Note that this approach would also have the cons as mentioned before and relies even more (now for signIn/sql dbs) on the current db-engine/settings

2.
If you want to implement the somewhat messed up standards and enable strict distinguishing within JHipster, just refactor findOneByEmailIgnoreCase to findOneByEmail.
Trade-offs will be:
- users with non strict providers can signUp multiple accounts with one/the same email-address just by stating a different upper-lower-case combination each time they signUp

Note:
Current email max length is set to 100 - however an email-address is valid/will be transported even when the email-address length is up to 254 bytes.
