### PR TITLE
fix test in Windows if Git repo is cloned with autocrlf

### DIFF
--- a/generators/server/templates/src/test/java/package/service/MailServiceIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/MailServiceIntTest.java.ejs
@@ -148,7 +148,7 @@ public class MailServiceIntTest <% if (databaseType === 'cassandra') { %>extends
         assertThat(message.getSubject()).isEqualTo("test title");
         assertThat(message.getAllRecipients()[0].toString()).isEqualTo(user.getEmail());
         assertThat(message.getFrom()[0].toString()).isEqualTo("test@localhost");
-        assertThat(message.getContent().toString()).isEqualTo("<html>test title, http://127.0.0.1:8080, john</html>\n");
+        assertThat(message.getContent().toString()).isEqualToNormalizingNewlines("<html>test title, http://127.0.0.1:8080, john</html>\n");
         assertThat(message.getDataHandler().getContentType()).isEqualTo("text/html;charset=UTF-8");
     }
     <%_ if (authenticationType !== 'oauth2') { _%>


### PR DESCRIPTION
This fixes following workflow in Windows:
- someone who didn't generate app, clones generated app from remote Git repo
- Windows Git client is configured `autocrlf=true`
- `gradlew check` fails because test currently expects `\n` as newline but in cloned repo this is `\r\n`

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
