### PR TITLE
Fix the syntax of the mysql kubernetes yaml

### DIFF
--- a/generators/kubernetes/templates/db/mysql.yml.ejs
+++ b/generators/kubernetes/templates/db/mysql.yml.ejs
@@ -41,10 +41,11 @@ spec:
           value: 'yes'
         - name: MYSQL_DATABASE
           value: <%= app.baseName.toLowerCase() %>
-#        command:
-#        - mysqld
-#        - --lower_case_table_names=1
-#        - --skip-ssl
+        args:
+        - --lower_case_table_names=1
+        - --skip-ssl
+        - --character_set_server=utf8
+        - --explicit_defaults_for_timestamp
         ports:
         - containerPort: 3306
         volumeMounts:


### PR DESCRIPTION
Fix the syntax of the mysql kubernetes yaml and add some missing args that appears in the src/main/docker/mysql.yml like --character_set_server=utf8 and --explicit_defaults_for_timestamp

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
