### PR TITLE
Add Yarn to engines

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -138,8 +138,8 @@
     "write-file-webpack-plugin": "4.2.0"
   },
   "engines": {
-    "node": ">=8.9.0",
-    "yarn": ">=1.3.2"
+    "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
+    "yarn": ">=1.3.2"<% } %>
   },
   <%_ if(!skipCommitHook) { _%>
   "lint-staged": {

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -138,7 +138,8 @@
     "write-file-webpack-plugin": "4.2.0"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=8.9.0",
+    "yarn": ">=1.3.2"
   },
   <%_ if(!skipCommitHook) { _%>
   "lint-staged": {

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -172,8 +172,8 @@ limitations under the License.
     "@types/react": "16.1.0"
   },
   "engines": {
-    "node": ">=8.9.0",
-    "yarn": ">=1.3.2"
+    "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
+    "yarn": ">=1.3.2"<% } %>
   },
   <%_ if(!skipCommitHook) { _%>
   "lint-staged": {

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -172,7 +172,8 @@ limitations under the License.
     "@types/react": "16.1.0"
   },
   "engines": {
-    "node": ">=8.9.0"
+    "node": ">=8.9.0",
+    "yarn": ">=1.3.2"
   },
   <%_ if(!skipCommitHook) { _%>
   "lint-staged": {


### PR DESCRIPTION
This will ensure that Yarn is installed (with the correct version) on platforms like Heroku.

Normally, Heroku looks for a `yarn.lock` file, and installs and runs `yarn` accordingly. But in some cases (either with apps generated from https://start.jhipster.tech or `jhipster --skip-install`) no `yarn.lock` is present. But Heroku should still work.