### PR TITLE
copy webapp into resources/static to generate executable jar

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -48,6 +48,11 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task, depend
 war {
     webAppDirName = '<%= CLIENT_MAIN_SRC_DIR %>'
 }
+
+task copyIntoStatic (type: Copy) {
+    from '<%= CLIENT_DIST_DIR %>'
+    into 'build/resources/main/static'
+}
 <%_ } _%>
 
 processResources {
@@ -72,6 +77,9 @@ processResources {
 
 <%_ if (!skipClient) { _%>
 processResources.dependsOn webpackBuildDev
+copyIntoStatic.dependsOn processResources
+bootJar.dependsOn copyIntoStatic
+
 yarn_install.onlyIf { shouldWebpackRun() == true }
 
 def shouldWebpackRun() {

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -51,6 +51,11 @@ task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: '<%
 war {
     webAppDirName = '<%= CLIENT_DIST_DIR %>'
 }
+
+task copyIntoStatic (type: Copy) {
+    from '<%= CLIENT_DIST_DIR %>'
+    into 'build/resources/main/static'
+}
 <%_ } _%>
 
 processResources {
@@ -86,4 +91,6 @@ gitProperties {
 <%_ if (!skipClient) { _%>
 test.dependsOn webpack_test
 processResources.dependsOn webpack
+copyIntoStatic.dependsOn processResources
+bootJar.dependsOn copyIntoStatic
 <%_ } _%>


### PR DESCRIPTION
when executing `bootJar` the compiled webapp is copied to `src/main/resources` such that it can be served from the jar file.

updates #8172

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
