### PR TITLE
AWS Elastic-beanstalk role creation for new environments

### DIFF
--- a/generators/aws/index.js
+++ b/generators/aws/index.js
@@ -209,6 +209,19 @@ module.exports = class extends BaseGenerator {
                     }
                 });
             },
+            verifyRoles() {
+                const cb = this.async();
+                this.log();
+                this.log(chalk.bold('Verifying ElasticBeanstalk Roles'));
+                const iam = this.awsFactory.getIam();
+                iam.verifyRoles({}, (err) => {
+                    if (err) {
+                        this.error(chalk.red(err.message));
+                    } else {
+                        cb();
+                    }
+                });
+            },
             createApplication() {
                 const cb = this.async();
                 this.log();

--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -2,6 +2,7 @@ const S3 = require('./s3.js');
 const Rds = require('./rds.js');
 const shelljs = require('shelljs');
 const Eb = require('./eb.js');
+const Iam = require('./iam.js');
 
 let Aws;
 let generator;
@@ -39,4 +40,8 @@ AwsFactory.prototype.getRds = function getRds() {
 
 AwsFactory.prototype.getEb = function getEb() {
     return new Eb(Aws, generator);
+};
+
+AwsFactory.prototype.getIam = function getIa() {
+    return new Iam(Aws, generator);
 };

--- a/generators/aws/lib/eb.js
+++ b/generators/aws/lib/eb.js
@@ -159,11 +159,6 @@ function createEnvironment(params, callback) {
                     Namespace: 'aws:autoscaling:launchconfiguration',
                     OptionName: 'InstanceType',
                     Value: instanceType
-                },
-                {
-                    Namespace: 'aws:autoscaling:launchconfiguration',
-                    OptionName: 'IamInstanceProfile',
-                    Value: 'aws-elasticbeanstalk-ec2-role'
                 }
             ],
             SolutionStackName: solutionStackName,

--- a/generators/aws/lib/iam.js
+++ b/generators/aws/lib/iam.js
@@ -1,0 +1,140 @@
+const INSTANCE_PROFILE_ROLE = 'aws-elasticbeanstalk-ec2-role';
+const SERVICE_PROFILE_ROLE = 'aws-elasticbeanstalk-service-role';
+const AWS_POLICY_ARN = suffix => `arn:aws:iam::aws:policy/${suffix}`;
+const AWS_SERVICE_ARN = suffix => `arn:aws:iam::aws:policy/service-role/${suffix}`;
+
+let aws;
+let log;
+
+const Iam = module.exports = function Iam(Aws, generator) {
+    aws = Aws;
+    log = generator.log;
+};
+
+const createRole = (RoleName, Description, AssumeRolePolicyDocument) => {
+    const iam = new aws.IAM();
+    return iam.createRole({
+        RoleName,
+        Description,
+        AssumeRolePolicyDocument
+    }).promise();
+};
+
+const attachRolePolicy = (PolicyArn, RoleName) => {
+    const iam = new aws.IAM();
+    return iam.attachRolePolicy({ PolicyArn, RoleName }).promise();
+};
+
+
+const attachServicePolicyToRole = (policySuffix, roleName) => attachRolePolicy(AWS_SERVICE_ARN(policySuffix), roleName);
+const attachPolicyToRole = (policySuffix, roleName) => attachRolePolicy(AWS_POLICY_ARN(policySuffix), roleName);
+
+const getRole = (RoleName) => {
+    const iam = new aws.IAM();
+    return iam.getRole({ RoleName }).promise();
+};
+
+const hasRole = roleName => getRole(roleName).then(() => true).catch((err) => {
+    if (err && err.code === 'NoSuchEntity') {
+        return false;
+    }
+    throw err;
+});
+
+const hasInstanceProfile = () => hasRole(INSTANCE_PROFILE_ROLE);
+const hasServiceProfile = () => hasRole(SERVICE_PROFILE_ROLE);
+
+
+const createServiceProfileWithAttachedPolicies = () => {
+    const roleName = SERVICE_PROFILE_ROLE;
+    const description = 'Default Elastic Beanstalk Service profile created by JHipster.';
+    const assumedPolicyDoc = `{
+  "Version": "2012-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "elasticbeanstalk.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole",
+      "Condition": {
+        "StringEquals": {
+          "sts:ExternalId": "elasticbeanstalk"
+        }
+      }
+    }
+  ]
+}`;
+
+    return createRole(roleName, description, assumedPolicyDoc)
+        .then(() => {
+            const policiesToAttach = [
+                attachServicePolicyToRole('AWSElasticBeanstalkEnhancedHealth', roleName),
+                attachServicePolicyToRole('AWSElasticBeanstalkService', roleName)
+            ];
+            return Promise.all(policiesToAttach);
+        });
+};
+
+const createInstanceProfileWithAttachedPolicies = () => {
+    const roleName = INSTANCE_PROFILE_ROLE;
+    const description = 'Default Elastic Beanstalk instance profile created by JHipster.';
+    const assumedPolicyDoc = `{
+  "Version": "2008-10-17",
+  "Statement": [
+    {
+      "Effect": "Allow",
+      "Principal": {
+        "Service": "ec2.amazonaws.com"
+      },
+      "Action": "sts:AssumeRole"
+    }
+  ]
+}`;
+
+    return createRole(roleName, description, assumedPolicyDoc)
+        .then(() => {
+            const policiesToAttach = [
+                attachPolicyToRole('AWSElasticBeanstalkWebTier', roleName),
+                attachPolicyToRole('AWSElasticBeanstalkWorkerTier', roleName),
+                attachPolicyToRole('AWSElasticBeanstalkMulticontainerDocker', roleName)
+            ];
+            return Promise.all(policiesToAttach);
+        });
+};
+
+
+/**
+ * Verifies that the Elastic Beanstalk roles have been created in the IAM Account. This is for situations
+ * where we're deploying to a new/fresh AWS account, and an Elastic Beanstalk application has not been deployed via
+ * the web-application or CLI.
+ *
+ * See [service role info here]{@link https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-servicerole.html}
+ * and [instance profile info here]{@link https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-verify}
+ * @param params
+ * @param callback
+ */
+Iam.prototype.verifyRoles = function verifyRoles(params, callback) {
+    hasInstanceProfile()
+        .then((instanceProfileExists) => {
+            if (!instanceProfileExists) {
+                log(`Instance profile '${INSTANCE_PROFILE_ROLE}' does not exist. Creating based on defaults.`);
+                return createInstanceProfileWithAttachedPolicies();
+            }
+
+            return new Promise();
+        })
+        .then(() => hasServiceProfile())
+        .then((serviceProfileExists) => {
+            if (!serviceProfileExists) {
+                log(`Service Profile profile '${SERVICE_PROFILE_ROLE}' does not exist. Creating based on defaults.`);
+                return createServiceProfileWithAttachedPolicies();
+            }
+
+            return new Promise();
+        })
+        .then(() => callback(null, null))
+        .catch((err) => {
+            callback({ message: err.message }, null);
+        });
+};

--- a/generators/aws/lib/iam.js
+++ b/generators/aws/lib/iam.js
@@ -122,7 +122,7 @@ Iam.prototype.verifyRoles = function verifyRoles(params, callback) {
                 return createInstanceProfileWithAttachedPolicies();
             }
 
-            return new Promise();
+            return instanceProfileExists;
         })
         .then(() => hasServiceProfile())
         .then((serviceProfileExists) => {
@@ -131,7 +131,7 @@ Iam.prototype.verifyRoles = function verifyRoles(params, callback) {
                 return createServiceProfileWithAttachedPolicies();
             }
 
-            return new Promise();
+            return serviceProfileExists;
         })
         .then(() => callback(null, null))
         .catch((err) => {

--- a/generators/aws/lib/rds.js
+++ b/generators/aws/lib/rds.js
@@ -18,7 +18,7 @@ Rds.prototype.createDatabase = function createDatabase(params, callback) {
             const rdsSecurityGroupId = data.rdsSecurityGroupId;
 
             if (!rdsSecurityGroupId) {
-                callback(null, { message: `Database ${dbName} already exists` });
+                callback(null, { message: `Database ${dbName} already exists (based on security group)` });
             } else {
                 authorizeSecurityGroupIngress({ rdsSecurityGroupId }, (err) => {
                     if (err) {


### PR DESCRIPTION
In AWS environments where an elastic-beanstalk application hasn't been deployed via the environment management console initially, then two dependent roles are missing from IAM: [aws-elasticbeanstalk-ec2-role](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-instanceprofile.html#iam-instanceprofile-verify), and [aws-elasticbeanstalk-service-role](https://docs.aws.amazon.com/elasticbeanstalk/latest/dg/iam-servicerole.html). This fix will generate the appropriate default roles, based on the documentation, allowing the environment to start once deployed.

I'm hoping it fixes #7086

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
