### PR TITLE
Elasticsearch save bug

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
@@ -27,10 +27,10 @@ if (!viaService) {
     if (dto === 'mapstruct') {
         resultEntity = entityInstance; %>
         <%= entityClass %> <%= entityInstance %> = <%= dtoToEntity %>(<%= instanceName %>);
-        <%= entityInstance %> = <%= entityInstance %>Repository.saveAndFlush(<%= entityInstance %>);
+        <%= entityInstance %> = <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);
         <%= returnPrefix %> <%= entityToDto %>(<%= entityInstance %>);<% } else {
     resultEntity = 'result'; %>
-        <%= returnPrefix %> <%= entityInstance %>Repository.saveAndFlush(<%= entityInstance %>);<% } if (searchEngine === 'elasticsearch') { %>
+        <%= returnPrefix %> <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= entityInstance %>);<% } if (searchEngine === 'elasticsearch') { %>
         <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% if (returnDirectly) { %>
         return result;<% }}} else { %>
         <%= returnPrefix %> <%= entityInstance %>Service.save(<%= instanceName %>);<% } %>

--- a/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
@@ -27,10 +27,10 @@ if (!viaService) {
     if (dto === 'mapstruct') {
         resultEntity = entityInstance; %>
         <%= entityClass %> <%= entityInstance %> = <%= dtoToEntity %>(<%= instanceName %>);
-        <%= entityInstance %> = <%= entityInstance %>Repository.save(<%= entityInstance %>);
+        <%= entityInstance %> = <%= entityInstance %>Repository.saveAndFlush(<%= entityInstance %>);
         <%= returnPrefix %> <%= entityToDto %>(<%= entityInstance %>);<% } else {
     resultEntity = 'result'; %>
-        <%= returnPrefix %> <%= entityInstance %>Repository.save(<%= entityInstance %>);<% } if (searchEngine === 'elasticsearch') { %>
+        <%= returnPrefix %> <%= entityInstance %>Repository.saveAndFlush(<%= entityInstance %>);<% } if (searchEngine === 'elasticsearch') { %>
         <%= entityInstance %>SearchRepository.save(<%= resultEntity %>);<% if (returnDirectly) { %>
         return result;<% }}} else { %>
         <%= returnPrefix %> <%= entityInstance %>Service.save(<%= instanceName %>);<% } %>


### PR DESCRIPTION
Repository.save will return the newest entity when creating an entity, but when updating, it will not.  So that when I use elasticsearch and entityAudit module, the test of entity update failed, because elasticsearch saved the old entity returned by Repository.save
