### PR TITLE
Fix React+NPM applications

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -74,7 +74,7 @@ limitations under the License.
     "@types/mocha": "5.2.5",
     <%_ } _%>
     "@types/node": "10.9.2",
-    "@types/react": "16.4.11",
+    "@types/react": "16.4.12",
     "@types/react-dom": "16.0.7",
     "@types/react-redux": "6.0.6",
     "@types/react-router-dom": "4.3.0",
@@ -171,7 +171,7 @@ limitations under the License.
     <%_ } _%>
   },
   "resolutions": {
-    "@types/react": "16.4.11"
+    "@types/react": "16.4.12"
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,


### PR DESCRIPTION
I'm working on https://github.com/jhipster/generator-jhipster/issues/8162

When generating a React application with NPM, I got this error, that I don't have with Yarn:

```
ERROR in /home/pgrimaud/tmp/react-npm/node_modules/@types/react/index.d.ts
ERROR in /home/pgrimaud/tmp/react-npm/node_modules/@types/react/index.d.ts(2232,33):
TS2339: Property 'exact' does not exist on type 'typeof import("/home/pgrimaud/tmp/react-npm/node_modules/@types/prop-types/index")'.

ERROR in /home/pgrimaud/tmp/react-npm/node_modules/@types/react/index.d.ts
ERROR in /home/pgrimaud/tmp/react-npm/node_modules/@types/react/index.d.ts(2312,54):
TS2694: Namespace '"/home/pgrimaud/tmp/react-npm/node_modules/@types/prop-types/index"' has no exported member 'InferProps'.

ERROR in /home/pgrimaud/tmp/react-npm/node_modules/@types/react/index.d.ts
ERROR in /home/pgrimaud/tmp/react-npm/node_modules/@types/react/index.d.ts(2314,47):
TS2694: Namespace '"/home/pgrimaud/tmp/react-npm/node_modules/@types/prop-types/index"' has no exported member 'InferProps'.
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! jhreactnpm@0.0.0 webpack: `node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js "--config" "webpack/webpack.dev.js" "--env.stats=normal"`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the jhreactnpm@0.0.0 webpack script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pgrimaud/.npm/_logs/2018-08-29T21_36_42_360Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! jhreactnpm@0.0.0 webpack:build:main: `npm run webpack -- --config webpack/webpack.dev.js --env.stats=normal`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the jhreactnpm@0.0.0 webpack:build:main script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pgrimaud/.npm/_logs/2018-08-29T21_36_42_385Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! jhreactnpm@0.0.0 webpack:build: `npm run cleanup && npm run webpack:build:main`
npm ERR! Exit status 2
npm ERR! 
npm ERR! Failed at the jhreactnpm@0.0.0 webpack:build script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pgrimaud/.npm/_logs/2018-08-29T21_36_42_409Z-debug.log
```

Hope this PR can fix it.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
