### PR TITLE
Allow multiple required relationships to entity with unique field

### DIFF
--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -370,23 +370,28 @@ _%>
                 <%_ } _%>
             <%_ } _%>
         <%_ } _%>
-        <%_ for (idx in relationships) {
+        <%_
+        const alreadyGeneratedEntities = []
+        for (idx in relationships) {
             const relationshipValidate = relationships[idx].relationshipValidate;
+            const otherEntityName = relationships[idx].otherEntityName;
             const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-            const relationshipFieldName = relationships[idx].relationshipFieldName;
             const relationshipType = relationships[idx].relationshipType;
             const relationshipNameCapitalizedPlural = relationships[idx].relationshipNameCapitalizedPlural;
             const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
             if (relationshipValidate !== null && relationshipValidate === true) { _%>
         // Add required entity
-        <%= otherEntityNameCapitalized %> <%= relationshipFieldName %> = <%= otherEntityNameCapitalized %>ResourceIntTest.createEntity(em);
-        em.persist(<%= relationshipFieldName %>);
+            <%_ if (alreadyGeneratedEntities.indexOf(otherEntityName) == -1) { _%>
+        <%= otherEntityNameCapitalized %> <%= otherEntityName %> = <%= otherEntityNameCapitalized %>ResourceIntTest.createEntity(em);
+        em.persist(<%= otherEntityName %>);
         em.flush();
-            <%_ if (relationshipType === 'many-to-many' || relationshipType === 'one-to-many') { _%>
-        <%= entityInstance %>.get<%= relationshipNameCapitalizedPlural %>().add(<%= relationshipFieldName %>);
-            <%_ } else { _%>
-        <%= entityInstance %>.set<%= relationshipNameCapitalized %>(<%= relationshipFieldName %>);
             <%_ } _%>
+            <%_ if (relationshipType === 'many-to-many' || relationshipType === 'one-to-many') { _%>
+        <%= entityInstance %>.get<%= relationshipNameCapitalizedPlural %>().add(<%= otherEntityName %>);
+            <%_ } else { _%>
+        <%= entityInstance %>.set<%= relationshipNameCapitalized %>(<%= otherEntityName %>);
+            <%_ } _%>
+        <%_ alreadyGeneratedEntities.push(otherEntityName) _%>
         <%_ } } _%>
         return <%= entityInstance %>;
     }

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -720,10 +720,10 @@ module.exports = class extends BaseGenerator {
                         if (relationship.otherEntityNameCapitalized !== 'User') {
                             relationship.otherEntityModuleName = `${context.angularXAppName + relationship.otherEntityNameCapitalized}Module`;
                             relationship.otherEntityFileName = _.kebabCase(relationship.otherEntityAngularName);
-                            if (context.skipUiGrouping || otherEntityData === undefined) {
+                            if (context.skipUiGrouping || otherEntityData === undefined || otherEntityData.clientRootFolder === undefined) {
                                 relationship.otherEntityClientRootFolder = '';
                             } else {
-                                relationship.otherEntityClientRootFolder = otherEntityData.clientRootFolder;
+                                relationship.otherEntityClientRootFolder = `${otherEntityData.clientRootFolder}/`;
                             }
                             if (otherEntityData !== undefined && otherEntityData.clientRootFolder) {
                                 if (context.clientRootFolder === otherEntityData.clientRootFolder) {

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -985,7 +985,7 @@ module.exports = class extends Generator {
                 if (otherEntityAngularName === 'User') {
                     importPath = clientFramework === 'angularX' ? 'app/core/user/user.model' : './user.model';
                 } else {
-                    importPath = `./${relationship.otherEntityFileName}.model`;
+                    importPath = clientFramework === 'angularX' ? `app/shared/model/${relationship.otherEntityClientRootFolder}${relationship.otherEntityFileName}.model` : `./${relationship.otherEntityFileName}.model`;
                 }
                 typeImports.set(importType, importPath);
             }

--- a/travis/samples/.jhipster/TestTwoRelationshipsSameEntity.json
+++ b/travis/samples/.jhipster/TestTwoRelationshipsSameEntity.json
@@ -24,6 +24,20 @@
             "otherEntityName": "user",
             "relationshipType": "one-to-one",
             "ownerSide": true
+        },
+        {
+            "relationshipType": "many-to-one",
+            "relationshipName": "firstUniqueRequiredRelation",
+            "relationshipValidateRules": "required",
+            "otherEntityName": "division",
+            "otherEntityField": "id"
+        },
+        {
+            "relationshipType": "many-to-one",
+            "relationshipName": "secondUniqueRequiredRelation",
+            "relationshipValidateRules": "required",
+            "otherEntityName": "division",
+            "otherEntityField": "id"
         }
     ],
     "fields": [],


### PR DESCRIPTION
Fix #6860

This creates only one instance of each related entity, preventing issues with multiple required relationships to an entity with a unique field.

Added tests which led me to fix a bug with relationships between entities with different client-root-folders

 Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
