### PR TITLE
fix user management previous state to redirect to previous page

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -58,7 +58,7 @@ export class UserMgmtUpdateComponent implements OnInit {
     }
 
     previousState() {
-        this.router.navigate(['/admin/user-management']);
+        window.history.back();
     }
 
     save() {


### PR DESCRIPTION
Changed how the previousState functions to redirect to previous page
instead of going to default user-management page.

fixes #8398

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
