### PR TITLE
Add application name on path in application java

### DIFF
--- a/generators/server/templates/src/main/java/package/Application.java.ejs
+++ b/generators/server/templates/src/main/java/package/Application.java.ejs
@@ -115,15 +115,17 @@ public class <%= mainClass %> {
         }
         log.info("\n----------------------------------------------------------\n\t" +
                 "Application '{}' is running! Access URLs:\n\t" +
-                "Local: \t\t{}://localhost:{}\n\t" +
-                "External: \t{}://{}:{}\n\t" +
+                "Local: \t\t{}://localhost:{}/{}\n\t" +
+                "External: \t{}://{}:{}/{}\n\t" +
                 "Profile(s): \t{}\n----------------------------------------------------------",
             env.getProperty("spring.application.name"),
             protocol,
             env.getProperty("server.port"),
+			env.getProperty("spring.application.name"),
             protocol,
             hostAddress,
             env.getProperty("server.port"),
+			env.getProperty("spring.application.name"),
             env.getActiveProfiles());
         <%_ if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa')) { _%>
 


### PR DESCRIPTION
With the new version of the generator, the message that the application started successfully is confusing. I added the name of the application in the end message after the local url and the external url. Indeed, the local and external url as it is presented returns to an error 404.

Example:
```
----------------------------------------------------------
        Application 'jhipster' is running! Access URLs:
        Local:          http://localhost:8081
        External:       http://127.0.1.1:8081
        Profile(s):     [dev, swagger]
----------------------------------------------------------
```

becomes:

```
----------------------------------------------------------
        Application 'jhipster' is running! Access URLs:
        Local:          http://localhost:8081/jhipster
        External:       http://127.0.1.1:8081/jhipster
        Profile(s):     [dev, swagger]
----------------------------------------------------------
```