### PR TITLE
Improve error message when Heroku CLI is not installed

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -154,8 +154,8 @@ module.exports = class extends BaseGenerator {
 
                 exec('heroku --version', (err) => {
                     if (err) {
-                        this.log.error('You don\'t have the Heroku Toolbelt installed. ' +
-                            'Download it from https://toolbelt.heroku.com/');
+                        this.log.error('You don\'t have the Heroku CLI installed. ' +
+                            'Download it from https://cli.heroku.com/');
                         this.abort = true;
                     }
                     done();


### PR DESCRIPTION
The term "toolbelt" is no longer used by Heroku.