### PR TITLE
Fix #7928 : Adding jest-junit back, and adjust filename reports

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -86,6 +86,7 @@
     "husky": "0.14.3",
     <%_ } _%>
     "jest": "22.4.3",
+    "jest-junit": "5.1.0",
     "jest-preset-angular": "5.2.2",
     "jest-sonar-reporter": "2.0.0",
     <%_ if (protractorTests) { _%>
@@ -180,6 +181,6 @@
   },
   "jestSonar": {
     "reportPath": "<%= BUILD_DIR %>test-results/jest",
-    "reportFile": "TESTS-results.xml"
+    "reportFile": "TESTS-results-sonar.xml"
   }
 }

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -12,7 +12,8 @@ module.exports = {
         'app/(.*)': '<rootDir>/src/main/webapp/app/$1'
     },
     reporters: [
-        'default'
+        'default',
+        [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/jest/TESTS-results.xml' } ]
     ],
     testResultsProcessor: 'jest-sonar-reporter',
     transformIgnorePatterns: ['node_modules/(?!@angular/common/locales)'],

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -106,6 +106,7 @@ limitations under the License.
     <%_ } _%>
     "image-webpack-loader": "4.3.1",
     "jest": "23.2.0",
+    "jest-junit": "5.1.0",
     "jest-sonar-reporter": "2.0.0",
     <%_ if (protractorTests) { _%>
     "chai-as-promised": "7.1.1",
@@ -208,6 +209,6 @@ limitations under the License.
   },
   "jestSonar": {
     "reportPath": "<%= BUILD_DIR %>test-results/jest",
-    "reportFile": "TESTS-results.xml"
+    "reportFile": "TESTS-results-sonar.xml"
   }
 }

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -11,7 +11,8 @@ module.exports = {
     '\\.(css|scss)$': 'identity-obj-proxy'
   },
   reporters: [
-    'default'
+    'default',
+    [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/jest/TESTS-results.xml' } ]
   ],
   testResultsProcessor: 'jest-sonar-reporter',
   testPathIgnorePatterns: [

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -121,7 +121,7 @@
         <sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey>squid:UndocumentedApi</sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey>
         <sonar.jacoco.reportPaths>${project.testresult.directory}/coverage/jacoco/jacoco.exec</sonar.jacoco.reportPaths>
         <sonar.java.codeCoveragePlugin>jacoco</sonar.java.codeCoveragePlugin>
-        <sonar.testExecutionReportPaths>${project.testresult.directory}/jest/TESTS-results.xml</sonar.testExecutionReportPaths>
+        <sonar.testExecutionReportPaths>${project.testresult.directory}/jest/TESTS-results-sonar.xml</sonar.testExecutionReportPaths>
         <sonar.typescript.lcov.reportPaths>${project.testresult.directory}/lcov.info</sonar.typescript.lcov.reportPaths>
         <sonar.sources>${project.basedir}/<%= MAIN_DIR %></sonar.sources>
         <sonar.surefire.reportsPath>${project.testresult.directory}/surefire-reports</sonar.surefire.reportsPath>


### PR DESCRIPTION
Fix #7928
Adding jest-junit back, and adjust filename reports with Jenkins and Sonar.
Jenkins and Sonar needs different files.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
