### PR TITLE
Fix webpack 4 issues with "start" script

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -65,18 +65,19 @@
     "@types/selenium-webdriver": "3.0.4",
     <%_ } _%>
     "angular2-template-loader": "0.6.2",
-    "awesome-typescript-loader": "5.0.0-1",
-    "browser-sync": "2.18.13",
-    "browser-sync-webpack-plugin": "1.2.0",
-    "codelyzer": "4.0.1",
-    "copy-webpack-plugin": "4.4.1",
+    "browser-sync": "2.23.6",
+    "browser-sync-webpack-plugin": "2.0.1",
+    "cache-loader": "1.2.2",
+    "codelyzer": "4.2.1",
+    "copy-webpack-plugin": "4.5.1",
     "css-loader": "0.28.10",
-    "exports-loader": "0.6.4",
+    "exports-loader": "0.7.0",
     "extract-text-webpack-plugin": "4.0.0-beta.0",
-    "file-loader": "1.1.6",
+    "file-loader": "1.1.11",
+    "fork-ts-checker-webpack-plugin": "0.4.1",
     "generator-jhipster": "<%= packagejs.version %>",
-    "html-loader": "0.5.0",
-    "html-webpack-plugin": "3.0.0",
+    "html-loader": "0.5.5",
+    "html-webpack-plugin": "3.0.6",
     "husky": "0.14.3",
     "jasmine-core": "2.7.0",
     <%_ if (protractorTests) { _%>
@@ -92,11 +93,11 @@
     "karma-remap-istanbul": "0.6.0",
     "karma-sourcemap-loader": "0.3.7",
     "karma-webpack": "2.0.13",
-    "lint-staged": "6.0.0",
+    "lint-staged": "7.0.0",
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.14",
     <%_ } _%>
-    "prettier": "1.9.2",
+    "prettier": "1.11.1",
     "puppeteer": "1.1.1",
     <%_ if (protractorTests) { _%>
     "protractor": "5.1.2",
@@ -106,16 +107,18 @@
     "rimraf": "2.6.1",
     "source-map": "0.6.1",
     "sourcemap-istanbul-instrumenter-loader": "0.2.0",
-    "style-loader": "0.20.2",
-    "tapable": "1.0.0-beta.5",
+    "style-loader": "0.20.3",
+    "tapable": "1.0.0",
     "to-string-loader": "1.1.5",
     <%_ if (protractorTests) { _%>
-    "ts-node": "3.3.0",
+    "ts-node": "5.0.1",
     <%_ } _%>
-    "tslint": "5.5.0",
+    "ts-loader": "4.0.1",
+    "tslint": "5.9.1",
     "tslint-config-prettier": "1.6.0",
-    "tslint-loader": "sendilkumarn/tslint-loader",
+    "tslint-loader": "3.6.0",
     "typescript": "2.7.2",
+    "thread-loader": "1.1.5",
     <%_ if (useSass) { _%>
     "sass-loader": "6.0.6",
     "node-sass": "4.5.3",
@@ -127,15 +130,15 @@
     <%_ otherModules.forEach(module => { _%>
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
-    "uglifyjs-webpack-plugin": "1.2.2",
-    "webpack": "4.0.0",
-    "webpack-cli": "2.0.10",
-    "webpack-dev-server": "3.0.1-beta.0",
-    "webpack-merge": "4.1.1",
-    "webpack-notifier": "1.5.1",
+    "uglifyjs-webpack-plugin": "1.2.3",
+    "webpack": "4.1.1",
+    "webpack-cli": "2.0.11",
+    "webpack-dev-server": "3.1.1",
+    "webpack-merge": "4.1.2",
+    "webpack-notifier": "1.6.0",
     "webpack-visualizer-plugin": "0.1.11",
     "workbox-webpack-plugin": "3.0.0-beta.1",
-    "write-file-webpack-plugin": "4.1.0"
+    "write-file-webpack-plugin": "4.2.0"
   },
   "engines": {
     "node": ">=8.9.0"

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -91,7 +91,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                     }
                 },
                 {
-                loader: 'ts-loader',
+                    loader: 'ts-loader',
                     options: {
                         transpileOnly: true,
                         happyPackMode: true

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -21,6 +21,7 @@ const writeFilePlugin = require('write-file-webpack-plugin');
 const webpackMerge = require('webpack-merge');
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const WebpackNotifierPlugin = require('webpack-notifier');
+const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 const path = require('path');
 
 const utils = require('./utils.js');
@@ -79,12 +80,26 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         },
         {
             test: /\.ts$/,
-            loaders: [
-                'angular2-template-loader',
-                'awesome-typescript-loader',
-                'angular-router-loader'
+            use: [
+                { loader: 'angular2-template-loader' },
+                { loader: 'cache-loader' },
+                {
+                    loader: 'thread-loader',
+                    options: {
+                        // there should be 1 cpu for the fork-ts-checker-webpack-plugin
+                        workers: require('os').cpus().length - 1
+                    }
+                },
+                {
+                loader: 'ts-loader',
+                    options: {
+                        transpileOnly: true,
+                        happyPackMode: true
+                    }
+                },
+                { loader: 'angular-router-loader' }
             ],
-            exclude: ['node_modules/generator-jhipster']
+            exclude: ['node_modules']
         },
         <%_ if (useSass) { _%>
         {
@@ -108,6 +123,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         }]
     },
     plugins: [
+        new ForkTsCheckerWebpackPlugin({ tslint: true }),
         new BrowserSyncPlugin({
             host: 'localhost',
             port: 9000,

--- a/generators/client/templates/angular/webpack/webpack.test.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.test.js.ejs
@@ -33,13 +33,18 @@ module.exports = (WATCH) => ({
     module: {
         rules: [
             {
-                test: /\.ts$/, enforce: 'pre',
+                test: /\.ts$/,
+                enforce: 'pre',
                 loader: 'tslint-loader',
                 exclude: /node_modules/
             },
             {
                 test: /\.ts$/,
-                loaders: ['awesome-typescript-loader', 'angular2-template-loader?keepUrl=true'],
+                use: [
+                    { loader: 'cache-loader' },
+                    { loader: 'ts-loader' },
+                    { loader: 'angular2-template-loader?keepUrl=true' }
+                ],
                 exclude: /node_modules/
             },
             {

--- a/generators/client/templates/angular/webpack/webpack.test.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.test.js.ejs
@@ -43,7 +43,12 @@ module.exports = (WATCH) => ({
                 use: [
                     { loader: 'cache-loader' },
                     { loader: 'ts-loader' },
-                    { loader: 'angular2-template-loader?keepUrl=true' }
+                    {
+                        loader: 'angular2-template-loader',
+                        options: {
+                            keepUrl: true
+                        }
+                    }
                 ],
                 exclude: /node_modules/
             },


### PR DESCRIPTION
Had some issues after updating a file with "yarn start" running, webpack crashed, I needed to bump some versions to make it work.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
