### PR TITLE
remove duplicated index on email and login

### DIFF
--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -101,19 +101,7 @@
             <column name="last_modified_by" type="varchar(50)"/>
             <column name="last_modified_date" type="timestamp"/>
         </createTable>
-    <%_ if (prodDatabaseType !== 'oracle') { _%>
-        <createIndex indexName="idx_user_login"
-            tableName="<%= jhiTablePrefix %>_user"
-            unique="true">
-            <column name="login" type="varchar(50)"/>
-        </createIndex>
 
-        <createIndex indexName="idx_user_email"
-            tableName="<%= jhiTablePrefix %>_user"
-            unique="true">
-            <column name="email" type="varchar(100)"/>
-        </createIndex>
-    <%_ } _%>
         <createTable tableName="<%= jhiTablePrefix %>_authority">
             <column name="name" type="varchar(50)">
                 <constraints primaryKey="true" nullable="false"/>


### PR DESCRIPTION
Having unique constraints on login and email,
`<constraints unique="true" nullable="false" uniqueConstraintName="ux_user_login"/>`
`<constraints unique="true" nullable="true" uniqueConstraintName="ux_user_email"/>`

It acts as an index:

`explain select login from jhi_user where login = 'admin';`
```
                                     QUERY PLAN
-------------------------------------------------------------------------------------
 Index Only Scan using ux_user_login on jhi_user  (cost=0.14..8.16 rows=1 width=118)
   Index Cond: (login = 'admin'::text)
(2 rows)
```

So we don't need those index creation:
```
<createIndex indexName="idx_user_login"
            tableName="<%= jhiTablePrefix %>_user"
            unique="true">
            <column name="login" type="varchar(50)"/>
</createIndex>
<createIndex indexName="idx_user_email"
            tableName="<%= jhiTablePrefix %>_user"
            unique="true">
            <column name="email" type="varchar(100)"/>
</createIndex>
```
It is the case for postgreSQL (and oracle as it is already ignored). I'm not sure about MySQL and MSSQL, it should be the same I guess but I don't have those databases installed yet. 
I'll let you know !
