### PR TITLE
Fix match regexp for e2e with React+Cassandra

### DIFF
--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -117,7 +117,7 @@ describe('<%= entityClass %> e2e test', () => {
         <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption();
         <%_ } else if (fieldType === 'UUID'){ _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match('64c99148-3908-465d-8c4a-e510e3ade974');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match(/64c99148-3908-465d-8c4a-e510e3ade974/);
         <%_ } else { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match(/<%= fieldName %>/);


### PR DESCRIPTION
It's for fixing this error:

```
[18:01:02] E/launcher - Error: TSError: ⨯ Unable to compile TypeScript
src/test/javascript/e2e/entities/cass-bank-account-my-suffix/cass-bank-account-my-suffix.spec.ts (40,71): Argument of type '"64c99148-3908-465d-8c4a-e510e3ade974"' is not assignable to parameter of type 'RegExp'. (2345)
    at getOutput (/home/travis/app/node_modules/ts-node/src/index.ts:307:15)
    at /home/travis/app/node_modules/ts-node/src/index.ts:336:16
    at Object.compile (/home/travis/app/node_modules/ts-node/src/index.ts:498:11)
    at Module.m._compile (/home/travis/app/node_modules/ts-node/src/index.ts:392:43
```

_____

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
