### PR TITLE
Add a streaming/reactive endpoint for Mongo and Couchbase

### DIFF
--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -104,7 +104,7 @@ const serverFiles = {
             }]
         },
         {
-            condition: generator => (generator.reactive && ['mongo', 'couchbase'].includes(generator.databaseType)),
+            condition: generator => (generator.reactive && ['mongodb', 'couchbase'].includes(generator.databaseType)),
             path: SERVER_MAIN_SRC_DIR,
             templates: [{
                 file: 'package/repository/reactive/EntityReactiveRepository.java',

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -104,7 +104,7 @@ const serverFiles = {
             }]
         },
         {
-            condition: generator => generator.reactive === true,
+            condition: generator => (generator.reactive && ['mongo', 'couchbase'].includes(generator.databaseType)),
             path: SERVER_MAIN_SRC_DIR,
             templates: [{
                 file: 'package/repository/reactive/EntityReactiveRepository.java',

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -104,6 +104,14 @@ const serverFiles = {
             }]
         },
         {
+            condition: generator => generator.reactive === true,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [{
+                file: 'package/repository/reactive/EntityReactiveRepository.java',
+                renameTo: generator => `${generator.packageFolder}/repository/reactive/${generator.entityClass}ReactiveRepository.java`
+            }]
+        },
+        {
             condition: generator => generator.service === 'serviceImpl',
             path: SERVER_MAIN_SRC_DIR,
             templates: [

--- a/generators/entity-server/templates/src/main/java/package/common/inject_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/inject_template.ejs
@@ -27,6 +27,10 @@
 
     private final <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository;
     <%_ } _%>
+    <%_ if (reactiveRepositories) { _%>
+
+    private final <%= entityClass %>ReactiveRepository <%= entityInstance %>ReactiveRepository;
+    <%_ } _%>
 <%_  } else { _%>
 
     private final <%= entityClass %>Service <%= entityInstance %>Service;
@@ -36,7 +40,7 @@
     <%_ } _%>
 <%_ } _%>
 
-    public <%= constructorName %>(<% if (!viaService) { %><%= entityClass %>Repository <%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityClass %>Mapper <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository<% } %><%  } else { %><%= entityClass %>Service <%= entityInstance %>Service<% } %><% if (queryService && viaService) { %>, <%= entityClass %>QueryService <%= entityInstance %>QueryService<% } %>) {
+    public <%= constructorName %>(<% if (!viaService) { %><%= entityClass %>Repository <%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityClass %>Mapper <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, <%= entityClass %>SearchRepository <%= entityInstance %>SearchRepository<% } %><% if (reactiveRepositories) { %>, <%= entityClass %>ReactiveRepository <%= entityInstance %>ReactiveRepository<% } %><%  } else { %><%= entityClass %>Service <%= entityInstance %>Service<% } %><% if (queryService && viaService) { %>, <%= entityClass %>QueryService <%= entityInstance %>QueryService<% } %>) {
         <%_ if (!viaService) { _%>
         this.<%= entityInstance %>Repository = <%= entityInstance %>Repository;
             <%_ if (dto === 'mapstruct') { _%>
@@ -44,6 +48,9 @@
             <%_ } _%>
             <%_ if (searchEngine === 'elasticsearch') { _%>
         this.<%= entityInstance %>SearchRepository = <%= entityInstance %>SearchRepository;
+            <%_ } _%>
+            <%_ if (reactiveRepositories) { _%>
+        this.<%= entityInstance %>ReactiveRepository = <%= entityInstance %>ReactiveRepository;
             <%_ } _%>
         <%_  } else { _%>
         this.<%= entityInstance %>Service = <%= entityInstance %>Service;

--- a/generators/entity-server/templates/src/main/java/package/repository/reactive/EntityReactiveRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/reactive/EntityReactiveRepository.java.ejs
@@ -16,24 +16,34 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%=packageName%>.repository.reactive;
+package <%= packageName %>.repository.reactive;
 
-import <%=packageName%>.domain.<%=entityClass%>;
+import <%= packageName %>.domain.<%= entityClass %>;
 <%_ if (databaseType === 'cassandra') { _%>
 import org.springframework.data.cassandra.repository.ReactiveCassandraRepository;
 <%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
+import org.springframework.data.couchbase.core.query.Query;
 import org.springframework.data.couchbase.repository.ReactiveCouchbaseSortingRepository;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 <%_ } _%>
 import org.springframework.stereotype.Repository;
+<%_ if (databaseType === 'couchbase') { _%>
+import reactor.core.publisher.Flux;
+<%_ } _%>
 
 /**
  * Spring Data <% if (databaseType === 'mongodb') { %>MongoDB<% } if (databaseType === 'couchbase') { %>Couchbase<% } if (databaseType === 'cassandra') { %>Cassandra<% } %> reactive repository for the <%= entityClass %> entity.
  */
 @SuppressWarnings("unused")
 @Repository
-public interface <%=entityClass%>ReactiveRepository extends Reactive<% if (databaseType === 'mongodb') { %>Mongo<% } if (databaseType === 'couchbase') { %>CouchbaseSorting<% } if (databaseType === 'cassandra') { %>Cassandra<% } %>Repository<<%=entityClass%>, <%= pkType %>> {
+public interface <%= entityClass %>ReactiveRepository extends Reactive<% if (databaseType === 'mongodb') { %>Mongo<% } if (databaseType === 'couchbase') { %>CouchbaseSorting<% } if (databaseType === 'cassandra') { %>Cassandra<% } %>Repository<<%= entityClass %>, <%= pkType %>> {
+    <%_ if (databaseType === 'couchbase') { _%>
+
+    @Query("#{#n1ql.selectEntity} WHERE #{#n1ql.filter}")
+    Flux<<%= entityClass %>> findAll();
+
+    <%_ } _%>
 }

--- a/generators/entity-server/templates/src/main/java/package/repository/reactive/EntityReactiveRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/reactive/EntityReactiveRepository.java.ejs
@@ -1,0 +1,39 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.repository.reactive;
+
+import <%=packageName%>.domain.<%=entityClass%>;
+<%_ if (databaseType === 'cassandra') { _%>
+import org.springframework.data.cassandra.repository.ReactiveCassandraRepository;
+<%_ } _%>
+<%_ if (databaseType === 'couchbase') { _%>
+import org.springframework.data.couchbase.repository.support.ReactiveN1qlCouchbaseRepository;
+<%_ } _%>
+<%_ if (databaseType === 'mongodb') { _%>
+import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
+<%_ } _%>
+import org.springframework.stereotype.Repository;
+
+/**
+ * Spring Data <% if (databaseType === 'mongodb') { %>MongoDB<% } if (databaseType === 'couchbase') { %>Couchbase<% } if (databaseType === 'cassandra') { %>Cassandra<% } %> reactive repository for the <%= entityClass %> entity.
+ */
+@SuppressWarnings("unused")
+@Repository
+public interface <%=entityClass%>ReactiveRepository extends Reactive<% if (databaseType === 'mongodb') { %>Mongo<% } if (databaseType === 'couchbase') { %>N1qlCouchbase<% } if (databaseType === 'cassandra') { %>Cassandra<% } %>Repository<<%=entityClass%>, <%= pkType %>> {
+}

--- a/generators/entity-server/templates/src/main/java/package/repository/reactive/EntityReactiveRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/reactive/EntityReactiveRepository.java.ejs
@@ -23,7 +23,7 @@ import <%=packageName%>.domain.<%=entityClass%>;
 import org.springframework.data.cassandra.repository.ReactiveCassandraRepository;
 <%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
-import org.springframework.data.couchbase.repository.support.ReactiveN1qlCouchbaseRepository;
+import org.springframework.data.couchbase.repository.ReactiveCouchbaseSortingRepository;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
@@ -35,5 +35,5 @@ import org.springframework.stereotype.Repository;
  */
 @SuppressWarnings("unused")
 @Repository
-public interface <%=entityClass%>ReactiveRepository extends Reactive<% if (databaseType === 'mongodb') { %>Mongo<% } if (databaseType === 'couchbase') { %>N1qlCouchbase<% } if (databaseType === 'cassandra') { %>Cassandra<% } %>Repository<<%=entityClass%>, <%= pkType %>> {
+public interface <%=entityClass%>ReactiveRepository extends Reactive<% if (databaseType === 'mongodb') { %>Mongo<% } if (databaseType === 'couchbase') { %>CouchbaseSorting<% } if (databaseType === 'cassandra') { %>Cassandra<% } %>Repository<<%=entityClass%>, <%= pkType %>> {
 }

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -81,7 +81,7 @@ public interface <%= entityClass %>Service {
      * Get all the <%= entityInstancePlural %>.
      * @return the Flux of entities
      */
-    Flux<<%= instanceType %>> findAllAsStream();
+    Flux<<%= instanceType %>> findAllAsFlux();
 
     <%_ } _%>
     /**

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -29,6 +29,9 @@ import <%=packageName%>.domain.<%= entityClass %>;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 <%_ } _%>
+<%_ if (reactiveRepositories) { _%>
+import reactor.core.publisher.Flux;
+<%_ } _%>
 
 <%_ if (pagination === 'no' || fieldsContainNoOwnerOneToOne === true) { _%>
 import java.util.List;
@@ -73,6 +76,14 @@ public interface <%= entityClass %>Service {
     Page<<%= instanceType %>> findAllWithEagerRelationships(Pageable pageable);
     <% } -%>
 
+    <%_ if (reactiveRepositories) { _%>
+    /**
+     * Get all the <%= entityInstancePlural %>.
+     * @return the Flux of entities
+     */
+    Flux<<%= instanceType %>> findAllAsStream();
+
+    <%_ } _%>
     /**
      * Get the "id" <%= entityInstance %>.
      *

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%=packageName%>.service<% if (service === 'serviceImpl') { %>.impl<% } %>;
+package <%= packageName %>.service<% if (service === 'serviceImpl') { %>.impl<% } %>;
 <%  const serviceClassName = service === 'serviceImpl' ? entityClass + 'ServiceImpl' : entityClass + 'Service';
     let viaService = false;
     const instanceType = (dto === 'mapstruct') ? entityClass + 'DTO' : entityClass;
@@ -28,12 +28,19 @@ package <%=packageName%>.service<% if (service === 'serviceImpl') { %>.impl<% } 
     const repository = entityInstance  + 'Repository';
     const searchRepository = entityInstance  + 'SearchRepository';
     if (service === 'serviceImpl') { %>
-import <%=packageName%>.service.<%= entityClass %>Service;<% } %>
-import <%=packageName%>.domain.<%= entityClass %>;
-import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine === 'elasticsearch') { %>
-import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } if (dto === 'mapstruct') { %>
-import <%=packageName%>.service.dto.<%= entityClass %>DTO;
-import <%=packageName%>.service.mapper.<%= entityClass %>Mapper;<% } %>
+import <%= packageName %>.service.<%= entityClass %>Service;<% } %>
+import <%= packageName %>.domain.<%= entityClass %>;
+import <%= packageName %>.repository.<%= entityClass %>Repository;
+<%_ if (reactiveRepositories) { _%>
+import <%= packageName %>.repository.reactive.<%= entityClass %>ReactiveRepository;
+<%_ } _%>
+<%_ if (searchEngine === 'elasticsearch') { _%>
+import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;
+<%_ } _%>
+<%_ if (dto === 'mapstruct') { _%>
+import <%= packageName %>.service.dto.<%= entityClass %>DTO;
+import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
+<%_ } _%>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -45,11 +52,14 @@ import org.springframework.stereotype.Service;
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
+<%_ if (reactiveRepositories) { _%>
+import reactor.core.publisher.Flux;
+<%_ } _%>
 
-import java.util.Optional;
 <%_ if (dto === 'mapstruct' && (pagination === 'no' ||  fieldsContainNoOwnerOneToOne === true)) { _%>
 import java.util.LinkedList;<% } %><% if (pagination === 'no' ||  fieldsContainNoOwnerOneToOne === true) { %>
-import java.util.List;<% } %><% if (databaseType === 'cassandra') { %>
+import java.util.List;<% } %>
+import java.util.Optional;<% if (databaseType === 'cassandra') { %>
 import java.util.UUID;<% } %><% if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && ((searchEngine === 'elasticsearch' && !viaService) || dto === 'mapstruct'))) { %>
 import java.util.stream.Collectors;<% } %><% if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && searchEngine === 'elasticsearch' && !viaService)) { %>
 import java.util.stream.StreamSupport;<% } %><% if (searchEngine === 'elasticsearch') { %>
@@ -103,6 +113,18 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
             .map(<%= entityToDtoReference %>);<% } %>
         <%_ } _%>
     }
+    <%_ if (reactiveRepositories) { _%>
+
+    /**
+     * Get all the <%= entityInstancePlural %>.
+     * @return the Flux of entities
+     */
+    public Flux<<%= instanceType %>> findAllAsFlux() {
+        log.debug("Request to get all <%= entityClassPlural %> as a flux");
+        return <%= entityInstance %>ReactiveRepository.findAll()<% if (dto === 'mapstruct') { %>
+            .map(<%= entityToDtoReference %>)<% } %>;
+    }
+    <%_ } _%>
     <%_ if (fieldsContainOwnerManyToMany === true) { _%>
 
     /**

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -23,9 +23,16 @@ import com.codahale.metrics.annotation.Timed;
 import <%=packageName%>.domain.<%= entityClass %>;
 <%_ } _%>
 <%_ if (service !== 'no') { _%>
-import <%=packageName%>.service.<%= entityClass %>Service;<% } else { %>
-import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (searchEngine === 'elasticsearch') { %>
-import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% }} %>
+import <%=packageName%>.service.<%= entityClass %>Service;
+<%_ } else { _%>
+import <%=packageName%>.repository.<%= entityClass %>Repository;
+    <%_ if (reactiveRepositories) { _%>
+import <%=packageName%>.repository.reactive.<%= entityClass %>ReactiveRepository;
+    <%_ } _%>
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;
+    <%_ } _%>
+<%_ } _%>
 import <%=packageName%>.web.rest.errors.BadRequestAlertException;
 import <%=packageName%>.web.rest.util.HeaderUtil;<% if (pagination !== 'no') { %>
 import <%=packageName%>.web.rest.util.PaginationUtil;<% } %>
@@ -148,7 +155,7 @@ public class <%= entityClass %>Resource {
      * GET  /<%= entityApiUrl %> : get all the <%= entityInstancePlural %> as a stream.
      * @return the Flux of <%= entityInstancePlural %>
      */
-    @GetMapping("/<%= entityApiUrl %>", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
+    @GetMapping(value = "/<%= entityApiUrl %>", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
     @Timed
     public Flux<<%= instanceType %>> getAll<%= entityClassPlural %>AsStream() {
         log.debug("REST request to get all <%= entityClassPlural %> as a stream");

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -47,10 +47,18 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 <%_ } _%>
+<%_ if (reactiveRepositories) { _%>
+import org.springframework.http.MediaType;
+<%_ } _%>
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
-<% if (validation) { %>
-import javax.validation.Valid;<% } %>
+<%_ if (reactiveRepositories) { _%>
+import reactor.core.publisher.Flux;
+<%_ } _%>
+
+<%_ if (validation) { _%>
+import javax.validation.Valid;
+<%_ } _%>
 import java.net.URI;
 import java.net.URISyntaxException;
 <%_ const viaService = service !== 'no';
@@ -135,6 +143,23 @@ public class <%= entityClass %>Resource {
     @GetMapping("/<%= entityApiUrl %>")
     @Timed<%- include('../../common/get_all_template', {viaService: viaService}); -%>
 
+    <%_ if (reactiveRepositories) { _%>
+    /**
+     * GET  /<%= entityApiUrl %> : get all the <%= entityInstancePlural %> as a stream.
+     * @return the Flux of <%= entityInstancePlural %>
+     */
+    @GetMapping("/<%= entityApiUrl %>", produces = MediaType.APPLICATION_STREAM_JSON_VALUE)
+    @Timed
+    public Flux<<%= instanceType %>> getAll<%= entityClassPlural %>AsStream() {
+        log.debug("REST request to get all <%= entityClassPlural %> as a stream");
+        <%_ if (viaService) { _%>
+        return <%= entityInstance %>Service.findAllAsFlux();
+        <%_ } else { _%>
+        return <%= entityInstance %>ReactiveRepository.findAll();
+        <%_ } _%>
+    }
+
+    <%_ } _%>
     /**
      * GET  /<%= entityApiUrl %>/:id : get the "id" <%= entityInstance %>.
      *

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -720,8 +720,11 @@ _%>
 
         List<<%= entityClass %>> <%= entityInstance %>List = client.get().uri("/api/<%= entityApiUrl %>").accept(MediaType.APPLICATION_STREAM_JSON).exchange()
             .expectStatus().isOk()
-            .returnResult(<%= entityClass %>.class)
+            .returnResult(<%= entityClass %><% if (dto !== 'no') { %>DTO<% } %>.class)
             .getResponseBody()
+            <%_ if (dto !== 'no') { _%>
+            .map(<%= entityInstance %>Mapper::toEntity)
+            <%_ } _%>
             .filter(<%= entityInstance %>::equals)
             .collectList()
             .block(Duration.ofSeconds(5));

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -30,11 +30,19 @@ import <%=packageName%>.domain.<%= entityClass %>;
         if ((relationshipValidate !== null && relationshipValidate === true) || jpaMetamodelFiltering) { _%>
 import <%=packageName%>.domain.<%= otherEntityNameCapitalized %>;
 <%_ } } _%>
-import <%=packageName%>.repository.<%= entityClass %>Repository;<% if (service !== 'no') { %>
-import <%=packageName%>.service.<%= entityClass %>Service;<% } if (searchEngine === 'elasticsearch') { %>
-import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;<% } if (dto === 'mapstruct') { %>
+import <%=packageName%>.repository.<%= entityClass %>Repository;
+<%_ if (searchEngine === 'elasticsearch') { _%>
+import <%=packageName%>.repository.search.<%= entityClass %>SearchRepository;
+<%_ } _%>
+<%_ if (service !== 'no') { _%>
+import <%=packageName%>.service.<%= entityClass %>Service;
+<%_ } else if (reactiveRepositories) { _%>
+import <%=packageName%>.repository.reactive.<%= entityClass %>ReactiveRepository;
+<%_ } _%>
+<%_ if (dto === 'mapstruct') { _%>
 import <%=packageName%>.service.dto.<%= entityClass %>DTO;
-import <%=packageName%>.service.mapper.<%= entityClass %>Mapper;<% } %>
+import <%=packageName%>.service.mapper.<%= entityClass %>Mapper;
+<%_ } _%>
 import <%=packageName%>.web.rest.errors.ExceptionTranslator;
 <%_ if (jpaMetamodelFiltering) { _%>
 import <%=packageName%>.service.dto.<%= entityClass %>Criteria;
@@ -267,6 +275,11 @@ _%>
     @Autowired
     private <%= entityClass %>Repository <%= entityInstance %>Repository;
 
+    <%_ if (reactiveRepositories && service === 'no') { _%>
+    @Autowired
+    private <%= entityClass %>ReactiveRepository <%= entityInstance %>ReactiveRepository;
+
+    <%_ } _%>
     <%_ if (fieldsContainOwnerManyToMany === true) { _%>
     @Mock
     private <%= entityClass %>Repository <%= entityInstance %>RepositoryMock;<%_ } _%><% if (dto === 'mapstruct') { %>
@@ -317,7 +330,7 @@ _%>
         <%_ if (service !== 'no') { _%>
         final <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource(<%= entityInstance %>Service<% if (jpaMetamodelFiltering) { %>, <%= entityInstance %>QueryService<% } %>);
         <%_ } else { _%>
-        final <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource(<%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, mock<%= entityClass %>SearchRepository<% } %><% if (jpaMetamodelFiltering) { %>, <%= entityInstance %>QueryService<% } %>);
+        final <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource(<%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, mock<%= entityClass %>SearchRepository<% } %><% if (reactiveRepositories) { %>, <%= entityInstance %>ReactiveRepository<% } %><% if (jpaMetamodelFiltering) { %>, <%= entityInstance %>QueryService<% } %>);
         <%_ } _%>
         this.rest<%= entityClass %>MockMvc = MockMvcBuilders.standaloneSetup(<%= entityInstance %>Resource)
             .setCustomArgumentResolvers(pageableArgumentResolver)

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -706,6 +706,7 @@ _%>
 
 <%_  } _%>
 <%_ if (reactiveRepositories) { _%>
+
     @Test
     public void getAll<%= entityClassPlural %>AsStream() {
         // Initialize the database
@@ -720,7 +721,7 @@ _%>
 
         List<<%= entityClass %>> <%= entityInstance %>List = client.get().uri("/api/<%= entityApiUrl %>").accept(MediaType.APPLICATION_STREAM_JSON).exchange()
             .expectStatus().isOk()
-            .expectHeader().contentType(MediaType.APPLICATION_STREAM_JSON)
+            .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_STREAM_JSON)
             .returnResult(<%= entityClass %><% if (dto !== 'no') { %>DTO<% } %>.class)
             .getResponseBody()
             <%_ if (dto !== 'no') { _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -64,6 +64,9 @@ import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 import org.springframework.http.MediaType;
 import org.springframework.http.converter.json.MappingJackson2HttpMessageConverter;
 import org.springframework.test.context.junit4.SpringRunner;
+<%_ if (reactiveRepositories) { _%>
+import org.springframework.test.web.reactive.server.WebTestClient;
+<%_ } _%>
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;<% if (databaseType === 'sql') { %>
 import org.springframework.transaction.annotation.Transactional;<% } %><% if (fieldsContainBlob === true) { %>
@@ -71,7 +74,8 @@ import org.springframework.util.Base64Utils;<% } %>
 <% if (databaseType === 'sql') { %>
 import javax.persistence.EntityManager;<% } %><% if (fieldsContainBigDecimal === true) { %>
 import java.math.BigDecimal;<% } %><% if (fieldsContainBlob === true && databaseType === 'cassandra') { %>
-import java.nio.ByteBuffer;<% } %><% if (fieldsContainLocalDate === true) { %>
+import java.nio.ByteBuffer;<% } %><% if (reactiveRepositories) { %>
+import java.time.Duration;<% } %><% if (fieldsContainLocalDate === true) { %>
 import java.time.LocalDate;<% } %><% if (fieldsContainInstant === true || fieldsContainZonedDateTime === true) { %>
 import java.time.Instant;<% } %><% if (fieldsContainZonedDateTime === true) { %>
 import java.time.ZonedDateTime;
@@ -701,7 +705,43 @@ _%>
     }
 
 <%_  } _%>
+<%_ if (reactiveRepositories) { _%>
+    @Test
+    public void getAll<%= entityClassPlural %>AsStream() {
+        // Initialize the database
+        <%= entityInstance %>Repository.save(<%= entityInstance %>);
 
+        <%_ if (service !== 'no') { _%>
+        final <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource(<%= entityInstance %>Service<% if (jpaMetamodelFiltering) { %>, <%= entityInstance %>QueryService<% } %>);
+        <%_ } else { _%>
+        final <%= entityClass %>Resource <%= entityInstance %>Resource = new <%= entityClass %>Resource(<%= entityInstance %>Repository<% if (dto === 'mapstruct') { %>, <%= entityInstance %>Mapper<% } %><% if (searchEngine === 'elasticsearch') { %>, mock<%= entityClass %>SearchRepository<% } %><% if (reactiveRepositories) { %>, <%= entityInstance %>ReactiveRepository<% } %><% if (jpaMetamodelFiltering) { %>, <%= entityInstance %>QueryService<% } %>);
+        <%_ } _%>
+        WebTestClient client = WebTestClient.bindToController(<%= entityInstance %>Resource).build();
+
+        List<<%= entityClass %>> <%= entityInstance %>List = client.get().uri("/api/<%= entityApiUrl %>").accept(MediaType.APPLICATION_STREAM_JSON).exchange()
+            .expectStatus().isOk()
+            .returnResult(<%= entityClass %>.class)
+            .getResponseBody()
+            .filter(<%= entityInstance %>::equals)
+            .collectList()
+            .block(Duration.ofSeconds(5));
+
+        assertThat(<%= entityInstance %>List).isNotNull();
+        assertThat(<%= entityInstance %>List).hasSize(1);
+        <%= entityClass %> test<%= entityClass %> = <%= entityInstance %>List.get(0);
+        <%_ for (idx in fields) { if (fields[idx].fieldType === 'ZonedDateTime') { _%>
+        assertThat(test<%= entityClass %>.get<%=fields[idx].fieldInJavaBeanMethod%>()).isEqualTo(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>);
+        <%_ } else if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { _%>
+        assertThat(test<%= entityClass %>.get<%=fields[idx].fieldInJavaBeanMethod%>()).isEqualTo(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>);
+        assertThat(test<%= entityClass %>.get<%=fields[idx].fieldInJavaBeanMethod%>ContentType()).isEqualTo(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>_CONTENT_TYPE);
+        <%_ } else if (fields[idx].fieldType.toLowerCase() === 'boolean') { _%>
+        assertThat(test<%= entityClass %>.is<%=fields[idx].fieldInJavaBeanMethod%>()).isEqualTo(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>);
+        <%_ } else { _%>
+        assertThat(test<%= entityClass %>.get<%=fields[idx].fieldInJavaBeanMethod%>()).isEqualTo(<%='DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase()%>);
+        <%_ }} _%>
+    }
+
+    <%_  } _%>
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void getNonExisting<%= entityClass %>() throws Exception {

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -720,6 +720,7 @@ _%>
 
         List<<%= entityClass %>> <%= entityInstance %>List = client.get().uri("/api/<%= entityApiUrl %>").accept(MediaType.APPLICATION_STREAM_JSON).exchange()
             .expectStatus().isOk()
+            .expectHeader().contentType(MediaType.APPLICATION_STREAM_JSON)
             .returnResult(<%= entityClass %><% if (dto !== 'no') { %>DTO<% } %>.class)
             .getResponseBody()
             <%_ if (dto !== 'no') { _%>

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -133,6 +133,7 @@ module.exports = class extends BaseGenerator {
                 this.env.options.appPath = this.config.get('appPath') || constants.CLIENT_MAIN_SRC_DIR;
                 context.options = this.options;
                 context.baseName = this.config.get('baseName');
+                context.reactive = this.config.get('reactive');
                 context.capitalizedBaseName = _.upperFirst(context.baseName);
                 context.packageName = this.config.get('packageName');
                 context.applicationType = this.config.get('applicationType');
@@ -473,6 +474,7 @@ module.exports = class extends BaseGenerator {
                 context.entityTranslationKey = context.clientRootFolder ? _.camelCase(`${context.clientRootFolder}-${context.entityInstance}`) : context.entityInstance;
                 context.entityTranslationKeyMenu = _.camelCase(context.clientRootFolder ? `${context.clientRootFolder}-${context.entityStateName}` : context.entityStateName);
                 context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
+                context.reactiveRepositories = context.reactive && context.databaseType !== 'sql';
 
                 context.fieldsContainDate = false;
                 context.fieldsContainInstant = false;

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -474,7 +474,7 @@ module.exports = class extends BaseGenerator {
                 context.entityTranslationKey = context.clientRootFolder ? _.camelCase(`${context.clientRootFolder}-${context.entityInstance}`) : context.entityInstance;
                 context.entityTranslationKeyMenu = _.camelCase(context.clientRootFolder ? `${context.clientRootFolder}-${context.entityStateName}` : context.entityStateName);
                 context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
-                context.reactiveRepositories = context.reactive && ['mongo', 'couchbase'].includes(context.databaseType);
+                context.reactiveRepositories = context.reactive && ['mongodb', 'couchbase'].includes(context.databaseType);
 
                 context.fieldsContainDate = false;
                 context.fieldsContainInstant = false;

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -474,7 +474,7 @@ module.exports = class extends BaseGenerator {
                 context.entityTranslationKey = context.clientRootFolder ? _.camelCase(`${context.clientRootFolder}-${context.entityInstance}`) : context.entityInstance;
                 context.entityTranslationKeyMenu = _.camelCase(context.clientRootFolder ? `${context.clientRootFolder}-${context.entityStateName}` : context.entityStateName);
                 context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
-                context.reactiveRepositories = context.reactive && context.databaseType !== 'sql';
+                context.reactiveRepositories = context.reactive && ['mongo', 'couchbase'].includes(context.databaseType);
 
                 context.fieldsContainDate = false;
                 context.fieldsContainInstant = false;

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -297,7 +297,7 @@ dependencies {
     compile "net.java.dev.jna:jna"
     <%_ } _%>
     <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
-    compile "org.springframework.boot:spring-boot-starter-data-<%=databaseType%>"
+    compile "org.springframework.boot:spring-boot-starter-data-<%=databaseType%><% if (reactive === true) { %>-reactive<% } %>"
     <%_ } _%>
     <%_ if (messageBroker === 'kafka') { _%>
     compile "org.springframework.cloud:spring-cloud-stream"

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -522,7 +522,13 @@
         <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
         <dependency>
             <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-<%=databaseType%></artifactId>
+            <artifactId>spring-boot-starter-data-<%=databaseType%><% if (reactive === true) { %>-reactive<% } %></artifactId>
+        </dependency>
+        <%_ } _%>
+        <%_ if (databaseType === 'cassandra') { _%>
+        <dependency>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-data-cassandra-reactive</artifactId>
         </dependency>
         <%_ } _%>
         <dependency>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -525,12 +525,6 @@
             <artifactId>spring-boot-starter-data-<%=databaseType%><% if (reactive === true) { %>-reactive<% } %></artifactId>
         </dependency>
         <%_ } _%>
-        <%_ if (databaseType === 'cassandra') { _%>
-        <dependency>
-            <groupId>org.springframework.boot</groupId>
-            <artifactId>spring-boot-starter-data-cassandra-reactive</artifactId>
-        </dependency>
-        <%_ } _%>
         <dependency>
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-logging</artifactId>

--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -97,6 +97,9 @@ import org.springframework.data.couchbase.core.convert.CouchbaseCustomConversion
 import org.springframework.data.couchbase.core.mapping.event.ValidatingCouchbaseEventListener;
 import org.springframework.data.couchbase.repository.auditing.EnableCouchbaseAuditing;
 import org.springframework.data.couchbase.repository.config.EnableCouchbaseRepositories;
+    <%_ if (reactive) { _%>
+import org.springframework.data.couchbase.repository.config.EnableReactiveCouchbaseRepositories;
+    <%_ } _%>
 import org.springframework.util.StringUtils;<% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase') { %>
 import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;<% } %>
 <%_ if (databaseType === 'sql') { _%>

--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -46,8 +46,18 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 <%_ if (databaseType === 'mongodb') { _%>
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;<% } %><% if (databaseType === 'couchbase') { %>
-import org.springframework.boot.autoconfigure.couchbase.CouchbaseAutoConfiguration;<% } %><% if (databaseType === 'sql') { %>
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+    <%_ if (reactive) { _%>
+import org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfiguration;
+    <%_ } _%>
+<%_ } _%>
+<%_ if (databaseType === 'couchbase') { _%>
+import org.springframework.boot.autoconfigure.couchbase.CouchbaseAutoConfiguration;
+    <%_ if (reactive) { _%>
+import org.springframework.boot.autoconfigure.couchbase.CouchbaseReactiveAutoConfiguration;
+    <%_ } _%>
+<%_ } _%>
+<%_ if (databaseType === 'sql') { _%>
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;<% } %>
 import org.springframework.context.annotation.Bean;
@@ -55,7 +65,7 @@ import org.springframework.context.annotation.Configuration;
 <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
 import org.springframework.context.annotation.Import;
 <%_ } _%>
-<%_ if (searchEngine === 'elasticsearch' && databaseType === 'mongodb') { _%>
+<%_ if ((searchEngine === 'elasticsearch' || reactive) && databaseType === 'mongodb') { _%>
 import org.springframework.context.annotation.ComponentScan.Filter;
 import org.springframework.context.annotation.FilterType;
 <%_ } _%>
@@ -64,9 +74,6 @@ import org.springframework.context.annotation.Profile;<% } %><% if (databaseType
 import org.springframework.core.env.Environment;<% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase') { %>
 import org.springframework.core.convert.converter.Converter;<% } %>
 <%_ if (searchEngine === 'elasticsearch') { _%>
-    <%_ if (databaseType === 'mongodb') { _%>
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;
-    <%_ } _%>
 import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
@@ -74,10 +81,15 @@ import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener;
-    <%_ if (searchEngine === 'elasticsearch') { _%>
+    <%_ if (searchEngine === 'elasticsearch' || reactive) { _%>
 import org.springframework.data.mongodb.repository.MongoRepository;
     <%_ } _%>
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;<% } %><% if (databaseType === 'couchbase') { %>
+import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
+    <%_ if (reactive) { _%>
+import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
+    <%_ } _%>
+<%_ } _%>
+<%_ if (databaseType === 'couchbase') { _%>
 import org.springframework.data.convert.ReadingConverter;
 import org.springframework.data.convert.WritingConverter;
 import org.springframework.data.couchbase.config.BeanNames;
@@ -113,30 +125,44 @@ import java.util.Date;
 import java.util.List;
 <%_ } _%>
 
-@Configuration<% if (databaseType === 'sql') { %>
+@Configuration
+<%_ if (databaseType === 'sql') { _%>
 @EnableJpaRepositories("<%=packageName%>.repository")
 @EnableJpaAuditing(auditorAwareRef = "springSecurityAuditorAware")
-@EnableTransactionManagement<% } %>
-<%_ if (searchEngine === 'elasticsearch' && databaseType === 'mongodb') { _%>
-@EnableElasticsearchRepositories(basePackages = "<%=packageName%>.repository.search", excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MongoRepository.class))
-@EnableMongoRepositories(basePackages = "<%=packageName%>.repository", excludeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = ElasticsearchRepository.class))
+@EnableTransactionManagement
 <%_ } _%>
-<%_ if (searchEngine === 'elasticsearch' && databaseType != 'mongodb') { _%>
+<%_ if (searchEngine === 'elasticsearch') { _%>
 @EnableElasticsearchRepositories("<%=packageName%>.repository.search")
 <%_ } _%>
-<%_ if (searchEngine != 'elasticsearch' && databaseType === 'mongodb') { _%>
+<%_ if (databaseType === 'mongodb') { _%>
+    <%_ if (searchEngine === 'elasticsearch' || reactive) { _%>
+@EnableMongoRepositories(basePackages = "<%=packageName%>.repository", includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MongoRepository.class))
+    <%_ } else { _%>
 @EnableMongoRepositories("<%=packageName%>.repository")
+    <%_ } _%>
+    <%_ if (reactive) { _%>
+@EnableReactiveMongoRepositories("<%=packageName%>.repository.reactive")
+    <%_ } _%>
 <%_ } _%>
 <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
 @Profile("!" + JHipsterConstants.SPRING_PROFILE_CLOUD)
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
+    <%_ if (reactive) { _%>
+@Import(value = {MongoAutoConfiguration.class, MongoReactiveAutoConfiguration.class})
+    <%_ } else { _%>
 @Import(value = MongoAutoConfiguration.class)
+    <%_ } _%>
 @EnableMongoAuditing(auditorAwareRef = "springSecurityAuditorAware")
 <%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
 @EnableCouchbaseRepositories(repositoryBaseClass = CustomN1qlCouchbaseRepository.class, basePackages = "<%=packageName%>.repository")
+    <%_ if (reactive) { _%>
+@EnableReactiveCouchbaseRepositories("<%=packageName%>.repository.reactive")
+@Import(value = {CouchbaseAutoConfiguration.class, CouchbaseReactiveAutoConfiguration.class})
+    <%_ } else { _%>
 @Import(value = CouchbaseAutoConfiguration.class)
+    <%_ } _%>
 @EnableCouchbaseAuditing(auditorAwareRef = "springSecurityAuditorAware")
 <%_ } _%>
 public class DatabaseConfiguration {

--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -53,9 +53,6 @@ import org.springframework.boot.autoconfigure.mongo.MongoReactiveAutoConfigurati
 <%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
 import org.springframework.boot.autoconfigure.couchbase.CouchbaseAutoConfiguration;
-    <%_ if (reactive) { _%>
-import org.springframework.boot.autoconfigure.couchbase.CouchbaseReactiveAutoConfiguration;
-    <%_ } _%>
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.beans.factory.annotation.Qualifier;
@@ -162,10 +159,8 @@ import java.util.List;
 @EnableCouchbaseRepositories(repositoryBaseClass = CustomN1qlCouchbaseRepository.class, basePackages = "<%=packageName%>.repository")
     <%_ if (reactive) { _%>
 @EnableReactiveCouchbaseRepositories("<%=packageName%>.repository.reactive")
-@Import(value = {CouchbaseAutoConfiguration.class, CouchbaseReactiveAutoConfiguration.class})
-    <%_ } else { _%>
-@Import(value = CouchbaseAutoConfiguration.class)
     <%_ } _%>
+@Import(value = CouchbaseAutoConfiguration.class)
 @EnableCouchbaseAuditing(auditorAwareRef = "springSecurityAuditorAware")
 <%_ } _%>
 public class DatabaseConfiguration {

--- a/generators/server/templates/src/main/java/package/config/cassandra/CassandraConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/cassandra/CassandraConfiguration.java.ejs
@@ -53,6 +53,10 @@ import static java.util.Objects.nonNull;
 @Configuration<% if (applicationType === 'gateway' && databaseType !== 'cassandra') { %>
 @ConditionalOnProperty("jhipster.gateway.rate-limiting.enabled")<% } %>
 @EnableConfigurationProperties(CassandraProperties.class)
+<%_ if (reactive) { _%>
+@EnableReactiveCassandraRepositories("<%=packageName%>.repository.reactive")
+@Import(value = ReactiveCassandraAutoConfiguration.class)
+<%_ } _%>
 @Profile({JHipsterConstants.SPRING_PROFILE_DEVELOPMENT, JHipsterConstants.SPRING_PROFILE_PRODUCTION})
 public class CassandraConfiguration {
 

--- a/generators/server/templates/src/main/java/package/config/cassandra/CassandraConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/cassandra/CassandraConfiguration.java.ejs
@@ -26,22 +26,13 @@ import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.autoconfigure.cassandra.CassandraProperties;
-<%_ if (reactive) { _%>
-import org.springframework.boot.autoconfigure.cassandra.CassandraReactiveAutoConfiguration;
-<%_ } _%>
 <%_ if (applicationType === 'gateway' && databaseType !== 'cassandra') { _%>
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 <%_ } _%>
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-<%_ if (reactive) { _%>
-import org.springframework.context.annotation.Import;
-<%_ } _%>
 import org.springframework.context.annotation.Profile;
-<%_ if (reactive) { _%>
-import org.springframework.data.cassandra.repository.config.EnableReactiveCassandraRepositories;
-<%_ } _%>
 import org.springframework.util.StringUtils;
 
 import com.codahale.metrics.MetricRegistry;
@@ -64,10 +55,6 @@ import static java.util.Objects.nonNull;
 @Configuration<% if (applicationType === 'gateway' && databaseType !== 'cassandra') { %>
 @ConditionalOnProperty("jhipster.gateway.rate-limiting.enabled")<% } %>
 @EnableConfigurationProperties(CassandraProperties.class)
-<%_ if (reactive) { _%>
-@EnableReactiveCassandraRepositories("<%=packageName%>.repository.reactive")
-@Import(value = CassandraReactiveAutoConfiguration.class)
-<%_ } _%>
 @Profile({JHipsterConstants.SPRING_PROFILE_DEVELOPMENT, JHipsterConstants.SPRING_PROFILE_PRODUCTION})
 public class CassandraConfiguration {
 

--- a/generators/server/templates/src/main/java/package/config/cassandra/CassandraConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/cassandra/CassandraConfiguration.java.ejs
@@ -25,12 +25,23 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.BeanUtils;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.boot.autoconfigure.cassandra.CassandraProperties;<% if (applicationType === 'gateway' && databaseType !== 'cassandra') { %>
-import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;<% } %>
+import org.springframework.boot.autoconfigure.cassandra.CassandraProperties;
+<%_ if (reactive) { _%>
+import org.springframework.boot.autoconfigure.cassandra.CassandraReactiveAutoConfiguration;
+<%_ } _%>
+<%_ if (applicationType === 'gateway' && databaseType !== 'cassandra') { _%>
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+<%_ } _%>
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+<%_ if (reactive) { _%>
+import org.springframework.context.annotation.Import;
+<%_ } _%>
 import org.springframework.context.annotation.Profile;
+<%_ if (reactive) { _%>
+import org.springframework.data.cassandra.repository.config.EnableReactiveCassandraRepositories;
+<%_ } _%>
 import org.springframework.util.StringUtils;
 
 import com.codahale.metrics.MetricRegistry;
@@ -55,7 +66,7 @@ import static java.util.Objects.nonNull;
 @EnableConfigurationProperties(CassandraProperties.class)
 <%_ if (reactive) { _%>
 @EnableReactiveCassandraRepositories("<%=packageName%>.repository.reactive")
-@Import(value = ReactiveCassandraAutoConfiguration.class)
+@Import(value = CassandraReactiveAutoConfiguration.class)
 <%_ } _%>
 @Profile({JHipsterConstants.SPRING_PROFILE_DEVELOPMENT, JHipsterConstants.SPRING_PROFILE_PRODUCTION})
 public class CassandraConfiguration {

--- a/travis/samples/.jhipster/CassBankAccount.json
+++ b/travis/samples/.jhipster/CassBankAccount.json
@@ -58,7 +58,7 @@
     ],
     "changelogDate": "20150805124838",
     "dto": "mapstruct",
-    "service": "no",
+    "service": "serviceImpl",
     "angularJSSuffix": "mySuffix",
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/CassTestMapstructEntity.json
+++ b/travis/samples/.jhipster/CassTestMapstructEntity.json
@@ -213,6 +213,6 @@
     ],
     "changelogDate": "20160208184031",
     "dto": "mapstruct",
-    "service": "no",
+    "service": "serviceImpl",
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/DocumentBankAccount.json
+++ b/travis/samples/.jhipster/DocumentBankAccount.json
@@ -61,6 +61,6 @@
     ],
     "changelogDate": "20150805124838",
     "dto": "mapstruct",
-    "service": "no",
+    "service": "serviceImpl",
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/FieldTestMapstructEntity.json
+++ b/travis/samples/.jhipster/FieldTestMapstructEntity.json
@@ -318,6 +318,6 @@
     ],
     "changelogDate": "20160208184031",
     "dto": "mapstruct",
-    "service": "no",
+    "service": "serviceClass",
     "pagination": "no"
 }

--- a/travis/samples/ngx-couchbase/.yo-rc.json
+++ b/travis/samples/ngx-couchbase/.yo-rc.json
@@ -11,6 +11,7 @@
       "databaseType": "couchbase",
       "devDatabaseType": "couchbase",
       "prodDatabaseType": "couchbase",
+      "reactive": true,
       "searchEngine": false,
       "messageBroker": false,
       "serviceDiscoveryType": false,

--- a/travis/samples/ngx-mongodb-kafka-cucumber/.yo-rc.json
+++ b/travis/samples/ngx-mongodb-kafka-cucumber/.yo-rc.json
@@ -11,6 +11,7 @@
     "databaseType": "mongodb",
     "devDatabaseType": "mongodb",
     "prodDatabaseType": "mongodb",
+    "reactive": true,
     "searchEngine": false,
     "useSass": false,
     "buildTool": "maven",

--- a/travis/samples/ngx-session-cassandra-fr/.yo-rc.json
+++ b/travis/samples/ngx-session-cassandra-fr/.yo-rc.json
@@ -11,6 +11,7 @@
     "databaseType": "cassandra",
     "devDatabaseType": "cassandra",
     "prodDatabaseType": "cassandra",
+    "reactive": true,
     "searchEngine": false,
     "useSass": false,
     "buildTool": "maven",


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

This PR:
- creates a reactive repository if the reactive option is on for Mongo and Couchbase
- creates a streaming reactive WebFlux endpoint with mediatype application/stream+json
- adds a test using WebTestClient for this endpoint

This endpoint has the advantage to be fully reactive end-to-end. It can be used to fetch large collections out of the database without OOM (and without the drawbacks of pagination fetching such as add/delete of entities during the extract and repeated queries to the database).

Cassandra could also be done but this would require to completely move to spring-data-cassandra.
For JPA, there could be some interesting things to do with Scrollable ResultSets but I need to investigate more. 
