### PR TITLE
Jest junit

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -77,7 +77,7 @@ gradle-front-test:
         <%_ } _%>
     artifacts:
         paths:
-            - build/test-results/karma/*
+            - build/test-results/jest/*
     <%_ } _%>
 gradle-repackage:
     stage: package
@@ -129,7 +129,7 @@ maven-front-test:
         <%_ } _%>
     artifacts:
         paths:
-            - target/test-results/karma/*
+            - target/test-results/jest/*
     <%_ } _%>
     <%_ if (heroku.includes('gitlab')) { _%>
 maven-deploy:

--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -81,7 +81,7 @@ node {
 <%= indent %>        } catch(err) {
 <%= indent %>            throw err
 <%= indent %>        } finally {
-<%= indent %>            junit '**/target/test-results/karma/TESTS-*.xml'
+<%= indent %>            junit '**/target/test-results/jest/TESTS-*.xml'
 <%= indent %>        }
 <%= indent %>    }
 
@@ -135,7 +135,7 @@ node {
 <%= indent %>        } catch(err) {
 <%= indent %>            throw err
 <%= indent %>        } finally {
-<%= indent %>            junit '**/build/test-results/karma/TESTS-*.xml'
+<%= indent %>            junit '**/build/test-results/jest/TESTS-*.xml'
 <%= indent %>        }
 <%= indent %>    }
 

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -85,6 +85,7 @@
     "husky": "0.14.3",
     <%_ } _%>
     "jest": "22.4.3",
+    "jest-junit": "5.0.0",
     "jest-preset-angular": "5.2.2",
     <%_ if (protractorTests) { _%>
     "jasmine-reporters": "2.2.1",

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -1,7 +1,7 @@
 module.exports = {
     preset: 'jest-preset-angular',
     setupTestFrameworkScriptFile: '<rootDir>/src/test/javascript/jest.ts',
-    coverageDirectory: '<rootDir>/target/test-results/',
+    coverageDirectory: '<rootDir>/<%= BUILD_DIR %>test-results/',
     globals: {
         'ts-jest': {
             tsConfigFile: 'tsconfig.json'
@@ -11,6 +11,10 @@ module.exports = {
     moduleNameMapper: {
         'app/(.*)': '<rootDir>/src/main/webapp/app/$1'
     },
+    reporters: [
+        'default',
+        [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/jest/TESTS-results.xml' } ]
+    ],
     transformIgnorePatterns: ['node_modules/(?!@angular/common/locales)'],
     testMatch: ['<rootDir>/src/test/javascript/spec/**/+(*.)+(spec.ts)'],
     rootDir: '../../../'

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -103,6 +103,7 @@ limitations under the License.
     <%_ } _%>
     "image-webpack-loader": "4.2.0",
     "jest": "22.4.4",
+    "jest-junit": "5.0.0",
     <%_ if (protractorTests) { _%>
     "chai-as-promised": "7.1.1",
     <%_ } _%>

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -8,6 +8,10 @@ module.exports = {
   moduleNameMapper: {
     'app/(.*)': '<rootDir>/src/main/webapp/app/$1'
   },
+  reporters: [
+    'default',
+    [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/jest/TESTS-results.xml' } ]
+  ],
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/src/test/javascript/spec/app/modules/account/sessions/sessions.reducer.spec.ts'


### PR DESCRIPTION
I'm working on the CICD sub generator and there is a missing config for Jest, similar to what we had with Karma:
```js
        junitReporter: {
            outputFile: '../../../../<%= BUILD_DIR %>test-results/karma/TESTS-results.xml'
        },
```

Related to https://github.com/jhipster/generator-jhipster/pull/7636

_____

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
