### PR TITLE
Add needle to add maven repositories

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1467,6 +1467,44 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add a Maven Repository
+     *
+     * @param {string} url - url of the repository
+     * @param {string} username - (optional) username of the repository credentials
+     * @param {string} password - (optional) password of the repository credentials
+     */
+    addGradleMavenRepository(url, username, password) {
+        const fullPath = 'build.gradle';
+        try {
+            let repository = 'maven {\n';
+            if (url) {
+                repository += `        url "${url}"\n`;
+            }
+            if (username || password) {
+                repository += '        credentials {\n';
+                if (username) {
+                    repository += `            username = "${username}"\n`;
+                }
+                if (password) {
+                    repository += `            password = "${password}"\n`;
+                }
+                repository += '        }\n';
+            }
+            repository += '    }';
+            jhipsterUtils.rewriteFile({
+                file: fullPath,
+                needle: 'jhipster-needle-gradle-repositories',
+                splicable: [
+                    repository
+                ]
+            }, this);
+        } catch (e) {
+            this.log(chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required jhipster-needle. Reference to ') + url + chalk.yellow(' not added.\n'));
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
      * Generate a date to be used by Liquibase changelogs.
      */
     dateFormatForLiquibase() {

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -201,6 +201,7 @@ repositories {
     maven { url "https://repo.spring.io/milestone" }
     maven { url "https://repo.spring.io/snapshot" }
     maven { url "https://dl.bintray.com/jhipster/maven" }
+    //jhipster-needle-gradle-repositories - JHipster will add additional repositories
 }
 
 dependencies {


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

We're using jhipster for a bunch of microservices, project specific configs are then added by applying a jhipster-module on top of the default generator. Adding specific maven repositories is still done by search and replace. I guess using the needle functionality is way nicer and maybe helpful for others too.

Please feel free to ask for improvements of any kind
