### PR TITLE
Manually order chunks

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -105,7 +105,8 @@ module.exports = (options) => ({
         <%_ } _%>
         new HtmlWebpackPlugin({
             template: './<%= MAIN_SRC_DIR %>index.html',
-            chunksSortMode: 'dependency',
+            chunks: ['vendors', 'polyfills', 'global', 'main'],
+            chunksSortMode: 'manual',
             inject: 'body'
         })
     ]


### PR DESCRIPTION
Fixes #7798
`HTMLWebpackPlugin` doesn't seem to like the generated chunks from webpack in prod profile... Couldn't find why he was freezing but this manual order fixes the issue.
- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
