### PR TITLE
Set version to 5.0.0-alpha.1 for v5 generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "generator-jhipster",
-  "version": "4.14.0",
-  "description": "Spring Boot + Angular in one handy generator",
+  "version": "5.0.0-alpha.1",
+  "description": "Spring Boot + Angular/React in one handy generator",
   "files": [
     "cli",
     "generators"
@@ -14,7 +14,7 @@
     "Spring Security",
     "JPA",
     "Hibernate",
-    "AngularJS",
+    "React",
     "Angular",
     "Twitter Bootstrap"
   ],


### PR DESCRIPTION
We discussed it on mailing list but did not reach a conclusion.
I predict issues in support if we don't set it as users are already using v5.

Feel free to reject it, not much work here :)

Also mentioned React in package.json keywords and removed AngularJS

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
