### PR TITLE
avoid double suffixes in service/controller subgenerators

### DIFF
--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -106,8 +106,8 @@ module.exports = class extends BaseGenerator {
     _writing() {
         return {
             writing() {
-                this.controllerClass = _.upperFirst(this.name);
-                this.controllerInstance = _.lowerFirst(this.name);
+                this.controllerClass = _.upperFirst(this.name) + (this.name.endsWith('Resource') ? '' : 'Resource');
+                this.controllerInstance = _.lowerFirst(this.controllerClass);
                 this.apiPrefix = _.kebabCase(this.name);
 
                 if (this.controllerActions.length === 0) {
@@ -138,12 +138,12 @@ module.exports = class extends BaseGenerator {
 
                 this.template(
                     `${SERVER_MAIN_SRC_DIR}package/web/rest/Resource.java.ejs`,
-                    `${SERVER_MAIN_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}Resource.java`
+                    `${SERVER_MAIN_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}.java`
                 );
 
                 this.template(
                     `${SERVER_TEST_SRC_DIR}package/web/rest/ResourceIntTest.java.ejs`,
-                    `${SERVER_TEST_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}ResourceIntTest.java`
+                    `${SERVER_TEST_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}IntTest.java`
                 );
             }
         };

--- a/generators/spring-controller/templates/src/main/java/package/web/rest/Resource.java.ejs
+++ b/generators/spring-controller/templates/src/main/java/package/web/rest/Resource.java.ejs
@@ -39,9 +39,9 @@ import reactor.core.publisher.Mono;
  */
 @RestController
 @RequestMapping("/api/<%= apiPrefix %>")
-public class <%= controllerClass %>Resource {
+public class <%= controllerClass %> {
 
-    private final Logger log = LoggerFactory.getLogger(<%= controllerClass %>Resource.class);
+    private final Logger log = LoggerFactory.getLogger(<%= controllerClass %>.class);
 
     <%_ for(let idx in controllerActions) { _%>
     /**

--- a/generators/spring-controller/templates/src/test/java/package/web/rest/ResourceIntTest.java.ejs
+++ b/generators/spring-controller/templates/src/test/java/package/web/rest/ResourceIntTest.java.ejs
@@ -36,11 +36,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 /**
  * Test class for the <%= controllerClass %> REST controller.
  *
- * @see <%= controllerClass %>Resource
+ * @see <%= controllerClass %>
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class <%= controllerClass %>ResourceIntTest {
+public class <%= controllerClass %>IntTest {
 
     private MockMvc restMockMvc;
 
@@ -48,9 +48,9 @@ public class <%= controllerClass %>ResourceIntTest {
     public void setUp() {
         MockitoAnnotations.initMocks(this);
 
-        <%= controllerClass %>Resource <%= controllerInstance %>Resource = new <%= controllerClass %>Resource();
+        <%= controllerClass %> <%= controllerInstance %> = new <%= controllerClass %>();
         restMockMvc = MockMvcBuilders
-            .standaloneSetup(<%= controllerInstance %>Resource)
+            .standaloneSetup(<%= controllerInstance %>)
             .build();
     }
 

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -111,18 +111,18 @@ module.exports = class extends BaseGenerator {
     _writing() {
         return {
             write() {
-                this.serviceClass = _.upperFirst(this.name);
-                this.serviceInstance = _.lowerCase(this.name);
+                this.serviceClass = _.upperFirst(this.name) + (this.name.endsWith('Service') ? '' : 'Service');
+                this.serviceInstance = _.lowerCase(this.serviceClass);
 
                 this.template(
                     `${SERVER_MAIN_SRC_DIR}package/service/Service.java.ejs`,
-                    `${SERVER_MAIN_SRC_DIR + this.packageFolder}/service/${this.serviceClass}Service.java`
+                    `${SERVER_MAIN_SRC_DIR + this.packageFolder}/service/${this.serviceClass}.java`
                 );
 
                 if (this.useInterface) {
                     this.template(
                         `${SERVER_MAIN_SRC_DIR}package/service/impl/ServiceImpl.java.ejs`,
-                        `${SERVER_MAIN_SRC_DIR + this.packageFolder}/service/impl/${this.serviceClass}ServiceImpl.java`
+                        `${SERVER_MAIN_SRC_DIR + this.packageFolder}/service/impl/${this.serviceClass}Impl.java`
                     );
                 }
             }

--- a/generators/spring-service/templates/src/main/java/package/service/Service.java.ejs
+++ b/generators/spring-service/templates/src/main/java/package/service/Service.java.ejs
@@ -25,10 +25,10 @@ import org.springframework.transaction.annotation.Transactional;<% } %>
 
 @Service<% if (databaseType === 'sql') { %>
 @Transactional<% } %>
-public class <%= serviceClass %>Service {
+public class <%= serviceClass %> {
 
-    private final Logger log = LoggerFactory.getLogger(<%= serviceClass %>Service.class);
+    private final Logger log = LoggerFactory.getLogger(<%= serviceClass %>.class);
 
-}<% } else  { %>public interface <%= serviceClass %>Service {
+}<% } else  { %>public interface <%= serviceClass %> {
 
 }<% } %>

--- a/generators/spring-service/templates/src/main/java/package/service/impl/ServiceImpl.java.ejs
+++ b/generators/spring-service/templates/src/main/java/package/service/impl/ServiceImpl.java.ejs
@@ -18,7 +18,7 @@
 -%>
 package <%=packageName%>.service.impl;
 
-import <%=packageName%>.service.<%= serviceClass %>Service;
+import <%=packageName%>.service.<%= serviceClass %>;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;<% if (databaseType === 'sql') { %>
@@ -26,8 +26,8 @@ import org.springframework.transaction.annotation.Transactional;<% } %>
 
 @Service<% if (databaseType === 'sql') { %>
 @Transactional<% } %>
-public class <%= serviceClass %>ServiceImpl implements <%= serviceClass %>Service {
+public class <%= serviceClass %>Impl implements <%= serviceClass %> {
 
-    private final Logger log = LoggerFactory.getLogger(<%= serviceClass %>ServiceImpl.class);
+    private final Logger log = LoggerFactory.getLogger(<%= serviceClass %>Impl.class);
 
 }


### PR DESCRIPTION
This PR ensures that when you use the service/controller subgenerators, it doesn't end in a double suffix.  For example, running `jhipster service FooService` generated `FooServiceService` instead of `FooService`

This would also make it easier to configure the suffixes with a flag in case a user wants to use "Controller" instead of "Resource" (in the future)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
