### PR TITLE
Lazy load locale specific i18n bundles

### DIFF
--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -422,6 +422,13 @@ const files = {
             ]
         },
         {
+            condition: generator => generator.enableTranslation,
+            path: TEST_SRC_DIR,
+            templates: [
+                'spec/app/shared/reducers/locale.spec.ts'
+            ]
+        },
+        {
             condition: generator => generator.skipUserManagement,
             path: TEST_SRC_DIR,
             templates: [

--- a/generators/client/templates/react/src/main/webapp/app/config/translation.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/translation.ts.ejs
@@ -16,13 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import axios from 'axios';
 import { TranslatorContext, Storage } from 'react-jhipster';
 
 import { setLocale } from 'app/shared/reducers/locale';
 
-let currentLocale;
-const savedLocale = Storage.session.get('locale', '<%= nativeLanguage %>');
 TranslatorContext.setDefaultLocale('<%= nativeLanguage %>');
 TranslatorContext.setRenderInnerTextForMissingKeys(false);
 
@@ -39,19 +36,6 @@ export const locales = Object.keys(languages).sort();
 export const isRTL = (lang: string): boolean => languages[lang] && languages[lang].rtl;
 <%_ } _%>
 
-export const registerLocales = store => {
-  locales.forEach(locale => {
-    axios.get(`/i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`).then(response => {
-      TranslatorContext.registerTranslations(locale, response.data);
-    });
-  });
-  store.subscribe(() => {
-    const previousLocale = currentLocale;
-    currentLocale = store.getState().locale.currentLocale;
-    if (previousLocale !== currentLocale) {
-      Storage.session.set('locale', currentLocale);
-      TranslatorContext.setLocale(currentLocale);
-    }
-  });
-  store.dispatch(setLocale(savedLocale));
+export const registerLocale = store => {
+  store.dispatch(setLocale(Storage.session.get('locale', '<%= nativeLanguage %>')));
 };

--- a/generators/client/templates/react/src/main/webapp/app/index.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/index.tsx.ejs
@@ -25,7 +25,7 @@ import { AppContainer } from 'react-hot-loader';
 import DevTools from './config/devtools';
 import initStore from './config/store';
 <%_ if (enableTranslation) { _%>
-import { registerLocales } from './config/translation';
+import { registerLocale } from './config/translation';
 <%_ } _%>
 import setupAxiosInterceptors from './config/axios-interceptor';
 import { clearAuthentication } from './shared/reducers/authentication';
@@ -37,7 +37,7 @@ const devTools = process.env.NODE_ENV === 'development' ? <DevTools /> : null;
 
 const store = initStore();
 <%_ if (enableTranslation) { _%>
-registerLocales(store);
+registerLocale(store);
 <%_ } _%>
 
 const actions = bindActionCreators({ clearAuthentication }, store.dispatch);

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/locale.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/locale.tsx.ejs
@@ -23,7 +23,7 @@ import { languages } from 'app/config/translation';
 
 export const LocaleMenu = ({ currentLocale, onClick }) =>
   Object.keys(languages).length > 1 && (
-    <NavDropdown icon="flag" name={languages[currentLocale].name}>
+    <NavDropdown icon="flag" name={(currentLocale ? languages[currentLocale].name : undefined)}>
       {Object.keys(languages).sort().map(lang => (
         <DropdownItem key={lang} value={lang} onClick={onClick}>
           {languages[lang].name}

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -16,12 +16,16 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+import axios from 'axios';
+
+import { TranslatorContext, Storage } from 'react-jhipster';
+
 export const ACTION_TYPES = {
   SET_LOCALE: 'locale/SET_LOCALE'
 };
 
 const initialState = {
-  currentLocale: 'en'
+  currentLocale: undefined
 };
 
 export type LocaleState =  Readonly<typeof initialState>;
@@ -29,15 +33,26 @@ export type LocaleState =  Readonly<typeof initialState>;
 export default (state: LocaleState = initialState, action): LocaleState => {
   switch (action.type) {
     case ACTION_TYPES.SET_LOCALE:
+      const currentLocale = action.locale;
+      if (state.currentLocale !== currentLocale) {
+        Storage.session.set('locale', currentLocale);
+        TranslatorContext.setLocale(currentLocale);
+      }
       return {
-        currentLocale: action.locale || initialState.currentLocale
+        currentLocale
       };
     default:
       return state;
   }
 };
 
-export const setLocale = locale => ({
-  type: ACTION_TYPES.SET_LOCALE,
-  locale
-});
+export const setLocale = locale => async dispatch => {
+  if (Object.keys(TranslatorContext.context.translations).indexOf(locale) === -1) {
+    const response = await axios.get(`/i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
+    TranslatorContext.registerTranslations(locale, response.data);
+  }
+  dispatch({
+    type: ACTION_TYPES.SET_LOCALE,
+    locale
+  });
+};

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/locale.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/locale.spec.ts.ejs
@@ -1,0 +1,61 @@
+import axios from 'axios';
+import sinon from 'sinon';
+import configureStore from 'redux-mock-store';
+import thunk from 'redux-thunk';
+import { TranslatorContext } from 'react-jhipster';
+
+import locale, { setLocale, ACTION_TYPES } from 'app/shared/reducers/locale';
+
+describe('Locale reducer tests', () => {
+  it('should return the initial state', () => {
+    const localeState = locale(undefined, {});
+    expect(localeState).toMatchObject({
+      currentLocale: undefined
+    });
+  });
+
+  it('should correctly set the first time locale', () => {
+    const localeState = locale(undefined, { type: ACTION_TYPES.SET_LOCALE, locale: 'en' });
+    expect(localeState).toMatchObject({
+      currentLocale: 'en'
+    });
+    expect(TranslatorContext.context.locale).toEqual('en');
+  });
+
+  it('should correctly detect update in current locale state', () => {
+    TranslatorContext.setLocale('en');
+    expect(TranslatorContext.context.locale).toEqual('en');
+    const localeState = locale({ currentLocale: 'en' }, { type: ACTION_TYPES.SET_LOCALE, locale: 'es' });
+    expect(localeState).toMatchObject({
+      currentLocale: 'es'
+    });
+    expect(TranslatorContext.context.locale).toEqual('es');
+  });
+
+  describe('Locale actions', () => {
+    let store;
+    beforeEach(() => {
+      store = configureStore([thunk])({});
+      axios.get = sinon.stub().returns(Promise.resolve({ key: 'value' }));
+    });
+
+    it('dispatches SET_LOCALE action for default locale', async () => {
+      TranslatorContext.setDefaultLocale('en');
+      const defaultLocale = TranslatorContext.context.defaultLocale;
+      expect(Object.keys(TranslatorContext.context.translations)).not.toContainEqual(defaultLocale);
+
+      const expectedActions = [
+        {
+          type: ACTION_TYPES.SET_LOCALE,
+          locale: defaultLocale
+        }
+      ];
+
+      await store.dispatch(setLocale(defaultLocale)).then(() => {
+        expect(store.getActions()).toEqual(expectedActions);
+        expect(TranslatorContext.context.translations).toBeDefined();
+        expect(Object.keys(TranslatorContext.context.translations)).toContainEqual(defaultLocale);
+      });
+    });
+  });
+});


### PR DESCRIPTION
- By default load default/current locale i18n bundle.
- On locale change, check if translations for changed locale are cached. If yes, use those, otherwise, fetch from server.
- Unit tests for locale reducer

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
