### PR TITLE
Fix browsersync refresh loop

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -74,7 +74,7 @@
     <%_ } _%>
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",
-    "browser-sync": "2.24.4",
+    "browser-sync": "2.24.6",
     "browser-sync-webpack-plugin": "2.2.2",
     "cache-loader": "1.2.2",
     <%_ if (protractorTests) { _%>
@@ -144,7 +144,7 @@
     <%_ }); _%>
     "webpack": "4.8.0",
     "webpack-cli": "2.1.3",
-    "webpack-dev-server": "3.1.4",
+    "webpack-dev-server": "3.1.5",
     "webpack-merge": "4.1.2",
     "webpack-notifier": "1.6.0",
     "webpack-visualizer-plugin": "0.1.11",

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -156,6 +156,11 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
             proxy: {
                 target: 'http://localhost:9060'<% if (websocket === 'spring-websocket') { %>,
                 ws: true<% } %>
+            },
+            socket: {
+                clients: {
+                    heartbeatTimeout: 60000
+                }
             }
         }, {
             reload: false

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -84,7 +84,7 @@ limitations under the License.
     "@types/selenium-webdriver": "3.0.10",
     <%_ } _%>
     "@types/webpack-env": "1.13.6",
-    "browser-sync": "2.24.4",
+    "browser-sync": "2.24.6",
     "browser-sync-webpack-plugin": "2.2.2",
     "cache-loader": "1.2.2",
     <%_ if (protractorTests) { _%>
@@ -163,7 +163,7 @@ limitations under the License.
     "typescript": "3.0.1",
     "webpack": "4.17.1",
     "webpack-cli": "3.1.0",
-    "webpack-dev-server": "3.1.4",
+    "webpack-dev-server": "3.1.6",
     "webpack-merge": "4.1.4",
     "webpack-notifier": "1.6.0",
     "workbox-webpack-plugin": "3.4.1",

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -108,6 +108,11 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
       proxy: {
         target: 'http://localhost:9060'<% if (websocket === 'spring-websocket') { %>,
         ws: true<% } %>
+      },
+      socket: {
+        clients: {
+          heartbeatTimeout: 60000
+        }
       }
     }, {
       reload: false


### PR DESCRIPTION
- Fixes #8275 
- Default timeout is 5 seconds which may not suit in poor performing application.

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
