### PR TITLE
Add log level OFF + change color

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -34,11 +34,12 @@
         <tr *ngFor="let logger of (loggers | pureFilter:filter:'name' | orderBy:orderProp:reverse)">
             <td><small>{{logger.name | slice:0:140}}</small></td>
             <td>
-                <button (click)="changeLevel(logger.name, 'TRACE')" [ngClass]="(logger.level=='TRACE') ? 'btn-danger' : 'btn-light'" class="btn btn-sm">TRACE</button>
-                <button (click)="changeLevel(logger.name, 'DEBUG')" [ngClass]="(logger.level=='DEBUG') ? 'btn-warning' : 'btn-light'" class="btn btn-sm">DEBUG</button>
+                <button (click)="changeLevel(logger.name, 'TRACE')" [ngClass]="(logger.level=='TRACE') ? 'btn-primary' : 'btn-light'" class="btn btn-sm">TRACE</button>
+                <button (click)="changeLevel(logger.name, 'DEBUG')" [ngClass]="(logger.level=='DEBUG') ? 'btn-success' : 'btn-light'" class="btn btn-sm">DEBUG</button>
                 <button (click)="changeLevel(logger.name, 'INFO')" [ngClass]="(logger.level=='INFO') ? 'btn-info' : 'btn-light'" class="btn btn-sm">INFO</button>
-                <button (click)="changeLevel(logger.name, 'WARN')" [ngClass]="(logger.level=='WARN') ? 'btn-success' : 'btn-light'" class="btn btn-sm">WARN</button>
-                <button (click)="changeLevel(logger.name, 'ERROR')" [ngClass]="(logger.level=='ERROR') ? 'btn-primary' : 'btn-light'" class="btn btn-sm">ERROR</button>
+                <button (click)="changeLevel(logger.name, 'WARN')" [ngClass]="(logger.level=='WARN') ? 'btn-warning' : 'btn-light'" class="btn btn-sm">WARN</button>
+                <button (click)="changeLevel(logger.name, 'ERROR')" [ngClass]="(logger.level=='ERROR') ? 'btn-danger' : 'btn-light'" class="btn btn-sm">ERROR</button>
+                <button (click)="changeLevel(logger.name, 'OFF')" [ngClass]="(logger.level=='OFF') ? 'btn-secondary' : 'btn-light'" class="btn btn-sm">OFF</button>
             </td>
         </tr>
     </table>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/logs/logs.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/logs/logs.tsx.ejs
@@ -88,11 +88,12 @@ export class LogsPage extends React.Component<ILogsPageProps, ILogsPageState> {
                 <tr key={`log-row-${i}`}>
                   <td><small>{logger.name}</small></td>
                   <td>
-                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'TRACE')} className={this.getClassName(logger.level, 'TRACE', 'danger')}>TRACE</button>
-                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'DEBUG')} className={this.getClassName(logger.level, 'DEBUG', 'warning')}>DEBUG</button>
+                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'TRACE')} className={this.getClassName(logger.level, 'TRACE', 'primary')}>TRACE</button>
+                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'DEBUG')} className={this.getClassName(logger.level, 'DEBUG', 'success')}>DEBUG</button>
                     <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'INFO')} className={this.getClassName(logger.level, 'INFO', 'info')}>INFO</button>
-                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'WARN')} className={this.getClassName(logger.level, 'WARN', 'success')}>WARN</button>
-                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'ERROR')} className={this.getClassName(logger.level, 'ERROR', 'primary')}>ERROR</button>
+                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'WARN')} className={this.getClassName(logger.level, 'WARN', 'warning')}>WARN</button>
+                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'ERROR')} className={this.getClassName(logger.level, 'ERROR', 'danger')}>ERROR</button>
+                    <button disabled={isFetching} onClick={this.changeLevel(logger.name, 'OFF')} className={this.getClassName(logger.level, 'OFF', 'secondary')}>OFF</button>
                   </td>
                 </tr>
               )


### PR DESCRIPTION
Allow the user to set the log level to OFF.

I change the color too:
- trace -> primary (instead of error)
- debug -> success (instead of warning)
- info -> info
- warning -> warning (instead of success)
- error -> error (instead of primary)

![log-level-off](https://user-images.githubusercontent.com/9156882/38471563-29980d52-3b73-11e8-90b6-2a9230203396.png)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
