### PR TITLE
React UAA paths and SERVER_API_URL

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
@@ -29,7 +29,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(tap((event: HttpEvent<any>) => {}, (err: any) => {
             if (err instanceof HttpErrorResponse) {
-                if (!(err.status === 401 && (err.message === '' || (err.url && err.url.endsWith('/api/account'))))) {
+                if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('/api/account'))))) {
                     if (this.eventManager !== undefined) {
                         this.eventManager.broadcast({name: '<%=angularAppName%>.httpError', content: err});
                     }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
@@ -29,7 +29,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(tap((event: HttpEvent<any>) => {}, (err: any) => {
             if (err instanceof HttpErrorResponse) {
-                if (!(err.status === 401 && (err.message === '' || (err.url && err.url.indexOf('/api/account') === 0)))) {
+                if (!(err.status === 401 && (err.message === '' || (err.url && err.url.endsWith('/api/account'))))) {
                     if (this.eventManager !== undefined) {
                         this.eventManager.broadcast({name: '<%=angularAppName%>.httpError', content: err});
                     }

--- a/generators/client/templates/react/src/main/webapp/app/config/axios-interceptor.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/axios-interceptor.ts.ejs
@@ -19,6 +19,8 @@
 import axios from 'axios';
 import { getBasePath, Storage } from 'react-jhipster';
 
+import { SERVER_API_URL } from 'app/config/constants';
+
 const TIMEOUT = 1000000; // 10000
 const setupAxiosInterceptors = onUnauthenticated => {
   const onRequestSuccess = config => {
@@ -27,7 +29,7 @@ const setupAxiosInterceptors = onUnauthenticated => {
       config.headers.Authorization = `Bearer ${token}`;
     }
     config.timeout = TIMEOUT;
-    config.url = `${getBasePath().replace(/\/$/, '')}${config.url}`;
+    config.url = `${SERVER_API_URL ? SERVER_API_URL : getBasePath()}${config.url}`;
     return config;
   };
   const onResponseSuccess = response => response;

--- a/generators/client/templates/react/src/main/webapp/app/config/axios-interceptor.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/axios-interceptor.ts.ejs
@@ -29,7 +29,7 @@ const setupAxiosInterceptors = onUnauthenticated => {
       config.headers.Authorization = `Bearer ${token}`;
     }
     config.timeout = TIMEOUT;
-    config.url = `${SERVER_API_URL ? SERVER_API_URL : getBasePath()}${config.url}`;
+    config.url = `${SERVER_API_URL}${config.url}`;
     return config;
   };
   const onResponseSuccess = response => response;

--- a/generators/client/templates/react/src/main/webapp/app/config/constants.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/constants.ts.ejs
@@ -17,13 +17,12 @@
  limitations under the License.
 -%>
 const config = {
-  VERSION: process.env.VERSION,
-  SERVER_API_URL: process.env.SERVER_API_URL
+  VERSION: process.env.VERSION
 };
 
 export default config;
 
-export const SERVER_API_URL = '';
+export const SERVER_API_URL = process.env.SERVER_API_URL;
 
 export const AUTHORITIES = {
   ADMIN: 'ROLE_ADMIN',

--- a/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
@@ -73,7 +73,7 @@ export default () => next => action => {
       } else if (error && error.response) {
         const response = error.response;
         const data = response.data;
-        if (!(response.status === 401 && (error.message === '' || (data && data.path && data.path.indexOf('/api/account') === 0)))) {
+        if (!(response.status === 401 && (error.message === '' || (data && data.path && data.path.endsWith('/api/account'))))) {
           let i;
           switch (response.status) {
             // connection refused, server not reachable

--- a/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
@@ -73,7 +73,7 @@ export default () => next => action => {
       } else if (error && error.response) {
         const response = error.response;
         const data = response.data;
-        if (!(response.status === 401 && (error.message === '' || (data && data.path && data.path.endsWith('/api/account'))))) {
+        if (!(response.status === 401 && (error.message === '' || (data && data.path && data.path.includes('/api/account'))))) {
           let i;
           switch (response.status) {
             // connection refused, server not reachable

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/activate/activate.reducer.ts.ejs
@@ -61,7 +61,7 @@ export default (state: ActivateState = initialState, action): ActivateState => {
 // Actions
 export const activateAction = key => ({
   type: ACTION_TYPES.ACTIVATE_ACCOUNT,
-  payload: axios.get('/api/activate?key=' + key)
+  payload: axios.get('<%= apiUaaPath %>api/activate?key=' + key)
 });
 
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password-reset/password-reset.reducer.ts.ejs
@@ -67,7 +67,7 @@ export default (state: PasswordResetState = initialState, action): PasswordReset
   }
 };
 
-const apiUrl = '/api/account/reset-password';
+const apiUrl = '<%= apiUaaPath %>api/account/reset-password';
 
 // Actions
 export const handlePasswordResetInit = mail => ({

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/password/password.reducer.ts.ejs
@@ -69,7 +69,7 @@ export default (state: PasswordState = initialState, action): PasswordState => {
 };
 
 // Actions
-const apiUrl = '/api/account';
+const apiUrl = '<%= apiUaaPath %>api/account';
 
 export const savePassword = (currentPassword, newPassword) => ({
   type: ACTION_TYPES.UPDATE_PASSWORD,

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.reducer.ts.ejs
@@ -66,7 +66,7 @@ export default (state: RegisterState = initialState, action): RegisterState => {
 // Actions
 export const handleRegister = (login, email, password, langKey = 'en') => ({
   type: ACTION_TYPES.CREATE_ACCOUNT,
-  payload: axios.post('/api/register', { login, email, password, langKey }),
+  payload: axios.post('<%= apiUaaPath %>api/register', { login, email, password, langKey }),
   meta : {
     successMessage: translate('register.messages.success')
   }

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
@@ -70,7 +70,7 @@ export default (state: SettingsState = initialState, action): SettingsState => {
 };
 
 // Actions
-const apiUrl = '/api/account';
+const apiUrl = '<%= apiUaaPath %>api/account';
 
 export const saveAccountSettings = account => async dispatch => {
   await dispatch({

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
@@ -230,7 +230,7 @@ export const getEnv = () => ({
 });
 
 export const getAudits = (page, size, sort, fromDate, toDate) => {
-  let requestUrl = `/<%= apiUaaPath %>management/audits${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;
+  let requestUrl = `<%= apiUaaPath %>management/audits${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;
   if (fromDate) {
     requestUrl += `&fromDate=${fromDate}`;
   }

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.ts.ejs
@@ -181,28 +181,28 @@ export default (state: AdministrationState = initialState, action): Administrati
 <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
 export const gatewayRoutes = () => ({
   type: ACTION_TYPES.FETCH_GATEWAY_ROUTE,
-  payload: axios.get('/api/gateway/routes')
+  payload: axios.get('api/gateway/routes')
 });
 <%_ } _%>
 
 export const systemHealth = () => ({
   type: ACTION_TYPES.FETCH_HEALTH,
-  payload: axios.get('/management/health')
+  payload: axios.get('management/health')
 });
 
 export const systemMetrics = () => ({
   type: ACTION_TYPES.FETCH_METRICS,
-  payload: axios.get('/management/metrics')
+  payload: axios.get('management/metrics')
 });
 
 export const systemThreadDump = () => ({
   type: ACTION_TYPES.FETCH_THREAD_DUMP,
-  payload: axios.get('/management/threaddump')
+  payload: axios.get('management/threaddump')
 });
 
 export const getLoggers = () => ({
   type: ACTION_TYPES.FETCH_LOGS,
-  payload: axios.get('/management/logs')
+  payload: axios.get('management/logs')
 });
 
 export const changeLogLevel = (name, level) => {
@@ -213,7 +213,7 @@ export const changeLogLevel = (name, level) => {
   return async dispatch => {
     await dispatch({
       type: ACTION_TYPES.FETCH_LOGS_CHANGE_LEVEL,
-      payload: axios.put('/management/logs', body)
+      payload: axios.put('management/logs', body)
     });
     dispatch(getLoggers());
   };
@@ -221,12 +221,12 @@ export const changeLogLevel = (name, level) => {
 
 export const getConfigurations = () => ({
   type: ACTION_TYPES.FETCH_CONFIGURATIONS,
-  payload: axios.get('/management/configprops')
+  payload: axios.get('management/configprops')
 });
 
 export const getEnv = () => ({
   type: ACTION_TYPES.FETCH_ENV,
-  payload: axios.get('/management/env')
+  payload: axios.get('management/env')
 });
 
 export const getAudits = (page, size, sort, fromDate, toDate) => {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -126,7 +126,7 @@ export default (state: UserManagementState = initialState, action): UserManageme
   }
 };
 
-const apiUrl = '/<%= apiUaaPath %>api/users';
+const apiUrl = '<%= apiUaaPath %>api/users';
 // Actions
 export const getUsers: ICrudGetAllAction<IUser> = (page, size, sort) => {
   const requestUrl = `${apiUrl}${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/application-profile.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/application-profile.ts.ejs
@@ -49,5 +49,5 @@ export default (state: ApplicationProfileState = initialState, action): Applicat
 
 export const getProfile = () => ({
   type: ACTION_TYPES.GET_PROFILE,
-  payload: axios.get('/management/info')
+  payload: axios.get('management/info')
 });

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -136,7 +136,7 @@ export const displayAuthError = message => ({ type: ACTION_TYPES.ERROR_MESSAGE, 
 
 export const getSession = () => dispatch => dispatch({
   type: ACTION_TYPES.GET_SESSION,
-  payload: axios.get('/<%= apiUaaPath %>api/account')
+  payload: axios.get('<%= apiUaaPath %>api/account')
 });
 
 <%_ if (authenticationType === 'session') { _%>
@@ -144,7 +144,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
   const data = `j_username=${encodeURIComponent(username)}&j_password=${encodeURIComponent(password)}&remember-me=${rememberMe}&submit=Login`;
   await dispatch({
     type: ACTION_TYPES.LOGIN,
-    payload: axios.post('/api/authentication', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } })
+    payload: axios.post('api/authentication', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } })
   });
   dispatch(getSession());
 };
@@ -152,7 +152,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
   const result = await dispatch({
     type: ACTION_TYPES.LOGIN,
-    payload: axios.post('/api/authenticate', { username, password, rememberMe })
+    payload: axios.post('api/authenticate', { username, password, rememberMe })
   });
   const bearerToken = result.value.headers.authorization;
   if (bearerToken && bearerToken.slice(0, 7) === 'Bearer ') {
@@ -169,7 +169,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
   const result = await dispatch({
     type: ACTION_TYPES.LOGIN,
-    payload: axios.post('/auth/login', { username, password })
+    payload: axios.post('auth/login', { username, password })
   });
   dispatch(getSession());
 };
@@ -195,7 +195,7 @@ export const logout = () => dispatch => {
 export const logout = () => async dispatch => {
   await dispatch({
     type: ACTION_TYPES.LOGOUT,
-    payload: axios.post('/auth/logout', {})
+    payload: axios.post('auth/logout', {})
   });
   dispatch(getSession());
 };
@@ -203,7 +203,7 @@ export const logout = () => async dispatch => {
 export const logout = () => async dispatch => {
   await dispatch({
     type: ACTION_TYPES.LOGOUT,
-    payload: axios.post('/api/logout', {})
+    payload: axios.post('api/logout', {})
   });
   dispatch(getSession());
 };

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -48,7 +48,7 @@ export default (state: LocaleState = initialState, action): LocaleState => {
 
 export const setLocale = locale => async dispatch => {
   if (Object.keys(TranslatorContext.context.translations).indexOf(locale) === -1) {
-    const response = await axios.get(`/i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
+    const response = await axios.get(`i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
     TranslatorContext.registerTranslations(locale, response.data);
   }
   dispatch({

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/user-management.ts.ejs
@@ -61,7 +61,7 @@ export default (state: UserManagementState = initialState, action): UserManageme
   }
 };
 
-const apiUrl = '/api/users';
+const apiUrl = '<%= apiUaaPath %>api/users';
 // Actions
 export const getUsers: ICrudGetAllAction<IUser> = (page, size, sort) => {
   const requestUrl = `${apiUrl}${sort ? `?page=${page}&size=${size}&sort=${sort}` : ''}`;

--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -19,7 +19,7 @@
 <!doctype html>
 <html class="no-js" lang="<%= nativeLanguage %>" dir="ltr">
 <head>
-    <base href="/" />
+    <base href="./" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
@@ -186,9 +186,9 @@ export default (state: <%= entityReactName %>State = initialState, action): <%= 
   }
 };
 
-const apiUrl = <% if (applicationType === 'gateway' && locals.microserviceName) { %>'/<%= microserviceName.toLowerCase() %>/<% } else if (authenticationType === 'uaa') { %>'<% } %>api/<%= entityApiUrl %>';
+const apiUrl = '<% if (applicationType === 'gateway' && locals.microserviceName) { %><%= microserviceName.toLowerCase() %>/<% } %>api/<%= entityApiUrl %>';
 <%_ if (searchEngine === 'elasticsearch') { _%>
-const apiSearchUrl = <% if (applicationType === 'gateway' && locals.microserviceName) { %>'/<%= microserviceName.toLowerCase() %>/<% } else if (authenticationType === 'uaa') { %>'<% } %>api/_search/<%= entityApiUrl %>';
+const apiSearchUrl = '<% if (applicationType === 'gateway' && locals.microserviceName) { %><%= microserviceName.toLowerCase() %>/<% } %>api/_search/<%= entityApiUrl %>';
 <%_ } _%>
 
 // Actions

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.reducer.ts.ejs
@@ -36,7 +36,6 @@ import {
 
 import { cleanEntity } from 'app/shared/util/entity-utils';
 import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
-import { SERVER_API_URL } from 'app/config/constants';
 <%_ if (!(applicationType === 'gateway' && locals.microserviceName) && authenticationType !== 'uaa') { _%>
 
 <%_ } _%>
@@ -187,9 +186,9 @@ export default (state: <%= entityReactName %>State = initialState, action): <%= 
   }
 };
 
-const apiUrl = <% if (applicationType === 'gateway' && locals.microserviceName) { %>'/<%= microserviceName.toLowerCase() %><% } else if (authenticationType === 'uaa') { %>'<% } else { %>SERVER_API_URL + '<% } %>/api/<%= entityApiUrl %>';
+const apiUrl = <% if (applicationType === 'gateway' && locals.microserviceName) { %>'/<%= microserviceName.toLowerCase() %>/<% } else if (authenticationType === 'uaa') { %>'<% } %>api/<%= entityApiUrl %>';
 <%_ if (searchEngine === 'elasticsearch') { _%>
-const apiSearchUrl = <% if (applicationType === 'gateway' && locals.microserviceName) { %>'/<%= microserviceName.toLowerCase() %>/<% } else if (authenticationType === 'uaa') { %>'<% } else { %>SERVER_API_URL + '<% } %>/api/_search/<%= entityApiUrl %>';
+const apiSearchUrl = <% if (applicationType === 'gateway' && locals.microserviceName) { %>'/<%= microserviceName.toLowerCase() %>/<% } else if (authenticationType === 'uaa') { %>'<% } %>api/_search/<%= entityApiUrl %>';
 <%_ } _%>
 
 // Actions


### PR DESCRIPTION
This PR does the following:
 - Fix React Gateway UAA paths (currently can't register or use user-management)
 - Implements `SERVER_API_URL` for all requests in the React client (through Axios Interceptor)
 - Fixes React app when running on a context-path other than `/`
 - Fixes error notifications on 401 when running on a context-path other than `/`
 - Removes unused/empty register.ts file

Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
