### PR TITLE
Fix webpack warning during tests

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.test.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.test.js.ejs
@@ -69,7 +69,13 @@ module.exports = (WATCH) => ({
                 enforce: 'post',
                 exclude: /node_modules/,
                 loader: 'sourcemap-istanbul-instrumenter-loader?force-sourcemap=true'
-            }]
+            },
+            // Ignore warnings about System.import in Angular
+            {
+                test: /[\/\\]@angular[\/\\].+\.js$/,
+                parser: { system: true }
+            },
+        ]
     },
     plugins: [
         new webpack.DefinePlugin({


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/pull/7341

Currently, when launching `yarn test`:

```
WARNING in ./node_modules/@angular/core/esm5/core.js
6558:15-36 Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@angular/core/esm5/core.js
 @ ./node_modules/@angular/common/esm5/http/testing.js
 @ ./src/test/javascript/spec/app/admin/audits/audits.service.spec.ts
 @ ./src/test/javascript/spec sync \.spec
 @ ./src/test/javascript/spec/entry.ts

WARNING in ./node_modules/@angular/core/esm5/core.js
6578:15-102 Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@angular/core/esm5/core.js
 @ ./node_modules/@angular/common/esm5/http/testing.js
 @ ./src/test/javascript/spec/app/admin/audits/audits.service.spec.ts
 @ ./src/test/javascript/spec sync \.spec
 @ ./src/test/javascript/spec/entry.ts

WARNING in ./node_modules/@angular/core/esm5/core.js
System.import() is deprecated and will be removed soon. Use import() instead.
For more info visit https://webpack.js.org/guides/code-splitting/
 @ ./node_modules/@angular/common/esm5/http/testing.js 6558:15-36 7:0-53 502:16-26 531:16-24
 @ ./src/test/javascript/spec/app/admin/audits/audits.service.spec.ts
 @ ./src/test/javascript/spec sync \.spec
 @ ./src/test/javascript/spec/entry.ts

WARNING in ./node_modules/@angular/core/esm5/core.js
System.import() is deprecated and will be removed soon. Use import() instead.
For more info visit https://webpack.js.org/guides/code-splitting/
 @ ./node_modules/@angular/common/esm5/http/testing.js 6578:15-102 7:0-53 502:16-26 531:16-24
 @ ./src/test/javascript/spec/app/admin/audits/audits.service.spec.ts
 @ ./src/test/javascript/spec sync \.spec
 @ ./src/test/javascript/spec/entry.ts
webpack: Compiled with warnings.
08 04 2018 22:03:58.563:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
08 04 2018 22:03:58.564:INFO [launcher]: Launching browser ChromiumHeadlessNoSandbox with unlimited concurrency
08 04 2018 22:03:58.759:INFO [launcher]: Starting browser ChromiumHeadless
08 04 2018 22:03:59.732:INFO [HeadlessChrome 66.0.3347 (Linux 0.0.0)]: Connected on socket 3EnhrWTPAT46UrcRAAAA with id 30796880
 HeadlessChrome 66.0.3347 (Linux 0.0.0): Executed 62 of 62 SUCCESS (0 secs / 1.001 secs)
.
HeadlessChrome 66.0.3347 (Linux 0.0.0): Executed 62 of 62 SUCCESS (1.09 secs / 1.001 secs)

=============================== Coverage summary ===============================
Statements   : 73.97% ( 912/1233 )
Branches     : 45.28% ( 120/265 )
Functions    : 54.42% ( 160/294 )
Lines        : 72.59% ( 784/1080 )
================================================================================
Done in 16.97s.
```

With this change:

```
WARNING in ./node_modules/@angular/core/esm5/core.js
6558:15-36 Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@angular/core/esm5/core.js
 @ ./node_modules/@angular/platform-browser/esm5/platform-browser.js
 @ ./node_modules/@angular/platform-browser-dynamic/esm5/testing.js
 @ ./src/test/javascript/spec/entry.ts

WARNING in ./node_modules/@angular/core/esm5/core.js
6578:15-102 Critical dependency: the request of a dependency is an expression
 @ ./node_modules/@angular/core/esm5/core.js
 @ ./node_modules/@angular/platform-browser/esm5/platform-browser.js
 @ ./node_modules/@angular/platform-browser-dynamic/esm5/testing.js
 @ ./src/test/javascript/spec/entry.ts
webpack: Compiled with warnings.
08 04 2018 22:05:40.210:INFO [karma]: Karma v1.7.1 server started at http://0.0.0.0:9876/
08 04 2018 22:05:40.211:INFO [launcher]: Launching browser ChromiumHeadlessNoSandbox with unlimited concurrency
08 04 2018 22:05:40.346:INFO [launcher]: Starting browser ChromiumHeadless
08 04 2018 22:05:41.306:INFO [HeadlessChrome 66.0.3347 (Linux 0.0.0)]: Connected on socket OGf-23d27Fzms0KqAAAA with id 28889393
 HeadlessChrome 66.0.3347 (Linux 0.0.0): Executed 62 of 62 SUCCESS (0 secs / 0.92 secs)
.
HeadlessChrome 66.0.3347 (Linux 0.0.0): Executed 62 of 62 SUCCESS (0.998 secs / 0.92 secs)

=============================== Coverage summary ===============================
Statements   : 73.97% ( 912/1233 )
Branches     : 45.28% ( 120/265 )
Functions    : 54.42% ( 160/294 )
Lines        : 72.59% ( 784/1080 )
================================================================================
Done in 16.33s.
```


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
