### PR TITLE
React: add missing generator-jhipster dependencies

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -97,6 +97,7 @@ limitations under the License.
     "extract-text-webpack-plugin": "4.0.0-beta.0",
     "file-loader": "1.1.11",
     "fork-ts-checker-webpack-plugin": "0.4.1",
+    "generator-jhipster": "<%= packagejs.version %>",
     "html-webpack-plugin": "3.1.0",
     "http-proxy-middleware": "0.18.0",
     "identity-obj-proxy": "3.0.0",


### PR DESCRIPTION
Without this change, for React application, it will use the global version of JHipster

_____

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
