### PR TITLE
[heroku] move Liquibase migrations to release phase

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -64,7 +64,7 @@ module.exports = class extends BaseGenerator {
         this.serviceDiscoveryType = this.config.get('serviceDiscoveryType');
         this.herokuAppName = this.config.get('herokuAppName');
         this.dynoSize = 'Free';
-        this.herokuDeployType = this.config.get('herokuDeployType') || (this.herokuAppName ? 'jar' : null);
+        this.herokuDeployType = this.config.get('herokuDeployType');
     }
 
     get prompting() {

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -264,11 +264,11 @@ module.exports = class extends BaseGenerator {
                                             this.log.error(err);
                                         } else {
                                             this.log(stdout.trim());
+                                            this.config.set({
+                                                herokuAppName: this.herokuAppName,
+                                                herokuDeployType: this.herokuDeployType
+                                            });
                                         }
-                                        this.config.set({
-                                            herokuAppName: this.herokuAppName,
-                                            herokuDeployType: this.herokuDeployType
-                                        });
                                         done();
                                     });
                                 } else {

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 const fs = require('fs');
-const path = require('path');
 const exec = require('child_process').exec;
 const chalk = require('chalk');
 const _ = require('lodash');

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -75,7 +75,10 @@ module.exports = class extends BaseGenerator {
                 if (this.herokuAppName) {
                     exec('heroku apps:info --json', (err, stdout) => {
                         if (err) {
-                            this.config.set('herokuAppName', null);
+                            this.config.set({
+                                herokuAppName: null,
+                                herokuDeployType: this.herokuDeployType
+                            });
                             this.abort = true;
                             this.log.error(`Could not find app: ${chalk.cyan(this.herokuAppName)}`);
                             this.log.error('Run the generator again to create a new app.');
@@ -87,7 +90,10 @@ module.exports = class extends BaseGenerator {
                             }
                             this.log(`Deploying as existing app: ${chalk.bold(this.herokuAppName)}`);
                             this.herokuAppExists = true;
-                            this.config.set('herokuAppName', this.herokuAppName);
+                            this.config.set({
+                                herokuAppName: this.herokuAppName,
+                                herokuDeployType: this.herokuDeployType
+                            });
                         }
                         done();
                     });
@@ -140,7 +146,6 @@ module.exports = class extends BaseGenerator {
 
                 this.prompt(prompts).then((props) => {
                     this.herokuDeployType = props.herokuDeployType;
-                    this.config.set('herokuDeployType', this.herokuDeployType);
                     done();
                 });
             }
@@ -160,6 +165,13 @@ module.exports = class extends BaseGenerator {
                         this.abort = true;
                     }
                     done();
+                });
+            },
+
+            saveConfig() {
+                this.config.set({
+                    herokuAppName: this.herokuAppName,
+                    herokuDeployType: this.herokuDeployType
                 });
             }
         };
@@ -253,7 +265,10 @@ module.exports = class extends BaseGenerator {
                                         } else {
                                             this.log(stdout.trim());
                                         }
-                                        this.config.set('herokuAppName', this.herokuAppName);
+                                        this.config.set({
+                                            herokuAppName: this.herokuAppName,
+                                            herokuDeployType: this.herokuDeployType
+                                        });
                                         done();
                                     });
                                 } else {
@@ -272,7 +287,10 @@ module.exports = class extends BaseGenerator {
                                                     this.abort = true;
                                                     this.log.error(err);
                                                 } else {
-                                                    this.config.set('herokuAppName', this.herokuAppName);
+                                                    this.config.set({
+                                                        herokuAppName: this.herokuAppName,
+                                                        herokuDeployType: this.herokuDeployType
+                                                    });
                                                 }
                                                 done();
                                             });

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -446,7 +446,7 @@ module.exports = class extends BaseGenerator {
 
             addHerokuMavenProfile() {
                 if (this.buildTool === 'maven') {
-                    fs.readFile(path.join(__dirname, 'templates', 'pom-profile.xml.ejs'), (err, profile) => {
+                    this.render('pom-profile.xml.ejs', (profile) => {
                         this.addMavenProfile('heroku', `            ${profile.toString().trim()}`);
                     });
                 }

--- a/generators/heroku/templates/Procfile.ejs
+++ b/generators/heroku/templates/Procfile.ejs
@@ -16,4 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-web: java $JAVA_OPTS <% if (applicationType === 'gateway' || dynoSize === 'Free') { %>-Xmx256m<% } %> -jar <% if (buildTool === 'maven') { %>target<% } %><% if (buildTool === 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod,heroku --server.port=$PORT <% if (prodDatabaseType === 'mongodb') { %>--spring.data.mongodb.database=$(echo "$MONGODB_URI" | sed "s/^.*:[0-9]*\///g")<% } %>
+web: java $JAVA_OPTS <% if (applicationType === 'gateway' || dynoSize === 'Free') { %>-Xmx256m<% } %> -jar <% if (buildTool === 'maven') { %>target<% } %><% if (buildTool === 'gradle') { %>build/libs<% } %>/*.war --spring.profiles.active=prod,heroku<% if (buildTool == 'maven' && herokuDeployType == 'git') { %>,no-liquibase<% } %> --server.port=$PORT <% if (prodDatabaseType === 'mongodb') { %>--spring.data.mongodb.database=$(echo "$MONGODB_URI" | sed "s/^.*:[0-9]*\///g")<% } %>
+<%_ if (buildTool == 'maven' && herokuDeployType == 'git' && (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb')) { _%>
+release: cp -R src/main/resources/config config && ./mvnw liquibase:update -Pheroku
+<%_ } _%>

--- a/generators/heroku/templates/pom-profile.xml.ejs
+++ b/generators/heroku/templates/pom-profile.xml.ejs
@@ -1,6 +1,5 @@
             <build>
                 <plugins>
-                    <%_ if (herokuDeployType == 'git' && (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb')) { _%>
                     <plugin>
                         <groupId>org.liquibase</groupId>
                         <artifactId>liquibase-maven-plugin</artifactId>
@@ -18,7 +17,6 @@
                             <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
                         </configuration>
                     </plugin>
-                    <%_ } _%>
                     <plugin>
                         <artifactId>maven-clean-plugin</artifactId>
                         <version>${maven-clean-plugin.version}</version>

--- a/generators/heroku/templates/pom-profile.xml.ejs
+++ b/generators/heroku/templates/pom-profile.xml.ejs
@@ -1,5 +1,24 @@
             <build>
                 <plugins>
+                    <%_ if (herokuDeployType == 'git' && (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb')) { _%>
+                    <plugin>
+                        <groupId>org.liquibase</groupId>
+                        <artifactId>liquibase-maven-plugin</artifactId>
+                        <configuration combine.self="override">
+                            <changeLogFile>src/main/resources/config/liquibase/master.xml</changeLogFile>
+                            <diffChangeLogFile>src/main/resources/config/liquibase/changelog/${maven.build.timestamp}_changelog.xml</diffChangeLogFile>
+                            <driver></driver>
+                            <url>${env.JDBC_DATABASE_URL}</url>
+                            <defaultSchemaName></defaultSchemaName>
+                            <username>${env.JDBC_DATABASE_USERNAME}</username>
+                            <password>${env.JDBC_DATABASE_PASSWORD}</password>
+                            <referenceUrl>hibernate:spring:com.mycompany.myapp.domain?hibernate.physical_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringPhysicalNamingStrategy&amp;hibernate.implicit_naming_strategy=org.springframework.boot.orm.jpa.hibernate.SpringImplicitNamingStrategy</referenceUrl>
+                            <verbose>true</verbose>
+                            <logging>debug</logging>
+                            <promptOnNonLocalDatabase>false</promptOnNonLocalDatabase>
+                        </configuration>
+                    </plugin>
+                    <%_ } _%>
                     <plugin>
                         <artifactId>maven-clean-plugin</artifactId>
                         <version>${maven-clean-plugin.version}</version>


### PR DESCRIPTION
The change disabled liquibase migrations from running inline with the web process, and moves them to the [Heroku Release phase](https://devcenter.heroku.com/articles/release-phase). This will significantly improve startup time, and prevents common problems related to concurrency (i.e. migrations running on more than one server process at the same time).

In more detail, this will add special Liquibase configuration to the Maven profile, and a `release` command to the `Procfile`. Heroku treats the `release` process type specially, and runs it when appropriate (i.e. after a deploy, or when a new database is attached).

The change only affects Git deploy (which will eventually become the default deploy mechanism for this generator).

*NOTE:* This PR includes the changes from #8225 because they were require to get this working. We can choose to close that PR and merge this one, or I can rebase.

## Future work

* Apply this same improvement for Gradle
* Possibly pply a similar improvement for JAR deploys (this is a bit more complicated because the Maven plugin isn't present on the server)