### PR TITLE
Fix alert not displaying issue in Firefox

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
@@ -40,9 +40,9 @@ export class NotificationInterceptor implements HttpInterceptor {
                 let alertParams = null;
                 <%_ } _%>
                 arr.forEach((entry) => {
-                    if (entry.endsWith('app-alert')) {
+                    if (entry.toLowerCase().endsWith('app-alert')) {
                         alert = event.headers.get(entry);
-                    }<% if (enableTranslation) { %> else if (entry.endsWith('app-params')) {
+                    }<% if (enableTranslation) { %> else if (entry.toLowerCase().endsWith('app-params')) {
                         alertParams = event.headers.get(entry);
                     }<% } %>
                 });


### PR DESCRIPTION
Lower casing all the alert headers names seems to fix the issue  #7641 
It appears that all the headers names are now in lowercase in new browsers, except when using Firefox with port 8080 (dev/prod profile does not matter)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
