### PR TITLE
Fix: show link to other entities with entity id == 0

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
@@ -87,7 +87,7 @@
                         <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + '.' + relationshipFieldName + '?.id' %>, 'view']">{{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}</a>
                     </div>
                     <%_ } else { _%>
-                    <div *ngIf="<%= entityInstance + '.' + relationshipFieldName + "Id" %>">
+                    <div *ngIf="<%= entityInstance + '.' + relationshipFieldName + "Id" %> !== ''">
                         <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + '.' + relationshipFieldName + "Id" %>, 'view']">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
                     </div>
                     <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
@@ -130,7 +130,7 @@
                         <a [routerLink]="['../<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "?.id" %>, 'view' ]" >{{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}</a>
                     </div>
                         <%_ } else { _%>
-                    <div *ngIf="<%= entityInstance + "." + relationshipFieldName + "Id" %>">
+                    <div *ngIf="<%= entityInstance + "." + relationshipFieldName + "Id" %> !== ''">
                         <a [routerLink]="['../<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "Id" %> %>, 'view' ]" >{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
                     </div>
                             <%_ } _%>


### PR DESCRIPTION
I found the problem on my test project: entities with id == 0 is not shown. 
I'm resolved this issue on my project using strict comparison entity id with empty string.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
