### PR TITLE
update gradle prod profile with h2 testCompile dependency

### DIFF
--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -23,7 +23,7 @@ apply plugin: 'com.moowork.node'
 <%_ } _%>
 
 dependencies {
-
+    testCompile "com.h2database:h2"
 }
 
 def profiles = 'prod'


### PR DESCRIPTION
add h2 to prod profile for tests 

so that this command ./gradlew -P prod build buildDocker works

Fix #7888

I don't think this is testable other than adding the above build command to the CI scripts to ensure the prod profile tests always run correctly.  I also, ran the same process with maven `mvn clean package dockerfile:build` and it works correctly as the plugin inherits the test h2 dependency from the main pom section.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [X] Tests are added where necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
