### PR TITLE
AWS Elastic-beanstalk instance profile creation missing from new iam class

### DIFF
--- a/generators/aws/lib/eb.js
+++ b/generators/aws/lib/eb.js
@@ -159,6 +159,11 @@ function createEnvironment(params, callback) {
                     Namespace: 'aws:autoscaling:launchconfiguration',
                     OptionName: 'InstanceType',
                     Value: instanceType
+                },
+                {
+                    Namespace: 'aws:autoscaling:launchconfiguration',
+                    OptionName: 'IamInstanceProfile',
+                    Value: 'aws-elasticbeanstalk-ec2-role'
                 }
             ],
             SolutionStackName: solutionStackName,

--- a/generators/aws/lib/iam.js
+++ b/generators/aws/lib/iam.js
@@ -37,7 +37,10 @@ const addRoleToInstanceProfile = (InstanceProfileName, RoleName) => {
 
 const attachRolePolicy = (PolicyArn, RoleName) => {
     const iam = new aws.IAM();
-    return iam.attachRolePolicy({ PolicyArn, RoleName }).promise();
+    return iam.attachRolePolicy({
+        PolicyArn,
+        RoleName
+    }).promise();
 };
 
 
@@ -46,7 +49,9 @@ const attachPolicyToRole = (policySuffix, roleName) => attachRolePolicy(AWS_POLI
 
 const getRole = (RoleName) => {
     const iam = new aws.IAM();
-    return iam.getRole({ RoleName }).promise();
+    return iam.getRole({
+        RoleName
+    }).promise();
 };
 
 const hasRole = roleName => getRole(roleName).then(() => true).catch((err) => {
@@ -56,11 +61,29 @@ const hasRole = roleName => getRole(roleName).then(() => true).catch((err) => {
     throw err;
 });
 
-const hasInstanceProfile = () => hasRole(INSTANCE_PROFILE_ROLE);
-const hasServiceProfile = () => hasRole(SERVICE_PROFILE_ROLE);
+const hasInstanceProfileName = (InstanceProfileName) => {
+    const iam = new aws.IAM();
+    return iam.getInstanceProfile({
+        InstanceProfileName
+    }).promise()
+        .then(() => true)
+        .catch((err) => {
+            if (err && err.code === 'NoSuchEntity') {
+                return false;
+            }
+            throw err;
+        });
+};
 
+const hasInstanceProfile = () => hasInstanceProfileName(INSTANCE_PROFILE_ROLE);
+const hasInstanceRole = () => hasRole(INSTANCE_PROFILE_ROLE);
+const hasServiceProfileRole = () => hasRole(SERVICE_PROFILE_ROLE);
 
-const createServiceProfileWithAttachedPolicies = () => {
+const createInstanceProfileWithAttachment = () =>
+    createInstanceProfile(INSTANCE_PROFILE_ROLE)
+        .then(() => addRoleToInstanceProfile(INSTANCE_PROFILE_ROLE, INSTANCE_PROFILE_ROLE));
+
+const createServiceProfileRoleWithAttachedPolicies = () => {
     const roleName = SERVICE_PROFILE_ROLE;
     const description = 'Default Elastic Beanstalk Service profile created by JHipster.';
     const assumedPolicyDoc = `{
@@ -91,7 +114,7 @@ const createServiceProfileWithAttachedPolicies = () => {
         });
 };
 
-const createInstanceProfileWithAttachedPolicies = () => {
+const createInstanceRoleWithAttachedPolicies = () => {
     const roleName = INSTANCE_PROFILE_ROLE;
     const description = 'Default Elastic Beanstalk instance profile created by JHipster.';
     const assumedPolicyDoc = `{
@@ -108,8 +131,6 @@ const createInstanceProfileWithAttachedPolicies = () => {
 }`;
 
     return createRole(roleName, description, assumedPolicyDoc)
-        .then(() => createInstanceProfile(roleName))
-        .then(() => addRoleToInstanceProfile(roleName, roleName))
         .then(() => {
             const policiesToAttach = [
                 attachPolicyToRole('AWSElasticBeanstalkWebTier', roleName),
@@ -132,26 +153,37 @@ const createInstanceProfileWithAttachedPolicies = () => {
  * @param callback
  */
 Iam.prototype.verifyRoles = function verifyRoles(params, callback) {
-    hasInstanceProfile()
+    hasInstanceRole()
+        .then((instanceRole) => {
+            if (!instanceRole) {
+                log(`Instance role '${INSTANCE_PROFILE_ROLE}' does not exist. Creating based on defaults.`);
+                return createInstanceRoleWithAttachedPolicies();
+            }
+
+            return instanceRole;
+        })
+        .then(() => hasInstanceProfile())
         .then((instanceProfileExists) => {
             if (!instanceProfileExists) {
                 log(`Instance profile '${INSTANCE_PROFILE_ROLE}' does not exist. Creating based on defaults.`);
-                return createInstanceProfileWithAttachedPolicies();
+                return createInstanceProfileWithAttachment();
             }
 
             return instanceProfileExists;
         })
-        .then(() => hasServiceProfile())
+        .then(() => hasServiceProfileRole())
         .then((serviceProfileExists) => {
             if (!serviceProfileExists) {
                 log(`Service Profile profile '${SERVICE_PROFILE_ROLE}' does not exist. Creating based on defaults.`);
-                return createServiceProfileWithAttachedPolicies();
+                return createServiceProfileRoleWithAttachedPolicies();
             }
 
             return serviceProfileExists;
         })
         .then(() => callback(null, null))
         .catch((err) => {
-            callback({ message: err.message }, null);
+            callback({
+                message: err.message
+            }, null);
         });
 };

--- a/generators/aws/lib/iam.js
+++ b/generators/aws/lib/iam.js
@@ -20,6 +20,21 @@ const createRole = (RoleName, Description, AssumeRolePolicyDocument) => {
     }).promise();
 };
 
+const createInstanceProfile = (InstanceProfileName) => {
+    const iam = new aws.IAM();
+    return iam.createInstanceProfile({
+        InstanceProfileName,
+    }).promise();
+};
+
+const addRoleToInstanceProfile = (InstanceProfileName, RoleName) => {
+    const iam = new aws.IAM();
+    return iam.addRoleToInstanceProfile({
+        InstanceProfileName,
+        RoleName
+    }).promise();
+};
+
 const attachRolePolicy = (PolicyArn, RoleName) => {
     const iam = new aws.IAM();
     return iam.attachRolePolicy({ PolicyArn, RoleName }).promise();
@@ -93,6 +108,8 @@ const createInstanceProfileWithAttachedPolicies = () => {
 }`;
 
     return createRole(roleName, description, assumedPolicyDoc)
+        .then(() => createInstanceProfile(roleName))
+        .then(() => addRoleToInstanceProfile(roleName, roleName))
         .then(() => {
             const policiesToAttach = [
                 attachPolicyToRole('AWSElasticBeanstalkWebTier', roleName),


### PR DESCRIPTION
As part of #7443 I failed to correctly define the instance profile as part of the role creation process. When the instance profile is not available, the application will not deploy correctly in Elastic Beanstalk. 

@jdubois would you mind having a look at this PR before it's merged. You'll want to remove the following roles via the web-interface to verify the creation process:

- aws-elasticbeanstalk-ec2-role
- aws-elasticbeanstalk-service-role

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
