### PR TITLE
skip insight on upgrade

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -102,7 +102,7 @@ module.exports = class extends BaseGenerator {
             const generatorDir = this.clientPackageManager === 'yarn' ? shelljs.exec('yarn bin', { silent: this.silent }).stdout : shelljs.exec('npm bin', { silent: this.silent }).stdout;
             generatorCommand = `"${generatorDir.replace('\n', '')}/jhipster"`;
         }
-        const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install`;
+        const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --skip-insight`;
         this.info(regenerateCmd);
         shelljs.exec(regenerateCmd, { silent: this.silent }, (code, msg, err) => {
             if (code === 0) this.success(`Successfully regenerated application with JHipster ${version}`);


### PR DESCRIPTION
Avoids issues like [this StackOverflow](https://stackoverflow.com/questions/51923119/trying-to-upgrade-to-jhipster-release-5-2-1-stops-on-anonymous-statistics-promp).  Also makes the statistics more accurate as the upgrade generator runs `jhipster` twice 

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
