### PR TITLE
override host header for webpack dev proxy

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -45,7 +45,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                 '/auth'
             ],
             target: 'http://127.0.0.1:<%= serverPort %>',
-            secure: false
+            secure: false,
+            headers: { host: 'localhost:9000' }
         }<% if (websocket === 'spring-websocket') { %>,{
             context: [
                 '/websocket'

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -70,7 +70,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         '/auth'
       ],
       target: 'http://127.0.0.1:<%= serverPort %>',
-      secure: false
+      secure: false,
+      headers: { host: 'localhost:9000' }
     }<% if (websocket === 'spring-websocket') { %>,{
       context: [
         '/websocket'


### PR DESCRIPTION
fixes the issue of swagger using the wrong port (9060 instead of 9000) from the host header
this affects both OAuth and UAA auth types as they use cookies auth

I tested to make sure 301 redirects for keycloak still work as expected when using the webpack proxy

Fix #7185

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
