### PR TITLE
set default clientRootFolder for microservice entities

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -192,6 +192,12 @@ module.exports = class extends BaseGenerator {
                 context.mainClass = this.getMainClassName(context.baseName);
                 context.microserviceAppName = '';
 
+                if (context.applicationType === 'microservice') {
+                    context.microserviceName = context.baseName;
+                    if (!context.clientRootFolder) {
+                        context.clientRootFolder = context.microserviceName;
+                    }
+                }
                 context.filename = `${context.jhipsterConfigDirectory}/${context.entityNameCapitalized}.json`;
                 if (shelljs.test('-f', context.filename)) {
                     this.log(chalk.green(`\nFound the ${context.filename} configuration file, entity can be automatically generated!\n`));


### PR DESCRIPTION
Fixes the i18n header sent on entity CRUD actions from the microservice [entity's Resource.java](https://github.com/jhipster/generator-jhipster/blob/78318d79240ba228f1e7863a4a19ad4b25b63b85/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs#L94-L98).  This is already [set as the default value](https://github.com/jhipster/generator-jhipster/blob/78318d79240ba228f1e7863a4a19ad4b25b63b85/generators/entity/index.js#L420-L422) when generating microservice entities on the gateway.

Fix #7124 

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
