### PR TITLE
Fix issue in docker-prompt when directory path doesn't have a trailing slash

### DIFF
--- a/generators/docker-prompts.js
+++ b/generators/docker-prompts.js
@@ -129,6 +129,11 @@ function askForPath() {
 
     this.prompt(prompts).then((props) => {
         this.directoryPath = props.directoryPath;
+        // Patch the path if there is no trailing "/"
+        if (!this.directoryPath.endsWith('/')) {
+            this.log(chalk.yellow(`The path "${this.directoryPath}" does not end with a trailing "/", adding it anyway.`));
+            this.directoryPath += '/';
+        }
 
         this.appsFolders = getAppFolders.call(this, this.directoryPath, composeApplicationType);
 

--- a/test/docker-compose.spec.js
+++ b/test/docker-compose.spec.js
@@ -92,6 +92,33 @@ describe('JHipster Docker Compose Sub Generator', () => {
         });
     });
 
+    describe('one microservice and a directory path without a trailing slash', () => {
+        beforeEach((done) => {
+            helpers
+                .run(require.resolve('../generators/docker-compose'))
+                .inTmpDir((dir) => {
+                    fse.copySync(path.join(__dirname, './templates/compose/'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    composeApplicationType: 'microservice',
+                    directoryPath: '.',
+                    chosenApps: [
+                        '02-mysql'
+                    ],
+                    clusteredDbApps: [],
+                    monitoring: 'no'
+                })
+                .on('end', done);
+        });
+        it('creates expected default files', () => {
+            assert.file(expectedFiles.dockercompose);
+        });
+        it('Correct the directory path by appending a trailing slash', () => {
+            assert.fileContent('.yo-rc.json', '"directoryPath": "./"');
+        });
+    });
+
     describe('gateway and one microservice', () => {
         beforeEach((done) => {
             helpers


### PR DESCRIPTION
Force adding a trailing slash in docker prompt.
This fixes the issue when the user input a path that doesn't end with a trailing slash.
Currently this broke the subgen and was very confusing for users.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
