### PR TITLE
set config at once to ensure updates are saved

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -326,23 +326,26 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('jhipsterVersion', packagejs.version);
-                this.config.set('applicationType', this.applicationType);
-                this.config.set('baseName', this.baseName);
-                this.config.set('testFrameworks', this.testFrameworks);
-                this.config.set('jhiPrefix', this.jhiPrefix);
-                this.config.set('skipCheckLengthOfIdentifier', this.skipCheckLengthOfIdentifier);
-                this.config.set('otherModules', this.otherModules);
-                this.config.set('enableTranslation', this.enableTranslation);
+                const config = {
+                    jhipsterVersion: packagejs.version,
+                    applicationType: this.applicationType,
+                    baseName: this.baseName,
+                    testFrameworks: this.testFrameworks,
+                    jhiPrefix: this.jhiPrefix,
+                    skipCheckLengthOfIdentifier: this.skipCheckLengthOfIdentifier,
+                    otherModules: this.otherModules,
+                    enableTranslation: this.enableTranslation,
+                    clientPackageManager: this.clientPackageManager
+                };
                 if (this.enableTranslation) {
-                    this.config.set('nativeLanguage', this.nativeLanguage);
-                    this.config.set('languages', this.languages);
+                    config.nativeLanguage = this.nativeLanguage;
+                    config.languages = this.languages;
                 }
-                this.config.set('clientPackageManager', this.clientPackageManager);
-                this.blueprint && this.config.set('blueprint', this.blueprint);
-                this.skipClient && this.config.set('skipClient', true);
-                this.skipServer && this.config.set('skipServer', true);
-                this.skipUserManagement && this.config.set('skipUserManagement', true);
+                this.blueprint && (config.blueprint = this.blueprint);
+                this.skipClient && (config.skipClient = true);
+                this.skipServer && (config.skipServer = true);
+                this.skipUserManagement && (config.skipUserManagement = true);
+                this.config.set(config);
             }
         };
     }

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -272,30 +272,33 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('jhipsterVersion', packagejs.version);
-                this.config.set('applicationType', this.applicationType);
-                this.config.set('baseName', this.baseName);
-                this.config.set('clientFramework', this.clientFramework);
-                this.config.set('useSass', this.useSass);
-                this.config.set('enableTranslation', this.enableTranslation);
-                this.config.set('skipCommitHook', this.skipCommitHook);
+                const config = {
+                    jhipsterVersion: packagejs.version,
+                    applicationType: this.applicationType,
+                    baseName: this.baseName,
+                    clientFramework: this.clientFramework,
+                    useSass: this.useSass,
+                    enableTranslation: this.enableTranslation,
+                    skipCommitHook: this.skipCommitHook,
+                    clientPackageManager: this.clientPackageManager
+                };
                 if (this.enableTranslation && !this.configOptions.skipI18nQuestion) {
-                    this.config.set('nativeLanguage', this.nativeLanguage);
-                    this.config.set('languages', this.languages);
+                    config.nativeLanguage = this.nativeLanguage;
+                    config.languages = this.languages;
                 }
-                this.config.set('clientPackageManager', this.clientPackageManager);
                 if (this.skipServer) {
-                    this.authenticationType && this.config.set('authenticationType', this.authenticationType);
-                    this.uaaBaseName && this.config.set('uaaBaseName', this.uaaBaseName);
-                    this.cacheProvider && this.config.set('cacheProvider', this.cacheProvider);
-                    this.enableHibernateCache && this.config.set('enableHibernateCache', this.enableHibernateCache);
-                    this.websocket && this.config.set('websocket', this.websocket);
-                    this.databaseType && this.config.set('databaseType', this.databaseType);
-                    this.devDatabaseType && this.config.set('devDatabaseType', this.devDatabaseType);
-                    this.prodDatabaseType && this.config.set('prodDatabaseType', this.prodDatabaseType);
-                    this.searchEngine && this.config.set('searchEngine', this.searchEngine);
-                    this.buildTool && this.config.set('buildTool', this.buildTool);
+                    this.authenticationType && (config.authenticationType = this.authenticationType);
+                    this.uaaBaseName && (config.uaaBaseName = this.uaaBaseName);
+                    this.cacheProvider && (config.cacheProvider = this.cacheProvider);
+                    this.enableHibernateCache && (config.enableHibernateCache = this.enableHibernateCache);
+                    this.websocket && (config.websocket = this.websocket);
+                    this.databaseType && (config.databaseType = this.databaseType);
+                    this.devDatabaseType && (config.devDatabaseType = this.devDatabaseType);
+                    this.prodDatabaseType && (config.prodDatabaseType = this.prodDatabaseType);
+                    this.searchEngine && (config.searchEngine = this.searchEngine);
+                    this.buildTool && (config.buildTool = this.buildTool);
                 }
+                this.config.set(config);
             }
         };
     }

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -272,15 +272,17 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('appsFolders', this.appsFolders);
-                this.config.set('directoryPath', this.directoryPath);
-                this.config.set('gatewayType', this.gatewayType);
-                this.config.set('clusteredDbApps', this.clusteredDbApps);
-                this.config.set('monitoring', this.monitoring);
-                this.config.set('consoleOptions', this.consoleOptions);
-                this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
-                this.config.set('adminPassword', this.adminPassword);
-                this.config.set('jwtSecretKey', this.jwtSecretKey);
+                this.config.set({
+                    appsFolders: this.appsFolders,
+                    directoryPath: this.directoryPath,
+                    gatewayType: this.gatewayType,
+                    clusteredDbApps: this.clusteredDbApps,
+                    monitoring: this.monitoring,
+                    consoleOptions: this.consoleOptions,
+                    serviceDiscoveryType: this.serviceDiscoveryType,
+                    adminPassword: this.adminPassword,
+                    jwtSecretKey: this.jwtSecretKey
+                });
             }
         };
     }

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -591,17 +591,19 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('gcpProjectId', this.gcpProjectId);
-                this.config.set('gcpCloudSqlInstanceName', this.gcpCloudSqlInstanceName);
-                this.config.set('gcpCloudSqlUserName', this.gcpCloudSqlUserName);
-                this.config.set('gcpCloudSqlDatabaseName', this.gcpDatabaseName);
-                this.config.set('gaeServiceName', this.gaeServiceName);
-                this.config.set('gaeLocation', this.gaeLocation);
-                this.config.set('gaeInstanceClass', this.gaeInstanceClass);
-                this.config.set('gaeScalingType', this.gaeScalingType);
-                this.config.set('gaeInstances', this.gaeInstances);
-                this.config.set('gaeMinInstances', this.gaeMinInstances);
-                this.config.set('gaeMaxInstances', this.gaeMaxInstances);
+                this.config.set({
+                    gcpProjectId: this.gcpProjectId,
+                    gcpCloudSqlInstanceName: this.gcpCloudSqlInstanceName,
+                    gcpCloudSqlUserName: this.gcpCloudSqlUserName,
+                    gcpCloudSqlDatabaseName: this.gcpDatabaseName,
+                    gaeServiceName: this.gaeServiceName,
+                    gaeLocation: this.gaeLocation,
+                    gaeInstanceClass: this.gaeInstanceClass,
+                    gaeScalingType: this.gaeScalingType,
+                    gaeInstances: this.gaeInstances,
+                    gaeMinInstances: this.gaeMinInstances,
+                    gaeMaxInstances: this.gaeMaxInstances
+                });
             }
         };
     }

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -174,19 +174,21 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('appsFolders', this.appsFolders);
-                this.config.set('directoryPath', this.directoryPath);
-                this.config.set('clusteredDbApps', this.clusteredDbApps);
-                this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
-                this.config.set('jwtSecretKey', this.jwtSecretKey);
-                this.config.set('dockerRepositoryName', this.dockerRepositoryName);
-                this.config.set('dockerPushCommand', this.dockerPushCommand);
-                this.config.set('kubernetesNamespace', this.kubernetesNamespace);
-                this.config.set('kubernetesServiceType', this.kubernetesServiceType);
-                this.config.set('ingressDomain', this.ingressDomain);
-                this.config.set('monitoring', this.monitoring);
-                this.config.set('istio', this.istio);
-                this.config.set('istioRoute', this.istioRoute);
+                this.config.set({
+                    appsFolders: this.appsFolders,
+                    directoryPath: this.directoryPath,
+                    clusteredDbApps: this.clusteredDbApps,
+                    serviceDiscoveryType: this.serviceDiscoveryType,
+                    jwtSecretKey: this.jwtSecretKey,
+                    dockerRepositoryName: this.dockerRepositoryName,
+                    dockerPushCommand: this.dockerPushCommand,
+                    kubernetesNamespace: this.kubernetesNamespace,
+                    kubernetesServiceType: this.kubernetesServiceType,
+                    ingressDomain: this.ingressDomain,
+                    monitoring: this.monitoring,
+                    istio: this.istio,
+                    istioRoute: this.istioRoute
+                });
             }
         };
     }

--- a/generators/openshift/index.js
+++ b/generators/openshift/index.js
@@ -175,17 +175,19 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('appsFolders', this.appsFolders);
-                this.config.set('directoryPath', this.directoryPath);
-                this.config.set('clusteredDbApps', this.clusteredDbApps);
-                this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
-                this.config.set('monitoring', this.monitoring);
-                this.config.set('jwtSecretKey', this.jwtSecretKey);
-                this.config.set('dockerRepositoryName', this.dockerRepositoryName);
-                this.config.set('dockerPushCommand', this.dockerPushCommand);
-                this.config.set('openshiftNamespace', this.openshiftNamespace);
-                this.config.set('storageType', this.storageType);
-                this.config.set('registryReplicas', this.registryReplicas);
+                this.config.set({
+                    appsFolders: this.appsFolders,
+                    directoryPath: this.directoryPath,
+                    clusteredDbApps: this.clusteredDbApps,
+                    serviceDiscoveryType: this.serviceDiscoveryType,
+                    monitoring: this.monitoring,
+                    jwtSecretKey: this.jwtSecretKey,
+                    dockerRepositoryName: this.dockerRepositoryName,
+                    dockerPushCommand: this.dockerPushCommand,
+                    openshiftNamespace: this.openshiftNamespace,
+                    storageType: this.storageType,
+                    registryReplicas: this.registryReplicas
+                });
             }
         };
     }

--- a/generators/rancher-compose/index.js
+++ b/generators/rancher-compose/index.js
@@ -256,15 +256,17 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('appsFolders', this.appsFolders);
-                this.config.set('directoryPath', this.directoryPath);
-                this.config.set('monitoring', this.monitoring);
-                this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
-                this.config.set('adminPassword', this.adminPassword);
-                this.config.set('jwtSecretKey', this.jwtSecretKey);
-                this.config.set('dockerRepositoryName', this.dockerRepositoryName);
-                this.config.set('dockerPushCommand', this.dockerPushCommand);
-                this.config.set('enableRancherLoadBalancing', this.enableRancherLoadBalancing);
+                this.config.set({
+                    appsFolders: this.appsFolders,
+                    directoryPath: this.directoryPath,
+                    monitoring: this.monitoring,
+                    serviceDiscoveryType: this.serviceDiscoveryType,
+                    adminPassword: this.adminPassword,
+                    jwtSecretKey: this.jwtSecretKey,
+                    dockerRepositoryName: this.dockerRepositoryName,
+                    dockerPushCommand: this.dockerPushCommand,
+                    enableRancherLoadBalancing: this.enableRancherLoadBalancing
+                });
             }
         };
     }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -371,32 +371,35 @@ module.exports = class extends BaseGenerator {
             },
 
             saveConfig() {
-                this.config.set('jhipsterVersion', packagejs.version);
-                this.config.set('applicationType', this.applicationType);
-                this.config.set('baseName', this.baseName);
-                this.config.set('packageName', this.packageName);
-                this.config.set('packageFolder', this.packageFolder);
-                this.config.set('serverPort', this.serverPort);
-                this.config.set('authenticationType', this.authenticationType);
-                this.config.set('uaaBaseName', this.uaaBaseName);
-                this.config.set('cacheProvider', this.cacheProvider);
-                this.config.set('enableHibernateCache', this.enableHibernateCache);
-                this.config.set('websocket', this.websocket);
-                this.config.set('databaseType', this.databaseType);
-                this.config.set('devDatabaseType', this.devDatabaseType);
-                this.config.set('prodDatabaseType', this.prodDatabaseType);
-                this.config.set('searchEngine', this.searchEngine);
-                this.config.set('messageBroker', this.messageBroker);
-                this.config.set('serviceDiscoveryType', this.serviceDiscoveryType);
-                this.config.set('buildTool', this.buildTool);
-                this.config.set('enableSwaggerCodegen', this.enableSwaggerCodegen);
-                this.config.set('jwtSecretKey', this.jwtSecretKey);
-                this.config.set('rememberMeKey', this.rememberMeKey);
-                this.config.set('enableTranslation', this.enableTranslation);
+                const config = {
+                    jhipsterVersion: packagejs.version,
+                    applicationType: this.applicationType,
+                    baseName: this.baseName,
+                    packageName: this.packageName,
+                    packageFolder: this.packageFolder,
+                    serverPort: this.serverPort,
+                    authenticationType: this.authenticationType,
+                    uaaBaseName: this.uaaBaseName,
+                    cacheProvider: this.cacheProvider,
+                    enableHibernateCache: this.enableHibernateCache,
+                    websocket: this.websocket,
+                    databaseType: this.databaseType,
+                    devDatabaseType: this.devDatabaseType,
+                    prodDatabaseType: this.prodDatabaseType,
+                    searchEngine: this.searchEngine,
+                    messageBroker: this.messageBroker,
+                    serviceDiscoveryType: this.serviceDiscoveryType,
+                    buildTool: this.buildTool,
+                    enableSwaggerCodegen: this.enableSwaggerCodegen,
+                    jwtSecretKey: this.jwtSecretKey,
+                    rememberMeKey: this.rememberMeKey,
+                    enableTranslation: this.enableTranslation
+                };
                 if (this.enableTranslation && !this.configOptions.skipI18nQuestion) {
-                    this.config.set('nativeLanguage', this.nativeLanguage);
-                    this.config.set('languages', this.languages);
+                    config.nativeLanguage = this.nativeLanguage;
+                    config.languages = this.languages;
                 }
+                this.config.set(config);
             }
         };
     }


### PR DESCRIPTION
Weird issue - when you change your answers on the second run of a generator, the config isn't saved. 
 Saving the config items at once instead of separately updates the `.yo-rc.json` with the new prompt answers, I went ahead and changed it everywhere to be consistent.  Not sure why this works and setting individually doesn't work

Steps to reproduce:
 - Generate a monolith (use `--skip-install` for faster generation)
 - Make docker-compose config directory
 - Run `jhipster docker-compose` to generate Docker Compose config, choosing any options
 - Re-run `jhipster docker-compose` and change any of the prompt answers
 - Check the `.yo-rc.json` and see the new choices aren't saved


Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
