### PR TITLE
Add Memcached support

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
@@ -36,7 +36,7 @@
             </div>
             <%_ if (authenticationType !== 'oauth2') { _%>
             <div class="alert alert-warning" *ngSwitchCase="false">
-                <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>
+                <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>&nbsp;
                 <a class="alert-link" routerLink="register" jhiTranslate="global.messages.info.register.link">Register a new account</a>
             </div>
             <%_ } _%>

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -29,6 +29,7 @@ const DOCKER_CASSANDRA = 'cassandra:3.9';
 const DOCKER_MSSQL = 'microsoft/mssql-server-linux:latest';
 const DOCKER_ORACLE = 'sath89/oracle-12c:latest';
 const DOCKER_HAZELCAST_MANAGEMENT_CENTER = 'hazelcast/management-center:3.9.1';
+const DOCKER_MEMCACHED = 'memcached:1.5.7-alpine';
 const DOCKER_KEYCLOAK = 'jboss/keycloak:3.3.0.Final';
 const DOCKER_ELASTICSEARCH = 'elasticsearch:5.6.5'; // docker.elastic.co/elasticsearch/elasticsearch-oss:6.1.1
 const DOCKER_KAFKA = 'wurstmeister/kafka:1.0.0';
@@ -192,6 +193,7 @@ const constants = {
     DOCKER_MSSQL,
     DOCKER_ORACLE,
     DOCKER_HAZELCAST_MANAGEMENT_CENTER,
+    DOCKER_MEMCACHED,
     DOCKER_ELASTICSEARCH,
     DOCKER_KEYCLOAK,
     DOCKER_KAFKA,

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -92,6 +92,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_ORACLE = constants.DOCKER_ORACLE;
                 this.DOCKER_MONGODB = constants.DOCKER_MONGODB;
                 this.DOCKER_COUCHBASE = constants.DOCKER_COUCHBASE;
+                this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KAFKA = constants.DOCKER_KAFKA;
                 this.DOCKER_ZOOKEEPER = constants.DOCKER_ZOOKEEPER;

--- a/generators/openshift/index.js
+++ b/generators/openshift/index.js
@@ -88,6 +88,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_ORACLE = constants.DOCKER_ORACLE;
                 this.DOCKER_MONGODB = constants.DOCKER_MONGODB;
                 this.DOCKER_COUCHBASE = constants.DOCKER_COUCHBASE;
+                this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KAFKA = constants.DOCKER_KAFKA;
                 this.DOCKER_ZOOKEEPER = constants.DOCKER_ZOOKEEPER;

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -122,6 +122,13 @@ const serverFiles = {
             ]
         },
         {
+            condition: generator => generator.cacheProvider === 'memcached',
+            path: DOCKER_DIR,
+            templates: [
+                'memcached.yml'
+            ]
+        },
+        {
             condition: generator => generator.searchEngine === 'elasticsearch',
             path: DOCKER_DIR,
             templates: [
@@ -656,7 +663,7 @@ const serverFiles = {
             ]
         },
         {
-            condition: generator => ['ehcache', 'hazelcast', 'infinispan'].includes(generator.cacheProvider) || generator.applicationType === 'gateway',
+            condition: generator => ['ehcache', 'hazelcast', 'infinispan', 'memcached'].includes(generator.cacheProvider) || generator.applicationType === 'gateway',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 { file: 'package/config/CacheConfiguration.java', renameTo: generator => `${generator.javaDir}config/CacheConfiguration.java` }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -121,6 +121,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_MSSQL = constants.DOCKER_MSSQL;
                 this.DOCKER_ORACLE = constants.DOCKER_ORACLE;
                 this.DOCKER_HAZELCAST_MANAGEMENT_CENTER = constants.DOCKER_HAZELCAST_MANAGEMENT_CENTER;
+                this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_CASSANDRA = constants.DOCKER_CASSANDRA;
                 this.DOCKER_ELASTICSEARCH = constants.DOCKER_ELASTICSEARCH;
                 this.DOCKER_KEYCLOAK = constants.DOCKER_KEYCLOAK;
@@ -172,7 +173,7 @@ module.exports = class extends BaseGenerator {
                 }
 
                 this.cacheProvider = this.config.get('cacheProvider') || this.config.get('hibernateCache') || 'no';
-                this.enableHibernateCache = this.config.get('enableHibernateCache') || (this.config.get('hibernateCache') !== undefined && this.config.get('hibernateCache') !== 'no');
+                this.enableHibernateCache = this.config.get('enableHibernateCache') || (this.config.get('hibernateCache') !== undefined && this.config.get('hibernateCache') !== 'no' && this.config.get('hibernateCache') !== 'memcached');
 
                 this.databaseType = this.config.get('databaseType');
                 if (this.databaseType === 'mongodb') {
@@ -346,7 +347,7 @@ module.exports = class extends BaseGenerator {
                 this.lowercaseBaseName = this.baseName.toLowerCase();
                 this.humanizedBaseName = _.startCase(this.baseName);
                 this.mainClass = this.getMainClassName();
-                this.cacheManagerIsAvailable = ['ehcache', 'hazelcast', 'infinispan'].includes(this.cacheProvider) || this.applicationType === 'gateway';
+                this.cacheManagerIsAvailable = ['ehcache', 'hazelcast', 'infinispan', 'memcached'].includes(this.cacheProvider) || this.applicationType === 'gateway';
 
                 this.pkType = this.getPkType(this.databaseType);
 

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -230,14 +230,18 @@ function askForServerSideOpts(meta) {
                     name: '[BETA] Yes, with the Infinispan implementation (hybrid cache, for multiple nodes)'
                 },
                 {
+                    value: 'memcached',
+                    name: 'Yes, with Memcached (distributed cache) - Warning, when using an SQL database, this will disable the Hibernate 2nd level cache!'
+                },
+                {
                     value: 'no',
-                    name: 'No (when using an SQL database, this will also disable the Hibernate L2 cache)'
+                    name: 'No - Warning, when using an SQL database, this will disable the Hibernate 2nd level cache!'
                 }
             ],
             default: (applicationType === 'microservice' || applicationType === 'uaa') ? 1 : 0
         },
         {
-            when: response => ((response.cacheProvider !== 'no' || applicationType === 'gateway') && response.databaseType === 'sql'),
+            when: response => (((response.cacheProvider !== 'no' && response.cacheProvider !== 'memcached') || applicationType === 'gateway') && response.databaseType === 'sql'),
             type: 'confirm',
             name: 'enableHibernateCache',
             message: 'Do you want to use Hibernate 2nd level cache?',

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -251,6 +251,9 @@ dependencies {
         exclude module: 'undertow-core'
     }
     <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    compile "io.sixhours:infinispan-jcache:memcached-spring-boot-starter:1.2.0"
+    <%_ } _%>
     <%_ if (['ehcache', 'hazelcast', 'infinispan'].includes(cacheProvider) || applicationType === 'gateway') { _%>
     compile "javax.cache:cache-api"
     <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -281,6 +281,13 @@
         </dependency>
 -->
         <%_ } _%>
+        <%_ if (cacheProvider === 'memcached') { _%>
+        <dependency>
+            <groupId>io.sixhours</groupId>
+            <artifactId>memcached-spring-boot-starter</artifactId>
+            <version>1.2.0</version>
+        </dependency>
+        <%_ } _%>
         <dependency>
             <groupId>com.jayway.jsonpath</groupId>
             <artifactId>json-path</artifactId>

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -54,6 +54,9 @@ services:
             - SPRING_COUCHBASE_BOOTSTRAP_HOSTS=<%= baseName.toLowerCase() %>-couchbase
             - SPRING_COUCHBASE_BUCKET_NAME=<%= baseName %>
             <%_ } _%>
+            <%_ if (cacheProvider === 'memcached') { _%>
+            - MEMCACHED_CACHE_SERVERS=<%= baseName.toLowerCase() %>-memcached:11211
+            <%_ } _%>
             <%_ if (authenticationType === 'oauth2') { _%>
             # For keycloak to work, you need to add '127.0.0.1 keycloak' to your hosts file
             - SECURITY_OAUTH2_CLIENT_ACCESS_TOKEN_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/token
@@ -145,6 +148,12 @@ services:
             service: <%= baseName.toLowerCase() %>-cassandra-migration
         environment:
             - CREATE_KEYSPACE_SCRIPT=create-keyspace-prod.cql
+    <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    <%= baseName.toLowerCase() %>-memcached:
+        extends:
+            file: memcached.yml
+            service: <%= baseName.toLowerCase() %>-memcached
     <%_ } _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
     <%= baseName.toLowerCase() %>-elasticsearch:

--- a/generators/server/templates/src/main/docker/memcached.yml.ejs
+++ b/generators/server/templates/src/main/docker/memcached.yml.ejs
@@ -1,0 +1,24 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+version: '2'
+services:
+    <%= baseName.toLowerCase() %>-memcached:
+        image: <%= DOCKER_MEMCACHED %>
+        ports:
+            - "11211:11211"

--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -17,8 +17,8 @@
  limitations under the License.
 -%>
 package <%=packageName%>.config;
-<%_ if (cacheProvider === 'ehcache') { _%>
 
+<%_ if (cacheProvider === 'ehcache') { _%>
 import java.time.Duration;
 
 import org.ehcache.config.builders.*;
@@ -28,7 +28,6 @@ import io.github.jhipster.config.JHipsterProperties;
 
 <%_ } _%>
 <%_ if (cacheProvider === 'hazelcast') { _%>
-
 import io.github.jhipster.config.JHipsterConstants;
 import io.github.jhipster.config.JHipsterProperties;
 
@@ -52,11 +51,19 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
 
 import org.springframework.cache.CacheManager;
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.cache.CacheManager;
+<%_ } _%>
 import org.springframework.cache.annotation.EnableCaching;
 <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
 import org.springframework.cloud.client.ServiceInstance;
 import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.client.serviceregistry.Registration;
+<%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+import org.springframework.cache.support.NoOpCacheManager;
 <%_ } _%>
 import org.springframework.context.annotation.*;
 <%_ if (cacheProvider === 'hazelcast') { _%>
@@ -101,6 +108,10 @@ import org.springframework.beans.factory.BeanInitializationException;
 import java.util.ArrayList;
 import java.util.List;
     <%_ } _%>
+<%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+
+import io.github.jhipster.config.JHipsterConstants;
 <%_ } _%>
 
 @Configuration
@@ -591,5 +602,17 @@ public class CacheConfiguration {
         return channel;
     }
         <%_ } _%>
+    <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+
+    private final Logger log = LoggerFactory.getLogger(CacheConfiguration.class);
+
+    @Bean
+    @Profile(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT)
+    public CacheManager cacheManager() {
+        // Note that Memcached cannot work with Spring Boot devtools
+        log.debug("Memcached is disabled as the application is in development mode");
+        return new NoOpCacheManager();
+    }
     <%_ } _%>
 }

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -267,7 +267,7 @@ jhipster:
     <%_ } _%>
     http:
         version: V_1_1 # To use HTTP/2 you will need SSL support (see above the "server.ssl" configuration)
-    <%_ if (cacheProvider !== 'no') { _%>
+    <%_ if (cacheProvider !== 'no' && cacheProvider !== 'memcached') { _%>
     cache: # Cache configuration
         <%_ if (cacheProvider === 'hazelcast') { _%>
         hazelcast: # Hazelcast distributed cache

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -45,6 +45,15 @@ eureka:
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@localhost:8761/eureka/
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached') { _%>
+
+memcached:
+    cache:
+        servers: localhost:11211
+        mode: static
+        expiration: 86400
+        protocol: binary
+<%_ } _%>
 
 spring:
     devtools:
@@ -246,7 +255,7 @@ jhipster:
         version: V_1_1 # To use HTTP/2 you will need SSL support (see above the "server.ssl" configuration)
         cache: # Used by the CachingHttpHeadersFilter
             timeToLiveInDays: 1461
-    <%_ if (cacheProvider !== 'no') { _%>
+    <%_ if (cacheProvider !== 'no' && cacheProvider !== 'memcached') { _%>
     cache: # Cache configuration
         <%_ if (cacheProvider === 'hazelcast') { _%>
         hazelcast: # Hazelcast distributed cache

--- a/generators/server/templates/src/main/resources/logback-spring.xml.ejs
+++ b/generators/server/templates/src/main/resources/logback-spring.xml.ejs
@@ -92,6 +92,9 @@
     <%_ if (cacheProvider === 'infinispan') { _%>
     <logger name="org.infinispan" level="WARN"/>
     <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    <logger name="net.spy.memcached" level="WARN"/>
+    <%_ } _%>
     <logger name="org.springframework" level="WARN"/>
     <logger name="org.springframework.web" level="WARN"/>
     <logger name="org.springframework.security" level="WARN"/>

--- a/generators/server/templates/src/test/resources/logback.xml.ejs
+++ b/generators/server/templates/src/test/resources/logback.xml.ejs
@@ -72,6 +72,9 @@
     <%_ if (cacheProvider === 'infinispan') { _%>
     <logger name="org.infinispan" level="WARN"/>
     <%_ } _%>
+    <%_ if (cacheProvider === 'memcached') { _%>
+    <logger name="net.spy.memcached" level="WARN"/>
+    <%_ } _%>
     <logger name="org.springframework" level="WARN"/>
     <logger name="org.springframework.web" level="WARN"/>
     <logger name="org.springframework.security" level="WARN"/>

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -676,6 +676,39 @@ describe('JHipster generator', () => {
             });
         });
 
+        describe('Memcached', () => {
+            beforeEach((done) => {
+                helpers.run(path.join(__dirname, '../generators/app'))
+                    .withOptions({ skipInstall: true, skipChecks: true })
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        clientFramework: 'angularX',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'memcached',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        useSass: false,
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files with "Infinispan"', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.client);
+                assert.file(expectedFiles.memcached);
+            });
+        });
+
         describe('Messaging with Kafka configuration', () => {
             beforeEach((done) => {
                 helpers.run(path.join(__dirname, '../generators/app'))

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -133,6 +133,11 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheFactoryConfiguration.java`
     ],
 
+    memcached: [
+        `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+        `${DOCKER_DIR}memcached.yml`
+    ],
+
     gatling: [
         `${TEST_DIR}gatling/conf/gatling.conf`
     ],


### PR DESCRIPTION
Memcached can be used as a Spring Cache implementation, but not as an Hibernate L2 cache.
This is great for people running in cloud environments like AWS, GCP, Heroku, as those platforms provide cheap Memcached support, allowing the applications to scale easily without hitting the database too hard.

Ping @jkutner we'll need to add support for the MemCachier add-on with Heroku!
