### PR TITLE
Add an option [--skip-check-length-of-identifier] to skip check the length of identifier when generate entity

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -56,6 +56,13 @@ module.exports = class extends BaseGenerator {
             defaults: false
         });
 
+        // This adds support for a `--skip-check-length-of-identifier` flag
+        this.option('skip-check-length-of-identifier', {
+            desc: 'Skip check the length of identifier',
+            type: Boolean,
+            defaults: false
+        });
+
         // This adds support for a `--[no-]i18n` flag
         this.option('i18n', {
             desc: 'Disable or enable i18n when skipping client side generation, has no effect otherwise',
@@ -119,6 +126,7 @@ module.exports = class extends BaseGenerator {
         this.skipClient = this.configOptions.skipClient = this.options['skip-client'] || this.config.get('skipClient');
         this.skipServer = this.configOptions.skipServer = this.options['skip-server'] || this.config.get('skipServer');
         this.skipUserManagement = this.configOptions.skipUserManagement = this.options['skip-user-management'] || this.config.get('skipUserManagement');
+        this.skipCheckLengthOfIdentifier = this.configOptions.skipCheckLengthOfIdentifier = this.options['skip-check-length-of-identifier'] || this.config.get('skipCheckLengthOfIdentifier');
         this.jhiPrefix = this.configOptions.jhiPrefix = _.camelCase(this.config.get('jhiPrefix') || this.options['jhi-prefix']);
         this.withEntities = this.options['with-entities'];
         this.skipChecks = this.options['skip-checks'];
@@ -310,6 +318,7 @@ module.exports = class extends BaseGenerator {
                 this.config.set('baseName', this.baseName);
                 this.config.set('testFrameworks', this.testFrameworks);
                 this.config.set('jhiPrefix', this.jhiPrefix);
+                this.config.set('skipCheckLengthOfIdentifier', this.skipCheckLengthOfIdentifier);
                 this.config.set('otherModules', this.otherModules);
                 this.config.set('enableTranslation', this.enableTranslation);
                 if (this.enableTranslation) {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -141,6 +141,7 @@ module.exports = class extends BaseGenerator {
                 context.languages = this.config.get('languages');
                 context.buildTool = this.config.get('buildTool');
                 context.jhiPrefix = this.config.get('jhiPrefix');
+                context.skipCheckLengthOfIdentifier = this.config.get('skipCheckLengthOfIdentifier');
                 context.jhiPrefixDashed = _.kebabCase(context.jhiPrefix);
                 context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
                 context.testFrameworks = this.config.get('testFrameworks');
@@ -237,6 +238,7 @@ module.exports = class extends BaseGenerator {
                 const prodDatabaseType = context.prodDatabaseType;
                 const entityTableName = context.entityTableName;
                 const jhiTablePrefix = context.jhiTablePrefix;
+                const skipCheckLengthOfIdentifier = context.skipCheckLengthOfIdentifier;             
                 const instructions = `You can specify a different table name in your JDL file or change it in .jhipster/${context.name}.json file and then run again 'jhipster entity ${context.name}.'`;
 
                 if (!(/^([a-zA-Z0-9_]*)$/.test(entityTableName))) {
@@ -246,9 +248,9 @@ module.exports = class extends BaseGenerator {
                 } else if (jhiCore.isReservedTableName(entityTableName, prodDatabaseType)) {
                     this.warning(chalk.red(`The table name cannot contain the '${entityTableName.toUpperCase()}' reserved keyword, so it will be prefixed with '${jhiTablePrefix}_'.\n${instructions}`));
                     context.entityTableName = `${jhiTablePrefix}_${entityTableName}`;
-                } else if (prodDatabaseType === 'oracle' && entityTableName.length > 26) {
+                } else if (prodDatabaseType === 'oracle' && entityTableName.length > 26 && !skipCheckLengthOfIdentifier) {
                     this.error(chalk.red(`The table name is too long for Oracle, try a shorter name.\n${instructions}`));
-                } else if (prodDatabaseType === 'oracle' && entityTableName.length > 14) {
+                } else if (prodDatabaseType === 'oracle' && entityTableName.length > 14 && !skipCheckLengthOfIdentifier) {
                     this.warning(`The table name is long for Oracle, long table names can cause issues when used to create constraint names and join table names.\n${instructions}`);
                 }
             }

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -250,7 +250,8 @@ function askForTableName() {
     // don't prompt if there are no relationships
     const entityTableName = context.entityTableName;
     const prodDatabaseType = context.prodDatabaseType;
-    if (!context.relationships || context.relationships.length === 0 ||
+    const skipCheckLengthOfIdentifier = context.skipCheckLengthOfIdentifier;
+    if (skipCheckLengthOfIdentifier || !context.relationships || context.relationships.length === 0 ||
         !((prodDatabaseType === 'oracle' && entityTableName.length > 14) || entityTableName.length > 30)) {
         return;
     }
@@ -265,9 +266,9 @@ function askForTableName() {
                     return 'The table name cannot contain special characters';
                 } else if (input === '') {
                     return 'The table name cannot be empty';
-                } else if (prodDatabaseType === 'oracle' && input.length > 14) {
+                } else if (prodDatabaseType === 'oracle' && input.length > 14 && !skipCheckLengthOfIdentifier) {
                     return 'The table name is too long for Oracle, try a shorter name';
-                } else if (input.length > 30) {
+                } else if (input.length > 30 && !skipCheckLengthOfIdentifier) {
                     return 'The table name is too long, try a shorter name';
                 }
                 return true;
@@ -431,6 +432,7 @@ function askForField(done) {
     const prodDatabaseType = context.prodDatabaseType;
     const databaseType = context.databaseType;
     const fieldNamesUnderscored = context.fieldNamesUnderscored;
+    const skipCheckLengthOfIdentifier = context.skipCheckLengthOfIdentifier;
     const prompts = [
         {
             type: 'confirm',
@@ -453,7 +455,7 @@ function askForField(done) {
                     return 'Your field name cannot use an already existing field name';
                 } else if (!skipServer && jhiCore.isReservedFieldName(input)) {
                     return 'Your field name cannot contain a Java or Angular reserved keyword';
-                } else if (prodDatabaseType === 'oracle' && input.length > 30) {
+                } else if (prodDatabaseType === 'oracle' && input.length > 30 && !skipCheckLengthOfIdentifier) {
                     return 'The field name cannot be of more than 30 characters';
                 }
                 return true;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1853,6 +1853,7 @@ module.exports = class extends PrivateBase {
         context.javadoc = context.fileData.javadoc;
         context.entityTableName = context.fileData.entityTableName;
         context.jhiPrefix = context.fileData.jhiPrefix || context.jhiPrefix;
+        context.skipCheckLengthOfIdentifier = context.fileData.skipCheckLengthOfIdentifier || context.skipCheckLengthOfIdentifier;
         context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
         this.copyFilteringFlag(context.fileData, context, context);
         if (_.isUndefined(context.entityTableName)) {
@@ -2017,11 +2018,11 @@ module.exports = class extends PrivateBase {
     getJoinTableName(entityName, relationshipName, prodDatabaseType) {
         const joinTableName = `${this.getTableName(entityName)}_${this.getTableName(relationshipName)}`;
         let limit = 0;
-        if (prodDatabaseType === 'oracle' && joinTableName.length > 30) {
+        if (prodDatabaseType === 'oracle' && joinTableName.length > 30 && !this.skipCheckLengthOfIdentifier) {
             this.warning(`The generated join table "${joinTableName}" is too long for Oracle (which has a 30 characters limit). It will be truncated!`);
 
             limit = 30;
-        } else if (prodDatabaseType === 'mysql' && joinTableName.length > 64) {
+        } else if (prodDatabaseType === 'mysql' && joinTableName.length > 64 && !this.skipCheckLengthOfIdentifier) {
             this.warning(`The generated join table "${joinTableName}" is too long for MySQL (which has a 64 characters limit). It will be truncated!`);
 
             limit = 64;
@@ -2052,11 +2053,11 @@ module.exports = class extends PrivateBase {
         }
         let limit = 0;
 
-        if (prodDatabaseType === 'oracle' && constraintName.length > 30) {
+        if (prodDatabaseType === 'oracle' && constraintName.length > 30 && !this.skipCheckLengthOfIdentifier) {
             this.warning(`The generated constraint name "${constraintName}" is too long for Oracle (which has a 30 characters limit). It will be truncated!`);
 
             limit = 28;
-        } else if (prodDatabaseType === 'mysql' && constraintName.length > 64) {
+        } else if (prodDatabaseType === 'mysql' && constraintName.length > 64 && !this.skipCheckLengthOfIdentifier) {
             this.warning(`The generated constraint name "${constraintName}" is too long for MySQL (which has a 64 characters limit). It will be truncated!`);
 
             limit = 62;
@@ -2495,6 +2496,7 @@ module.exports = class extends PrivateBase {
 
         dest.regenerate = context.options.regenerate;
         dest.fluentMethods = context.options['fluent-methods'];
+        dest.skipCheckLengthOfIdentifier = context.options['skip-check-length-of-identifier'];
         dest.entityTableName = generator.getTableName(context.options['table-name'] || dest.name);
         dest.entityNameCapitalized = _.upperFirst(dest.name);
         dest.entityAngularJSSuffix = context.options['angular-suffix'];


### PR DESCRIPTION
Add an option [--skip-check-length-of-identifier] to skip check the length of identifier when generate entity

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
