### PR TITLE
fix missing translation for react navbar entity and home

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
@@ -63,7 +63,7 @@ export const Home = props => (
   <NavItem>
     <NavLink tag={Link} to="/" className="d-flex align-items-center">
       <FontAwesomeIcon icon="home" />
-      <span><Translate contentKey="global.menu.home" /></span>
+      <span><Translate contentKey="global.menu.home" />Home</span>
     </NavLink>
   </NavItem>
 );

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/entities.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/entities.tsx.ejs
@@ -21,7 +21,7 @@ import {
   DropdownItem
 } from 'reactstrap';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { translate } from 'react-jhipster';
+import { Translate, translate } from 'react-jhipster';
 import { NavLink as Link } from 'react-router-dom';
 import { NavDropdown } from '../header-components';
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -203,7 +203,7 @@ module.exports = class extends PrivateBase {
                     needle: 'jhipster-needle-add-entity-to-menu',
                     splicable: [
                         this.stripMargin(`|<DropdownItem tag={Link} to="/entity/${routerName}">
-                        |      <FontAwesomeIcon icon="asterisk" />&nbsp; ${_.startCase(routerName)}
+                        |      <FontAwesomeIcon icon="asterisk" />&nbsp;${enableTranslation ? `<Translate contentKey="global.menu.entities.${entityTranslationKeyMenu}" />` : `${_.startCase(routerName)}`}
                         |    </DropdownItem>`)
                     ]
                 }, this);


### PR DESCRIPTION
Fix #7946

Also fixes the Home text on React apps without translation (only the Home icon was showing)

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
