### PR TITLE
implement websockets tracker for react

### DIFF
--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -112,6 +112,13 @@ const files = {
             ]
         },
         {
+            condition: generator => generator.websocket === 'spring-websocket',
+            path: REACT_DIR,
+            templates: [
+                { file: 'config/websocket-middleware.ts', method: 'processJsx' }
+            ]
+        },
+        {
             condition: generator => generator.useSass,
             path: REACT_DIR,
             templates: [
@@ -256,13 +263,13 @@ const files = {
                 'modules/administration/administration.reducer.ts'
             ]
         },
-        // {
-        //   condition: generator => generator.websocket === 'spring-websocket',
-        //   path: REACT_DIR,
-        //   templates: [
-        //     { file: 'modules/administration/tracker/Tracker.js', method: 'processJsx' }
-        //   ]
-        // },
+        {
+            condition: generator => generator.websocket === 'spring-websocket',
+            path: REACT_DIR,
+            templates: [
+                { file: 'modules/administration/tracker/tracker.tsx', method: 'processJsx' }
+            ]
+        },
         {
             condition: generator => !generator.skipUserManagement,
             path: REACT_DIR,

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -393,6 +393,7 @@ const files = {
                 'spec/app/modules/account/password/password.reducer.spec.ts',
                 'spec/app/modules/account/settings/settings.reducer.spec.ts',
                 'spec/app/modules/administration/user-management/user-management.reducer.spec.ts',
+                { file: 'spec/app/modules/administration/administration.reducer.spec.ts', method: 'processJsx' },
                 // 'spec/app/account/activate/_activate.component.spec.js',
                 // 'spec/app/account/password/_password.component.spec.js',
                 // 'spec/app/account/password/_password-strength-bar.component.spec.js',
@@ -419,13 +420,6 @@ const files = {
     //     path: TEST_SRC_DIR,
     //     templates: [
     //       'spec/helpers/_mock-language.service.js'
-    //     ]
-    //   },
-    //   {
-    //     condition: generator => generator.websocket === 'spring-websocket',
-    //     path: TEST_SRC_DIR,
-    //     templates: [
-    //       'spec/helpers/_mock-tracker.service.js'
     //     ]
     //   },
     //   {

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -52,6 +52,10 @@ limitations under the License.
     "redux-promise-middleware": "4.4.2",
     "redux-thunk": "2.2.0",
     "tslib": "1.9.0",
+    <%_ if (websocket === 'spring-websocket') { _%>
+    "sockjs-client": "1.1.4",
+    "webstomp-client": "1.2.0",
+    <%_ } _%>
     "uuid": "3.2.1"
   },
   "devDependencies": {

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -53,6 +53,7 @@ limitations under the License.
     "redux-thunk": "2.2.0",
     "tslib": "1.9.0",
     <%_ if (websocket === 'spring-websocket') { _%>
+    "rxjs": "5.5.6",
     "sockjs-client": "1.1.4",
     "webstomp-client": "1.2.0",
     <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/config/store.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/store.ts.ejs
@@ -6,6 +6,9 @@ import DevTools from './devtools';
 import errorMiddleware from './error-middleware';
 import notificationMiddleware from './notification-middleware';
 import loggerMiddleware from './logger-middleware';
+<%_ if (websocket === 'spring-websocket') { _%>
+import websocketMiddleware from './websocket-middleware';
+<%_ } _%>
 import { loadingBarMiddleware } from 'react-redux-loading-bar';
 
 const defaultMiddlewares = [
@@ -14,6 +17,9 @@ const defaultMiddlewares = [
   notificationMiddleware,
   promiseMiddleware(),
   loadingBarMiddleware(),
+  <%_ if (websocket === 'spring-websocket') { _%>
+  websocketMiddleware,
+  <%_ } _%>
   loggerMiddleware
 ];
 const composedMiddlewares = middlewares => process.env.NODE_ENV === 'development' ?

--- a/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
@@ -2,103 +2,107 @@ import * as SockJS from 'sockjs-client';
 import * as Stomp from 'webstomp-client';
 import { Observable, Observer } from 'rxjs';
 import { Storage } from 'react-jhipster';
+import { ACTION_TYPES } from 'app/modules/administration/administration.reducer';
 
-class WebsocketService {
-  stompClient = null;
-  subscriber = null;
-  connection: Promise<any>;
-  connectedPromise: any = null;
-  listener: Observable<any>;
-  listenerObserver: Observer<any>;
+let stompClient = null;
+
+let subscriber = null;
+let connection: Promise<any>;
+let connectedPromise: any = null;
+let listener: Observable<any>;
+let listenerObserver: Observer<any>;
+let alreadyConnectedOnce = false;
+
+const createConnection = (): Promise<any> => new Promise((resolve, reject) => (connectedPromise = resolve));
+
+const createListener = (): Observable<any> =>
+  new Observable(observer => {
+    listenerObserver = observer;
+  });
+
+const sendActivity = () => {
+  connection.then(() => {
+    stompClient.send(
+      '/topic/activity', // destination
+      JSON.stringify({ page: window.location.hash }), // body
+      {} // header
+    );
+  });
+};
+
+const subscribe = () => {
+  connection.then(() => {
+    subscriber = stompClient.subscribe('/topic/tracker', data => {
+      listenerObserver.next(JSON.parse(data.body));
+    });
+  });
+};
+
+const connect = () => {
+  if (connectedPromise !== null || alreadyConnectedOnce) {
+    // the connection is already being established
+    return;
+  }
+  connection = createConnection();
+  listener = createListener();
+
+  // building absolute path so that websocket doesn't fail when deploying with a context path
+  const loc = window.location;
+  let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
+  const authToken = Storage.local.get('jhi-authenticationToken') || Storage.session.get('jhi-authenticationToken');
+  if (authToken) {
+    url += '?access_token=' + authToken;
+  }
+  const socket = new SockJS(url);
+  stompClient = Stomp.over(socket);
+  const headers = {};
+  stompClient.connect(headers, () => {
+    connectedPromise('success');
+    connectedPromise = null;
+    subscribe();
+    sendActivity();
+    if (!alreadyConnectedOnce) {
+      window.onhashchange = () => {
+        sendActivity();
+      };
+      alreadyConnectedOnce = true;
+    }
+  });
+};
+
+const disconnect = () => {
+  if (stompClient !== null) {
+    stompClient.disconnect();
+    stompClient = null;
+  }
+  window.onhashchange = () => {};
   alreadyConnectedOnce = false;
+};
 
-  public connect() {
-    if (this.connectedPromise !== null || this.alreadyConnectedOnce) {
-      // the connection is already being established
-      return;
-    }
-    this.connection = this.createConnection();
-    this.listener = this.createListener();
+const receive = () => listener;
 
-    // building absolute path so that websocket doesn't fail when deploying with a context path
-    const loc = window.location;
-    let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
-    const authToken = Storage.local.get('jhi-authenticationToken') || Storage.session.get('jhi-authenticationToken');
-    if (authToken) {
-      url += '?access_token=' + authToken;
-    }
-    const socket = new SockJS(url);
-    this.stompClient = Stomp.over(socket);
-    const headers = {};
-    this.stompClient.connect(headers, () => {
-      this.connectedPromise('success');
-      this.connectedPromise = null;
-      this.sendActivity();
-      if (!this.alreadyConnectedOnce) {
-        window.onhashchange = () => {
-          this.sendActivity();
-        };
-        this.alreadyConnectedOnce = true;
-      }
-    });
+
+const unsubscribe = () => {
+  if (subscriber !== null) {
+    subscriber.unsubscribe();
   }
+  listener = createListener();
+};
 
-  disconnect() {
-    if (this.stompClient !== null) {
-      this.stompClient.disconnect();
-      this.stompClient = null;
-    }
-    window.onhashchange = () => {}
-    this.alreadyConnectedOnce = false;
-  }
-
-  receive() {
-    return this.listener;
-  }
-
-  sendActivity() {
-    if (this.stompClient !== null && this.stompClient.connected) {
-      this.stompClient.send(
-        '/topic/activity', // destination
-        JSON.stringify({ page: window.location.hash }), // body
-        {} // header
-      );
-    }
-  }
-
-  subscribe() {
-    this.connection.then(() => {
-      this.subscriber = this.stompClient.subscribe('/topic/tracker', data => {
-        this.listenerObserver.next(JSON.parse(data.body));
-      });
-    });
-  }
-
-  unsubscribe() {
-    if (this.subscriber !== null) {
-      this.subscriber.unsubscribe();
-    }
-    this.listener = this.createListener();
-  }
-
-  private createListener(): Observable<any> {
-    return new Observable(observer => {
-      this.listenerObserver = observer;
-    });
-  }
-
-  private createConnection(): Promise<any> {
-    return new Promise((resolve, reject) => (this.connectedPromise = resolve));
-  }
-}
-
-export const TrackerService = new WebsocketService();
-
-export default () => next => action => {
+export default store => next => action => {
   if (action.type === 'authentication/GET_SESSION_FULFILLED') {
-    TrackerService.connect();
+    connect();
+    if (!alreadyConnectedOnce) {
+      receive().subscribe(activity => {
+        return store.dispatch({
+          type: ACTION_TYPES.WEBSOCKET_MESSAGE,
+          payload: activity
+        });
+      });
+    }
   } else if (action.type === 'authentication/GET_SESSION_REJECTED') {
-    TrackerService.disconnect();
+    unsubscribe();
+    disconnect();
   }
   return next(action);
 };

--- a/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
@@ -1,0 +1,104 @@
+import * as SockJS from 'sockjs-client';
+import * as Stomp from 'webstomp-client';
+import { Observable, Observer } from 'rxjs';
+import { Storage } from 'react-jhipster';
+
+class WebsocketService {
+  stompClient = null;
+  subscriber = null;
+  connection: Promise<any>;
+  connectedPromise: any = null;
+  listener: Observable<any>;
+  listenerObserver: Observer<any>;
+  alreadyConnectedOnce = false;
+
+  public connect() {
+    if (this.connectedPromise !== null || this.alreadyConnectedOnce) {
+      // the connection is already being established
+      return;
+    }
+    this.connection = this.createConnection();
+    this.listener = this.createListener();
+
+    // building absolute path so that websocket doesn't fail when deploying with a context path
+    const loc = window.location;
+    let url = '//' + loc.host + loc.pathname + 'websocket/tracker';
+    const authToken = Storage.local.get('jhi-authenticationToken') || Storage.session.get('jhi-authenticationToken');
+    if (authToken) {
+      url += '?access_token=' + authToken;
+    }
+    const socket = new SockJS(url);
+    this.stompClient = Stomp.over(socket);
+    const headers = {};
+    this.stompClient.connect(headers, () => {
+      this.connectedPromise('success');
+      this.connectedPromise = null;
+      this.sendActivity();
+      if (!this.alreadyConnectedOnce) {
+        window.onhashchange = () => {
+          this.sendActivity();
+        };
+        this.alreadyConnectedOnce = true;
+      }
+    });
+  }
+
+  disconnect() {
+    if (this.stompClient !== null) {
+      this.stompClient.disconnect();
+      this.stompClient = null;
+    }
+    window.onhashchange = () => {}
+    this.alreadyConnectedOnce = false;
+  }
+
+  receive() {
+    return this.listener;
+  }
+
+  sendActivity() {
+    if (this.stompClient !== null && this.stompClient.connected) {
+      this.stompClient.send(
+        '/topic/activity', // destination
+        JSON.stringify({ page: window.location.hash }), // body
+        {} // header
+      );
+    }
+  }
+
+  subscribe() {
+    this.connection.then(() => {
+      this.subscriber = this.stompClient.subscribe('/topic/tracker', data => {
+        this.listenerObserver.next(JSON.parse(data.body));
+      });
+    });
+  }
+
+  unsubscribe() {
+    if (this.subscriber !== null) {
+      this.subscriber.unsubscribe();
+    }
+    this.listener = this.createListener();
+  }
+
+  private createListener(): Observable<any> {
+    return new Observable(observer => {
+      this.listenerObserver = observer;
+    });
+  }
+
+  private createConnection(): Promise<any> {
+    return new Promise((resolve, reject) => (this.connectedPromise = resolve));
+  }
+}
+
+export const TrackerService = new WebsocketService();
+
+export default () => next => action => {
+  if (action.type === 'authentication/GET_SESSION_FULFILLED') {
+    TrackerService.connect();
+  } else if (action.type === 'authentication/GET_SESSION_REJECTED') {
+    TrackerService.disconnect();
+  }
+  return next(action);
+};

--- a/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
@@ -2,7 +2,10 @@ import * as SockJS from 'sockjs-client';
 import * as Stomp from 'webstomp-client';
 import { Observable, Observer } from 'rxjs';
 import { Storage } from 'react-jhipster';
-import { ACTION_TYPES } from 'app/modules/administration/administration.reducer';
+
+import { ACTION_TYPES as ADMIN_ACTIONS } from 'app/modules/administration/administration.reducer';
+import { ACTION_TYPES as AUTH_ACTIONS } from 'app/shared/reducers/authentication';
+import { SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
 
 let stompClient = null;
 
@@ -90,17 +93,17 @@ const unsubscribe = () => {
 };
 
 export default store => next => action => {
-  if (action.type === 'authentication/GET_SESSION_FULFILLED') {
+  if (action.type === SUCCESS(AUTH_ACTIONS.GET_SESSION)) {
     connect();
     if (!alreadyConnectedOnce) {
       receive().subscribe(activity => {
         return store.dispatch({
-          type: ACTION_TYPES.WEBSOCKET_MESSAGE,
+          type: ADMIN_ACTIONS.WEBSOCKET_ACTIVITY_MESSAGE,
           payload: activity
         });
       });
     }
-  } else if (action.type === 'authentication/GET_SESSION_REJECTED') {
+  } else if (action.type === FAILURE(AUTH_ACTIONS.GET_SESSION)) {
     unsubscribe();
     disconnect();
   }

--- a/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
@@ -1,6 +1,7 @@
 import * as SockJS from 'sockjs-client';
 import * as Stomp from 'webstomp-client';
-import { Observable, Observer } from 'rxjs';
+import { Observable } from 'rxjs/Observable'; // tslint:disable-line
+import { Observer } from 'rxjs/Observer'; // tslint:disable-line
 import { Storage } from 'react-jhipster';
 
 import { ACTION_TYPES as ADMIN_ACTIONS } from 'app/modules/administration/administration.reducer';

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
@@ -13,7 +13,7 @@ export const ACTION_TYPES = {
   FETCH_ENV: 'administration/FETCH_ENV',
   FETCH_AUDITS: 'administration/FETCH_AUDITS',
   <%_ if (websocket === 'spring-websocket') { _%>
-  WEBSOCKET_MESSAGE: 'administration/WEBSOCKET_MESSAGE'
+  WEBSOCKET_ACTIVITY_MESSAGE: 'administration/WEBSOCKET_ACTIVITY_MESSAGE'
   <%_ } _%>
 };
 
@@ -141,7 +141,8 @@ export default (state = initialState, action) => {
         loading: false,
         health: action.payload.data
       };
-     case ACTION_TYPES.WEBSOCKET_MESSAGE:
+     <%_ if (websocket === 'spring-websocket') { _%>
+     case ACTION_TYPES.WEBSOCKET_ACTIVITY_MESSAGE:
        // filter out activities from the same session
        const uniqueActivities = state.tracker.activities.filter(activity => activity.sessionId !== action.payload.sessionId);
        // remove any activities with the page of logout
@@ -150,6 +151,7 @@ export default (state = initialState, action) => {
          ...state,
          tracker: { activities }
        };
+     <%_ } _%>
     default:
       return state;
   }

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
@@ -11,7 +11,10 @@ export const ACTION_TYPES = {
   FETCH_THREAD_DUMP: 'administration/FETCH_THREAD_DUMP',
   FETCH_CONFIGURATIONS: 'administration/FETCH_CONFIGURATIONS',
   FETCH_ENV: 'administration/FETCH_ENV',
-  FETCH_AUDITS: 'administration/FETCH_AUDITS'
+  FETCH_AUDITS: 'administration/FETCH_AUDITS',
+  <%_ if (websocket === 'spring-websocket') { _%>
+  WEBSOCKET_MESSAGE: 'administration/WEBSOCKET_MESSAGE'
+  <%_ } _%>
 };
 
 const initialState = {
@@ -31,6 +34,11 @@ const initialState = {
     env: {}
   },
   audits: [],
+  <%_ if (websocket === 'spring-websocket') { _%>
+  tracker: {
+    activities: []
+  },
+  <%_ } _%>
   totalItems: 0
 };
 
@@ -133,6 +141,15 @@ export default (state = initialState, action) => {
         loading: false,
         health: action.payload.data
       };
+     case ACTION_TYPES.WEBSOCKET_MESSAGE:
+       // filter out activities from the same session
+       const uniqueActivities = state.tracker.activities.filter(activity => activity.sessionId !== action.payload.sessionId);
+       // remove any activities with the page of logout
+       const activities = [...uniqueActivities, action.payload].filter(activity => activity.page !== 'logout' );
+       return {
+         ...state,
+         tracker: { activities }
+       };
     default:
       return state;
   }

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/index.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/index.tsx.ejs
@@ -13,10 +13,16 @@ import Docs from './docs/docs';
 <%_ if (applicationType === 'gateway') { _%>
 import Gateway from './gateway/gateway';
 <%_ } _%>
+<%_ if (websocket === 'spring-websocket') { _%>
+import Tracker from './tracker/tracker';
+<%_ } _%>
 
 const Routes = ({ match }) => (
   <div>
     <Route path={`${match.url}/user-management`} component={UserManagement} />
+<%_ if (websocket === 'spring-websocket') { _%>
+    <Route exact path={`${match.url}/tracker`} component={Tracker} />
+<%_ } _%>
     <Route exact path={`${match.url}/health`} component={Health} />
 <%_ if (applicationType === 'gateway') { _%>
     <Route exact path={`${match.url}/gateway`} component={Gateway} />

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/tracker/tracker.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/tracker/tracker.tsx.ejs
@@ -1,0 +1,95 @@
+import * as React from 'react';
+import { Translate } from 'react-jhipster';
+
+import { TrackerService } from 'app/config/websocket-middleware';
+
+export interface ITrackerPageProps {
+  tracker: any;
+}
+
+export interface ITrackerPageState {
+  activities: any[];
+}
+
+export default class TrackerPage extends React.Component<ITrackerPageProps, ITrackerPageState> {
+  state: ITrackerPageState = {
+    activities: []
+  };
+
+  componentDidMount() {
+    TrackerService.subscribe();
+    TrackerService.receive().subscribe(activity => {
+      this.showActivity(activity);
+    });
+  }
+
+  componentWillUnmount() {
+    TrackerService.unsubscribe();
+  }
+
+  showActivity(activity: any) {
+    let existingActivity = false;
+    const activities = this.state.activities;
+    for (let index = 0; index < activities.length; index++) {
+      if (activities[index].sessionId === activity.sessionId) {
+        existingActivity = true;
+        if (activity.page === 'logout') {
+          activities.splice(index, 1);
+        } else {
+          activities[index] = activity;
+        }
+      }
+    }
+    if (!existingActivity && (activity.page !== 'logout')) {
+      activities.push(activity);
+    }
+    this.setState({ activities });
+  }
+
+  render() {
+    const activities = this.state.activities;
+    return (
+      <div>
+        <h2>
+          <Translate contentKey="tracker.title">Real-time user activities</Translate>
+        </h2>
+        <table className="table table-sm table-striped table-bordered">
+          <thead>
+            <tr>
+              <th>
+                <span>
+                  <Translate contentKey="tracker.table.userlogin">User</Translate>
+                </span>
+              </th>
+              <th>
+                <span>
+                  <Translate contentKey="tracker.table.ipaddress">IP Address</Translate>
+                </span>
+              </th>
+              <th>
+                <span>
+                  <Translate contentKey="tracker.table.page">Current page</Translate>
+                </span>
+              </th>
+              <th>
+                <span>
+                  <Translate contentKey="tracker.table.time">Time</Translate>
+                </span>
+              </th>
+            </tr>
+          </thead>
+          <tbody>
+            {activities.map((activity, i) => (
+              <tr key={`log-row-${i}`}>
+                <td>{activity.userLogin}</td>
+                <td>{activity.ipAddress}</td>
+                <td>{activity.page}</td>
+                <td>{activity.time}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    );
+  }
+}

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/tracker/tracker.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/tracker/tracker.tsx.ejs
@@ -1,53 +1,14 @@
 import * as React from 'react';
 import { Translate } from 'react-jhipster';
-
-import { TrackerService } from 'app/config/websocket-middleware';
+import { connect } from 'react-redux';
 
 export interface ITrackerPageProps {
-  tracker: any;
-}
-
-export interface ITrackerPageState {
   activities: any[];
 }
 
-export default class TrackerPage extends React.Component<ITrackerPageProps, ITrackerPageState> {
-  state: ITrackerPageState = {
-    activities: []
-  };
-
-  componentDidMount() {
-    TrackerService.subscribe();
-    TrackerService.receive().subscribe(activity => {
-      this.showActivity(activity);
-    });
-  }
-
-  componentWillUnmount() {
-    TrackerService.unsubscribe();
-  }
-
-  showActivity(activity: any) {
-    let existingActivity = false;
-    const activities = this.state.activities;
-    for (let index = 0; index < activities.length; index++) {
-      if (activities[index].sessionId === activity.sessionId) {
-        existingActivity = true;
-        if (activity.page === 'logout') {
-          activities.splice(index, 1);
-        } else {
-          activities[index] = activity;
-        }
-      }
-    }
-    if (!existingActivity && (activity.page !== 'logout')) {
-      activities.push(activity);
-    }
-    this.setState({ activities });
-  }
-
+export class TrackerPage extends React.Component<ITrackerPageProps> {
   render() {
-    const activities = this.state.activities;
+    const activities = this.props.activities;
     return (
       <div>
         <h2>
@@ -93,3 +54,9 @@ export default class TrackerPage extends React.Component<ITrackerPageProps, ITra
     );
   }
 }
+
+const mapStateToProps = ({ administration }) => ({
+  activities: administration.tracker.activities
+});
+
+export default connect(mapStateToProps)(TrackerPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/tracker/tracker.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/tracker/tracker.tsx.ejs
@@ -6,10 +6,7 @@ export interface ITrackerPageProps {
   activities: any[];
 }
 
-export class TrackerPage extends React.Component<ITrackerPageProps> {
-  render() {
-    const activities = this.props.activities;
-    return (
+export const TrackerPage = ({ activities }:ITrackerPageProps) => (
       <div>
         <h2>
           <Translate contentKey="tracker.title">Real-time user activities</Translate>
@@ -52,8 +49,6 @@ export class TrackerPage extends React.Component<ITrackerPageProps> {
         </table>
       </div>
     );
-  }
-}
 
 const mapStateToProps = ({ administration }) => ({
   activities: administration.tracker.activities

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
@@ -9,9 +9,11 @@ import {
 import {
   FaHome, FaThList, FaUserPlus, FaUser, <%_ if (enableTranslation) { _%>FaFlag,<%_ } _%> FaHeart,
   FaList, FaTasks, FaDashboard, FaBook, FaWrench, FaSignIn, FaSignOut,
-  FaClockO, FaEye, FaHddO,
+  FaClockO, FaHddO,
   // tslint:disable-next-line
   FaRoad,
+  // tslint:disable-next-line
+  FaEye,
   // tslint:disable-next-line
   FaAsterisk,
   // tslint:disable-next-line

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
@@ -9,7 +9,7 @@ import {
 import {
   FaHome, FaThList, FaUserPlus, FaUser, <%_ if (enableTranslation) { _%>FaFlag,<%_ } _%> FaHeart,
   FaList, FaTasks, FaDashboard, FaBook, FaWrench, FaSignIn, FaSignOut,
-  FaClockO, FaHddO,
+  FaClockO, FaEye, FaHddO,
   // tslint:disable-next-line
   FaRoad,
   // tslint:disable-next-line
@@ -81,7 +81,7 @@ export class Header extends React.Component<IHeaderProps, IHeaderState> {
       <DropdownItem tag={Link} key="user-management" to="/admin/user-management"><FaUser /> User Management</DropdownItem>,
     <%_ } _%>
     <%_ if (websocket === 'spring-websocket') { _%>
-        /* TOD: tracker menu */
+      <DropdownItem tag={Link} key="tracker" to="/admin/tracker"><FaEye /> Tracker</DropdownItem>,
     <%_ } _%>
       <DropdownItem tag={Link} key="metrics" to="/admin/metrics"><FaDashboard /> Metrics</DropdownItem>,
       <DropdownItem tag={Link} key="health" to="/admin/health"><FaHeart /> Health</DropdownItem>,

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/administration.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/administration.reducer.spec.ts.ejs
@@ -1,0 +1,213 @@
+import { expect } from 'chai';
+import { REQUEST, FAILURE, SUCCESS } from 'app/shared/reducers/action-type.util';
+
+import administration, { ACTION_TYPES } from 'app/modules/administration/administration.reducer';
+
+describe('User managment reducer tests', () => {
+  function isEmpty(element): boolean {
+    if (element instanceof Array) {
+      return element.length === 0;
+    } else {
+      return Object.keys(element).length === 0;
+    }
+  }
+
+  function testInitialState(state) {
+    expect(state).to.contain({
+      loading: false,
+      errorMessage: null,
+      totalItems: 0
+    });
+    expect(isEmpty(state.gateway.routes));
+    expect(isEmpty(state.logs.loggers));
+    expect(isEmpty(state.threadDump));
+    expect(isEmpty(state.audits));
+    <%_ if (websocket === 'spring-websocket') { _%>
+    expect(isEmpty(state.tracker.activities));
+    <%_ } _%>
+  }
+
+  function testMultipleTypes(types, payload, testFunction) {
+    types.forEach(e => {
+      testFunction(administration(undefined, { type: e, payload }));
+    });
+  }
+
+  describe('Common', () => {
+    it('should return the initial state', () => {
+      testInitialState(administration(undefined, {}));
+    });
+  });
+
+  describe('Requests', () => {
+    it('should set state to loading', () => {
+      testMultipleTypes(
+        [
+          REQUEST(ACTION_TYPES.FETCH_GATEWAY_ROUTE),
+          REQUEST(ACTION_TYPES.FETCH_LOGS),
+          REQUEST(ACTION_TYPES.FETCH_HEALTH),
+          REQUEST(ACTION_TYPES.FETCH_METRICS),
+          REQUEST(ACTION_TYPES.FETCH_THREAD_DUMP),
+          REQUEST(ACTION_TYPES.FETCH_CONFIGURATIONS),
+          REQUEST(ACTION_TYPES.FETCH_ENV),
+          REQUEST(ACTION_TYPES.FETCH_AUDITS)
+        ],
+        {},
+        state => {
+          expect(state).to.contain({
+            errorMessage: null,
+            loading: true
+          });
+        }
+      );
+    });
+  });
+
+  describe('Failures', () => {
+    it('should set state to failed and put an error message in errorMessage', () => {
+      testMultipleTypes(
+        [
+          FAILURE(ACTION_TYPES.FETCH_GATEWAY_ROUTE),
+          FAILURE(ACTION_TYPES.FETCH_LOGS),
+          FAILURE(ACTION_TYPES.FETCH_HEALTH),
+          FAILURE(ACTION_TYPES.FETCH_METRICS),
+          FAILURE(ACTION_TYPES.FETCH_THREAD_DUMP),
+          FAILURE(ACTION_TYPES.FETCH_CONFIGURATIONS),
+          FAILURE(ACTION_TYPES.FETCH_ENV),
+          FAILURE(ACTION_TYPES.FETCH_AUDITS)
+        ],
+        'something happened',
+        state => {
+          expect(state).to.contain({
+            loading: false,
+            errorMessage: 'something happened'
+          });
+        }
+      );
+    });
+  });
+
+  describe('Success', () => {
+    it('should update state according to a successful fetch gateway routes request', () => {
+      const payload = { data: [] };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_GATEWAY_ROUTE), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        gateway: { routes: payload.data }
+      });
+    });
+
+    it('should update state according to a successful fetch logs request', () => {
+      const payload = { data: [{ name: 'ROOT', level: 'DEBUG' }] };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_LOGS), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        logs: { loggers: payload.data }
+      });
+    });
+
+    it('should update state according to a successful fetch health request', () => {
+      const payload = { data: { status: 'UP' } };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_HEALTH), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        health: payload.data
+      });
+    });
+
+    it('should update state according to a successful fetch metrics request', () => {
+      const payload = { data: { version: '3.1.3', gauges: {} } };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_METRICS), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        metrics: payload.data
+      });
+    });
+
+    it('should update state according to a successful fetch thread dump request', () => {
+      const payload = { data: [{ threadName: 'hz.gateway.cached.thread-6', threadId: 9266 }] };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_THREAD_DUMP), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        threadDump: payload.data
+      });
+    });
+
+    it('should update state according to a successful fetch configurations request', () => {
+      const payload = { data: { contexts: { jhipster: { beans: {} } } } };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_CONFIGURATIONS), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        configuration: {
+          configProps: payload.data,
+          env: {}
+        }
+      });
+    });
+
+    it('should update state according to a successful fetch env request', () => {
+      const payload = { data: { activeProfiles: ['swagger', 'dev'] } };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_ENV), payload });
+
+      expect(toTest).to.deep.include({
+        loading: false,
+        configuration: {
+          configProps: {},
+          env: payload.data
+        }
+      });
+    });
+
+    it('should update state according to a successful fetch audits request', () => {
+      const headers = { ['x-total-count']: 1 };
+      const payload = { data: [{ id: 1, userLogin: 'admin' }], headers };
+      const toTest = administration(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_AUDITS), payload });
+
+      expect(toTest).to.contain({
+        loading: false,
+        audits: payload.data,
+        totalItems: headers['x-total-count']
+      });
+    });
+  });
+<%_ if (websocket === 'spring-websocket') { _%>
+  describe('Websocket Message Handling', () => {
+    it('should update state according to a successful websocket message receipt', () => {
+      const payload = { id: 1, userLogin: 'admin', page: 'home', sessionId: 'abc123' };
+      const toTest = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload });
+
+      expect(toTest).to.deep.include({
+        tracker: { activities: [payload] }
+      });
+    });
+
+    it('should update state according to a successful websocket message receipt - only one activity per session', () => {
+      const firstPayload = { id: 1, userLogin: 'admin', page: 'home', sessionId: 'abc123' };
+      const secondPayload = { id: 1, userLogin: 'admin', page: 'user-management', sessionId: 'abc123' };
+      const firstState = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: firstPayload });
+      const secondState = administration(firstState, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: secondPayload });
+
+      expect(secondState).to.deep.include({
+        tracker: { activities: [secondPayload] }
+      });
+    });
+
+    it('should update state according to a successful websocket message receipt - remove logged out sessions', () => {
+      const firstPayload = { id: 1, userLogin: 'admin', page: 'home', sessionId: 'abc123' };
+      const secondPayload = { id: 1, userLogin: 'admin', page: 'logout', sessionId: 'abc123' };
+      const firstState = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: firstPayload });
+      const secondState = administration(firstState, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: secondPayload });
+
+      expect(secondState).to.deep.include({
+        tracker: { activities: [] }
+      });
+    });
+  });
+<%_ } _%>
+});

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/administration.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/administration.reducer.spec.ts.ejs
@@ -226,148 +226,142 @@ describe('Administration reducer tests', () => {
     });
   });
 <%_ } _%>
-  describe('Administration actions', () => {
+  describe('Actions', () => {
     let store;
 
+    const resolvedObject = { value: 'whatever' };
     beforeEach(() => {
       const mockStore = configureStore([thunk, promiseMiddleware()]);
       store = mockStore({});
+      axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+      axios.put = sinon.stub().returns(Promise.resolve(resolvedObject));
     });
-
-    describe('getSystemProperties', () => {
-      const resolvedObject = { value: 'whatever' };
-      beforeEach(() => {
-        axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
-        axios.put = sinon.stub().returns(Promise.resolve(resolvedObject));
-      });
-
-      it('dispatches FETCH_GATEWAY_ROUTE_PENDING and FETCH_GATEWAY_ROUTE_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_GATEWAY_ROUTE)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_GATEWAY_ROUTE),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(gatewayRoutes()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_HEALTH_PENDING and FETCH_HEALTH_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_HEALTH)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_HEALTH),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(systemHealth()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_METRICS_PENDING and FETCH_METRICS_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_METRICS)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_METRICS),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(systemMetrics()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_THREAD_DUMP_PENDING and FETCH_THREAD_DUMP_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_THREAD_DUMP)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_THREAD_DUMP),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(systemThreadDump()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_LOGS_PENDING and FETCH_LOGS_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_LOGS)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_LOGS),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(getLoggers()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_LOGS_CHANGE_LEVEL_PENDING and FETCH_LOGS_CHANGE_LEVEL_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL),
-            payload: resolvedObject
-          },
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_LOGS)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_LOGS),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(changeLogLevel('ROOT', 'DEBUG')).then(() => expect(store.getActions()).to.deep.equal(expectedActions));
-      });
-      it('dispatches FETCH_CONFIGURATIONS_PENDING and FETCH_CONFIGURATIONS_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_CONFIGURATIONS)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_CONFIGURATIONS),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(getConfigurations()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_ENV_PENDING and FETCH_ENV_FULFILLED actions', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_ENV)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_ENV),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(getEnv()).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_AUDITS_PENDING and FETCH_AUDITS_FULFILLED actions with pagination variables - no sort', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_AUDITS)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_AUDITS),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(getAudits(1, 10, null, Date.now(), Date.now())).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
-      it('dispatches FETCH_AUDITS_PENDING and FETCH_AUDITS_FULFILLED actions with pagination variables - no dates', async () => {
-        const expectedActions = [
-          {
-            type: REQUEST(ACTION_TYPES.FETCH_AUDITS)
-          },
-          {
-            type: SUCCESS(ACTION_TYPES.FETCH_AUDITS),
-            payload: resolvedObject
-          }
-        ];
-        await store.dispatch(getAudits(1, 10, 'id,desc', null, null)).then(() => expect(store.getActions()).to.eql(expectedActions));
-      });
+    it('dispatches FETCH_GATEWAY_ROUTE_PENDING and FETCH_GATEWAY_ROUTE_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_GATEWAY_ROUTE)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_GATEWAY_ROUTE),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(gatewayRoutes()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_HEALTH_PENDING and FETCH_HEALTH_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_HEALTH)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_HEALTH),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(systemHealth()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_METRICS_PENDING and FETCH_METRICS_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_METRICS)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_METRICS),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(systemMetrics()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_THREAD_DUMP_PENDING and FETCH_THREAD_DUMP_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_THREAD_DUMP)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_THREAD_DUMP),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(systemThreadDump()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_LOGS_PENDING and FETCH_LOGS_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_LOGS)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_LOGS),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getLoggers()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_LOGS_CHANGE_LEVEL_PENDING and FETCH_LOGS_CHANGE_LEVEL_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL),
+          payload: resolvedObject
+        },
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_LOGS)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_LOGS),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(changeLogLevel('ROOT', 'DEBUG')).then(() => expect(store.getActions()).to.deep.equal(expectedActions));
+    });
+    it('dispatches FETCH_CONFIGURATIONS_PENDING and FETCH_CONFIGURATIONS_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_CONFIGURATIONS)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_CONFIGURATIONS),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getConfigurations()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_ENV_PENDING and FETCH_ENV_FULFILLED actions', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_ENV)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_ENV),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getEnv()).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_AUDITS_PENDING and FETCH_AUDITS_FULFILLED actions with pagination variables - no sort', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_AUDITS)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_AUDITS),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getAudits(1, 10, null, Date.now(), Date.now())).then(() => expect(store.getActions()).to.eql(expectedActions));
+    });
+    it('dispatches FETCH_AUDITS_PENDING and FETCH_AUDITS_FULFILLED actions with pagination variables - no dates', async () => {
+      const expectedActions = [
+        {
+          type: REQUEST(ACTION_TYPES.FETCH_AUDITS)
+        },
+        {
+          type: SUCCESS(ACTION_TYPES.FETCH_AUDITS),
+          payload: resolvedObject
+        }
+      ];
+      await store.dispatch(getAudits(1, 10, 'id,desc', null, null)).then(() => expect(store.getActions()).to.eql(expectedActions));
     });
   });
 });

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/administration.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/administration.reducer.spec.ts.ejs
@@ -1,9 +1,25 @@
 import { expect } from 'chai';
+import configureStore from 'redux-mock-store';
+import promiseMiddleware from 'redux-promise-middleware';
+import axios from 'axios';
+import thunk from 'redux-thunk';
+import * as sinon from 'sinon';
+
 import { REQUEST, FAILURE, SUCCESS } from 'app/shared/reducers/action-type.util';
+import administration, {
+  ACTION_TYPES,
+  gatewayRoutes,
+  systemHealth,
+  systemMetrics,
+  systemThreadDump,
+  getLoggers,
+  changeLogLevel,
+  getConfigurations,
+  getEnv,
+  getAudits
+} from 'app/modules/administration/administration.reducer';
 
-import administration, { ACTION_TYPES } from 'app/modules/administration/administration.reducer';
-
-describe('User managment reducer tests', () => {
+describe('Administration reducer tests', () => {
   function isEmpty(element): boolean {
     if (element instanceof Array) {
       return element.length === 0;
@@ -180,7 +196,7 @@ describe('User managment reducer tests', () => {
   describe('Websocket Message Handling', () => {
     it('should update state according to a successful websocket message receipt', () => {
       const payload = { id: 1, userLogin: 'admin', page: 'home', sessionId: 'abc123' };
-      const toTest = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload });
+      const toTest = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_ACTIVITY_MESSAGE, payload });
 
       expect(toTest).to.deep.include({
         tracker: { activities: [payload] }
@@ -190,8 +206,8 @@ describe('User managment reducer tests', () => {
     it('should update state according to a successful websocket message receipt - only one activity per session', () => {
       const firstPayload = { id: 1, userLogin: 'admin', page: 'home', sessionId: 'abc123' };
       const secondPayload = { id: 1, userLogin: 'admin', page: 'user-management', sessionId: 'abc123' };
-      const firstState = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: firstPayload });
-      const secondState = administration(firstState, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: secondPayload });
+      const firstState = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_ACTIVITY_MESSAGE, payload: firstPayload });
+      const secondState = administration(firstState, { type: ACTION_TYPES.WEBSOCKET_ACTIVITY_MESSAGE, payload: secondPayload });
 
       expect(secondState).to.deep.include({
         tracker: { activities: [secondPayload] }
@@ -201,8 +217,8 @@ describe('User managment reducer tests', () => {
     it('should update state according to a successful websocket message receipt - remove logged out sessions', () => {
       const firstPayload = { id: 1, userLogin: 'admin', page: 'home', sessionId: 'abc123' };
       const secondPayload = { id: 1, userLogin: 'admin', page: 'logout', sessionId: 'abc123' };
-      const firstState = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: firstPayload });
-      const secondState = administration(firstState, { type: ACTION_TYPES.WEBSOCKET_MESSAGE, payload: secondPayload });
+      const firstState = administration(undefined, { type: ACTION_TYPES.WEBSOCKET_ACTIVITY_MESSAGE, payload: firstPayload });
+      const secondState = administration(firstState, { type: ACTION_TYPES.WEBSOCKET_ACTIVITY_MESSAGE, payload: secondPayload });
 
       expect(secondState).to.deep.include({
         tracker: { activities: [] }
@@ -210,4 +226,148 @@ describe('User managment reducer tests', () => {
     });
   });
 <%_ } _%>
+  describe('Administration actions', () => {
+    let store;
+
+    beforeEach(() => {
+      const mockStore = configureStore([thunk, promiseMiddleware()]);
+      store = mockStore({});
+    });
+
+    describe('getSystemProperties', () => {
+      const resolvedObject = { value: 'whatever' };
+      beforeEach(() => {
+        axios.get = sinon.stub().returns(Promise.resolve(resolvedObject));
+        axios.put = sinon.stub().returns(Promise.resolve(resolvedObject));
+      });
+
+      it('dispatches FETCH_GATEWAY_ROUTE_PENDING and FETCH_GATEWAY_ROUTE_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_GATEWAY_ROUTE)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_GATEWAY_ROUTE),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(gatewayRoutes()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_HEALTH_PENDING and FETCH_HEALTH_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_HEALTH)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_HEALTH),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(systemHealth()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_METRICS_PENDING and FETCH_METRICS_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_METRICS)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_METRICS),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(systemMetrics()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_THREAD_DUMP_PENDING and FETCH_THREAD_DUMP_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_THREAD_DUMP)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_THREAD_DUMP),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(systemThreadDump()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_LOGS_PENDING and FETCH_LOGS_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_LOGS)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_LOGS),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(getLoggers()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_LOGS_CHANGE_LEVEL_PENDING and FETCH_LOGS_CHANGE_LEVEL_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL),
+            payload: resolvedObject
+          },
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_LOGS)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_LOGS),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(changeLogLevel('ROOT', 'DEBUG')).then(() => expect(store.getActions()).to.deep.equal(expectedActions));
+      });
+      it('dispatches FETCH_CONFIGURATIONS_PENDING and FETCH_CONFIGURATIONS_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_CONFIGURATIONS)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_CONFIGURATIONS),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(getConfigurations()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_ENV_PENDING and FETCH_ENV_FULFILLED actions', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_ENV)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_ENV),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(getEnv()).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_AUDITS_PENDING and FETCH_AUDITS_FULFILLED actions with pagination variables - no sort', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_AUDITS)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_AUDITS),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(getAudits(1, 10, null, Date.now(), Date.now())).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+      it('dispatches FETCH_AUDITS_PENDING and FETCH_AUDITS_FULFILLED actions with pagination variables - no dates', async () => {
+        const expectedActions = [
+          {
+            type: REQUEST(ACTION_TYPES.FETCH_AUDITS)
+          },
+          {
+            type: SUCCESS(ACTION_TYPES.FETCH_AUDITS),
+            payload: resolvedObject
+          }
+        ];
+        await store.dispatch(getAudits(1, 10, 'id,desc', null, null)).then(() => expect(store.getActions()).to.eql(expectedActions));
+      });
+    });
+  });
 });


### PR DESCRIPTION
- add Tracker frontend
- add `tracker` in Administration reducer for storing user activities
- add Administration reducer test
- add websocket middleware
- add sockjs and webstomp to package.json

The standard place for websockets in a React+Redux project seems to be in a middleware, a developer normally wants access to the redux store when receiving messages.  The tracker page is now working and uses the new `tracker` key in the Administration reducers for keeping track of user activities.

I'm still new to React on web so there are probably things I'm missing (ex: I couldn't figure out how to subscribe to the route changes so I used `window.onhashchange` to send pages to the tracker).

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
