### PR TITLE
save authorities in to sync user roles/groups between IdP and JHipste…

### DIFF
--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -514,6 +514,17 @@ public class UserService {
     }
 
     private User syncUserWithIdP(Map<String, Object> details, User user) {
+        // save authorities in to sync user roles/groups between IdP and JHipster's local database
+        List<String> dbAuthorities = getAuthorities();
+        List<String> userAuthorities = user.getAuthorities().stream().map(Authority::getName).collect(Collectors.toList());
+        for (String authority :userAuthorities) {
+            if (!dbAuthorities.contains(authority)) {
+                log.debug("Saving authority '{}' in local database ...", authority);
+                Authority authoritytoSave = new Authority();
+                authoritytoSave.setName(authority);
+                authorityRepository.save(authoritytoSave);
+            }
+        }
         // save account in to sync users between IdP and JHipster's local database
         Optional<User> existingUser = userRepository.findOneByLogin(user.getLogin());
         if (existingUser.isPresent()) {


### PR DESCRIPTION
save authorities in to sync user roles/groups between IdP and local database

this PR allow to fix a bug occurs when we try to login user with a specific role

Fix Issue #7350