### PR TITLE
Fix 'has no exported member 'JhiTrackerService'' Error

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
@@ -29,7 +29,7 @@ import { JhiLanguageHelper, Principal, AccountService<% if (authenticationType !
 <%_ } else { _%>
 import { JhiDataUtils, JhiDateUtils, JhiEventManager, JhiAlertService, JhiParseLinks } from 'ng-jhipster';
 
-import { Principal, AccountService<% if (authenticationType !== 'oauth2') { %>, LoginModalService<% } %><% if (websocket === 'spring-websocket') { %>, JhiTrackerService<% } %> } from 'app/core';
+import { Principal, AccountService<% if (authenticationType !== 'oauth2') { %>, LoginModalService<% } %><% if (websocket === 'spring-websocket') { %>, <%=jhiPrefixCapitalized%>TrackerService<% } %> } from 'app/core';
 <%_ } _%>
 import { MockPrincipal } from './helpers/mock-principal.service';
 import { MockAccountService } from './helpers/mock-account.service';


### PR DESCRIPTION
fix :
when set a custom jhiPrefix and enabled spring-websocket, there get a error on run jhipster command:

ERROR in /xxxx/xxxx/src/test/javascript/spec/test.module.ts
(8,56): Module '"/xxxx/xxxx/src/main/webapp/app/core/index"' has no exported member 'JhiTrackerService'.

ERROR in /xxxx/xxxx/src/test/javascript/spec/test.module.ts
(22,22): Cannot find name 'DfsTrackerService'.