### PR TITLE
add missing constraint for oauth apps

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -940,14 +940,16 @@ const serverFiles = {
     ],
     serverJavaUserManagement: [
         {
-            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2') || (!generator.skipUserManagement && generator.databaseType === 'sql'),
+            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.applicationType === 'monolith')
+                || (!generator.skipUserManagement && generator.databaseType === 'sql'),
             path: SERVER_MAIN_RES_DIR,
             templates: [
                 'config/liquibase/users.csv',
             ]
         },
         {
-            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.databaseType === 'sql') || (!generator.skipUserManagement && generator.databaseType === 'sql'),
+            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.applicationType === 'monolith' && generator.databaseType === 'sql')
+                || (!generator.skipUserManagement && generator.databaseType === 'sql'),
             path: SERVER_MAIN_RES_DIR,
             templates: [
                 'config/liquibase/authorities.csv',

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -940,7 +940,7 @@ const serverFiles = {
     ],
     serverJavaUserManagement: [
         {
-            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.applicationType === 'monolith')
+            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.applicationType !== 'microservice')
                 || (!generator.skipUserManagement && generator.databaseType === 'sql'),
             path: SERVER_MAIN_RES_DIR,
             templates: [
@@ -948,7 +948,7 @@ const serverFiles = {
             ]
         },
         {
-            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.applicationType === 'monolith' && generator.databaseType === 'sql')
+            condition: generator => (generator.skipUserManagement && generator.authenticationType === 'oauth2' && generator.applicationType !== 'microservice' && generator.databaseType === 'sql')
                 || (!generator.skipUserManagement && generator.databaseType === 'sql'),
             path: SERVER_MAIN_RES_DIR,
             templates: [

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -159,7 +159,7 @@
                                  referencedColumnNames="id"
                                  referencedTableName="<%= jhiTablePrefix %>_user"/>
     <%_ } _%>
-    <%_ if (authenticationType !== 'oauth2' || (authenticationType === 'oauth2' && applicationType === 'monolith')) { _%>
+    <%_ if (authenticationType !== 'oauth2' || (authenticationType === 'oauth2' && applicationType !== 'microservice')) { _%>
         <<% if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { %>ext:<% } %>loadData encoding="UTF-8"
                   file="config/liquibase/users.csv"
                   separator=";"

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -139,13 +139,14 @@
                                  constraintName="fk_authority_name"
                                  referencedColumnNames="name"
                                  referencedTableName="<%= jhiTablePrefix %>_authority"/>
-    <%_ if (authenticationType !== 'oauth2') { _%>
+
         <addForeignKeyConstraint baseColumnNames="user_id"
                                  baseTableName="<%= jhiTablePrefix %>_user_authority"
                                  constraintName="fk_user_id"
                                  referencedColumnNames="id"
                                  referencedTableName="<%= jhiTablePrefix %>_user"/>
 
+    <%_ if (authenticationType !== 'oauth2') { _%>
         <addNotNullConstraint   columnName="password_hash"
                                 columnDataType="varchar(60)"
                                 tableName="<%= jhiTablePrefix %>_user"/>
@@ -170,7 +171,6 @@
             <column name="created_date" type="timestamp"/>
         </<% if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { %>ext:<% } %>loadData>
         <dropDefaultValue tableName="<%= jhiTablePrefix %>_user" columnName="created_date" columnDataType="datetime"/>
-    <%_ } _%>
         <<% if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { %>ext:<% } %>loadData encoding="UTF-8"
                   file="config/liquibase/authorities.csv"
                   separator=";"
@@ -186,6 +186,7 @@
                   identityInsertEnabled="true"
                   <%_ } _%>
                   tableName="<%= jhiTablePrefix %>_user_authority"/>
+    <%_ } _%>
 <%_ } _%>
         <createTable tableName="<%= jhiTablePrefix %>_persistent_audit_event">
             <column name="event_id" type="bigint" autoIncrement="${autoIncrement}">

--- a/generators/server/templates/src/main/resources/config/liquibase/users_authorities.csv.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/users_authorities.csv.ejs
@@ -1,6 +1,8 @@
 user_id;authority_name
 1;ROLE_ADMIN
 1;ROLE_USER
+<%_ if (authenticationType !== 'oauth2') { _%>
 3;ROLE_ADMIN
 3;ROLE_USER
 4;ROLE_USER
+<%_ } _%>

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIntTest.java.ejs
@@ -716,7 +716,8 @@ public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extend
         assertThat(userList).hasSize(databaseSizeBeforeDelete - 1);
     }
     <%_ } _%>
-    <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
+    <%_ if ((databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase')
+        && (!(authenticationType === 'oauth2' && applicationType === 'microservice'))) { _%>
 
     @Test
     <%_ if (databaseType === 'sql') { _%>


### PR DESCRIPTION
Fix #8018

This PR does the following:
 - Adds missing constraint between `jhi_user <-> jhi_authorities` that `liquibase:diff` will generate on a fresh OAuth2 app.  
 - Prevents the copy and import of the `.csv` files that are unused in OAuth2 microservices.
   - Eventually we could cleanup the User/Authority relationship in OAuth2 microservices since it is unused (only the User is synced for relationships in OAuth2 microservices), but it would definitely complicate the templates and might be a breaking change
 - Removes the invalid entries in `jhi_authorities` that point to non-existant users.  These prevents the constraint from being added for OAuth apps

OAuth2 apps upgrading from a previous version will need to delete the old invalid values in `jhi_user_authority` and add the constraint.  The following changelog does that:
```
<?xml version="1.1" encoding="UTF-8" standalone="no"?>
<databaseChangeLog xmlns="http://www.liquibase.org/xml/ns/dbchangelog" xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd">
      <changeSet author="jhipster (generated)" id="1535605615692-1">
       <sql dbms="mysql, mariadb, postgresql, mssql"
            endDelimiter="\nGO"
            splitStatements="true"
            stripComments="true">delete from jhi_user_authority where user_id in ('3','4');
            <comment>Removes invalid authorities inserted from old CSV file</comment>
        </sql>
        <addForeignKeyConstraint baseColumnNames="user_id" baseTableName="jhi_user_authority" constraintName="FK290okww5jujghp4el5i7mgwu0" deferrable="false" initiallyDeferred="false" referencedColumnNames="id" referencedTableName="jhi_user"/>
    </changeSet>
</databaseChangeLog>

```

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
