### PR TITLE
fix: remove blank space in social auth users names

### DIFF
--- a/generators/server/templates/src/main/java/package/service/_SocialService.java
+++ b/generators/server/templates/src/main/java/package/service/_SocialService.java
@@ -151,7 +151,7 @@ public class SocialService {
             case "twitter":
                 return userProfile.getUsername().toLowerCase();
             default:
-                return userProfile.getFirstName().toLowerCase() + "_" + userProfile.getLastName().toLowerCase();
+                return userProfile.getFirstName().toLowerCase().replace(" ", "_") + "_" + userProfile.getLastName().toLowerCase().replace(" ", "_");
         }
     }
 


### PR DESCRIPTION
Google users (or facebook users) with space in lastname or firstname can't register into JHipster app because of : ConstraintViolationException in User Entity. 
This is a fix to replace space with '_'

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
