### PR TITLE
add control for locale string format

### DIFF
--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -606,8 +606,13 @@ public class UserService {
             user.setLangKey((String) details.get("langKey"));
         } else if (details.get("locale") != null) {
             String locale = (String) details.get("locale");
-            String langKey = locale.substring(0, locale.indexOf("-"));
-            user.setLangKey(langKey);
+            if (locale.contains("-")) {
+              String langKey = locale.substring(0, locale.indexOf("-"));
+              user.setLangKey(langKey);
+            } else if (locale.contains("_")) {
+              String langKey = locale.substring(0, locale.indexOf("_"));
+              user.setLangKey(langKey);
+            }
         }
         if (details.get("picture") != null) {
             user.setImageUrl((String) details.get("picture"));


### PR DESCRIPTION
add a control to distinguish different format of locale string en-US/en_US in reading profile infos in UserService class

Fix #7866

@mraible 
- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed