### PR TITLE
avoid warning on user relationship

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -684,7 +684,7 @@ module.exports = class extends BaseGenerator {
                     const jhiTablePrefix = context.jhiTablePrefix;
 
                     if (context.dto && context.dto === 'mapstruct') {
-                        if (otherEntityData && (!otherEntityData.dto || otherEntityData.dto !== 'mapstruct')) {
+                        if (otherEntityData && (!otherEntityData.dto || otherEntityData.dto !== 'mapstruct') && otherEntityName !== 'user') {
                             this.warning(chalk.red(`This entity has the DTO option, and it has a relationship with entity "${otherEntityName}" that doesn't have the DTO option. This will result in an error.`));
                         }
                     }


### PR DESCRIPTION
When creating a relationship with `User`, it shouldn't warn about `User` not having `DTO`

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

This should close #8293
