### PR TITLE
New env var for e2e in headless mode

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
     # if JHIPSTER_BRANCH value is release, use the release from NPM
     - JHIPSTER_REPO=https://github.com/jhipster/generator-jhipster.git
     - JHIPSTER_BRANCH=release
-    - DISABLE_WEBPACK_LOGS=true
+    - JH_DISABLE_WEBPACK_LOGS=true
 
   matrix:
     - JHIPSTER=webflux-mongodb

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -30,7 +30,9 @@ exports.config = {
     capabilities: {
         browserName: 'chrome',
         chromeOptions: {
-            args: [ "--disable-gpu", "--window-size=800,600" ]
+            args: process.env.JH_E2E_HEADLESS
+                ? [ "--headless", "--disable-gpu", "--window-size=800,600" ]
+                : [ "--disable-gpu", "--window-size=800,600" ]
         }
     },
 

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -141,9 +141,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
             use: ['style-loader', 'css-loader']
         }]
     },
-    stats: process.env.DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
+    stats: process.env.JH_DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
     plugins: [
-        process.env.DISABLE_WEBPACK_LOGS
+        process.env.JH_DISABLE_WEBPACK_LOGS
             ? null
             : new SimpleProgressWebpackPlugin({
                 format: options.stats === 'minimal' ? 'compact' : 'expanded'

--- a/generators/client/templates/react/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/protractor.conf.js.ejs
@@ -13,7 +13,9 @@ exports.config = {
   capabilities: {
     browserName: 'chrome',
     chromeOptions: {
-        args: [ '--disable-gpu', '--window-size=800,600' ]
+        args: process.env.JH_E2E_HEADLESS
+          ? [ '--headless', '--disable-gpu', '--window-size=800,600' ]
+          : [ '--disable-gpu', '--window-size=800,600' ]
     }
   },
 

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -94,9 +94,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
       ignored: /node_modules/
     }
   },
-  stats: process.env.DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
+  stats: process.env.JH_DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
   plugins: [
-    process.env.DISABLE_WEBPACK_LOGS
+    process.env.JH_DISABLE_WEBPACK_LOGS
       ? null
       : new SimpleProgressWebpackPlugin({
           format: options.stats === 'minimal' ? 'compact' : 'expanded'


### PR DESCRIPTION
When launching Protractor in Azure DevOps, I need to use Chrome in Headless mode.
So I added a new environment variable in Protractor config for that, beginning with `JH_` , so few chance to have same variable in their environment

I rename `DISABLE_WEBPACK_LOGS` to `JH_DISABLE_WEBPACK_LOGS` to be consistent (recently added by @wmarques)

```
export JH_E2E_HEADLESS=true
npm run e2e
```

Another solution would be to create a new goal in `package.json`, like `e2e-headless` but I don't know how to achieve this.

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
