### PR TITLE
Keycloak: Enable implicit flow for web_app client by default

### DIFF
--- a/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
+++ b/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
@@ -755,7 +755,7 @@
       "bearerOnly": false,
       "consentRequired": false,
       "standardFlowEnabled": true,
-      "implicitFlowEnabled": false,
+      "implicitFlowEnabled": true,
       "directAccessGrantsEnabled": false,
       "serviceAccountsEnabled": false,
       "publicClient": true,


### PR DESCRIPTION
This allows the JHipster for Ionic and Ignite JHipster to work out-of-the-box. Without this change, the modules would need to 1) include instructions for how to turn it on or 2) manually parse the default realm and change the behavior (which doesn't seem that easy).

Fixes #8314.