### PR TITLE
Remove the unecessary api call

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/_auth-session.service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/_auth-session.service.ts
@@ -43,8 +43,10 @@ export class AuthServerProvider {
     logout(): Observable<any> {
         // logout from the server
         return this.http.post(SERVER_API_URL + 'api/logout', {}, { observe: 'response' }).map((response: HttpResponse<any>) => {
+            <%_ if (applicationType !== 'gateway') { _%>
             // to get a new csrf token call the api
             this.http.get(SERVER_API_URL + 'api/account').subscribe(() => {}, () => {});
+            <%_ } _%>
             return response;
         });
     }


### PR DESCRIPTION
Remove the unecessary call to get a new CSRF token when CSRF is disabled.

Fix #7090