### PR TITLE
Angular: Remove angular2-moment

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -34,7 +34,6 @@
     "@angular/platform-browser-dynamic": "5.2.0",
     "@angular/router": "5.2.0",
     "@ng-bootstrap/ng-bootstrap": "1.0.0",
-    "angular2-moment": "1.8.0",
     "bootstrap": "4.0.0",
     "core-js": "2.4.1",
     "font-awesome": "4.7.0",

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
@@ -24,7 +24,6 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgJhipsterModule } from 'ng-jhipster';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { CookieModule } from 'ngx-cookie';
-import { MomentModule } from 'angular2-moment';
 
 @NgModule({
     imports: [
@@ -38,7 +37,6 @@ import { MomentModule } from 'angular2-moment';
             <%_ } _%>
         }),
         InfiniteScrollModule,
-        MomentModule,
         CookieModule.forRoot()
     ],
     exports: [

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { NgbDateAdapter } from '@ng-bootstrap/ng-bootstrap';
-import { DateFormatPipe, ParsePipe } from 'angular2-moment';
 
 import { NgbDateMomentAdapter } from './util/datepicker-adapter';
 import {
@@ -47,7 +46,7 @@ import {
         <%_ } _%>
         HasAnyAuthorityDirective
     ],
-    providers: [ ParsePipe, DateFormatPipe,
+    providers: [
         { provide: NgbDateAdapter, useClass: NgbDateMomentAdapter},
     ],
     <%_ if (authenticationType !== 'oauth2') { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-dialog.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-dialog.component.ts.ejs
@@ -34,7 +34,7 @@ import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs/Observable';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 <%_ if ( fieldsContainInstant || fieldsContainZonedDateTime ) { _%>
-import { DateFormatPipe, ParsePipe } from 'angular2-moment';
+import * as moment from 'moment';
 import { DATE_TIME_FORMAT } from 'app/shared/constants/input.constants';
 <%_ } _%>
 import { JhiEventManager<% if (queries && queries.length > 0) { %>, JhiAlertService<% } %><% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
@@ -106,10 +106,6 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
                 }
             }
         }); _%>
-        <%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
-        private stringToMomentPipe: ParsePipe,
-        private momentToStringPipe: DateFormatPipe,
-        <%_ } _%>
         <%_ if (fieldsContainImageBlob) { _%>
         private elementRef: ElementRef,
         <%_ } _%>
@@ -154,7 +150,7 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
             const fieldName = fields[ idx ].fieldName;
             const fieldType = fields[idx].fieldType;
             if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType)) { _%>
-                this.<%= entityInstance %>.<%= fieldName %> = this.stringToMomentPipe.transform(this.<%= fieldName %>, DATE_TIME_FORMAT);
+                this.<%= entityInstance %>.<%= fieldName %> = moment(this.<%= fieldName %>, DATE_TIME_FORMAT);
         <%_ }
         } _%>
         if (this.<%= entityInstance %>.id !== undefined) {
@@ -220,7 +216,7 @@ export class <%= entityAngularName %>DialogComponent implements OnInit {
         const fieldName = fields[idx].fieldName;
         const fieldType = fields[idx].fieldType;
         if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-        this.<%= fieldName %> = this.momentToStringPipe.transform(<%= entityInstance %>.<%= fieldName %>);
+        this.<%= fieldName %> = moment(<%= entityInstance %>.<%= fieldName %>).format();
      <%_ } } _%>
     }
 }

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-dialog.component.spec.ts.ejs
@@ -25,7 +25,6 @@ import { HttpResponse } from '@angular/common/http';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Observable } from 'rxjs/Observable';
 import { JhiEventManager } from 'ng-jhipster';
-import { DateFormatPipe, ParsePipe } from 'angular2-moment';
 
 import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
 import { <%= entityAngularName %>DialogComponent } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>-dialog.component';
@@ -67,7 +66,7 @@ describe('Component Tests', () => {
             TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
                 declarations: [<%= entityAngularName %>DialogComponent],
-                providers: [ParsePipe, DateFormatPipe,
+                providers: [
     <%_ Object.keys(differentRelationships).forEach(key => {
         if (differentRelationships[key].some(rel => rel.relationshipType !== 'one-to-many')) {
             const uniqueRel = differentRelationships[key][0];

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -22,7 +22,6 @@ _%>
 /* tslint:disable max-line-length */
 import { TestBed, getTestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { DateFormatPipe, ParsePipe } from 'angular2-moment';
 import { <%= entityAngularName %>Service } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.service';
 import { <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { SERVER_API_URL } from 'app/app.constants';
@@ -40,7 +39,7 @@ describe('Service Tests', () => {
                     HttpClientTestingModule
                 ],
                 providers: [
-                    ParsePipe, DateFormatPipe, <%= entityAngularName %>Service
+                    <%= entityAngularName %>Service
                 ]
             });
             injector = getTestBed();


### PR DESCRIPTION
Angular2-moment makes the application bundle contains `moment` twice, which is quite huge... I think we should only use moment to do date manipulation.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
