### PR TITLE
add heroku buildpack to all mvn commands for all providers

### DIFF
--- a/generators/ci-cd/templates/circle.yml.ejs
+++ b/generators/ci-cd/templates/circle.yml.ejs
@@ -67,7 +67,7 @@ test:
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
     <%_ if (cicdIntegrations.includes('circle')) { _%>
-        - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+        - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.buildpacks=heroku/jvm -Dheroku.appName=<%= herokuAppName %>
     <%_ } else { _%>
         - ./mvnw verify -Pprod -DskipTests
     <%_ } _%>

--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -88,7 +88,7 @@ node {
     <%_ } _%>
     <%_ if (cicdIntegrations.includes('heroku')) { _%>
 <%= indent %>    stage('package and deploy') {
-<%= indent %>        sh "./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>"
+<%= indent %>        sh "./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.buildpacks=heroku/jvm -Dheroku.appName=<%= herokuAppName %>"
     <%_ } else { _%>
 <%= indent %>    stage('packaging') {
 <%= indent %>        sh "./mvnw verify <% if (cicdIntegrations.includes('deploy')) { %>deploy <% } %>-Pprod -DskipTests"

--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -87,7 +87,7 @@ script:
   <%_ } _%>
   - ./mvnw verify -Pprod -DskipTests
   <%_ if (cicdIntegrations.includes('heroku')) { _%>
-  - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.appName=<%= herokuAppName %>
+  - ./mvnw com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.buildpacks=heroku/jvm -Dheroku.appName=<%= herokuAppName %>
   <%_ } _%>
 <%_ } else if (buildTool === 'gradle') { _%>
   <%_ if (cicdIntegrations.includes('sonar')) { _%>


### PR DESCRIPTION
Follow up for https://github.com/jhipster/generator-jhipster/pull/8375 

Adding the heroku build pack to all mvn commands for all generators. The required change for gradle is contained here: https://github.com/jhipster/generator-jhipster/pull/8368

- [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
- [ ] Tests are added where necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
