### PR TITLE
Add --default flag for spring-service and spring-controller

### DIFF
--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -35,8 +35,8 @@ module.exports = class extends BaseGenerator {
         this.name = this.options.name;
 
         this.option('default', {
-            type: String,
-            required: false,
+            type: Boolean,
+            default: false,
             description: 'default option'
         });
         this.defaultOption = this.options.default;

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -34,6 +34,13 @@ module.exports = class extends BaseGenerator {
         this.argument('name', { type: String, required: true });
         this.name = this.options.name;
 
+        this.option('default', {
+            type: String,
+            required: false,
+            description: 'default option'
+        });
+        this.defaultOption = this.options.default;
+
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -49,7 +49,8 @@ module.exports = class extends BaseGenerator {
                 'spring-controller',
                 {
                     force: this.options.force,
-                    arguments: [this.name]
+                    arguments: [this.name],
+                    default: this.options.default
                 }
             );
         } else {

--- a/generators/spring-controller/prompts.js
+++ b/generators/spring-controller/prompts.js
@@ -77,20 +77,24 @@ function askForControllerActions() {
             }
         ];
 
-        this.prompt(prompts).then((props) => {
-            if (props.actionAdd) {
-                const controllerAction = {
-                    actionName: props.actionName,
-                    actionMethod: props.actionMethod
-                };
+        if (!this.defaultOption) {
+            this.prompt(prompts).then((props) => {
+                if (props.actionAdd) {
+                    const controllerAction = {
+                        actionName: props.actionName,
+                        actionMethod: props.actionMethod
+                    };
 
-                this.controllerActions.push(controllerAction);
+                    this.controllerActions.push(controllerAction);
 
-                askForControllerAction(done);
-            } else {
-                done();
-            }
-        });
+                    askForControllerAction(done);
+                } else {
+                    done();
+                }
+            });
+        } else {
+            done();
+        }
     };
 
     const done = this.async();

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -31,8 +31,8 @@ module.exports = class extends BaseGenerator {
         this.name = this.options.name;
 
         this.option('default', {
-            type: String,
-            required: false,
+            type: Boolean,
+            default: false,
             description: 'default option'
         });
         this.defaultOption = this.options.default;

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -45,7 +45,8 @@ module.exports = class extends BaseGenerator {
                 'spring-service',
                 {
                     force: this.options.force,
-                    arguments: [this.name]
+                    arguments: [this.name],
+                    default: this.options.default
                 }
             );
         } else {

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -29,6 +29,14 @@ module.exports = class extends BaseGenerator {
         super(args, opts);
         this.argument('name', { type: String, required: true });
         this.name = this.options.name;
+
+        this.option('default', {
+            type: String,
+            required: false,
+            description: 'default option'
+        });
+        this.defaultOption = this.options.default;
+
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
@@ -68,8 +76,6 @@ module.exports = class extends BaseGenerator {
     _prompting() {
         return {
             prompting() {
-                const done = this.async();
-
                 const prompts = [
                     {
                         type: 'confirm',
@@ -78,10 +84,15 @@ module.exports = class extends BaseGenerator {
                         default: false
                     }
                 ];
-                this.prompt(prompts).then((props) => {
-                    this.useInterface = props.useInterface;
-                    done();
-                });
+                if (!this.defaultOption) {
+                    const done = this.async();
+                    this.prompt(prompts).then((props) => {
+                        this.useInterface = props.useInterface;
+                        done();
+                    });
+                } else {
+                    this.useInterface = true;
+                }
             }
         };
     }

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -55,4 +55,23 @@ describe('JHipster generator service', () => {
             ]);
         });
     });
+
+    describe('creates service with --default flag', () => {
+        beforeEach((done) => {
+            helpers.run(require.resolve('../generators/spring-service'))
+                .inTmpDir((dir) => {
+                    fse.copySync(path.join(__dirname, '../test/templates/default'), dir);
+                })
+                .withArguments(['foo'])
+                .withOptions({ default: true })
+                .on('end', done);
+        });
+
+        it('creates service file', () => {
+            assert.file([
+                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/FooService.java`,
+                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/impl/FooServiceImpl.java`
+            ]);
+        });
+    });
 });

--- a/test/spring-controller.spec.js
+++ b/test/spring-controller.spec.js
@@ -33,4 +33,26 @@ describe('JHipster generator spring-controller', () => {
             ]);
         });
     });
+
+    describe('creates spring controller with --default flag', () => {
+        beforeEach((done) => {
+            helpers.run(require.resolve('../generators/spring-controller'))
+                .inTmpDir((dir) => {
+                    fse.copySync(path.join(__dirname, '../test/templates/default'), dir);
+                })
+                .withArguments(['foo'])
+                .withOptions({ default: true })
+                .on('end', done);
+        });
+
+        it('creates controller files', () => {
+            assert.file([
+                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`
+            ]);
+
+            assert.file([
+                `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIntTest.java`
+            ]);
+        });
+    });
 });


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster-blueprint/issues/5#issuecomment-405186956

Now, you can use:
- `jhipster spring-controller hello --default`
- `jhipster spring-service hello --default`

_____

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
