### PR TITLE
minor refactoring on AuditEventConverter#convertDataToStrings

### DIFF
--- a/generators/server/templates/src/main/java/package/config/audit/_AuditEventConverter.java
+++ b/generators/server/templates/src/main/java/package/config/audit/_AuditEventConverter.java
@@ -89,21 +89,16 @@ public class AuditEventConverter {
 
         if (data != null) {
             for (Map.Entry<String, Object> entry : data.entrySet()) {
-                Object object = entry.getValue();
-
                 // Extract the data that will be saved.
-                if (object instanceof WebAuthenticationDetails) {
-                    WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) object;
+                if (entry.getValue() instanceof WebAuthenticationDetails) {
+                    WebAuthenticationDetails authenticationDetails = (WebAuthenticationDetails) entry.getValue();
                     results.put("remoteAddress", authenticationDetails.getRemoteAddress());
                     results.put("sessionId", authenticationDetails.getSessionId());
-                } else if (object != null) {
-                    results.put(entry.getKey(), object.toString());
                 } else {
-                    results.put(entry.getKey(), "null");
+                    results.put(entry.getKey(), Objects.toString(entry.getValue()));
                 }
             }
         }
-
         return results;
     }
 }


### PR DESCRIPTION
using Objects.toString (already imported) and directly entry#getValue

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

don't know if it's policy to do these kind of minor refactoring on the maintenance branch
* it should succeed on the relevant tests (as the result on {{null}} objects toString is also "null")

my arguments;
* it's less and more standard code
* using the intermediate var for the remaining 2 usages was didn't feel useful
* the naming of the var didn't make it more readable the just using entry#getValue directly