### PR TITLE
Prevent sending insight stats when running unit tests

### DIFF
--- a/generators/statistics.js
+++ b/generators/statistics.js
@@ -128,6 +128,7 @@ class Statistics {
     }
 
     sendYoRc(yorc, isARegeneration, generatorVersion) {
+        if (this.noInsight) return;
         this.postRequest('/s/entry', {
             'generator-jhipster': yorc,
             'generator-id': this.clientId,
@@ -151,6 +152,7 @@ class Statistics {
     }
 
     sendSubGenEvent(source, type, event) {
+        if (this.noInsight) return;
         const strEvent = event === '' ? event : JSON.stringify(event);
         this.postRequest(`/s/event/${this.clientId}`,
             { source, type, event: strEvent },
@@ -174,6 +176,7 @@ class Statistics {
      * @param {any} eventObject events that you want to send
      */
     sendInsightSubGenEvents(prefix, eventObject) {
+        if (this.noInsight) return;
         if (typeof eventObject === 'object') {
             Object.keys(eventObject).forEach((key) => {
                 if (typeof eventObject[key] === 'object') {
@@ -188,6 +191,7 @@ class Statistics {
     }
 
     sendEntityStats(fields, relationships, pagination, dto, service, fluentMethods) {
+        if (this.noInsight) return;
         this.postRequest(`/s/entity/${this.clientId}`, {
             fields,
             relationships,

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
     "ejs-lint": "npm run test:unit -- test/ejslint.js",
     "ejslint": "ejslint",
     "pretest": "npm run lint",
-    "test": "npm run test:unit -- test/*.spec.js",
+    "test": "npm run test:unit -- test/*.spec.js --no-insight",
     "test:unit": "mocha --timeout 20000 --slow 0 --reporter spec",
     "jsdoc": "jsdoc --configure jsdoc-conf.json"
   },


### PR DESCRIPTION
I noticed strange patterns when looking at the graphs. They looked like they are produced by an automated system. Look how openshift and k8s stats follow the exact same trend !

<img width="926" alt="screen shot 2018-09-03 at 17 56 48" src="https://user-images.githubusercontent.com/513471/44995300-c6d1c880-afa2-11e8-8662-cf5da3d83a15.png">

It seems the --no-insight option is correctly set for Travis builds, however after adding some log in the analytics code, I noticed that it's our unit tests that are causing the issue.

<img width="492" alt="screen shot 2018-08-30 at 18 15 45" src="https://user-images.githubusercontent.com/513471/44995418-3cd62f80-afa3-11e8-8445-0e1a39fe78f9.png">

The solution is to pass the --no-insight flag to npm test as well.
