### PR TITLE
Add jcenter to pom.xml and a needle to add a repository to the pom

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1077,6 +1077,32 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add a remote Maven Repository to the Maven build.
+     *
+     * @param {string} id - id of the repository
+     * @param {string} url - url of the repository
+     */
+    addMavenRepository(id, url) {
+        const fullPath = 'pom.xml';
+        try {
+            const repository = `${'<repository>\n' +
+                '            <id>'}${id}</id>\n` +
+                `            <url>${url}</url>\n` +
+                '        </repository>';
+            jhipsterUtils.rewriteFile({
+                file: fullPath,
+                needle: 'jhipster-needle-maven-repository',
+                splicable: [
+                    repository
+                ]
+            }, this);
+        } catch (e) {
+            this.log(`${chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required jhipster-needle. Reference to ')}maven repository (id: ${id}, url:${url})${chalk.yellow(' not added.\n')}`);
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
      * Add a new Maven property.
      *
      * @param {string} name - property name

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -26,8 +26,12 @@
     <packaging>war</packaging>
     <name><%= humanizedBaseName %></name>
 
-    <!-- TODO Remove snapshot repositories after final Spring Boot 2 release -->
     <repositories>
+        <repository>
+            <id>jcenter</id>
+            <url>https://jcenter.bintray.com/</url>
+        </repository>
+        <!-- TODO Remove snapshot repositories after final Spring Boot 2 release -->
         <repository>
             <id>sonatype-snapshot</id>
             <name>JHipster Snapshots</name>
@@ -57,6 +61,7 @@
             </releases>
         </repository>
     <%_ } _%>
+        <!-- jhipster-needle-maven-repository -->
     </repositories>
     <pluginRepositories>
         <pluginRepository>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -27,10 +27,6 @@
     <name><%= humanizedBaseName %></name>
 
     <repositories>
-        <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
-        </repository>
         <!-- TODO Remove snapshot repositories after final Spring Boot 2 release -->
         <repository>
             <id>sonatype-snapshot</id>


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Gradle build uses jcenter which is a superset of maven central.
I think we should do the same for the pom.xml at least for consistency.
