### PR TITLE
Added support for Elasticsearch to the Heroku generator

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -56,6 +56,7 @@ module.exports = class extends BaseGenerator {
         this.enableHibernateCache = this.config.get('enableHibernateCache') || (this.config.get('hibernateCache') !== undefined && this.config.get('hibernateCache') !== 'no');
         this.databaseType = this.config.get('databaseType');
         this.prodDatabaseType = this.config.get('prodDatabaseType');
+        this.searchEngine = this.config.get('searchEngine');
         this.angularAppName = this.getAngularAppName();
         this.buildTool = this.config.get('buildTool');
         this.applicationType = this.config.get('applicationType');
@@ -305,6 +306,26 @@ module.exports = class extends BaseGenerator {
                 if (this.abort) return;
                 const done = this.async();
 
+                const addonCreateCallback = (addon, err, stdout, stderr) => {
+                    if (err) {
+                        const verifyAccountUrl = 'https://heroku.com/verify';
+                        if (_.includes(err, verifyAccountUrl)) {
+                            this.abort = true;
+                            this.log.error(`Account must be verified to use addons. Please go to: ${verifyAccountUrl}`);
+                            this.log.error(err);
+                        } else {
+                            this.log(`No new ${addon} addon created`);
+                        }
+                    } else {
+                        this.log(`Created ${addon} addon`);
+                    }
+                };
+
+                this.log(chalk.bold('\nProvisioning addons'));
+                if (this.searchEngine === 'elasticsearch') {
+                    exec(`heroku addons:create searchbox:starter --as SEARCHBOX --app ${this.herokuAppName}`, addonCreateCallback.bind(this, 'Elasticsearch'));
+                }
+
                 let dbAddOn = '';
                 if (this.prodDatabaseType === 'postgresql') {
                     dbAddOn = 'heroku-postgresql --as DATABASE';
@@ -315,23 +336,12 @@ module.exports = class extends BaseGenerator {
                 } else if (this.prodDatabaseType === 'mongodb') {
                     dbAddOn = 'mongolab:sandbox --as MONGODB';
                 } else {
+                    done();
                     return;
                 }
 
-                this.log(chalk.bold('\nProvisioning addons'));
                 exec(`heroku addons:create ${dbAddOn} --app ${this.herokuAppName}`, (err, stdout, stderr) => {
-                    if (err) {
-                        const verifyAccountUrl = 'https://heroku.com/verify';
-                        if (_.includes(err, verifyAccountUrl)) {
-                            this.abort = true;
-                            this.log.error(`Account must be verified to use addons. Please go to: ${verifyAccountUrl}`);
-                            this.log.error(err);
-                        } else {
-                            this.log('No new addons created');
-                        }
-                    } else {
-                        this.log(`Created ${dbAddOn}`);
-                    }
+                    addonCreateCallback('Database', err, stdout, stderr);
                     done();
                 });
             },

--- a/test/templates/default-elasticsearch/.yo-rc.json
+++ b/test/templates/default-elasticsearch/.yo-rc.json
@@ -1,0 +1,28 @@
+{
+  "generator-jhipster": {
+    "applicationType": "monolith",
+    "baseName": "sampleMysql",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "authenticationType": "session",
+    "cacheProvider": "ehcache",
+    "websocket": "no",
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mysql",
+    "searchEngine": "elasticsearch",
+    "useSass": false,
+    "buildTool": "maven",
+    "enableTranslation": true,
+    "nativeLanguage": "en",
+    "languages": [
+      "en",
+      "fr"
+    ],
+    "enableSocialSignIn": false,
+    "rememberMeKey": "2bb60a80889aa6e6767e9ccd8714982681152aa5",
+    "testFrameworks": [
+      "gatling"
+    ]
+  }
+}


### PR DESCRIPTION
This will automatically create a *free* Elasticsearch add-on attached to the Heroku app when the generator detects `"searchEngine": "elasticsearch"` in the config. For this to really work, I think the elasticsearch generator needs to add these to the `application.yml`

```
spring:
    data:
        elasticsearch:
            cluster-name:
            cluster-nodes:
            properties:
                path:
                    logs: target/elasticsearch/log
                    data: target/elasticsearch/data
```