### PR TITLE
fix react protractor test

### DIFF
--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -31,12 +31,9 @@ describe('Administration', () => {
 
   before(() => {
     browser.get('/');
+    navBarPage = new NavBarPage(true);
     <%_ if (authenticationType !== 'oauth2') { _%>
-    navBarPage = new NavBarPage(true);
     navBarPage.autoSignIn();
-    <%_ } else { _%>
-    navBarPage = new NavBarPage(true);
-    navBarPage.getSignInPage();
     <%_ } _%>
   });
 


### PR DESCRIPTION
Right now there is no signout for the oauth2 tests, so at this stage in the test admin is still logged in.
Therefore `#login-item` cannot be found.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
