### PR TITLE
remove feign annotations causing duplicate interceptors

### DIFF
--- a/generators/server/templates/src/main/java/package/client/OAuth2InterceptedFeignConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/client/OAuth2InterceptedFeignConfiguration.java.ejs
@@ -23,13 +23,11 @@ import java.io.IOException;
 
 import org.springframework.cloud.security.oauth2.client.feign.OAuth2FeignRequestInterceptor;
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.security.oauth2.client.DefaultOAuth2ClientContext;
 
 import feign.RequestInterceptor;
 import io.github.jhipster.security.uaa.LoadBalancedResourceDetails;
 
-@Configuration
 public class OAuth2InterceptedFeignConfiguration {
 
     private final LoadBalancedResourceDetails loadBalancedResourceDetails;

--- a/generators/server/templates/src/main/java/package/client/OAuth2UserClientFeignConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/client/OAuth2UserClientFeignConfiguration.java.ejs
@@ -21,11 +21,9 @@ package <%=packageName%>.client;
 import java.io.IOException;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import feign.RequestInterceptor;
 
-@Configuration
 public class OAuth2UserClientFeignConfiguration {
 
     @Bean(name = "userFeignClientInterceptor")

--- a/generators/server/templates/src/main/java/package/client/OAuth2_UserFeignClientInterceptor.java.ejs
+++ b/generators/server/templates/src/main/java/package/client/OAuth2_UserFeignClientInterceptor.java.ejs
@@ -22,12 +22,10 @@ import org.springframework.security.core.Authentication;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.oauth2.provider.authentication.OAuth2AuthenticationDetails;
-import org.springframework.stereotype.Component;
 
 import feign.RequestInterceptor;
 import feign.RequestTemplate;
 
-@Component
 public class UserFeignClientInterceptor implements RequestInterceptor{
 
     private static final String AUTHORIZATION_HEADER = "Authorization";


### PR DESCRIPTION
Fix #7756 

I left the `@Component` annotation on the `JWT_UserFeignClientInterceptor.java` because it is not declared as a bean like `OAuth2_UserFeignClientInterceptor.java`, not sure if that matters.  That class is copied for jwt microservices only

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
