### PR TITLE
correct the comment for entityRecourceTest

### DIFF
--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -854,7 +854,7 @@ _%>
         // Create the <%= entityClass %><% if (dto === 'mapstruct') { %>
         <%= entityClass %>DTO <%= entityInstance %>DTO = <%= entityInstance %>Mapper.toDto(<%= entityInstance %>);<% } %>
 
-        // If the entity doesn't have an ID, it will be created instead of just being updated
+        // If the entity doesn't have an ID, it will throw BadRequestAlertException 
         rest<%= entityClass %>MockMvc.perform(put("/api/<%= entityApiUrl %>")
             .contentType(TestUtil.APPLICATION_JSON_UTF8)
             .content(TestUtil.convertObjectToJsonBytes(<%= entityInstance %><% if (dto === 'mapstruct') { %>DTO<% } %>)))


### PR DESCRIPTION
Update the comment in the `updateNonExistingEntity` case  for `EntityResourceTest`
- in the Jhipter 4.x:  when we updateNonExistingEntity, it will create a new one.
- in the Jhipster 5.x: when we updateNonExistingEntity, it will throw a error.

- Please make sure the below checklist is followed for Pull Requests.

- [X] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
