### PR TITLE
fixing: UserService missing flush #8303

### DIFF
--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -227,25 +227,14 @@ public class UserService {
     public <% if (reactive) { %>Mono<User><% } else { %>User<% } %> registerUser(UserDTO userDTO, String password) {
     <%_ if (!reactive) { _%>
         userRepository.findOneByLogin(userDTO.getLogin().toLowerCase()).ifPresent(existingUser -> {
-            if (!existingUser.getActivated()) {
-                userRepository.delete(existingUser);
-                <%_ if (cacheManagerIsAvailable === true) { _%>
-                this.clearUserCaches(existingUser);
-                <%_ } _%>
-            } else {
+            boolean removed = removeNonActivatedUser(existingUser);
+            if (!removed) {
                 throw new LoginAlreadyUsedException();
             }
         });
         userRepository.findOneByEmailIgnoreCase(userDTO.getEmail()).ifPresent(existingUser -> {
-            if (!existingUser.getActivated()) {
-                userRepository.delete(existingUser);
-                <%_ if (databaseType === 'sql') { _%>
-                userRepository.flush();
-                <%_ } _%>
-                <%_ if (cacheManagerIsAvailable === true) { _%>
-                this.clearUserCaches(existingUser);
-                <%_ } _%>
-            } else {
+            boolean removed = removeNonActivatedUser(existingUser);
+            if (!removed) {
                 throw new EmailAlreadyUsedException();
             }
         });
@@ -330,6 +319,19 @@ public class UserService {
                     .doOnNext(user -> log.debug("Created Information for User: {}", user));
             });
     <%_ } _%>
+    }
+    private boolean removeNonActivatedUser(User existingUser){
+        if(existingUser.getActivated()) {
+             return false;
+        }
+        userRepository.delete(existingUser);
+        <%_ if (databaseType === 'sql') { _%>
+        userRepository.flush();
+        <%_ } _%>
+        <%_ if (cacheManagerIsAvailable === true) { _%>
+        this.clearUserCaches(existingUser);
+        <%_ } _%>
+        return true;
     }
 
     public <% if (reactive) { %>Mono<User><% } else { %>User<% } %> createUser(UserDTO userDTO) {

--- a/generators/server/templates/src/test/java/package/web/rest/AccountResourceIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AccountResourceIntTest.java.ejs
@@ -762,7 +762,7 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
         // Duplicate email - with uppercase email address
         ManagedUserVM userWithUpperCaseEmail = new ManagedUserVM();
         userWithUpperCaseEmail.setId(firstUser.getId());
-        userWithUpperCaseEmail.setLogin("test-register-duplicate-email-2");
+        userWithUpperCaseEmail.setLogin("test-register-duplicate-email-3");
         userWithUpperCaseEmail.setPassword(firstUser.getPassword());
         userWithUpperCaseEmail.setFirstName(firstUser.getFirstName());
         userWithUpperCaseEmail.setLastName(firstUser.getLastName());
@@ -788,7 +788,7 @@ public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>ext
             .expectStatus().isCreated();
         <%_ } _%>
 
-        Optional<User> testUser4 = userRepository.findOneByLogin("test-register-duplicate-email-2")<% if (reactive) { %>.blockOptional()<% } %>;
+        Optional<User> testUser4 = userRepository.findOneByLogin("test-register-duplicate-email-3")<% if (reactive) { %>.blockOptional()<% } %>;
         assertThat(testUser4.isPresent()).isTrue();
         assertThat(testUser4.get().getEmail()).isEqualTo("test-register-duplicate-email@example.com");
 


### PR DESCRIPTION
Making delete activated user equall for both login and email so both have the flush and fixing test which wrongly hit duplicated login while trying to test duplicated email with casing.

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
checking that
- [x ] Tests are added where necessary
- [x ] Documentation is added/updated where necessary
- [x ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

