### PR TITLE
change dbtype from timestamp to datetime for mysql

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -82,17 +82,9 @@
             } else if (fieldType === 'LocalDate') {
                 columnType="date";
             } else if (fieldType === 'Instant') {
-                if (prodDatabaseType === 'mysql') {
-                    columnType="datetime";
-                } else {
-                    columnType="timestamp";
-                }
+                columnType="datetime";
             } else if (fieldType === 'ZonedDateTime') {
-                if (prodDatabaseType === 'mysql') {
-                    columnType="datetime";
-                } else {
-                    columnType="timestamp";
-                }
+                columnType="datetime";
             } else if (fieldType === 'byte[]' && fieldTypeBlobContent !== 'text') {
                 if (prodDatabaseType === 'mysql' || prodDatabaseType === 'postgresql') {
                     columnType="longblob";
@@ -139,13 +131,9 @@
             <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
         </createTable>
         <%_ for (const idx in fields) {
-            if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { 
-                if (prodDatabaseType === 'mysql') {_%>
+            if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { _%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="datetime"/>
-            <%_ } else { _%>
-        <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="timestamp"/>
-            <%_ }
-          } 
+        <%_ }
         } _%>
         <% for (idx in relationships) {
             const relationshipType = relationships[idx].relationshipType,

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -82,9 +82,17 @@
             } else if (fieldType === 'LocalDate') {
                 columnType="date";
             } else if (fieldType === 'Instant') {
-                columnType="timestamp";
+                if (prodDatabaseType === 'mysql') {
+                    columnType="datetime";
+                } else {
+                    columnType="timestamp";
+                }
             } else if (fieldType === 'ZonedDateTime') {
-                columnType="timestamp";
+                if (prodDatabaseType === 'mysql') {
+                    columnType="datetime";
+                } else {
+                    columnType="timestamp";
+                }
             } else if (fieldType === 'byte[]' && fieldTypeBlobContent !== 'text') {
                 if (prodDatabaseType === 'mysql' || prodDatabaseType === 'postgresql') {
                     columnType="longblob";
@@ -131,8 +139,12 @@
             <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
         </createTable>
         <%_ for (const idx in fields) {
-            if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { _%>
+            if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { 
+                if (prodDatabaseType === 'mysql') {_%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="datetime"/>
+            <%_ } else () <%_ {
+        <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="timestamp"/>
+            <%_ }
         <%_ }
         } _%>
         <% for (idx in relationships) {

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -140,7 +140,7 @@
         </createTable>
         <%_ for (const idx in fields) {
             if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { 
-                if (prodDatabaseType === 'mysql') { _%>
+                if (prodDatabaseType === 'mysql') {_%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="datetime"/>
             <%_ } else { _%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="timestamp"/>

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -140,12 +140,12 @@
         </createTable>
         <%_ for (const idx in fields) {
             if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { 
-                if (prodDatabaseType === 'mysql') {_%>
+                if (prodDatabaseType === 'mysql') { _%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="datetime"/>
-            <%_ } else { <%_
+            <%_ } else { _%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="timestamp"/>
             <%_ }
-        <%_ }
+          } 
         } _%>
         <% for (idx in relationships) {
             const relationshipType = relationships[idx].relationshipType,

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -142,7 +142,7 @@
             if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { 
                 if (prodDatabaseType === 'mysql') {_%>
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="datetime"/>
-            <%_ } else () <%_ {
+            <%_ } else { <%_
         <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%=fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="timestamp"/>
             <%_ }
         <%_ }


### PR DESCRIPTION
For the db type `ZonedDateTime` and `Instant` , we use convert it into `timestamp` for the db type. but there is limitation in mysql that the 'timestamp' only support a range of '1970-01-01 00:00:01' UTC to '2038-01-19 03:14:07'.


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
