### PR TITLE
update elasticsearch port and use http scheme

### DIFF
--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -134,7 +134,7 @@ spec:
         <%_ } _%>
         <%_ if (app.searchEngine === 'elasticsearch') { _%>
         - name: SPRING_DATA_JEST_URI
-          value: <%= app.baseName.toLowerCase() %>-elasticsearch.<%= kubernetesNamespace %>.svc.cluster.local:9300
+          value: http://<%= app.baseName.toLowerCase() %>-elasticsearch.<%= kubernetesNamespace %>.svc.cluster.local:9200
         <%_ } _%>
         <%_ if (app.messageBroker === 'kafka') { _%>
         - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS

--- a/generators/openshift/templates/deployment.yml.ejs
+++ b/generators/openshift/templates/deployment.yml.ejs
@@ -228,7 +228,7 @@ objects:
             <%_ } _%>
             <%_ if (app.searchEngine === 'elasticsearch') { _%>
             - name: SPRING_DATA_JEST_URI
-              value: ${APPLICATION_NAME}-elasticsearch:9300
+              value: http://${APPLICATION_NAME}-elasticsearch:9200
             <%_ } _%>
             <%_ if (app.messageBroker === 'kafka') { _%>
             - name: SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -86,7 +86,7 @@ services:
                 <%_ } _%>
             <%_ } _%>
             <%_ if (searchEngine === 'elasticsearch') { _%>
-            - SPRING_DATA_JEST_URI=<%= baseName.toLowerCase() %>-elasticsearch:9300
+            - SPRING_DATA_JEST_URI=http://<%= baseName.toLowerCase() %>-elasticsearch:9200
             <%_ } _%>
             <%_ if (messageBroker === 'kafka') { _%>
             - SPRING_CLOUD_STREAM_KAFKA_BINDER_BROKERS=kafka

--- a/test/templates/compose/03-psql/src/main/docker/app.yml
+++ b/test/templates/compose/03-psql/src/main/docker/app.yml
@@ -6,7 +6,7 @@ services:
             - SPRING_PROFILES_ACTIVE=prod
             - SPRING_CLOUD_CONFIG_URI=http://admin:admin@jhipster-registry:8761/config
             - SPRING_DATASOURCE_URL=jdbc:postgresql://mspsql-postgresql:5432/mspsql
-            - SPRING_DATA_JEST_URI=mspsql-elasticsearch:9300
+            - SPRING_DATA_JEST_URI=http://mspsql-elasticsearch:9200
     mspsql-postgresql:
         extends:
             file: postgresql.yml


### PR DESCRIPTION
Fix #8326

- spring-data-jest uses port 9200 instead of 9300 (which spring-data-elasticsearch used)
- url must begin with a scheme

Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
