### PR TITLE
Remove profile-info resource and it's security mappings during upgrade to v5.x

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -141,11 +141,13 @@ function cleanupOldServerFiles(generator, javaDir, testDir, mainResourceDir, tes
     }
     if (generator.isJhipsterVersionLessThan('5.0.0')) {
         generator.removeFile(`${javaDir}config/ThymeleafConfiguration.java`);
+        generator.removeFile(`${javaDir}web/rest/ProfileInfoResource.java`);
         generator.removeFile(`${mainResourceDir}mails/activationEmail.html`);
         generator.removeFile(`${mainResourceDir}mails/creationEmail.html`);
         generator.removeFile(`${mainResourceDir}mails/passwordResetEmail.html`);
         generator.removeFile(`${mainResourceDir}mails/socialRegistrationValidationEmail.html`);
         generator.removeFile(`${testResourceDir}mail/testEmail.html`);
+        generator.removeFile(`${testDir}web/rest/ProfileInfoResourceIntTest.java`);
         generator.removeFile('gradle/mapstruct.gradle');
     }
 }

--- a/generators/server/templates/src/main/java/package/client/OAuth2InterceptedFeignConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/client/OAuth2InterceptedFeignConfiguration.java.ejs
@@ -46,13 +46,11 @@ public class OAuth2InterceptedFeignConfiguration {
 import java.io.IOException;
 
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 
 import feign.RequestInterceptor;
 
 import <%=packageName%>.security.oauth2.AuthorizationHeaderUtil;
 
-@Configuration
 public class OAuth2InterceptedFeignConfiguration {
 
     @Bean(name = "oauth2RequestInterceptor")

--- a/generators/server/templates/src/main/java/package/config/OAuth2SsoConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/OAuth2SsoConfiguration.java.ejs
@@ -79,7 +79,6 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter {
             .logoutSuccessHandler(ajaxLogoutSuccessHandler())
         .and()
             .authorizeRequests()
-            .antMatchers("/api/profile-info").permitAll()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)

--- a/generators/server/templates/src/main/java/package/config/UaaConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/UaaConfiguration.java.ejs
@@ -106,7 +106,6 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter imple
                 .antMatchers("/api/authenticate").permitAll()
                 .antMatchers("/api/account/reset-password/init").permitAll()
                 .antMatchers("/api/account/reset-password/finish").permitAll()
-                .antMatchers("/api/profile-info").permitAll()
                 .antMatchers("/api/**").authenticated()<% if (websocket === 'spring-websocket') { %>
                 .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
                 .antMatchers("/websocket/**").permitAll()<% } %>


### PR DESCRIPTION
Fixes compilation issues after upgrade from v4.14.5 ( #8086 )

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
