### PR TITLE
React: typed redux store

### DIFF
--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -229,6 +229,7 @@ const files = {
     ],
     accountModule: [
         {
+            condition: generator => generator.authenticationType !== 'oauth2',
             path: REACT_DIR,
             templates: [
                 { file: 'modules/account/index.tsx', method: 'processJsx' },
@@ -378,11 +379,6 @@ const files = {
                 'spec/app/shared/auth/private-route.spec.tsx',
                 'spec/app/shared/layout/header/header.spec.tsx',
                 'spec/app/shared/layout/header/menus/account.spec.tsx',
-                'spec/app/modules/account/register/register.spec.tsx',
-                'spec/app/modules/account/register/register.reducer.spec.ts',
-                'spec/app/modules/account/activate/activate.reducer.spec.ts',
-                'spec/app/modules/account/password/password.reducer.spec.ts',
-                'spec/app/modules/account/settings/settings.reducer.spec.ts',
                 'spec/app/modules/administration/administration.reducer.spec.ts',
                 // 'spec/app/account/activate/_activate.component.spec.js',
                 // 'spec/app/account/password/_password.component.spec.js',
@@ -396,6 +392,17 @@ const files = {
                 // 'spec/helpers/_mock-account.service.js',
                 // 'spec/helpers/_mock-principal.service.js',
                 // 'spec/helpers/_mock-route.service.js'
+            ]
+        },
+        {
+            condition: generator => generator.authenticationType !== 'oauth2',
+            path: TEST_SRC_DIR,
+            templates: [
+                'spec/app/modules/account/register/register.spec.tsx',
+                'spec/app/modules/account/register/register.reducer.spec.ts',
+                'spec/app/modules/account/activate/activate.reducer.spec.ts',
+                'spec/app/modules/account/password/password.reducer.spec.ts',
+                'spec/app/modules/account/settings/settings.reducer.spec.ts',
             ]
         },
         {

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -72,6 +72,7 @@ limitations under the License.
     "@types/react-dom": "16.0.4",
     "@types/react-router-dom": "4.2.6",
     "@types/redux": "3.6.31",
+    "@types/react-redux": "5.0.19",
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "3.0.7",
     <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
@@ -24,6 +24,7 @@ import { Card } from 'reactstrap';
 import { HashRouter as Router } from 'react-router-dom';
 import { ToastContainer, toast } from 'react-toastify';
 
+import { RootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 import { getProfile } from 'app/shared/reducers/application-profile';
 <%_ if (enableTranslation) { _%>
@@ -35,19 +36,7 @@ import { hasAnyAuthority } from 'app/shared/auth/private-route';
 import { AUTHORITIES } from 'app/config/constants';
 import AppRoutes from 'app/routes';
 
-export interface IAppProps {
-  isAuthenticated: boolean;
-  isAdmin: boolean;
-  ribbonEnv: string;
-  isInProduction: boolean;
-  isSwaggerEnabled: boolean;
-  <%_ if (enableTranslation) { _%>
-  currentLocale: string;
-  setLocale: Function;
-  <%_ } _%>
-  getSession: Function;
-  getProfile: Function;
-}
+export interface IAppProps extends StateProps, DispatchProps {}
 
 export class App extends React.Component<IAppProps> {
   componentDidMount() {
@@ -84,7 +73,7 @@ export class App extends React.Component<IAppProps> {
   }
 }
 
-const mapStateToProps = ({ authentication, applicationProfile<% if (enableTranslation) { %>, locale<% } %> }) => ({
+const mapStateToProps = ({ authentication, applicationProfile<% if (enableTranslation) { %>, locale<% } %> }: RootState) => ({
   <%_ if (enableTranslation) { _%>
   currentLocale: locale.currentLocale,
   <%_ } _%>
@@ -96,5 +85,8 @@ const mapStateToProps = ({ authentication, applicationProfile<% if (enableTransl
 });
 
 const mapDispatchToProps = { <% if (enableTranslation) { %>setLocale, <% } %>getSession, getProfile };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(App);

--- a/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
@@ -24,7 +24,7 @@ import { Card } from 'reactstrap';
 import { HashRouter as Router } from 'react-router-dom';
 import { ToastContainer, toast } from 'react-toastify';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 import { getProfile } from 'app/shared/reducers/application-profile';
 <%_ if (enableTranslation) { _%>
@@ -73,7 +73,7 @@ export class App extends React.Component<IAppProps> {
   }
 }
 
-const mapStateToProps = ({ authentication, applicationProfile<% if (enableTranslation) { %>, locale<% } %> }: RootState) => ({
+const mapStateToProps = ({ authentication, applicationProfile<% if (enableTranslation) { %>, locale<% } %> }: IRootState) => ({
   <%_ if (enableTranslation) { _%>
   currentLocale: locale.currentLocale,
   <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/config/store.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/store.ts.ejs
@@ -19,7 +19,7 @@
 import { createStore, applyMiddleware, compose, GenericStoreEnhancer } from 'redux';
 import promiseMiddleware from 'redux-promise-middleware';
 import thunkMiddleware from 'redux-thunk';
-import reducer, { RootState } from 'app/shared/reducers';
+import reducer, { IRootState } from 'app/shared/reducers';
 import DevTools from './devtools';
 import errorMiddleware from './error-middleware';
 import notificationMiddleware from './notification-middleware';
@@ -44,7 +44,7 @@ const composedMiddlewares = middlewares => process.env.NODE_ENV === 'development
   (compose(applyMiddleware(...defaultMiddlewares, ...middlewares), DevTools.instrument()) as GenericStoreEnhancer) :
   compose(applyMiddleware(...defaultMiddlewares, ...middlewares));
 
-const initialize = (initialState?: RootState, middlewares = []) =>
+const initialize = (initialState?: IRootState, middlewares = []) =>
     createStore(reducer, initialState, composedMiddlewares(middlewares));
 
 export default initialize;

--- a/generators/client/templates/react/src/main/webapp/app/config/store.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/store.ts.ejs
@@ -16,10 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { createStore, applyMiddleware, compose } from 'redux';
+import { createStore, applyMiddleware, compose, GenericStoreEnhancer } from 'redux';
 import promiseMiddleware from 'redux-promise-middleware';
 import thunkMiddleware from 'redux-thunk';
-import reducer from 'app/shared/reducers';
+import reducer, { RootState } from 'app/shared/reducers';
 import DevTools from './devtools';
 import errorMiddleware from './error-middleware';
 import notificationMiddleware from './notification-middleware';
@@ -41,10 +41,10 @@ const defaultMiddlewares = [
   loggerMiddleware
 ];
 const composedMiddlewares = middlewares => process.env.NODE_ENV === 'development' ?
-  compose(applyMiddleware(...defaultMiddlewares, ...middlewares), DevTools.instrument()) :
+  (compose(applyMiddleware(...defaultMiddlewares, ...middlewares), DevTools.instrument()) as GenericStoreEnhancer) :
   compose(applyMiddleware(...defaultMiddlewares, ...middlewares));
 
-const initialize = (initialState = {}, middlewares = []) =>
+const initialize = (initialState?: RootState, middlewares = []) =>
     createStore(reducer, initialState, composedMiddlewares(middlewares));
 
 export default initialize;

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.reducer.ts.ejs
@@ -30,8 +30,10 @@ const initialState = {
   activationFailure: false
 };
 
+export type ActivateState = typeof initialState;
+
 // Reducer
-export default (state = initialState, action) => {
+export default (state = initialState, action): ActivateState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.ACTIVATE_ACCOUNT):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.reducer.ts.ejs
@@ -30,10 +30,10 @@ const initialState = {
   activationFailure: false
 };
 
-export type ActivateState = typeof initialState;
+export type ActivateState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action): ActivateState => {
+export default (state: ActivateState = initialState, action): ActivateState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.ACTIVATE_ACCOUNT):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.tsx.ejs
@@ -18,10 +18,11 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { Row, Col, Alert } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 
+import { RootState } from 'app/shared/reducers';
 import { activateAction, reset } from './activate.reducer';
 
 const successAlert = (
@@ -43,13 +44,7 @@ const failureAlert = (
   </Alert>
 );
 
-export interface IActivateProps {
-  activateAction: Function;
-  reset: Function;
-  activationSuccess: boolean;
-  activationFailure: boolean;
-  match: any;
-}
+export interface IActivateProps extends StateProps, DispatchProps, RouteComponentProps<{key: any}>  {}
 
 export class ActivatePage extends React.Component<IActivateProps> {
   componentWillUnmount() {
@@ -80,11 +75,14 @@ export class ActivatePage extends React.Component<IActivateProps> {
   }
 }
 
-const mapStateToProps = ({ activate }) => ({
+const mapStateToProps = ({ activate }: RootState) => ({
   activationSuccess: activate.activationSuccess,
   activationFailure: activate.activationFailure
 });
 
 const mapDispatchToProps = { activateAction, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(ActivatePage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.tsx.ejs
@@ -22,7 +22,7 @@ import { Link, RouteComponentProps } from 'react-router-dom';
 import { Row, Col, Alert } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { activateAction, reset } from './activate.reducer';
 
 const successAlert = (
@@ -75,7 +75,7 @@ export class ActivatePage extends React.Component<IActivateProps> {
   }
 }
 
-const mapStateToProps = ({ activate }: RootState) => ({
+const mapStateToProps = ({ activate }: IRootState) => ({
   activationSuccess: activate.activationSuccess,
   activationFailure: activate.activationFailure
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -21,8 +21,9 @@ import { connect } from 'react-redux';
 import { Alert, Col, Row, Button } from 'reactstrap';
 import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Translate, translate } from 'react-jhipster';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 
+import { RootState } from 'app/shared/reducers';
 import { handlePasswordResetFinish, reset } from '../password-reset.reducer';
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 
@@ -58,13 +59,7 @@ const missingArgAlert = (
   </Alert>
 );
 
-export interface IPasswordResetFinishProps {
-  resetPasswordSuccess: boolean;
-  resetPasswordFailure: boolean;
-  handlePasswordResetFinish: Function;
-  reset: Function;
-  match: any;
-}
+export interface IPasswordResetFinishProps extends StateProps, DispatchProps, RouteComponentProps<{key: string}>  {}
 
 export interface IPasswordResetFinishState {
   password: string;
@@ -149,11 +144,14 @@ export class PasswordResetFinishPage extends React.Component<IPasswordResetFinis
   }
 }
 
-const mapStateToProps = ({ passwordReset }) => ({
+const mapStateToProps = ({ passwordReset }: RootState) => ({
   resetPasswordSuccess: passwordReset.resetPasswordSuccess,
   resetPasswordFailure: passwordReset.resetPasswordFailure
 });
 
 const mapDispatchToProps = { handlePasswordResetFinish, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(PasswordResetFinishPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/finish/password-reset-finish.tsx.ejs
@@ -23,7 +23,7 @@ import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Translate, translate } from 'react-jhipster';
 import { Link, RouteComponentProps } from 'react-router-dom';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { handlePasswordResetFinish, reset } from '../password-reset.reducer';
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 
@@ -144,7 +144,7 @@ export class PasswordResetFinishPage extends React.Component<IPasswordResetFinis
   }
 }
 
-const mapStateToProps = ({ passwordReset }: RootState) => ({
+const mapStateToProps = ({ passwordReset }: IRootState) => ({
   resetPasswordSuccess: passwordReset.resetPasswordSuccess,
   resetPasswordFailure: passwordReset.resetPasswordFailure
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
@@ -22,14 +22,10 @@ import { connect } from 'react-redux';
 import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Button, Alert, Col, Row } from 'reactstrap';
 
+import { RootState } from 'app/shared/reducers';
 import { handlePasswordResetInit, reset } from '../password-reset.reducer';
 
-export interface IPasswordResetInitProps {
-  handlePasswordResetInit: Function;
-  reset: Function;
-  resetPasswordSuccess: boolean;
-  resetPasswordFailure: boolean;
-}
+export interface IPasswordResetInitProps extends StateProps, DispatchProps  {}
 
 export class PasswordResetInit extends React.Component<IPasswordResetInitProps> {
   componentWillUnmount() {
@@ -101,11 +97,14 @@ export class PasswordResetInit extends React.Component<IPasswordResetInitProps> 
   }
 }
 
-const mapStateToProps = ({ passwordReset }) => ({
+const mapStateToProps = ({ passwordReset }: RootState) => ({
   resetPasswordSuccess: passwordReset.resetPasswordSuccess,
   resetPasswordFailure: passwordReset.resetPasswordFailure,
 });
 
 const mapDispatchToProps = { handlePasswordResetInit, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(PasswordResetInit);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/init/password-reset-init.tsx.ejs
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Button, Alert, Col, Row } from 'reactstrap';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { handlePasswordResetInit, reset } from '../password-reset.reducer';
 
 export interface IPasswordResetInitProps extends StateProps, DispatchProps  {}
@@ -97,7 +97,7 @@ export class PasswordResetInit extends React.Component<IPasswordResetInitProps> 
   }
 }
 
-const mapStateToProps = ({ passwordReset }: RootState) => ({
+const mapStateToProps = ({ passwordReset }: IRootState) => ({
   resetPasswordSuccess: passwordReset.resetPasswordSuccess,
   resetPasswordFailure: passwordReset.resetPasswordFailure,
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
@@ -32,10 +32,10 @@ const initialState = {
   resetPasswordFailure: false,
 };
 
-export type PasswordResetState = typeof initialState;
+export type PasswordResetState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action): PasswordResetState => {
+export default (state: PasswordResetState = initialState, action): PasswordResetState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.RESET_PASSWORD_FINISH):
     case REQUEST(ACTION_TYPES.RESET_PASSWORD_INIT):

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
@@ -32,8 +32,10 @@ const initialState = {
   resetPasswordFailure: false,
 };
 
+export type PasswordResetState = typeof initialState;
+
 // Reducer
-export default (state = initialState, action) => {
+export default (state = initialState, action): PasswordResetState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.RESET_PASSWORD_FINISH):
     case REQUEST(ACTION_TYPES.RESET_PASSWORD_INIT):

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.reducer.ts.ejs
@@ -33,8 +33,10 @@ const initialState = {
   updateFailure: false
 };
 
+export type PasswordState = typeof initialState;
+
 // Reducer
-export default (state = initialState, action) => {
+export default (state = initialState, action): PasswordState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.UPDATE_PASSWORD):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.reducer.ts.ejs
@@ -33,10 +33,10 @@ const initialState = {
   updateFailure: false
 };
 
-export type PasswordState = typeof initialState;
+export type PasswordState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action): PasswordState => {
+export default (state: PasswordState = initialState, action): PasswordState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.UPDATE_PASSWORD):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -22,7 +22,7 @@ import { connect } from 'react-redux';
 import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Row, Col, Button } from 'reactstrap';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 import { savePassword, reset } from './password.reducer';
@@ -117,7 +117,7 @@ export class PasswordPage extends React.Component<IUserPasswordProps, IUserPassw
   }
 }
 
-const mapStateToProps = ({ authentication }: RootState) => ({
+const mapStateToProps = ({ authentication }: IRootState) => ({
   account: authentication.account,
   isAuthenticated: authentication.isAuthenticated
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.tsx.ejs
@@ -22,16 +22,12 @@ import { connect } from 'react-redux';
 import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Row, Col, Button } from 'reactstrap';
 
+import { RootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
 import { savePassword, reset } from './password.reducer';
 
-export interface IUserPasswordProps {
-  account: any;
-  getSession: Function;
-  savePassword: Function;
-  reset: Function;
-}
+export interface IUserPasswordProps extends StateProps, DispatchProps {}
 
 export interface IUserPasswordState {
   password: string;
@@ -121,11 +117,14 @@ export class PasswordPage extends React.Component<IUserPasswordProps, IUserPassw
   }
 }
 
-const mapStateToProps = ({ authentication }) => ({
+const mapStateToProps = ({ authentication }: RootState) => ({
   account: authentication.account,
   isAuthenticated: authentication.isAuthenticated
 });
 
 const mapDispatchToProps = { getSession, savePassword, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(PasswordPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.reducer.ts.ejs
@@ -32,6 +32,8 @@ const initialState = {
   errorMessage: null
 };
 
+export type RegisterState = typeof initialState;
+
 // Reducer
 export default (state = initialState, action) => {
   switch (action.type) {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.reducer.ts.ejs
@@ -32,10 +32,10 @@ const initialState = {
   errorMessage: null
 };
 
-export type RegisterState = typeof initialState;
+export type RegisterState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action) => {
+export default (state: RegisterState = initialState, action): RegisterState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.CREATE_ACCOUNT):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -23,6 +23,7 @@ import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Row, Col, Alert, Button } from 'reactstrap';
 
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
+import { RootState } from 'app/shared/reducers';
 import { handleRegister, reset } from './register.reducer';
 
 export const mainErrorMessages = {
@@ -43,16 +44,7 @@ export const mainErrorMessages = {
   )
 };
 
-export interface IRegisterProps {
-  handleRegister: Function;
-  reset: Function;
-  registrationSuccess: boolean;
-  registrationFailure: boolean;
-  errorMessage: string;
-<%_ if (enableTranslation) { _%>
-  currentLocale: string;
-<%_ } _%>
-}
+export interface IRegisterProps extends StateProps, DispatchProps  {}
 
 export interface IRegisterState {
   password: string;
@@ -189,7 +181,7 @@ export class RegisterPage extends React.Component<IRegisterProps, IRegisterState
   }
 }
 
-const mapStateToProps = ({ register<%_ if (enableTranslation) { _%>, locale <%_ } _%>}) => ({
+const mapStateToProps = ({ register<%_ if (enableTranslation) { _%>, locale <%_ } _%>}: RootState) => ({
   registrationSuccess: register.registrationSuccess,
   registrationFailure: register.registrationFailure,
   errorMessage: register.errorMessage,
@@ -199,5 +191,8 @@ const mapStateToProps = ({ register<%_ if (enableTranslation) { _%>, locale <%_ 
 });
 
 const mapDispatchToProps = { handleRegister, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(RegisterPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -23,7 +23,7 @@ import { AvForm, AvField } from 'availity-reactstrap-validation';
 import { Row, Col, Alert, Button } from 'reactstrap';
 
 import PasswordStrengthBar from 'app/shared/layout/password/password-strength-bar';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { handleRegister, reset } from './register.reducer';
 
 export const mainErrorMessages = {
@@ -181,7 +181,7 @@ export class RegisterPage extends React.Component<IRegisterProps, IRegisterState
   }
 }
 
-const mapStateToProps = ({ register<%_ if (enableTranslation) { _%>, locale <%_ } _%>}: RootState) => ({
+const mapStateToProps = ({ register<%_ if (enableTranslation) { _%>, locale <%_ } _%>}: IRootState) => ({
   registrationSuccess: register.registrationSuccess,
   registrationFailure: register.registrationFailure,
   errorMessage: register.errorMessage,

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.reducer.ts.ejs
@@ -32,10 +32,10 @@ const initialState = {
   updateFailure: false
 };
 
-export type SessionsState = typeof initialState;
+export type SessionsState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action): SessionsState => {
+export default (state: SessionsState = initialState, action): SessionsState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FIND_ALL):
     case REQUEST(ACTION_TYPES.INVALIDATE):

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.reducer.ts.ejs
@@ -32,8 +32,10 @@ const initialState = {
   updateFailure: false
 };
 
+export type SessionsState = typeof initialState;
+
 // Reducer
-export default (state = initialState, action) => {
+export default (state = initialState, action): SessionsState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FIND_ALL):
     case REQUEST(ACTION_TYPES.INVALIDATE):

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.tsx.ejs
@@ -21,17 +21,10 @@ import { connect } from 'react-redux';
 import { Alert, Table, Button } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 import { getSession } from 'app/shared/reducers/authentication';
+import { RootState } from 'app/shared/reducers';
 import { findAll, invalidateSession } from './sessions.reducer';
 
-export interface ISessionsProps {
-  getSession: Function;
-  findAll: Function;
-  invalidateSession: Function;
-  account: any;
-  sessions: any;
-  updateSuccess: boolean;
-  updateFailure: boolean;
-}
+export interface ISessionsProps extends StateProps, DispatchProps {}
 
 export class SessionsPage extends React.Component<ISessionsProps> {
   componentDidMount() {
@@ -108,7 +101,7 @@ export class SessionsPage extends React.Component<ISessionsProps> {
   }
 }
 
-const mapStateToProps = ({ authentication, sessions }) => ({
+const mapStateToProps = ({ authentication, sessions }: RootState) => ({
   account: authentication.account,
   sessions: sessions.sessions,
   updateSuccess: sessions.updateSuccess,
@@ -116,5 +109,8 @@ const mapStateToProps = ({ authentication, sessions }) => ({
 });
 
 const mapDispatchToProps = { getSession, findAll, invalidateSession };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(SessionsPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.tsx.ejs
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
 import { Alert, Table, Button } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 import { getSession } from 'app/shared/reducers/authentication';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { findAll, invalidateSession } from './sessions.reducer';
 
 export interface ISessionsProps extends StateProps, DispatchProps {}
@@ -101,7 +101,7 @@ export class SessionsPage extends React.Component<ISessionsProps> {
   }
 }
 
-const mapStateToProps = ({ authentication, sessions }: RootState) => ({
+const mapStateToProps = ({ authentication, sessions }: IRootState) => ({
   account: authentication.account,
   sessions: sessions.sessions,
   updateSuccess: sessions.updateSuccess,

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
@@ -33,10 +33,10 @@ const initialState = {
   updateFailure: false
 };
 
-export type SettingsState = typeof initialState;
+export type SettingsState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action): SettingsState => {
+export default (state: SettingsState = initialState, action): SettingsState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.UPDATE_ACCOUNT):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
@@ -33,8 +33,10 @@ const initialState = {
   updateFailure: false
 };
 
+export type SettingsState = typeof initialState;
+
 // Reducer
-export default (state = initialState, action) => {
+export default (state = initialState, action): SettingsState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.UPDATE_ACCOUNT):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -25,6 +25,7 @@ import { AvForm, AvField } from 'availity-reactstrap-validation';
 <%_ if (enableTranslation) { _%>
 import { locales } from 'app/config/translation';
 <%_ } _%>
+import { RootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 import { saveAccountSettings, reset } from './settings.reducer';
 
@@ -36,13 +37,7 @@ const successAlert = (
   </Alert>
 );
 
-export interface IUserSettingsProps {
-  account: any;
-  getSession: Function;
-  saveAccountSettings: Function;
-  reset: Function;
-  updateSuccess: boolean;
-}
+export interface IUserSettingsProps extends StateProps, DispatchProps  {}
 
 export interface IUserSettingsState {
   account: any;
@@ -173,7 +168,7 @@ export class SettingsPage extends React.Component<IUserSettingsProps, IUserSetti
   }
 }
 
-const mapStateToProps = ({ authentication, settings }) => ({
+const mapStateToProps = ({ authentication, settings }: RootState) => ({
   account: authentication.account,
   isAuthenticated: authentication.isAuthenticated,
   updateSuccess: settings.updateSuccess,
@@ -181,5 +176,8 @@ const mapStateToProps = ({ authentication, settings }) => ({
 });
 
 const mapDispatchToProps = { getSession, saveAccountSettings, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(SettingsPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -25,7 +25,7 @@ import { AvForm, AvField } from 'availity-reactstrap-validation';
 <%_ if (enableTranslation) { _%>
 import { locales } from 'app/config/translation';
 <%_ } _%>
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 import { saveAccountSettings, reset } from './settings.reducer';
 
@@ -168,7 +168,7 @@ export class SettingsPage extends React.Component<IUserSettingsProps, IUserSetti
   }
 }
 
-const mapStateToProps = ({ authentication, settings }: RootState) => ({
+const mapStateToProps = ({ authentication, settings }: IRootState) => ({
   account: authentication.account,
   isAuthenticated: authentication.isAuthenticated,
   updateSuccess: settings.updateSuccess,

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
@@ -42,14 +42,14 @@ const initialState = {
     routes: []
   },
   logs: {
-    loggers: []
+    loggers: [] as any[]
   },
-  health: {},
+  health: {} as any,
   metrics: {},
   threadDump: [],
   configuration: {
-    configProps: {},
-    env: {}
+    configProps: {} as any,
+    env: {} as any
   },
   audits: [],
   <%_ if (websocket === 'spring-websocket') { _%>
@@ -60,9 +60,11 @@ const initialState = {
   totalItems: 0
 };
 
+export type AdministrationState = typeof initialState;
+
 // Reducer
 
-export default (state = initialState, action) => {
+export default (state = initialState, action): AdministrationState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FETCH_GATEWAY_ROUTE):
     case REQUEST(ACTION_TYPES.FETCH_METRICS):

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
@@ -60,11 +60,11 @@ const initialState = {
   totalItems: 0
 };
 
-export type AdministrationState = typeof initialState;
+export type AdministrationState =  Readonly<typeof initialState>;
 
 // Reducer
 
-export default (state = initialState, action): AdministrationState => {
+export default (state: AdministrationState = initialState, action): AdministrationState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FETCH_GATEWAY_ROUTE):
     case REQUEST(ACTION_TYPES.FETCH_METRICS):

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/audits/audits.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/audits/audits.tsx.ejs
@@ -18,6 +18,7 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router';
 import { Input, Row, Table } from 'reactstrap';
 import {
   Translate,
@@ -31,18 +32,11 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import { APP_TIMESTAMP_FORMAT } from 'app/config/constants';
 import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
+
+import { RootState } from 'app/shared/reducers';
 import { getAudits } from '../administration.reducer';
 
-export interface IAuditsPageProps {
-  isFetching?: boolean;
-  audits: any[];
-  getAudits: Function;
-  totalItems: 0;
-  history: any;
-  location: any;
-  onChangeFromDate: any;
-  onChangeToDate: any;
-}
+export interface IAuditsPageProps extends StateProps, DispatchProps, RouteComponentProps<{}> {}
 
 export interface IAuditsPageState extends IPaginationBaseState {
   fromDate: string;
@@ -164,11 +158,14 @@ export class AuditsPage extends React.Component<IAuditsPageProps, IAuditsPageSta
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   audits: storeState.administration.audits,
   totalItems: storeState.administration.totalItems
 });
 
 const mapDispatchToProps = { getAudits };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(AuditsPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/audits/audits.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/audits/audits.tsx.ejs
@@ -33,7 +33,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { APP_TIMESTAMP_FORMAT } from 'app/config/constants';
 import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getAudits } from '../administration.reducer';
 
 export interface IAuditsPageProps extends StateProps, DispatchProps, RouteComponentProps<{}> {}
@@ -158,7 +158,7 @@ export class AuditsPage extends React.Component<IAuditsPageProps, IAuditsPageSta
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   audits: storeState.administration.audits,
   totalItems: storeState.administration.totalItems
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/configuration/configuration.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/configuration/configuration.tsx.ejs
@@ -22,13 +22,9 @@ import { Table, Input, Row, Col, Badge } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 
 import { getConfigurations, getEnv } from '../administration.reducer';
+import { RootState } from 'app/shared/reducers';
 
-export interface IConfigurationPageProps {
-  isFetching?: boolean;
-  getConfigurations: Function;
-  getEnv: Function;
-  configuration: any;
-}
+export interface IConfigurationPageProps extends StateProps, DispatchProps {}
 
 export interface IConfigurationPageState {
   filter: string;
@@ -150,11 +146,14 @@ export class ConfigurationPage extends React.Component<IConfigurationPageProps, 
   }
 }
 
-const mapStateToProps = ({ administration }) => ({
+const mapStateToProps = ({ administration }: RootState) => ({
   configuration: administration.configuration,
-  isFetching: administration.isFetching
+  isFetching: administration.loading
 });
 
 const mapDispatchToProps = { getConfigurations, getEnv };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(ConfigurationPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/configuration/configuration.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/configuration/configuration.tsx.ejs
@@ -22,7 +22,7 @@ import { Table, Input, Row, Col, Badge } from 'reactstrap';
 import { Translate } from 'react-jhipster';
 
 import { getConfigurations, getEnv } from '../administration.reducer';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface IConfigurationPageProps extends StateProps, DispatchProps {}
 
@@ -146,7 +146,7 @@ export class ConfigurationPage extends React.Component<IConfigurationPageProps, 
   }
 }
 
-const mapStateToProps = ({ administration }: RootState) => ({
+const mapStateToProps = ({ administration }: IRootState) => ({
   configuration: administration.configuration,
   isFetching: administration.loading
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx.ejs
@@ -22,15 +22,11 @@ import { Translate } from 'react-jhipster';
 import { Table, Badge, Col, Row, Button } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
+import { RootState } from 'app/shared/reducers';
 import { systemHealth } from '../administration.reducer';
 import HealthModal from './health-modal';
 
-export interface IHealthPageProps {
-  isFetching?: boolean;
-  systemHealth: Function;
-  health: any;
-  systemHealthInfo: any;
-}
+export interface IHealthPageProps extends StateProps, DispatchProps {}
 
 export interface IHealthPageState {
   healthObject: any,
@@ -127,11 +123,14 @@ export class HealthPage extends React.Component<IHealthPageProps, IHealthPageSta
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   health: storeState.administration.health,
-  isFetching: storeState.administration.isFetching
+  isFetching: storeState.administration.loading
 });
 
 const mapDispatchToProps = { systemHealth };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(HealthPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/health/health.tsx.ejs
@@ -22,7 +22,7 @@ import { Translate } from 'react-jhipster';
 import { Table, Badge, Col, Row, Button } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { systemHealth } from '../administration.reducer';
 import HealthModal from './health-modal';
 
@@ -123,7 +123,7 @@ export class HealthPage extends React.Component<IHealthPageProps, IHealthPageSta
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   health: storeState.administration.health,
   isFetching: storeState.administration.loading
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/logs/logs.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/logs/logs.tsx.ejs
@@ -21,13 +21,9 @@ import { connect } from 'react-redux';
 import { Translate } from 'react-jhipster';
 
 import { getLoggers, changeLogLevel } from '../administration.reducer';
+import { RootState } from 'app/shared/reducers';
 
-export interface ILogsPageProps {
-  isFetching?: boolean;
-  getLoggers: Function;
-  changeLogLevel: Function;
-  logs: any;
-}
+export interface ILogsPageProps extends StateProps, DispatchProps {}
 
 export interface ILogsPageState {
   filter: string
@@ -66,11 +62,11 @@ export class LogsPage extends React.Component<ILogsPageProps, ILogsPageState> {
   render() {
     const { logs, isFetching } = this.props;
     const { filter } = this.state;
-    const loggers = logs ? logs.loggers : {};
+    const loggers = logs ? logs.loggers : [];
     return (
         <div>
           <h2><Translate contentKey="logs.title">Logs</Translate></h2>
-          <p><Translate contentKey="logs.nbloggers" interpolate={{ total: loggers.length }}>There are {loggers.length} loggers.</Translate></p>
+          <p><Translate contentKey="logs.nbloggers" interpolate={{ total: loggers.length }}>There are {loggers.length.toString() /* TODO: allow numbers in translate? */} loggers.</Translate></p>
 
           <span><Translate contentKey="logs.filter">Filter</Translate></span>
           <input type="text" value={filter} onChange={this.setFilter} className="form-control" disabled={isFetching} />
@@ -105,11 +101,14 @@ export class LogsPage extends React.Component<ILogsPageProps, ILogsPageState> {
   }
 }
 
-const mapStateToProps = ({ administration }) => ({
+const mapStateToProps = ({ administration }: RootState) => ({
   logs: administration.logs,
-  isFetching: administration.isFetching
+  isFetching: administration.loading
 });
 
 const mapDispatchToProps = { getLoggers, changeLogLevel };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(LogsPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/logs/logs.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/logs/logs.tsx.ejs
@@ -21,7 +21,7 @@ import { connect } from 'react-redux';
 import { Translate } from 'react-jhipster';
 
 import { getLoggers, changeLogLevel } from '../administration.reducer';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface ILogsPageProps extends StateProps, DispatchProps {}
 
@@ -101,7 +101,7 @@ export class LogsPage extends React.Component<ILogsPageProps, ILogsPageState> {
   }
 }
 
-const mapStateToProps = ({ administration }: RootState) => ({
+const mapStateToProps = ({ administration }: IRootState) => ({
   logs: administration.logs,
   isFetching: administration.loading
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
@@ -25,14 +25,9 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { APP_WHOLE_NUMBER_FORMAT, APP_TWO_DIGITS_AFTER_POINT_NUMBER_FORMAT } from 'app/config/constants';
 import { systemMetrics, systemThreadDump } from '../administration.reducer';
 import MetricsModal from './metrics-modal';
+import { RootState } from 'app/shared/reducers';
 
-export interface IMetricsPageProps {
-  isFetching?: boolean;
-  systemMetrics: Function;
-  systemThreadDump: Function;
-  metrics: any;
-  threadDump: any;
-}
+export interface IMetricsPageProps extends StateProps, DispatchProps {}
 
 export interface IMetricsPageState {
   showModal: boolean;
@@ -608,12 +603,15 @@ export class MetricsPage extends React.Component<any, IMetricsPageState> {
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   metrics: storeState.administration.metrics,
-  isFetching: storeState.administration.isFetching,
+  isFetching: storeState.administration.loading,
   threadDump: storeState.administration.threadDump
 });
 
 const mapDispatchToProps = { systemMetrics, systemThreadDump };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(MetricsPage);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
@@ -25,7 +25,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { APP_WHOLE_NUMBER_FORMAT, APP_TWO_DIGITS_AFTER_POINT_NUMBER_FORMAT } from 'app/config/constants';
 import { systemMetrics, systemThreadDump } from '../administration.reducer';
 import MetricsModal from './metrics-modal';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface IMetricsPageProps extends StateProps, DispatchProps {}
 
@@ -603,7 +603,7 @@ export class MetricsPage extends React.Component<any, IMetricsPageState> {
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   metrics: storeState.administration.metrics,
   isFetching: storeState.administration.loading,
   threadDump: storeState.administration.threadDump

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
@@ -18,20 +18,16 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { Translate, ICrudGetAction, ICrudDeleteAction } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import { IUser } from 'app/shared/model/user.model';
 import { getUser, deleteUser } from './user-management.reducer';
+import { RootState } from 'app/shared/reducers';
 
-export interface IUserManagementDeleteDialogProps {
-  getUser: ICrudGetAction<IUser>;
-  deleteUser: ICrudDeleteAction<IUser>;
-  user: IUser;
-  match: any;
-  history: any;
-}
+export interface IUserManagementDeleteDialogProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
 
 export class UserManagementDeleteDialog extends React.Component<IUserManagementDeleteDialogProps> {
   componentDidMount() {
@@ -71,10 +67,13 @@ export class UserManagementDeleteDialog extends React.Component<IUserManagementD
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   user: storeState.userManagement.user
 });
 
 const mapDispatchToProps = { getUser, deleteUser };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserManagementDeleteDialog);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
@@ -25,7 +25,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import { IUser } from 'app/shared/model/user.model';
 import { getUser, deleteUser } from './user-management.reducer';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface IUserManagementDeleteDialogProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
 
@@ -67,7 +67,7 @@ export class UserManagementDeleteDialog extends React.Component<IUserManagementD
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   user: storeState.userManagement.user
 });
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -26,7 +26,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { APP_DATE_FORMAT } from 'app/config/constants';
 import { IUser } from 'app/shared/model/user.model';
 import { getUser } from './user-management.reducer';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface IUserManagementDetailProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
 
@@ -99,7 +99,7 @@ export class UserManagementDetail extends React.Component<IUserManagementDetailP
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   user: storeState.userManagement.user
 });
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -18,7 +18,7 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { Button, Row, Badge } from 'reactstrap';
 import { Translate, ICrudGetAction, TextFormat } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
@@ -26,12 +26,9 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { APP_DATE_FORMAT } from 'app/config/constants';
 import { IUser } from 'app/shared/model/user.model';
 import { getUser } from './user-management.reducer';
+import { RootState } from 'app/shared/reducers';
 
-export interface IUserManagementDetailProps {
-  getUser: ICrudGetAction<IUser>;
-  user: IUser;
-  match: any;
-}
+export interface IUserManagementDetailProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
 
 export class UserManagementDetail extends React.Component<IUserManagementDetailProps> {
   componentDidMount() {
@@ -102,10 +99,13 @@ export class UserManagementDetail extends React.Component<IUserManagementDetailP
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   user: storeState.userManagement.user
 });
 
 const mapDispatchToProps = { getUser };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserManagementDetail);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -29,7 +29,7 @@ import { locales } from 'app/config/translation';
 <%_ } _%>
 import { IUser } from 'app/shared/model/user.model';
 import { getUser, getRoles, updateUser, createUser, reset } from './user-management.reducer';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface IUserManagementUpdateProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
 
@@ -231,7 +231,7 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   user: storeState.userManagement.user,
   roles: storeState.userManagement.authorities,
   loading: storeState.userManagement.loading,

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -18,7 +18,7 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { Button, Label, Row, Col } from 'reactstrap';
 import { AvForm, AvGroup, AvInput, AvField, AvFeedback } from 'availity-reactstrap-validation';
 import { Translate, translate, ICrudGetAction, ICrudGetAllAction, ICrudPutAction } from 'react-jhipster';
@@ -29,20 +29,9 @@ import { locales } from 'app/config/translation';
 <%_ } _%>
 import { IUser } from 'app/shared/model/user.model';
 import { getUser, getRoles, updateUser, createUser, reset } from './user-management.reducer';
+import { RootState } from 'app/shared/reducers';
 
-export interface IUserManagementUpdateProps {
-  getUser: ICrudGetAction<IUser>;
-  getRoles: ICrudGetAllAction<any>;
-  updateUser: ICrudPutAction<IUser>;
-  createUser: ICrudPutAction<IUser>;
-  reset: Function;
-  loading: boolean;
-  updating: boolean;
-  user: IUser;
-  roles: any[];
-  match: any;
-  history: any;
-}
+export interface IUserManagementUpdateProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
 
 export interface IUserManagementUpdateState {
   isNew: boolean;
@@ -242,7 +231,7 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   user: storeState.userManagement.user,
   roles: storeState.userManagement.authorities,
   loading: storeState.userManagement.loading,
@@ -250,5 +239,8 @@ const mapStateToProps = storeState => ({
 });
 
 const mapDispatchToProps = { getUser, getRoles, updateUser, createUser, reset };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserManagementUpdate);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -20,7 +20,7 @@ import axios from 'axios';
 import { ICrudGetAction, ICrudGetAllAction, ICrudPutAction, ICrudDeleteAction } from 'react-jhipster';
 
 import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
-import { IUser } from 'app/shared/model/user.model';
+import { IUser, User } from 'app/shared/model/user.model';
 
 export const ACTION_TYPES = {
   FETCH_ROLES: 'userManagement/FETCH_ROLES',
@@ -35,13 +35,15 @@ export const ACTION_TYPES = {
 const initialState = {
   loading: false,
   errorMessage: null,
-  users: [],
-  authorities: [],
-  user: {},
+  users: [] as IUser[],
+  authorities: [] as any[],
+  user: new User(),
   updating: false,
   updateSuccess: false,
   totalItems: 0
 };
+
+export type UserManagementState = typeof initialState;
 
 // Reducer
 export default (state = initialState, action) => {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -132,20 +132,20 @@ export const getUsers: ICrudGetAllAction<IUser> = (page, size, sort) => {
   const requestUrl = `${apiUrl}${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;
   return {
     type: ACTION_TYPES.FETCH_USERS,
-    payload: axios.get(requestUrl) as Promise<IUser>
+    payload: axios.get<IUser>(requestUrl)
   };
 };
 
 export const getRoles = () => ({
   type: ACTION_TYPES.FETCH_ROLES,
-  payload: axios.get(`${apiUrl}/authorities`) as Promise<any>
+  payload: axios.get(`${apiUrl}/authorities`)
 });
 
 export const getUser: ICrudGetAction<IUser> = id => {
   const requestUrl = `${apiUrl}/${id}`;
   return {
     type: ACTION_TYPES.FETCH_USER,
-    payload: axios.get(requestUrl) as Promise<IUser>
+    payload: axios.get<IUser>(requestUrl)
   };
 };
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -136,7 +136,7 @@ export const getUsers: ICrudGetAllAction<IUser> = (page, size, sort) => {
   };
 };
 
-export const getRoles: ICrudGetAction<any> = () => ({
+export const getRoles = () => ({
   type: ACTION_TYPES.FETCH_ROLES,
   payload: axios.get(`${apiUrl}/authorities`) as Promise<any>
 });

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -20,7 +20,7 @@ import axios from 'axios';
 import { ICrudGetAction, ICrudGetAllAction, ICrudPutAction, ICrudDeleteAction } from 'react-jhipster';
 
 import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
-import { IUser, User } from 'app/shared/model/user.model';
+import { IUser, defaultValue } from 'app/shared/model/user.model';
 
 export const ACTION_TYPES = {
   FETCH_ROLES: 'userManagement/FETCH_ROLES',
@@ -35,18 +35,18 @@ export const ACTION_TYPES = {
 const initialState = {
   loading: false,
   errorMessage: null,
-  users: [] as IUser[],
+  users: [] as ReadonlyArray<IUser>,
   authorities: [] as any[],
-  user: new User(),
+  user: defaultValue,
   updating: false,
   updateSuccess: false,
   totalItems: 0
 };
 
-export type UserManagementState = typeof initialState;
+export type UserManagementState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action) => {
+export default (state: UserManagementState = initialState, action): UserManagementState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FETCH_ROLES):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
@@ -35,7 +35,7 @@ import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { APP_DATE_FORMAT } from 'app/config/constants';
 import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
 import { getUsers, updateUser } from './user-management.reducer';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 export interface IUserManagementProps extends StateProps, DispatchProps, RouteComponentProps<{}> {}
 
@@ -190,7 +190,7 @@ export class UserManagement extends React.Component<IUserManagementProps, IPagin
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   users: storeState.userManagement.users,
   totalItems: storeState.userManagement.totalItems,
   account: storeState.authentication.account

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
@@ -18,7 +18,7 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { Button, Table, Row, Badge } from 'reactstrap';
 import {
   Translate,
@@ -33,20 +33,11 @@ import {
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import { APP_DATE_FORMAT } from 'app/config/constants';
-import { IUser } from 'app/shared/model/user.model';
 import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
 import { getUsers, updateUser } from './user-management.reducer';
+import { RootState } from 'app/shared/reducers';
 
-export interface IUserManagementProps {
-  getUsers: ICrudGetAllAction<IUser>;
-  updateUser: ICrudPutAction<IUser>;
-  users: IUser[];
-  account: any;
-  match: any;
-  totalItems: 0;
-  history: any;
-  location: any;
-}
+export interface IUserManagementProps extends StateProps, DispatchProps, RouteComponentProps<{}> {}
 
 export class UserManagement extends React.Component<IUserManagementProps, IPaginationBaseState> {
   state: IPaginationBaseState = {
@@ -199,12 +190,15 @@ export class UserManagement extends React.Component<IUserManagementProps, IPagin
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   users: storeState.userManagement.users,
   totalItems: storeState.userManagement.totalItems,
   account: storeState.authentication.account
 });
 
 const mapDispatchToProps = { getUsers, updateUser };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(UserManagement);

--- a/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
@@ -24,7 +24,7 @@ import { Translate } from 'react-jhipster';
 import { connect } from 'react-redux';
 import { Row, Col, Alert } from 'reactstrap';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { getLoginUrl } from 'app/shared/util/url-utils';

--- a/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
@@ -24,15 +24,13 @@ import { Translate } from 'react-jhipster';
 import { connect } from 'react-redux';
 import { Row, Col, Alert } from 'reactstrap';
 
+import { RootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { getLoginUrl } from 'app/shared/util/url-utils';
 <%_ } _%>
 
-export interface IHomeProp {
-  account: any;
-  getSession: Function;
-}
+export interface IHomeProp extends StateProps, DispatchProps {}
 
 export interface IHomeState {
   currentUser: any;
@@ -143,5 +141,8 @@ const mapStateToProps = storeState => ({
 });
 
 const mapDispatchToProps = { getSession };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(Home);

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/login.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/login.tsx.ejs
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Redirect, RouteComponentProps } from 'react-router-dom';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { login } from 'app/shared/reducers/authentication';
 import LoginModal from './login-modal';
 
@@ -70,7 +70,7 @@ export class Login extends React.Component<ILoginProps, ILoginState> {
   }
 }
 
-const mapStateToProps = ({ authentication }: RootState) => ({
+const mapStateToProps = ({ authentication }: IRootState) => ({
   isAuthenticated: authentication.isAuthenticated,
   loginError: authentication.loginError,
   showModal: authentication.showModalLogin

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/login.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/login.tsx.ejs
@@ -18,18 +18,13 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Redirect } from 'react-router-dom';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
 
+import { RootState } from 'app/shared/reducers';
 import { login } from 'app/shared/reducers/authentication';
 import LoginModal from './login-modal';
 
-export interface ILoginProps {
-  isAuthenticated: boolean;
-  showModal: boolean;
-  loginError?: boolean;
-  location: any;
-  login: Function;
-}
+export interface ILoginProps extends StateProps, DispatchProps, RouteComponentProps<{}> {}
 
 export interface ILoginState {
   showModal: boolean;
@@ -75,12 +70,15 @@ export class Login extends React.Component<ILoginProps, ILoginState> {
   }
 }
 
-const mapStateToProps = ({ authentication }) => ({
+const mapStateToProps = ({ authentication }: RootState) => ({
   isAuthenticated: authentication.isAuthenticated,
   loginError: authentication.loginError,
   showModal: authentication.showModalLogin
 });
 
 const mapDispatchToProps = { login };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(Login);

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { logout } from 'app/shared/reducers/authentication';
 
 export interface ILogoutProps extends StateProps, DispatchProps {}
@@ -43,7 +43,7 @@ export class Logout extends React.Component<ILogoutProps> {
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({});
+const mapStateToProps = (storeState: IRootState) => ({});
 
 const mapDispatchToProps = { logout };
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
@@ -20,11 +20,10 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Redirect } from 'react-router-dom';
 
+import { RootState } from 'app/shared/reducers';
 import { logout } from 'app/shared/reducers/authentication';
 
-export interface ILogoutProps {
-  logout: Function;
-}
+export interface ILogoutProps extends StateProps, DispatchProps {}
 
 export class Logout extends React.Component<ILogoutProps> {
 
@@ -44,8 +43,11 @@ export class Logout extends React.Component<ILogoutProps> {
   }
 }
 
-const mapStateToProps = storeState => ({});
+const mapStateToProps = (storeState: RootState) => ({});
 
 const mapDispatchToProps = { logout };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(Logout);

--- a/generators/client/templates/react/src/main/webapp/app/routes.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/routes.tsx.ejs
@@ -21,15 +21,15 @@ import { Route, Switch } from 'react-router-dom';
 
 <%_ if (authenticationType !== 'oauth2') { _%>
 import Login from 'app/modules/login/login';
-<%_ } _%>
-import Logout from 'app/modules/login/logout';
 import Register from 'app/modules/account/register/register';
-import Home from 'app/modules/home/home';
-import Admin from 'app/modules/administration';
 import Account from 'app/modules/account';
 import Activate from 'app/modules/account/activate/activate';
 import PasswordResetInit from 'app/modules/account/password-reset/init/password-reset-init';
 import PasswordResetFinish from 'app/modules/account/password-reset/finish/password-reset-finish';
+<%_ } _%>
+import Logout from 'app/modules/login/logout';
+import Home from 'app/modules/home/home';
+import Admin from 'app/modules/administration';
 import Entities from 'app/entities';
 import PrivateRoute from 'app/shared/auth/private-route';
 import { AUTHORITIES } from 'app/config/constants';
@@ -41,12 +41,16 @@ const Routes = () => (
     <%_ } _%>
     <Switch>
       <Route path="/logout" component={Logout} />
+    <%_ if (authenticationType !== 'oauth2') { _%>
       <Route path="/register" component={Register} />
       <Route path="/activate/:key?" component={Activate} />
       <Route path="/reset/request" component={PasswordResetInit} />
       <Route path="/reset/finish/:key?" component={PasswordResetFinish} />
+    <%_ } _%>
       <PrivateRoute path="/admin" component={Admin} hasAnyAuthorities={[AUTHORITIES.ADMIN]}/>
+    <%_ if (authenticationType !== 'oauth2') { _%>
       <PrivateRoute path="/account" component={Account} hasAnyAuthorities={[AUTHORITIES.ADMIN, AUTHORITIES.USER]}/>
+    <%_ } _%>
       <PrivateRoute path="/entity" component={Entities} hasAnyAuthorities={[AUTHORITIES.USER]}/>
       <Route path="/" component={Home}/>
     </Switch>

--- a/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -4,9 +4,11 @@ import { Route, Redirect, RouteProps } from 'react-router-dom';
 import { Translate } from 'react-jhipster';
 import { RootState } from 'app/shared/reducers';
 
-export interface IPrivateRouteProps extends StateProps, RouteProps {
+interface IOwnProps {
   hasAnyAuthorities?: string[];
 }
+
+export interface IPrivateRouteProps extends IOwnProps, StateProps, RouteProps {}
 
 export const PrivateRouteComponent = ({
   component: Component,
@@ -54,7 +56,7 @@ export const hasAnyAuthority = (authorities: string[], hasAnyAuthorities: string
   return false;
 };
 
-const mapStateToProps = ({ authentication: { isAuthenticated, account } }: RootState, { hasAnyAuthorities = [] }) => ({
+const mapStateToProps = ({ authentication: { isAuthenticated, account } }: RootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
   isAuthenticated,
   isAuthorized: hasAnyAuthority(account.authorities, hasAnyAuthorities)
 });

--- a/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -1,14 +1,11 @@
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Route, Redirect } from 'react-router-dom';
+import { Route, Redirect, RouteProps } from 'react-router-dom';
 import { Translate } from 'react-jhipster';
+import { RootState } from 'app/shared/reducers';
 
-export interface IPrivateRouteProps {
-  component: any;
-  isAuthenticated: boolean;
-  isAuthorized: boolean;
+export interface IPrivateRouteProps extends StateProps, RouteProps {
   hasAnyAuthorities?: string[];
-  [key: string]: any;
 }
 
 export const PrivateRouteComponent = ({
@@ -57,16 +54,19 @@ export const hasAnyAuthority = (authorities: string[], hasAnyAuthorities: string
   return false;
 };
 
-const mapStoreToProps = ({ authentication: { isAuthenticated, account } }, { hasAnyAuthorities = [] }) => ({
+const mapStateToProps = ({ authentication: { isAuthenticated, account } }: RootState, { hasAnyAuthorities = [] }) => ({
   isAuthenticated,
   isAuthorized: hasAnyAuthority(account.authorities, hasAnyAuthorities)
 });
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+// type DispatchProps = typeof mapDispatchToProps;
 
 /**
  * A route wrapped in an authentication check so that routing happens only when you are authenticated.
  * Accepts same props as React router Route.
  * The route also checks for authorization if hasAnyAuthorities is specified.
  */
-export const PrivateRoute = connect(mapStoreToProps, null, null, { pure: false })(PrivateRouteComponent);
+export const PrivateRoute = connect(mapStateToProps, null, null, { pure: false })(PrivateRouteComponent);
 
 export default PrivateRoute;

--- a/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -2,7 +2,7 @@ import * as React from 'react';
 import { connect } from 'react-redux';
 import { Route, Redirect, RouteProps } from 'react-router-dom';
 import { Translate } from 'react-jhipster';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 interface IOwnProps {
   hasAnyAuthorities?: string[];
@@ -56,7 +56,7 @@ export const hasAnyAuthority = (authorities: string[], hasAnyAuthorities: string
   return false;
 };
 
-const mapStateToProps = ({ authentication: { isAuthenticated, account } }: RootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
+const mapStateToProps = ({ authentication: { isAuthenticated, account } }: IRootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
   isAuthenticated,
   isAuthorized: hasAnyAuthority(account.authorities, hasAnyAuthorities)
 });

--- a/generators/client/templates/react/src/main/webapp/app/shared/model/user.model.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/model/user.model.ts.ejs
@@ -33,34 +33,18 @@ export interface IUser {
     password?: string;
 }
 
-export class User implements IUser {
-    constructor(
-        public id?: any,
-        public login?: string,
-        public firstName?: string,
-        public lastName?: string,
-        public email?: string,
-        public activated?: boolean,
-        public langKey?: string,
-        public authorities?: any[],
-        public createdBy?: string,
-        public createdDate?: Date,
-        public lastModifiedBy?: string,
-        public lastModifiedDate?: Date,
-        public password?: string
-    ) {
-        this.id = id ? id : null;
-        this.login = login ? login : null;
-        this.firstName = firstName ? firstName : null;
-        this.lastName = lastName ? lastName : null;
-        this.email = email ? email : null;
-        this.activated = activated ? activated : false;
-        this.langKey = langKey ? langKey : null;
-        this.authorities = authorities ? authorities : null;
-        this.createdBy = createdBy ? createdBy : null;
-        this.createdDate = createdDate ? createdDate : null;
-        this.lastModifiedBy = lastModifiedBy ? lastModifiedBy : null;
-        this.lastModifiedDate = lastModifiedDate ? lastModifiedDate : null;
-        this.password = password ? password : null;
-    }
+export const defaultValue:  Readonly<IUser> = {
+    id: null,
+    login: null,
+    firstName: null,
+    lastName: null,
+    email: null,
+    activated: false,
+    langKey: null,
+    authorities: null,
+    createdBy: null,
+    createdDate: null,
+    lastModifiedBy: null,
+    lastModifiedDate: null,
+    password: null
 }

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/application-profile.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/application-profile.ts.ejs
@@ -30,7 +30,9 @@ const initialState = {
   isSwaggerEnabled: false
 };
 
-export default (state = initialState, action) => {
+export type ApplicationProfileState = typeof initialState;
+
+export default (state = initialState, action): ApplicationProfileState => {
   switch (action.type) {
     case SUCCESS(ACTION_TYPES.GET_PROFILE):
       const { data } = action.payload;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/application-profile.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/application-profile.ts.ejs
@@ -30,9 +30,9 @@ const initialState = {
   isSwaggerEnabled: false
 };
 
-export type ApplicationProfileState = typeof initialState;
+export type ApplicationProfileState =  Readonly<typeof initialState>;
 
-export default (state = initialState, action): ApplicationProfileState => {
+export default (state: ApplicationProfileState = initialState, action): ApplicationProfileState => {
   switch (action.type) {
     case SUCCESS(ACTION_TYPES.GET_PROFILE):
       const { data } = action.payload;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -45,14 +45,16 @@ const initialState = {
   loginError: false, // Errors returned from server side
   showModalLogin: false,
   <%_ } _%>
-  account: {},
-  errorMessage: null, // Errors returned from server side
-  redirectMessage: null
+  account: {} as any,
+  errorMessage: null as string, // Errors returned from server side
+  redirectMessage: null as string
 };
+
+export type AuthenticationState = typeof initialState;
 
 // Reducer
 
-export default (state = initialState, action) => {
+export default (state = initialState, action): AuthenticationState => {
   switch (action.type) {
     <%_ if (authenticationType !== 'oauth2') { _%>
     case REQUEST(ACTION_TYPES.LOGIN):

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -50,11 +50,11 @@ const initialState = {
   redirectMessage: null as string
 };
 
-export type AuthenticationState = typeof initialState;
+export type AuthenticationState =  Readonly<typeof initialState>;
 
 // Reducer
 
-export default (state = initialState, action): AuthenticationState => {
+export default (state: AuthenticationState = initialState, action): AuthenticationState => {
   switch (action.type) {
     <%_ if (authenticationType !== 'oauth2') { _%>
     case REQUEST(ACTION_TYPES.LOGIN):

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -78,7 +78,9 @@ export default (state = initialState, action): AuthenticationState => {
         ...state,
         loading: false,
         isAuthenticated: false,
+      <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
+      <%_ } _%>
         errorMessage: action.payload
       };
     <%_ if (authenticationType !== 'oauth2') { _%>
@@ -94,7 +96,9 @@ export default (state = initialState, action): AuthenticationState => {
     case ACTION_TYPES.LOGOUT:
       return {
         ...initialState,
+      <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true
+      <%_ } _%>
       };
     case SUCCESS(ACTION_TYPES.GET_SESSION):
       {
@@ -109,14 +113,18 @@ export default (state = initialState, action): AuthenticationState => {
     case ACTION_TYPES.ERROR_MESSAGE:
       return {
         ...initialState,
+      <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
+      <%_ } _%>
         redirectMessage: action.message
       };
     case ACTION_TYPES.CLEAR_AUTH:
       return {
         ...state,
         loading: false,
+      <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
+      <%_ } _%>
         isAuthenticated: false
       };
     default:

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
@@ -44,25 +44,25 @@ import sessions, { SessionsState } from 'app/modules/account/sessions/sessions.r
 /* jhipster-needle-add-reducer-import - JHipster will add reducer here */
 
 export interface IRootState {
-  authentication: AuthenticationState;
+  readonly authentication: AuthenticationState;
   <%_ if (enableTranslation) { _%>
-  locale: LocaleState;
+  readonly locale: LocaleState;
   <%_ } _%>
-  applicationProfile: ApplicationProfileState;
-  administration: AdministrationState;
-  userManagement: UserManagementState;
+  readonly applicationProfile: ApplicationProfileState;
+  readonly administration: AdministrationState;
+  readonly userManagement: UserManagementState;
   <%_ if (authenticationType !== 'oauth2') { _%>
-  register: RegisterState;
-  activate: ActivateState;
-  passwordReset: PasswordResetState;
-  password: PasswordState;
-  settings: SettingsState;
+  readonly register: RegisterState;
+  readonly activate: ActivateState;
+  readonly passwordReset: PasswordResetState;
+  readonly password: PasswordState;
+  readonly settings: SettingsState;
     <%_ if (authenticationType === 'session') { _%>
-  sessions: SessionsState;
+  readonly sessions: SessionsState;
     <%_ } _%>
   <%_ } _%>
   /* jhipster-needle-add-reducer-type - JHipster will add reducer type here */
-  loadingBar: any;
+  readonly loadingBar: any;
 }
 
 const rootReducer = combineReducers<IRootState>({

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
@@ -43,8 +43,7 @@ import sessions, { SessionsState } from 'app/modules/account/sessions/sessions.r
 <%_ } _%>
 /* jhipster-needle-add-reducer-import - JHipster will add reducer here */
 
-// tslint:disable-next-line:interface-over-type-literal
-export type RootState = {
+export interface IRootState {
   authentication: AuthenticationState;
   <%_ if (enableTranslation) { _%>
   locale: LocaleState;
@@ -66,7 +65,7 @@ export type RootState = {
   loadingBar: any;
 }
 
-const rootReducer = combineReducers<RootState>({
+const rootReducer = combineReducers<IRootState>({
   authentication,
   <%_ if (enableTranslation) { _%>
   locale,

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
@@ -20,30 +20,53 @@ import { combineReducers } from 'redux';
 import { loadingBarReducer as loadingBar } from 'react-redux-loading-bar';
 
 <%_ if (enableTranslation) { _%>
-import locale from './locale';
+import locale, { LocaleState } from './locale';
 <%_ } _%>
-import authentication from './authentication';
-import applicationProfile from './application-profile';
+import authentication, { AuthenticationState } from './authentication';
+import applicationProfile, { ApplicationProfileState } from './application-profile';
 
-import administration from 'app/modules/administration/administration.reducer';
+import administration, { AdministrationState } from 'app/modules/administration/administration.reducer';
 <%_ if (!skipUserManagement) { _%>
-import userManagement from 'app/modules/administration/user-management/user-management.reducer';
+import userManagement, { UserManagementState } from 'app/modules/administration/user-management/user-management.reducer';
 <%_ } else { _%>
-import userManagement from './user-management';
+import userManagement, { UserManagementState } from './user-management';
 <%_ } _%>
 <%_ if (authenticationType !== 'oauth2') { _%>
-import register from 'app/modules/account/register/register.reducer';
-import activate from 'app/modules/account/activate/activate.reducer';
-import password from 'app/modules/account/password/password.reducer';
-import settings from 'app/modules/account/settings/settings.reducer';
-import passwordReset from 'app/modules/account/password-reset/password-reset.reducer';
+import register, { RegisterState } from 'app/modules/account/register/register.reducer';
+import activate, { ActivateState } from 'app/modules/account/activate/activate.reducer';
+import password, { PasswordState } from 'app/modules/account/password/password.reducer';
+import settings, { SettingsState } from 'app/modules/account/settings/settings.reducer';
+import passwordReset, { PasswordResetState } from 'app/modules/account/password-reset/password-reset.reducer';
   <%_ if (authenticationType === 'session') { _%>
-import sessions from 'app/modules/account/sessions/sessions.reducer';
+import sessions, { SessionsState } from 'app/modules/account/sessions/sessions.reducer';
   <%_ } _%>
 <%_ } _%>
 /* jhipster-needle-add-reducer-import - JHipster will add reducer here */
 
-export default combineReducers({
+// tslint:disable-next-line:interface-over-type-literal
+export type RootState = {
+  authentication: AuthenticationState;
+  <%_ if (enableTranslation) { _%>
+  locale: LocaleState;
+  <%_ } _%>
+  applicationProfile: ApplicationProfileState;
+  administration: AdministrationState;
+  userManagement: UserManagementState;
+  <%_ if (authenticationType !== 'oauth2') { _%>
+  register: RegisterState;
+  activate: ActivateState;
+  passwordReset: PasswordResetState;
+  password: PasswordState;
+  settings: SettingsState;
+    <%_ if (authenticationType === 'session') { _%>
+  sessions: SessionsState;
+    <%_ } _%>
+  <%_ } _%>
+  /* jhipster-needle-add-reducer-type - JHipster will add reducer type here */
+  loadingBar: any;
+}
+
+const rootReducer = combineReducers<RootState>({
   authentication,
   <%_ if (enableTranslation) { _%>
   locale,
@@ -64,3 +87,5 @@ export default combineReducers({
   /* jhipster-needle-add-reducer-combine - JHipster will add reducer here */
   loadingBar
 });
+
+export default rootReducer;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -24,9 +24,9 @@ const initialState = {
   currentLocale: 'en'
 };
 
-export type LocaleState = typeof initialState;
+export type LocaleState =  Readonly<typeof initialState>;
 
-export default (state = initialState, action): LocaleState => {
+export default (state: LocaleState = initialState, action): LocaleState => {
   switch (action.type) {
     case ACTION_TYPES.SET_LOCALE:
       return {

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -24,7 +24,9 @@ const initialState = {
   currentLocale: 'en'
 };
 
-export default (state = initialState, action) => {
+export type LocaleState = typeof initialState;
+
+export default (state = initialState, action): LocaleState => {
   switch (action.type) {
     case ACTION_TYPES.SET_LOCALE:
       return {

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
@@ -54,7 +54,7 @@ export default (state = initialState, action): UserManagementState => {
     case ACTION_TYPES.RESET:
       return {
         ...state,
-        user: {}
+        users: []
       };
     default:
       return state;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
@@ -29,13 +29,13 @@ export const ACTION_TYPES = {
 
 const initialState = {
   errorMessage: null,
-  users: [] as IUser[],
+  users: [] as ReadonlyArray<IUser>,
 };
 
-export type UserManagementState = typeof initialState;
+export type UserManagementState =  Readonly<typeof initialState>;
 
 // Reducer
-export default (state = initialState, action): UserManagementState => {
+export default (state: UserManagementState = initialState, action): UserManagementState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FETCH_USERS):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
@@ -29,11 +29,13 @@ export const ACTION_TYPES = {
 
 const initialState = {
   errorMessage: null,
-  users: [],
+  users: [] as IUser[],
 };
 
+export type UserManagementState = typeof initialState;
+
 // Reducer
-export default (state = initialState, action) => {
+export default (state = initialState, action): UserManagementState => {
   switch (action.type) {
     case REQUEST(ACTION_TYPES.FETCH_USERS):
       return {

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
@@ -67,7 +67,7 @@ export const getUsers: ICrudGetAllAction<IUser> = (page, size, sort) => {
   const requestUrl = `${apiUrl}${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;
   return {
     type: ACTION_TYPES.FETCH_USERS,
-    payload: axios.get(requestUrl) as Promise<IUser>
+    payload: axios.get<IUser>(requestUrl)
   };
 };
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/util/entity-utils.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/util/entity-utils.ts.ejs
@@ -40,4 +40,4 @@ export const cleanEntity = entity => {
  * @param data Array that contains the values.
  * @param fieldName Name of the field that contains the key in the value.
  */
-export const keysToValues = (keyList: any[], data: any[], fieldName: string) => keyList.map((k: any) => data.find((e: any) => e[fieldName] === k));
+export const keysToValues = (keyList: ReadonlyArray<any>, data: ReadonlyArray<any>, fieldName: string) => keyList.map((k: any) => data.find((e: any) => e[fieldName] === k));

--- a/generators/client/templates/react/src/main/webapp/app/typings.d.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/typings.d.ts.ejs
@@ -16,6 +16,20 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+import { AxiosPromise } from 'axios';
+
+// TEMPORARY
+declare module 'react-jhipster' {
+  export interface IPayload<T> {
+    type: string;
+    payload: AxiosPromise<T>;
+    meta?: any;
+  }
+  export type ICrudGetAction<T> = (id: string | number) => IPayload<T> | ((dispatch: any) => IPayload<T>);
+  export type ICrudGetAllAction<T> = (page?: number, size?: number, sort?: string) => IPayload<T> | ((dispatch: any) => IPayload<T>);
+  export type ICrudSearchAction<T> = (search?: string) => IPayload<T> | ((dispatch: any) => IPayload<T>);
+}
+
 declare module '*.json' {
     const value: any;
     export default value;

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
@@ -223,7 +223,7 @@ describe('User management reducer tests', () => {
           payload: resolvedObject
         }
       ];
-      await store.dispatch(getRoles('admin')).then(() => expect(store.getActions()).to.eql(expectedActions));
+      await store.dispatch(getRoles()).then(() => expect(store.getActions()).to.eql(expectedActions));
     });
     it('dispatches FETCH_USER_PENDING and FETCH_USER_FULFILLED actions', async () => {
       const expectedActions = [

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
@@ -24,7 +24,7 @@ import { Translate, ICrudGetAction, ICrudDeleteAction } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getEntity, deleteEntity } from './<%= entityFileName %>.reducer';
 
 export interface I<%= entityReactName %>DeleteDialogProps extends StateProps, DispatchProps, RouteComponentProps<{id: number}>  {}
@@ -69,7 +69,7 @@ export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= ent
   }
 }
 
-const mapStateToProps = ({ <%= entityInstance %> }: RootState) => ({
+const mapStateToProps = ({ <%= entityInstance %> }: IRootState) => ({
     <%= entityInstance %>: <%= entityInstance %>.entity
 });
 

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
@@ -18,20 +18,16 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
+import { RouteComponentProps } from 'react-router-dom';
 import { Modal, ModalHeader, ModalBody, ModalFooter, Button } from 'reactstrap';
 import { Translate, ICrudGetAction, ICrudDeleteAction } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
 import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
+import { RootState } from 'app/shared/reducers';
 import { getEntity, deleteEntity } from './<%= entityFileName %>.reducer';
 
-export interface I<%= entityReactName %>DeleteDialogProps {
-  getEntity: ICrudGetAction<I<%= entityReactName %>>;
-  deleteEntity: ICrudDeleteAction<I<%= entityReactName %>>;
-  <%= entityInstance %>: I<%= entityReactName %>;
-  match: any;
-  history: any;
-}
+export interface I<%= entityReactName %>DeleteDialogProps extends StateProps, DispatchProps, RouteComponentProps<{id: number}>  {}
 
 export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= entityReactName %>DeleteDialogProps> {
   componentDidMount() {
@@ -73,10 +69,13 @@ export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= ent
   }
 }
 
-const mapStateToProps = ({ <%= entityInstance %> }) => ({
+const mapStateToProps = ({ <%= entityInstance %> }: RootState) => ({
     <%= entityInstance %>: <%= entityInstance %>.entity
 });
 
 const mapDispatchToProps = { getEntity, deleteEntity };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(<%= entityReactName %>DeleteDialog);

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -18,7 +18,7 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { Button, <% if (haveFieldWithJavadoc) { %>UncontrolledTooltip, <% } %>Row, Col } from 'reactstrap';
 // tslint:disable-next-line:no-unused-variable
 import {
@@ -36,16 +36,13 @@ import {
 } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
+import { RootState } from 'app/shared/reducers';
 import { getEntity } from './<%= entityFileName %>.reducer';
 import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 // tslint:disable-next-line:no-unused-variable
 import { APP_DATE_FORMAT, APP_LOCAL_DATE_FORMAT } from 'app/config/constants';
 
-export interface I<%= entityReactName %>DetailProps {
-  getEntity: ICrudGetAction<I<%= entityReactName %>>;
-  <%= entityInstance %>: I<%= entityReactName %>;
-  match: any;
-}
+export interface I<%= entityReactName %>DetailProps extends StateProps, DispatchProps, RouteComponentProps<{id: number}>  {}
 
 export class <%= entityReactName %>Detail extends React.Component<I<%= entityReactName %>DetailProps> {
 
@@ -184,10 +181,13 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
   }
 }
 
-const mapStateToProps = ({ <%= entityInstance %> }) => ({
+const mapStateToProps = ({ <%= entityInstance %> }: RootState) => ({
     <%= entityInstance %>: <%= entityInstance %>.entity
 });
 
 const mapDispatchToProps = { getEntity };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(<%= entityReactName %>Detail);

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -36,7 +36,7 @@ import {
 } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import { getEntity } from './<%= entityFileName %>.reducer';
 import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 // tslint:disable-next-line:no-unused-variable
@@ -181,7 +181,7 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
   }
 }
 
-const mapStateToProps = ({ <%= entityInstance %> }: RootState) => ({
+const mapStateToProps = ({ <%= entityInstance %> }: IRootState) => ({
     <%= entityInstance %>: <%= entityInstance %>.entity
 });
 

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -30,7 +30,7 @@ for (const idx in fields) {
 _%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import {
   Button,
   Row,
@@ -52,6 +52,7 @@ import {
   ICrudPutAction
 } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { RootState } from 'app/shared/reducers';
 
 <%_
 let hasRelationshipQuery = false;
@@ -120,24 +121,7 @@ import { convertDateTimeFromServer } from 'app/shared/util/date-utils';
 import { keysToValues } from 'app/shared/util/entity-utils';
 <%_ } _%>
 
-export interface I<%= entityReactName %>UpdateProps {
-  getEntity: ICrudGetAction<I<%= entityReactName %>>;
-  updateEntity: ICrudPutAction<I<%= entityReactName %>>;
-  createEntity: ICrudPutAction<I<%= entityReactName %>>;
-  <%_ otherEntityActions.forEach(val => { _%>
-  <%= val.action %>: ICrudGetAllAction<I<%= val.entity %>>;
-  <%= val.instance %>: I<%= val.entity %>[];
-  <%_ }) _%>
-  <%= entityInstance %>: I<%= entityReactName %>;
-  <%_ if (fieldsContainBlob) { _%>
-  setBlob: Function;
-  <%_ } _%>
-  reset: Function;
-  loading: boolean;
-  updating: boolean;
-  match: any;
-  history: any;
-}
+export interface I<%= entityReactName %>UpdateProps extends StateProps, DispatchProps, RouteComponentProps<{id: number}>  {}
 
 export interface I<%= entityReactName %>UpdateState {
   isNew: boolean;
@@ -648,7 +632,7 @@ _%>
   }
 }
 
-const mapStateToProps = storeState => ({
+const mapStateToProps = (storeState: RootState) => ({
   <%_ otherEntityActions.forEach(val => { _%>
     <%= val.instance %>: storeState.<%= val.reducer %>.<%= val.entity === 'User' ? val.instance : 'entities' %>,
   <%_ }) _%>
@@ -669,5 +653,8 @@ const mapDispatchToProps = {
   createEntity,
   reset
 };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(<%= entityReactName %>Update);

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -52,7 +52,7 @@ import {
   ICrudPutAction
 } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 
 <%_
 let hasRelationshipQuery = false;
@@ -632,7 +632,7 @@ _%>
   }
 }
 
-const mapStateToProps = (storeState: RootState) => ({
+const mapStateToProps = (storeState: IRootState) => ({
   <%_ otherEntityActions.forEach(val => { _%>
     <%= val.instance %>: storeState.<%= val.reducer %>.<%= val.entity === 'User' ? val.instance : 'entities' %>,
   <%_ }) _%>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -19,7 +19,7 @@
 <%
 const variablesWithTypes = generateEntityClientFields(pkType, fields, relationships, dto);
 const typeImports = generateEntityClientImports(relationships, dto);
-const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
+const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields, 'react');
 %>
 <%_ if (fieldsContainInstant || fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 import { Moment } from 'moment';
@@ -47,10 +47,6 @@ export interface I<%= entityReactName %> {
     <%_ }); _%>
 }
 
-export class <%= entityReactName %> implements I<%= entityReactName %> {
-    constructor(<% variablesWithTypes.forEach(variablesWithType => { %>
-        public <%- variablesWithType %>,<% }); %>
-    ) {<% for (idx in defaultVariablesValues) { %>
-        <%- defaultVariablesValues[idx] %><% } %>
-    }
-}
+export const defaultValue:  Readonly<I<%= entityReactName %>> = {
+<% for (idx in defaultVariablesValues) { %><%- defaultVariablesValues[idx] %><% } %>
+};

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
@@ -43,7 +43,7 @@ import { SERVER_API_URL } from 'app/config/constants';
 <%_ if (fieldsContainDate) { _%>
 
 <%_ } _%>
-import { I<%= entityReactName %>, <%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
+import { I<%= entityReactName %>, defaultValue } from 'app/shared/model/<%= entityModelFileName %>.model';
 
 export const ACTION_TYPES = {
   <%_ if (searchEngine === 'elasticsearch') { _%>
@@ -63,8 +63,8 @@ export const ACTION_TYPES = {
 const initialState = {
   loading: false,
   errorMessage: null,
-  entities: [] as I<%= entityReactName %>[],
-  entity: new <%= entityReactName %>(),
+  entities: [] as ReadonlyArray<I<%= entityReactName %>>,
+  entity: defaultValue,
   <%_ if (pagination === 'infinite-scroll') { _%>
   links: {
     last: 0
@@ -77,11 +77,11 @@ const initialState = {
   updateSuccess: false
 };
 
-export type <%= entityReactName %>State = typeof initialState;
+export type <%= entityReactName %>State =  Readonly<typeof initialState>;
 
 // Reducer
 
-export default (state = initialState, action): <%= entityReactName %>State => {
+export default (state: <%= entityReactName %>State = initialState, action): <%= entityReactName %>State => {
   switch (action.type) {
     <%_ if (searchEngine === 'elasticsearch') { _%>
     case REQUEST(ACTION_TYPES.SEARCH_<%= entityActionNamePlural %>):

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
@@ -197,7 +197,7 @@ const apiSearchUrl = <% if (applicationType === 'gateway' && locals.microservice
 <%_ if (searchEngine === 'elasticsearch') { _%>
 export const getSearchEntities: ICrudSearchAction<I<%= entityReactName %>> = query => ({
   type: ACTION_TYPES.SEARCH_<%= entityActionNamePlural %>,
-  payload: axios.get(`${apiSearchUrl}?query=` + query) as Promise<I<%= entityReactName %>>
+  payload: axios.get<I<%= entityReactName %>>(`${apiSearchUrl}?query=` + query)
 });
 
 <%_ } _%>
@@ -207,13 +207,13 @@ export const getEntities: ICrudGetAllAction<I<%= entityReactName %>> = (page, si
   const requestUrl = `${apiUrl}${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;
   return {
     type: ACTION_TYPES.FETCH_<%= entityActionName %>_LIST,
-    payload: axios.get(`${requestUrl}${sort ? '&' : '?'}cacheBuster=${new Date().getTime()}`) as Promise<I<%= entityReactName %>>
+    payload: axios.get<I<%= entityReactName %>>(`${requestUrl}${sort ? '&' : '?'}cacheBuster=${new Date().getTime()}`)
   }
 }
 <%_ } else { _%>
 ({
   type: ACTION_TYPES.FETCH_<%= entityActionName %>_LIST,
-  payload: axios.get(`${apiUrl}?cacheBuster=${new Date().getTime()}`) as Promise<I<%= entityReactName %>>
+  payload: axios.get<I<%= entityReactName %>>(`${apiUrl}?cacheBuster=${new Date().getTime()}`)
 });
 <%_ } _%>
 
@@ -221,7 +221,7 @@ export const getEntity: ICrudGetAction<I<%= entityReactName %>> = id => {
   const requestUrl = `${apiUrl}/${id}`;
   return {
     type: ACTION_TYPES.FETCH_<%= entityActionName %>,
-    payload: axios.get(requestUrl) as Promise<I<%= entityReactName %>>
+    payload: axios.get<I<%= entityReactName %>>(requestUrl)
   };
 };
 

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
@@ -43,7 +43,7 @@ import { SERVER_API_URL } from 'app/config/constants';
 <%_ if (fieldsContainDate) { _%>
 
 <%_ } _%>
-import { I<%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
+import { I<%= entityReactName %>, <%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 
 export const ACTION_TYPES = {
   <%_ if (searchEngine === 'elasticsearch') { _%>
@@ -63,8 +63,8 @@ export const ACTION_TYPES = {
 const initialState = {
   loading: false,
   errorMessage: null,
-  entities: [],
-  entity: {},
+  entities: [] as I<%= entityReactName %>[],
+  entity: new <%= entityReactName %>(),
   <%_ if (pagination === 'infinite-scroll') { _%>
   links: {
     last: 0
@@ -77,9 +77,11 @@ const initialState = {
   updateSuccess: false
 };
 
+export type <%= entityReactName %>State = typeof initialState;
+
 // Reducer
 
-export default (state = initialState, action) => {
+export default (state = initialState, action): <%= entityReactName %>State => {
   switch (action.type) {
     <%_ if (searchEngine === 'elasticsearch') { _%>
     case REQUEST(ACTION_TYPES.SEARCH_<%= entityActionNamePlural %>):

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
@@ -21,7 +21,7 @@ import * as React from 'react';
 import * as InfiniteScroll from 'react-infinite-scroller';
 <%_ } _%>
 import { connect } from 'react-redux';
-import { Link } from 'react-router-dom';
+import { Link, RouteComponentProps } from 'react-router-dom';
 import { Button, <% if (searchEngine === 'elasticsearch') { %>InputGroup, <% } %>Col, Row, Table } from 'reactstrap';
 <%_ if (searchEngine === 'elasticsearch') { _%>
 import { AvForm, AvGroup, AvInput } from 'availity-reactstrap-validation';
@@ -44,6 +44,7 @@ import {
 } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
+import { RootState } from 'app/shared/reducers';
 import {
   <%_ if (searchEngine === 'elasticsearch') { _%>
   getSearchEntities,
@@ -60,29 +61,7 @@ import { APP_DATE_FORMAT, APP_LOCAL_DATE_FORMAT } from 'app/config/constants';
 import { ITEMS_PER_PAGE } from 'app/shared/util/pagination.constants';
 <%_ } _%>
 
-export interface I<%= entityReactName %>Props {
-  getEntities: ICrudGetAllAction<I<%= entityReactName %>>;
-  <%_ if (pagination === 'infinite-scroll') { _%>
-  reset: Function;
-  <%_ } _%>
-  <%_ if (searchEngine === 'elasticsearch') { _%>
-  getSearchEntities: ICrudSearchAction<I<%= entityReactName %>>;
-  <%_ } _%>
-  <%= entityInstance %>List: I<%= entityReactName %>[];
-  <%_ if (pagination === 'infinite-scroll') { _%>
-  links: {
-    last: 0
-  };
-  <%_ } _%>
-  <%_ if (pagination !== 'no') { _%>
-  totalItems: 0;
-  location: any;
-  <%_ } _%>
-  <%_ if (pagination === 'pagination' || pagination === 'pager') { _%>
-  history: any;
-  <%_ } _%>
-  match: any;
-}
+export interface I<%= entityReactName %>Props extends StateProps, DispatchProps, RouteComponentProps<{url: string}> {}
 
 <% if (searchEngine === 'elasticsearch' && pagination !== 'no') { _%>
 export interface I<%= entityReactName %>State extends IPaginationBaseState {
@@ -375,7 +354,7 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
   }
 }
 
-const mapStateToProps = ({ <%= entityInstance %> }) => ({
+const mapStateToProps = ({ <%= entityInstance %> }: RootState) => ({
   <%= entityInstance %>List: <%= entityInstance %>.entities,
   <%_ if (pagination !== 'no') { _%>
   totalItems: <%= entityInstance %>.totalItems,
@@ -394,5 +373,8 @@ const mapDispatchToProps = {
  reset
  <%_ } _%>
 };
+
+type StateProps = ReturnType<typeof mapStateToProps>;
+type DispatchProps = typeof mapDispatchToProps;
 
 export default connect(mapStateToProps, mapDispatchToProps)(<%= entityReactName %>);

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
@@ -44,7 +44,7 @@ import {
 } from 'react-jhipster';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 
-import { RootState } from 'app/shared/reducers';
+import { IRootState } from 'app/shared/reducers';
 import {
   <%_ if (searchEngine === 'elasticsearch') { _%>
   getSearchEntities,
@@ -354,7 +354,7 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
   }
 }
 
-const mapStateToProps = ({ <%= entityInstance %> }: RootState) => ({
+const mapStateToProps = ({ <%= entityInstance %> }: IRootState) => ({
   <%= entityInstance %>List: <%= entityInstance %>.entities,
   <%_ if (pagination !== 'no') { _%>
   totalItems: <%= entityInstance %>.totalItems,

--- a/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
@@ -34,7 +34,7 @@ import reducer, {
   ACTION_TYPES, createEntity, deleteEntity, getEntities, getEntity, updateEntity<% if (pagination === 'infinite-scroll') { %>, reset<% } %>
 } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.reducer';
 import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
-import { I<%= entityReactName %>, <%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
+import { I<%= entityReactName %>, defaultValue } from 'app/shared/model/<%= entityModelFileName %>.model';
 
 // tslint:disable no-invalid-template-strings
 describe('Entities reducer tests', () => {
@@ -50,8 +50,8 @@ describe('Entities reducer tests', () => {
   const initialState = {
     loading: false,
     errorMessage: null,
-    entities: [] as I<%= entityReactName %>[],
-    entity: new <%= entityReactName %>(),
+    entities: [] as ReadonlyArray<I<%= entityReactName %>>,
+    entity: defaultValue,
     <%_ if (pagination === 'infinite-scroll') { _%>
     links: {
       last: 0

--- a/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
@@ -34,6 +34,7 @@ import reducer, {
   ACTION_TYPES, createEntity, deleteEntity, getEntities, getEntity, updateEntity<% if (pagination === 'infinite-scroll') { %>, reset<% } %>
 } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.reducer';
 import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
+import { I<%= entityReactName %>, <%= entityReactName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 
 // tslint:disable no-invalid-template-strings
 describe('Entities reducer tests', () => {
@@ -49,8 +50,8 @@ describe('Entities reducer tests', () => {
   const initialState = {
     loading: false,
     errorMessage: null,
-    entities: [],
-    entity: {},
+    entities: [] as I<%= entityReactName %>[],
+    entity: new <%= entityReactName %>(),
     <%_ if (pagination === 'infinite-scroll') { _%>
     links: {
       last: 0
@@ -304,6 +305,7 @@ describe('Entities reducer tests', () => {
       })).to.eql({
         ...initialState,
         entity: {
+          ...initialState.entity,
           fancyBlobName: payload.data,
           fancyBlobNameContentType: payload.contentType
         }

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -864,13 +864,17 @@ module.exports = class extends Generator {
      * @param {Array|Object} fields - array of fields
      * @returns {Array} defaultVariablesValues
      */
-    generateEntityClientFieldDefaultValues(fields) {
+    generateEntityClientFieldDefaultValues(fields, clientFramework = 'angularX') {
         const defaultVariablesValues = {};
         fields.forEach((field) => {
             const fieldType = field.fieldType;
             const fieldName = field.fieldName;
             if (fieldType === 'Boolean') {
-                defaultVariablesValues[fieldName] = `this.${fieldName} = false;`;
+                if (clientFramework === 'react') {
+                    defaultVariablesValues[fieldName] = `${fieldName}: false,`;
+                } else {
+                    defaultVariablesValues[fieldName] = `this.${fieldName} = false;`;
+                }
             }
         });
         return defaultVariablesValues;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -283,7 +283,15 @@ module.exports = class extends PrivateBase {
                     file: indexReducerPath,
                     needle: 'jhipster-needle-add-reducer-import',
                     splicable: [
-                        this.stripMargin(`|import ${entityInstance} from 'app/entities/${entityFolderName}/${entityFileName}.reducer';`)
+                        this.stripMargin(`|import ${entityInstance}, { ${entityAngularName}State } from 'app/entities/${entityFolderName}/${entityFileName}.reducer';`)
+                    ]
+                }, this);
+
+                jhipsterUtils.rewriteFile({
+                    file: indexReducerPath,
+                    needle: 'jhipster-needle-add-reducer-type',
+                    splicable: [
+                        this.stripMargin(`|  ${entityInstance}: ${entityAngularName}State;`)
                     ]
                 }, this);
 
@@ -291,7 +299,7 @@ module.exports = class extends PrivateBase {
                     file: indexReducerPath,
                     needle: 'jhipster-needle-add-reducer-combine',
                     splicable: [
-                        this.stripMargin(`${entityInstance},`)
+                        this.stripMargin(`|  ${entityInstance},`)
                     ]
                 }, this);
             }

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -283,7 +283,10 @@ module.exports = class extends PrivateBase {
                     file: indexReducerPath,
                     needle: 'jhipster-needle-add-reducer-import',
                     splicable: [
-                        this.stripMargin(`|import ${entityInstance}, { ${entityAngularName}State } from 'app/entities/${entityFolderName}/${entityFileName}.reducer';`)
+                        this.stripMargin(`|// prettier-ignore
+                            |import ${entityInstance}, {
+                            |  ${entityAngularName}State
+                            |} from 'app/entities/${entityFolderName}/${entityFileName}.reducer';`)
                     ]
                 }, this);
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -294,7 +294,7 @@ module.exports = class extends PrivateBase {
                     file: indexReducerPath,
                     needle: 'jhipster-needle-add-reducer-type',
                     splicable: [
-                        this.stripMargin(`|  ${entityInstance}: ${entityAngularName}State;`)
+                        this.stripMargin(`|  readonly ${entityInstance}: ${entityAngularName}State;`)
                     ]
                 }, this);
 


### PR DESCRIPTION
These changes will make the redux store typed.

* In the reducers, the state type is infered from the `initialState`
* These are combined into a `RootState` type
* `mapStateToProps` uses the `RootState` to infer its return type `StateProps`
* This return type is combined with the 'typeof' dispatchToProps `DispatchProps` to create Component interfaces
* Where necessary `RouteComponentProps` were added.

This way the correct types have to be declared only once, in the initialState.



- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
