### PR TITLE
Improvements to Heroku deploy in CI/CD generator

### DIFF
--- a/generators/ci-cd/prompts.js
+++ b/generators/ci-cd/prompts.js
@@ -136,7 +136,7 @@ function askIntegrations() {
             when: (this.pipelines.includes('jenkins') || this.pipelines.includes('gitlab') || this.pipelines.includes('circle') || this.pipelines.includes('travis')) && this.herokuAppName,
             type: 'checkbox',
             name: 'heroku',
-            message: 'Deploy to heroku?',
+            message: 'Deploy to heroku (requires HEROKU_API_KEY set on CI service)?',
             default: [],
             choices: herokuChoices
         }

--- a/generators/ci-cd/templates/circle.yml.ejs
+++ b/generators/ci-cd/templates/circle.yml.ejs
@@ -67,7 +67,7 @@ test:
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
     <%_ if (heroku.includes('circle')) { _%>
-        - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+        - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
     <%_ } else { _%>
         - ./mvnw verify -Pprod -DskipTests
     <%_ } _%>

--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -88,7 +88,7 @@ node {
     <%_ } _%>
     <%_ if (heroku.includes('jenkins')) { _%>
 <%= indent %>    stage('package and deploy') {
-<%= indent %>        sh "./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
+<%= indent %>        sh "./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
     <%_ } else { _%>
 <%= indent %>    stage('packaging') {
 <%= indent %>        sh "./mvnw verify -Pprod -DskipTests"

--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -83,7 +83,7 @@ script:
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
   <%_ if (heroku.includes('travis')) { _%>
-  - ./mvnw com.heroku.sdk:heroku-maven-plugin:1.1.1:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+  - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
   <%_ } else { _%>
   - ./mvnw verify -Pprod -DskipTests
   <%_ } _%>


### PR DESCRIPTION
Fixes #7821 

I was hoping we could automatically set the env var, but that was too optimistic. We would have to require the `travis` CLI be installed, and such.

Includes a bump to the heroku-maven-plugin version.