### PR TITLE
Use relative reference to node_modules

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
@@ -26,10 +26,10 @@ eg $input-color: red;
 // Override Boostrap variables
 @import "bootstrap-variables";
 // Import Bootstrap source files from node_modules
-@import 'node_modules/bootstrap/scss/bootstrap';
+@import '~bootstrap/scss/bootstrap';
 <%_ if (enableI18nRTL) { _%>
 @import 'src/main/webapp/content/scss/rtl.scss';
 <%_ } _%>
-@import 'node_modules/font-awesome/scss/font-awesome';
+@import '~font-awesome/scss/font-awesome';
 
 /* jhipster-needle-scss-add-vendor JHipster will add new css style */


### PR DESCRIPTION
Tools like Intellij Karma plugin fails if the reference is 'hard coded', using relative reference (~) fixes the issue.

- Please make sure the below checklist is followed for Pull Requests.

- [ x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ x] Tests are added where necessary
- [ x] Documentation is added/updated where necessary
- [x ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
