### PR TITLE
update the gitlab ci deprecated variable

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -22,7 +22,7 @@ image: openjdk:8
 
 <%_ if (buildTool === 'gradle') { _%>
 cache:
-    key: "$CI_BUILD_REF_NAME"
+    key: "$CI_COMMIT_REF_NAME"
     paths:
         - node_modules
         - .gradle/wrapper

--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -30,7 +30,7 @@ cache:
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
 cache:
-    key: "$CI_BUILD_REF_NAME"
+    key: "$CI_COMMIT_REF_NAME"
     paths:
         - node_modules
         - .maven


### PR DESCRIPTION
Currently jhipster is using deprecated CI variable.
[https://docs.gitlab.com/ee/ci/variables/#9-0-renaming](https://docs.gitlab.com/ee/ci/variables/#9-0-renaming)
This PR will update to use recommended one.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed