### PR TITLE
dont request account on password reset screens

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 import { Route } from '@angular/router';
 
-import { UserRouteAccessService } from 'app/core';
 import { PasswordResetFinishComponent } from './password-reset-finish.component';
 
 export const passwordResetFinishRoute: Route = {
@@ -27,6 +26,5 @@ export const passwordResetFinishRoute: Route = {
     data: {
         authorities: [],
         pageTitle: 'global.menu.account.password'
-    },
-    canActivate: [UserRouteAccessService]
+    }
 };

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.route.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 import { Route } from '@angular/router';
 
-import { UserRouteAccessService } from 'app/core';
 import { PasswordResetInitComponent } from './password-reset-init.component';
 
 export const passwordResetInitRoute: Route = {
@@ -27,6 +26,5 @@ export const passwordResetInitRoute: Route = {
     data: {
         authorities: [],
         pageTitle: 'global.menu.account.password'
-    },
-    canActivate: [UserRouteAccessService]
+    }
 };


### PR DESCRIPTION
addresses an issue with uaa auth type where 401 redirects to home page

modeled the route config after the `register` route which doesn't request the account

Fix #7773

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
