### PR TITLE
Servlet context-path startup log

### DIFF
--- a/generators/server/templates/src/main/java/package/Application.java.ejs
+++ b/generators/server/templates/src/main/java/package/Application.java.ejs
@@ -26,6 +26,7 @@ import <%=packageName%>.config.DefaultProfileUtil;
 
 import io.github.jhipster.config.JHipsterConstants;
 
+import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.SpringApplication;
@@ -103,9 +104,18 @@ public class <%= mainClass %> {
         SpringApplication app = new SpringApplication(<%= mainClass %>.class);
         DefaultProfileUtil.addDefaultProfile(app);
         Environment env = app.run(args).getEnvironment();
+        logApplicationStartup(env);
+    }
+
+    private static void logApplicationStartup(Environment env) {
         String protocol = "http";
         if (env.getProperty("server.ssl.key-store") != null) {
             protocol = "https";
+        }
+        String serverPort = env.getProperty("server.port");
+        String contextPath = env.getProperty("server.servlet.context-path");
+        if (StringUtils.isBlank(contextPath)) {
+            contextPath = "/";
         }
         String hostAddress = "localhost";
         try {
@@ -115,15 +125,17 @@ public class <%= mainClass %> {
         }
         log.info("\n----------------------------------------------------------\n\t" +
                 "Application '{}' is running! Access URLs:\n\t" +
-                "Local: \t\t{}://localhost:{}\n\t" +
-                "External: \t{}://{}:{}\n\t" +
+                "Local: \t\t{}://localhost:{}{}\n\t" +
+                "External: \t{}://{}:{}{}\n\t" +
                 "Profile(s): \t{}\n----------------------------------------------------------",
             env.getProperty("spring.application.name"),
             protocol,
-            env.getProperty("server.port"),
+            serverPort,
+            contextPath,
             protocol,
             hostAddress,
-            env.getProperty("server.port"),
+            serverPort,
+            contextPath,
             env.getActiveProfiles());
         <%_ if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa')) { _%>
 

--- a/generators/server/templates/src/main/java/package/Application.java.ejs
+++ b/generators/server/templates/src/main/java/package/Application.java.ejs
@@ -49,6 +49,7 @@ import org.springframework.core.env.Environment;
 
 import javax.annotation.PostConstruct;
 import java.net.InetAddress;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Collection;
 
@@ -120,7 +121,7 @@ public class <%= mainClass %> {
         String hostAddress = "localhost";
         try {
             hostAddress = InetAddress.getLocalHost().getHostAddress();
-        } catch (Exception e) {
+        } catch (UnknownHostException e) {
             log.warn("The host name could not be determined, using `localhost` as fallback");
         }
         log.info("\n----------------------------------------------------------\n\t" +
@@ -140,9 +141,11 @@ public class <%= mainClass %> {
         <%_ if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa')) { _%>
 
         String configServerStatus = env.getProperty("configserver.status");
+        if (configServerStatus == null) {
+            configServerStatus = "Not found or not setup for this application";
+        }
         log.info("\n----------------------------------------------------------\n\t" +
-                "Config Server: \t{}\n----------------------------------------------------------",
-            configServerStatus == null ? "Not found or not setup for this application" : configServerStatus);
+                "Config Server: \t{}\n----------------------------------------------------------", configServerStatus);
         <%_ } _%>
     }
 }

--- a/generators/server/templates/src/main/resources/static/microservices_index.html.ejs
+++ b/generators/server/templates/src/main/resources/static/microservices_index.html.ejs
@@ -79,7 +79,7 @@
     <ul>
         <li>It does not have a front-end. The front-end should be generated on a JHipster gateway</li>
         <li>It is serving REST APIs, under the '/api' URLs.</li>
-        <li>Swagger documentation endpoint for those APIs is at <a href="/v2/api-docs">/v2/api-docs</a>, but if you want access to the full Swagger UI, you should use a JHipster gateway, which will serve as an API developer portal</li>
+        <li>Swagger documentation endpoint for those APIs is at <a href="./v2/api-docs">/v2/api-docs</a>, but if you want access to the full Swagger UI, you should use a JHipster gateway, which will serve as an API developer portal</li>
     </ul>
 
     <h2>


### PR DESCRIPTION
As discussed here: https://github.com/jhipster/generator-jhipster/pull/8151#issuecomment-4154188038151#issuecomment-415418803

```
2018-09-14 14:12:03.763  INFO 75207 --- [  restartedMain] com.mycompany.myapp.App0914App           :
----------------------------------------------------------
	Application 'app' is running! Access URLs:
	Local: 		http://localhost:8081/app
	External: 	http://172.32.67.148:8081/app
	Profile(s): 	[dev, swagger]
----------------------------------------------------------
```

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed