### PR TITLE
Allow Spring boot Scheduled tasks to have multiple threads

### DIFF
--- a/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
@@ -29,13 +29,18 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.scheduling.annotation.*;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.annotation.SchedulingConfigurer;
+import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 
 import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+
+
 
 @Configuration
 @EnableAsync
 @EnableScheduling
-public class AsyncConfiguration implements AsyncConfigurer {
+public class AsyncConfiguration implements AsyncConfigurer,SchedulingConfigurer {
 
     private final Logger log = LoggerFactory.getLogger(AsyncConfiguration.class);
 
@@ -60,5 +65,16 @@ public class AsyncConfiguration implements AsyncConfigurer {
     @Override
     public AsyncUncaughtExceptionHandler getAsyncUncaughtExceptionHandler() {
         return new SimpleAsyncUncaughtExceptionHandler();
+    }
+    
+        @Override
+    public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
+        taskRegistrar.setScheduler(taskScheduledExecutor());
+    }
+
+    @Bean(destroyMethod="shutdown")
+    public Executor taskScheduledExecutor() {
+        return Executors.newScheduledThreadPool(jHipsterProperties.getAsync().getCorePoolSize());
+
     }
 }

--- a/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
@@ -67,10 +67,10 @@ public class AsyncConfiguration implements AsyncConfigurer, SchedulingConfigurer
     
     @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
-        taskRegistrar.setScheduler(taskScheduledExecutor());
+        taskRegistrar.setScheduler(scheduledTaskExecutor());
     }
 
-    @Bean(destroyMethod="shutdown")
+    @Bean
     public Executor scheduledTaskExecutor() {
         return Executors.newScheduledThreadPool(jHipsterProperties.getAsync().getCorePoolSize());
     }

--- a/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
@@ -65,7 +65,7 @@ public class AsyncConfiguration implements AsyncConfigurer, SchedulingConfigurer
         return new SimpleAsyncUncaughtExceptionHandler();
     }
     
-        @Override
+    @Override
     public void configureTasks(ScheduledTaskRegistrar taskRegistrar) {
         taskRegistrar.setScheduler(taskScheduledExecutor());
     }
@@ -73,6 +73,5 @@ public class AsyncConfiguration implements AsyncConfigurer, SchedulingConfigurer
     @Bean(destroyMethod="shutdown")
     public Executor taskScheduledExecutor() {
         return Executors.newScheduledThreadPool(jHipsterProperties.getAsync().getCorePoolSize());
-
     }
 }

--- a/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
@@ -35,12 +35,10 @@ import org.springframework.scheduling.config.ScheduledTaskRegistrar;
 import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 
-
-
 @Configuration
 @EnableAsync
 @EnableScheduling
-public class AsyncConfiguration implements AsyncConfigurer,SchedulingConfigurer {
+public class AsyncConfiguration implements AsyncConfigurer, SchedulingConfigurer {
 
     private final Logger log = LoggerFactory.getLogger(AsyncConfiguration.class);
 

--- a/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/AsyncConfiguration.java.ejs
@@ -71,7 +71,7 @@ public class AsyncConfiguration implements AsyncConfigurer, SchedulingConfigurer
     }
 
     @Bean(destroyMethod="shutdown")
-    public Executor taskScheduledExecutor() {
+    public Executor scheduledTaskExecutor() {
         return Executors.newScheduledThreadPool(jHipsterProperties.getAsync().getCorePoolSize());
     }
 }


### PR DESCRIPTION
The Async configuration currently only allows us to set the async pool size and not the scheduler pool size.
This results in spring scheduled tasks having only one thread to execute all it's tasks.

The proposed change allows us to have the number of scheduler tasks to be the size of the core pool.

Ideally we should have one more configuration value in application.yml which will dictate the size of the executor pool.

See: https://docs.spring.io/spring/docs/current/javadoc-api/org/springframework/scheduling/annotation/EnableScheduling.html

"By default, will be searching for an associated scheduler definition: either a unique TaskScheduler bean in the context, or a TaskScheduler bean named "taskScheduler" otherwise; the same lookup will also be performed for a ScheduledExecutorService bean. If neither of the two is resolvable, a local single-threaded default scheduler will be created and used within the registrar. "

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
