### PR TITLE
Use openapi-generator for API-first option

### DIFF
--- a/generators/server/templates/README.md.ejs
+++ b/generators/server/templates/README.md.ejs
@@ -206,9 +206,9 @@ will generate few files:
 <%_ } _%>
 
 <%_ if (enableSwaggerCodegen) { _%>
-### Doing API-First development using swagger-codegen
+### Doing API-First development using openapi-generator
 
-[Swagger-Codegen]() is configured for this application. You can generate API code from the `src/main/resources/swagger/api.yml` definition file by running:
+[OpenAPI-Generator]() is configured for this application. You can generate API code from the `src/main/resources/swagger/api.yml` definition file by running:
     <%_ if (buildTool === 'maven') { _%>
 ```bash
 ./mvnw generate-sources
@@ -216,10 +216,10 @@ will generate few files:
     <%_ } _%>
     <%_ if (buildTool === 'gradle') { _%>
 ```bash
-./gradlew swagger
+./gradlew openapi
 ```
     <%_ } _%>
-Then implements the generated interfaces with `@RestController` classes.
+Then implements the generated delegate classes with `@Service` classes.
 
 To edit the `api.yml` definition file, you can use a tool such as [Swagger-Editor](). Start a local instance of the swagger-editor using docker by running: `docker-compose -f src/main/docker/swagger-editor.yml up -d`. The editor will then be reachable at [http://localhost:7742](http://localhost:7742).
 
@@ -324,7 +324,7 @@ To configure CI for your project, run the ci-cd sub-generator (`jhipster ci-cd`)
 [DefinitelyTyped]: http://definitelytyped.org/
 <%_ } _%>
 <%_ if (enableSwaggerCodegen) { _%>
-[Swagger-Codegen]: https://github.com/swagger-api/swagger-codegen
+[OpenAPI-Generator]: https://openapi-generator.tech
 [Swagger-Editor]: http://editor.swagger.io
 [Doing API-First development]: <%= DOCUMENTATION_ARCHIVE_URL %>/doing-api-first-development/
 <%_ } _%>

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -30,9 +30,6 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}"
         classpath "io.spring.gradle:propdeps-plugin:0.0.10.RELEASE"
-        <%_ if (enableSwaggerCodegen) { _%>
-        classpath "gradle.plugin.org.detoeuf:swagger-codegen-plugin:1.7.4"
-        <%_ } _%>
         classpath "gradle.plugin.com.gorylenko.gradle-git-properties:gradle-git-properties:1.4.21"
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }

--- a/generators/server/templates/gradle/swagger.gradle.ejs
+++ b/generators/server/templates/gradle/swagger.gradle.ejs
@@ -17,29 +17,43 @@
  limitations under the License.
 -%>
 /*
- * Plugin that provides API-first development using swagger-codegen to
- * generate Spring-MVC endpoint stubs at compile time from a swagger definition file
+ * Task that provides API-first development using opeenapi-generator to
+ * generate Spring-MVC endpoint stubs at compile time from an OpenAPI definition file
  */
+buildscript {
+    repositories {
+        mavenCentral()
+    }
+    dependencies {
+        classpath('org.openapitools:openapi-generator:3.0.0')
+    }
+}
 
-apply plugin: "org.detoeuf.swagger-codegen"
+import org.openapitools.codegen.config.CodegenConfigurator
+import org.openapitools.codegen.DefaultGenerator
 
-swagger {
-    inputSpec = file('<%= SERVER_MAIN_RES_DIR %>swagger/api.yml').absolutePath
-    outputDir = file('build/swagger')
-    lang = 'spring'
+def swaggerInput = file("<%= SERVER_MAIN_RES_DIR %>swagger/api.yml")
+def swaggerOutputDir = file('build/openapi')
+task openapi {
+    inputs.file(swaggerInput)
+    outputs.dir(swaggerOutputDir)
+    doLast {
+        def config = new CodegenConfigurator()
+            .setInputSpec(swaggerInput.absolutePath)
+            .setOutputDir(swaggerOutputDir.absolutePath)
+            .setGeneratorName('spring')
+            .setApiPackage('<%= packageName %>.web.api')
+            .setModelPackage('<%= packageName %>.web.api.model')
+            .addSystemProperty('apis', '')
+            .addSystemProperty('models', '')
+            .addSystemProperty('supportingFiles', 'ApiUtil.java')
+            .addAdditionalProperty('delegatePattern', true)
+        new DefaultGenerator().opts(config.toClientOptInput()).generate()
+    }
+}
 
-    addDynamicProperty 'interfaceOnly', true
-    addDynamicProperty 'java8', true
-
-    additionalProperties = [
-        'modelPackage' : '<%= packageName %>.web.api.model',
-        'apiPackage'   : '<%= packageName %>.web.api'
-    ]
-
-    systemProperties = [
-        'models' : '',
-        'apis'   : ''
-    ]
+clean.doFirst {
+    delete(swaggerOutputDir)
 }
 
 sourceSets {
@@ -50,4 +64,4 @@ sourceSets {
     }
 }
 
-compileJava.dependsOn('swagger')
+compileJava.dependsOn("openapi")

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -123,7 +123,7 @@
         <scala-maven-plugin.version>3.3.2</scala-maven-plugin.version>
         <sonar-maven-plugin.version>3.4.0.905</sonar-maven-plugin.version>
         <%_ if (enableSwaggerCodegen) { _%>
-        <swagger-codegen-maven-plugin.version>2.3.1</swagger-codegen-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>3.0.0</openapi-generator-maven-plugin.version>
         <%_ } _%>
 
         <!-- Sonar properties -->
@@ -1019,12 +1019,12 @@
             <%_ if (enableSwaggerCodegen) { _%>
             <plugin>
                 <!--
-                    Plugin that provides API-first development using swagger-codegen to
-                    generate Spring-MVC endpoint stubs at compile time from a swagger definition file
+                    Plugin that provides API-first development using openapi-generator to
+                    generate Spring-MVC endpoint stubs at compile time from an OpenAPI definition file
                 -->
-                <groupId>io.swagger</groupId>
-                <artifactId>swagger-codegen-maven-plugin</artifactId>
-                <version>${swagger-codegen-maven-plugin.version}</version>
+                <groupId>org.openapitools</groupId>
+                <artifactId>openapi-generator-maven-plugin</artifactId>
+                <version>${openapi-generator-maven-plugin.version}</version>
                 <executions>
                     <execution>
                         <goals>
@@ -1032,13 +1032,12 @@
                         </goals>
                         <configuration>
                             <inputSpec>${project.basedir}/<%= SERVER_MAIN_RES_DIR %>swagger/api.yml</inputSpec>
-                            <language>spring</language>
+                            <generatorName>spring</generatorName>
                             <apiPackage><%= packageName %>.web.api</apiPackage>
                             <modelPackage><%= packageName %>.web.api.model</modelPackage>
-                            <generateSupportingFiles>false</generateSupportingFiles>
+                            <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
                             <configOptions>
-                                <interfaceOnly>true</interfaceOnly>
-                                <java8>true</java8>
+                                <delegatePattern>true</delegatePattern>
                             </configOptions>
                         </configuration>
                     </execution>
@@ -1102,9 +1101,9 @@
                                 <%_ if (enableSwaggerCodegen) { _%>
                                 <pluginExecution>
                                     <pluginExecutionFilter>
-                                        <groupId>io.swagger</groupId>
-                                        <artifactId>swagger-codegen-maven-plugin</artifactId>
-                                        <versionRange>${swagger-codegen-maven-plugin.version}</versionRange>
+                                        <groupId>org.openapitools</groupId>
+                                        <artifactId>openapi-generator-maven-plugin</artifactId>
+                                        <versionRange>${openapi-generator-maven-plugin.version}</versionRange>
                                         <goals>
                                             <goal>generate</goal>
                                         </goals>

--- a/generators/server/templates/src/main/resources/swagger/api.yml.ejs
+++ b/generators/server/templates/src/main/resources/swagger/api.yml.ejs
@@ -16,9 +16,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-# API-first development with swagger
-# This file will be used at compile time to generate Spring-MVC endpoint stubs using swagger-codegen
-swagger: "2.0"
+# API-first development with OpenAPI
+# This file will be used at compile time to generate Spring-MVC endpoint stubs using openapi-generator
+openapi: "3.0.1"
 info:
   version: 0.0.1
 paths: {}


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

[openapi-generator](https://openapi-generator.tech) is a community-driven fork of swagger-codegen. Using it has the following advantages:
* Supports both swagger v2.0 and OpenAPI v3.0 formats
* Will generate "delegate" interfaces that are called from the controller classes. So you don't need to add annotations such as `@RequestParam` in the implementation methods.
* Supports Webflux so it can be used with the future `reactive` option.