### PR TITLE
React : Upgrade font-awesome lib

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -26,6 +26,9 @@ limitations under the License.
     "node_modules"
   ],
   "dependencies": {
+    "@fortawesome/fontawesome": "1.1.5",
+    "@fortawesome/fontawesome-free-solid": "5.0.10",
+    "@fortawesome/react-fontawesome": "0.0.18",
     "availity-reactstrap-validation": "2.0.2",
     "axios": "0.18.0",
     "bootstrap": "4.0.0",
@@ -37,7 +40,6 @@ limitations under the License.
     "react-addons-transition-group": "16.0.0-alpha.3",
     "react-dom": "16.3.0",
     "react-hot-loader": "3.1.1",
-    "react-icons": "2.2.7",
     "react-jhipster": "0.4.13",
     "react-redux": "5.0.7",
     "react-redux-loading-bar": "3.1.2",

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/audits/audits.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/audits/audits.tsx.ejs
@@ -27,7 +27,8 @@ import {
   getSortState,
   IPaginationBaseState
 } from 'react-jhipster';
-import { FaSort } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faSort } from '@fortawesome/fontawesome-free-solid';
 
 import { APP_TIMESTAMP_FORMAT } from 'app/config/constants';
 import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
@@ -120,9 +121,9 @@ export class AuditsPage extends React.Component<IAuditsPageProps, IAuditsPageSta
         <Table striped responsive>
           <thead>
             <tr>
-              <th onClick={this.sort('auditEventDate')}><Translate contentKey="audits.table.header.date">Date</Translate><FaSort /></th>
-              <th onClick={this.sort('principal')}><Translate contentKey="audits.table.header.principal">User</Translate><FaSort /></th>
-              <th onClick={this.sort('auditEventType')}><Translate contentKey="audits.table.header.status">State</Translate><FaSort /></th>
+              <th onClick={this.sort('auditEventDate')}><Translate contentKey="audits.table.header.date">Date</Translate><FontAwesomeIcon icon={faSort} /></th>
+              <th onClick={this.sort('principal')}><Translate contentKey="audits.table.header.principal">User</Translate><FontAwesomeIcon icon={faSort} /></th>
+              <th onClick={this.sort('auditEventType')}><Translate contentKey="audits.table.header.status">State</Translate><FontAwesomeIcon icon={faSort} /></th>
               <th><Translate contentKey="audits.table.header.data">Extra data</Translate></th>
             </tr>
           </thead>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/gateway/gateway.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/gateway/gateway.tsx.ejs
@@ -19,7 +19,8 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
 import { Translate } from 'react-jhipster';
-import { FaRefresh } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faSync } from '@fortawesome/fontawesome-free-solid';
 import { Badge, Table, Button } from 'reactstrap';
 
 import { gatewayRoutes } from '../administration.reducer';
@@ -94,11 +95,11 @@ export class GatewayPage extends React.Component<IGatewayPageProps> {
         <h2>Gateway</h2>
           <p>
             <Button onClick={this.gatewayRoutes} color={isFetching ? 'danger' : 'primary'} disabled={isFetching}>
-              <FaRefresh />&nbsp;
+              <FontAwesomeIcon icon={faSync} />&nbsp;
               <Translate component="span" contentKey="health.refresh.button" />
             </Button>
           </p>
-          
+
           <Table striped responsive>
             <thead>
               <tr key="header">
@@ -117,7 +118,7 @@ export class GatewayPage extends React.Component<IGatewayPageProps> {
             )}
             </tbody>
           </Table>
-          
+
         </div>
     );
   }

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx.ejs
@@ -20,7 +20,8 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Translate } from 'react-jhipster';
 import { Table, Badge, Col, Row, Button } from 'reactstrap';
-import { FaEye, FaRefresh } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faEye, faSync } from '@fortawesome/fontawesome-free-solid';
 
 import { systemHealth } from '../administration.reducer';
 import HealthModal from './health-modal';
@@ -84,7 +85,7 @@ export class HealthPage extends React.Component<IHealthPageProps, IHealthPageSta
           <h2>Health Checks</h2>
           <p>
             <Button onClick={this.getSystemHealth} color={isFetching ? 'btn btn-danger' : 'btn btn-primary'} disabled={isFetching}>
-              <FaRefresh />&nbsp;
+              <FontAwesomeIcon icon={faSync} />&nbsp;
               <Translate component="span" contentKey="health.refresh.button">Refresh</Translate>
             </Button>
           </p>
@@ -111,7 +112,7 @@ export class HealthPage extends React.Component<IHealthPageProps, IHealthPageSta
                     <td>
                       {data[configPropKey].details ? (
                       <a onClick={this.getSystemHealthInfo(configPropKey, data[configPropKey])}>
-                        <FaEye />
+                        <FontAwesomeIcon icon={faEye} />
                       </a>) : null}
                     </td>
                   </tr>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
@@ -20,7 +20,8 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Table, Progress, Col, Row, Button } from 'reactstrap';
 import { Translate, TextFormat } from 'react-jhipster';
-import { FaEye, FaRefresh } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faEye, faSync } from '@fortawesome/fontawesome-free-solid';
 
 import { APP_WHOLE_NUMBER_FORMAT, APP_TWO_DIGITS_AFTER_POINT_NUMBER_FORMAT } from 'app/config/constants';
 import { systemMetrics, systemThreadDump } from '../administration.reducer';
@@ -184,7 +185,7 @@ export class MetricsPage extends React.Component<any, IMetricsPageState> {
             </Progress>
           </Col>
           <Col md="4">
-            <b>Threads</b> (Total: {metrics.gauges['jvm.threads.count'].value}) <FaEye className="hand" onClick={this.getThreadDump}/>
+            <b>Threads</b> (Total: {metrics.gauges['jvm.threads.count'].value}) <FontAwesomeIcon icon={faEye} className="hand" onClick={this.getThreadDump}/>
             <p><span>Runnable</span> {metrics.gauges['jvm.threads.runnable.count'].value}</p>
             <Progress animated min="0" value={metrics.gauges['jvm.threads.runnable.count'].value} max={metrics.gauges['jvm.threads.count'].value} color="success">
               <span>
@@ -262,7 +263,7 @@ export class MetricsPage extends React.Component<any, IMetricsPageState> {
           <h2>Application Metrics</h2>
           <p>
             <Button onClick={this.getMetrics} color={isFetching ? 'btn btn-danger' : 'btn btn-primary'} disabled={isFetching}>
-              <FaRefresh/>&nbsp;
+              <FontAwesomeIcon icon={faSync} />&nbsp;
               <Translate component="span" contentKey="health.refresh.button">Refresh</Translate>
             </Button>
           </p>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
@@ -20,7 +20,8 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { Translate, ICrudGetAction, ICrudDeleteAction } from 'react-jhipster';
-import { FaBan, FaTrash } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faBan, faTrash } from '@fortawesome/fontawesome-free-solid';
 
 import { IUser } from 'app/shared/model/user.model';
 import { getUser, deleteUser } from './user-management.reducer';
@@ -58,11 +59,11 @@ export class UserManagementDeleteDialog extends React.Component<IUserManagementD
       </ModalBody>
       <ModalFooter>
         <Button color="secondary" onClick={this.handleClose}>
-          <FaBan/>&nbsp;
+          <FontAwesomeIcon icon={faBan} />&nbsp;
           <Translate contentKey="entity.action.cancel">Cancel</Translate>
         </Button>
         <Button color="danger" onClick={this.confirmDelete}>
-          <FaTrash/>&nbsp;
+          <FontAwesomeIcon icon={faTrash} />&nbsp;
           <Translate contentKey="entity.action.delete">Delete</Translate>
         </Button>
       </ModalFooter>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -21,7 +21,8 @@ import { connect } from 'react-redux';
 import { Link } from 'react-router-dom';
 import { Button, Row, Badge } from 'reactstrap';
 import { Translate, ICrudGetAction, TextFormat } from 'react-jhipster';
-import { FaArrowLeft } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faArrowLeft } from '@fortawesome/fontawesome-free-solid';
 
 import { APP_DATE_FORMAT } from 'app/config/constants';
 import { IUser } from 'app/shared/model/user.model';
@@ -95,7 +96,7 @@ export class UserManagementDetail extends React.Component<IUserManagementDetailP
           tag={Link} to="/admin/user-management" replace
           color="info"
         >
-          <FaArrowLeft/> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
+          <FontAwesomeIcon icon={faArrowLeft} /> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
         </Button>
       </div>
     );

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -22,7 +22,8 @@ import { Link } from 'react-router-dom';
 import { Button, Label, Row, Col } from 'reactstrap';
 import { AvForm, AvGroup, AvInput, AvField, AvFeedback } from 'availity-reactstrap-validation';
 import { Translate, translate, ICrudGetAction, ICrudGetAllAction, ICrudPutAction } from 'react-jhipster';
-import { FaBan, FaFloppyO, FaArrowLeft } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faBan, faSave, faArrowLeft } from '@fortawesome/fontawesome-free-solid';
 
 <%_ if (enableTranslation) { _%>
 import { locales } from 'app/config/translation';
@@ -223,12 +224,12 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
               </AvInput>
             </AvGroup>
             <Button tag={Link} to="/admin/user-management" replace color="info" >
-              <FaArrowLeft />&nbsp;
+              <FontAwesomeIcon icon={faArrowLeft} />&nbsp;
               <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
             </Button>
             &nbsp;
             <Button color="primary" type="submit" disabled={isInvalid || updating}>
-              <FaFloppyO />&nbsp;
+              <FontAwesomeIcon icon={faSave} />&nbsp;
               <Translate contentKey="entity.action.save">Save</Translate>
             </Button>
           </AvForm>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
@@ -30,7 +30,14 @@ import {
   getSortState,
   IPaginationBaseState
 } from 'react-jhipster';
-import { FaPlus, FaEye, FaPencil, FaSort, FaTrash } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import {
+  faPlus,
+  faEye,
+  faPencilAlt,
+  faSort,
+  faTrash
+} from '@fortawesome/fontawesome-free-solid';
 
 import { APP_DATE_FORMAT } from 'app/config/constants';
 import { IUser } from 'app/shared/model/user.model';
@@ -90,27 +97,27 @@ export class UserManagement extends React.Component<IUserManagementProps, IPagin
         <h2>
           <Translate contentKey="userManagement.home.title">Users</Translate>
           <Link to={`${match.url}/new`} className="btn btn-primary float-right jh-create-entity">
-            <FaPlus /> <Translate contentKey="userManagement.home.createLabel">Create a new user</Translate>
+            <FontAwesomeIcon icon={faPlus} /> <Translate contentKey="userManagement.home.createLabel">Create a new user</Translate>
           </Link>
         </h2>
         <Table responsive striped>
           <thead>
             <tr>
-              <th className="hand" onClick={this.sort('id')}><Translate contentKey="global.field.id">ID</Translate><FaSort/></th>
-              <th className="hand" onClick={this.sort('login')}><Translate contentKey="userManagement.login">Login</Translate><FaSort/></th>
-              <th className="hand" onClick={this.sort('email')}><Translate contentKey="userManagement.email">Email</Translate><FaSort/></th>
+              <th className="hand" onClick={this.sort('id')}><Translate contentKey="global.field.id">ID</Translate><FontAwesomeIcon icon={faSort} /></th>
+              <th className="hand" onClick={this.sort('login')}><Translate contentKey="userManagement.login">Login</Translate><FontAwesomeIcon icon={faSort} /></th>
+              <th className="hand" onClick={this.sort('email')}><Translate contentKey="userManagement.email">Email</Translate><FontAwesomeIcon icon={faSort} /></th>
               <th />
               <%_ if (enableTranslation) { _%>
-              <th className="hand" onClick={this.sort('langKey')}><Translate contentKey="userManagement.langKey">Lang Key</Translate><FaSort/></th>
+              <th className="hand" onClick={this.sort('langKey')}><Translate contentKey="userManagement.langKey">Lang Key</Translate><FontAwesomeIcon icon={faSort} /></th>
               <%_ } _%>
               <th><Translate contentKey="userManagement.profiles">Profiles</Translate></th>
               <%_ if (databaseType !== 'cassandra') { _%>
-              <th className="hand" onClick={this.sort('createdDate')}><Translate contentKey="userManagement.createdDate">Created Date</Translate><FaSort/></th>
+              <th className="hand" onClick={this.sort('createdDate')}><Translate contentKey="userManagement.createdDate">Created Date</Translate><FontAwesomeIcon icon={faSort} /></th>
               <th className="hand" onClick={this.sort('lastModifiedBy')}>
-                <Translate contentKey="userManagement.lastModifiedBy">Last Modified By</Translate><FaSort/>
+                <Translate contentKey="userManagement.lastModifiedBy">Last Modified By</Translate><FontAwesomeIcon icon={faSort} />
               </th>
               <th className="hand" onClick={this.sort('lastModifiedDate')}>
-                <Translate contentKey="userManagement.lastModifiedDate">Last Modified Date</Translate><FaSort/>
+                <Translate contentKey="userManagement.lastModifiedDate">Last Modified Date</Translate><FontAwesomeIcon icon={faSort} />
               </th>
               <th />
               <%_ } _%>
@@ -165,19 +172,19 @@ export class UserManagement extends React.Component<IUserManagementProps, IPagin
                       tag={Link} to={`${match.url}/${user.login}`}
                       color="info" size="sm"
                     >
-                      <FaEye/> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.view">View</Translate></span>
+                      <FontAwesomeIcon icon={faEye} /> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.view">View</Translate></span>
                     </Button>
                     <Button
                       tag={Link} to={`${match.url}/${user.login}/edit`}
                       color="primary" size="sm"
                     >
-                      <FaPencil/> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
+                      <FontAwesomeIcon icon={faPencilAlt} /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
                     </Button>
                     <Button
                       tag={Link} to={`${match.url}/${user.login}/delete`}
                       color="danger" size="sm" disabled={account.login === user.login}
                     >
-                      <FaTrash/> <span className="d-none d-md-inline"><Translate contentKey="entity.action.delete">Delete</Translate></span>
+                      <FontAwesomeIcon icon={faTrash} /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.delete">Delete</Translate></span>
                     </Button>
                   </div>
                 </td>

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
@@ -24,22 +24,41 @@ import {
   Navbar, Nav, NavItem, NavLink, NavbarToggler, NavbarBrand, Collapse,
   UncontrolledDropdown, DropdownToggle, DropdownMenu, DropdownItem
 } from 'reactstrap';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import {
-  FaHome, FaThList, FaUserPlus, FaUser, <%_ if (enableTranslation) { _%>FaFlag,<%_ } _%> FaHeart,
-  FaList, FaTasks, FaDashboard, FaBook, FaWrench, FaSignIn, FaSignOut,
-  FaClockO, FaHddO,
-  <%_ if (authenticationType === 'session') { _%>
-  FaCloud,
-  <%_ } _%>
+  faUser,
+  faTachometerAlt,
+  faHeart,
+  faList,
+  faTasks,
+  faBook,
+  faHdd,
+  faClock,
+  faSignInAlt,
+  faSignOutAlt,
+  faWrench,
+  faThList,
+  faUserPlus,
   // tslint:disable-next-line
-  FaRoad,
-  // tslint:disable-next-line
-  FaEye,
-  // tslint:disable-next-line
-  FaAsterisk,
-  // tslint:disable-next-line
-  FaBell
-} from 'react-icons/lib/fa';
+  faAsterisk,
+<%_ if (enableTranslation) { _%>
+  faFlag,
+<%_ } _%>
+<%_ if (authenticationType === 'session') { _%>
+  faCloud,
+<%_ } _%>
+<%_ if (applicationType === 'gateway') { _%>
+  faRoad,
+<%_ } _%>
+<%_ if (websocket === 'spring-websocket') { _%>
+  faEye,
+<%_ } _%>
+<%_ if (databaseType !== 'cassandra') { _%>
+  faBell,
+<%_ } _%>
+  faHome
+} from '@fortawesome/fontawesome-free-solid';
+
 import { NavLink as Link } from 'react-router-dom';
 import LoadingBar from 'react-redux-loading-bar';
 
@@ -120,34 +139,34 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
     /* jhipster-needle-add-element-to-menu - JHipster will add entities to the menu here */
     const adminMenuItems = [
     <%_ if (applicationType === 'gateway') { _%>
-      <DropdownItem tag={Link} key="gateway" to="/admin/gateway"><FaRoad /> Gateway</DropdownItem>,
+      <DropdownItem tag={Link} key="gateway" to="/admin/gateway"><FontAwesomeIcon icon={faRoad} /> Gateway</DropdownItem>,
     <%_ } _%>
     <%_ if (!skipUserManagement) { _%>
-      <DropdownItem tag={Link} key="user-management" to="/admin/user-management"><FaUser /> User Management</DropdownItem>,
+      <DropdownItem tag={Link} key="user-management" to="/admin/user-management"><FontAwesomeIcon icon={faUser} /> User Management</DropdownItem>,
     <%_ } _%>
     <%_ if (websocket === 'spring-websocket') { _%>
-      <DropdownItem tag={Link} key="tracker" to="/admin/tracker"><FaEye /> Tracker</DropdownItem>,
+      <DropdownItem tag={Link} key="tracker" to="/admin/tracker"><FontAwesomeIcon icon={faEye} /> Tracker</DropdownItem>,
     <%_ } _%>
-      <DropdownItem tag={Link} key="metrics" to="/admin/metrics"><FaDashboard /> Metrics</DropdownItem>,
-      <DropdownItem tag={Link} key="health" to="/admin/health"><FaHeart /> Health</DropdownItem>,
-      <DropdownItem tag={Link} key="configuration" to="/admin/configuration"><FaList /> Configuration</DropdownItem>,
+      <DropdownItem tag={Link} key="metrics" to="/admin/metrics"><FontAwesomeIcon icon={faTachometerAlt} /> Metrics</DropdownItem>,
+      <DropdownItem tag={Link} key="health" to="/admin/health"><FontAwesomeIcon icon={faHeart} /> Health</DropdownItem>,
+      <DropdownItem tag={Link} key="configuration" to="/admin/configuration"><FontAwesomeIcon icon={faList} /> Configuration</DropdownItem>,
       <%_ if (databaseType !== 'cassandra') { _%>
-      <DropdownItem tag={Link} key="audits" to="/admin/audits"><FaBell /> Audits</DropdownItem>,
+      <DropdownItem tag={Link} key="audits" to="/admin/audits"><FontAwesomeIcon icon={faBell} /> Audits</DropdownItem>,
       <%_ } _%>
       /* jhipster-needle-add-element-to-admin-menu - JHipster will add entities to the admin menu here */
-      <DropdownItem tag={Link} key="logs" to="/admin/logs"><FaTasks /> Logs</DropdownItem>
+      <DropdownItem tag={Link} key="logs" to="/admin/logs"><FontAwesomeIcon icon={faTasks} /> Logs</DropdownItem>
     ];
 
     const swaggerItem = (
       <DropdownItem tag={Link} key="docs" to="/admin/docs">
-        <FaBook /> API Docs
+        <FontAwesomeIcon icon={faBook} /> API Docs
       </DropdownItem>
     );
 
     <% if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %>
     const databaseItem = [
       <DropdownItem tag="a" key="h2-console" href="./h2-console" target="_tab">
-        <FaHddO /> Database
+        <FontAwesomeIcon icon={faHdd} /> Database
       </DropdownItem>
     ];
     <%_ } _%>
@@ -156,23 +175,23 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
     if (isAuthenticated) {
       accountMenuItems.push(
         <%_ if (authenticationType !== 'oauth2') { _%>
-        <DropdownItem tag={Link} key="settings" to="/account/settings"><FaWrench /> Settings</DropdownItem>,
-        <DropdownItem tag={Link} key="password" to="/account/password"><FaClockO /> Password</DropdownItem>,
+        <DropdownItem tag={Link} key="settings" to="/account/settings"><FontAwesomeIcon icon={faWrench} /> Settings</DropdownItem>,
+        <DropdownItem tag={Link} key="password" to="/account/password"><FontAwesomeIcon icon={faClock} /> Password</DropdownItem>,
         <%_ } _%>
         <%_ if (authenticationType === 'session') { _%>
-        <DropdownItem tag={Link} key="sessions" to="/account/sessions"><FaCloud /> Sessions</DropdownItem>,
+        <DropdownItem tag={Link} key="sessions" to="/account/sessions"><FontAwesomeIcon icon={faCloud} /> Sessions</DropdownItem>,
         <%_ } _%>
-        <DropdownItem tag={Link} key="logout" to="/logout"><FaSignOut /> Logout</DropdownItem>
+        <DropdownItem tag={Link} key="logout" to="/logout"><FontAwesomeIcon icon={faSignOutAlt} /> Logout</DropdownItem>
       );
     } else {
       <%_ if (authenticationType !== 'oauth2') { _%>
       accountMenuItems.push(
-        <DropdownItem tag={Link} key="login" to="/login"><FaSignIn /> Login</DropdownItem>,
-        <DropdownItem tag={Link} key="register" to="/register"><FaSignIn /> Register</DropdownItem>
+        <DropdownItem tag={Link} key="login" to="/login"><FontAwesomeIcon icon={faSignInAlt} /> Login</DropdownItem>,
+        <DropdownItem tag={Link} key="register" to="/register"><FontAwesomeIcon icon={faSignInAlt} /> Register</DropdownItem>
       );
       <%_ } else { _%>
       accountMenuItems.push(
-        <DropdownItem tag="a" key="login" href={getLoginUrl()}><FaSignIn /> Login</DropdownItem>
+        <DropdownItem tag="a" key="login" href={getLoginUrl()}><FontAwesomeIcon icon={faSignInAlt} /> Login</DropdownItem>
       );
       <%_ } _%>
     }
@@ -180,7 +199,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
     const entitiesMenu = (
       <UncontrolledDropdown nav inNavbar key="entities">
         <DropdownToggle nav caret className="d-flex align-items-center">
-          <FaThList />
+          <FontAwesomeIcon icon={faThList} />
           <span>Entities</span>
         </DropdownToggle>
         <DropdownMenu right>{entityMenuItems}</DropdownMenu>
@@ -189,7 +208,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
     const adminMenu = (
       <UncontrolledDropdown nav inNavbar key="admin">
         <DropdownToggle nav caret className="d-flex align-items-center">
-          <FaUserPlus />
+          <FontAwesomeIcon icon={faUserPlus} />
           <span>Administration</span>
         </DropdownToggle>
         <DropdownMenu right style={{ width: '130%' }}>
@@ -217,7 +236,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
             <Nav className="ml-auto" navbar>
               <NavItem>
                 <NavLink tag={Link} to="/" className="d-flex align-items-center">
-                  <FaHome />
+                  <FontAwesomeIcon icon={faHome} />
                   <span>Home</span>
                 </NavLink>
               </NavItem>
@@ -226,7 +245,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
               { locales.length > 1 ?
                 <UncontrolledDropdown nav inNavbar>
                   <DropdownToggle nav caret className="d-flex align-items-center">
-                    <FaFlag />
+                    <FontAwesomeIcon icon={faFlag} />
                     <span>{currentLocale.toUpperCase()}</span>
                   </DropdownToggle>
                   <DropdownMenu right>
@@ -237,7 +256,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
             <%_ } _%>
               <UncontrolledDropdown nav inNavbar>
                 <DropdownToggle nav caret className="d-flex align-items-center">
-                  <FaUser />
+                  <FontAwesomeIcon icon={faUser} />
                   <span>Account</span>
                 </DropdownToggle>
                 <DropdownMenu right>

--- a/generators/client/templates/react/tslint.json.ejs
+++ b/generators/client/templates/react/tslint.json.ejs
@@ -204,7 +204,7 @@
     "no-invalid-this": [true],
     "no-magic-numbers": false,
     "ban-types": [true, ["Object", "Use {} instead."]],
-    "no-submodule-imports": [true, "uuid/v4", "react-icons/lib/fa", "app"],
+    "no-submodule-imports": [true, "uuid/v4", "app"],
 
     "ter-arrow-body-style": [true],
     "ter-no-irregular-whitespace": [true],

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
@@ -20,7 +20,8 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { Translate, ICrudGetAction, ICrudDeleteAction } from 'react-jhipster';
-import { FaBan, FaTrash } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faBan, faTrash } from '@fortawesome/fontawesome-free-solid';
 
 import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { getEntity, deleteEntity } from './<%= entityFileName %>.reducer';
@@ -60,11 +61,11 @@ export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= ent
       </ModalBody>
       <ModalFooter>
         <Button color="secondary" onClick={this.handleClose}>
-          <FaBan/>&nbsp;
+          <FontAwesomeIcon icon={faBan} />&nbsp;
           <Translate contentKey="entity.action.cancel">Cancel</Translate>
         </Button>
         <Button color="danger" onClick={this.confirmDelete}>
-          <FaTrash/>&nbsp;
+          <FontAwesomeIcon icon={faTrash} />&nbsp;
           <Translate contentKey="entity.action.delete">Delete</Translate>
         </Button>
       </ModalFooter>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -34,7 +34,8 @@ import {
   TextFormat
   <%_ } _%>
 } from 'react-jhipster';
-import { FaArrowLeft, FaPencil } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faArrowLeft, faPencilAlt } from '@fortawesome/fontawesome-free-solid';
 
 import { getEntity } from './<%= entityFileName %>.reducer';
 import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
@@ -175,10 +176,10 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
             </dl>
           </Row>
           <Button tag={Link} to="/entity/<%= entityFileName %>" replace color="info">
-            <FaArrowLeft/> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
+            <FontAwesomeIcon icon={faArrowLeft} /> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
           </Button>
           <Button tag={Link} to={`/entity/<%= entityFileName %>/${<%=entityInstance %>.id}/edit`} replace color="primary">
-            <FaPencil/> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
+            <FontAwesomeIcon icon={faPencilAlt} /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
           </Button>
         </Col>
       </Row>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -51,7 +51,8 @@ import {
   <%_ } _%>
   ICrudPutAction
 } from 'react-jhipster';
-import { FaBan, <% if(fieldsContainBlob) { %>FaTimesCircle, <% } %>FaFloppyO, FaArrowLeft } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faBan, <% if(fieldsContainBlob) { %>faTimesCircle, <% } %>faSave, faArrowLeft } from '@fortawesome/fontawesome-free-solid';
 
 <%_
 let hasRelationshipQuery = false;
@@ -422,7 +423,7 @@ _%>
                       <span>{<%= fieldName %>ContentType}, {byteSize(<%= fieldName %>)}</span>
                     </Col>
                     <Col md="1">
-                      <Button color="danger" onClick={this.clearBlob('<%= fieldName %>')}><FaTimesCircle /></Button>
+                      <Button color="danger" onClick={this.clearBlob('<%= fieldName %>')}><FontAwesomeIcon icon={faTimesCircle} /></Button>
                     </Col>
                   </Row>
                 </div>
@@ -620,12 +621,12 @@ _%>
             <%_ } _%>
           <%_ }) _%>
             <Button tag={Link} id="cancel-save" to="/entity/<%= entityFileName %>" replace color="info">
-              <FaArrowLeft/>&nbsp;
+              <FontAwesomeIcon icon={faArrowLeft} />&nbsp;
               <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
             </Button>
             &nbsp;
             <Button color="primary" id="save-entity" type="submit" disabled={isInvalid || updating}>
-              <FaFloppyO/>&nbsp;
+              <FontAwesomeIcon icon={faSave} />&nbsp;
               <Translate contentKey="entity.action.save">Save</Translate>
             </Button>
           </AvForm>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
@@ -42,7 +42,8 @@ import {
   , getPaginationItemsNumber, JhiPagination
   <%_ }} _%>
 } from 'react-jhipster';
-import { FaPlus, FaEye, FaPencil, FaTrash<% if (pagination !== 'no') { %>, FaSort<% } %><% if (searchEngine === 'elasticsearch') { %>, FaSearch<% } %> } from 'react-icons/lib/fa';
+import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { faPlus, faEye, faPencilAlt, faTrash<% if (pagination !== 'no') { %>, faSort<% } %><% if (searchEngine === 'elasticsearch') { %>, faSearch<% } %> } from '@fortawesome/fontawesome-free-solid';
 
 import {
   <%_ if (searchEngine === 'elasticsearch') { _%>
@@ -183,7 +184,7 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
         <h2 id="page-heading">
           <Translate contentKey="<%= i18nKeyPrefix %>.home.title"><%= entityClassPluralHumanized %></Translate>
           <Link to={`${match.url}/new`} className="btn btn-primary float-right jh-create-entity" id="jh-create-entity">
-            <FaPlus />
+            <FontAwesomeIcon icon={faPlus} />&nbsp;
             <Translate contentKey="<%= i18nKeyPrefix %>.home.createLabel">
               Create new <%= entityClassHumanized %>
             </Translate>
@@ -198,10 +199,10 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
                   <AvInput type="text" name="search" value={this.state.search} onChange={this.handleSearch}
                     placeholder=<% if (enableTranslation) { %>{translate('<%= i18nKeyPrefix %>.home.search')}<% } else { %>"Search"<% } %>/>
                   <Button className="input-group-addon">
-                    <FaSearch/>
+                    <FontAwesomeIcon icon={faSearch} />
                   </Button>
                   <Button type="reset" className="input-group-addon" onClick={this.clear}>
-                    <FaTrash/>
+                    <FontAwesomeIcon icon={faTrash} />
                   </Button>
                 </InputGroup>
               </AvGroup>
@@ -221,16 +222,16 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
           <Table responsive>
             <thead>
               <tr>
-                <th<% if (pagination !== 'no') { %> className="hand" onClick={this.sort('id')} <%_ } _%>><Translate contentKey="global.field.id">ID</Translate><% if (pagination !== 'no') { %> <FaSort /><% } %></th>
+                <th<% if (pagination !== 'no') { %> className="hand" onClick={this.sort('id')} <%_ } _%>><Translate contentKey="global.field.id">ID</Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon={faSort} /><% } %></th>
                 <%_ for (idx in fields) { _%>
-                <th<% if (pagination !== 'no') { %> className="hand" onClick={this.sort('<%=fields[idx].fieldName%>')} <%_ } _%>><Translate contentKey="<%= `${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></Translate><% if (pagination !== 'no') { %> <FaSort /><% } %></th>
+                <th<% if (pagination !== 'no') { %> className="hand" onClick={this.sort('<%=fields[idx].fieldName%>')} <%_ } _%>><Translate contentKey="<%= `${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon={faSort} /><% } %></th>
                 <%_ } _%>
                 <%_ for (idx in relationships) { _%>
                     <%_ if (relationships[idx].relationshipType === 'many-to-one'
                     || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
                     || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
                     const fieldName = dto === 'no' ? "." + relationships[idx].otherEntityField : relationships[idx].otherEntityFieldCapitalized;_%>
-                <th<% if (pagination !== 'no') { %> <% } %>><Translate contentKey="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></Translate><% if (pagination !== 'no') { %> <FaSort /><% } %></th>
+                <th<% if (pagination !== 'no') { %> <% } %>><Translate contentKey="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon={faSort} /><% } %></th>
                     <%_ } _%>
                 <%_ } _%>
                 <th />
@@ -341,13 +342,13 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
                     <td className="text-right">
                       <div className="btn-group flex-btn-group-container">
                         <Button tag={Link} to={`${match.url}/${<%=entityInstance %>.id}`} color="info" size="sm">
-                          <FaEye/> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.view">View</Translate></span>
+                          <FontAwesomeIcon icon={faEye} /> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.view">View</Translate></span>
                         </Button>
                         <Button tag={Link} to={`${match.url}/${<%=entityInstance %>.id}/edit`} color="primary" size="sm">
-                          <FaPencil/> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
+                          <FontAwesomeIcon icon={faPencilAlt} /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
                         </Button>
                         <Button tag={Link} to={`${match.url}/${<%=entityInstance %>.id}/delete`} color="danger" size="sm">
-                          <FaTrash/> <span className="d-none d-md-inline"><Translate contentKey="entity.action.delete">Delete</Translate></span>
+                          <FontAwesomeIcon icon={faTrash} /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.delete">Delete</Translate></span>
                         </Button>
                       </div>
                     </td>

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -204,7 +204,7 @@ module.exports = class extends PrivateBase {
                     splicable: [
                         this.stripMargin(`|(
                         |        <DropdownItem tag={Link} key="${routerName}" to="/entity/${routerName}">
-                        |          <FaAsterisk />&nbsp;
+                        |          <FontAwesomeIcon icon={faAsterisk} />&nbsp;
                         |          ${_.startCase(routerName)}
                         |        </DropdownItem>
                         |      ),`)


### PR DESCRIPTION
Related to #7516.
@gomesp Here's the PR.

@deepu105 The lib [documentation](https://github.com/FortAwesome/react-fontawesome/blob/master/README.md#build-a-library-to-reference-icons-throughout-your-app-more-conveniently) specifies that we could do something like this:
```javascript
import ReactDOM from 'react-dom';
import fontawesome from '@fortawesome/fontawesome'
import FontAwesomeIcon from '@fortawesome/react-fontawesome'
import brands from '@fortawesome/fontawesome-free-brands'
import faCheckSquare from '@fortawesome/fontawesome-free-solid/faCheckSquare'
import faCoffee from '@fortawesome/fontawesome-free-solid/faCoffee'

fontawesome.library.add(brands, faCheckSquare, faCoffee)
```
to add every icons we need once and then use a simmple string as key for the icon prop, `<FontAwesomeIcon icon="sync" />` for instance. I didn't do it because it would be a bit complicated to make sure we have the right icons loaded depending on the option the user chose for his application. Do you agree ?

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
