### PR TITLE
Fix cli tests when cloning with specific name

### DIFF
--- a/test/cli.spec.js
+++ b/test/cli.spec.js
@@ -18,7 +18,7 @@ describe('jhipster cli test', () => {
             // corrected test for windows user
             cmd = cmd.replace(/\\/g, '/');
         }
-        expect(cmd).to.match(/node (.*)generator-jhipster\/cli\/jhipster/g);
+        expect(cmd).to.match(/node (.*)\/cli\/jhipster/g);
     });
 
     it('--help should run without errors', (done) => {


### PR DESCRIPTION
To reproduce the issue:
- `git clone https://github.com/jhipster/generator-jhipster toto`
- `cd toto`
- `npm run test:unit test/cli.spec.js` or `npm test`

Here the logs:
```
  jhipster cli test
    1) verify correct cmd format
    ✓ --help should run without errors (567ms)
    ✓ --version should run without errors (561ms)
    ✓ should return error on unknown command (593ms)

  3 passing (2s)
  1 failing

  1) jhipster cli test
       verify correct cmd format:
     AssertionError: expected 'node /home/pgrimaud/tmp/toto/cli/jhipster ' to match /node (.*)generator-jhipster\/cli\/jhipster/g
      at Context.it (test/cli.spec.js:21:24)
```

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
