### PR TITLE
default to h2 for keycloak container [ci skip]

### DIFF
--- a/generators/docker-compose/templates/keycloak.yml.ejs
+++ b/generators/docker-compose/templates/keycloak.yml.ejs
@@ -26,6 +26,7 @@ services:
     environment:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin
+      - DB_VENDOR=h2
     ports:
       - 9080:9080
       - 9443:9443

--- a/generators/server/templates/src/main/docker/keycloak.yml.ejs
+++ b/generators/server/templates/src/main/docker/keycloak.yml.ejs
@@ -26,6 +26,7 @@ services:
     environment:
       - KEYCLOAK_USER=admin
       - KEYCLOAK_PASSWORD=admin
+      - DB_VENDOR=h2
     ports:
       - 9080:9080
       - 9443:9443


### PR DESCRIPTION
Keycloak's vendor database detection is broken as of v4 (from https://github.com/jboss-dockerfiles/keycloak/pull/119), [this section](https://github.com/jboss-dockerfiles/keycloak/pull/119/files#diff-d0463d5d7460c28597180b6a29b001b8R20) always defaults to postgresql instead of h2

This is a workaround to set h2 by default so the Keycloak docker-compose file we provide doesn't crash on startup.

Mentioned in #7865

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
