### PR TITLE
fix entity conflicts with RouteComponentProps in React

### DIFF
--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-delete-dialog.tsx.ejs
@@ -35,7 +35,7 @@ export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= ent
   }
 
   confirmDelete = event => {
-    this.props.deleteEntity(this.props.<%= entityInstance %>.id);
+    this.props.deleteEntity(this.props.<%= entityInstance %>Entity.id);
     this.handleClose(event);
   }
 
@@ -45,12 +45,12 @@ export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= ent
   };
 
   render() {
-    const { <%= entityInstance %> } = this.props;
+    const { <%= entityInstance %>Entity } = this.props;
     return (
       <Modal isOpen toggle={this.handleClose}>
       <ModalHeader toggle={this.handleClose}><Translate contentKey="entity.delete.title">Confirm delete operation</Translate></ModalHeader>
       <ModalBody>
-        <Translate contentKey="<%= i18nKeyPrefix %>.delete.question" interpolate={{ id: <%= entityInstance %>.id }}>
+        <Translate contentKey="<%= i18nKeyPrefix %>.delete.question" interpolate={{ id: <%= entityInstance %>Entity.id }}>
             Are you sure you want to delete this <%= entityClass %>?
         </Translate>
       </ModalBody>
@@ -70,7 +70,7 @@ export class <%= entityReactName %>DeleteDialog extends React.Component<I<%= ent
 }
 
 const mapStateToProps = ({ <%= entityInstance %> }: IRootState) => ({
-    <%= entityInstance %>: <%= entityInstance %>.entity
+    <%= entityInstance %>Entity: <%= entityInstance %>.entity
 });
 
 const mapDispatchToProps = { getEntity, deleteEntity };

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -51,12 +51,12 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
   }
 
   render() {
-    const { <%= entityInstance %> } = this.props;
+    const { <%= entityInstance %>Entity } = this.props;
     return (
       <Row>
         <Col md="8">
           <h2>
-            <Translate contentKey="<%= i18nKeyPrefix %>.detail.title"><%= entityClass %></Translate> [<b>{<%= entityInstance %>.id}</b>]
+            <Translate contentKey="<%= i18nKeyPrefix %>.detail.title"><%= entityClass %></Translate> [<b>{<%= entityInstance %>Entity.id}</b>]
           </h2>
             <dl className="jh-entity-details">
             <%_ for (idx in fields) {
@@ -82,34 +82,34 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
               </dt>
               <dd>
               <%_ if (fieldType === 'Boolean') { _%>
-                {<%= entityInstance %>.<%=fieldName%> ? 'true' : 'false'}
+                {<%= entityInstance %>Entity.<%=fieldName%> ? 'true' : 'false'}
               <%_ } else if (fieldType === 'Instant' || fieldType === 'ZonedDateTime') { _%>
-                <TextFormat value={<%= entityInstance %>.<%=fieldName%>} type="date" format={APP_DATE_FORMAT} />
+                <TextFormat value={<%= entityInstance %>Entity.<%=fieldName%>} type="date" format={APP_DATE_FORMAT} />
               <%_ } else if (fieldType === 'LocalDate') { _%>
-                <TextFormat value={<%= entityInstance %>.<%=fieldName%>} type="date" format={APP_LOCAL_DATE_FORMAT} />
+                <TextFormat value={<%= entityInstance %>Entity.<%=fieldName%>} type="date" format={APP_LOCAL_DATE_FORMAT} />
               <%_
                   } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) {
 
                     const fieldBlobType = fields[idx].fieldTypeBlobContent;
                     if (fieldBlobType !== 'text') {
               _%>
-                  {<%= entityInstance %>.<%=fieldName%> ? (
+                  {<%= entityInstance %>Entity.<%=fieldName%> ? (
                     <div>
-                      <a onClick={openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)}>
+                      <a onClick={openFile(<%= entityInstance %>Entity.<%= fieldName %>ContentType, <%= entityInstance %>Entity.<%= fieldName %>)}>
                       <%_ if (fieldBlobType === 'image') { _%>
-                        <img src={`data:${<%= entityInstance %>.<%= fieldName %>ContentType};base64,${<%= entityInstance %>.<%= fieldName %>}`} style={{ maxHeight: '30px' }} />
+                        <img src={`data:${<%= entityInstance %>Entity.<%= fieldName %>ContentType};base64,${<%= entityInstance %>Entity.<%= fieldName %>}`} style={{ maxHeight: '30px' }} />
                       <%_ } else { _%>
                         <Translate contentKey="entity.action.open">Open</Translate>&nbsp;
                       <%_ } _%>
                       </a>
-                      <span>{<%= entityInstance %>.<%=fieldName%>ContentType}, {byteSize(<%= entityInstance %>.<%=fieldName%>)}</span>
+                      <span>{<%= entityInstance %>Entity.<%=fieldName%>ContentType}, {byteSize(<%= entityInstance %>Entity.<%=fieldName%>)}</span>
                     </div>
                   ) : null}
                 <%_ } else { _%>
-                  {<%= entityInstance %>.<%= fields[idx].fieldName %>}
+                  {<%= entityInstance %>Entity.<%= fields[idx].fieldName %>}
                 <%_ } _%>
               <%_ } else { _%>
-              {<%= entityInstance %>.<%= fields[idx].fieldName %>}
+              {<%= entityInstance %>Entity.<%= fields[idx].fieldName %>}
               <%_ } _%>
               </dd>
               <%_ } _%>
@@ -136,32 +136,32 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
                   <%_ if (otherEntityName === 'user') { _%>
                       <%_ if (relationshipType === 'many-to-many') { _%>
       {
-        (<%= entityInstance %>.<%= relationshipFieldNamePlural %>) ?
-            (<%= entityInstance %>.<%= relationshipFieldNamePlural %>.map((val, i) =>
-                <span key={val.id}><a>{val.<%= otherEntityField %>}</a>{(i === <%= entityInstance %>.<%= relationshipFieldNamePlural %>.length - 1) ? '' : ', '}</span>
+        (<%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>) ?
+            (<%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>.map((val, i) =>
+                <span key={val.id}><a>{val.<%= otherEntityField %>}</a>{(i === <%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>.length - 1) ? '' : ', '}</span>
             )
         ) : null
       }                  <%_ } else { _%>
                           <%_ if (dto === 'no') { _%>
-                  {(<%= entityInstance + "." + relationshipFieldName %>) ? <%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %> : ''}
+                  {(<%= entityInstance + "Entity." + relationshipFieldName %>) ? <%= entityInstance + "Entity." + relationshipFieldName + "." + otherEntityField %> : ''}
                               <%_ } else { _%>
-                  {<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> ? <%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> : ''}
+                  {<%= entityInstance + "Entity." + relationshipFieldName + otherEntityFieldCapitalized %> ? <%= entityInstance + "Entity." + relationshipFieldName + otherEntityFieldCapitalized %> : ''}
                           <%_ } _%>
                       <%_ } _%>
                   <%_ } else { _%>
                       <%_ if (relationshipType === 'many-to-many') { _%>
       {
-          (<%= entityInstance %>.<%= relationshipFieldNamePlural %>) ?
-              (<%= entityInstance %>.<%= relationshipFieldNamePlural %>.map((val, i) =>
-                  <span key={val.id}><a>{val.<%= otherEntityField %>}</a>{(i === <%= entityInstance %>.<%= relationshipFieldNamePlural %>.length - 1) ? '' : ', '}</span>
+          (<%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>) ?
+              (<%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>.map((val, i) =>
+                  <span key={val.id}><a>{val.<%= otherEntityField %>}</a>{(i === <%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>.length - 1) ? '' : ', '}</span>
               )
           ) : null
       }
                       <%_ } else { _%>
                           <%_ if (dto === 'no') { _%>
-                  {(<%= entityInstance + "." + relationshipFieldName %>) ? <%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %> : ''}
+                  {(<%= entityInstance + "Entity." + relationshipFieldName %>) ? <%= entityInstance + "Entity." + relationshipFieldName + "." + otherEntityField %> : ''}
                           <%_ } else { _%>
-                  {<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> ? <%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> : ''}
+                  {<%= entityInstance + "Entity." + relationshipFieldName + otherEntityFieldCapitalized %> ? <%= entityInstance + "Entity." + relationshipFieldName + otherEntityFieldCapitalized %> : ''}
                           <%_ } _%>
                       <%_ } _%>
                   <%_ } _%>
@@ -172,7 +172,7 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
           <Button tag={Link} to="/entity/<%= entityFileName %>" replace color="info">
             <FontAwesomeIcon icon="arrow-left" /> <span className="d-none d-md-inline" ><Translate contentKey="entity.action.back">Back</Translate></span>
           </Button>&nbsp;
-          <Button tag={Link} to={`/entity/<%= entityFileName %>/${<%=entityInstance %>.id}/edit`} replace color="primary">
+          <Button tag={Link} to={`/entity/<%= entityFileName %>/${<%=entityInstance %>Entity.id}/edit`} replace color="primary">
             <FontAwesomeIcon icon="pencil-alt" /> <span className="d-none d-md-inline"><Translate contentKey="entity.action.edit">Edit</Translate></span>
           </Button>
         </Col>
@@ -182,7 +182,7 @@ export class <%= entityReactName %>Detail extends React.Component<I<%= entityRea
 }
 
 const mapStateToProps = ({ <%= entityInstance %> }: IRootState) => ({
-    <%= entityInstance %>: <%= entityInstance %>.entity
+    <%= entityInstance %>Entity: <%= entityInstance %>.entity
 });
 
 const mapDispatchToProps = { getEntity };

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -181,9 +181,9 @@ export class <%= entityReactName %>Update extends React.Component<I<%= entityRea
     <%_ } _%>
 
     if (errors.length === 0) {
-      const { <%= entityInstance %> } = this.props;
+      const { <%= entityInstance %>Entity } = this.props;
       const entity = {
-        ...<%= entityInstance %>,
+        ...<%= entityInstance %>Entity,
         ...values
       }
 
@@ -274,7 +274,7 @@ _%>
 <%_ }) _%>
   render() {
     const isInvalid = false;
-    const { <%= entityInstance %>,<%
+    const { <%= entityInstance %>Entity,<%
     uniqueRealtionFields.forEach(rel => {
     %> <%= rel %>,<% }) %> loading, updating } = this.props;
     const { isNew } = this.state;
@@ -291,7 +291,7 @@ _%>
       , <%= b.fieldName %>ContentType
       <%_ } _%>
       <%_ if (i+1 === blobFields.length) { _%>
-      } = <%= entityInstance %>;
+      } = <%= entityInstance %>Entity;
       <%_ } else { _%>
       ,
       <%_ } _%>
@@ -309,7 +309,7 @@ _%>
       <Row className="justify-content-center">
         <Col md="8">
           { loading ? <p>Loading...</p> :
-          <AvForm model={isNew ? {} : <%= entityInstance %>} onSubmit={this.saveEntity} >
+          <AvForm model={isNew ? {} : <%= entityInstance %>Entity} onSubmit={this.saveEntity} >
             { !isNew ?
               <AvGroup>
                 <Label for="id"><Translate contentKey="global.field.id">ID</Translate></Label>
@@ -341,7 +341,7 @@ _%>
                 type="datetime-local"
                 className="form-control"
                 name="<%= fieldName %>"
-                value={isNew ? null : convertDateTimeFromServer(this.props.<%= entityInstance %>.<%= fieldName %>)}
+                value={isNew ? null : convertDateTimeFromServer(this.props.<%= entityInstance %>Entity.<%= fieldName %>)}
                 <%- include react_validators %>
               />
             <%_ } else if (fieldType === 'LocalDate') { _%>
@@ -371,7 +371,7 @@ _%>
                 type="select"
                 className="form-control"
                 name="<%= fieldName %>"
-                value={(!isNew && <%= entityInstance %>.<%= fieldName%>) || '<%= values[0] %>'}
+                value={(!isNew && <%= entityInstance %>Entity.<%= fieldName%>) || '<%= values[0] %>'}
               >
               <%_
                 const enumPrefix = angularAppName + '.'+ fieldType;
@@ -618,7 +618,7 @@ _%>
                 multiple
                 className="form-control"
                 name="fake<%= otherEntityNamePlural %>"
-                value={this.display<%= relationshipName %>(<%= entityInstance %>)}
+                value={this.display<%= relationshipName %>(<%= entityInstance %>Entity)}
                 onChange={this.<%= relationshipFieldName %>Update}>
                 <option value="" key="0" />
                 {
@@ -662,7 +662,7 @@ const mapStateToProps = (storeState: IRootState) => ({
   <%_ otherEntityActions.forEach(val => { _%>
     <%= val.instance %>: storeState.<%= val.reducer %>.<%= val.entity === 'User' ? val.instance : 'entities' %>,
   <%_ }) _%>
-  <%= entityInstance %>: storeState.<%= entityInstance %>.entity,
+  <%= entityInstance %>Entity: storeState.<%= entityInstance %>.entity,
   loading: storeState.<%= entityInstance %>.loading,
   updating: storeState.<%= entityInstance %>.updating
 });


### PR DESCRIPTION
Fix jhipster/jhipster-core#220

By extending RouteComponentProps in update/delete/detail React pages, we run into conflicts if an entity has the name `history`, `location`, etc.  This PR adds a suffix to the entity props object on those pages.  Another possible fix is to add the words to the reserved list, `Location` is in the example on JDL Studio so I went with this solution instead.
```
export interface RouteComponentProps<P, C extends StaticContext = StaticContext> {
  history: H.History;
  location: H.Location;
  match: match<P>;
  staticContext: C | undefined;
}
```

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
