### PR TITLE
remove extra call to DTO mapper

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
@@ -72,7 +72,7 @@
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityApiUrl %>");
         <%_ } _%>
     <%_ } _%>
-        return new ResponseEntity<>(<% if (!viaService && dto === 'mapstruct' && fieldsContainOwnerManyToMany) { %><%= entityListToDtoListReference %>(page.getContent())<% } else { %>page.getContent()<% } %>, headers, HttpStatus.OK);
+        return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     <%_ } _%>
     }
 <%_ } _%>

--- a/travis/samples/.jhipster/TestManyRelWithPaginationAndDTO.json
+++ b/travis/samples/.jhipster/TestManyRelWithPaginationAndDTO.json
@@ -1,0 +1,19 @@
+{
+    "fluentMethods": true,
+    "relationships": [
+        {
+            "relationshipName": "testMapstruct",
+            "otherEntityName": "testMapstruct",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "id",
+            "ownerSide": true
+        }
+    ],
+    "fields": [],
+    "changelogDate": "20160208210534",
+    "dto": "mapstruct",
+    "service": "no",
+    "angularJSSuffix": "mySuffix",
+    "entityTableName": "test_many_many_pagination_dto",
+    "pagination": "pagination"
+}

--- a/travis/samples/.jhipster/TestMapstruct.json
+++ b/travis/samples/.jhipster/TestMapstruct.json
@@ -15,6 +15,13 @@
             "otherEntityRelationshipName": "testMapstruct"
         },
         {
+            "relationshipName": "testManyRelWithPaginationAndDTO",
+            "otherEntityName": "testManyRelWithPaginationAndDTO",
+            "relationshipType": "many-to-many",
+            "ownerSide": false,
+            "otherEntityRelationshipName": "testMapstruct"
+        },
+        {
             "relationshipName": "testOneToOne",
             "otherEntityName": "testOneToOne",
             "relationshipType": "one-to-one",

--- a/travis/scripts/01-generate-entities.sh
+++ b/travis/scripts/01-generate-entities.sh
@@ -106,6 +106,7 @@ elif [[ ( "$JHIPSTER" == *"mysql"* ) || ( "$JHIPSTER" == *"psql"* ) ]]; then
     moveEntity TestPagination
     moveEntity TestManyToOne
     moveEntity TestManyToMany
+    moveEntity TestManyRelWithPaginationAndDTO
     moveEntity TestOneToOne
     moveEntity TestCustomTableName
     moveEntity TestTwoRelationshipsSameEntity


### PR DESCRIPTION
Fix #7430 

The `page` variable is already mapped to DTO in the code above the `return` 

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
