### PR TITLE
7791 images are not found when referenced from content folder

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -55,7 +55,7 @@ module.exports = (options) => ({
             },
             {
                 test: /\.(jpe?g|png|gif|svg|woff2?|ttf|eot)$/i,
-                loaders: ['file-loader?hash=sha512&digest=hex&name=content/[hash].[ext]']
+                loaders: ['file-loader?hash=sha512&digest=hex&name=/content/[hash].[ext]']
             },
             {
                 test: /manifest.webapp$/,


### PR DESCRIPTION
Assets places in the images folder referenced from css in the content folder will result in error not found for these assets
Issue : 7791

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed


