### PR TITLE
Fix Sonar Reporting for Jest

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -85,8 +85,8 @@
     "husky": "0.14.3",
     <%_ } _%>
     "jest": "22.4.3",
-    "jest-junit": "5.0.0",
     "jest-preset-angular": "5.2.2",
+    "jest-sonar-reporter": "2.0.0",
     <%_ if (protractorTests) { _%>
     "jasmine-reporters": "2.2.1",
     <%_ } _%>
@@ -174,5 +174,9 @@
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"
+  },
+  "jestSonar": {
+    "reportPath": "<%= BUILD_DIR %>test-results/jest",
+    "reportFile": "TESTS-results.xml"
   }
 }

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -12,9 +12,9 @@ module.exports = {
         'app/(.*)': '<rootDir>/src/main/webapp/app/$1'
     },
     reporters: [
-        'default',
-        [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/jest/TESTS-results.xml' } ]
+        'default'
     ],
+    testResultsProcessor: 'jest-sonar-reporter',
     transformIgnorePatterns: ['node_modules/(?!@angular/common/locales)'],
     testMatch: ['<rootDir>/src/test/javascript/spec/**/+(*.)+(spec.ts)'],
     rootDir: '../../../'

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -103,7 +103,7 @@ limitations under the License.
     <%_ } _%>
     "image-webpack-loader": "4.2.0",
     "jest": "22.4.4",
-    "jest-junit": "5.0.0",
+    "jest-sonar-reporter": "2.0.0",
     <%_ if (protractorTests) { _%>
     "chai-as-promised": "7.1.1",
     <%_ } _%>
@@ -199,5 +199,9 @@ limitations under the License.
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"
+  },
+  "jestSonar": {
+    "reportPath": "<%= BUILD_DIR %>test-results/jest",
+    "reportFile": "TESTS-results.xml"
   }
 }

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -9,9 +9,9 @@ module.exports = {
     'app/(.*)': '<rootDir>/src/main/webapp/app/$1'
   },
   reporters: [
-    'default',
-    [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/jest/TESTS-results.xml' } ]
+    'default'
   ],
+  testResultsProcessor: 'jest-sonar-reporter',
   testPathIgnorePatterns: [
     '<rootDir>/node_modules/',
     '<rootDir>/src/test/javascript/spec/app/modules/account/sessions/sessions.reducer.spec.ts'

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -140,7 +140,7 @@
         <sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey>squid:UndocumentedApi</sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey>
         <sonar.jacoco.reportPaths>${project.testresult.directory}/coverage/jacoco/jacoco.exec</sonar.jacoco.reportPaths>
         <sonar.java.codeCoveragePlugin>jacoco</sonar.java.codeCoveragePlugin>
-        <sonar.javascript.jstestdriver.reportsPath>${project.testresult.directory}/karma</sonar.javascript.jstestdriver.reportsPath>
+        <sonar.testExecutionReportPaths>${project.testresult.directory}/jest/TESTS-results.xml</sonar.testExecutionReportPaths>
         <sonar.typescript.lcov.reportPaths>${project.testresult.directory}/lcov.info</sonar.typescript.lcov.reportPaths>
         <sonar.sources>${project.basedir}/<%= MAIN_DIR %></sonar.sources>
         <sonar.surefire.reportsPath>${project.testresult.directory}/surefire-reports</sonar.surefire.reportsPath>


### PR DESCRIPTION
It seems that sonar wasn't seeing the front unit tests, they probably changed their XML format. @jdubois pointed that to me, thanks !

I couldn't find a way to externalize the jestSonar config so I put it in the package.json file as the [doc](https://github.com/3dmind/jest-sonar-reporter) says...

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
