### PR TITLE
WIP: Clean scss

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/_bootstrap-variables.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/_bootstrap-variables.scss.ejs
@@ -43,4 +43,25 @@ $border-radius-sm:       .1rem;
 // Body:
 // Settings for the `<body>` element.
 
-$body-bg:                   #e4e5e6;
+$body-bg:                   #fafafa;
+
+
+$sizes: (
+  40: 40%,
+  60: 60%
+);
+
+
+$gray-jh:               #353d47;
+$blue-jh:               #3e8acc;
+$brown-jh:              #533f03;
+
+$blue:                  $blue-jh;
+$dark:                  $gray-jh;
+
+$component-active-bg:   $gray-jh;
+
+$link-color:            $brown-jh;
+$link-hover-decoration: none;
+
+$navbar-nav-link-padding-x: 1rem;

--- a/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
@@ -23,44 +23,42 @@
 <%_ if (enableI18nRTL) { _%>
 @import 'rtl.scss';
 <%_ } _%>
-body {
-  background: #fafafa;
-  margin: 0;
+
+.navbar-version {
+  font-size: $font-size-base * 0.65;
+  color: $navbar-dark-color;
+}
+
+.brand-title {
+  font-size: $h4-font-size;
+}
+
+.brand-logo {
+  margin-top: $navbar-brand-padding-y * -1;
+  margin-bottom: $navbar-brand-padding-y * -1;
+  display: inline-block;
+}
+
+.nav-item {
+  a {
+    font-weight: $font-weight-normal;
+  }
 }
 
 a {
-  color: #533f03;
-  font-weight: bold;
+  font-weight: $font-weight-bold;
 }
 
-* {
-  -moz-box-sizing: border-box;
-  box-sizing: border-box;
-  &:after,
-  &::before {
-    -moz-box-sizing: border-box;
-    box-sizing: border-box;
-  }
+//card without flexbox
+.jh-card {
+  background-color: $card-bg;
+  background-clip: border-box;
+  border: $card-border-width solid $card-border-color;
+  @include border-radius($card-border-radius);
 }
 
-.app-container {
-  box-sizing: border-box;
-  .view-container {
-    width: 100%;
-    height: calc(100% - 40px);
-    overflow-y: auto;
-    overflow-x: hidden;
-    padding: 1rem;
-    .card {
-      padding: 1rem;
-    }
-    .view-routes {
-      height: 100%;
-      > div {
-        height: 100%;
-      }
-    }
-  }
+.container-narrow {
+  max-width: 600px;
 }
 
 .fullscreen {
@@ -85,56 +83,6 @@ Browser Upgrade Prompt
   padding: 0.2em 0;
 }
 
-/* ==========================================================================
-Custom button styles
-========================================================================== */
-
-.icon-button > .btn {
-  background-color: transparent;
-  border-color: transparent;
-  padding: 0.5rem;
-  line-height: 1rem;
-  &:hover {
-    background-color: transparent;
-    border-color: transparent;
-  }
-  &:focus {
-    -webkit-box-shadow: none;
-    box-shadow: none;
-  }
-}
-
-/* ==========================================================================
-Generic styles
-========================================================================== */
-
-/* Temperory workaround for availity-reactstrap-validation */
-.invalid-feedback {
-  display: inline;
-}
-
-/* other generic styles */
-
-.title {
-  font-size: 1.25em;
-  margin: 1px 10px 1px 10px;
-}
-
-.description {
-  font-size: 0.9em;
-  margin: 1px 10px 1px 10px;
-}
-
-.shadow {
-  box-shadow: rgba(0, 0, 0, 0.12) 0px 1px 6px, rgba(0, 0, 0, 0.12) 0px 1px 4px;
-  border-radius: 2px;
-}
-
-.error {
-  color: white;
-  background-color: red;
-}
-
 .break {
   white-space: normal;
   word-break: break-all;
@@ -149,129 +97,6 @@ Generic styles
   white-space: pre-wrap;
 }
 
-/* padding helpers */
-
-@mixin pad($size, $side) {
-  @if $size== "" {
-    @if $side== "" {
-      .pad {
-        padding: 10px !important;
-      }
-    } @else {
-      .pad {
-        padding-#{$side}: 10px !important;
-      }
-    }
-  } @else {
-    @if $side== "" {
-      .pad-#{$size} {
-        padding: #{$size}px !important;
-      }
-    } @else {
-      .pad-#{$side}-#{$size} {
-        padding-#{$side}: #{$size}px !important;
-      }
-    }
-  }
-}
-
-@include pad("", "");
-@include pad("2", "");
-@include pad("3", "");
-@include pad("5", "");
-@include pad("10", "");
-@include pad("20", "");
-@include pad("25", "");
-@include pad("30", "");
-@include pad("50", "");
-@include pad("75", "");
-@include pad("100", "");
-@include pad("4", "top");
-@include pad("5", "top");
-@include pad("10", "top");
-@include pad("20", "top");
-@include pad("25", "top");
-@include pad("30", "top");
-@include pad("50", "top");
-@include pad("75", "top");
-@include pad("100", "top");
-@include pad("4", "bottom");
-@include pad("5", "bottom");
-@include pad("10", "bottom");
-@include pad("20", "bottom");
-@include pad("25", "bottom");
-@include pad("30", "bottom");
-@include pad("50", "bottom");
-@include pad("75", "bottom");
-@include pad("100", "bottom");
-@include pad("5", "right");
-@include pad("10", "right");
-@include pad("20", "right");
-@include pad("25", "right");
-@include pad("30", "right");
-@include pad("50", "right");
-@include pad("75", "right");
-@include pad("100", "right");
-@include pad("5", "left");
-@include pad("10", "left");
-@include pad("20", "left");
-@include pad("25", "left");
-@include pad("30", "left");
-@include pad("50", "left");
-@include pad("75", "left");
-@include pad("100", "left");
-
-@mixin no-padding($side) {
-  @if $side== "all" {
-    .no-padding {
-      padding: 0 !important;
-    }
-  } @else {
-    .no-padding-#{$side} {
-      padding-#{$side}: 0 !important;
-    }
-  }
-}
-
-@include no-padding("left");
-@include no-padding("right");
-@include no-padding("top");
-@include no-padding("bottom");
-@include no-padding("all");
-
-/* end of padding helpers */
-
-.no-margin {
-  margin: 0px;
-}
-@mixin voffset($size) {
-  @if $size== "" {
-    .voffset {
-      margin-top: 2px !important;
-    }
-  } @else {
-    .voffset-#{$size} {
-      margin-top: #{$size}px !important;
-    }
-  }
-}
-
-@include voffset("");
-@include voffset("5");
-@include voffset("10");
-@include voffset("15");
-@include voffset("30");
-@include voffset("40");
-@include voffset("60");
-@include voffset("80");
-@include voffset("100");
-@include voffset("150");
-
-.readonly {
-  background-color: #eee;
-  opacity: 1;
-}
-
 /* ==========================================================================
 make sure browsers use the pointer cursor for anchors, even with no href
 ========================================================================== */
@@ -284,51 +109,6 @@ a:hover {
   cursor: pointer;
 }
 
-button.anchor-btn {
-  background: none;
-  border: none;
-  padding: 0;
-  align-items: initial;
-  text-align: initial;
-  width: 100%;
-}
-
-a.anchor-btn:hover {
-  text-decoration: none;
-}
-
-/* ==========================================================================
-Metrics and Health styles
-========================================================================== */
-
-#threadDump .popover,
-#healthCheck .popover {
-  top: inherit;
-  display: block;
-  font-size: 10px;
-  max-width: 1024px;
-}
-
-.thread-dump-modal-lock {
-  max-width: 450px;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-#healthCheck .popover {
-  margin-left: -50px;
-}
-
-.health-details {
-  min-width: 400px;
-}
-
-/* bootstrap 3 input-group 100% width
-http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
-
-.width-min {
-  width: 1% !important;
-}
 
 /* jhipster-needle-css-add-main JHipster will add new css style */
+

--- a/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
@@ -47,10 +47,9 @@ export class App extends React.Component<IAppProps> {
   }
 
   render() {
-    const paddingTop = '60px';
     return (
       <Router>
-        <div className="app-container" style={{ paddingTop }}>
+        <div className="app-container">
           <ToastContainer position={toast.POSITION.TOP_LEFT as ToastPosition} className="toastify-container" toastClassName="toastify-toast"/>
           <ErrorBoundary>
             <Header
@@ -65,8 +64,8 @@ export class App extends React.Component<IAppProps> {
               isSwaggerEnabled={this.props.isSwaggerEnabled}
             />
           </ErrorBoundary>
-          <div className="container-fluid view-container" id="app-view-container">
-            <Card className="jh-card">
+          <div className="container-fluid view-container mt-3" id="app-view-container">
+            <Card className="jh-card p-3">
               <ErrorBoundary>
                 <AppRoutes/>
               </ErrorBoundary>

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
@@ -86,22 +86,22 @@ export class UserManagement extends React.Component<IUserManagementProps, IPagin
         </h2>
         <Table responsive striped>
           <thead>
-            <tr>
-              <th className="hand" onClick={this.sort('id')}><Translate contentKey="global.field.id">ID</Translate><FontAwesomeIcon icon="sort" /></th>
-              <th className="hand" onClick={this.sort('login')}><Translate contentKey="userManagement.login">Login</Translate><FontAwesomeIcon icon="sort" /></th>
-              <th className="hand" onClick={this.sort('email')}><Translate contentKey="userManagement.email">Email</Translate><FontAwesomeIcon icon="sort" /></th>
+            <tr className="text-nowrap">
+              <th className="hand" onClick={this.sort('id')}><Translate contentKey="global.field.id">ID</Translate> <FontAwesomeIcon icon="sort" /></th>
+              <th className="hand" onClick={this.sort('login')}><Translate contentKey="userManagement.login">Login</Translate> <FontAwesomeIcon icon="sort" /></th>
+              <th className="hand" onClick={this.sort('email')}><Translate contentKey="userManagement.email">Email</Translate> <FontAwesomeIcon icon="sort" /></th>
               <th />
               <%_ if (enableTranslation) { _%>
-              <th className="hand" onClick={this.sort('langKey')}><Translate contentKey="userManagement.langKey">Lang Key</Translate><FontAwesomeIcon icon="sort" /></th>
+              <th className="hand" onClick={this.sort('langKey')}><Translate contentKey="userManagement.langKey">Lang Key</Translate> <FontAwesomeIcon icon="sort" /></th>
               <%_ } _%>
               <th><Translate contentKey="userManagement.profiles">Profiles</Translate></th>
               <%_ if (databaseType !== 'cassandra') { _%>
-              <th className="hand" onClick={this.sort('createdDate')}><Translate contentKey="userManagement.createdDate">Created Date</Translate><FontAwesomeIcon icon="sort" /></th>
+              <th className="hand" onClick={this.sort('createdDate')}><Translate contentKey="userManagement.createdDate">Created Date</Translate> <FontAwesomeIcon icon="sort" /></th>
               <th className="hand" onClick={this.sort('lastModifiedBy')}>
-                <Translate contentKey="userManagement.lastModifiedBy">Last Modified By</Translate><FontAwesomeIcon icon="sort" />
+                <Translate contentKey="userManagement.lastModifiedBy">Last Modified By</Translate> <FontAwesomeIcon icon="sort" />
               </th>
               <th className="hand" onClick={this.sort('lastModifiedDate')}>
-                <Translate contentKey="userManagement.lastModifiedDate">Last Modified Date</Translate><FontAwesomeIcon icon="sort" />
+                <Translate contentKey="userManagement.lastModifiedDate">Last Modified Date</Translate> <FontAwesomeIcon icon="sort" />
               </th>
               <th />
               <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header-components.tsx.ejs
@@ -34,36 +34,29 @@ import appConfig from 'app/config/constants';
 
 export const NavDropdown = props => (
   <UncontrolledDropdown nav inNavbar id={props.id}>
-    <DropdownToggle nav caret className="d-flex align-items-center">
+    <DropdownToggle nav caret className="align-items-center text-nowrap">
       <FontAwesomeIcon icon={props.icon} />
-      <span>{props.name}</span>
+      <span> {props.name}</span>
     </DropdownToggle>
     <DropdownMenu right style={props.style}>{props.children}</DropdownMenu>
   </UncontrolledDropdown>
 );
 
-export const BrandIcon = props => (
-  <div {...props} className="brand-icon">
-    <img
-      src="content/images/logo-jhipster-react.svg"
-      alt="Logo"
-    />
-  </div>
-);
-
 export const Brand = props => (
-<NavbarBrand tag={Link} to="/" className="brand-logo">
-  <BrandIcon />
+<NavbarBrand tag={Link} to="/">
+  <div className="brand-logo">
+    <img src="content/images/logo-jhipster-react.svg" height="45" alt="Logo" />
+  </div>
   <span className="brand-title"><Translate contentKey="global.title"><%= capitalizedBaseName %></Translate></span>
-  <span className="navbar-version">{appConfig.VERSION}</span>
+  <span className="navbar-version pl-2">{appConfig.VERSION}</span>
 </NavbarBrand>
 );
 
 export const Home = props => (
   <NavItem>
-    <NavLink tag={Link} to="/" className="d-flex align-items-center">
+    <NavLink tag={Link} to="/" className="align-items-center text-nowrap">
       <FontAwesomeIcon icon="home" />
-      <span><Translate contentKey="global.menu.home">Home</Translate></span>
+      <span> <Translate contentKey="global.menu.home">Home</Translate></span>
     </NavLink>
   </NavItem>
 );

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.css.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.css.ejs
@@ -96,13 +96,8 @@ Navbar styles
 .brand-logo:hover {
   text-decoration: none;
 }
-.brand-logo .brand-icon {
-  height: 35px;
-  width: auto;
+.brand-logo {
   display: inline-block;
-}
-.brand-logo .brand-icon img {
-  height: 45px;
 }
 .brand-title {
   font-size: 24px;

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.scss.ejs
@@ -16,9 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-$header-color: #fff;
-$header-color-secondary: #bbb;
-$header-color-hover: darken($header-color, 20%);
 
 /* ==========================================================================
 Developement Ribbon
@@ -49,76 +46,6 @@ Developement Ribbon
     text-decoration: none;
     text-shadow: 0 0 5px #444;
     pointer-events: none;
-  }
-}
-
-/* ==========================================================================
-Navbar styles
-========================================================================== */
-.jh-navbar {
-  background-color: #353d47;
-  padding: 0.2em 1em;
-  .profile-image {
-    margin: -10px 0px;
-    height: 40px;
-    width: 40px;
-    border-radius: 50%;
-  }
-  .dropdown-item.active,
-  .dropdown-item.active:focus,
-  .dropdown-item.active:hover {
-    background-color: #353d47;
-  }
-  .dropdown-toggle::after {
-    margin-left: 0.15em;
-  }
-  ul.navbar-nav {
-    padding: 0.5em;
-    .nav-item {
-      margin-left: 1.5rem;
-    }
-  }
-  a.nav-link {
-    font-weight: 400;
-    > span {
-      margin-left: 5px;
-    }
-  }
-  .jh-navbar-toggler {
-    color: #ccc;
-    font-size: 1.5em;
-    padding: 10px;
-    &:hover {
-      color: #fff;
-    }
-  }
-}
-.navbar-version {
-  font-size: 10px;
-  color: $header-color-secondary;
-  padding: 0 0 0 10px;
-}
-
-.brand-logo {
-  &:hover {
-    text-decoration: none;
-  }
-  .brand-icon {
-    height: 35px;
-    width: auto;
-    display: inline-block;
-    img {
-      height: 45px;
-    }
-  }
-}
-
-.brand-title {
-  font-size: 24px;
-  color: $header-color;
-  &:hover {
-    color: $header-color-hover;
-    text-decoration: none;
   }
 }
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
@@ -96,10 +96,10 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
     /* jhipster-needle-add-element-to-menu - JHipster will add new menu items here */
 
     return (
-      <div id="app-header">
+      <div id="app-header" className="sticky-top">
         {this.renderDevRibbon()}
         <LoadingBar className="loading-bar"/>
-        <Navbar dark expand="sm" fixed="top" className="jh-navbar">
+        <Navbar dark color="dark" expand="sm" className="jh-navbar">
           <NavbarToggler aria-label="Menu" onClick={this.toggleMenu} />
           <Brand />
           <Collapse isOpen={this.state.menuOpen} navbar>


### PR DESCRIPTION
### Proposal to change sass/css structure

In this PR i would like to test and share some ideas regarding css.

#### Remove division between sass / css
The prefered way to theme bootstrap is via setting bootstrap variables, right now this is not fully utilized.
On the other hand there are small local component styles that would probably never benefit from sass.
I would like to suggest to remove the sass option from the generator and always use scss for theming boostrap and plain css for the rest.


#### Replace node-sass with the js version of  dart-sass
So we don't need binaries when using sass.
http://sass-lang.com/dart-sass
This is not really needed, but i can imagine that node-sass is one of the reasons not to use the sass option when generating.

#### Share the themed bootstrap between  react / angular
`_bootstrap-variables.scss` and `bootstrap-jhipser.scss` could eventually be shared between frontends.


#### To try it:
These changes currently only work with a react monolith with sass support enabled.
It should look mostly identical, with a lot less ad-hoc styles.


What do you think, is it worth it to complete some or all of the idea's?


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
