### PR TITLE
prevent 'auth' from being a UAA baseName

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2224,6 +2224,9 @@ module.exports = class extends PrivateBase {
                 if ((generator.applicationType === 'microservice' || generator.applicationType === 'uaa') && /_/.test(input)) {
                     return 'Your base name cannot contain underscores as this does not meet the URI spec';
                 }
+                if (generator.applicationType === 'uaa' && input === 'auth') {
+                    return 'Your UAA base name cannot be named \'auth\' as it conflicts with the gateway login routes';
+                }
                 if (input === 'application') {
                     return 'Your base name cannot be named \'application\' as this is a reserved name for Spring Boot';
                 }


### PR DESCRIPTION
prevents conflicts with the gateway's generated routes for login (`/auth/login`)

Fix #8107

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
