### PR TITLE
Avoid removing simple quotes when using docker-compose with mssql

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -282,17 +282,14 @@ module.exports = class extends BaseGenerator {
                     this.authenticationType = appConfig.authenticationType;
 
                     // Dump the file
-                    let yamlString = jsyaml.dump(parentConfiguration, { indent: 4 });
+                    let yamlString = jsyaml.dump(parentConfiguration, { indent: 4, lineWidth: -1 });
 
-                    // Fix the output file which is totally broken!!!
+                    // Add extra indentation for each lines
                     const yamlArray = yamlString.split('\n');
                     for (let j = 0; j < yamlArray.length; j++) {
                         yamlArray[j] = `    ${yamlArray[j]}`;
-                        yamlArray[j] = yamlArray[j].replace(/'/g, '');
                     }
                     yamlString = yamlArray.join('\n');
-                    yamlString = yamlString.replace(/>-\n/g, '');
-                    yamlString = yamlString.replace(/-\s\s+/g, '- ');
                     this.appsYaml.push(yamlString);
                 });
             },


### PR DESCRIPTION
Fix #8428 

I actually did two changes in this PR:
- Max line width is now unlimited (by default it's 80 chars):
I don't see any issue having unlimited line width and it avoids having to replace weird characters (>-) added by the js-yaml library when the line is too long.
- Simple quotes are no longer removed:
The js-yaml library adds simple quotes when the value is an url or contains special characters. I decided to keep those simple quotes since they don't make the yaml invalid and it's more simple than having a special case for mssql to avoid removing the simple quotes when they are actually needed (could happen for an other component than mssql).

@stevehouel: can you take a look and let me know if you agree with the changes?

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed