### PR TITLE
only allow no-db for non-oauth ms and uaa gway

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -168,7 +168,8 @@ function askForServerSideOpts(meta) {
                     }
                 ];
                 if (
-                    applicationType === 'microservice' || (response.authenticationType === 'jwt' && applicationType === 'gateway')
+                    (response.authenticationType !== 'oauth2' && applicationType === 'microservice')
+                    || (response.authenticationType === 'uaa' && applicationType === 'gateway')
                 ) {
                     opts.push({
                         value: 'no',


### PR DESCRIPTION
This prevents generation of projects that don't compile

Fix #7669
Fix #7889 

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
