### PR TITLE
Move saveConfig() method from 'default' to 'configuring' priority queue

### DIFF
--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -135,6 +135,17 @@ module.exports = class extends BaseGenerator {
         }
     }
 
+    get configuring() {
+        return {
+            saveConfig() {
+                if (this.enableTranslation) {
+                    this.languages = _.union(this.currentLanguages, this.languagesToApply);
+                    this.config.set('languages', this.languages);
+                }
+            }
+        };
+    }
+
     get default() {
         return {
             insight() {
@@ -174,13 +185,6 @@ module.exports = class extends BaseGenerator {
                 }
                 if (configOptions.clientFramework) {
                     this.clientFramework = configOptions.clientFramework;
-                }
-            },
-
-            saveConfig() {
-                if (this.enableTranslation) {
-                    this.languages = _.union(this.currentLanguages, this.languagesToApply);
-                    this.config.set('languages', this.languages);
                 }
             }
         };


### PR DESCRIPTION
- Should close the last open item in #8086 fix #8086
- As per yeoman docs, `configuring` priority queue is the correct phase to save/update configurations. All sub-generators except languages were following that.
- Ideally, main generator should also follow to save configurations in `configuring` phase instead of `default` phase, but, that doesn't seems to work at moment and need to be looked further.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
