### PR TITLE
WIP: add command to create the app DB in MSSQL

### DIFF
--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -41,7 +41,7 @@ services:
             - SPRING_DATASOURCE_URL=jdbc:postgresql://<%= baseName.toLowerCase() %>-postgresql:5432/<%= baseName %>
             <%_ } _%>
             <%_ if (prodDatabaseType === 'mssql') { _%>
-            - SPRING_DATASOURCE_URL=jdbc:sqlserver://<%= baseName.toLowerCase() %>-mssql:1433;database=tempdb
+            - SPRING_DATASOURCE_URL=jdbc:sqlserver://<%= baseName.toLowerCase() %>-mssql:1433;database=<%= baseName %>
             <%_ } _%>
             <%_ if (prodDatabaseType === 'oracle') { _%>
             - SPRING_DATASOURCE_URL=jdbc:oracle:thin:@<%= baseName.toLowerCase() %>-oracle:1521:<%= baseName %>

--- a/generators/server/templates/src/main/docker/mssql.yml.ejs
+++ b/generators/server/templates/src/main/docker/mssql.yml.ejs
@@ -26,5 +26,8 @@ services:
         environment:
             - ACCEPT_EULA=Y
             - SA_PASSWORD=yourStrong(!)Password
+            - MSSQL_DATABASE=<%= baseName %>
+            - MSSQL_SLEEP=7
         ports:
             - 1433:1433
+        command: /bin/bash -c '/opt/mssql/bin/sqlservr & echo "wait $$MSSQL_SLEEP sec for DB to start "; sleep $$MSSQL_SLEEP; /opt/mssql-tools/bin/sqlcmd -U sa -P $$SA_PASSWORD -d tempdb -q "EXIT(CREATE DATABASE $$MSSQL_DATABASE)"; wait;'

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -100,8 +100,6 @@ spring:
         username: system
         password: oracle
         <%_ } else if (devDatabaseType === 'mssql') { _%>
-        # If you use the Docker Compose configuration provided by JHipster, the database name is "tempdb"
-        # So you should use url: jdbc:sqlserver://localhost:1433;database=tempdb
         url: jdbc:sqlserver://localhost:1433;database=<%= baseName %>
         username: SA
         password: yourStrong(!)Password

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -88,8 +88,6 @@ spring:
         username: <%= baseName %>
         password:
         <%_ } else if (prodDatabaseType === 'mssql') { _%>
-        # If you use the Docker Compose configuration provided by JHipster, the database name is "tempdb"
-        # So you should use url: jdbc:sqlserver://localhost:1433;database=tempdb
         url: jdbc:sqlserver://localhost:1433;database=<%= baseName %>
         username: SA
         password: yourStrong(!)Password


### PR DESCRIPTION
Fix #8215 
at the moment the output in docker-compose.yml is not well formatted:

`
command:             /bin/bash -c /opt/mssql/bin/sqlservr & echo "wait $$MSSQL_SLEEP sec for
            DB to start "; sleep $$MSSQL_SLEEP; /opt/mssql-tools/bin/sqlcmd -U sa -P
            $$SA_PASSWORD -d tempdb -q "EXIT(CREATE DATABASE $$MSSQL_DATABASE)";
            wait;
`
I guess that when the mssql.yml is read and printed [here](https://github.com/jhipster/generator-jhipster/blob/master/generators/docker-compose/templates/docker-compose.yml.ejs#L22) then the layout of the  command is changed.


- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
