### PR TITLE
AWS Containers Generator Using Old DatabaseType

### DIFF
--- a/generators/aws-containers/index.js
+++ b/generators/aws-containers/index.js
@@ -18,7 +18,7 @@
  */
 const _ = require('lodash');
 const chalk = require('chalk');
-const databaseTypes = require('jhipster-core').JHipsterDatabaseTypes.Types;
+const databaseTypes = require('jhipster-core').JHipsterDatabaseTypes;
 
 const BaseGenerator = require('../generator-base');
 const docker = require('../docker-base');
@@ -301,7 +301,7 @@ module.exports = class extends BaseGenerator {
                 if (this.abort) return;
                 this.appConfigs.forEach((appConfig) => {
                     const app = this.aws.apps.find(a => a.baseName === appConfig.baseName);
-                    const postgresqlType = databaseTypes.postgresql;
+                    const postgresqlType = databaseTypes.POSTGRESQL;
                     app.dbType = appConfig.prodDatabaseType;
 
                     app.auroraEngine = appConfig.prodDatabaseType === postgresqlType ? 'aurora-postgresql' : 'aurora-mysql';

--- a/generators/aws-containers/prompts.js
+++ b/generators/aws-containers/prompts.js
@@ -18,7 +18,7 @@
  */
 const _ = require('lodash');
 const chalk = require('chalk');
-const databaseTypes = require('jhipster-core').JHipsterDatabaseTypes.Types;
+const databaseTypes = require('jhipster-core').JHipsterDatabaseTypes;
 
 const AURORA_DB_PASSORD_REGEX = /^[^@"\/]{8,42}$/; // eslint-disable-line
 const CLOUDFORMATION_STACK_NAME = /[a-zA-Z][-a-zA-Z0-9]*/; // eslint-disable-line
@@ -57,7 +57,7 @@ const PERF_TO_CONFIG = {
         },
         database: {
             size: 'db.t2.small',
-            supportedEngines: [databaseTypes.mariadb, databaseTypes.mysql]
+            supportedEngines: [databaseTypes.MARIADB, databaseTypes.MYSQL]
         }
     },
     medium: {
@@ -67,7 +67,7 @@ const PERF_TO_CONFIG = {
         },
         database: {
             size: 'db.t2.medium',
-            supportedEngines: [databaseTypes.mariadb, databaseTypes.mysql]
+            supportedEngines: [databaseTypes.MARIADB, databaseTypes.MYSQL]
         }
     },
     high: {
@@ -77,7 +77,7 @@ const PERF_TO_CONFIG = {
         },
         database: {
             size: 'db.r4.large',
-            supportedEngines: [databaseTypes.mariadb, databaseTypes.mysql, databaseTypes.postgresql]
+            supportedEngines: [databaseTypes.MARIADB, databaseTypes.MYSQL, databaseTypes.POSTGRESQL]
         }
     }
 };


### PR DESCRIPTION
Modified the AWS Containers generator to use the new JHipsterDatabaseTypes changes from JHipster-Core [#178](https://github.com/jhipster/jhipster-core/issues/178).

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
