### PR TITLE
Webpack polish

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -40,7 +40,6 @@
     "@ng-bootstrap/ng-bootstrap": "3.0.0",
     "bootstrap": "4.1.3",
     "core-js": "2.5.7",
-    "jquery": "3.3.1",
     "moment": "2.22.2",
     "ng-jhipster": "0.5.4",
     "ngx-cookie": "2.0.1",

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -40,7 +40,6 @@ module.exports = (options) => ({
     },
     module: {
         rules: [
-            { test: /bootstrap\/dist\/js\/umd\//, loader: 'imports-loader?jQuery=jquery' },
             {
                 test: /\.html$/,
                 loader: 'html-loader',
@@ -55,11 +54,19 @@ module.exports = (options) => ({
             },
             {
                 test: /\.(jpe?g|png|gif|svg|woff2?|ttf|eot)$/i,
-                loaders: ['file-loader?hash=sha512&digest=hex&name=content/[hash].[ext]']
+                loader: 'file-loader',
+                options: {
+                    digest: 'hex',
+                    hash: 'sha512',
+                    name: 'content/[hash].[ext]'
+                }
             },
             {
                 test: /manifest.webapp$/,
-                loader: 'file-loader?name=manifest.webapp'
+                loader: 'file-loader',
+                options: {
+                    name: 'manifest.webapp'
+                }
             },
             // Ignore warnings about System.import in Angular
             { test: /[\/\\]@angular[\/\\].+\.js$/, parser: { system: true } },

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -97,10 +97,6 @@ module.exports = (options) => ({
             // jhipster-needle-add-assets-to-webpack - JHipster will add/remove third-party resources in this array
             { from: './<%= MAIN_SRC_DIR %>robots.txt', to: 'robots.txt' }
         ]),
-        new webpack.ProvidePlugin({
-            $: "jquery",
-            jQuery: "jquery"
-        }),
         <%_ if (enableTranslation) { _%>
         new MergeJsonWebpackPlugin({
             output: {

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -79,13 +79,13 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         rules: [{
             test: /\.ts$/,
             enforce: 'pre',
-            loaders: 'tslint-loader',
+            loader: 'tslint-loader',
             exclude: ['node_modules', new RegExp('reflect-metadata\\' + path.sep + 'Reflect\\.ts')]
         },
         {
             test: /\.ts$/,
             use: [
-                { loader: 'angular2-template-loader' },
+                'angular2-template-loader',
                 {
                     loader: 'cache-loader',
                     options: {
@@ -106,29 +106,29 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                         happyPackMode: true
                     }
                 },
-                { loader: 'angular-router-loader' }
+                'angular-router-loader'
             ],
             exclude: ['node_modules']
         },
         <%_ if (useSass) { _%>
         {
             test: /\.scss$/,
-            loaders: ['to-string-loader', 'css-loader', 'sass-loader'],
+            use: ['to-string-loader', 'css-loader', 'sass-loader'],
             exclude: /(vendor\.scss|global\.scss)/
         },
         {
             test: /(vendor\.scss|global\.scss)/,
-            loaders: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader']
+            use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader']
         },
         <%_ } _%>
         {
             test: /\.css$/,
-            loaders: ['to-string-loader', 'css-loader'],
+            use: ['to-string-loader', 'css-loader'],
             exclude: /(vendor\.css|global\.css)/
         },
         {
             test: /(vendor\.css|global\.css)/,
-            loaders: ['style-loader', 'css-loader']
+            use: ['style-loader', 'css-loader']
         }]
     },
     stats: options.stats,

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -56,12 +56,12 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
     module: {
         rules: [{
             test: /(?:\.ngfactory\.js|\.ngstyle\.js|\.ts)$/,
-            use: [ '@ngtools/webpack' ]
+            loader: '@ngtools/webpack'
         },
         <%_ if (useSass) { _%>
         {
             test: /\.scss$/,
-            loaders: ['to-string-loader', 'css-loader', 'sass-loader'],
+            use: ['to-string-loader', 'css-loader', 'sass-loader'],
             exclude: /(vendor\.scss|global\.scss)/
         },
         {
@@ -75,7 +75,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         <%_ } _%>
         {
             test: /\.css$/,
-            loaders: ['to-string-loader', 'css-loader'],
+            use: ['to-string-loader', 'css-loader'],
             exclude: /(vendor\.css|global\.css)/
         },
         {

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -79,7 +79,12 @@ module.exports = options => ({
       },
       {
         test: /\.(jpe?g|png|gif|svg|woff2?|ttf|eot)$/i,
-        loaders: ['file-loader?hash=sha512&digest=hex&name=content/[hash].[ext]']
+        loader: 'file-loader',
+        options: {
+            digest: 'hex',
+            hash: 'sha512',
+            name: 'content/[hash].[ext]'
+        }
       },
       {
         enforce: 'pre',
@@ -89,7 +94,7 @@ module.exports = options => ({
       {
         test: /\.tsx?$/,
         enforce: 'pre',
-        loaders: 'tslint-loader',
+        loader: 'tslint-loader',
         exclude: ['node_modules']
       }
     ]

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -47,12 +47,12 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
       <%_ if (useSass) { _%>
       {
         test: /\.(sa|sc|c)ss$/,
-        loaders: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader']
+        use: ['style-loader', 'css-loader', 'postcss-loader', 'sass-loader']
       },
       <%_ } else { _%>
       {
         test: /\.css$/,
-        loaders: ['style-loader', 'css-loader']
+        use: ['style-loader', 'css-loader']
       }
       <%_ } _%>
     ]


### PR DESCRIPTION
Just made some changes to make the Webpack configurations more consistent and replaced deprecated `loaders` by `use`.

I also removed jquery from the Angular dependencies, it doesn't seem used.


- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
