### PR TITLE
Adding undertow ordered cipher configuration

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -405,6 +405,7 @@ function writeFiles() {
             this.template(`${SERVER_MAIN_SRC_DIR}package/config/MetricsConfiguration.java.ejs`, `${javaDir}config/MetricsConfiguration.java`);
             this.template(`${SERVER_MAIN_SRC_DIR}package/config/ThymeleafConfiguration.java.ejs`, `${javaDir}config/ThymeleafConfiguration.java`);
             this.template(`${SERVER_MAIN_SRC_DIR}package/config/WebConfigurer.java.ejs`, `${javaDir}config/WebConfigurer.java`);
+            this.template(`${SERVER_MAIN_SRC_DIR}package/config/_UndertowConfiguration.java`, `${javaDir}config/UndertowConfiguration.java`);
             if (this.websocket === 'spring-websocket') {
                 this.template(`${SERVER_MAIN_SRC_DIR}package/config/WebsocketConfiguration.java.ejs`, `${javaDir}config/WebsocketConfiguration.java`);
                 this.template(`${SERVER_MAIN_SRC_DIR}package/config/WebsocketSecurityConfiguration.java.ejs`, `${javaDir}config/WebsocketSecurityConfiguration.java`);

--- a/generators/server/templates/src/main/java/package/config/_UndertowConfiguration.java
+++ b/generators/server/templates/src/main/java/package/config/_UndertowConfiguration.java
@@ -1,0 +1,61 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+
+package <%=packageName%>.config;
+
+import io.github.jhipster.config.JHipsterConstants;
+import io.undertow.UndertowOptions;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.web.embedded.undertow.UndertowServletWebServerFactory;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+import java.util.Arrays;
+import java.util.Collection;
+
+@Configuration
+public class UndertowConfiguration {
+
+    private final Environment env;
+
+    private final Logger log = LoggerFactory.getLogger(UndertowConfiguration.class);
+
+    public UndertowConfiguration(Environment env) {
+        this.env = env;
+    }
+
+    @Bean
+    public UndertowServletWebServerFactory embeddedServletContainerFactory() {
+        UndertowServletWebServerFactory factory = new UndertowServletWebServerFactory();
+        log.info("Configuring Undertow");
+        Collection<String> activeProfiles = Arrays.asList(env.getActiveProfiles());
+        boolean isHttpsActive = env.getProperty("server.ssl.key-store") != null;
+        boolean userCipherPresent = env.getProperty("server.ssl.ciphers") != null;
+        boolean prodProfileActive = activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_PRODUCTION);
+
+        if (isHttpsActive && prodProfileActive && userCipherPresent) {
+            log.info("Setting user cipher suite order to true");
+            factory.addBuilderCustomizers(builder -> builder.setSocketOption(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER, Boolean.TRUE));
+        }
+
+        return factory;
+    }
+}

--- a/generators/server/templates/src/test/java/package/config/WebConfigurerTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/WebConfigurerTest.java.ejs
@@ -73,6 +73,8 @@ public class WebConfigurerTest {
 
     private MetricRegistry metricRegistry;
 
+    private UndertowConfiguration undertowConfiguration;
+
     @Before
     public void setup() {
         servletContext = spy(new MockServletContext());
@@ -87,6 +89,7 @@ public class WebConfigurerTest {
         webConfigurer = new WebConfigurer(env, props);
         metricRegistry = new MetricRegistry();
         webConfigurer.setMetricRegistry(metricRegistry);
+        undertowConfiguration = new UndertowConfiguration(env);
     }
 
     @Test
@@ -231,5 +234,52 @@ public class WebConfigurerTest {
                 .header(HttpHeaders.ORIGIN, "other.domain.com"))
             .andExpect(status().isOk())
             .andExpect(header().doesNotExist(HttpHeaders.ACCESS_CONTROL_ALLOW_ORIGIN));
+    }
+
+    @Test
+    public void testUndertownConfigurationOk() throws Exception {
+        env.setProperty("server.ssl.key-store", "store");
+        env.setProperty("server.ssl.ciphers", "cipher");
+        env.setActiveProfiles(JHipsterConstants.SPRING_PROFILE_PRODUCTION);
+
+        UndertowServletWebServerFactory container = undertowConfiguration.embeddedServletContainerFactory();
+
+        Builder builder = Undertow.builder();
+        container.getBuilderCustomizers().forEach(c -> c.customize(builder));
+        OptionMap.Builder serverOptions = (OptionMap.Builder) ReflectionTestUtils.getField(builder, "socketOptions");
+
+        assertThat(container).isNotNull();
+        assertThat(serverOptions.getMap().get(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER)).isTrue();
+    }
+
+    @Test
+    public void testUndertownConfigurationNoHttps() throws Exception {
+        env.setProperty("server.ssl.ciphers", "cipher");
+        env.setActiveProfiles(JHipsterConstants.SPRING_PROFILE_PRODUCTION);
+
+        UndertowServletWebServerFactory container = undertowConfiguration.embeddedServletContainerFactory();
+
+        Builder builder = Undertow.builder();
+        container.getBuilderCustomizers().forEach(c -> c.customize(builder));
+        OptionMap.Builder serverOptions = (OptionMap.Builder) ReflectionTestUtils.getField(builder, "socketOptions");
+
+        assertThat(container).isNotNull();
+        assertThat(serverOptions.getMap().get(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER)).isNull();
+    }
+
+    @Test
+    public void testUndertownConfigurationNoProd() throws Exception {
+        env.setProperty("server.ssl.key-store", "store");
+        env.setProperty("server.ssl.ciphers", "cipher");
+        env.setActiveProfiles(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT);
+
+        UndertowServletWebServerFactory container = undertowConfiguration.embeddedServletContainerFactory();
+
+        Builder builder = Undertow.builder();
+        container.getBuilderCustomizers().forEach(c -> c.customize(builder));
+        OptionMap.Builder serverOptions = (OptionMap.Builder) ReflectionTestUtils.getField(builder, "socketOptions");
+
+        assertThat(container).isNotNull();
+        assertThat(serverOptions.getMap().get(UndertowOptions.SSL_USER_CIPHER_SUITES_ORDER)).isNull();
     }
 }

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -71,6 +71,7 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/SecurityConfiguration.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/ThymeleafConfiguration.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/WebConfigurer.java`,
+        `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/UndertowConfiguration.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/audit/package-info.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/audit/AuditEventConverter.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/domain/package-info.java`,


### PR DESCRIPTION
It will force the order of the cipher define in the properties file.
The purpose of this is to achieve perfect forward secrecy for SSL [(More infos)](https://github.com/ssllabs/research/wiki/SSL-and-TLS-Deployment-Best-Practices#25-use-forward-secrecy) in combination of the cipher list in the comments SSL section in the spring boot properties file.

It's the missing part of my first [PR](https://github.com/jhipster/generator-jhipster/pull/6938)

The only thing left will be to add this JVM flag
`-Djdk.tls.ephemeralDHKeySize=2048`

 But I don't really know how we can automate this since it depends on the cloud / hosting providers

With all of these the grade in [SSLLabs](https://www.ssllabs.com/ssltest/) will be A+ instead of B

Tell me what you think about that 😃 

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
