### PR TITLE
Use getMongoClientDatabase() instead of getDatabase()

### DIFF
--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -232,7 +232,7 @@ public class DatabaseConfiguration {
     public Mongobee mongobee(MongoClient mongoClient, MongoTemplate mongoTemplate, MongoProperties mongoProperties) {
         log.debug("Configuring Mongobee");
         Mongobee mongobee = new Mongobee(mongoClient);
-        mongobee.setDbName(mongoProperties.getDatabase());
+        mongobee.setDbName(mongoProperties.getMongoClientDatabase());
         mongobee.setMongoTemplate(mongoTemplate);
         // package to scan for migrations
         mongobee.setChangeLogsScanPackage("<%=packageName%>.config.dbmigrations");


### PR DESCRIPTION
This will prevent having a Mongobee exception when the database name is in the property **spring.data.mongodb.uri** (ex: mongodb://localhost:27017/jhipster) and the property **spring.data.mongodb.database** is null.

Looking at the source of [MongoProperties](https://github.com/spring-projects/spring-boot/blob/master/spring-boot-project/spring-boot-autoconfigure/src/main/java/org/springframework/boot/autoconfigure/mongo/MongoProperties.java#L169) shows that **getMongoClientDatabase()** will act as **getDatabase()** when the property **spring.data.mongodb.database** is not null.

I understand that this PR doesn't fix anything but it will save time for people that changed properties to use only **spring.data.mongodb.uri**.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
