### PR TITLE
Fix classpath jar workaround for Windows

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -95,9 +95,10 @@ springBoot {
 }
 
 if (OperatingSystem.current().isWindows()) {
-    task pathingJar(type: Jar) {
+    // https://stackoverflow.com/questions/40037487/the-filename-or-extension-is-too-long-error-using-gradle
+    task classpathJar(type: Jar) {
         dependsOn configurations.runtime
-        appendix = 'pathing'
+        appendix = 'classpath'
 
         doFirst {
             manifest {
@@ -109,9 +110,9 @@ if (OperatingSystem.current().isWindows()) {
     }
 
     bootRun {
-        dependsOn pathingJar
+        dependsOn classpathJar
         doFirst {
-            classpath += files("$buildDir/classes/java/main", "$buildDir/resources/main", pathingJar.archivePath)
+            classpath = files("$buildDir/classes/java/main", "$buildDir/resources/main", classpathJar.archivePath)
         }
     }
 }


### PR DESCRIPTION
Classpath is already too long to be handled on windows, so classpath should be **replaced** with classpath jar (btw, renamed task and jar to better reflect what it does). In current version of jhipster, classpath jar is **added** to already-too-long-classpath, so workaround doesn't work. Btw, this workaround is not needed on Windows 10, if "Long Paths" feature is enabled (see https://www.howtogeek.com/266621/how-to-make-windows-10-accept-file-paths-over-260-characters/), basically LongPathsEnabled should be "1" under HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Control\FileSystem registry path.
