### PR TITLE
For logout resource, return 204 OK response instead of 200 OK

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/_AuthResource.java
+++ b/generators/server/templates/src/main/java/package/web/rest/_AuthResource.java
@@ -81,6 +81,6 @@ public class AuthResource {
     public ResponseEntity<?> logout(HttpServletRequest request, HttpServletResponse response) {
         log.info("logging out user {}", SecurityContextHolder.getContext().getAuthentication().getName());
         authenticationService.logout(request, response);
-        return ResponseEntity.ok(null);
+        return ResponseEntity.noContent().build();
     }
 }


### PR DESCRIPTION
With 200 OK response without body, Firefox gives warning on console as it expects
root xml element (treating response as text/xml in absence of content-type header)

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
