### PR TITLE
Fix (react):  Language key to name mapping on user-mgmt and settings page

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.tsx.ejs
@@ -23,7 +23,7 @@ import { Translate, translate } from 'react-jhipster';
 import { AvForm, AvField } from 'availity-reactstrap-validation';
 
 <%_ if (enableTranslation) { _%>
-import { locales } from 'app/config/translation';
+import { locales, languages } from 'app/config/translation';
 <%_ } _%>
 import { IRootState } from 'app/shared/reducers';
 import { getSession } from 'app/shared/reducers/authentication';
@@ -117,12 +117,11 @@ export class SettingsPage extends React.Component<IUserSettingsProps, IUserSetti
                 label={translate('settings.form.language')}
                 value={account.langKey}
               >
-                {/* TODO: Add findLanguageFromKey translation to options */}
-                {locales.map(lang => (
-                  <option value={lang} key={lang}>
-                    {lang}
+                {locales.map(locale =>
+                  <option value={locale} key={locale}>
+                    {languages[locale].name}
                   </option>
-                ))}
+                )}
               </AvField>
               <%_ } _%>
               <Button color="primary" type="submit">

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -20,11 +20,11 @@ import React from 'react';
 import { connect } from 'react-redux';
 import { Link, RouteComponentProps } from 'react-router-dom';
 import { Button, Row, Badge } from 'reactstrap';
-import { Translate, ICrudGetAction, TextFormat } from 'react-jhipster';
+import { Translate, TextFormat } from 'react-jhipster';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { APP_DATE_FORMAT } from 'app/config/constants';
-import { IUser } from 'app/shared/model/user.model';
+<% if (enableTranslation) { %>import { languages } from 'app/config/translation';<% } %>
 import { getUser } from './user-management.reducer';
 import { IRootState } from 'app/shared/reducers';
 
@@ -63,7 +63,7 @@ export class UserManagementDetail extends React.Component<IUserManagementDetailP
             <dd>{user.email}</dd>
             <%_ if (enableTranslation) { _%>
             <dt><Translate contentKey="userManagement.langKey">Lang Key</Translate></dt>
-            <dd>{user.langKey}</dd>
+            <dd>{user.langKey ? languages[user.langKey].name : undefined}</dd>
             <%_ } _%>
             <dt><Translate contentKey="userManagement.createdBy">Created By</Translate></dt>
             <dd>{user.createdBy}</dd>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -25,9 +25,8 @@ import { Translate, translate, ICrudGetAction, ICrudGetAllAction, ICrudPutAction
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 <%_ if (enableTranslation) { _%>
-import { locales } from 'app/config/translation';
+import { locales, languages } from 'app/config/translation';
 <%_ } _%>
-import { IUser } from 'app/shared/model/user.model';
 import { getUser, getRoles, updateUser, createUser, reset } from './user-management.reducer';
 import { IRootState } from 'app/shared/reducers';
 
@@ -190,12 +189,12 @@ export class UserManagementUpdate extends React.Component<IUserManagementUpdateP
               <Label for="langKey">
                 <Translate contentKey="userManagement.langKey">Language Key</Translate>
               </Label>
-              <AvField type="select" className="form-control" name="langKey" defaultValue={locales[0]}>
-                {locales.map(lang => (
-                  <option value={lang} key={lang}>
-                    {lang}
+              <AvField type="select" className="form-control" name="langKey" value={user.langKey}>
+                {locales.map(locale =>
+                  <option value={locale} key={locale}>
+                    {languages[locale].name}
                   </option>
-                ))}
+                )}
               </AvField>
             </AvGroup>
     <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/locale.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/menus/locale.tsx.ejs
@@ -19,14 +19,14 @@
 import React from 'react';
 import { DropdownItem } from 'reactstrap';
 import { NavDropdown } from '../header-components';
-import { languages } from 'app/config/translation';
+import { locales, languages } from 'app/config/translation';
 
 export const LocaleMenu = ({ currentLocale, onClick }) =>
   Object.keys(languages).length > 1 && (
     <NavDropdown icon="flag" name={(currentLocale ? languages[currentLocale].name : undefined)}>
-      {Object.keys(languages).sort().map(lang => (
-        <DropdownItem key={lang} value={lang} onClick={onClick}>
-          {languages[lang].name}
+      {locales.map(locale => (
+        <DropdownItem key={locale} value={locale} onClick={onClick}>
+          {languages[locale].name}
         </DropdownItem>
       ))}
     </NavDropdown>


### PR DESCRIPTION
- Language key to name mapping on user-management and settings page
- Removed unused imports

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
