### PR TITLE
Remove useless Moment locales from production build

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -101,6 +101,7 @@
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.14",
     <%_ } _%>
+    "moment-locales-webpack-plugin": "^1.0.5",
     "prettier": "1.11.1",
     <%_ if (protractorTests) { _%>
     "protractor": "5.1.2",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -101,7 +101,7 @@
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.14",
     <%_ } _%>
-    "moment-locales-webpack-plugin": "^1.0.5",
+    "moment-locales-webpack-plugin": "1.0.5",
     "prettier": "1.11.1",
     <%_ if (protractorTests) { _%>
     "protractor": "5.1.2",

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -20,6 +20,7 @@ const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const Visualizer = require('webpack-visualizer-plugin');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const UglifyJSPlugin = require('uglifyjs-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const AngularCompilerPlugin = require('@ngtools/webpack').AngularCompilerPlugin;
@@ -129,6 +130,11 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         extractSASS,
         <%_ } _%>
         extractCSS,
+        new MomentLocalesPlugin({
+            localesToKeep: [
+                // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array
+            ]
+        }),
         new Visualizer({
             // Webpack statistics in target folder
             filename: '../stats.html'

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -117,6 +117,7 @@ limitations under the License.
     "merge-jsons-webpack-plugin": "1.0.14",
     <%_ } _%>
     "mocha": "5.0.5",
+    "moment-locales-webpack-plugin": "1.0.5",
     "prettier": "1.11.1",
     <%_ if (protractorTests) { _%>
     "protractor": "5.1.2",

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -21,6 +21,7 @@ const webpackMerge = require('webpack-merge');
 const ExtractTextPlugin = require("extract-text-webpack-plugin");
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const UglifyJsPlugin = require('uglifyjs-webpack-plugin');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const path = require('path');
 
 const utils = require('./utils.js');

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -102,6 +102,11 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
     <%_ if (useSass) { _%>
     extractSASS,
     <%_ } _%>
+    new MomentLocalesPlugin({
+      localesToKeep: [
+        // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array
+      ]
+    }),
     new webpack.LoaderOptionsPlugin({
       minimize: true,
       debug: false

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -261,11 +261,11 @@ module.exports = class extends Generator {
     }
 
     /**
-     * Update Languages In Webpack
+     * Update Moment Locales to keep in webpack prod build
      *
      * @param languages
      */
-    updateLanguagesInMomentWebpack(languages) {
+    updateLanguagesInMomentWebpackNgx(languages) {
         const fullPath = 'webpack/webpack.prod.js';
         try {
             let content = 'localesToKeep: [\n';
@@ -275,6 +275,33 @@ module.exports = class extends Generator {
             content +=
                 '                    // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array\n' +
                 '                ]';
+
+            jhipsterUtils.replaceContent({
+                file: fullPath,
+                pattern: /localesToKeep:.*\[([^\]]*jhipster-needle-i18n-language-moment-webpack[^\]]*)\]/g,
+                content
+            }, this);
+        } catch (e) {
+            this.log(chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required jhipster-needle. Webpack language task not updated with languages: ') + languages + chalk.yellow(' since block was not found. Check if you have enabled translation support.\n'));
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
+     * Update Moment Locales to keep in webpack prod build
+     *
+     * @param languages
+     */
+    updateLanguagesInMomentWebpackReact(languages) {
+        const fullPath = 'webpack/webpack.prod.js';
+        try {
+            let content = 'localesToKeep: [\n';
+            languages.forEach((language, i) => {
+                content += `        '${language}'${i !== languages.length - 1 ? ',' : ''}\n`;
+            });
+            content +=
+                '        // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array\n' +
+                '      ]';
 
             jhipsterUtils.replaceContent({
                 file: fullPath,

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -261,6 +261,33 @@ module.exports = class extends Generator {
     }
 
     /**
+     * Update Languages In Webpack
+     *
+     * @param languages
+     */
+    updateLanguagesInMomentWebpack(languages) {
+        const fullPath = 'webpack/webpack.prod.js';
+        try {
+            let content = 'localesToKeep: [\n';
+            languages.forEach((language, i) => {
+                content += `                    '${language}'${i !== languages.length - 1 ? ',' : ''}\n`;
+            });
+            content +=
+                '                    // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array\n' +
+                '                ]';
+
+            jhipsterUtils.replaceContent({
+                file: fullPath,
+                pattern: /localesToKeep:.*\[([^\]]*jhipster-needle-i18n-language-moment-webpack[^\]]*)\]/g,
+                content
+            }, this);
+        } catch (e) {
+            this.log(chalk.yellow('\nUnable to find ') + fullPath + chalk.yellow(' or missing required jhipster-needle. Webpack language task not updated with languages: ') + languages + chalk.yellow(' since block was not found. Check if you have enabled translation support.\n'));
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
      * insight
      *
      * @param trackingCode

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -191,6 +191,7 @@ module.exports = class extends BaseGenerator {
             this.updateLanguagesInLanguagePipe(this.config.get('languages'));
             this.updateLanguagesInLanguageConstantNG2(this.config.get('languages'));
             this.updateLanguagesInWebpack(this.config.get('languages'));
+            this.updateLanguagesInMomentWebpack(this.config.get('languages'));
         }
     }
 };

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -191,7 +191,12 @@ module.exports = class extends BaseGenerator {
             this.updateLanguagesInLanguagePipe(this.config.get('languages'));
             this.updateLanguagesInLanguageConstantNG2(this.config.get('languages'));
             this.updateLanguagesInWebpack(this.config.get('languages'));
-            this.updateLanguagesInMomentWebpack(this.config.get('languages'));
+            if (this.clientFramework === 'angularX') {
+                this.updateLanguagesInMomentWebpackNgx(this.config.get('languages'));
+            }
+            if (this.clientFramework === 'react') {
+                this.updateLanguagesInMomentWebpackReact(this.config.get('languages'));
+            }
         }
     }
 };


### PR DESCRIPTION
Moment is quite a big library as it imports ALL the locales by default. We can use [this plugin](https://github.com/iamakulov/moment-locales-webpack-plugin) in order to keep only the locales the user wants to use and remove the rests, which result in a reduced bundle size 🎉 

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
