### PR TITLE
Add heroku/jvm buildpack to ci deploy

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -96,7 +96,7 @@ maven-build:
         <%_ } _%>
         - ./mvnw verify <% if (cicdIntegrations.includes('deploy')) { %>deploy <% } %>-Pprod -DskipTests -Dmaven.repo.local=$MAVEN_USER_HOME
         <%_ if (cicdIntegrations.includes('heroku')) { _%>
-        - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %> -Dmaven.repo.local=$MAVEN_USER_HOME
+        - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.buildpacks=heroku/jvm -Dheroku.appName=<%= herokuAppName %> -Dmaven.repo.local=$MAVEN_USER_HOME
         <%_ } _%>
     artifacts:
         paths:


### PR DESCRIPTION
This will ensure the app uses the right buildpack, even if a Git deploy has been done with `jhipster heroku`, which sets a different buildpack.