### PR TITLE
Fix build output buffering issue in Heroku sub-generator

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -448,8 +448,7 @@ module.exports = class extends BaseGenerator {
                 this.buildCmd = child.buildCmd;
 
                 child.stdout.on('data', (data) => {
-                    const line = data.toString().trim();
-                    if (line.length !== 0) this.log(line);
+                    process.stdout.write(data.toString());
                 });
             },
 


### PR DESCRIPTION
This fixes a problem where the Heroku sub-generator was inserting newlines into the middle of the build output

Output used to look like this:

```
------------------
-----------------------
[I
NFO] Total time: 9.075
s
[INFO]
Finished at: 2018-03-13T19:05
:32-05:00
[INFO] -
-----------------
-----------------
----------------
---------------
------
```

Now it looks like this:

```
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
[INFO] Total time: 9.251 s
[INFO] Finished at: 2018-03-13T19:13:23-05:00
[INFO] ------------------------------------------------------------------------
```