### PR TITLE
Reduce Webpack logs in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,6 +37,7 @@ env:
     # if JHIPSTER_BRANCH value is release, use the release from NPM
     - JHIPSTER_REPO=https://github.com/jhipster/generator-jhipster.git
     - JHIPSTER_BRANCH=release
+    - DISABLE_WEBPACK_LOGS=true
 
   matrix:
     - JHIPSTER=webflux-mongodb

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -116,16 +116,16 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         <%_ if (useSass) { _%>
         {
             test: /\.scss$/,
-            use: ['to-string-loader', 'css-loader', { 
-                loader: 'sass-loader', 
+            use: ['to-string-loader', 'css-loader', {
+                loader: 'sass-loader',
                 options: { implementation: sass }
             }],
             exclude: /(vendor\.scss|global\.scss)/
         },
         {
             test: /(vendor\.scss|global\.scss)/,
-            use: ['style-loader', 'css-loader', 'postcss-loader', { 
-                loader: 'sass-loader', 
+            use: ['style-loader', 'css-loader', 'postcss-loader', {
+                loader: 'sass-loader',
                 options: { implementation: sass }
             }]
         },
@@ -140,11 +140,13 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
             use: ['style-loader', 'css-loader']
         }]
     },
-    stats: options.stats,
+    stats: process.env.DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
     plugins: [
-        new SimpleProgressWebpackPlugin({
-            format: options.stats === 'minimal' ? 'compact' : 'expanded'
-        }),
+        process.env.DISABLE_WEBPACK_LOGS
+            ? null
+            : new SimpleProgressWebpackPlugin({
+                format: options.stats === 'minimal' ? 'compact' : 'expanded'
+              }),
         new FriendlyErrorsWebpackPlugin(),
         new ForkTsCheckerWebpackPlugin(),
         new BrowserSyncPlugin({
@@ -169,6 +171,6 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
             title: 'JHipster',
             contentImage: path.join(__dirname, 'logo-jhipster.png')
         })
-    ],
+    ].filter(Boolean),
     mode: 'development'
 });

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -93,10 +93,13 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
       ignored: /node_modules/
     }
   },
+  stats: process.env.DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
   plugins: [
-    new SimpleProgressWebpackPlugin({
-      format: options.stats === 'minimal' ? 'compact' : 'expanded'
-    }),
+    process.env.DISABLE_WEBPACK_LOGS
+      ? null
+      : new SimpleProgressWebpackPlugin({
+          format: options.stats === 'minimal' ? 'compact' : 'expanded'
+        }),
     new FriendlyErrorsWebpackPlugin(),
     new BrowserSyncPlugin({
       host: 'localhost',
@@ -117,5 +120,5 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
       title: 'JHipster',
       contentImage: path.join(__dirname, 'logo-jhipster.png')
     })
-  ]
+  ].filter(Boolean)
 });


### PR DESCRIPTION
This reduces the logs in our Travis builds using an environment variable `DISABLE_WEBPACK_LOGS`.
I'm not a fan of adding this into our webpack configurations because I prefer to keep it clean, but I don't know how to do that without doing this...

The `filter(Boolean)` is here to remove the `null` plugins in the configuration, see https://github.com/webpack/webpack/issues/5699

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
