### PR TITLE
fix Prettier error in Windows

### DIFF
--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -146,7 +146,7 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "prettier:format":"<%= clientPackageManager %> prettier --write '**/*.ts'",
+    "prettier:format":"<%= clientPackageManager %> prettier --write \"**/*.ts\"",
     "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "ngc": "ngc -p tsconfig-aot.json",

--- a/generators/client/templates/angular/_package.json
+++ b/generators/client/templates/angular/_package.json
@@ -146,7 +146,7 @@
   },
   "scripts": {
     "precommit": "lint-staged",
-    "prettier:format":"<%= clientPackageManager %> prettier --write \"**/*.ts\"",
+    "prettier:format":"<%= clientPackageManager %> prettier --write **/*.ts",
     "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "ngc": "ngc -p tsconfig-aot.json",

--- a/generators/client/templates/react/_package.json
+++ b/generators/client/templates/react/_package.json
@@ -162,7 +162,7 @@ limitations under the License.
   },
   "scripts": {
     "precommit": "lint-staged",
-    "prettier:format":"<%= clientPackageManager %> prettier --write \"**/*.{ts,tsx}\"",
+    "prettier:format":"<%= clientPackageManager %> prettier --write **/*.{ts,tsx}",
     "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "cleanup": "rimraf <%= BUILD_DIR %>www",

--- a/generators/client/templates/react/_package.json
+++ b/generators/client/templates/react/_package.json
@@ -162,7 +162,7 @@ limitations under the License.
   },
   "scripts": {
     "precommit": "lint-staged",
-    "prettier:format":"<%= clientPackageManager %> prettier --write '**/*.{ts,tsx}'",
+    "prettier:format":"<%= clientPackageManager %> prettier --write \"**/*.{ts,tsx}\"",
     "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "cleanup": "rimraf <%= BUILD_DIR %>www",


### PR DESCRIPTION
Prettier wants quotes instead of apostrophes in Windows.
Without this fix there is Prettier error in Windows:
Angular: [error] No matching files. Patterns tried: '**/*.ts' !**/node_modules/** !./node_modules/**
React: [error] No matching files. Patterns tried: '**/*.{ts,tsx}' !**/node_modules/** !./node_modules/**

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
