### PR TITLE
Fix jhlang and react rtl support

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/config/translation.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/translation.ts.ejs
@@ -27,35 +27,30 @@ const mergeTranslations = requireContext => requireContext.keys().reduce(
   {}
 );
 
-// tslint:disable:object-literal-key-quotes
-const translations = {
-<%_ languages.forEach((lang, index) => { _%>
-   '<%= lang %>': mergeTranslations(require.context('../../i18n/<%= lang %>', false, /.json$/))<%= index !== languages.length - 1 ? ',' : '' %>
-<%_ }); _%>
-};
-// tslint:enable
-
 let currentLocale;
 const savedLocale = Storage.session.get('locale', '<%= nativeLanguage %>');
 TranslatorContext.setDefaultLocale('<%= nativeLanguage %>');
 TranslatorContext.setRenderInnerTextForMissingKeys(false);
 
-<%_ if(enableI18nRTL) { _%>
 const languages: any = {
   <%_ getAllSupportedLanguageOptions().filter(lang => languages.includes(lang.value)).forEach((ln, i) => { _%>
-    '<%= ln.value %>': { name: '<%= ln.dispName %>', rtl: <%= ln.rtl || false %> }<%= i !== languages.length - 1 ? ',' : '' %>
+  '<%= ln.value %>': {
+    name: '<%= ln.dispName %>',
+    translation: (mergeTranslations(require.context('../../i18n/<%= ln.value %>', false, /.json$/))),
+    rtl: <%= ln.rtl || false %> }<%= i !== languages.length - 1 ? ',' : '' %>
   <%_ }); _%>
   // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
 };
 
+<%_ if(enableI18nRTL) { _%>
 export const isRTL = (lang: string): boolean => languages[lang] && languages[lang].rtl;
 <%_ } _%>
 
-export const locales = Object.keys(translations);
+export const locales = Object.keys(languages);
 
 export const registerLocales = store => {
   locales.forEach(key => {
-    TranslatorContext.registerTranslations(key, translations[key]);
+    TranslatorContext.registerTranslations(key, languages[key].translation);
   });
   store.subscribe(() => {
     const previousLocale = currentLocale;

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
@@ -63,7 +63,7 @@ export const Home = props => (
   <NavItem>
     <NavLink tag={Link} to="/" className="d-flex align-items-center">
       <FontAwesomeIcon icon="home" />
-      <span>Home</span>
+      <span><Translate contentKey="global.menu.home" /></span>
     </NavLink>
   </NavItem>
 );

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/account.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/account.tsx.ejs
@@ -22,37 +22,39 @@ import {
 } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { NavLink as Link } from 'react-router-dom';
+import { Translate, translate } from 'react-jhipster';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { getLoginUrl } from 'app/shared/util/url-utils';
 <%_ } _%>
 import { NavDropdown } from '../header-components';
 
+
 const accountMenuItemsAuthenticated = (
   <>
   <%_ if (authenticationType !== 'oauth2') { _%>
-    <DropdownItem tag={Link} to="/account/settings"><FontAwesomeIcon icon="wrench" /> Settings</DropdownItem>
-    <DropdownItem tag={Link} to="/account/password"><FontAwesomeIcon icon="clock" /> Password</DropdownItem>
+    <DropdownItem tag={Link} to="/account/settings"><FontAwesomeIcon icon="wrench" /> <Translate contentKey="global.menu.account.settings" /></DropdownItem>
+    <DropdownItem tag={Link} to="/account/password"><FontAwesomeIcon icon="clock" /> <Translate contentKey="global.menu.admin.password" /></DropdownItem>
   <%_ } _%>
   <%_ if (authenticationType === 'session') { _%>
-    <DropdownItem tag={Link} to="/account/sessions"><FontAwesomeIcon icon="cloud" /> Sessions</DropdownItem>
+    <DropdownItem tag={Link} to="/account/sessions"><FontAwesomeIcon icon="cloud" /> <Translate contentKey="global.menu.account.sessions" /></DropdownItem>
   <%_ } _%>
-    <DropdownItem tag={Link} to="/logout"><FontAwesomeIcon icon="sign-out-alt" /> Logout</DropdownItem>
+    <DropdownItem tag={Link} to="/logout"><FontAwesomeIcon icon="sign-out-alt" /> <Translate contentKey="global.menu.account.logout" /></DropdownItem>
   </>
   );
 
 const accountMenuItems = (
   <>
   <%_ if (authenticationType !== 'oauth2') { _%>
-    <DropdownItem id="login-item" tag={Link} to="/login"><FontAwesomeIcon icon="sign-in-alt" /> Login</DropdownItem>
-    <DropdownItem tag={Link} to="/register"><FontAwesomeIcon icon="sign-in-alt" /> Register</DropdownItem>
+    <DropdownItem id="login-item" tag={Link} to="/login"><FontAwesomeIcon icon="sign-in-alt" /> <Translate contentKey="global.menu.account.login" /></DropdownItem>
+    <DropdownItem tag={Link} to="/register"><FontAwesomeIcon icon="sign-in-alt" /> <Translate contentKey="global.menu.account.register" /></DropdownItem>
   <%_ } else { _%>
-    <DropdownItem id="login-item" tag="a" href={getLoginUrl()}><FontAwesomeIcon icon="sign-in-alt" /> Login</DropdownItem>
+    <DropdownItem id="login-item" tag="a" href={getLoginUrl()}><FontAwesomeIcon icon="sign-in-alt" /> <Translate contentKey="global.menu.account.login" /></DropdownItem>
   <%_ } _%>
   </>
 );
 
 export const AccountMenu = ({ isAuthenticated = false }) => (
-  <NavDropdown icon="user" name="Account" id="account-menu">
+  <NavDropdown icon="user" name={translate('global.menu.account.main')} id="account-menu">
     {isAuthenticated ? accountMenuItemsAuthenticated : accountMenuItems}
   </NavDropdown>
 );

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/admin.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/admin.tsx.ejs
@@ -23,45 +23,46 @@ import {
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
 import { NavLink as Link } from 'react-router-dom';
 import { NavDropdown } from '../header-components';
+import { Translate, translate } from 'react-jhipster';
 
 const adminMenuItems = (
   <>
   <%_ if (applicationType === 'gateway') { _%>
-    <DropdownItem tag={Link} to="/admin/gateway"><FontAwesomeIcon icon="road" /> Gateway</DropdownItem>
+    <DropdownItem tag={Link} to="/admin/gateway"><FontAwesomeIcon icon="road" /> <Translate contentKey="global.menu.admin.gateway" /></DropdownItem>
   <%_ } _%>
   <%_ if (!skipUserManagement) { _%>
-    <DropdownItem tag={Link} to="/admin/user-management"><FontAwesomeIcon icon="user" /> User Management</DropdownItem>
+    <DropdownItem tag={Link} to="/admin/user-management"><FontAwesomeIcon icon="user" /> <Translate contentKey="global.menu.admin.userManagement" /></DropdownItem>
   <%_ } _%>
   <%_ if (websocket === 'spring-websocket') { _%>
-    <DropdownItem tag={Link} to="/admin/tracker"><FontAwesomeIcon icon="eye" /> Tracker</DropdownItem>
+    <DropdownItem tag={Link} to="/admin/tracker"><FontAwesomeIcon icon="eye" /> <Translate contentKey="global.menu.admin.tracker" /></DropdownItem>
   <%_ } _%>
-    <DropdownItem tag={Link} to="/admin/metrics"><FontAwesomeIcon icon="tachometer-alt" /> Metrics</DropdownItem>
-    <DropdownItem tag={Link} to="/admin/health"><FontAwesomeIcon icon="heart" /> Health</DropdownItem>
-    <DropdownItem tag={Link} to="/admin/configuration"><FontAwesomeIcon icon="list" /> Configuration</DropdownItem>
+    <DropdownItem tag={Link} to="/admin/metrics"><FontAwesomeIcon icon="tachometer-alt" /> <Translate contentKey="global.menu.admin.metrics" /></DropdownItem>
+    <DropdownItem tag={Link} to="/admin/health"><FontAwesomeIcon icon="heart" /> <Translate contentKey="global.menu.admin.health" /></DropdownItem>
+    <DropdownItem tag={Link} to="/admin/configuration"><FontAwesomeIcon icon="list" /> <Translate contentKey="global.menu.admin.configuration" /></DropdownItem>
     <%_ if (databaseType !== 'cassandra') { _%>
-    <DropdownItem tag={Link} to="/admin/audits"><FontAwesomeIcon icon="bell" /> Audits</DropdownItem>
+    <DropdownItem tag={Link} to="/admin/audits"><FontAwesomeIcon icon="bell" /> <Translate contentKey="global.menu.admin.audits" /></DropdownItem>
     <%_ } _%>
   {/* jhipster-needle-add-element-to-admin-menu - JHipster will add entities to the admin menu here */}
-    <DropdownItem tag={Link} to="/admin/logs"><FontAwesomeIcon icon="tasks" /> Logs</DropdownItem>
+    <DropdownItem tag={Link} to="/admin/logs"><FontAwesomeIcon icon="tasks" /> <Translate contentKey="global.menu.admin.logs" /></DropdownItem>
   </>
 );
 
 const swaggerItem = (
   <DropdownItem tag={Link} to="/admin/docs">
-    <FontAwesomeIcon icon="book" /> API Docs
+    <FontAwesomeIcon icon="book" /> <Translate contentKey="global.menu.admin.apidocs" />
   </DropdownItem>
 );
 
 <% if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %>
 const databaseItem = (
   <DropdownItem tag="a" href="./h2-console" target="_tab">
-    <FontAwesomeIcon icon="hdd" /> Database
+    <FontAwesomeIcon icon="hdd" /> <Translate contentKey="global.menu.admin.database" />
   </DropdownItem>
 );
 <%_ } _%>
 
 export const AdminMenu = ({ showSwagger <% if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %>, showDatabase <%_ } _%>}) => (
-  <NavDropdown icon="user-plus" name="Administration" style={{ width: '130%' }} id="admin-menu">
+  <NavDropdown icon="user-plus" name={translate('global.menu.admin.main')} style={{ width: '140%' }} id="admin-menu">
       {adminMenuItems}
       {showSwagger && swaggerItem}
       <% if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %>

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/entities.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/entities.tsx.ejs
@@ -21,12 +21,13 @@ import {
   DropdownItem
 } from 'reactstrap';
 import FontAwesomeIcon from '@fortawesome/react-fontawesome';
+import { translate } from 'react-jhipster';
 import { NavLink as Link } from 'react-router-dom';
 import { NavDropdown } from '../header-components';
 
 export const EntitiesMenu = props => (
   // tslint:disable-next-line:jsx-self-close
-  <NavDropdown icon="th-list" name="Entities" id="entity-menu">
+  <NavDropdown icon="th-list" name={translate('global.menu.entities.main')} id="entity-menu">
     {/* jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here */}
   </NavDropdown>
 );

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1060,7 +1060,7 @@ module.exports = class extends Generator {
         const selectedLangs = this.getAllSupportedLanguageOptions().filter(lang => languages.includes(lang.value));
         if (clientFramework === 'react') {
             return selectedLangs.map(lang =>
-                `'${lang.value}': { name: '${lang.dispName}', translation: (mergeTranslations(require.context('../../i18n/${lang.value}', false, /.json$/))),${lang.rtl ? ', rtl: true' : ''} }`);
+                `'${lang.value}': { name: '${lang.dispName}', translation: (mergeTranslations(require.context('../../i18n/${lang.value}', false, /.json$/)))${lang.rtl ? ', rtl: true' : ''} }`);
         }
 
         return selectedLangs.map(lang => `'${lang.value}': { name: '${lang.dispName}'${lang.rtl ? ', rtl: true' : ''} }`);

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -211,13 +211,14 @@ module.exports = class extends Generator {
      * @param languages
      */
     updateLanguagesInLanguagePipe(languages) {
-        if (this.clientFramework !== 'angularX') {
+        if (!['angularX', 'react'].includes(this.clientFramework)) {
             return;
         }
-        const fullPath = `${CLIENT_MAIN_SRC_DIR}app/shared/language/find-language-from-key.pipe.ts`;
+
+        const fullPath = this.clientFramework === 'angularX' ? `${CLIENT_MAIN_SRC_DIR}app/shared/language/find-language-from-key.pipe.ts` : `${CLIENT_MAIN_SRC_DIR}/app/config/translation.ts`;
         try {
             let content = '{\n';
-            this.generateLanguageOptions(languages).forEach((ln, i) => {
+            this.generateLanguageOptions(languages, this.clientFramework).forEach((ln, i) => {
                 content += `        ${ln}${i !== languages.length - 1 ? ',' : ''}\n`;
             });
             content +=
@@ -1055,8 +1056,13 @@ module.exports = class extends Generator {
      * @param {string[]} languages
      * @returns generated language options
      */
-    generateLanguageOptions(languages) {
+    generateLanguageOptions(languages, clientFramework) {
         const selectedLangs = this.getAllSupportedLanguageOptions().filter(lang => languages.includes(lang.value));
+        if (clientFramework === 'react') {
+            return selectedLangs.map(lang =>
+                `'${lang.value}': { name: '${lang.dispName}', translation: (mergeTranslations(require.context('../../i18n/${lang.value}', false, /.json$/))),${lang.rtl ? ', rtl: true' : ''} }`);
+        }
+
         return selectedLangs.map(lang => `'${lang.value}': { name: '${lang.dispName}'${lang.rtl ? ', rtl: true' : ''} }`);
     }
 

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -170,7 +170,8 @@ module.exports = class extends BaseGenerator {
 
             saveConfig() {
                 if (this.enableTranslation) {
-                    this.config.set('languages', _.union(this.currentLanguages, this.languagesToApply));
+                    this.languages = _.union(this.currentLanguages, this.languagesToApply);
+                    this.config.set('languages', this.languages);
                 }
             }
         };
@@ -188,14 +189,14 @@ module.exports = class extends BaseGenerator {
             insight.track('languages/language', language);
         });
         if (!this.skipClient) {
-            this.updateLanguagesInLanguagePipe(this.config.get('languages'));
-            this.updateLanguagesInLanguageConstantNG2(this.config.get('languages'));
-            this.updateLanguagesInWebpack(this.config.get('languages'));
+            this.updateLanguagesInLanguagePipe(this.languages);
+            this.updateLanguagesInLanguageConstantNG2(this.languages);
+            this.updateLanguagesInWebpack(this.languages);
             if (this.clientFramework === 'angularX') {
-                this.updateLanguagesInMomentWebpackNgx(this.config.get('languages'));
+                this.updateLanguagesInMomentWebpackNgx(this.languages);
             }
             if (this.clientFramework === 'react') {
-                this.updateLanguagesInMomentWebpackReact(this.config.get('languages'));
+                this.updateLanguagesInMomentWebpackReact(this.languages);
             }
         }
     }


### PR DESCRIPTION
fix #7786 
For some reason, in the languages sub-gen, `this.config.set('languages', _.union(this.currentLanguages, this.languagesToApply));` was not updating languages during the generation but after. It was preventing the subgen to properly add the new desired language.

On the other side, RTL support was a bit messed up for React. I fixed it because it was preventing the needle from being printed in the file when there was no RTL languages selected.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
