### PR TITLE
fixed broken relationship link in listing page

### DIFF
--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
@@ -304,19 +304,19 @@ export class <%= entityReactName %> extends React.Component<I<%= entityReactName
                       {
                         (<%= entityInstance %>.<%= relationshipFieldNamePlural %>) ?
                             (<%= entityInstance %>.<%= relationshipFieldNamePlural %>.map((val, j) =>
-                                <span key={j}><Link to={`<%= otherEntityName %>/${val.id}`}>{val.<%= otherEntityField %>}</Link>{(j === <%= entityInstance %>.<%= relationshipFieldNamePlural %>.length - 1) ? '' : ', '}</span>
+                                <span key={j}><Link to={`<%= otherEntityStateName %>/${val.id}`}>{val.<%= otherEntityField %>}</Link>{(j === <%= entityInstance %>.<%= relationshipFieldNamePlural %>.length - 1) ? '' : ', '}</span>
                             )
                         ) : null
                       }
                         <%_ } else { _%>
                             <%_ if (dto === 'no') { _%>
                       {<%= entityInstance + "." + relationshipFieldName %> ?
-                      <Link to={`<%= otherEntityName %>/${<%= entityInstance + "." + relationshipFieldName + ".id}" %>`}>
+                      <Link to={`<%= otherEntityStateName %>/${<%= entityInstance + "." + relationshipFieldName + ".id}" %>`}>
                         {<%= entityInstance + "." + relationshipFieldName + "." + otherEntityField %>}
                       </Link> : ''}
                             <%_ } else { _%>
                       {<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> ?
-                      <Link to={`<%= otherEntityName %>/${<%= entityInstance + "." + relationshipFieldName + "Id}" %>`}>
+                      <Link to={`<%= otherEntityStateName %>/${<%= entityInstance + "." + relationshipFieldName + "Id}" %>`}>
                         {<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}
                       </Link> : ''}
                             <%_ } _%>


### PR DESCRIPTION
When it deals with an entity name with MultipleCamelCaseWord in relationship It was populating links like this:

`<Link to={`otherEntityName/${entityInstance.otherEntityName.id}`}>{entityInstance.otherEntityName.id}</Link>`

while it should have had it like this:

`<Link to={`other-entity-name/${entityInstance.otherEntityName.id}`}>{entityInstance.otherEntityName.id}</Link>`

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
