### PR TITLE
Use the new SonarCloud badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,10 +51,10 @@ Additional builds on [hipster-labs/jhipster-travis-build](https://github.com/hip
 [image-react]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=react
 
 [sonar-url]: https://sonarcloud.io/dashboard?id=io.github.jhipster.sample%3Ajhipster-sample-application
-[sonar-quality-gate]: https://sonarcloud.io/api/badges/gate?key=io.github.jhipster.sample%3Ajhipster-sample-application
-[sonar-coverage]: https://sonarcloud.io/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=coverage
-[sonar-bugs]: https://sonarcloud.io/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=bugs
-[sonar-vulnerabilities]: https://sonarcloud.io/api/badges/measure?key=io.github.jhipster.sample%3Ajhipster-sample-application&metric=vulnerabilities
+[sonar-quality-gate]: https://sonarcloud.io/api/project_badges/measure?project=io.github.jhipster.sample%3Ajhipster-sample-application&metric=alert_status
+[sonar-coverage]: https://sonarcloud.io/api/project_badges/measure?project=io.github.jhipster.sample%3Ajhipster-sample-application&metric=coverage
+[sonar-bugs]: https://sonarcloud.io/api/project_badges/measure?project=io.github.jhipster.sample%3Ajhipster-sample-application&metric=bugs
+[sonar-vulnerabilities]: https://sonarcloud.io/api/project_badges/measure?project=io.github.jhipster.sample%3Ajhipster-sample-application&metric=vulnerabilities
 
 [jhipster-image]: https://raw.githubusercontent.com/jhipster/jhipster.github.io/master/images/logo/logo-jhipster2x.png
 [jhipster-url]: http://www.jhipster.tech/


### PR DESCRIPTION
New badges are available on SonarCloud, and the old ones will be removed soon.

You can read more at https://about.sonarcloud.io/news/2018/02/05/new-project-badges.html

And BTW: congrats guys for the great figures you get for JHipster!
