### PR TITLE
Fix some IE11 incompatibilities when header attributes on HTTP response are used

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -57,9 +57,9 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                     let errorHeader = null;
                     let entityKey = null;
                     arr.forEach((entry) => {
-                        if (entry.endsWith('app-error')) {
+                        if (entry.toLowerCase().endsWith('app-error')) {
                             errorHeader = httpErrorResponse.headers.get(entry);
-                        } else if (entry.endsWith('app-params')) {
+                        } else if (entry.toLowerCase().endsWith('app-params')) {
                             entityKey = httpErrorResponse.headers.get(entry);
                         }
                     });

--- a/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
@@ -50,9 +50,9 @@ export default () => next => action => {
         let alertParams: string = null;
         <%_ } _%>
         Object.entries(headers).forEach(([k, v]: [string, string]) => {
-          if (k.endsWith('app-alert')) {
+          if (k.toLowerCase().endsWith('app-alert')) {
             alert = v;
-          }<% if (enableTranslation) { %> else if (k.endsWith('app-params')) {
+          }<% if (enableTranslation) { %> else if (k.toLowerCase().endsWith('app-params')) {
             alertParams = v;
           }<% } %>
         });
@@ -86,9 +86,9 @@ export default () => next => action => {
               let errorHeader = null;
               let entityKey = null;
               headers.forEach(([k, v]: [string, string]) => {
-                if (k.endsWith('app-error')) {
+                if (k.toLowerCase().endsWith('app-error')) {
                   errorHeader = v;
-                } else if (k.endsWith('app-params')) {
+                } else if (k.toLowerCase().endsWith('app-params')) {
                   entityKey = v;
                 }
               });


### PR DESCRIPTION
- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
In addition to #7641 and #7653, my team noticed alerting messages on IE11 on prod profile were displayed randomly... Some `.toLowerCase()` were missing every time we tried to use header parameters...

We added them and alerting messages are now correctly displayed...

(OK... It's IE11 bullshit... Some companies still want to use it 👎 )
(Not sure about React fix, it seems obvious but still....)