### PR TITLE
correct gradle sonar config

### DIFF
--- a/generators/server/templates/gradle/sonar.gradle.ejs
+++ b/generators/server/templates/gradle/sonar.gradle.ejs
@@ -63,7 +63,7 @@ sonarqube {
         property "sonar.testExecutionReportPaths", "${project.buildDir}/test-results/jest/TESTS-results-sonar.xml"
         <%_ } _%>
         property "sonar.typescript.lcov.reportPaths", "${project.buildDir}/test-results/lcov.info"
-        property "sonar.junit.reportsPath", "${project.buildDir}/test-results/test/"
+        property "sonar.junit.reportPaths", "${project.buildDir}/test-results/test"
         property "sonar.sources", "${project.projectDir}/<%= MAIN_DIR %>"
         property "sonar.tests", "${project.projectDir}/<%= TEST_DIR %>"
     }


### PR DESCRIPTION
I just corrected the junit report path. The coverage results for both maven and gradle are the same (empty, default projects each).

fix #8220

![screenshot_2018-09-15 projects](https://user-images.githubusercontent.com/203401/45586090-e9dc7080-b8f0-11e8-809e-148725a0d317.png)

- Please make sure the below checklist is followed for Pull Requests.

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

