### PR TITLE
CVE fixed at server side (Web Parameter Tampering)

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/GatewayResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/GatewayResource.java.ejs
@@ -27,6 +27,8 @@ import org.springframework.cloud.client.discovery.DiscoveryClient;
 import org.springframework.cloud.netflix.zuul.filters.Route;
 import org.springframework.cloud.netflix.zuul.filters.RouteLocator;
 import org.springframework.http.*;
+import org.springframework.security.access.annotation.Secured;
+import <%=packageName%>.security.AuthoritiesConstants;
 import org.springframework.web.bind.annotation.*;
 
 import com.codahale.metrics.annotation.Timed;
@@ -54,6 +56,7 @@ public class GatewayResource {
      */
     @GetMapping("/routes")
     @Timed
+    @Secured(AuthoritiesConstants.ADMIN)
     public ResponseEntity<List<RouteVM>> activeRoutes() {
         List<Route> routes = routeLocator.getRoutes();
         List<RouteVM> routeVMs = new ArrayList<>();

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -196,6 +196,7 @@ public class UserResource {
      */
     @GetMapping("/users")
     @Timed
+    @Secured(AuthoritiesConstants.ADMIN)
     <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
     public ResponseEntity<List<UserDTO>> getAllUsers(Pageable pageable) {
         final Page<UserDTO> page = userService.getAllManagedUsers(pageable);


### PR DESCRIPTION
At gateway, attacker can intercept response of uaa/api/account and chance authorities that client will use for build screen, adding ROLE_ADMIN, you can see Administration menu, and list all users and routes, exposing privileged informations.