### PR TITLE
Log an error in browser console when access to route is denied

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/_user-route-access-service.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/_user-route-access-service.ts
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Injectable } from '@angular/core';
+import { Injectable, isDevMode } from '@angular/core';
 import { ActivatedRouteSnapshot, CanActivate, Router, RouterStateSnapshot } from '@angular/router';
 
 import { Principal } from '../';
@@ -61,6 +61,9 @@ export class UserRouteAccessService implements CanActivate {
                 return principal.hasAnyAuthority(authorities).then((response) => {
                     if (response) {
                         return true;
+                    }
+                    if (isDevMode()) {
+                        console.error('User has not any of required authorities: ', authorities);
                     }
                     return false;
                 });


### PR DESCRIPTION
When an authenticated user tries to navigate to a route and is denied access because of insufficient authorities, the UserRouteAccessService now logs an error in console:

> User has not any of required authorities: [ROLE_ADMIN]

This is enabled only in Angular dev mode.

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
