### PR TITLE
Fix oauth redirect issue

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -14,7 +14,7 @@ export interface IPrivateRouteProps extends IOwnProps, StateProps {}
 export const PrivateRouteComponent = ({
   component: Component,
   isAuthenticated,
-  isGettingTheSession,
+  sessionHasBeenFetched,
   isAuthorized,
   hasAnyAuthorities = [],
   ...rest
@@ -33,8 +33,8 @@ export const PrivateRouteComponent = ({
     );
 
     const renderRedirect = props => {
-      if (isGettingTheSession) {
-        return (<div>Checking you authentication status.</div>);
+      if (!sessionHasBeenFetched) {
+        return (<div></div>);
       } else {
         return isAuthenticated ? (
           checkAuthorities(props)
@@ -66,10 +66,10 @@ export const hasAnyAuthority = (authorities: string[], hasAnyAuthorities: string
   return false;
 };
 
-const mapStateToProps = ({ authentication: { isAuthenticated, account, isGettingTheSession } }: IRootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
+const mapStateToProps = ({ authentication: { isAuthenticated, account, sessionHasBeenFetched } }: IRootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
   isAuthenticated,
   isAuthorized: hasAnyAuthority(account.authorities, hasAnyAuthorities),
-  isGettingTheSession
+  sessionHasBeenFetched
 });
 
 type StateProps = ReturnType<typeof mapStateToProps>;

--- a/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/auth/private-route.tsx.ejs
@@ -14,6 +14,7 @@ export interface IPrivateRouteProps extends IOwnProps, StateProps {}
 export const PrivateRouteComponent = ({
   component: Component,
   isAuthenticated,
+  isGettingTheSession,
   isAuthorized,
   hasAnyAuthorities = [],
   ...rest
@@ -31,18 +32,24 @@ export const PrivateRouteComponent = ({
       </div>
     );
 
-  const renderRedirect = props =>
-    isAuthenticated ? (
-      checkAuthorities(props)
-    ) : (
-      <Redirect
-        to={{
-          pathname: '/login',
-          search: props.location.search,
-          state: { from: props.location }
-        }}
-      />
-    );
+    const renderRedirect = props => {
+      if (isGettingTheSession) {
+        return (<div>Checking you authentication status.</div>);
+      } else {
+        return isAuthenticated ? (
+          checkAuthorities(props)
+        ) : (
+          <Redirect
+            to={{
+              pathname: '/login',
+              search: props.location.search,
+              state: { from: props.location }
+            }}
+          />
+        );
+      }
+    };
+
 
   if (!Component) throw new Error(`A component needs to be specified for private route for path ${(rest as any).path}`);
 
@@ -59,9 +66,10 @@ export const hasAnyAuthority = (authorities: string[], hasAnyAuthorities: string
   return false;
 };
 
-const mapStateToProps = ({ authentication: { isAuthenticated, account } }: IRootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
+const mapStateToProps = ({ authentication: { isAuthenticated, account, isGettingTheSession } }: IRootState, { hasAnyAuthorities = [] }: IOwnProps) => ({
   isAuthenticated,
-  isAuthorized: hasAnyAuthority(account.authorities, hasAnyAuthorities)
+  isAuthorized: hasAnyAuthority(account.authorities, hasAnyAuthorities),
+  isGettingTheSession
 });
 
 type StateProps = ReturnType<typeof mapStateToProps>;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -49,7 +49,7 @@ const initialState = {
   account: {} as any,
   errorMessage: null as string, // Errors returned from server side
   redirectMessage: null as string,
-  isGettingTheSession: true
+  sessionHasBeenFetched: false
 };
 
 export type AuthenticationState =  Readonly<typeof initialState>;
@@ -64,8 +64,7 @@ export default (state: AuthenticationState = initialState, action): Authenticati
     case REQUEST(ACTION_TYPES.GET_SESSION):
       return {
         ...state,
-        loading: true,
-        isGettingTheSession: true
+        loading: true
       };
     <%_ if (authenticationType !== 'oauth2') { _%>
     case FAILURE(ACTION_TYPES.LOGIN):
@@ -81,7 +80,7 @@ export default (state: AuthenticationState = initialState, action): Authenticati
         ...state,
         loading: false,
         isAuthenticated: false,
-        isGettingTheSession: false,
+        sessionHasBeenFetched: true,
       <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
       <%_ } _%>
@@ -100,7 +99,6 @@ export default (state: AuthenticationState = initialState, action): Authenticati
     case ACTION_TYPES.LOGOUT:
       return {
         ...initialState,
-        isGettingTheSession: false,
       <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true
       <%_ } _%>
@@ -112,14 +110,13 @@ export default (state: AuthenticationState = initialState, action): Authenticati
           ...state,
           isAuthenticated,
           loading: false,
-          isGettingTheSession: false,
+          sessionHasBeenFetched: true,
           account: action.payload.data
         };
       }
     case ACTION_TYPES.ERROR_MESSAGE:
       return {
         ...initialState,
-        isGettingTheSession: false,
       <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
       <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -48,7 +48,8 @@ const initialState = {
   <%_ } _%>
   account: {} as any,
   errorMessage: null as string, // Errors returned from server side
-  redirectMessage: null as string
+  redirectMessage: null as string,
+  isGettingTheSession: true
 };
 
 export type AuthenticationState =  Readonly<typeof initialState>;
@@ -63,7 +64,8 @@ export default (state: AuthenticationState = initialState, action): Authenticati
     case REQUEST(ACTION_TYPES.GET_SESSION):
       return {
         ...state,
-        loading: true
+        loading: true,
+        isGettingTheSession: true
       };
     <%_ if (authenticationType !== 'oauth2') { _%>
     case FAILURE(ACTION_TYPES.LOGIN):
@@ -79,6 +81,7 @@ export default (state: AuthenticationState = initialState, action): Authenticati
         ...state,
         loading: false,
         isAuthenticated: false,
+        isGettingTheSession: false,
       <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
       <%_ } _%>
@@ -97,6 +100,7 @@ export default (state: AuthenticationState = initialState, action): Authenticati
     case ACTION_TYPES.LOGOUT:
       return {
         ...initialState,
+        isGettingTheSession: false,
       <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true
       <%_ } _%>
@@ -108,12 +112,14 @@ export default (state: AuthenticationState = initialState, action): Authenticati
           ...state,
           isAuthenticated,
           loading: false,
+          isGettingTheSession: false,
           account: action.payload.data
         };
       }
     case ACTION_TYPES.ERROR_MESSAGE:
       return {
         ...initialState,
+        isGettingTheSession: false,
       <%_ if (authenticationType !== 'oauth2') { _%>
         showModalLogin: true,
       <%_ } _%>

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/auth/private-route.spec.tsx.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/auth/private-route.spec.tsx.ejs
@@ -13,7 +13,7 @@ describe('private-route component', () => {
   });
 
   it('Should render an error message when the user has no authorities', () => {
-    const route = shallow(<PrivateRouteComponent component={TestComp} isAuthenticated isAuthorized={false} path="/" />);
+    const route = shallow(<PrivateRouteComponent component={TestComp} isAuthenticated sessionHasBeenFetched isAuthorized={false} path="/" />);
     const renderedRoute = route.find(Route);
     const renderFn: Function = renderedRoute.props().render;
     const comp = shallow(
@@ -34,7 +34,7 @@ describe('private-route component', () => {
   });
 
   it('Should render a route for the component provided when authenticated', () => {
-    const route = shallow(<PrivateRouteComponent component={TestComp} isAuthenticated isAuthorized path="/" />);
+    const route = shallow(<PrivateRouteComponent component={TestComp} isAuthenticated sessionHasBeenFetched isAuthorized path="/" />);
     const renderedRoute = route.find(Route);
     expect(renderedRoute.length).toEqual(1);
     expect(renderedRoute.props().path).toEqual('/');
@@ -51,7 +51,7 @@ describe('private-route component', () => {
   });
 
   it('Should render a redirect to login when not authenticated', () => {
-    const route = shallow(<PrivateRouteComponent component={TestComp} isAuthenticated={false} isAuthorized path="/" />);
+    const route = shallow(<PrivateRouteComponent component={TestComp} isAuthenticated={false} sessionHasBeenFetched isAuthorized path="/" />);
     const renderedRoute = route.find(Route);
     expect(renderedRoute.length).toEqual(1);
     const renderFn: Function = renderedRoute.props().render;


### PR DESCRIPTION
fix #7850 

So here's the idea. When you refresh your browser, private routes are rendered before the getSession is done. This redirects the application to home. The easy fix is to ask private routes to wait before at least one getSession is performed before doing anything.

I made a some simple modifications to fix that but it's kinda ugly tbh. I'll prolly make better version tomorrow.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
