### PR TITLE
fix constraint truncation when too long

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1958,7 +1958,7 @@ module.exports = class extends PrivateBase {
         if (limit > 0) {
             const halfLimit = Math.floor(limit / 2);
             const entityTable = noSnakeCase ? entityName.substring(0, halfLimit) : _.snakeCase(this.getTableName(entityName).substring(0, halfLimit));
-            const relationTable = noSnakeCase ? relationshipName.substring(0, halfLimit - 1) : _.snakeCase(this.getTableName(relationshipName).substring(0, halfLimit - 1));
+            const relationTable = noSnakeCase ? relationshipName.substring(0, halfLimit - 2) : _.snakeCase(this.getTableName(relationshipName).substring(0, halfLimit - 2));
             return `${entityTable}_${relationTable}_id`;
         }
         return constraintName;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1922,8 +1922,8 @@ module.exports = class extends PrivateBase {
         }
         if (limit > 0) {
             const halfLimit = Math.floor(limit / 2);
-            const entityTable = _.snakeCase(this.getTableName(entityName).substring(0, halfLimit));
-            const relationTable = _.snakeCase(this.getTableName(relationshipName).substring(0, halfLimit - 1));
+            const entityTable = this.getTableName(entityName).substring(0, halfLimit);
+            const relationTable = this.getTableName(relationshipName).substring(0, halfLimit - 1);
             return `${entityTable}_${relationTable}`;
         }
         return joinTableName;
@@ -1957,8 +1957,8 @@ module.exports = class extends PrivateBase {
         }
         if (limit > 0) {
             const halfLimit = Math.floor(limit / 2);
-            const entityTable = noSnakeCase ? entityName.substring(0, halfLimit) : _.snakeCase(this.getTableName(entityName).substring(0, halfLimit));
-            const relationTable = noSnakeCase ? relationshipName.substring(0, halfLimit - 2) : _.snakeCase(this.getTableName(relationshipName).substring(0, halfLimit - 2));
+            const entityTable = noSnakeCase ? entityName.substring(0, halfLimit) : this.getTableName(entityName).substring(0, halfLimit);
+            const relationTable = noSnakeCase ? relationshipName.substring(0, halfLimit - 2) : this.getTableName(relationshipName).substring(0, halfLimit - 2);
             return `${entityTable}_${relationTable}_id`;
         }
         return constraintName;

--- a/test/generator-base.spec.js
+++ b/test/generator-base.spec.js
@@ -116,10 +116,22 @@ describe('Generator Base', () => {
                 expect(BaseGenerator.getConstraintName('entityName', 'relationshipName', 'mysql')).to.equal('fk_entity_name_relationship_name_id');
             });
         });
-        describe('when called with a long name', () => {
+        describe('when called with a long name and oracle', () => {
             it('returns a proper constraint name', () => {
-                expect(BaseGenerator.getConstraintName('entityNameLongerName', 'relationshipName', 'oracle')).to.have.length(30);
-                expect(BaseGenerator.getConstraintName('entityNameLongerName', 'relationshipName', 'oracle')).to.equal('entity_name_lo_relationship_id');
+                expect(BaseGenerator.getConstraintName('entityNameLongerName', 'relationshipLongerName', 'oracle')).to.have.length(30);
+                expect(BaseGenerator.getConstraintName('entityNameLongerName', 'relationshipLongerName', 'oracle')).to.equal('entity_name_lo_relationship_id');
+            });
+        });
+        describe('when called with a long name and mysql', () => {
+            it('returns a proper constraint name', () => {
+                expect(BaseGenerator.getConstraintName('entityLongerNameWithPaginationAndDTO', 'relationshipLongerNameWithPaginationAndDTO', 'mysql')).to.have.length(64);
+                expect(BaseGenerator.getConstraintName('entityLongerNameWithPaginationAndDTO', 'relationshipLongerNameWithPaginationAndDTO', 'mysql')).to.equal('entity_longer_name_with_paginat_relationship_longer_name_with_id');
+            });
+        });
+        describe('when called with a long name and no snake case', () => {
+            it('returns a proper constraint name', () => {
+                expect(BaseGenerator.getConstraintName('entityNameLongerName', 'relationshipLongerName', 'oracle', true)).to.have.length(30);
+                expect(BaseGenerator.getConstraintName('entityNameLongerName', 'relationshipLongerName', 'oracle', true)).to.equal('entityNameLong_relationship_id');
             });
         });
     });


### PR DESCRIPTION
Fix #7537
Related to #7489

We used the same logic as when we shorten the table name, but only reduced the length by two when we add `_id` (length 3)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
