### PR TITLE
set default client root folder for microservices with JDL

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -423,8 +423,11 @@ module.exports = class extends BaseGenerator {
                     this.warning(`pagination is missing in .jhipster/${entityName}.json, using no as fallback`);
                     context.pagination = 'no';
                 }
-                if (!context.clientRootFolder && !context.skipUiGrouping && context.applicationType === 'gateway' && context.useMicroserviceJson) {
-                    context.clientRootFolder = context.microserviceName;
+                if (!context.clientRootFolder && !context.skipUiGrouping) {
+                    // if it is a gateway generating from a microservice, or a microservice
+                    if (context.useMicroserviceJson || context.applicationType === 'microservice') {
+                        context.clientRootFolder = context.microserviceName;
+                    }
                 }
             },
 


### PR DESCRIPTION
related to #8178, this fixes entity generation when it loads from the JSON file.  This also fixes old entities when upgrading, since regenerating your entities [doesn't update the `Entity.json` file](https://github.com/jhipster/generator-jhipster/blob/7461029601bfc4db9911c8f9204a68f74f2cde7e/generators/entity/index.js#L433-L435).

The JDL -> JSON conversion doesn't set the value in the microservice entity JSON, but that's a fix in `jhipster-core`. I'll try to look into it this weekend.  

Currently, the `client-root-folder` for microservices [is ignored in JDL](https://github.com/jhipster/jhipster-core/blob/40971397069abf04b9ac70b08e53718361d68a91/lib/parser/document_parser.js#L286-L290) but it's needed if you want the translation keys to match (only when mixing entities with default and non-default `client-root-folder`).  It might be better to use the microservice name in the entity translation key (rather than `client-root-folder`) so you don't have to sync this value across projects.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
