### PR TITLE
Caching Improvements

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -31,9 +31,9 @@ const commonConfig = require('./webpack.common.js');
 
 const ENV = 'production';
 <%_ if (useSass) { _%>
-const extractSASS = new ExtractTextPlugin(`[name]-sass.[hash].css`);
+const extractSASS = new ExtractTextPlugin(`content/[name]-sass.[hash].css`);
 <%_ } _%>
-const extractCSS = new ExtractTextPlugin(`[name].[hash].css`);
+const extractCSS = new ExtractTextPlugin(`content/[name].[hash].css`);
 
 module.exports = webpackMerge(commonConfig({ env: ENV }), {
     // Enable source maps. Please note that this will slow down the build.
@@ -81,7 +81,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
             test: /(vendor\.css|global\.css)/,
             use: extractCSS.extract({
                 fallback: 'style-loader',
-                use: ['css-loader']
+                use: ['css-loader'],
+                publicPath: '../'
             })
         }]
     },

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -70,7 +70,7 @@ module.exports = options => ({
       },
       {
         test: /\.(jpe?g|png|gif|svg|woff2?|ttf|eot)$/i,
-        loaders: ['file-loader?hash=sha512&digest=hex&name=[hash].[ext]']
+        loaders: ['file-loader?hash=sha512&digest=hex&name=content/[hash].[ext]']
       },
       {
         enforce: 'pre',

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -28,9 +28,9 @@ const utils = require('./utils.js');
 const commonConfig = require('./webpack.common.js');
 
 const ENV = 'production';
-const extractCSS = new ExtractTextPlugin(`[name].[hash].css`);
+const extractCSS = new ExtractTextPlugin(`content/[name].[hash].css`);
 <%_ if (useSass) { _%>
-const extractSASS = new ExtractTextPlugin(`[name]-sass.[hash].css`);
+const extractSASS = new ExtractTextPlugin(`content/[name]-sass.[hash].css`);
 <%_ } _%>
 
 module.exports = webpackMerge(commonConfig({ env: ENV }), {
@@ -64,7 +64,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         test: /\.css$/,
         use: extractCSS.extract({
           fallback: 'style-loader',
-          use: ['css-loader']
+          use: ['css-loader'],
+          publicPath: '../'
         })
       }
     ]


### PR DESCRIPTION
For Angular, CSS files are stored at the root of the of the app.  For React, CSS files and images referenced in CSS are stored at the root of the app.  This means those files [don't receive the caching headers](https://github.com/jhipster/generator-jhipster/blob/master/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs#L181-L182).  I updated the Webpack config to put the CSS and referenced image files in the `content` folder like what was done in AngularJS

React also has a static folder with images such as the navbar logo, it isn't hashed by webpack or cached.  Not sure what we wanted to do with that so the react config may need tweaking.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed