### PR TITLE
Spring Data Jest : Restore and adapt ES config to handle JSR310

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,13 @@
 
 [![Logo][jhipster-image]][jhipster-url]
 
+[![NPM version][npm-image]][npm-url] [![Build Status][travis-image]][travis-url-main] [![Dependency Status][daviddm-image]][daviddm-url]
+
 Greetings, Java Hipster!
 
 Full documentation and information is available on our website at [https://www.jhipster.tech/][jhipster-url]
 
 Please read our [guidelines](/CONTRIBUTING.md#submitting-an-issue) before submitting an issue. If your issue is a bug, please use the bug template pre-populated [here](issue-template). For feature requests and queries you can use [this template][feature-template].
-
-[![NPM version][npm-image]][npm-url]
-[![Build Status][travis-image]][travis-url-main]
-[![Dependency Status][daviddm-image]][daviddm-url]
 
 ## Sponsors
 
@@ -37,14 +35,13 @@ Additional builds on [hipster-labs/jhipster-travis-build](https://github.com/hip
 | ngx-maven     | [![Build Status][image-ngx-maven]][travis-url]           | Builds for ngx Maven           |
 | ngx-gradle    | [![Build Status][image-ngx-gradle]][travis-url]          | Builds for ngx Gradle          |
 | microservices | [![Build Status][image-microservices]][travis-url]       | Builds for Microservices       |
+| ms-gradle     | [![Build Status][image-ms-gradle]][travis-url]           | Builds for MS+Gradle           |
 | react         | [![Build Status][image-react]][travis-url]               | Builds for React               |
+| node latest   | [![Build Status][image-node-latest]][travis-url]         | Builds for Node Latest         |
 
 ## Analysis of the sample JHipster project
 
-[![sonar-quality-gate][sonar-quality-gate]][sonar-url]
-[![sonar-coverage][sonar-coverage]][sonar-url]
-[![sonar-bugs][sonar-bugs]][sonar-url]
-[![sonar-vulnerabilities][sonar-vulnerabilities]][sonar-url]
+[![sonar-quality-gate][sonar-quality-gate]][sonar-url] [![sonar-coverage][sonar-coverage]][sonar-url] [![sonar-bugs][sonar-bugs]][sonar-url] [![sonar-vulnerabilities][sonar-vulnerabilities]][sonar-url]
 
 
 [travis-url]: https://travis-ci.org/hipster-labs/jhipster-travis-build/branches
@@ -52,7 +49,9 @@ Additional builds on [hipster-labs/jhipster-travis-build](https://github.com/hip
 [image-ngx-maven]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=ngx-maven
 [image-ngx-gradle]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=ngx-gradle
 [image-microservices]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=microservices
+[image-ms-gradle]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=microservices-gradle
 [image-react]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=react
+[image-node-latest]: https://travis-ci.org/hipster-labs/jhipster-travis-build.svg?branch=node-latest
 
 [sonar-url]: https://sonarcloud.io/dashboard?id=io.github.jhipster.sample%3Ajhipster-sample-application
 [sonar-quality-gate]: https://sonarcloud.io/api/project_badges/measure?project=io.github.jhipster.sample%3Ajhipster-sample-application&metric=alert_status

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -747,6 +747,13 @@ const serverFiles = {
             ]
         },
         {
+            condition: generator => generator.searchEngine === 'elasticsearch',
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                { file: 'package/config/ElasticsearchConfiguration.java', renameTo: generator => `${generator.javaDir}config/ElasticsearchConfiguration.java` },
+            ]
+        },
+        {
             condition: generator => generator.messageBroker === 'kafka',
             path: SERVER_MAIN_SRC_DIR,
             templates: [

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -328,7 +328,7 @@ dependencies {
     <%_ if (searchEngine === 'elasticsearch') { _%>
     compile "org.springframework.boot:spring-boot-starter-data-elasticsearch"
     // Spring Data Jest dependencies for Elasticsearch
-    runtime ("com.github.vanroy:spring-boot-starter-data-jest") {
+    compile ("com.github.vanroy:spring-boot-starter-data-jest") {
         exclude module: 'commons-logging'
     }
     // log4j needed to create embedded elasticsearch instance

--- a/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
@@ -20,9 +20,12 @@ package <%=packageName%>.config;
 
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
 import com.github.vanroy.springdata.jest.JestElasticsearchTemplate;
 import com.github.vanroy.springdata.jest.mapper.DefaultJestResultsMapper;
 import io.searchbox.client.JestClient;
+import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchProperties;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Primary;
@@ -30,23 +33,34 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.EntityMapper;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
-import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
 
 import java.io.IOException;
 
 @Configuration
+@EnableConfigurationProperties(ElasticsearchProperties.class)
 public class ElasticsearchConfiguration {
+
+    private ObjectMapper mapper;
+
+    public ElasticsearchConfiguration(ObjectMapper mapper) {
+        this.mapper = mapper;
+    }
+
+    @Bean
+    public EntityMapper getEntityMapper() {
+        return new CustomEntityMapper(mapper);
+    }
 
     @Bean
     @Primary
     public ElasticsearchOperations elasticsearchTemplate(final JestClient jestClient,
                                                          final ElasticsearchConverter elasticsearchConverter,
                                                          final SimpleElasticsearchMappingContext simpleElasticsearchMappingContext,
-                                                         Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder) {
+                                                         EntityMapper mapper) {
         return new JestElasticsearchTemplate(
             jestClient,
             elasticsearchConverter,
-            new DefaultJestResultsMapper(simpleElasticsearchMappingContext, new CustomEntityMapper(jackson2ObjectMapperBuilder.createXmlMapper(false).build())));
+            new DefaultJestResultsMapper(simpleElasticsearchMappingContext, mapper));
     }
 
     public class CustomEntityMapper implements EntityMapper {
@@ -57,6 +71,9 @@ public class ElasticsearchConfiguration {
             this.objectMapper = objectMapper;
             objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
             objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+            objectMapper.configure(SerializationFeature.WRITE_DATE_TIMESTAMPS_AS_NANOSECONDS, true);
+            objectMapper.configure(SerializationFeature.INDENT_OUTPUT, false);
+            objectMapper.configure(DeserializationFeature.READ_DATE_TIMESTAMPS_AS_NANOSECONDS, true);
         }
 
         @Override
@@ -69,4 +86,5 @@ public class ElasticsearchConfiguration {
             return objectMapper.readValue(source, clazz);
         }
     }
+
 }

--- a/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
@@ -1,0 +1,72 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.config;
+
+import com.fasterxml.jackson.databind.DeserializationFeature;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.github.vanroy.springdata.jest.JestElasticsearchTemplate;
+import com.github.vanroy.springdata.jest.mapper.DefaultJestResultsMapper;
+import io.searchbox.client.JestClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Primary;
+import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+import org.springframework.data.elasticsearch.core.EntityMapper;
+import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+import org.springframework.http.converter.json.Jackson2ObjectMapperBuilder;
+
+import java.io.IOException;
+
+@Configuration
+public class ElasticsearchConfiguration {
+
+    @Bean
+    @Primary
+    public ElasticsearchOperations elasticsearchTemplate(final JestClient jestClient,
+                                                         final ElasticsearchConverter elasticsearchConverter,
+                                                         final SimpleElasticsearchMappingContext simpleElasticsearchMappingContext,
+                                                         Jackson2ObjectMapperBuilder jackson2ObjectMapperBuilder) {
+        return new JestElasticsearchTemplate(
+            jestClient,
+            elasticsearchConverter,
+            new DefaultJestResultsMapper(simpleElasticsearchMappingContext, new CustomEntityMapper(jackson2ObjectMapperBuilder.createXmlMapper(false).build())));
+    }
+
+    public class CustomEntityMapper implements EntityMapper {
+
+        private ObjectMapper objectMapper;
+
+        public CustomEntityMapper(ObjectMapper objectMapper) {
+            this.objectMapper = objectMapper;
+            objectMapper.configure(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES, false);
+            objectMapper.configure(DeserializationFeature.ACCEPT_SINGLE_VALUE_AS_ARRAY, true);
+        }
+
+        @Override
+        public String mapToString(Object object) throws IOException {
+            return objectMapper.writeValueAsString(object);
+        }
+
+        @Override
+        public <T> T mapToObject(String source, Class<T> clazz) throws IOException {
+            return objectMapper.readValue(source, clazz);
+        }
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/JacksonConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/JacksonConfiguration.java.ejs
@@ -21,6 +21,8 @@ package <%=packageName%>.config;
 <%_ if (databaseType === 'sql') { _%>
 import com.fasterxml.jackson.datatype.hibernate5.Hibernate5Module;
 <%_ } _%>
+import com.fasterxml.jackson.datatype.jdk8.Jdk8Module;
+import com.fasterxml.jackson.datatype.jsr310.JavaTimeModule;
 import com.fasterxml.jackson.module.afterburner.AfterburnerModule;
 
 import org.springframework.context.annotation.Bean;
@@ -30,6 +32,21 @@ import org.zalando.problem.violations.ConstraintViolationProblemModule;
 
 @Configuration
 public class JacksonConfiguration {
+
+    /**
+     * Support for Java date and time API.
+     * @return the corresponding Jackson module.
+     */
+    @Bean
+    public JavaTimeModule javaTimeModule() {
+        return new JavaTimeModule();
+    }
+
+    @Bean
+    public Jdk8Module jdk8TimeModule() {
+        return new Jdk8Module();
+    }
+
 <%_ if (databaseType === 'sql') { _%>
 
     /*


### PR DESCRIPTION
Spring Data Jest use by default Gson and is not configured to map the Java Date JSR310. This config switch the DefaultJestResultsMapper to Jackson with jackson-datatype-jsr310 module.

Fix #8249

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
