### PR TITLE
Add Memcached support

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -162,20 +162,21 @@
     "start": "<%= clientPackageManager %> run webpack:dev",
     "serve": "<%= clientPackageManager %> run start",
     "build": "<%= clientPackageManager %> run webpack:prod",
-    "test": "<%= clientPackageManager %> run lint && jest",
-    "test:coverage": "<%= clientPackageManager %> run lint && jest --coverage",
+    "test": "<%= clientPackageManager %> run lint && jest --coverage",
     "test:watch": "<%= clientPackageManager %> test <%= optionsForwarder %>--watch --clearCache",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server <%= optionsForwarder %>--config webpack/webpack.dev.js --progress --inline --hot --profile --port=9060 --watch-content-base",
     "webpack:build:main": "<%= clientPackageManager %> run webpack <%= optionsForwarder %>--config webpack/webpack.dev.js --progress --profile",
     "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:main",
     "webpack:prod:main": "<%= clientPackageManager %> run webpack <%= optionsForwarder %>--config webpack/webpack.prod.js --profile",
     "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:prod:main && <%= clientPackageManager %> run clean-www",
+    "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"
   },
   "jest": {
     "preset": "jest-preset-angular",
     "setupTestFrameworkScriptFile": "<rootDir>/src/test/javascript/jest.ts",
+    "coverageDirectory": "<rootDir>/<%= BUILD_DIR %>test-results/",
     "globals": {
         "ts-jest": {
             "tsConfigFile": "tsconfig.json"

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -162,7 +162,7 @@
     "start": "<%= clientPackageManager %> run webpack:dev",
     "serve": "<%= clientPackageManager %> run start",
     "build": "<%= clientPackageManager %> run webpack:prod",
-    "test": "<%= clientPackageManager %> run lint && jest --coverage",
+    "test": "<%= clientPackageManager %> run lint && jest --coverage --logHeapUsage -w=2",
     "test:watch": "<%= clientPackageManager %> test <%= optionsForwarder %>--watch --clearCache",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server <%= optionsForwarder %>--config webpack/webpack.dev.js --progress --inline --hot --profile --port=9060 --watch-content-base",
     "webpack:build:main": "<%= clientPackageManager %> run webpack <%= optionsForwarder %>--config webpack/webpack.dev.js --progress --profile",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -34,6 +34,7 @@
     "@angular/platform-browser": "6.0.0",
     "@angular/platform-browser-dynamic": "6.0.0",
     "@angular/router": "6.0.0",
+    "@fortawesome/angular-fontawesome": "0.1.0-9",
     "@fortawesome/fontawesome-svg-core": "1.2.0-11",
     "@fortawesome/free-solid-svg-icons": "5.1.0-8",
     "@ng-bootstrap/ng-bootstrap": "2.0.0",

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
@@ -40,9 +40,9 @@
         <table class="table table-sm table-striped">
             <thead>
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
-                <th jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span> <span class="fas fa-sort"></span></th>
-                <th jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span> <span class="fas fa-sort"></span></th>
-                <th jhiSortBy="auditEventType"><span jhiTranslate="audits.table.header.status">State</span> <span class="fas fa-sort"></span></th>
+                <th jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span><fa-icon [icon]="'sort'"></fa-icon></th>
+                <th jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span><fa-icon [icon]="'sort'"></fa-icon></th>
+                <th jhiSortBy="auditEventType"><span jhiTranslate="audits.table.header.status">State</span><fa-icon [icon]="'sort'"></fa-icon></th>
                 <th><span jhiTranslate="audits.table.header.data">Extra data</span></th>
             </tr>
             </thead>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
@@ -20,7 +20,7 @@
     <h2>
         <span jhiTranslate="gateway.title">Gateway</span>
         <button class="btn btn-primary float-xs-right" (click)="refresh()" (disabled)="updatingRoutes">
-            <span class="fas fa-sync"></span> <span jhiTranslate="gateway.refresh.button">Refresh</span>
+            <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="gateway.refresh.button">Refresh</span>
         </button>
     </h2>
     <h3 jhiTranslate="gateway.routes.title">Current routes</h3>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -20,7 +20,7 @@
     <h2>
         <span jhiTranslate="health.title">Health Checks</span>
         <button class="btn btn-primary float-right" (click)="refresh()">
-            <span class="fas fa-sync"></span> <span jhiTranslate="health.refresh.button">Refresh</span>
+            <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="health.refresh.button">Refresh</span>
         </button>
     </h2>
     <div class="table-responsive">
@@ -42,7 +42,7 @@
                     </td>
                     <td class="text-center">
                         <a class="hand" (click)="showHealth(health)" *ngIf="health.details || health.error">
-                            <i class="fas fa-eye"></i>
+                            <fa-icon [icon]="'eye'"></fa-icon>
                         </a>
                     </td>
                 </tr>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -20,7 +20,7 @@
     <h2>
         <span jhiTranslate="metrics.title">Application Metrics</span>
         <button class="btn btn-primary float-right" (click)="refresh()">
-            <span class="fas fa-sync"></span> <span jhiTranslate="metrics.refresh.button">Refresh</span>
+            <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="metrics.refresh.button">Refresh</span>
         </button>
     </h2>
 
@@ -42,7 +42,7 @@
             </ngb-progressbar>
         </div>
         <div class="col-md-4">
-            <b jhiTranslate="metrics.jvm.threads.title">Threads</b> (Total: {{metrics.gauges['jvm.threads.count'].value}}) <a class="hand" (click)="refreshThreadDumpData()" data-toggle="modal" data-target="#threadDump"><i class="fas fa-eye"></i></a>
+            <b jhiTranslate="metrics.jvm.threads.title">Threads</b> (Total: {{metrics.gauges['jvm.threads.count'].value}}) <a class="hand" (click)="refreshThreadDumpData()" data-toggle="modal" data-target="#threadDump"><fa-icon [icon]="'eye'"></fa-icon></a>
             <p><span jhiTranslate="metrics.jvm.threads.runnable">Runnable</span> {{metrics.gauges['jvm.threads.runnable.count'].value}}</p>
             <ngb-progressbar [value]="metrics.gauges['jvm.threads.runnable.count'].value" [max]="metrics.gauges['jvm.threads.count'].value" [striped]="true" [animated]="false" type="success">
                 <span>{{metrics.gauges['jvm.threads.runnable.count'].value * 100 / metrics.gauges['jvm.threads.count'].value  | number:'1.0-0'}}%</span>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
@@ -28,10 +28,10 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
-            <span class="fas fa-ban"></span>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
+            <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
         <button type="submit" class="btn btn-danger">
-            <span class="fas fa-times"></span>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
+            <fa-icon [icon]="'times'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
         </button>
     </div>
 </form>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.html.ejs
@@ -67,7 +67,7 @@
             <button type="submit"
                     routerLink="../../"
                     class="btn btn-info">
-                <span class="fas fa-arrow-left"></span>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
+                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
             </button>
         </div>
     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
@@ -132,11 +132,11 @@
             </div>
             <div>
                 <button type="button" class="btn btn-secondary" (click)="previousState()">
-                    <span class="fas fa-ban"></span>&nbsp;<span
+                    <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span
                     jhiTranslate="entity.action.cancel">Cancel</span>
                 </button>
                 <button type="submit" [disabled]="editForm.form.invalid || isSaving" class="btn btn-primary">
-                    <span class="fas fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
+                    <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
                 </button>
             </div>
         </form>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
@@ -20,7 +20,7 @@
     <h2>
         <span jhiTranslate="userManagement.home.title">Users</span>
         <button class="btn btn-primary float-right jh-create-entity" [routerLink]="['./new']">
-            <span class="fas fa-plus"></span> <span jhiTranslate="userManagement.home.createLabel">Create a new User</span>
+            <fa-icon [icon]="'plus'"></fa-icon> <span jhiTranslate="userManagement.home.createLabel">Create a new User</span>
         </button>
     </h2>
     <<%= jhiPrefixDashed %>-alert></<%= jhiPrefixDashed %>-alert>
@@ -28,18 +28,18 @@
         <table class="table table-striped">
             <thead>
             <tr<% if (databaseType !== 'cassandra') { %> jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)"<% } %>>
-                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (databaseType !== 'cassandra') { %> <span class="fas fa-sort"></span><% } %></th>
-                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="login"<% } %>><span jhiTranslate="userManagement.login">Login</span><% if (databaseType !== 'cassandra') { %> <span class="fas fa-sort"></span><% } %></th>
-                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="email"<% } %>><span jhiTranslate="userManagement.email">Email</span><% if (databaseType !== 'cassandra') { %> <span class="fas fa-sort"></span><% } %></th>
+                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="login"<% } %>><span jhiTranslate="userManagement.login">Login</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="email"<% } %>><span jhiTranslate="userManagement.email">Email</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
                 <th></th>
                 <%_ if (enableTranslation) { _%>
-                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="langKey"<% } %>> <span jhiTranslate="userManagement.langKey">Lang Key</span><% if (databaseType !== 'cassandra') { %> <span class="fas fa-sort"></span><% } %></th>
+                <th<% if (databaseType !== 'cassandra') { %> jhiSortBy="langKey"<% } %>> <span jhiTranslate="userManagement.langKey">Lang Key</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
                 <%_ } _%>
                 <th><span jhiTranslate="userManagement.profiles">Profiles</span></th>
                 <%_ if (databaseType !== 'cassandra') { _%>
-                <th jhiSortBy="createdDate"><span jhiTranslate="userManagement.createdDate">Created Date</span> <span class="fas fa-sort"></span></th>
-                <th jhiSortBy="lastModifiedBy"><span jhiTranslate="userManagement.lastModifiedBy">Last Modified By</span> <span class="fas fa-sort"></span></th>
-                <th jhiSortBy="lastModifiedDate"><span jhiTranslate="userManagement.lastModifiedDate">Last Modified Date</span> <span class="fas fa-sort"></span></th>
+                <th jhiSortBy="createdDate"><span jhiTranslate="userManagement.createdDate">Created Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                <th jhiSortBy="lastModifiedBy"><span jhiTranslate="userManagement.lastModifiedBy">Last Modified By</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                <th jhiSortBy="lastModifiedDate"><span jhiTranslate="userManagement.lastModifiedDate">Last Modified Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
                 <%_ } _%>
                 <th></th>
             </tr>
@@ -71,19 +71,19 @@
                         <button type="submit"
                                 [routerLink]="['./', user.login, 'view']"
                                 class="btn btn-info btn-sm">
-                            <span class="fas fa-eye"></span>
+                            <fa-icon [icon]="'eye'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
                         </button>
                         <button type="submit"
                                 [routerLink]="['./', user.login, 'edit']"
                                 queryParamsHandling="merge"
                                 class="btn btn-primary btn-sm">
-                            <span class="fas fa-pencil-alt"></span>
+                            <fa-icon [icon]="'pencil-alt'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
                         </button>
                         <button type="button" (click)="deleteUser(user)"
                                 class="btn btn-danger btn-sm" [disabled]="currentAccount.login === user.login">
-                            <span class="fas fa-times"></span>
+                            <fa-icon [icon]="'times'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
                         </button>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
@@ -36,7 +36,7 @@
             </div>
             <%_ if (authenticationType !== 'oauth2') { _%>
             <div class="alert alert-warning" *ngSwitchCase="false">
-                <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>
+                <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>&nbsp;
                 <a class="alert-link" routerLink="register" jhiTranslate="global.messages.info.register.link">Register a new account</a>
             </div>
             <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -19,7 +19,7 @@
 <nav class="navbar navbar-dark navbar-expand-md jh-navbar">
     <div class="jh-logo-container float-left">
         <a class="jh-navbar-toggler d-lg-none float-right" href="javascript:void(0);" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation" (click)="toggleNavbar()">
-            <i class="fas fa-bars"></i>
+            <fa-icon [icon]="'bars'"></fa-icon>
         </a>
         <a class="navbar-brand logo float-left" routerLink="/" (click)="collapseNavbar()">
             <span class="logo-img"></span>
@@ -31,7 +31,7 @@
             <li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link" routerLink="/" (click)="collapseNavbar()">
                     <span>
-                        <i class="fas fa-home" aria-hidden="true"></i>
+                        <fa-icon [icon]="'home'"></fa-icon>
                         <span jhiTranslate="global.menu.home">Home</span>
                     </span>
                 </a>
@@ -40,7 +40,7 @@
             <li *ngSwitchCase="true" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="entity-menu">
                     <span>
-                        <i class="fas fa-th-list" aria-hidden="true"></i>
+                        <fa-icon [icon]="'th-list'"></fa-icon>
                         <span jhiTranslate="global.menu.entities.main">
                             Entities
                         </span>
@@ -53,7 +53,7 @@
             <li *<%=jhiPrefix%>HasAnyAuthority="'ROLE_ADMIN'" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="admin-menu">
                     <span>
-                        <i class="fas fa-user-plus" aria-hidden="true"></i>
+                        <fa-icon [icon]="'user-plus'"></fa-icon>
                         <span jhiTranslate="global.menu.admin.main">Administration</span>
                     </span>
                 </a>
@@ -61,7 +61,7 @@
                     <%_ if (applicationType === 'gateway') { _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/gateway" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-road" aria-hidden="true"></i>
+                            <fa-icon [icon]="'road'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.gateway">Gateway</span>
                         </a>
                     </li>
@@ -69,7 +69,7 @@
                     <%_ if (!skipUserManagement) { _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/user-management" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-user" aria-hidden="true"></i>
+                            <fa-icon [icon]="'user'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.userManagement">User management</span>
                         </a>
                     </li>
@@ -77,46 +77,46 @@
                     <%_ if (websocket === 'spring-websocket') { _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/<%= jhiPrefixDashed %>-tracker" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-eye" aria-hidden="true"></i>
+                            <fa-icon [icon]="'eye'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.tracker">User tracker</span>
                         </a>
                     </li>
                     <%_ } _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/<%= jhiPrefixDashed %>-metrics" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-tachometer-alt" aria-hidden="true"></i>
+                            <fa-icon [icon]="'tachometer-alt'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.metrics">Metrics</span>
                         </a>
                     </li>
                     <li>
                         <a class="dropdown-item" routerLink="admin/<%= jhiPrefixDashed %>-health" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-heart" aria-hidden="true"></i>
+                            <fa-icon [icon]="'heart'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.health">Health</span>
                         </a>
                     </li>
                     <li>
                         <a class="dropdown-item" routerLink="admin/<%= jhiPrefixDashed %>-configuration" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-list" aria-hidden="true"></i>
+                            <fa-icon [icon]="'list'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.configuration">Configuration</span>
                         </a>
                     </li>
                     <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/audits" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-bell" aria-hidden="true"></i>
+                            <fa-icon [icon]="'bell'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.audits">Audits</span>
                         </a>
                     </li>
                     <%_ } _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/logs" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-tasks" aria-hidden="true"></i>
+                            <fa-icon [icon]="'tasks'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.logs">Logs</span>
                         </a>
                     </li>
                     <li *ngIf="swaggerEnabled">
                         <a class="dropdown-item" routerLink="admin/docs" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-book" aria-hidden="true"></i>
+                            <fa-icon [icon]="'book'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.apidocs">API</span>
                         </a>
                     </li>
@@ -124,7 +124,7 @@
                     <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
                     <li *ngIf="!inProduction">
                         <a class="dropdown-item" href='./h2-console' target="_tab" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-hdd" aria-hidden="true"></i>
+                            <fa-icon [icon]="'hdd'"></fa-icon>
                             <span jhiTranslate="global.menu.admin.database">Database</span>
                         </a>
                     </li>
@@ -135,7 +135,7 @@
             <li ngbDropdown class="nav-item dropdown pointer" *ngIf="languages">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="languagesnavBarDropdown" *ngIf="languages.length > 1">
                     <span>
-                        <i class="fas fa-flag" aria-hidden="true"></i>
+                        <fa-icon [icon]="'flag'"></fa-icon>
                         <span jhiTranslate="global.menu.language">Language</span>
                     </span>
                 </a>
@@ -149,7 +149,7 @@
             <li ngbDropdown class="nav-item dropdown pointer" placement="bottom-right" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="account-menu">
                   <span *ngIf="!getImageUrl()">
-                    <i class="fas fa-user" aria-hidden="true"></i>
+                    <fa-icon [icon]="'user'"></fa-icon>
                     <span jhiTranslate="global.menu.account.main">
                       Account
                     </span>
@@ -162,13 +162,13 @@
                     <%_ if (authenticationType !== 'oauth2') { _%>
                     <li *ngSwitchCase="true">
                         <a class="dropdown-item" routerLink="settings" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-wrench" aria-hidden="true"></i>
+                            <fa-icon [icon]="'wrench'"></fa-icon>
                             <span jhiTranslate="global.menu.account.settings">Settings</span>
                         </a>
                     </li>
                     <li *ngSwitchCase="true">
                         <a class="dropdown-item" routerLink="password" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-clock" aria-hidden="true"></i>
+                            <fa-icon [icon]="'clock'"></fa-icon>
                             <span jhiTranslate="global.menu.account.password">Password</span>
                         </a>
                     </li>
@@ -176,27 +176,27 @@
                     <%_ if (authenticationType === 'session') { _%>
                     <li *ngSwitchCase="true">
                         <a class="dropdown-item" routerLink="sessions" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-cloud" aria-hidden="true"></i>
+                            <fa-icon [icon]="'cloud'"></fa-icon>
                             <span jhiTranslate="global.menu.account.sessions">Sessions</span>
                         </a>
                     </li>
                     <%_ } _%>
                     <li *ngSwitchCase="true">
                         <a class="dropdown-item" (click)="logout()" id="logout">
-                            <i class="fas fa-fw fa-sign-out-alt" aria-hidden="true"></i>
+                            <fa-icon [icon]="'sign-out-alt'"></fa-icon>
                             <span jhiTranslate="global.menu.account.logout">Sign out</span>
                         </a>
                     </li>
                     <li *ngSwitchCase="false">
                         <a class="dropdown-item" (click)="login()" id="login">
-                            <i class="fas fa-fw fa-sign-in-alt" aria-hidden="true"></i>
+                            <fa-icon [icon]="'sign-in-alt'"></fa-icon>
                             <span jhiTranslate="global.menu.account.login">Sign in</span>
                         </a>
                     </li>
                     <%_ if (authenticationType !== 'oauth2') { _%>
                     <li *ngSwitchCase="false">
                         <a class="dropdown-item" routerLink="register" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-fw fa-user-plus" aria-hidden="true"></i>
+                            <fa-icon [icon]="'user-plus'"></fa-icon>
                             <span jhiTranslate="global.menu.account.register">Register</span>
                         </a>
                     </li>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
@@ -23,6 +23,7 @@ import { NgbModule } from '@ng-bootstrap/ng-bootstrap';
 import { NgJhipsterModule } from 'ng-jhipster';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { CookieModule } from 'ngx-cookie';
+import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
 
 @NgModule({
     imports: [
@@ -36,14 +37,16 @@ import { CookieModule } from 'ngx-cookie';
             <%_ } _%>
         }),
         InfiniteScrollModule,
-        CookieModule.forRoot()
+        CookieModule.forRoot(),
+        FontAwesomeModule
     ],
     exports: [
         FormsModule,
         CommonModule,
         NgbModule,
         NgJhipsterModule,
-        InfiniteScrollModule
+        InfiniteScrollModule,
+        FontAwesomeModule
     ]
 })
 export class <%=angularXAppName%>SharedLibsModule {}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
@@ -28,10 +28,10 @@
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
-            <span class="fas fa-ban"></span>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
+            <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
         <button type="submit" class="btn btn-danger">
-            <span class="fas fa-times"></span>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
+            <fa-icon [icon]="'times'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
         </button>
     </div>
 </form>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
@@ -101,13 +101,13 @@
             <button type="submit"
                     (click)="previousState()"
                     class="btn btn-info">
-                <span class="fas fa-arrow-left"></span>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
+                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
             </button>
 
             <button type="button"
                     [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'edit']"
                     class="btn btn-primary">
-                <span class="fas fa-pencil-alt"></span>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
+                <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
             </button>
         </div>
     </div>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -78,7 +78,7 @@
                             <button type="button" (click)="<%= entityInstance %>.<%= fieldName %>=null;<%= entityInstance %>.<%= fieldName %>ContentType=null;"
                                     class="btn btn-secondary btn-xs pull-right">
                             <%_ } _%>
-                                <span class="fas fa-times"></span>
+                                <fa-icon [icon]="'times'"></fa-icon>
                             </button>
                         </div>
                         <input type="file" id="file_<%= fieldName %>" (change)="setFileData($event, <%= entityInstance %>, '<%= fieldName %>', <% if (fieldTypeBlobContent === 'image') { %>true)" accept="image/*" jhiTranslate="entity.action.addimage"<% } else { %>false)" jhiTranslate="entity.action.addblob"<% } %>/>
@@ -89,7 +89,7 @@
                         <input id="field_<%= fieldName %>" type="text" class="form-control" name="<%= fieldName %>" ngbDatepicker  #<%= fieldName %>Dp="ngbDatepicker" [(ngModel)]="<%= entityInstance %>.<%= fieldName %>"
                         <%- include ng_validators %>/>
                         <span class="input-group-append">
-                            <button type="button" class="btn btn-secondary" (click)="<%= fieldName %>Dp.toggle()"><i class="fas fa-calendar-alt"></i></button>
+                            <button type="button" class="btn btn-secondary" (click)="<%= fieldName %>Dp.toggle()"><fa-icon [icon]="'calendar-alt'"></fa-icon></button>
                         </span>
                     </div>
                     <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
@@ -258,10 +258,10 @@
             </div>
             <div>
                 <button type="button" id="cancel-save" class="btn btn-secondary"  (click)="previousState()">
-                    <span class="fas fa-ban"></span>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
+                    <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
                 </button>
                 <button type="submit" id="save-entity" [disabled]="editForm.form.invalid || isSaving" class="btn btn-primary">
-                    <span class="fas fa-save"></span>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
+                    <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
                 </button>
             </div>
         </form>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
@@ -20,7 +20,7 @@
     <h2 id="page-heading">
         <span jhiTranslate="<%= i18nKeyPrefix %>.home.title"><%= entityClassPluralHumanized %></span>
         <button id="jh-create-entity" class="btn btn-primary float-right jh-create-entity create-<%= entityUrl %>" [routerLink]="['/<%= entityUrl %>/new']">
-            <span class="fas fa-plus"></span>
+            <fa-icon [icon]="'plus'"></fa-icon>
             <span <% if (searchEngine === 'elasticsearch') { %>class="hidden-sm-down" <% } %> jhiTranslate="<%= i18nKeyPrefix %>.home.createLabel">
             Create new <%= entityClassHumanized %>
             </span>
@@ -34,10 +34,10 @@
                 <div class="input-group w-100 mt-3">
                     <input type="text" class="form-control" [(ngModel)]="currentSearch" id="currentSearch" name="currentSearch" placeholder="<% if (enableTranslation) { %>{{ '<%= i18nKeyPrefix %>.home.search' | translate }}<% } else { %>Query<% } %>">
                     <button class="input-group-append btn btn-info" (click)="search(currentSearch)">
-                        <span class="fas fa-search"></span>
+                        <fa-icon [icon]="'search'"></fa-icon>
                     </button>
                     <button class="input-group-append btn btn-danger" (click)="clear()" *ngIf="currentSearch">
-                        <span class="fas fa-trash-alt"></span>
+                        <fa-icon [icon]="'trash-alt'"></fa-icon>
                     </button>
                 </div>
             </form>
@@ -49,16 +49,16 @@
         <table class="table table-striped">
             <thead>
             <tr<% if (pagination !== 'no') { %> jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="<%=pagination !== 'infinite-scroll' ? 'transition.bind(this)' : 'reset.bind(this)'%>"<% } %>>
-            <th<% if (pagination !== 'no') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (pagination !== 'no') { %> <span class="fas fa-sort"></span><% } %></th>
+            <th<% if (pagination !== 'no') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
             <%_ for (idx in fields) { _%>
-            <th<% if (pagination !== 'no') { %> jhiSortBy="<%= fields[idx].fieldName%>"<% } %>><span jhiTranslate="<%=`${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <span class="fas fa-sort"></span><% } %></th>
+            <th<% if (pagination !== 'no') { %> jhiSortBy="<%= fields[idx].fieldName%>"<% } %>><span jhiTranslate="<%=`${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
             <%_ } _%>
             <%_ for (idx in relationships) { _%>
             <%_ if (relationships[idx].relationshipType === 'many-to-one'
             || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
             || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
             const fieldName = dto === 'no' ? "." + relationships[idx].otherEntityField : relationships[idx].otherEntityFieldCapitalized;_%>
-            <th<% if (pagination !== 'no') { %> jhiSortBy="<%=relationships[idx].relationshipName + (fieldName)%>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <span class="fas fa-sort"></span><% } %></th>
+            <th<% if (pagination !== 'no') { %> jhiSortBy="<%=relationships[idx].relationshipName + (fieldName)%>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
             <%_ } _%>
             <%_ } _%>
             <th></th>
@@ -144,13 +144,13 @@
                         <button type="submit"
                                 [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view' ]"
                                 class="btn btn-info btn-sm">
-                            <span class="fas fa-eye"></span>
+                            <fa-icon [icon]="'eye'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
                         </button>
                         <button type="submit"
                                 [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'edit']"
                                 class="btn btn-primary btn-sm">
-                            <span class="fas fa-pencil-alt"></span>
+                            <fa-icon [icon]="'pencil-alt'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
                         </button>
                         <button type="submit"
@@ -158,7 +158,7 @@
                                 replaceUrl="true"
                                 queryParamsHandling="merge"
                                 class="btn btn-danger btn-sm">
-                            <span class="fas fa-times"></span>
+                            <fa-icon [icon]="'times'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
                         </button>
                     </div>

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -515,7 +515,7 @@ module.exports = class extends BaseGenerator {
                         'String', 'Integer', 'Long', 'Float', 'Double', 'BigDecimal',
                         'LocalDate', 'Instant', 'ZonedDateTime', 'Boolean', 'byte[]', 'ByteBuffer'
                     ].includes(fieldType);
-                    if ((['sql', 'mongodb', 'couchbase'].includes(context.databaseType)) && !nonEnumType) {
+                    if ((['sql', 'mongodb', 'couchbase', 'no'].includes(context.databaseType)) && !nonEnumType) {
                         field.fieldIsEnum = true;
                     } else {
                         field.fieldIsEnum = false;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -83,7 +83,7 @@ module.exports = class extends PrivateBase {
                     needle: 'jhipster-needle-add-element-to-menu',
                     splicable: [`<li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                                 <a class="nav-link" routerLink="${routerName}" (click)="collapseNavbar()">
-                                    <i class="fas fa-${glyphiconName}"></i>&nbsp;
+                                    <fa-icon [icon]="'${glyphiconName}'"></fa-icon>&nbsp;
                                     <span${enableTranslation ? ` jhiTranslate="global.menu.${routerName}"` : ''}>${_.startCase(routerName)}</span>
                                 </a>
                             </li>`
@@ -143,7 +143,7 @@ module.exports = class extends PrivateBase {
                     needle: 'jhipster-needle-add-element-to-admin-menu',
                     splicable: [`<li>
                         <a class="dropdown-item" routerLink="${routerName}" routerLinkActive="active" (click)="collapseNavbar()">
-                            <i class="fas fa-${glyphiconName}" aria-hidden="true"></i>&nbsp;
+                            <fa-icon [icon]="'${glyphiconName}'"></fa-icon>&nbsp;
                             <span${enableTranslation ? ` jhiTranslate="global.menu.admin.${routerName}"` : ''}>${_.startCase(routerName)}</span>
                         </a>
                     </li>`
@@ -189,7 +189,7 @@ module.exports = class extends PrivateBase {
                     splicable: [
                         this.stripMargin(`|<li>
                              |                        <a class="dropdown-item" routerLink="${routerName}" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="collapseNavbar()">
-                             |                            <i class="fas fa-fw fa-asterisk" aria-hidden="true"></i>
+                             |                            <fa-icon [icon]="['fw', 'asterisk']"></fa-icon>
                              |                            <span${enableTranslation ? ` jhiTranslate="global.menu.entities.${entityTranslationKeyMenu}"` : ''}>${_.startCase(routerName)}</span>
                              |                        </a>
                              |                    </li>`)

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -29,6 +29,7 @@ const DOCKER_CASSANDRA = 'cassandra:3.9';
 const DOCKER_MSSQL = 'microsoft/mssql-server-linux:latest';
 const DOCKER_ORACLE = 'sath89/oracle-12c:latest';
 const DOCKER_HAZELCAST_MANAGEMENT_CENTER = 'hazelcast/management-center:3.9.1';
+const DOCKER_MEMCACHED = 'memcached:1.5.7-alpine';
 const DOCKER_KEYCLOAK = 'jboss/keycloak:3.3.0.Final';
 const DOCKER_ELASTICSEARCH = 'elasticsearch:5.6.5'; // docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1
 const DOCKER_KAFKA = 'wurstmeister/kafka:1.0.0';
@@ -192,6 +193,7 @@ const constants = {
     DOCKER_MSSQL,
     DOCKER_ORACLE,
     DOCKER_HAZELCAST_MANAGEMENT_CENTER,
+    DOCKER_MEMCACHED,
     DOCKER_ELASTICSEARCH,
     DOCKER_KEYCLOAK,
     DOCKER_KAFKA,

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -92,6 +92,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_ORACLE = constants.DOCKER_ORACLE;
                 this.DOCKER_MONGODB = constants.DOCKER_MONGODB;
                 this.DOCKER_COUCHBASE = constants.DOCKER_COUCHBASE;
+                this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KAFKA = constants.DOCKER_KAFKA;
                 this.DOCKER_ZOOKEEPER = constants.DOCKER_ZOOKEEPER;

--- a/generators/openshift/index.js
+++ b/generators/openshift/index.js
@@ -88,6 +88,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_ORACLE = constants.DOCKER_ORACLE;
                 this.DOCKER_MONGODB = constants.DOCKER_MONGODB;
                 this.DOCKER_COUCHBASE = constants.DOCKER_COUCHBASE;
+                this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KAFKA = constants.DOCKER_KAFKA;
                 this.DOCKER_ZOOKEEPER = constants.DOCKER_ZOOKEEPER;

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -122,6 +122,13 @@ const serverFiles = {
             ]
         },
         {
+            condition: generator => generator.cacheProvider === 'memcached',
+            path: DOCKER_DIR,
+            templates: [
+                'memcached.yml'
+            ]
+        },
+        {
             condition: generator => generator.searchEngine === 'elasticsearch',
             path: DOCKER_DIR,
             templates: [
@@ -656,7 +663,7 @@ const serverFiles = {
             ]
         },
         {
-            condition: generator => ['ehcache', 'hazelcast', 'infinispan'].includes(generator.cacheProvider) || generator.applicationType === 'gateway',
+            condition: generator => ['ehcache', 'hazelcast', 'infinispan', 'memcached'].includes(generator.cacheProvider) || generator.applicationType === 'gateway',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 { file: 'package/config/CacheConfiguration.java', renameTo: generator => `${generator.javaDir}config/CacheConfiguration.java` }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -121,6 +121,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_MSSQL = constants.DOCKER_MSSQL;
                 this.DOCKER_ORACLE = constants.DOCKER_ORACLE;
                 this.DOCKER_HAZELCAST_MANAGEMENT_CENTER = constants.DOCKER_HAZELCAST_MANAGEMENT_CENTER;
+                this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_CASSANDRA = constants.DOCKER_CASSANDRA;
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KEYCLOAK = constants.DOCKER_KEYCLOAK;
@@ -172,7 +173,7 @@ module.exports = class extends BaseGenerator {
                 }
 
                 this.cacheProvider = this.config.get('cacheProvider') || this.config.get('hibernateCache') || 'no';
-                this.enableHibernateCache = this.config.get('enableHibernateCache') || (this.config.get('hibernateCache') !== undefined && this.config.get('hibernateCache') !== 'no');
+                this.enableHibernateCache = this.config.get('enableHibernateCache') || (this.config.get('hibernateCache') !== undefined && this.config.get('hibernateCache') !== 'no' && this.config.get('hibernateCache') !== 'memcached');
 
                 this.databaseType = this.config.get('databaseType');
                 if (this.databaseType === 'mongodb') {
@@ -346,7 +347,7 @@ module.exports = class extends BaseGenerator {
                 this.lowercaseBaseName = this.baseName.toLowerCase();
                 this.humanizedBaseName = _.startCase(this.baseName);
                 this.mainClass = this.getMainClassName();
-                this.cacheManagerIsAvailable = ['ehcache', 'hazelcast', 'infinispan'].includes(this.cacheProvider) || this.applicationType === 'gateway';
+                this.cacheManagerIsAvailable = ['ehcache', 'hazelcast', 'infinispan', 'memcached'].includes(this.cacheProvider) || this.applicationType === 'gateway';
 
                 this.pkType = this.getPkType(this.databaseType);
 

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -230,14 +230,18 @@ function askForServerSideOpts(meta) {
                     name: '[BETA] Yes, with the Infinispan implementation (hybrid cache, for multiple nodes)'
                 },
                 {
+                    value: 'memcached',
+                    name: 'Yes, with Memcached (distributed cache) - Warning, when using an SQL database, this will disable the Hibernate 2nd level cache!'
+                },
+                {
                     value: 'no',
-                    name: 'No (when using an SQL database, this will also disable the Hibernate L2 cache)'
+                    name: 'No - Warning, when using an SQL database, this will disable the Hibernate 2nd level cache!'
                 }
             ],
             default: (applicationType === 'microservice' || applicationType === 'uaa') ? 1 : 0
         },
         {
-            when: response => ((response.cacheProvider !== 'no' || applicationType === 'gateway') && response.databaseType === 'sql'),
+            when: response => (((response.cacheProvider !== 'no' && response.cacheProvider !== 'memcached') || applicationType === 'gateway') && response.databaseType === 'sql'),
             type: 'confirm',
             name: 'enableHibernateCache',
             message: 'Do you want to use Hibernate 2nd level cache?',

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -251,6 +251,9 @@ dependencies {
         exclude module: 'undertow-core'
     }
     <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    compile "io.sixhours:infinispan-jcache:memcached-spring-boot-starter:1.2.0"
+    <%_ } _%>
     <%_ if (['ehcache', 'hazelcast', 'infinispan'].includes(cacheProvider) || applicationType === 'gateway') { _%>
     compile "javax.cache:cache-api"
     <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -138,11 +138,10 @@
         <!-- Rule https://sonarcloud.io/coding_rules?open=squid%3AUndocumentedApi&rule_key=squid%3AUndocumentedApi is ignored, as we want to follow "clean code" guidelines and classes, methods and arguments names should be self-explanatory -->
         <sonar.issue.ignore.multicriteria.UndocumentedApi.resourceKey><%= MAIN_DIR %>java/**/*</sonar.issue.ignore.multicriteria.UndocumentedApi.resourceKey>
         <sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey>squid:UndocumentedApi</sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey>
-        <sonar.jacoco.itReportPath>${project.testresult.directory}/coverage/jacoco/jacoco-it.exec</sonar.jacoco.itReportPath>
-        <sonar.jacoco.reportPath>${project.testresult.directory}/coverage/jacoco/jacoco.exec</sonar.jacoco.reportPath>
+        <sonar.jacoco.reportPaths>${project.testresult.directory}/coverage/jacoco/jacoco.exec</sonar.jacoco.reportPaths>
         <sonar.java.codeCoveragePlugin>jacoco</sonar.java.codeCoveragePlugin>
         <sonar.javascript.jstestdriver.reportsPath>${project.testresult.directory}/karma</sonar.javascript.jstestdriver.reportsPath>
-        <sonar.typescript.lcov.reportPaths>${project.testresult.directory}/coverage/report-lcov/lcov.info</sonar.typescript.lcov.reportPaths>
+        <sonar.typescript.lcov.reportPaths>${project.testresult.directory}/lcov.info</sonar.typescript.lcov.reportPaths>
         <sonar.sources>${project.basedir}/<%= MAIN_DIR %></sonar.sources>
         <sonar.surefire.reportsPath>${project.testresult.directory}/surefire-reports</sonar.surefire.reportsPath>
         <sonar.tests>${project.basedir}/<%= TEST_DIR %></sonar.tests>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -281,6 +281,13 @@
         </dependency>
 -->
         <%_ } _%>
+        <%_ if (cacheProvider === 'memcached') { _%>
+        <dependency>
+            <groupId>io.sixhours</groupId>
+            <artifactId>memcached-spring-boot-starter</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <%_ } _%>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -54,6 +54,9 @@ services:
             - SPRING_COUCHBASE_BOOTSTRAP_HOSTS=<%= baseName.toLowerCase() %>-couchbase
             - SPRING_COUCHBASE_BUCKET_NAME=<%= baseName %>
             <%_ } _%>
+            <%_ if (cacheProvider === 'memcached') { _%>
+            - MEMCACHED_CACHE_SERVERS=<%= baseName.toLowerCase() %>-memcached:11211
+            <%_ } _%>
             <%_ if (authenticationType === 'oauth2') { _%>
             # For keycloak to work, you need to add '127.0.0.1 keycloak' to your hosts file
             - SECURITY_OAUTH2_CLIENT_ACCESS_TOKEN_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/token
@@ -145,6 +148,12 @@ services:
             service: <%= baseName.toLowerCase() %>-cassandra-migration
         environment:
             - CREATE_KEYSPACE_SCRIPT=create-keyspace-prod.cql
+    <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    <%= baseName.toLowerCase() %>-memcached:
+        extends:
+            file: memcached.yml
+            service: <%= baseName.toLowerCase() %>-memcached
     <%_ } _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
     <%= baseName.toLowerCase() %>-elasticsearch:

--- a/generators/server/templates/src/main/docker/memcached.yml.ejs
+++ b/generators/server/templates/src/main/docker/memcached.yml.ejs
@@ -1,0 +1,24 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+version: '2'
+services:
+    <%= baseName.toLowerCase() %>-memcached:
+        image: <%= DOCKER_MEMCACHED %>
+        ports:
+            - "11211:11211"

--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -17,8 +17,8 @@
  limitations under the License.
 -%>
 package <%=packageName%>.config;
-<%_ if (cacheProvider === 'ehcache') { _%>
 
+<%_ if (cacheProvider === 'ehcache') { _%>
 import java.time.Duration;
 
 import org.ehcache.config.builders.*;
@@ -28,7 +28,6 @@ import io.github.jhipster.config.JHipsterProperties;
 
 <%_ } _%>
 <%_ if (cacheProvider === 'hazelcast') { _%>
-
 import io.github.jhipster.config.JHipsterConstants;
 import io.github.jhipster.config.JHipsterProperties;
 
@@ -52,11 +51,19 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
 
 import org.springframework.cache.CacheManager;
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.CacheManager;
+<%_ } _%>
 import org.springframework.cache.annotation.EnableCaching;
 <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.serviceregistry.Registration;
+<%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+import org.springframework.cache.support.NoOpCacheManager;
 <%_ } _%>
 import org.springframework.context.annotation.*;
 <%_ if (cacheProvider === 'hazelcast') { _%>
@@ -101,6 +108,10 @@ import org.springframework.beans.factory.BeanInitializationException;
 import java.util.ArrayList;
 import java.util.List;
     <%_ } _%>
+<%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+
+import io.github.jhipster.config.JHipsterConstants;
 <%_ } _%>
 
 @Configuration
@@ -591,5 +602,17 @@ public class CacheConfiguration {
         return channel;
     }
         <%_ } _%>
+    <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+
+    private final Logger log = LoggerFactory.getLogger(CacheConfiguration.class);
+
+    @Bean
+    @Profile(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)
+    public CacheManager cacheManager() {
+        // Note that Memcached cannot work with Spring Boot devtools
+        log.debug("Memcached is disabled as the application is in development mode");
+        return new NoOpCacheManager();
+    }
     <%_ } _%>
 }

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -48,6 +48,15 @@ eureka:
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@localhost:8761/eureka/
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+
+memcached:
+    cache:
+        servers: localhost:11211
+        mode: static
+        expiration: 86400
+        protocol: binary
+<%_ } _%>
 
 spring:
     profiles:

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -48,6 +48,15 @@ eureka:
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@localhost:8761/eureka/
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+
+memcached:
+    cache:
+        servers: localhost:11211
+        mode: static
+        expiration: 86400
+        protocol: binary
+<%_ } _%>
 
 spring:
     profiles:
@@ -267,7 +276,7 @@ jhipster:
     <%_ } _%>
     http:
         version: V_1_1 # To use HTTP/2 you will need SSL support (see above the "server.ssl" configuration)
-    <%_ if (cacheProvider !== 'no') { _%>
+    <%_ if (cacheProvider !== 'no' && cacheProvider !== 'memcached') { _%>
     cache: # Cache configuration
         <%_ if (cacheProvider === 'hazelcast') { _%>
         hazelcast: # Hazelcast distributed cache

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -48,15 +48,6 @@ eureka:
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@localhost:8761/eureka/
 <%_ } _%>
-<%_ if (cacheProvider === 'memcached') { _%>
-
-memcached:
-    cache:
-        servers: localhost:11211
-        mode: static
-        expiration: 86400
-        protocol: binary
-<%_ } _%>
 
 spring:
     profiles:

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -45,6 +45,15 @@ eureka:
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@localhost:8761/eureka/
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+
+memcached:
+    cache:
+        servers: localhost:11211
+        mode: static
+        expiration: 86400
+        protocol: binary
+<%_ } _%>
 
 spring:
     devtools:
@@ -246,7 +255,7 @@ jhipster:
         version: V_1_1 # To use HTTP/2 you will need SSL support (see above the "server.ssl" configuration)
         cache: # Used by the CachingHttpHeadersFilter
             timeToLiveInDays: 1461
-    <%_ if (cacheProvider !== 'no') { _%>
+    <%_ if (cacheProvider !== 'no' && cacheProvider !== 'memcached') { _%>
     cache: # Cache configuration
         <%_ if (cacheProvider === 'hazelcast') { _%>
         hazelcast: # Hazelcast distributed cache

--- a/generators/server/templates/src/main/resources/logback-spring.xml.ejs
+++ b/generators/server/templates/src/main/resources/logback-spring.xml.ejs
@@ -92,6 +92,9 @@
     <%_ if (cacheProvider === 'infinispan') { _%>
     <logger name="org.infinispan" level="WARN"/>
     <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    <logger name="net.spy.memcached" level="WARN"/>
+    <%_ } _%>
     <logger name="org.springframework" level="WARN"/>
     <logger name="org.springframework.web" level="WARN"/>
     <logger name="org.springframework.security" level="WARN"/>

--- a/generators/server/templates/src/test/resources/logback.xml.ejs
+++ b/generators/server/templates/src/test/resources/logback.xml.ejs
@@ -72,6 +72,9 @@
     <%_ if (cacheProvider === 'infinispan') { _%>
     <logger name="org.infinispan" level="WARN"/>
     <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    <logger name="net.spy.memcached" level="WARN"/>
+    <%_ } _%>
     <logger name="org.springframework" level="WARN"/>
     <logger name="org.springframework.web" level="WARN"/>
     <logger name="org.springframework.security" level="WARN"/>

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -676,6 +676,39 @@ describe('JHipster generator', () => {
             });
         });
 
+        describe('Memcached', () => {
+            beforeEach((done) => {
+                helpers.run(path.join(__dirname, '../generators/app'))
+                    .withOptions({ skipInstall: true, skipChecks: true })
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        clientFramework: 'angularX',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'memcached',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        useSass: false,
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files with "Infinispan"', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.client);
+                assert.file(expectedFiles.memcached);
+            });
+        });
+
         describe('Messaging with Kafka configuration', () => {
             beforeEach((done) => {
                 helpers.run(path.join(__dirname, '../generators/app'))

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -133,6 +133,11 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheFactoryConfiguration.java`
     ],
 
+    memcached: [
+        `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+        `${DOCKER_DIR}memcached.yml`
+    ],
+
     gatling: [
         `${TEST_DIR}gatling/conf/gatling.conf`
     ],


### PR DESCRIPTION
Memcached can be used as a Spring Cache implementation, but not as an Hibernate L2 cache.
This is great for people running in cloud environments like AWS, GCP, Heroku, as those platforms provide cheap Memcached support, allowing the applications to scale easily without hitting the database too hard.

Ping @jkutner we'll need to add support for the MemCachier add-on with Heroku!