### PR TITLE
update deprecated reactstrap component

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
@@ -4,7 +4,7 @@ import * as React from 'react';
 import { Translate } from 'react-jhipster';
 import {
   Navbar, Nav, NavItem, NavLink, NavbarToggler, NavbarBrand, Collapse,
-  UncontrolledNavDropdown, DropdownToggle, DropdownMenu, DropdownItem
+  UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem
 } from 'reactstrap';
 import {
   FaHome, FaThList, FaUserPlus, FaUser, FaFlag, FaHeart,
@@ -127,7 +127,7 @@ export class Header extends React.Component<<%if (enableTranslation) { %>IHeader
                 </NavLink>
               </NavItem>
               {isAuthenticated ? [
-                <UncontrolledNavDropdown key="entities">
+                <UncontrolledDropdown nav key="entities">
                   <DropdownToggle nav caret className="d-flex align-items-center">
                     <FaThList />
                     <span>Entities</span>
@@ -135,8 +135,8 @@ export class Header extends React.Component<<%if (enableTranslation) { %>IHeader
                   <DropdownMenu right>
                     {entityMenuItems}
                   </DropdownMenu>
-                </UncontrolledNavDropdown>,
-                <UncontrolledNavDropdown key="admin">
+                </UncontrolledDropdown>,
+                <UncontrolledDropdown nav key="admin">
                   <DropdownToggle nav caret className="d-flex align-items-center">
                     <FaUserPlus />
                     <span>Administration</span>
@@ -144,11 +144,11 @@ export class Header extends React.Component<<%if (enableTranslation) { %>IHeader
                   <DropdownMenu right style={{ width: '120%' }}>
                     {adminMenuItems}
                   </DropdownMenu>
-                </UncontrolledNavDropdown>
+                </UncontrolledDropdown>
               ] : null}
             <%_ if (enableTranslation) { _%>
               { locales.length > 1 ?
-                <UncontrolledNavDropdown>
+                <UncontrolledDropdown nav>
                   <DropdownToggle nav caret className="d-flex align-items-center">
                     <FaFlag />
                     <span>{currentLocale.toUpperCase()}</span>
@@ -156,10 +156,10 @@ export class Header extends React.Component<<%if (enableTranslation) { %>IHeader
                   <DropdownMenu right>
                     {locales.map(lang => <DropdownItem key={lang} value={lang} onClick={this.handleLocaleChange}>{lang.toUpperCase()}</DropdownItem>)}
                   </DropdownMenu>
-                </UncontrolledNavDropdown> : null
+                </UncontrolledDropdown> : null
               }
             <%_ } _%>
-              <UncontrolledNavDropdown>
+              <UncontrolledDropdown nav>
                 <DropdownToggle nav caret className="d-flex align-items-center">
                   <FaUser />
                   <span>Account</span>
@@ -167,7 +167,7 @@ export class Header extends React.Component<<%if (enableTranslation) { %>IHeader
                 <DropdownMenu right>
                   {accountMenuItems}
                 </DropdownMenu>
-              </UncontrolledNavDropdown>
+              </UncontrolledDropdown>
             </Nav>
           </Collapse>
         </Navbar>


### PR DESCRIPTION
- replace UncontrolledNavDropdown with UncontrolledDropdown
- add nav prop

Fixes error message in console:
```
The "UncontrolledNavDropdown" component has been deprecated.
Please use component "UncontrolledDropdown" with nav prop.
```

My first React PR 😄 

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
