### PR TITLE
create jwt-secret.yml for apps not using ingress or service discovery [k8s]

### DIFF
--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -38,9 +38,9 @@ function writeFiles() {
                 }
                 if ((this.app.applicationType === 'gateway' || this.app.applicationType === 'monolith') && this.kubernetesServiceType === 'Ingress') {
                     this.template('ingress.yml.ejs', `${appName}/${appName}-ingress.yml`);
-                    if (!this.app.serviceDiscoveryType && this.app.authenticationType === 'jwt') {
-                        this.template('secret/jwt-secret.yml.ejs', `${appName}/jwt-secret.yml`);
-                    }
+                }
+                if (!this.app.serviceDiscoveryType && this.app.authenticationType === 'jwt') {
+                    this.template('secret/jwt-secret.yml.ejs', `${appName}/jwt-secret.yml`);
                 }
                 if (this.monitoring === 'prometheus') {
                     this.template('monitoring/jhipster-prometheus-sm.yml.ejs', `${appName}/${appName}-prometheus-sm.yml`);


### PR DESCRIPTION
Any JWT apps not using service-discovery need this file for Kubernetes to deploy correctly ([used here](https://github.com/jhipster/generator-jhipster/blob/master/generators/kubernetes/templates/deployment.yml.ejs#L104-L110))

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
