### PR TITLE
Chunk Order Fix

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -108,7 +108,7 @@ module.exports = (options) => ({
         <%_ } _%>
         new HtmlWebpackPlugin({
             template: './<%= MAIN_SRC_DIR %>index.html',
-            chunks: ['vendors', 'polyfills', 'global', 'main'],
+            chunks: ['vendors', 'polyfills', 'main', 'global'],
             chunksSortMode: 'manual',
             inject: 'body'
         })


### PR DESCRIPTION
Fixing the order that chuncks are loaded so that the global file is loaded after the main.  This will ensure CSS overrides of bootstrap in the global.css/global.sass work.  https://github.com/jantimon/html-webpack-plugin#options

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
