### PR TITLE
dockerignore: remove full ignore **/*, and use blacklist instead

### DIFF
--- a/generators/server/templates/src/main/docker/.dockerignore.ejs
+++ b/generators/server/templates/src/main/docker/.dockerignore.ejs
@@ -17,8 +17,17 @@
  limitations under the License.
 -%>
 # https://docs.docker.com/engine/reference/builder/#dockerignore-file
-# by default ignore everything except the jar file
-**/*
+classes/
+generated-sources/
+generated-test-sources/
+h2db/
+maven-archiver/
+maven-status/
+reports/
+surefire-reports/
+test-classes/
+test-results/
+www/
 !*.jar
 !*.war
 <%_ if (prodDatabaseType === 'cassandra') { _%>


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/7455

I keep the exclusion for jar, war, cassandra and couchbase for securing the Docker build.
Hope this new version will work on Mac / Windows.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
