### PR TITLE
React: remove (to-be) deprecated lifecycle functions

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -49,10 +49,6 @@ export interface IUserSettingsState {
 }
 
 export class SettingsPage extends React.Component<IUserSettingsProps, IUserSettingsState> {
-  state: IUserSettingsState = {
-    account: this.props.account
-  };
-
   componentDidMount() {
     this.props.getSession();
   }
@@ -61,28 +57,11 @@ export class SettingsPage extends React.Component<IUserSettingsProps, IUserSetti
     this.props.reset();
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      account: nextProps.account
-    });
-  }
-
-  <%_ if (enableTranslation) { _%>
-  setLangKey = event => {
-    this.setState({
-      account: {
-        ...this.state.account,
-        langKey: event.target.value
-      }
-    });
-  };
-
-  <%_ } _%>
+  
   handleValidSubmit = (event, values) => {
     const account = {
-      ...this.state.account,
-      ...values<% if (enableTranslation) { %>,
-      langKey: this.state.account.langKey<% } %>
+      ...this.props.account,
+      ...values
     };
 
     this.props.saveAccountSettings(account);
@@ -90,7 +69,7 @@ export class SettingsPage extends React.Component<IUserSettingsProps, IUserSetti
   };
 
   render() {
-    const { account } = this.state;
+    const { account } = this.props;
     const { updateSuccess } = this.props;
 
     return (
@@ -151,8 +130,7 @@ export class SettingsPage extends React.Component<IUserSettingsProps, IUserSetti
                 name="langKey"
                 className="form-control"
                 label={translate('settings.form.language')}
-                onChange={this.setLangKey}
-                defaultValue={account.langKey}
+                value={account.langKey}
               >
                 {/* TODO: Add findLanguageFromKey translation to options */}
                 {locales.map(lang => (

--- a/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
@@ -34,37 +34,23 @@ export interface IHomeProp {
   getSession: Function;
 }
 
-export interface IHomeState {
-  currentUser: any;
-}
-
-export class Home extends React.Component<IHomeProp, IHomeState> {
-  state: IHomeState = {
-    currentUser: this.props.account
-  };
-
-  componentWillMount() {
+export class Home extends React.Component<IHomeProp> {
+  componentDidMount() {
     this.props.getSession();
   }
 
-  componentWillReceiveProps(nextProps) {
-    this.setState({
-      currentUser: nextProps.account
-    });
-  }
-
   render() {
-    const { currentUser } = this.state;
+    const { account } = this.props;
     return (
       <Row>
         <Col md="9">
           <h2><Translate contentKey="home.title">Welcome, Java Hipster!</Translate></h2>
           <p className="lead"><Translate contentKey="home.subtitle">This is your homepage</Translate></p>
           {
-            (currentUser && currentUser.login) ? (
+            (account && account.login) ? (
               <div>
                 <Alert color="success">
-                  <Translate contentKey="home.logged.message" interpolate={{ username: currentUser.login }}>You are logged in as user {currentUser.login}.</Translate>
+                  <Translate contentKey="home.logged.message" interpolate={{ username: account.login }}>You are logged in as user {account.login}.</Translate>
                 </Alert>
               </div>
             ) : (

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/login.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/login.tsx.ejs
@@ -18,36 +18,32 @@
 -%>
 import * as React from 'react';
 import { connect } from 'react-redux';
-import { Redirect } from 'react-router-dom';
+import { Redirect, RouteComponentProps } from 'react-router-dom';
 
 import { login } from 'app/shared/reducers/authentication';
 import LoginModal from './login-modal';
 
-export interface ILoginProps {
+export interface ILoginProps extends RouteComponentProps<{}> {
   isAuthenticated: boolean;
   showModal: boolean;
   loginError?: boolean;
-  location: any;
   login: Function;
 }
 
 export interface ILoginState {
   showModal: boolean;
-  redirectToReferrer: boolean;
 }
 
 export class Login extends React.Component<ILoginProps, ILoginState> {
 
   state: ILoginState = {
     showModal: this.props.showModal,
-    redirectToReferrer: this.props.isAuthenticated
   };
 
-  componentWillReceiveProps(nextProps: ILoginProps) {
-    this.setState({
-      showModal: nextProps.showModal,
-      redirectToReferrer: nextProps.isAuthenticated
-    });
+  componentDidUpdate(prevProps: ILoginProps, prevState) {
+    if (this.props !== prevProps) {
+      this.setState({ showModal: this.props.showModal });
+    }
   }
 
   handleLogin = (username, password, rememberMe = false) => {
@@ -59,9 +55,10 @@ export class Login extends React.Component<ILoginProps, ILoginState> {
   }
 
   render() {
-    const { from } = this.props.location.state || { from: { pathname: '/', search: this.props.location.search } };
-    const { showModal, redirectToReferrer } = this.state;
-    if (redirectToReferrer) {
+    const { location, isAuthenticated } = this.props;
+    const { from } = location.state || { from: { pathname: '/', search: location.search } };
+    const { showModal } = this.state;
+    if (isAuthenticated) {
       return <Redirect to={from} />;
     }
     return (

--- a/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/login/logout.tsx.ejs
@@ -28,7 +28,7 @@ export interface ILogoutProps {
 
 export class Logout extends React.Component<ILogoutProps> {
 
-  componentWillMount() {
+  componentDidMount() {
     this.props.logout();
   }
 


### PR DESCRIPTION
This change will make upgrading React in the future easier.

* remove componentWill[update|mount|receiveProps] methods and either replace them with componentDid... or use props directly. 

See: [Update on Async Rendering](https://reactjs.org/blog/2018/03/27/update-on-async-rendering.html)


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
