### PR TITLE
Make Angular e2e tests use async/await

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div *ngIf="audits">
-    <h2 class="audits-page-heading" jhiTranslate="audits.title">Audits</h2>
+    <h2 id="audits-page-heading" jhiTranslate="audits.title">Audits</h2>
 
     <div class="row">
         <div class="col-md-5">

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div *ngIf="audits">
-    <h2 jhiTranslate="audits.title">Audits</h2>
+    <h2 class="audits-page-heading" jhiTranslate="audits.title">Audits</h2>
 
     <div class="row">
         <div class="col-md-5">

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div *ngIf="allConfiguration && configuration">
-    <h2 class="configuration-page-heading" jhiTranslate="configuration.title">Configuration</h2>
+    <h2 id="configuration-page-heading" jhiTranslate="configuration.title">Configuration</h2>
 
     <span jhiTranslate="configuration.filter">Filter (by prefix)</span> <input type="text" [(ngModel)]="filter" class="form-control">
     <h3>Spring configuration</h3>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div *ngIf="allConfiguration && configuration">
-    <h2 jhiTranslate="configuration.title">Configuration</h2>
+    <h2 class="configuration-page-heading" jhiTranslate="configuration.title">Configuration</h2>
 
     <span jhiTranslate="configuration.filter">Filter (by prefix)</span> <input type="text" [(ngModel)]="filter" class="form-control">
     <h3>Spring configuration</h3>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span class="gateway-page-heading" jhiTranslate="gateway.title">Gateway</span>
+        <span id="gateway-page-heading" jhiTranslate="gateway.title">Gateway</span>
         <button class="btn btn-primary float-xs-right" (click)="refresh()" (disabled)="updatingRoutes">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="gateway.refresh.button">Refresh</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span jhiTranslate="gateway.title">Gateway</span>
+        <span class="gateway-page-heading" jhiTranslate="gateway.title">Gateway</span>
         <button class="btn btn-primary float-xs-right" (click)="refresh()" (disabled)="updatingRoutes">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="gateway.refresh.button">Refresh</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span jhiTranslate="health.title">Health Checks</span>
+        <span class="health-page-heading" jhiTranslate="health.title">Health Checks</span>
         <button class="btn btn-primary float-right" (click)="refresh()">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="health.refresh.button">Refresh</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span class="health-page-heading" jhiTranslate="health.title">Health Checks</span>
+        <span id="health-page-heading" jhiTranslate="health.title">Health Checks</span>
         <button class="btn btn-primary float-right" (click)="refresh()">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="health.refresh.button">Refresh</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div class="table-responsive" *ngIf="loggers">
-    <h2 class="logs-page-heading" jhiTranslate="logs.title">Logs</h2>
+    <h2 id="logs-page-heading" jhiTranslate="logs.title">Logs</h2>
 
     <p jhiTranslate="logs.nbloggers" translateValues="{total: '{{ loggers.length }}'}">There are {{ loggers.length }} loggers.</p>
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div class="table-responsive" *ngIf="loggers">
-    <h2 jhiTranslate="logs.title">Logs</h2>
+    <h2 class="logs-page-heading" jhiTranslate="logs.title">Logs</h2>
 
     <p jhiTranslate="logs.nbloggers" translateValues="{total: '{{ loggers.length }}'}">There are {{ loggers.length }} loggers.</p>
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span jhiTranslate="metrics.title">Application Metrics</span>
+        <span class="metrics-page-heading" jhiTranslate="metrics.title">Application Metrics</span>
         <button class="btn btn-primary float-right" (click)="refresh()">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="metrics.refresh.button">Refresh</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span class="metrics-page-heading" jhiTranslate="metrics.title">Application Metrics</span>
+        <span id="metrics-page-heading" jhiTranslate="metrics.title">Application Metrics</span>
         <button class="btn btn-primary float-right" (click)="refresh()">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="metrics.refresh.button">Refresh</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div>
-    <h2 jhiTranslate="tracker.title">Real-time user activities</h2>
+    <h2 class="tracker-page-heading" jhiTranslate="tracker.title">Real-time user activities</h2>
 
     <div class="table-responsive">
         <table class="table table-striped">

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div>
-    <h2 class="tracker-page-heading" jhiTranslate="tracker.title">Real-time user activities</h2>
+    <h2 id="tracker-page-heading" jhiTranslate="tracker.title">Real-time user activities</h2>
 
     <div class="table-responsive">
         <table class="table table-striped">

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span jhiTranslate="userManagement.home.title">Users</span>
+        <span class="userManagement-page-heading" jhiTranslate="userManagement.home.title">Users</span>
         <button class="btn btn-primary float-right jh-create-entity" [routerLink]="['./new']">
             <fa-icon [icon]="'plus'"></fa-icon> <span jhiTranslate="userManagement.home.createLabel">Create a new User</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
@@ -18,7 +18,7 @@
 -%>
 <div>
     <h2>
-        <span class="userManagement-page-heading" jhiTranslate="userManagement.home.title">Users</span>
+        <span id="user-management-page-heading" jhiTranslate="userManagement.home.title">Users</span>
         <button class="btn btn-primary float-right jh-create-entity" [routerLink]="['./new']">
             <fa-icon [icon]="'plus'"></fa-icon> <span jhiTranslate="userManagement.home.createLabel">Create a new User</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
@@ -26,7 +26,7 @@
 
         <div [ngSwitch]="isAuthenticated()">
             <div class="alert alert-success" *ngSwitchCase="true">
-                <span *ngIf="account" jhiTranslate="home.logged.message"
+                <span id="home-logged-message" *ngIf="account" jhiTranslate="home.logged.message"
                     translateValues="{username: '{{account.login}}'}"> You are logged in as user "{{account.login}}". </span>
             </div>
 

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
@@ -31,7 +31,7 @@
         <div class="col-md-8">
             <form class="form" role="form" (ngSubmit)="login()">
                 <div class="form-group">
-                    <label for="username" jhiTranslate="global.form.username">Login</label>
+                    <label class="username-label" for="username" jhiTranslate="global.form.username">Login</label>
                     <input type="text" class="form-control" name="username" id="username" placeholder="{{'global.form.username.placeholder' | translate}}"
                     [(ngModel)]="username">
                 </div>

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -76,6 +76,9 @@ describe('account', () => {
 
     it('should login successfully with admin account', async () => {
         <%_ if (authenticationType !== 'oauth2') { _%>
+        await browser.get('/');
+        signInPage = await navBarPage.getSignInPage();
+
         <%_ if (enableTranslation) { _%>
         const expect1 = /global.form.username/;
         <%_ } else { _%>
@@ -84,11 +87,8 @@ describe('account', () => {
         const value1 = await element(by.className('username-label')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
         <%_ } _%>
-        await signInPage.clearUserName();
-        await signInPage.setUserName('admin');
-        await signInPage.clearPassword();
-        await signInPage.setPassword('admin');
-        await signInPage.login();
+
+        await signInPage.autoSignInUsing('admin', 'admin');
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /home.logged.message/;

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -34,8 +34,8 @@ describe('account', () => {
     let settingsPage: SettingsPage;
     <%_ } _%>
 
-    beforeAll(() => {
-        browser.get('/');
+    beforeAll(async () => {
+        await browser.get('/');
         navBarPage = new NavBarPage(true);
     });
 
@@ -96,8 +96,8 @@ describe('account', () => {
         const expect2 = /You are logged in as user "admin"/;
         <%_ } _%>
         <%_ if (authenticationType !== 'oauth2') { _%>
-        const value2 = await element.all(by.css('.alert-success span')).first().<%- elementGetter %>;
-        expect(value2).toMatch(expect2);
+        const value2 = element.all(by.css('.alert-success span')).first();
+        expect(await value2.<%- elementGetter %>).toMatch(expect2);
         <%_ } else { _%>
         const success = element.all(by.css('.alert-success span')).first();
         await browser.wait(ec.visibilityOf(success), 5000);

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -59,8 +59,8 @@ describe('account', () => {
         const value2 = await element(by.css('.alert-danger')).<%- elementGetter %>;
         expect(value2).toMatch(expect2);
     <%_ } else { _%>
-        signInPage = navBarPage.getSignInPage();
-        signInPage.loginWithOAuth('admin', 'foo');
+        signInPage = await navBarPage.getSignInPage();
+        await signInPage.loginWithOAuth('admin', 'foo');
 
         // Keycloak
         const alert = element(by.css('.alert-error'));
@@ -103,7 +103,7 @@ describe('account', () => {
         await browser.wait(ec.visibilityOf(success), 5000);
         expect(await success.<%- elementGetter %>).toMatch(expect2);
 
-        navBarPage.autoSignOut();
+        await navBarPage.autoSignOut();
         <%_ } _%>
     });
 <%_ if (authenticationType !== 'oauth2') { _%>

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -96,7 +96,7 @@ describe('account', () => {
         const expect2 = /You are logged in as user "admin"/;
         <%_ } _%>
         <%_ if (authenticationType !== 'oauth2') { _%>
-        const value2 = element.all(by.css('.alert-success span')).first();
+        const value2 = element(by.id('home-logged-message'));
         expect(await value2.<%- elementGetter %>).toMatch(expect2);
         <%_ } else { _%>
         const success = element.all(by.css('.alert-success span')).first();
@@ -106,6 +106,7 @@ describe('account', () => {
         await navBarPage.autoSignOut();
         <%_ } _%>
     });
+    
 <%_ if (authenticationType !== 'oauth2') { _%>
     it('should be able to update settings', async () => {
         settingsPage = await navBarPage.getSettingsPage();

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -81,7 +81,7 @@ describe('account', () => {
         <%_ } else { _%>
         const expect1 = /Login/;
         <%_ } _%>
-        const value1 = await element(by.css('.modal-content label')).<%- elementGetter %>;
+        const value1 = await element(by.className('username-label')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
         <%_ } _%>
         signInPage.clearUserName();
@@ -90,23 +90,18 @@ describe('account', () => {
         signInPage.setPassword('admin');
         signInPage.login();
 
-        browser.waitForAngular();
-
         <%_ if (enableTranslation) { _%>
         const expect2 = /home.logged.message/;
         <%_ } else { _%>
         const expect2 = /You are logged in as user "admin"/;
         <%_ } _%>
         <%_ if (authenticationType !== 'oauth2') { _%>
-        const value2 = await element(by.css('.alert-success span')).<%- elementGetter %>;
+        const value2 = await element.all(by.css('.alert-success span')).first().<%- elementGetter %>;
         expect(value2).toMatch(expect2);
         <%_ } else { _%>
-        const success = element(by.css('.alert-success span'));
-        browser.wait(ec.visibilityOf(success), 5000).then(() => {
-            success.<%- elementGetter %>.then((value) => {
-                expect(value).toMatch(expect2);
-            });
-        });
+        const success = element.all(by.css('.alert-success span')).first();
+        await browser.wait(ec.visibilityOf(success), 5000);
+        expect(await success.<%- elementGetter %>).toMatch(expect2);
 
         navBarPage.autoSignOut();
         <%_ } _%>
@@ -176,7 +171,7 @@ describe('account', () => {
         <%_ } else { _%>
         const expect2 = /Password changed!/;
         <%_ } _%>
-        const value2 = element(by.css('.alert-success')).<%- elementGetter %>;
+        const value2 = await element(by.css('.alert-success')).<%- elementGetter %>;
         expect(value2).toMatch(expect2);
         navBarPage.autoSignOut();
         navBarPage.goToSignInPage();

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -48,8 +48,8 @@ describe('account', () => {
         const value1 = await element(by.css('h1')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     <%_ if (authenticationType !== 'oauth2') { _%>
-        signInPage = navBarPage.getSignInPage();
-        signInPage.autoSignInUsing('admin', 'foo');
+        signInPage = await navBarPage.getSignInPage();
+        await signInPage.autoSignInUsing('admin', 'foo');
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /login.messages.error.authentication/;
@@ -84,11 +84,11 @@ describe('account', () => {
         const value1 = await element(by.className('username-label')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
         <%_ } _%>
-        signInPage.clearUserName();
-        signInPage.setUserName('admin');
-        signInPage.clearPassword();
-        signInPage.setPassword('admin');
-        signInPage.login();
+        await signInPage.clearUserName();
+        await signInPage.setUserName('admin');
+        await signInPage.clearPassword();
+        await signInPage.setPassword('admin');
+        await signInPage.login();
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /home.logged.message/;
@@ -108,7 +108,7 @@ describe('account', () => {
     });
 <%_ if (authenticationType !== 'oauth2') { _%>
     it('should be able to update settings', async () => {
-        settingsPage = navBarPage.getSettingsPage();
+        settingsPage = await navBarPage.getSettingsPage();
 
         <%_ if (enableTranslation) { _%>
         const expect1 = /settings.title/;
@@ -117,7 +117,7 @@ describe('account', () => {
         <%_ } _%>
         const value1 = await settingsPage.getTitle();
         expect(value1).toMatch(expect1);
-        settingsPage.save();
+        await settingsPage.save();
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /settings.messages.success/;
@@ -129,7 +129,7 @@ describe('account', () => {
     });
 
     it('should fail to update password when using incorrect current password', async () => {
-        passwordPage = navBarPage.getPasswordPage();
+        passwordPage = await navBarPage.getPasswordPage();
 
         <%_ if (enableTranslation) { _%>
         expect(await passwordPage.getTitle()).toMatch(/password.title/);
@@ -137,10 +137,10 @@ describe('account', () => {
         expect(await passwordPage.getTitle()).toMatch(/Password for \[admin\]/);
         <%_ } _%>
 
-        passwordPage.setCurrentPassword('wrong_current_password');
-        passwordPage.setPassword('new_password');
-        passwordPage.setConfirmPassword('new_password');
-        passwordPage.save();
+        await passwordPage.setCurrentPassword('wrong_current_password');
+        await passwordPage.setPassword('new_password');
+        await passwordPage.setConfirmPassword('new_password');
+        await passwordPage.save();
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /password.messages.error/;
@@ -149,11 +149,11 @@ describe('account', () => {
         <%_ } _%>
         const value2 = await element(by.css('.alert-danger')).<%- elementGetter %>;
         expect(value2).toMatch(expect2);
-        settingsPage = navBarPage.getSettingsPage();
+        settingsPage = await navBarPage.getSettingsPage();
     });
 
     it('should be able to update password', async () => {
-        passwordPage = navBarPage.getPasswordPage();
+        passwordPage = await navBarPage.getPasswordPage();
 
         <%_ if (enableTranslation) { _%>
         expect(await passwordPage.getTitle()).toMatch(/password.title/);
@@ -161,10 +161,10 @@ describe('account', () => {
         expect(await passwordPage.getTitle()).toMatch(/Password for \[admin\]/);
         <%_ } _%>
 
-        passwordPage.setCurrentPassword('admin');
-        passwordPage.setPassword('newpassword');
-        passwordPage.setConfirmPassword('newpassword');
-        passwordPage.save();
+        await passwordPage.setCurrentPassword('admin');
+        await passwordPage.setPassword('newpassword');
+        await passwordPage.setConfirmPassword('newpassword');
+        await passwordPage.save();
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /password.messages.success/;
@@ -173,20 +173,20 @@ describe('account', () => {
         <%_ } _%>
         const value2 = await element(by.css('.alert-success')).<%- elementGetter %>;
         expect(value2).toMatch(expect2);
-        navBarPage.autoSignOut();
-        navBarPage.goToSignInPage();
-        signInPage.autoSignInUsing('admin', 'newpassword');
+        await navBarPage.autoSignOut();
+        await navBarPage.goToSignInPage();
+        await signInPage.autoSignInUsing('admin', 'newpassword');
 
         // change back to default
-        navBarPage.goToPasswordMenu();
-        passwordPage.setCurrentPassword('newpassword');
-        passwordPage.setPassword('admin');
-        passwordPage.setConfirmPassword('admin');
-        passwordPage.save();
+        await navBarPage.goToPasswordMenu();
+        await passwordPage.setCurrentPassword('newpassword');
+        await passwordPage.setPassword('admin');
+        await passwordPage.setConfirmPassword('admin');
+        await passwordPage.save();
     });
 
-    afterAll(() => {
-        navBarPage.autoSignOut();
+    afterAll(async () => {
+        await navBarPage.autoSignOut();
     });
 <%_ } _%>
 });

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { browser, element, by<% if (authenticationType === 'oauth2') { _%>, ExpectedConditions as ec<%_ } %> } from 'protractor';
-import { NavBarPage, SignInPage<%_ if (authenticationType !== 'oauth2') { _%>, PasswordPage, SettingsPage<%_ } _%> } from './../page-objects/jhi-page-objects';
+
+import { NavBarPage, SignInPage<%_ if (authenticationType !== 'oauth2') { _%>, PasswordPage, SettingsPage<%_ } _%> } from '../page-objects/jhi-page-objects';
 <%_
 let elementGetter = `getText()`;
 if (enableTranslation) {
@@ -35,20 +36,17 @@ describe('account', () => {
 
     beforeAll(() => {
         browser.get('/');
-        browser.waitForAngular();
         navBarPage = new NavBarPage(true);
-        browser.waitForAngular();
     });
 
-    it('should fail to login with bad password', () => {
+    it('should fail to login with bad password', async () => {
         <%_ if (enableTranslation) { _%>
         const expect1 = /home.title/;
         <%_ } else { _%>
         const expect1 = /Welcome, Java Hipster!/;
         <%_ } _%>
-        element.all(by.css('h1')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h1')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     <%_ if (authenticationType !== 'oauth2') { _%>
         signInPage = navBarPage.getSignInPage();
         signInPage.autoSignInUsing('admin', 'foo');
@@ -58,39 +56,33 @@ describe('account', () => {
         <%_ } else { _%>
         const expect2 = /Failed to sign in!/;
         <%_ } _%>
-        element.all(by.css('.alert-danger')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect2);
-        });
+        const value2 = await element(by.css('.alert-danger')).<%- elementGetter %>;
+        expect(value2).toMatch(expect2);
     <%_ } else { _%>
         signInPage = navBarPage.getSignInPage();
         signInPage.loginWithOAuth('admin', 'foo');
 
         // Keycloak
-        const alert = element.all(by.css('.alert-error'));
-        alert.isPresent().then((result) => {
-            if (result) {
-                expect(alert.first().getText()).toMatch('Invalid username or password.');
-            } else {
-                // Okta
-                const error = element.all(by.css('.infobox-error')).first();
-                browser.wait(ec.visibilityOf(error), 2000).then(() => {
-                    expect(error.getText()).toMatch('Sign in failed!');
-                });
-            }
-        });
+        const alert = element(by.css('.alert-error'));
+        if (await alert.isPresent()) {
+            expect(await alert.getText()).toMatch('Invalid username or password.');
+        } else {
+            // Okta
+            const error = element(by.css('.infobox-error'));
+            expect(await error.getText()).toMatch('Sign in failed!');
+        }
     <%_ } _%>
     });
 
-    it('should login successfully with admin account', () => {
+    it('should login successfully with admin account', async () => {
         <%_ if (authenticationType !== 'oauth2') { _%>
         <%_ if (enableTranslation) { _%>
         const expect1 = /global.form.username/;
         <%_ } else { _%>
         const expect1 = /Login/;
         <%_ } _%>
-        element.all(by.css('.modal-content label')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('.modal-content label')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
         <%_ } _%>
         signInPage.clearUserName();
         signInPage.setUserName('admin');
@@ -106,11 +98,10 @@ describe('account', () => {
         const expect2 = /You are logged in as user "admin"/;
         <%_ } _%>
         <%_ if (authenticationType !== 'oauth2') { _%>
-        element.all(by.css('.alert-success span')).<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect2);
-        });
+        const value2 = await element(by.css('.alert-success span')).<%- elementGetter %>;
+        expect(value2).toMatch(expect2);
         <%_ } else { _%>
-        const success = element.all(by.css('.alert-success span')).first();
+        const success = element(by.css('.alert-success span'));
         browser.wait(ec.visibilityOf(success), 5000).then(() => {
             success.<%- elementGetter %>.then((value) => {
                 expect(value).toMatch(expect2);
@@ -121,7 +112,7 @@ describe('account', () => {
         <%_ } _%>
     });
 <%_ if (authenticationType !== 'oauth2') { _%>
-    it('should be able to update settings', () => {
+    it('should be able to update settings', async () => {
         settingsPage = navBarPage.getSettingsPage();
 
         <%_ if (enableTranslation) { _%>
@@ -129,9 +120,8 @@ describe('account', () => {
         <%_ } else { _%>
         const expect1 = /User settings for \[admin\]/;
         <%_ } _%>
-        settingsPage.getTitle().then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await settingsPage.getTitle();
+        expect(value1).toMatch(expect1);
         settingsPage.save();
 
         <%_ if (enableTranslation) { _%>
@@ -139,18 +129,17 @@ describe('account', () => {
         <%_ } else { _%>
         const expect2 = /Settings saved!/;
         <%_ } _%>
-        element.all(by.css('.alert-success')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect2);
-        });
+        const value2 = await element(by.css('.alert-success')).<%- elementGetter %>;
+        expect(value2).toMatch(expect2);
     });
 
-    it('should fail to update password when using incorrect current password', () => {
+    it('should fail to update password when using incorrect current password', async () => {
         passwordPage = navBarPage.getPasswordPage();
 
         <%_ if (enableTranslation) { _%>
-        expect(passwordPage.getTitle()).toMatch(/password.title/);
+        expect(await passwordPage.getTitle()).toMatch(/password.title/);
         <%_ } else { _%>
-        expect(passwordPage.getTitle()).toMatch(/Password for \[admin\]/);
+        expect(await passwordPage.getTitle()).toMatch(/Password for \[admin\]/);
         <%_ } _%>
 
         passwordPage.setCurrentPassword('wrong_current_password');
@@ -163,19 +152,18 @@ describe('account', () => {
         <%_ } else { _%>
         const expect2 = /An error has occurred! The password could not be changed./;
         <%_ } _%>
-        element.all(by.css('.alert-danger')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect2);
-        });
+        const value2 = await element(by.css('.alert-danger')).<%- elementGetter %>;
+        expect(value2).toMatch(expect2);
         settingsPage = navBarPage.getSettingsPage();
     });
 
-    it('should be able to update password', () => {
+    it('should be able to update password', async () => {
         passwordPage = navBarPage.getPasswordPage();
 
         <%_ if (enableTranslation) { _%>
-        expect(passwordPage.getTitle()).toMatch(/password.title/);
+        expect(await passwordPage.getTitle()).toMatch(/password.title/);
         <%_ } else { _%>
-        expect(passwordPage.getTitle()).toMatch(/Password for \[admin\]/);
+        expect(await passwordPage.getTitle()).toMatch(/Password for \[admin\]/);
         <%_ } _%>
 
         passwordPage.setCurrentPassword('admin');
@@ -188,9 +176,8 @@ describe('account', () => {
         <%_ } else { _%>
         const expect2 = /Password changed!/;
         <%_ } _%>
-        element.all(by.css('.alert-success')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect2);
-        });
+        const value2 = element(by.css('.alert-success')).<%- elementGetter %>;
+        expect(value2).toMatch(expect2);
         navBarPage.autoSignOut();
         navBarPage.goToSignInPage();
         signInPage.autoSignInUsing('admin', 'newpassword');

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { browser, element, by<% if (authenticationType === 'oauth2') { _%>, ExpectedConditions as ec<%_ } %> } from 'protractor';
+import { browser, element, by, ExpectedConditions as ec } from 'protractor';
 
 import { NavBarPage, SignInPage<%_ if (authenticationType !== 'oauth2') { _%>, PasswordPage, SettingsPage<%_ } _%> } from '../page-objects/jhi-page-objects';
 <%_
@@ -97,6 +97,7 @@ describe('account', () => {
         <%_ } _%>
         <%_ if (authenticationType !== 'oauth2') { _%>
         const value2 = element(by.id('home-logged-message'));
+        await browser.wait(ec.visibilityOf(value2), 5000);
         expect(await value2.<%- elementGetter %>).toMatch(expect2);
         <%_ } else { _%>
         const success = element.all(by.css('.alert-success span')).first();

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -86,24 +86,21 @@ describe('account', () => {
         <%_ } _%>
         const value1 = await element(by.className('username-label')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
-        <%_ } _%>
-
         await signInPage.autoSignInUsing('admin', 'admin');
+        <%_ } else {_%>
+        await signInPage.loginWithOAuth('', 'admin');
+        <%_ } _%>
 
         <%_ if (enableTranslation) { _%>
         const expect2 = /home.logged.message/;
         <%_ } else { _%>
         const expect2 = /You are logged in as user "admin"/;
         <%_ } _%>
-        <%_ if (authenticationType !== 'oauth2') { _%>
         const value2 = element(by.id('home-logged-message'));
         await browser.wait(ec.visibilityOf(value2), 5000);
         expect(await value2.<%- elementGetter %>).toMatch(expect2);
-        <%_ } else { _%>
-        const success = element.all(by.css('.alert-success span')).first();
-        await browser.wait(ec.visibilityOf(success), 5000);
-        expect(await success.<%- elementGetter %>).toMatch(expect2);
-
+    
+        <%_ if (authenticationType === 'oauth2') { _%>
         await navBarPage.autoSignOut();
         <%_ } _%>
     });

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { browser, element, by } from 'protractor';
 
-import { NavBarPage } from '../page-objects/jhi-page-objects';
+import { NavBarPage, SignInPage } from '../page-objects/jhi-page-objects';
 <%_
 let elementGetter = `getText()`;
 if (enableTranslation) {
@@ -28,12 +28,14 @@ if (enableTranslation) {
 describe('administration', () => {
 
     let navBarPage: NavBarPage;
+    let signInPage: SignInPage;
 
     beforeAll(async () => {
         await browser.get('/');
         navBarPage = new NavBarPage(true);
         <%_ if (authenticationType !== 'oauth2') { _%>
-        navBarPage.getSignInPage().autoSignInUsing('admin', 'admin');
+        signInPage = await navBarPage.getSignInPage();
+        await signInPage.autoSignInUsing('admin', 'admin');
         <%_ } else { _%>
         navBarPage.getSignInPage().loginWithOAuth('admin', 'admin');
         <%_ } _%>

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -33,11 +33,11 @@ describe('administration', () => {
     beforeAll(async () => {
         await browser.get('/');
         navBarPage = new NavBarPage(true);
-        <%_ if (authenticationType !== 'oauth2') { _%>
         signInPage = await navBarPage.getSignInPage();
+        <%_ if (authenticationType !== 'oauth2') { _%>
         await signInPage.autoSignInUsing('admin', 'admin');
         <%_ } else { _%>
-        navBarPage.getSignInPage().loginWithOAuth('admin', 'admin');
+        await signInPage.loginWithOAuth('admin', 'admin');
         <%_ } _%>
     });
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { browser, element, by } from 'protractor';
-import { NavBarPage } from './../page-objects/jhi-page-objects';
+
+import { NavBarPage } from '../page-objects/jhi-page-objects';
 <%_
 let elementGetter = `getText()`;
 if (enableTranslation) {
@@ -30,93 +31,85 @@ describe('administration', () => {
 
     beforeAll(() => {
         browser.get('/');
-        browser.waitForAngular();
         navBarPage = new NavBarPage(true);
         <%_ if (authenticationType !== 'oauth2') { _%>
         navBarPage.getSignInPage().autoSignInUsing('admin', 'admin');
         <%_ } else { _%>
         navBarPage.getSignInPage().loginWithOAuth('admin', 'admin');
         <%_ } _%>
-        browser.waitForAngular();
     });
 
     beforeEach(() => {
         navBarPage.clickOnAdminMenu();
     });
     <%_ if (authenticationType !== 'oauth2') { _%>
-    it('should load user management', () => {
+    it('should load user management', async () => {
         navBarPage.clickOnAdmin('user-management');
         <%_ if (enableTranslation) { _%>
         const expect1 = /userManagement.home.title/;
         <%_ } else { _%>
         const expect1 = /Users/;
         <%_ } _%>
-        element.all(by.css('h2 span')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h2 span')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     });
     <%_ } _%>
 
-    it('should load metrics', () => {
+    it('should load metrics', async () => {
         navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-metrics');
         <%_ if (enableTranslation) { _%>
         const expect1 = /metrics.title/;
         <%_ } else { _%>
         const expect1 = /Application Metrics/;
         <%_ } _%>
-        element.all(by.css('h2 span')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h2 span')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     });
 
-    it('should load health', () => {
+    it('should load health', async () => {
         navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-health');
         <%_ if (enableTranslation) { _%>
         const expect1 = /health.title/;
         <%_ } else { _%>
         const expect1 = /Health Checks/;
         <%_ } _%>
-        element.all(by.css('h2 span')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h2 span')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     });
 
-    it('should load configuration', () => {
+    it('should load configuration', async () => {
         navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-configuration');
         <%_ if (enableTranslation) { _%>
         const expect1 = /configuration.title/;
         <%_ } else { _%>
         const expect1 = /Configuration/;
         <%_ } _%>
-        element.all(by.css('h2')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h2')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     });
 
 <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
-    it('should load audits', () => {
+    it('should load audits', async () => {
         navBarPage.clickOnAdmin('audits');
         <%_ if (enableTranslation) { _%>
         const expect1 = /audits.title/;
         <%_ } else { _%>
         const expect1 = /Audits/;
         <%_ } _%>
-        element.all(by.css('h2')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h2')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     });
 
 <%_ } _%>
-    it('should load logs', () => {
+    it('should load logs', async () => {
         navBarPage.clickOnAdmin('logs');
         <%_ if (enableTranslation) { _%>
         const expect1 = /logs.title/;
         <%_ } else { _%>
         const expect1 = /Logs/;
         <%_ } _%>
-        element.all(by.css('h2')).first().<%- elementGetter %>.then((value) => {
-            expect(value).toMatch(expect1);
-        });
+        const value1 = await element(by.css('h2')).<%- elementGetter %>;
+        expect(value1).toMatch(expect1);
     });
 
     afterAll(() => {

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -42,6 +42,7 @@ describe('administration', () => {
     beforeEach(() => {
         navBarPage.clickOnAdminMenu();
     });
+    
     <%_ if (authenticationType !== 'oauth2') { _%>
     it('should load user management', async () => {
         navBarPage.clickOnAdmin('user-management');
@@ -50,7 +51,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Users/;
         <%_ } _%>
-        const value1 = await element(by.css('h2 span')).<%- elementGetter %>;
+        const value1 = await element(by.className('userManagement-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
     <%_ } _%>
@@ -62,7 +63,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Application Metrics/;
         <%_ } _%>
-        const value1 = await element(by.css('h2 span')).<%- elementGetter %>;
+        const value1 = await element(by.className('metrics-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -73,7 +74,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Health Checks/;
         <%_ } _%>
-        const value1 = await element(by.css('h2 span')).<%- elementGetter %>;
+        const value1 = await element(by.className('health-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -84,7 +85,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Configuration/;
         <%_ } _%>
-        const value1 = await element(by.css('h2')).<%- elementGetter %>;
+        const value1 = await element(by.className('configuration-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -96,7 +97,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Audits/;
         <%_ } _%>
-        const value1 = await element(by.css('h2')).<%- elementGetter %>;
+        const value1 = await element(by.className('audits-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -108,7 +109,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Logs/;
         <%_ } _%>
-        const value1 = await element(by.css('h2')).<%- elementGetter %>;
+        const value1 = await element(by.className('logs-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -29,8 +29,8 @@ describe('administration', () => {
 
     let navBarPage: NavBarPage;
 
-    beforeAll(() => {
-        browser.get('/');
+    beforeAll(async () => {
+        await browser.get('/');
         navBarPage = new NavBarPage(true);
         <%_ if (authenticationType !== 'oauth2') { _%>
         navBarPage.getSignInPage().autoSignInUsing('admin', 'admin');
@@ -39,13 +39,13 @@ describe('administration', () => {
         <%_ } _%>
     });
 
-    beforeEach(() => {
-        navBarPage.clickOnAdminMenu();
+    beforeEach(async () => {
+        await navBarPage.clickOnAdminMenu();
     });
     
     <%_ if (authenticationType !== 'oauth2') { _%>
     it('should load user management', async () => {
-        navBarPage.clickOnAdmin('user-management');
+        await navBarPage.clickOnAdmin('user-management');
         <%_ if (enableTranslation) { _%>
         const expect1 = /userManagement.home.title/;
         <%_ } else { _%>
@@ -57,7 +57,7 @@ describe('administration', () => {
     <%_ } _%>
 
     it('should load metrics', async () => {
-        navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-metrics');
+        await navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-metrics');
         <%_ if (enableTranslation) { _%>
         const expect1 = /metrics.title/;
         <%_ } else { _%>
@@ -68,7 +68,7 @@ describe('administration', () => {
     });
 
     it('should load health', async () => {
-        navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-health');
+        await navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-health');
         <%_ if (enableTranslation) { _%>
         const expect1 = /health.title/;
         <%_ } else { _%>
@@ -79,7 +79,7 @@ describe('administration', () => {
     });
 
     it('should load configuration', async () => {
-        navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-configuration');
+        await navBarPage.clickOnAdmin('<%= jhiPrefixDashed %>-configuration');
         <%_ if (enableTranslation) { _%>
         const expect1 = /configuration.title/;
         <%_ } else { _%>
@@ -91,7 +91,7 @@ describe('administration', () => {
 
 <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
     it('should load audits', async () => {
-        navBarPage.clickOnAdmin('audits');
+        await navBarPage.clickOnAdmin('audits');
         <%_ if (enableTranslation) { _%>
         const expect1 = /audits.title/;
         <%_ } else { _%>
@@ -103,7 +103,7 @@ describe('administration', () => {
 
 <%_ } _%>
     it('should load logs', async () => {
-        navBarPage.clickOnAdmin('logs');
+        await navBarPage.clickOnAdmin('logs');
         <%_ if (enableTranslation) { _%>
         const expect1 = /logs.title/;
         <%_ } else { _%>
@@ -113,7 +113,7 @@ describe('administration', () => {
         expect(value1).toMatch(expect1);
     });
 
-    afterAll(() => {
-        navBarPage.autoSignOut();
+    afterAll(async () => {
+        await navBarPage.autoSignOut();
     });
 });

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -53,7 +53,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Users/;
         <%_ } _%>
-        const value1 = await element(by.className('userManagement-page-heading')).<%- elementGetter %>;
+        const value1 = await element(by.id('user-management-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
     <%_ } _%>
@@ -65,7 +65,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Application Metrics/;
         <%_ } _%>
-        const value1 = await element(by.className('metrics-page-heading')).<%- elementGetter %>;
+        const value1 = await element(by.id('metrics-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -76,7 +76,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Health Checks/;
         <%_ } _%>
-        const value1 = await element(by.className('health-page-heading')).<%- elementGetter %>;
+        const value1 = await element(by.id('health-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -87,7 +87,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Configuration/;
         <%_ } _%>
-        const value1 = await element(by.className('configuration-page-heading')).<%- elementGetter %>;
+        const value1 = await element(by.id('configuration-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -99,7 +99,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Audits/;
         <%_ } _%>
-        const value1 = await element(by.className('audits-page-heading')).<%- elementGetter %>;
+        const value1 = await element(by.id('audits-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 
@@ -111,7 +111,7 @@ describe('administration', () => {
         <%_ } else { _%>
         const expect1 = /Logs/;
         <%_ } _%>
-        const value1 = await element(by.className('logs-page-heading')).<%- elementGetter %>;
+        const value1 = await element(by.id('logs-page-heading')).<%- elementGetter %>;
         expect(value1).toMatch(expect1);
     });
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -144,18 +144,17 @@ export class SignInPage {
     }
     <%_ } else { _%>
 
-    loginWithOAuth(username: string, password: string) {
-
+    async loginWithOAuth(username: string, password: string) {
         // Entering non angular site, tell webdriver to switch to synchronous mode.
         browser.waitForAngularEnabled(false);
 
-        this.username.isPresent().then(() => {
-            this.username.sendKeys(username);
-            this.password.sendKeys(password);
-            this.loginButton.click();
-        }).catch((error) => {
+        if (await this.username.isPresent()) {
+            await this.username.sendKeys(username);
+            await this.password.sendKeys(password);
+            await this.loginButton.click();
+        } else {
             browser.waitForAngularEnabled(true);
-        });
+        }
     }
     <%_ } _%>
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -116,7 +116,7 @@ export class SignInPage {
         await this.username.sendKeys(username);
     }
 
-    getUserName() {
+    async getUserName() {
         return this.username.getAttribute('value');
     }
 
@@ -128,7 +128,7 @@ export class SignInPage {
         await this.password.sendKeys(password);
     }
 
-    getPassword() {
+    async getPassword() {
         return this.password.getAttribute('value');
     }
 
@@ -179,7 +179,7 @@ export class PasswordPage {
         await this.password.sendKeys(password);
     }
 
-    getPassword() {
+    async getPassword() {
         return this.password.getAttribute('value');
     }
 
@@ -191,7 +191,7 @@ export class PasswordPage {
         await this.confirmPassword.sendKeys(confirmPassword);
     }
 
-    getConfirmPassword() {
+    async getConfirmPassword() {
         return this.confirmPassword.getAttribute('value');
     }
 
@@ -199,7 +199,7 @@ export class PasswordPage {
         await this.confirmPassword.clear();
     }
 
-    getTitle() {
+    async getTitle() {
         return this.title.<%- elementGetter %>;
     }
 
@@ -219,7 +219,7 @@ export class SettingsPage {
         await this.firstName.sendKeys(firstName);
     }
 
-    getFirstName() {
+    async getFirstName() {
         return this.firstName.getAttribute('value');
     }
 
@@ -231,7 +231,7 @@ export class SettingsPage {
         await this.lastName.sendKeys(lastName);
     }
 
-    getLastName() {
+    async getLastName() {
         return this.lastName.getAttribute('value');
     }
 
@@ -243,7 +243,7 @@ export class SettingsPage {
         await this.email.sendKeys(email);
     }
 
-    getEmail() {
+    async getEmail() {
         return this.email.getAttribute('value');
     }
 
@@ -251,7 +251,7 @@ export class SettingsPage {
         await this.email.clear();
     }
 
-    getTitle() {
+    async getTitle() {
         return this.title.<%- elementGetter %>;
     }
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -21,44 +21,44 @@ export class NavBarPage {
         }
     }
 
-    clickOnEntityMenu() {
-        return this.entityMenu.click();
+    async clickOnEntityMenu() {
+        await this.entityMenu.click();
     }
 
-    clickOnAccountMenu() {
-        return this.accountMenu.click();
+    async clickOnAccountMenu() {
+        await this.accountMenu.click();
     }
 
-    clickOnAdminMenu() {
-        return this.adminMenu.click();
+    async clickOnAdminMenu() {
+        await this.adminMenu.click();
     }
 
-    clickOnSignIn() {
-        return this.signIn.click();
+    async clickOnSignIn() {
+        await this.signIn.click();
     }
 
-    clickOnRegister() {
-        return this.signIn.click();
+    async clickOnRegister() {
+        await this.signIn.click();
     }
 
-    clickOnSignOut() {
-        return this.signOut.click();
+    async clickOnSignOut() {
+        await this.signOut.click();
     }
 
-    clickOnPasswordMenu() {
-        return this.passwordMenu.click();
+    async clickOnPasswordMenu() {
+        await this.passwordMenu.click();
     }
 
-    clickOnSettingsMenu() {
-        return this.settingsMenu.click();
+    async clickOnSettingsMenu() {
+        await this.settingsMenu.click();
     }
 
-    clickOnEntity(entityName: string) {
-        return element(by.css('[routerLink="' + entityName + '"]')).click();
+    async clickOnEntity(entityName: string) {
+        await element(by.css('[routerLink="' + entityName + '"]')).click();
     }
 
-    clickOnAdmin(entityName: string) {
-        return element(by.css('[routerLink="admin/' + entityName + '"]')).click();
+    async clickOnAdmin(entityName: string) {
+        await element(by.css('[routerLink="admin/' + entityName + '"]')).click();
     }
 
     getSignInPage() {

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -61,43 +61,43 @@ export class NavBarPage {
         await element(by.css('[routerLink="admin/' + entityName + '"]')).click();
     }
 
-    getSignInPage() {
-        this.clickOnAccountMenu();
-        this.clickOnSignIn();
+    async getSignInPage() {
+        await this.clickOnAccountMenu();
+        await this.clickOnSignIn();
         return new SignInPage();
     }
     <%_ if (authenticationType !== 'oauth2') { _%>
-    getPasswordPage() {
-        this.clickOnAccountMenu();
-        this.clickOnPasswordMenu();
+    async getPasswordPage() {
+        await this.clickOnAccountMenu();
+        await this.clickOnPasswordMenu();
         return new PasswordPage();
     }
 
-    getSettingsPage() {
-        this.clickOnAccountMenu();
-        this.clickOnSettingsMenu();
+    async getSettingsPage() {
+        await this.clickOnAccountMenu();
+        await this.clickOnSettingsMenu();
         return new SettingsPage();
     }
     <%_ } _%>
 
-    goToEntity(entityName: string) {
-        this.clickOnEntityMenu();
-        return this.clickOnEntity(entityName);
+    async goToEntity(entityName: string) {
+        await this.clickOnEntityMenu();
+        await this.clickOnEntity(entityName);
     }
 
-    goToSignInPage() {
-        this.clickOnAccountMenu();
-        this.clickOnSignIn();
+    async goToSignInPage() {
+        await this.clickOnAccountMenu();
+        await this.clickOnSignIn();
     }
 
-    goToPasswordMenu() {
-        this.clickOnAccountMenu();
-        this.clickOnPasswordMenu();
+    async goToPasswordMenu() {
+        await this.clickOnAccountMenu();
+        await this.clickOnPasswordMenu();
     }
 
-    autoSignOut() {
-        this.clickOnAccountMenu();
-        this.clickOnSignOut();
+    async autoSignOut() {
+        await this.clickOnAccountMenu();
+        await this.clickOnSignOut();
     }
 }
 
@@ -112,35 +112,35 @@ export class SignInPage {
     loginButton = element(by.css('input[type=submit]'));
     <%_ } _%>
 
-    setUserName(username) {
-        this.username.sendKeys(username);
+    async setUserName(username) {
+        await this.username.sendKeys(username);
     }
 
     getUserName() {
         return this.username.getAttribute('value');
     }
 
-    clearUserName() {
-        this.username.clear();
+    async clearUserName() {
+        await this.username.clear();
     }
 
-    setPassword(password) {
-        this.password.sendKeys(password);
+    async setPassword(password) {
+        await this.password.sendKeys(password);
     }
 
     getPassword() {
         return this.password.getAttribute('value');
     }
 
-    clearPassword() {
-        this.password.clear();
+    async clearPassword() {
+        await this.password.clear();
     }
     <%_ if (authenticationType !== 'oauth2') { _%>
 
-    autoSignInUsing(username: string, password: string) {
-        this.setUserName(username);
-        this.setPassword(password);
-        return this.login();
+    async autoSignInUsing(username: string, password: string) {
+        await this.setUserName(username);
+        await this.setPassword(password);
+        await this.login();
     }
     <%_ } else { _%>
 
@@ -159,8 +159,8 @@ export class SignInPage {
     }
     <%_ } _%>
 
-    login() {
-        return this.loginButton.click();
+    async login() {
+        await this.loginButton.click();
     }
 }
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -171,40 +171,40 @@ export class PasswordPage {
     saveButton = element(by.css('button[type=submit]'));
     title = element.all(by.css('h2')).first();
 
-    setCurrentPassword(password) {
-        this.currentPassword.sendKeys(password);
+    async setCurrentPassword(password) {
+        await this.currentPassword.sendKeys(password);
     }
 
-    setPassword(password) {
-        this.password.sendKeys(password);
+    async setPassword(password) {
+        await this.password.sendKeys(password);
     }
 
     getPassword() {
         return this.password.getAttribute('value');
     }
 
-    clearPassword() {
-        this.password.clear();
+    async clearPassword() {
+        await this.password.clear();
     }
 
-    setConfirmPassword(confirmPassword) {
-        this.confirmPassword.sendKeys(confirmPassword);
+    async setConfirmPassword(confirmPassword) {
+        await this.confirmPassword.sendKeys(confirmPassword);
     }
 
     getConfirmPassword() {
         return this.confirmPassword.getAttribute('value');
     }
 
-    clearConfirmPassword() {
-        this.confirmPassword.clear();
+    async clearConfirmPassword() {
+        await this.confirmPassword.clear();
     }
 
     getTitle() {
         return this.title.<%- elementGetter %>;
     }
 
-    save() {
-        return this.saveButton.click();
+    async save() {
+        await this.saveButton.click();
     }
 }
 
@@ -215,48 +215,48 @@ export class SettingsPage {
     saveButton = element(by.css('button[type=submit]'));
     title = element.all(by.css('h2')).first();
 
-    setFirstName(firstName) {
-        this.firstName.sendKeys(firstName);
+    async setFirstName(firstName) {
+        await this.firstName.sendKeys(firstName);
     }
 
     getFirstName() {
         return this.firstName.getAttribute('value');
     }
 
-    clearFirstName() {
-        this.firstName.clear();
+    async clearFirstName() {
+        await this.firstName.clear();
     }
 
-    setLastName(lastName) {
-        this.lastName.sendKeys(lastName);
+    async setLastName(lastName) {
+        await this.lastName.sendKeys(lastName);
     }
 
     getLastName() {
         return this.lastName.getAttribute('value');
     }
 
-    clearLastName() {
-        this.lastName.clear();
+    async clearLastName() {
+        await this.lastName.clear();
     }
 
-    setEmail(email) {
-        this.email.sendKeys(email);
+    async setEmail(email) {
+        await this.email.sendKeys(email);
     }
 
     getEmail() {
         return this.email.getAttribute('value');
     }
 
-    clearEmail() {
-        this.email.clear();
+    async clearEmail() {
+        await this.email.clear();
     }
 
     getTitle() {
         return this.title.<%- elementGetter %>;
     }
 
-    save() {
-        return this.saveButton.click();
+    async save() {
+        await this.saveButton.click();
     }
 }
 <%_ } _%>

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -42,6 +42,8 @@ exports.config = {
 
     framework: 'jasmine2',
 
+    SELENIUM_PROMISE_MANAER: false,
+
     jasmineNodeOpts: {
         showColors: true,
         defaultTimeoutInterval: 720000

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -42,7 +42,7 @@ exports.config = {
 
     framework: 'jasmine2',
 
-    SELENIUM_PROMISE_MANAER: false,
+    SELENIUM_PROMISE_MANAGER: false,
 
     jasmineNodeOpts: {
         showColors: true,

--- a/generators/client/templates/angular/tslint.json.ejs
+++ b/generators/client/templates/angular/tslint.json.ejs
@@ -117,7 +117,13 @@
         "import-spacing": true,
         "no-consecutive-blank-lines": [true],
         "object-literal-shorthand": true,
-        "space-before-function-paren": [true, "never"],
+        "space-before-function-paren": [true, {
+            "asyncArrow": "always",
+            "anonymous": "never",
+            "constructor": "never",
+            "method": "never",
+            "named": "never"
+        }],
 
         "directive-selector": [true, "attribute", "<%=jhiPrefix%>", "camelCase"],
         "component-selector": [true, "element", "<%= jhiPrefixDashed %>", "kebab-case"],

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -47,7 +47,7 @@ export default (state: LocaleState = initialState, action): LocaleState => {
 };
 
 export const setLocale = locale => async dispatch => {
-  if (Object.keys(TranslatorContext.context.translations).indexOf(locale) === -1) {
+  if (!Object.keys(TranslatorContext.context.translations).includes(locale)) {
     const response = await axios.get(`i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
     TranslatorContext.registerTranslations(locale, response.data);
   }

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -41,7 +41,7 @@ export class <%= entityClass %>ComponentsPage {
     }
 
     async getTitle() {
-        await this.title.<%- elementGetter %>;
+        return this.title.<%- elementGetter %>;
     }
 }
 
@@ -76,7 +76,7 @@ export class <%= entityClass %>UpdatePage {
     <%_ }); _%>
 
     async getPageTitle() {
-        await this.pageTitle.<%- elementGetter %>;
+        return this.pageTitle.<%- elementGetter %>;
     }
 
     <%_ fields.forEach((field) => {
@@ -99,7 +99,7 @@ export class <%= entityClass %>UpdatePage {
     }
 
     async get<%= fieldNameCapitalized %>Select() {
-        await this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
+        return this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
     }
 
     async <%=fieldName %>SelectLastOption() {
@@ -112,7 +112,7 @@ export class <%= entityClass %>UpdatePage {
     }
 
     async get<%= fieldNameCapitalized %>Input() {
-        await this.<%= fieldName %>Input.getAttribute('value');
+        return this.<%= fieldName %>Input.getAttribute('value');
     }
 
     <%_ } else { _%>
@@ -121,7 +121,7 @@ export class <%= entityClass %>UpdatePage {
     }
 
     async get<%= fieldNameCapitalized %>Input() {
-        await this.<%= fieldName %>Input.getAttribute('value');
+        return this.<%= fieldName %>Input.getAttribute('value');
     }
 
     <%_ } _%>
@@ -147,7 +147,7 @@ export class <%= entityClass %>UpdatePage {
     }
 
     async get<%=relationshipNameCapitalized %>SelectedOption() {
-        await this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
+        return this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
     }
 
     <%_ } _%>

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { element, by, promise, ElementFinder } from 'protractor';
+import { element, by, ElementFinder } from 'protractor';
 
 <%_
 let elementGetter = `getText()`;
@@ -36,12 +36,12 @@ export class <%= entityClass %>ComponentsPage {
     createButton = element(by.id('jh-create-entity'));
     title = element.all(by.css('<%= jhiPrefixDashed %>-<%= entityFileName %> div h2#page-heading span')).first();
 
-    clickOnCreateButton(): promise.Promise<void> {
-        return this.createButton.click();
+    async clickOnCreateButton() {
+        await this.createButton.click();
     }
 
-    getTitle(): any {
-        return this.title.<%- elementGetter %>;
+    async getTitle() {
+        await this.title.<%- elementGetter %>;
     }
 }
 
@@ -75,8 +75,8 @@ export class <%= entityClass %>UpdatePage {
     <%_ } _%>
     <%_ }); _%>
 
-    getPageTitle() {
-        return this.pageTitle.<%- elementGetter %>;
+    async getPageTitle() {
+        await this.pageTitle.<%- elementGetter %>;
     }
 
     <%_ fields.forEach((field) => {
@@ -94,33 +94,34 @@ export class <%= entityClass %>UpdatePage {
         return this.<%= fieldName %>Input;
     }
             <%_ } else if (fieldIsEnum) { _%>
-    set<%= fieldNameCapitalized %>Select(<%= fieldName %>): promise.Promise<void> {
-        return this.<%= fieldName %>Select.sendKeys(<%= fieldName %>);
+    async set<%= fieldNameCapitalized %>Select(<%= fieldName %>) {
+        await this.<%= fieldName %>Select.sendKeys(<%= fieldName %>);
     }
 
-    get<%= fieldNameCapitalized %>Select() {
-        return this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
+    async get<%= fieldNameCapitalized %>Select() {
+        await this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
     }
 
-    <%=fieldName %>SelectLastOption(): promise.Promise<void> {
-        return this.<%=fieldName %>Select.all(by.tagName('option')).last().click();
+    async <%=fieldName %>SelectLastOption() {
+        await this.<%=fieldName %>Select.all(by.tagName('option')).last().click();
     }
+
     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
-    set<%= fieldNameCapitalized %>Input(<%= fieldName %>): promise.Promise<void> {
-        return this.<%= fieldName %>Input.sendKeys(<%= fieldName %>);
+    async set<%= fieldNameCapitalized %>Input(<%= fieldName %>) {
+        await this.<%= fieldName %>Input.sendKeys(<%= fieldName %>);
     }
 
-    get<%= fieldNameCapitalized %>Input() {
-        return this.<%= fieldName %>Input.getAttribute('value');
+    async get<%= fieldNameCapitalized %>Input() {
+        await this.<%= fieldName %>Input.getAttribute('value');
     }
 
     <%_ } else { _%>
-    set<%= fieldNameCapitalized %>Input(<%= fieldName %>): promise.Promise<void> {
-        return this.<%= fieldName %>Input.sendKeys(<%= fieldName %>);
+    async set<%= fieldNameCapitalized %>Input(<%= fieldName %>) {
+        await this.<%= fieldName %>Input.sendKeys(<%= fieldName %>);
     }
 
-    get<%= fieldNameCapitalized %>Input() {
-        return this.<%= fieldName %>Input.getAttribute('value');
+    async get<%= fieldNameCapitalized %>Input() {
+        await this.<%= fieldName %>Input.getAttribute('value');
     }
 
     <%_ } _%>
@@ -131,31 +132,32 @@ export class <%= entityClass %>UpdatePage {
         const relationshipName = relationship.relationshipName;
         const relationshipFieldName = relationship.relationshipFieldName;
         const relationshipNameCapitalized = relationship.relationshipNameCapitalized; _%>
+
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-    <%=relationshipName %>SelectLastOption(): promise.Promise<void> {
-        return this.<%=relationshipName %>Select.all(by.tagName('option')).last().click();
+    async <%=relationshipName %>SelectLastOption() {
+        await this.<%=relationshipName %>Select.all(by.tagName('option')).last().click();
     }
 
-    <%=relationshipName %>SelectOption(option): promise.Promise<void> {
-        return this.<%=relationshipName %>Select.sendKeys(option);
+    async <%=relationshipName %>SelectOption(option) {
+        await this.<%=relationshipName %>Select.sendKeys(option);
     }
 
     get<%=relationshipNameCapitalized %>Select(): ElementFinder {
         return this.<%=relationshipName %>Select;
     }
 
-    get<%=relationshipNameCapitalized %>SelectedOption() {
-        return this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
+    async get<%=relationshipNameCapitalized %>SelectedOption() {
+        await this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
     }
 
     <%_ } _%>
     <%_ }); _%>
-    save(): promise.Promise<void> {
-        return this.saveButton.click();
+    async save() {
+        await this.saveButton.click();
     }
 
-    cancel(): promise.Promise<void> {
-        return this.cancelButton.click();
+    async cancel() {
+        await this.cancelButton.click();
     }
 
     getSaveButton(): ElementFinder {

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { browser, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor<% } %> } from 'protractor';
-import { NavBarPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
+import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
 
 import { <%= entityClass %>ComponentsPage, <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
 <%_ if (fieldsContainBlobOrImage) { _%>
@@ -41,6 +41,7 @@ for (let relationship of relationships) {
 describe('<%= entityClass %> e2e test', () => {
 
     let navBarPage: NavBarPage;
+    let signInPage: SignInPage;
     let <%= entityInstance %>UpdatePage: <%= entityClass %>UpdatePage;
     let <%= entityInstance %>ComponentsPage: <%= entityClass %>ComponentsPage;
     <%_ if (fieldsContainBlobOrImage) { _%>
@@ -48,18 +49,19 @@ describe('<%= entityClass %> e2e test', () => {
     const absolutePath = path.resolve(__dirname, fileToUpload);
     <%_ } _%>
 
-    beforeAll(() => {
-        browser.get('/');
+    beforeAll(async () => {
+        await browser.get('/');
         navBarPage = new NavBarPage();
         <%_ if (authenticationType === 'oauth2') { _%>
         navBarPage.getSignInPage().loginWithOAuth('admin', 'admin');
         <%_ } else { _%>
-        navBarPage.getSignInPage().autoSignInUsing('admin', 'admin');
+        signInPage = await navBarPage.getSignInPage();
+        await signInPage.autoSignInUsing('admin', 'admin');
         <%_ } _%>
     });
 
     it('should load <%= entityClassPlural %>', async () => {
-        navBarPage.goToEntity('<%= entityStateName %>');
+        await navBarPage.goToEntity('<%= entityStateName %>');
         <%= entityInstance %>ComponentsPage = new <%= entityClass %>ComponentsPage();
         <%_ if (enableTranslation) { _%>
         expect(await <%= entityInstance %>ComponentsPage.getTitle())
@@ -71,7 +73,7 @@ describe('<%= entityClass %> e2e test', () => {
     });
 
     it('should load create <%= entityClass %> page', async () => {
-        <%= entityInstance %>ComponentsPage.clickOnCreateButton();
+        await <%= entityInstance %>ComponentsPage.clickOnCreateButton();
         <%= entityInstance %>UpdatePage = new <%= entityClass %>UpdatePage();
         <%_ if (enableTranslation) { _%>
         expect(await <%= entityInstance %>UpdatePage.getPageTitle())
@@ -80,11 +82,11 @@ describe('<%= entityClass %> e2e test', () => {
         expect(await <%= entityInstance %>UpdatePage.getPageTitle())
             .toMatch(/Create or edit a <%= entityClassHumanized %>/);
         <%_ } _%>
-        <%= entityInstance %>UpdatePage.cancel();
+        await <%= entityInstance %>UpdatePage.cancel();
     });
 
    <%= openBlockComment %> it('should create and save <%= entityClassPlural %>', async () => {
-        <%= entityInstance %>ComponentsPage.clickOnCreateButton();
+        await <%= entityInstance %>ComponentsPage.clickOnCreateButton();
         <%_ fields.forEach((field) => {
             const fieldName = field.fieldName;
             const fieldNameCapitalized = field.fieldNameCapitalized;
@@ -93,36 +95,35 @@ describe('<%= entityClass %> e2e test', () => {
             const fieldIsEnum = field.fieldIsEnum;
         _%>
         <%_ if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5');
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('5');
         <%_ } else if (fieldType === 'LocalDate') { _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('2000-12-31');
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('2000-12-31');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('2000-12-31');
         <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('01/01/2001' + protractor.Key.TAB + '02:30AM');
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('01/01/2001' + protractor.Key.TAB + '02:30AM');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toContain('2001-01-01T02:30');
         <%_ } else if (fieldType === 'Boolean') { _%>
-        <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected().then((selected) => {
-            if (selected) {
-                <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
-                expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeFalsy();
-            } else {
-                <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
-                expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeTruthy();
-            }
-        });
+        const selected<%= fieldNameCapitalized %> = <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input();
+        if (await selected<%= fieldNameCapitalized %>.isSelected()) {
+            await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
+            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeFalsy();
+        } else {
+            await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
+            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeTruthy();
+        }
         <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('<%= fieldName %>');
         <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath);
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath);
         <%_ } else if (fieldIsEnum) { _%>
-        <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption();
+        await <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption();
         <%_ } else if (fieldType === 'UUID'){ _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('64c99148-3908-465d-8c4a-e510e3ade974');
         <%_ } else { _%>
-        <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
+        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('<%= fieldName %>');
         <%_ } _%>
         <%_ }); _%>
@@ -132,16 +133,16 @@ describe('<%= entityClass %> e2e test', () => {
             const relationshipName = relationship.relationshipName;
             const relationshipFieldName = relationship.relationshipFieldName; _%>
         <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-        <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
+        await <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
         <%_ } else if ((relationshipType === 'many-to-many' && ownerSide === true)) { _%>
         // <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
         <%_ } _%>
         <%_ }); _%>
-        <%= entityInstance %>UpdatePage.save();
+        await <%= entityInstance %>UpdatePage.save();
         expect(await <%= entityInstance %>UpdatePage.getSaveButton().isPresent()).toBeFalsy();
     });<%= closeBlockComment %>
 
-    afterAll(() => {
-        navBarPage.autoSignOut();
+    afterAll(async () => {
+        await navBarPage.autoSignOut();
     });
 });

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -17,7 +17,8 @@
  limitations under the License.
 -%>
 import { browser, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor<% } %> } from 'protractor';
-import { NavBarPage } from './../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
+import { NavBarPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
+
 import { <%= entityClass %>ComponentsPage, <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
 <%_ if (fieldsContainBlobOrImage) { _%>
 import * as path from 'path';
@@ -49,43 +50,40 @@ describe('<%= entityClass %> e2e test', () => {
 
     beforeAll(() => {
         browser.get('/');
-        browser.waitForAngular();
         navBarPage = new NavBarPage();
         <%_ if (authenticationType === 'oauth2') { _%>
         navBarPage.getSignInPage().loginWithOAuth('admin', 'admin');
         <%_ } else { _%>
         navBarPage.getSignInPage().autoSignInUsing('admin', 'admin');
         <%_ } _%>
-        browser.waitForAngular();
     });
 
-    it('should load <%= entityClassPlural %>', () => {
+    it('should load <%= entityClassPlural %>', async () => {
         navBarPage.goToEntity('<%= entityStateName %>');
         <%= entityInstance %>ComponentsPage = new <%= entityClass %>ComponentsPage();
         <%_ if (enableTranslation) { _%>
-        expect(<%= entityInstance %>ComponentsPage.getTitle())
+        expect(await <%= entityInstance %>ComponentsPage.getTitle())
             .toMatch(/<%= angularAppName %>.<%= entityTranslationKey %>.home.title/);
         <%_ } else { _%>
-        expect(<%= entityInstance %>ComponentsPage.getTitle())
+        expect(await <%= entityInstance %>ComponentsPage.getTitle())
             .toMatch(/<%= entityClassPluralHumanized %>/);
         <%_ } _%>
-
     });
 
-    it('should load create <%= entityClass %> page', () => {
+    it('should load create <%= entityClass %> page', async () => {
         <%= entityInstance %>ComponentsPage.clickOnCreateButton();
         <%= entityInstance %>UpdatePage = new <%= entityClass %>UpdatePage();
         <%_ if (enableTranslation) { _%>
-        expect(<%= entityInstance %>UpdatePage.getPageTitle())
+        expect(await <%= entityInstance %>UpdatePage.getPageTitle())
             .toMatch(/<%= angularAppName %>.<%= entityTranslationKey %>.home.createOrEditLabel/);
         <%_ } else { _%>
-        expect(<%= entityInstance %>UpdatePage.getPageTitle())
+        expect(await <%= entityInstance %>UpdatePage.getPageTitle())
             .toMatch(/Create or edit a <%= entityClassHumanized %>/);
         <%_ } _%>
         <%= entityInstance %>UpdatePage.cancel();
     });
 
-   <%= openBlockComment %> it('should create and save <%= entityClassPlural %>', () => {
+   <%= openBlockComment %> it('should create and save <%= entityClassPlural %>', async () => {
         <%= entityInstance %>ComponentsPage.clickOnCreateButton();
         <%_ fields.forEach((field) => {
             const fieldName = field.fieldName;
@@ -96,36 +94,36 @@ describe('<%= entityClass %> e2e test', () => {
         _%>
         <%_ if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5');
-        expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('5');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('5');
         <%_ } else if (fieldType === 'LocalDate') { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('2000-12-31');
-        expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('2000-12-31');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('2000-12-31');
         <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('01/01/2001' + protractor.Key.TAB + '02:30AM');
-        expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toContain('2001-01-01T02:30');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toContain('2001-01-01T02:30');
         <%_ } else if (fieldType === 'Boolean') { _%>
         <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected().then((selected) => {
             if (selected) {
                 <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
-                expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeFalsy();
+                expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeFalsy();
             } else {
                 <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
-                expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeTruthy();
+                expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).toBeTruthy();
             }
         });
         <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
-        expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('<%= fieldName %>');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('<%= fieldName %>');
         <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath);
         <%_ } else if (fieldIsEnum) { _%>
         <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption();
         <%_ } else if (fieldType === 'UUID'){ _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
-        expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('64c99148-3908-465d-8c4a-e510e3ade974');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('64c99148-3908-465d-8c4a-e510e3ade974');
         <%_ } else { _%>
         <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
-        expect(<%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('<%= fieldName %>');
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).toMatch('<%= fieldName %>');
         <%_ } _%>
         <%_ }); _%>
         <%_ relationships.forEach((relationship) => {
@@ -140,7 +138,7 @@ describe('<%= entityClass %> e2e test', () => {
         <%_ } _%>
         <%_ }); _%>
         <%= entityInstance %>UpdatePage.save();
-        expect(<%= entityInstance %>UpdatePage.getSaveButton().isPresent()).toBeFalsy();
+        expect(await <%= entityInstance %>UpdatePage.getSaveButton().isPresent()).toBeFalsy();
     });<%= closeBlockComment %>
 
     afterAll(() => {

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -52,10 +52,10 @@ describe('<%= entityClass %> e2e test', () => {
     beforeAll(async () => {
         await browser.get('/');
         navBarPage = new NavBarPage();
-        <%_ if (authenticationType === 'oauth2') { _%>
-        navBarPage.getSignInPage().loginWithOAuth('admin', 'admin');
-        <%_ } else { _%>
         signInPage = await navBarPage.getSignInPage();
+        <%_ if (authenticationType === 'oauth2') { _%>
+        await signInPage.loginWithOAuth('admin', 'admin');
+        <%_ } else { _%>
         await signInPage.autoSignInUsing('admin', 'admin');
         <%_ } _%>
     });

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { browser, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor<% } %> } from 'protractor';
+import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor<% } %> } from 'protractor';
 import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
 
 import { <%= entityClass %>ComponentsPage, <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
@@ -58,6 +58,7 @@ describe('<%= entityClass %> e2e test', () => {
         <%_ } else { _%>
         await signInPage.autoSignInUsing('admin', 'admin');
         <%_ } _%>
+        await browser.wait(ec.visibilityOf(navBarPage.entityMenu), 5000);
     });
 
     it('should load <%= entityClassPlural %>', async () => {


### PR DESCRIPTION
As the Selenium promise manager will surely be deprecated in the future, we should use async/await to handle promises and it is more readable than .then() imo

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
