### PR TITLE
restore uaa auth files when serviceDiscoveryType is false

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -531,7 +531,7 @@ const serverFiles = {
             ]
         },
         {
-            condition: generator => generator.applicationType === 'gateway' && generator.authenticationType === 'uaa' && generator.serviceDiscoveryType,
+            condition: generator => generator.applicationType === 'gateway' && generator.authenticationType === 'uaa',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 { file: 'package/web/rest/AuthResource.java', renameTo: generator => `${generator.javaDir}web/rest/AuthResource.java` },

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -217,7 +217,7 @@ security:
 
 server:
     servlet:
-        <%_ if (applicationType === 'microservice' && !serviceDiscoveryType) { _%>
+        <%_ if ((applicationType === 'microservice' || applicationType === 'uaa') && !serviceDiscoveryType) { _%>
         context-path: /${spring.application.name}
         <%_ } _%>
         session:


### PR DESCRIPTION
also adds context-path to uaa without serviceDiscoveryType

This restores the authentication code to UAA Gateways with no service discovery.  Logging in won't work out-of-the-box because it points to the UAA, a developer who chooses these options will need to update the path to point to their UAA or set up a proxy like Istio does.  This is the same situation for regular microservices with no service discovery type (fetching entities doesn't work out-of-the-box).

It should work with a proxy or Istio though thanks to the new context-path for UAAs with no service discovery (this is how microservices work, and the UAA functions the same - it's requested by including the base name in the URL).

Fix #8297

- Please make sure the below checklist is followed for Pull Requests.

- [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [x] Tests are added where necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
