### PR TITLE
Less guava

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -229,6 +229,9 @@ dependencies {
     compile "com.fasterxml.jackson.core:jackson-databind"
     compile "com.fasterxml.jackson.module:jackson-module-afterburner"
     compile "com.ryantenney.metrics:metrics-spring"
+    <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
+    compile "org.apache.httpcomponents:httpclient"
+    <%_ } _%>
     <%_ if (cacheProvider === 'hazelcast') { _%>
     compile "com.hazelcast:hazelcast"
     <%_ if (enableHibernateCache) { _%>

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -363,9 +363,6 @@ dependencies {
     compile "org.springframework.security:spring-security-jwt"
         <%_ } _%>
     <%_ } _%>
-    <%_ if (authenticationType === 'session') { _%>
-    compile "com.google.guava:guava"
-    <%_ } _%>
     <%_ if (authenticationType === 'jwt') { _%>
     compile "io.jsonwebtoken:jjwt"
     <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -237,6 +237,12 @@
             <artifactId>h2</artifactId>
             <scope>test</scope>
         </dependency>
+        <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
+        <dependency>
+            <groupId>org.apache.httpcomponents</groupId>
+            <artifactId>httpclient</artifactId>
+        </dependency>
+        <%_ } _%>
         <%_ if (cacheProvider === 'hazelcast' || applicationType === 'gateway') { _%>
         <dependency>
             <groupId>com.hazelcast</groupId>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -607,12 +607,6 @@
         </dependency>
             <%_ } _%>
         <%_ } _%>
-        <%_ if (authenticationType === 'session') { _%>
-        <dependency>
-            <groupId>com.google.guava</groupId>
-            <artifactId>guava</artifactId>
-        </dependency>
-        <%_ } _%>
         <%_ if (authenticationType === 'jwt') { _%>
         <dependency>
             <groupId>io.jsonwebtoken</groupId>

--- a/generators/server/templates/src/main/java/package/security/PersistentTokenRememberMeServices.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/PersistentTokenRememberMeServices.java.ejs
@@ -26,10 +26,9 @@ import <%=packageName%>.service.util.RandomUtil;
 <%_ if (databaseType === 'cassandra') { _%>
 import com.datastax.driver.core.exceptions.DriverException;
 <%_ } _%>
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
 
 import io.github.jhipster.config.JHipsterProperties;
+import io.github.jhipster.security.PersistentTokenCache;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;<% if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { %>
@@ -49,7 +48,6 @@ import java.time.LocalDate;
 <%_ if (databaseType === 'cassandra') { _%>
 import java.time.temporal.ChronoUnit;
 <%_ } _%>
-import java.util.concurrent.TimeUnit;
 import java.util.*;
 
 /**
@@ -90,11 +88,9 @@ public class PersistentTokenRememberMeServices extends
 
     private static final int TOKEN_VALIDITY_SECONDS = 60 * 60 * 24 * TOKEN_VALIDITY_DAYS;
 
-    private static final int UPGRADED_TOKEN_VALIDITY_SECONDS = 5;
+    private static final long UPGRADED_TOKEN_VALIDITY_MILLIS = 5000l;
 
-    private Cache<String, UpgradedRememberMeToken> upgradedTokenCache = CacheBuilder.newBuilder()
-            .expireAfterWrite(UPGRADED_TOKEN_VALIDITY_SECONDS, TimeUnit.SECONDS)
-            .build();
+    private final PersistentTokenCache<UpgradedRememberMeToken> upgradedTokenCache;
 
     private final PersistentTokenRepository persistentTokenRepository;
 
@@ -107,6 +103,7 @@ public class PersistentTokenRememberMeServices extends
         super(jHipsterProperties.getSecurity().getRememberMe().getKey(), userDetailsService);
         this.persistentTokenRepository = persistentTokenRepository;
         this.userRepository = userRepository;
+        upgradedTokenCache = new PersistentTokenCache<>(UPGRADED_TOKEN_VALIDITY_MILLIS);
     }
 
     @Override
@@ -115,9 +112,9 @@ public class PersistentTokenRememberMeServices extends
 
         synchronized (this) { // prevent 2 authentication requests from the same user in parallel
             String login = null;
-            UpgradedRememberMeToken upgradedToken = upgradedTokenCache.getIfPresent(cookieTokens[0]);
+            UpgradedRememberMeToken upgradedToken = upgradedTokenCache.get(cookieTokens[0]);
             if (upgradedToken != null) {
-                login = upgradedToken.getUserLoginIfValidAndRecentUpgrade(cookieTokens);
+                login = upgradedToken.getUserLoginIfValid(cookieTokens);
                 log.debug("Detected previously upgraded login token for user '{}'", login);
             }
 
@@ -248,22 +245,18 @@ public class PersistentTokenRememberMeServices extends
 
         private static final long serialVersionUID = 1L;
 
-        private String[] upgradedToken;
+        private final String[] upgradedToken;
 
-        private Date upgradeTime;
-
-        private String userLogin;
+        private final String userLogin;
 
         UpgradedRememberMeToken(String[] upgradedToken, String userLogin) {
             this.upgradedToken = upgradedToken;
             this.userLogin = userLogin;
-            this.upgradeTime = new Date();
         }
 
-        String getUserLoginIfValidAndRecentUpgrade(String[] currentToken) {
+        String getUserLoginIfValid(String[] currentToken) {
             if (currentToken[0].equals(this.upgradedToken[0]) &&
-                    currentToken[1].equals(this.upgradedToken[1]) &&
-                    (upgradeTime.getTime() + UPGRADED_TOKEN_VALIDITY_SECONDS * 1000) > new Date().getTime()) {
+                    currentToken[1].equals(this.upgradedToken[1])) {
                 return this.userLogin;
             }
             return null;

--- a/generators/server/templates/src/main/java/package/security/oauth2/OAuth2AuthenticationService.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/OAuth2AuthenticationService.java.ejs
@@ -18,8 +18,7 @@
 -%>
 package <%=packageName%>.security.oauth2;
 
-import com.google.common.cache.Cache;
-import com.google.common.cache.CacheBuilder;
+import io.github.jhipster.security.PersistentTokenCache;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -29,7 +28,6 @@ import javax.servlet.http.Cookie;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
 /**
  * Manages authentication cases for OAuth2 updating the cookies holding access and refresh tokens accordingly.
@@ -41,14 +39,15 @@ public class OAuth2AuthenticationService {
     private final Logger log = LoggerFactory.getLogger(OAuth2AuthenticationService.class);
 
     /**
-     * Number of seconds to cache refresh token grants so we don't have to repeat them in case of parallel requests.
+     * Number of milliseconds to cache refresh token grants so we don't have to repeat them in case of parallel requests.
      */
-    private static final long REFRESH_TOKEN_CACHE_SECS = 10l;
+    private static final long REFRESH_TOKEN_VALIDITY_MILLIS = 10000l;
 
     /**
      * Used to contact the OAuth2 token endpoint.
      */
     private final OAuth2TokenEndpointClient authorizationClient;
+
     /**
      * Helps us with cookie handling.
      */
@@ -58,14 +57,12 @@ public class OAuth2AuthenticationService {
      * Caches Refresh grant results for a refresh token value so we can reuse them.
      * This avoids hammering UAA in case of several multi-threaded requests arriving in parallel.
      */
-    private final Cache<String, OAuth2Cookies> recentlyRefreshed;
+    private final PersistentTokenCache<OAuth2Cookies> recentlyRefreshed;
 
     public OAuth2AuthenticationService(OAuth2TokenEndpointClient authorizationClient, OAuth2CookieHelper cookieHelper) {
         this.authorizationClient = authorizationClient;
         this.cookieHelper = cookieHelper;
-        recentlyRefreshed = CacheBuilder.newBuilder()
-            .expireAfterWrite(REFRESH_TOKEN_CACHE_SECS, TimeUnit.SECONDS)
-            .build();
+        recentlyRefreshed = new PersistentTokenCache<>(REFRESH_TOKEN_VALIDITY_MILLIS);
     }
 
     /**
@@ -149,7 +146,7 @@ public class OAuth2AuthenticationService {
      */
     private OAuth2Cookies getCachedCookies(String refreshTokenValue) {
         synchronized (recentlyRefreshed) {
-            OAuth2Cookies ctx = recentlyRefreshed.getIfPresent(refreshTokenValue);
+            OAuth2Cookies ctx = recentlyRefreshed.get(refreshTokenValue);
             if (ctx == null) {
                 ctx = new OAuth2Cookies();
                 recentlyRefreshed.put(refreshTokenValue, ctx);

--- a/generators/server/templates/src/main/java/package/security/oauth2/OAuth2CookieHelper.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/OAuth2CookieHelper.java.ejs
@@ -19,8 +19,7 @@
 package <%=packageName%>.security.oauth2;
 
 import <%=packageName%>.config.oauth2.OAuth2Properties;
-import com.google.common.net.InetAddresses;
-import com.google.common.net.InternetDomainName;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.json.JsonParser;
@@ -39,6 +38,11 @@ import javax.servlet.http.HttpServletResponse;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+
+import static org.apache.http.conn.util.InetAddressUtils.isIPv4Address;
+import static org.apache.http.conn.util.InetAddressUtils.isIPv6Address;
+import org.apache.http.conn.util.PublicSuffixMatcher;
+import org.apache.http.conn.util.PublicSuffixMatcherLoader;
 
 /**
  * Helps with OAuth2 cookie handling.
@@ -68,6 +72,11 @@ public class OAuth2CookieHelper {
      */
     private static final long REFRESH_TOKEN_EXPIRATION_WINDOW_SECS = 3L;
 
+    /**
+     * Public suffix matcher (to strip private subdomains off cookie scope).
+     */
+    PublicSuffixMatcher suffixMatcher;
+
     private final Logger log = LoggerFactory.getLogger(OAuth2CookieHelper.class);
 
     private OAuth2Properties oAuth2Properties;
@@ -79,6 +88,9 @@ public class OAuth2CookieHelper {
 
     public OAuth2CookieHelper(OAuth2Properties oAuth2Properties) {
         this.oAuth2Properties = oAuth2Properties;
+
+        // Alternatively, always get an up-to-date list by passing an URL
+        this.suffixMatcher = PublicSuffixMatcherLoader.getDefault();
     }
 
     public static Cookie getAccessTokenCookie(HttpServletRequest request) {
@@ -305,22 +317,22 @@ public class OAuth2CookieHelper {
         if (domain != null) {
             return domain;
         }
-        //if not explicitly defined, use top-level domain
+        // if not explicitly defined, use top-level domain
         domain = request.getServerName().toLowerCase();
-        //strip off leading www.
+        // strip off leading www.
         if (domain.startsWith("www.")) {
             domain = domain.substring(4);
         }
-        //if it isn't an IP address
-        if (!InetAddresses.isInetAddress(domain)) {
-            //strip off subdomains, leaving the top level domain only
-            InternetDomainName domainName = InternetDomainName.from(domain);
-            if (domainName.isUnderPublicSuffix() && !domainName.isTopPrivateDomain()) {
-                //preserve leading dot
-                return "." + domainName.topPrivateDomain().toString();
+        // if it isn't an IP address
+        if (!isIPv4Address(domain) && !isIPv6Address(domain)) {
+            // strip off private subdomains, leaving public TLD only
+            String suffix = suffixMatcher.getDomainRoot(domain);
+            if (suffix != null && !suffix.equals(domain)) {
+                // preserve leading dot
+                return "." + suffix;
             }
         }
-        //no top-level domain, stick with default domain
+        // no top-level domain, stick with default domain
         return null;
     }
 


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

I'd like to get rid of the huge Guava dependency, which we only use for two "small" purposes that are easily replaced.

Specifically, this PR
- Replaces an Guava cache (which is needlessly complex anyway, we don't need the concurrency features here) with a simple linked map. 
- Uses apache's httpclient to do some public suffix / TLD magic instead of Guava.

This has a counterpart PR on the server lib, [here](https://github.com/jhipster/jhipster/pull/71).

I will cancel failing Travis due to this mutual dependence, see here for passing tests with both PRs applied:
https://travis-ci.org/erikkemperman/generator-jhipster/builds/385181814
https://travis-ci.org/erikkemperman/jhipster/builds/385181785