### PR TITLE
Use 64 bytes of JWT Secret Key length

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -259,7 +259,7 @@ module.exports = class extends BaseGenerator {
 
                     // Generate JWT secret key if key does not already exist in config
                     if (this.authenticationType === 'jwt' && this.jwtSecretKey === undefined) {
-                        this.jwtSecretKey = Buffer.from(crypto.randomBytes(100).toString('hex')).toString('base64');
+                        this.jwtSecretKey = Buffer.from(crypto.randomBytes(64).toString('hex')).toString('base64');
                     }
 
                     // If translation is not defined, it is enabled by default

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -285,7 +285,7 @@ function askForServerSideOpts(meta) {
         }
 
         if (this.authenticationType === 'jwt' || this.applicationType === 'microservice') {
-            this.jwtSecretKey = Buffer.from(crypto.randomBytes(100).toString('hex')).toString('base64');
+            this.jwtSecretKey = Buffer.from(crypto.randomBytes(64).toString('hex')).toString('base64');
         }
 
         // user-management will be handled by UAA app, oauth expects users to be managed in IpP


### PR DESCRIPTION
64 bytes is sufficient since that's 512 bytes - the max needed for any JWT HMAC SHA algorithm.

