### PR TITLE
support unused needle

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1440,6 +1440,28 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add Gradle plugin to the plugins block
+     *
+     * @param {string} id - plugin id
+     * @param {string} version - explicit plugin version number
+     */
+    addGradlePluginToPluginsBlock(id, version) {
+        const fullPath = 'build.gradle';
+        try {
+            jhipsterUtils.rewriteFile({
+                file: fullPath,
+                needle: 'jhipster-needle-gradle-plugins',
+                splicable: [
+                    `id "${id}" version "${version}"`
+                ]
+            }, this);
+        } catch (e) {
+            this.log(`${chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required jhipster-needle. Reference to ')}id ${id} version ${version}${chalk.yellow(' not added.\n')}`);
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
      * A new dependency to build.gradle file.
      *
      * @param {string} scope - scope of the new dependency, e.g. compile

--- a/generators/modules/index.js
+++ b/generators/modules/index.js
@@ -97,6 +97,7 @@ module.exports = class extends BaseGenerator {
         jhipsterFunc.addMavenDependencyManagement = this.addMavenDependencyManagement;
         jhipsterFunc.addMavenPlugin = this.addMavenPlugin;
         jhipsterFunc.addGradlePlugin = this.addGradlePlugin;
+        jhipsterFunc.addGradlePluginToPluginsBlock = this.addGradlePluginToPluginsBlock;
         jhipsterFunc.addGradleDependency = this.addGradleDependency;
         jhipsterFunc.addGradleDependencyManagement = this.addGradleDependencyManagement;
         jhipsterFunc.addSocialConfiguration = this.addSocialConfiguration;


### PR DESCRIPTION
The needle was added to `_build.gradle` in this commit https://github.com/jhipster/generator-jhipster/commit/a1a89b3f3ba9cd201d7b82da5835b478140721ba but was apparently never implemented.

I would love to use it for a jhipster module im creating.

Maybe the name is not great `addGradlePluginToPluginsBlock` since `addGradlePlugin` is already taken by the needle adding to the buildscripts block

