### PR TITLE
Warn the user when no keytool, instead of error

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2115,7 +2115,7 @@ module.exports = class extends PrivateBase {
                 + `-dname "CN=Java Hipster, OU=Development, O=${this.packageName}, L=, ST=, C="`,
                 (code) => {
                     if (code !== 0) {
-                        this.error('\nFailed to create a KeyStore with \'keytool\'', code);
+                        this.warning('\nFailed to create a KeyStore with \'keytool\'', code);
                     } else {
                         this.log(chalk.green(`\nKeyStore '${keyStoreFile}' generated successfully.\n`));
                     }


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/8216

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
