### PR TITLE
fix translation-not-found error

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/global.json.ejs
@@ -59,6 +59,8 @@
         "form": {
             "username": "账号",
             "username.placeholder": "您的账号",
+            "currentpassword": "当前密码",
+            "currentpassword.placeholder": "您的当前密码",
             "newpassword": "新密码",
             "newpassword.placeholder": "您的新密码",
             "confirmpassword": "新密码确认",


### PR DESCRIPTION
fix Account ->Password  page ,  show  translation-not-found[global.form.currentpassword], translation-not-found[global.form.currentpassword.placeholder] errors.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
