### PR TITLE
generate cucumber tests under java folder

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -916,12 +916,12 @@ const serverFiles = {
         },
         {
             condition: generator => generator.cucumberTests,
-            path: TEST_DIR,
+            path: SERVER_TEST_SRC_DIR,
             templates: [
                 // Create Cucumber test files
-                { file: 'java/package/cucumber/CucumberTest.java', renameTo: generator => `${generator.testDir}cucumber/CucumberTest.java` },
-                { file: 'java/package/cucumber/stepdefs/StepDefs.java', renameTo: generator => `${generator.testDir}cucumber/stepdefs/StepDefs.java` },
-                { file: 'features/gitkeep', noEjs: true }
+                { file: 'package/cucumber/CucumberTest.java', renameTo: generator => `${generator.testDir}cucumber/CucumberTest.java` },
+                { file: 'package/cucumber/stepdefs/StepDefs.java', renameTo: generator => `${generator.testDir}cucumber/stepdefs/StepDefs.java` },
+                { file: '../features/gitkeep', noEjs: true }
             ]
         },
         {
@@ -1094,11 +1094,11 @@ const serverFiles = {
         },
         {
             condition: generator => !generator.skipUserManagement && generator.cucumberTests,
-            path: TEST_DIR,
+            path: SERVER_TEST_SRC_DIR,
             templates: [
 
-                { file: 'java/package/cucumber/stepdefs/UserStepDefs.java', renameTo: generator => `${generator.testDir}cucumber/stepdefs/UserStepDefs.java` },
-                'features/user/user.feature'
+                { file: 'package/cucumber/stepdefs/UserStepDefs.java', renameTo: generator => `${generator.testDir}cucumber/stepdefs/UserStepDefs.java` },
+                '../features/user/user.feature'
             ]
         },
         {

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -1111,9 +1111,7 @@ describe('JHipster generator', () => {
 
             it('creates expected files with Cucumber enabled', () => {
                 assert.file(expectedFiles.server);
-                assert.file([
-                    `${TEST_DIR}features/user/user.feature`
-                ]);
+                assert.file(expectedFiles.cucumber);
                 assert.noFile([
                     `${TEST_DIR}gatling/conf/gatling.conf`,
                     `${TEST_DIR}gatling/conf/logback.xml`

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -537,6 +537,14 @@ const expectedFiles = {
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/repository/search/UserSearchRepositoryMockConfiguration.java`
     ],
 
+    cucumber: [
+        `${TEST_DIR}features/user/user.feature`,
+        `${TEST_DIR}features/gitkeep`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/UserStepDefs.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/StepDefs.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberTest.java`
+    ],
+
     eureka: [
         `${DOCKER_DIR}central-server-config/localhost-config/application.yml`,
         `${DOCKER_DIR}central-server-config/docker-config/application.yml`,


### PR DESCRIPTION
Cucumber tests are generated in the wrong directory, it's missing the `java` prefix, I think it started in https://github.com/jhipster/generator-jhipster/commit/8c2e42bc682533f68b41bbe14d15dd5547ccb7a9, it's fine in v4

    #currently generated in
    src/test/com/mycompany/myapp/cucumber/CucumberTest.java

    # should be generated in
    src/test/java/com/mycompany/myapp/cucumber/CucumberTest.java

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
