### PR TITLE
tweak bootstrap color contrasts to make them accessible

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.css.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.css.ejs
@@ -56,6 +56,15 @@ Navbar
 
 .jh-navbar a.nav-link {
     font-weight: 400;
+    color: rgba(255, 255, 255, 0.7);
+}
+
+.jh-navbar a.nav-link:hover {
+    color: #fff;
+}
+
+.jh-navbar .navbar-nav .active > .nav-link {
+    color: #fff;
 }
 
 .jh-navbar .jh-navbar-toggler {

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.scss.ejs
@@ -51,6 +51,13 @@ Navbar
     }
     a.nav-link {
         font-weight: 400;
+        color: rgba(255, 255, 255, 0.7);
+        &:hover {
+            color: #fff;
+        }
+    }
+    .navbar-nav .active > .nav-link {
+        color: #fff;
     }
     .jh-navbar-toggler {
         color: #ccc;

--- a/generators/client/templates/angular/src/main/webapp/content/css/global.css.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/css/global.css.ejs
@@ -28,13 +28,13 @@ body {
     background: #e4e5e6;
 }
 
-a {
-    color: #533f03;
+body a {
+    color: #286396; 
     font-weight: bold;
 }
 
-a:hover {
-    color: #533f03;
+body a:hover {
+    color: #255c8c;
     font-weight: bold;
 }
 
@@ -241,6 +241,107 @@ ui bootstrap tweaks
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+/* ==========================================================================
+bootstrap color tweaks to comply with WCAG 2.0 AA standard
+========================================================================== */
+.progress-bar.bg-primary {
+    background-color: #317ab9 !important;
+}
+
+.progress-bar.bg-success {
+    background-color: #218838 !important;
+}
+
+.progress-bar.bg-info {
+    background-color: #128091 !important;
+}
+
+.progress-bar.bg-warning {
+    color: #000;
+}
+
+.btn.btn-primary {
+    background-color: #317ab9;
+    border-color: #317ab9;
+}
+
+.btn.btn-primary:hover {
+    background-color: #29669b;
+    border-color: #265f91;
+}
+
+.btn.btn-primary:focus {
+    box-shadow: 0 0 0 0.2rem rgba(49, 122, 185, 0.5);
+}
+
+.btn.btn-primary:not(:disabled):not(.disabled):active {
+    background-color: #265f91;
+    border-color: #245987;
+}
+
+.btn.btn-info {
+    background-color: #128091;
+    border-color: #128091;
+}
+
+.btn.btn-info:hover {
+    background-color: #0e626f;
+    border-color: #0c5864;
+}
+
+.btn.btn-info:focus {
+    box-shadow: 0 0 0 0.2rem rgba(18, 128, 145, 0.5);
+}
+
+.btn.btn-info:not(:disabled):not(.disabled):active {
+    background-color: #0c5864;
+    border-color: #0b4e58;
+}
+
+.btn.btn-success {
+    background-color: #218838;
+    border-color: #218838;
+}
+
+.btn.btn-success:hover {
+    background-color: #1a692b;
+    border-color: #175f27;
+}
+
+.btn.btn-success:focus {
+    box-shadow: 0 0 0 0.2rem rgba(33, 136, 56, 0.5);
+}
+
+.btn.btn-success:not(:disabled):not(.disabled):active {
+    background-color: #175f27;
+    border-color: #155523;
+}
+
+.btn.btn-link {
+    color: #3871a3;
+}
+
+.badge.badge-primary {
+    background-color: #317ab9;
+}
+
+.badge.badge-info {
+    background-color: #128091;
+}
+
+.badge.badge-success {
+    background-color: #218838;
+}
+
+.pagination .page-item.active .page-link {
+    background-color: #317ab9;
+    border-color: #317ab9;
+}
+
+.pagination .page-item .page-link {
+    color: #286396;
 }
 
 /* jhipster-needle-css-add-main JHipster will add new css style */

--- a/generators/client/templates/angular/src/main/webapp/content/scss/_bootstrap-variables.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/_bootstrap-variables.scss.ejs
@@ -8,9 +8,9 @@
 // Colors:
 // Grayscale and brand colors for use across Bootstrap.
 
-$primary: #3e8acc;
-$success: #28a745;
-$info: #17a2b8;
+$primary: #317ab9;
+$success: #218838;
+$info: #128091;
 $warning: #ffc107;
 $danger: #dc3545;
 

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -25,13 +25,13 @@ h4 {
     font-weight: 300;
 }
 
-a {
-    color: #533f03;
+body a {
+    color: #286396; 
     font-weight: bold;
 }
 
-a:hover {
-    color: #533f03;
+body a:hover {
+    color: #255c8c;
     font-weight: bold;
 }
 
@@ -239,6 +239,15 @@ ui bootstrap tweaks
     overflow: hidden;
     text-overflow: ellipsis;
     white-space: nowrap;
+}
+
+/* ==========================================================================
+bootstrap color tweaks to comply with WCAG 2.0 AA standard
+========================================================================== */
+.progress-bar {
+    &.bg-warning {
+        color: #000;
+    }
 }
 
 /* jhipster-needle-scss-add-main JHipster will add new css style */

--- a/generators/client/templates/react/src/main/webapp/app/_bootstrap-variables.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/_bootstrap-variables.scss.ejs
@@ -23,6 +23,15 @@
 * Make sure not to add !default to values here
 */
 
+// Colors:
+// Grayscale and brand colors for use across Bootstrap.
+
+$primary: #317ab9;
+$success: #218838;
+$info: #128091;
+$warning: #ffc107;
+$danger: #dc3545;
+
 // Options:
 // Quickly modify global styling by enabling or disabling optional features.
 $enable-rounded:            true;

--- a/generators/client/templates/react/src/main/webapp/app/app.css.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.css.ejs
@@ -250,4 +250,105 @@ ui bootstrap tweaks
   white-space: nowrap;
 }
 
+/* ==========================================================================
+bootstrap color tweaks to comply with WCAG 2.0 AA standard
+========================================================================== */
+.progress-bar.bg-primary {
+    background-color: #317ab9 !important;
+}
+
+.progress-bar.bg-success {
+    background-color: #218838 !important;
+}
+
+.progress-bar.bg-info {
+    background-color: #128091 !important;
+}
+
+.progress-bar.bg-warning {
+    color: #000;
+}
+
+.btn.btn-primary {
+    background-color: #317ab9;
+    border-color: #317ab9;
+}
+
+.btn.btn-primary:hover {
+    background-color: #29669b;
+    border-color: #265f91;
+}
+
+.btn.btn-primary:focus {
+    box-shadow: 0 0 0 0.2rem rgba(49, 122, 185, 0.5);
+}
+
+.btn.btn-primary:not(:disabled):not(.disabled):active {
+    background-color: #265f91;
+    border-color: #245987;
+}
+
+.btn.btn-info {
+    background-color: #128091;
+    border-color: #128091;
+}
+
+.btn.btn-info:hover {
+    background-color: #0e626f;
+    border-color: #0c5864;
+}
+
+.btn.btn-info:focus {
+    box-shadow: 0 0 0 0.2rem rgba(18, 128, 145, 0.5);
+}
+
+.btn.btn-info:not(:disabled):not(.disabled):active {
+    background-color: #0c5864;
+    border-color: #0b4e58;
+}
+
+.btn.btn-success {
+    background-color: #218838;
+    border-color: #218838;
+}
+
+.btn.btn-success:hover {
+    background-color: #1a692b;
+    border-color: #175f27;
+}
+
+.btn.btn-success:focus {
+    box-shadow: 0 0 0 0.2rem rgba(33, 136, 56, 0.5);
+}
+
+.btn.btn-success:not(:disabled):not(.disabled):active {
+    background-color: #175f27;
+    border-color: #155523;
+}
+
+.btn.btn-link {
+    color: #3871a3;
+}
+
+.badge.badge-primary {
+    background-color: #317ab9;
+}
+
+.badge.badge-info {
+    background-color: #128091;
+}
+
+.badge.badge-success {
+    background-color: #218838;
+}
+
+.pagination .page-item.active .page-link {
+    background-color: #317ab9;
+    border-color: #317ab9;
+}
+
+.pagination .page-item .page-link {
+    color: #286396;
+}
+
 /* jhipster-needle-css-add-main JHipster will add new css style */

--- a/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
@@ -28,14 +28,14 @@ body {
   margin: 0;
 }
 
-a {
-  color: #533f03;
-  font-weight: bold;
+body a {
+    color: #286396; 
+    font-weight: bold;
 }
 
-a:hover {
-  color: #533f03;
-  font-weight: bold;
+body a:hover {
+    color: #255c8c;
+    font-weight: bold;
 }
 
 * {
@@ -360,6 +360,21 @@ http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
 
 .width-min {
   width: 1% !important;
+}
+
+/* ==========================================================================
+bootstrap color tweaks to comply with WCAG 2.0 AA standard
+========================================================================== */
+.progress-bar {
+    &.bg-warning {
+        color: #000;
+    }
+}
+
+.btn {
+  &.btn-link {
+    color: #3871a3;
+  }
 }
 
 /* jhipster-needle-css-add-main JHipster will add new css style */

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.css.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.css.ejs
@@ -74,8 +74,15 @@ Navbar styles
 .jh-navbar ul.navbar-nav .nav-item {
   margin-left: 1.5rem;
 }
-.jh-navbar a.nav-link {
-  font-weight: 400;
+.jh-navbar .navbar-nav a.nav-link {
+    font-weight: 400;
+    color: rgba(255, 255, 255, 0.7);
+}
+.jh-navbar .navbar-nav a.nav-link:hover {
+    color: #fff;
+}
+.jh-navbar .navbar-nav .active > .nav-link {
+    color: #fff;
 }
 .jh-navbar a.nav-link > span {
   margin-left: 5px;

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.scss.ejs
@@ -78,11 +78,18 @@ Navbar styles
       margin-left: 1.5rem;
     }
   }
-  a.nav-link {
+  .navbar-nav  a.nav-link {
     font-weight: 400;
+    color: rgba(255, 255, 255, 0.7);
     > span {
       margin-left: 5px;
     }
+    &:hover {
+        color: #fff;
+    }
+  }
+  .navbar-nav .active > .nav-link {
+      color: #fff;
   }
   .jh-navbar-toggler {
     color: #ccc;


### PR DESCRIPTION
tweak bootstrap color contrasts for auto generated components to comply with WCAG 2.0 AA standards

Fix #7961

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
