### PR TITLE
Fix display for healthcheck details when the values are objects and not plain text

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/_health-modal.component.ts
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/_health-modal.component.ts
@@ -40,16 +40,20 @@ export class <%=jhiPrefixCapitalized%>HealthModalComponent {
     }
 
     readableValue(value: number) {
-        if (this.currentHealth.name !== 'diskSpace') {
-            return value.toString();
+        if (this.currentHealth.name === 'diskSpace') {
+            // Should display storage space in an human readable unit
+            const val = value / 1073741824;
+            if (val > 1) { // Value
+                return val.toFixed(2) + ' GB';
+            } else {
+                return (value / 1048576).toFixed(2) + ' MB';
+            }
         }
 
-        // Should display storage space in an human readable unit
-        const val = value / 1073741824;
-        if (val > 1) { // Value
-            return val.toFixed(2) + ' GB';
+        if (typeof value === 'object') {
+            return JSON.stringify(value);
         } else {
-            return (value / 1048576).toFixed(2) + ' MB';
+            return value.toString();
         }
     }
 }


### PR DESCRIPTION
Fix display for healthcheck details when the values are objects and not plain text

If the health check details returned from the server are objects and not just a plain strings, fallback to displaying a JSON.stringify'ed version instead of [object Object]

Fix #7152

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
