### PR TITLE
React : fix user management update page

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -92,13 +92,13 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
         <Row className="justify-content-center">
           <Col md="8">
           { loading ? <p>Loading...</p>
-          : <AvForm model={isNew ? {} : user} onValidSubmit={this.saveUser}>
+          : <AvForm onValidSubmit={this.saveUser}>
             {user.id ? (
               <AvGroup>
                 <Label for="id">
                   <Translate contentKey="global.field.id">ID</Translate>
                 </Label>
-                <AvField type="text" className="form-control" name="id" required readOnly />
+                <AvField type="text" className="form-control" name="id" required readOnly value={user.id} />
               </AvGroup>
             ) : null}
             <AvGroup>
@@ -127,6 +127,7 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
                     errorMessage: translate('register.messages.validate.login.maxlength')
                   }
                 }}
+                value={user.login}
               />
             </AvGroup>
             <AvGroup>
@@ -143,6 +144,7 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
                     errorMessage: translate('entity.validation.maxlength', { max: 50 })
                   }
                 }}
+                value={user.firstName}
                 />
             </AvGroup>
             <AvGroup>
@@ -159,6 +161,7 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
                     errorMessage: translate('entity.validation.maxlength', { max: 50 })
                   }
                 }}
+                value={user.lastName}
               />
               <AvFeedback>This field cannot be longer than 50 characters.</AvFeedback>
             </AvGroup>
@@ -185,6 +188,7 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
                     errorMessage: translate('global.messages.validate.email.maxlength')
                   }
               }}
+              value={user.email}
             />
             </AvGroup>
             <AvGroup check>


### PR DESCRIPTION
Using `model={isNew ? {} : user}` was sometimes displaying outdated values in form when updating an User. For instance, if you were editing `user` and then directly switching to `admin`, you had 50% chances that values in the form were still about `user` and not `admin` as you would expect.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
