### PR TITLE
Fix react tests on node 10

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
@@ -86,7 +86,7 @@ export const saveAccountSettings = account => async <% if (enableTranslation) { 
 
   const accountState = getState().authentication.account;
   if (accountState && accountState.langKey) {
-    dispatch(setLocale(accountState.langKey));
+    await dispatch(setLocale(accountState.langKey));
   }
   <%_ } else { _%>
   dispatch(getSession());

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -181,7 +181,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
 
   const account = getState().authentication.account;
   if (account && account.langKey) {
-    dispatch(setLocale(account.langKey));
+    await dispatch(setLocale(account.langKey));
   }
   <%_ } else { _%>
   dispatch(getSession());
@@ -198,7 +198,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
 
   const account = getState().authentication.account;
   if (account && account.langKey) {
-    dispatch(setLocale(account.langKey));
+    await dispatch(setLocale(account.langKey));
   }
   <%_ } else { _%>
   dispatch(getSession());

--- a/generators/client/templates/react/src/test/javascript/spec/storage-mock.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/storage-mock.ts.ejs
@@ -1,9 +1,10 @@
 let StorageMock = () => {
-  let store = {};
+  let storage = {};
   return {
-    get: (key: any) => store[key] || null,
-    set: (key: any, value: any) => (store[key] = value.toString()),
-    clear: () => (store = {})
+    getItem: key => (key in storage ? storage[key] : null),
+    setItem: (key, value) => (storage[key] = value || ''),
+    removeItem: key => delete storage[key],
+    clear: () => (storage = {})
   };
 };
 


### PR DESCRIPTION
It seems that the storage mocks for Jest were wrong on React. This caused the tests to fail on Node 10, I don't know why this worked on the LTS...

Also, I had some errors on async reducers tests so I needed to add `await` keywords before some `dispatch()`, I'm not a React expert so tell me if that's a normal way to dispatch actions or not...

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
