### PR TITLE
remove old rxjs imports from before pipeable operators

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
@@ -23,10 +23,6 @@ import '../content/scss/vendor.scss';
 <%_} else { _%>
 import '../content/css/vendor.css';
 <%_ } _%>
-import 'rxjs/add/operator/map';
-import 'rxjs/add/operator/catch';
-import 'rxjs/add/observable/of';
-import 'rxjs/add/observable/throw';
 
 // Imports all fontawesome core and solid icons
 


### PR DESCRIPTION
These imports are no longer needed as we switched to pipeable operators.

Related to https://github.com/jhipster/generator-jhipster/pull/6899 and https://github.com/jhipster/generator-jhipster/pull/7582


- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
