### PR TITLE
Fix create user form being already filled after edit/view

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -25,7 +25,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { APP_DATE_FORMAT } from 'app/config/constants';
 <% if (enableTranslation) { %>import { languages } from 'app/config/translation';<% } %>
-import { getUser } from './user-management.reducer';
+import { getUser, reset } from './user-management.reducer';
 import { IRootState } from 'app/shared/reducers';
 
 export interface IUserManagementDetailProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
@@ -33,6 +33,10 @@ export interface IUserManagementDetailProps extends StateProps, DispatchProps, R
 export class UserManagementDetail extends React.Component<IUserManagementDetailProps> {
   componentDidMount() {
     this.props.getUser(this.props.match.params.login);
+  }
+
+  componentWillUnmount() {
+    this.props.reset();
   }
 
   render() {
@@ -103,7 +107,7 @@ const mapStateToProps = (storeState: IRootState) => ({
   user: storeState.userManagement.user
 });
 
-const mapDispatchToProps = { getUser };
+const mapDispatchToProps = { getUser, reset };
 
 type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = typeof mapDispatchToProps;

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -162,6 +162,7 @@ export const updateUser: ICrudPutAction<IUser> = user => async dispatch => {
     type: ACTION_TYPES.UPDATE_USER,
     payload: axios.put(apiUrl, user)
   });
+  await dispatch(reset());
   dispatch(getUsers());
   return result;
 };


### PR DESCRIPTION
After viewing user, reset store.
After updating user, wait until update is complete to reset store.

In `UserManagementUpdate.tsx`, 

```js
  componentWillUnmount() {
    this.props.reset();
  }
```

is executed before ` this.props.updateUser(values)` finished, that's why user is repopulated (this works fine in viewing user component).

I tried to `reset` when mounting `UserManagementUpdate` component, but for some reason I don't understand (due to some action dispatching interaction?), this caused a runtime error, so I dispatched a `reset` after updating user.

Fix #8302
