### PR TITLE
Do not click on the "modified by" button when using Cassandra

### DIFF
--- a/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -28,7 +28,9 @@ import SettingsPage from '../../page-objects/settings-page';
 import {
   getToastByInnerText,
   getUserDeactivatedButtonByLogin,
+<%_ if (databaseType !== 'cassandra') { _%>
   getModifiedDateSortButton,
+<%_ } _%>
   waitUntilDisplayed,
   waitUntilHidden
 } from '../../util/utils';
@@ -155,10 +157,12 @@ describe('Account', () => {
 
   it('should activate the new registered user', async () => {
     expect(await element(by.id('user-management-page-heading')).isPresent()).to.be.true;
+<%_ if (databaseType !== 'cassandra') { _%>
 
     const modifiedDateSortButton = getModifiedDateSortButton();
     await waitUntilDisplayed(modifiedDateSortButton);
     await modifiedDateSortButton.click();
+<%_ } _%>
 
     const deactivatedButton = getUserDeactivatedButtonByLogin('user_test');
     await waitUntilDisplayed(deactivatedButton);

--- a/generators/client/templates/react/src/test/javascript/e2e/util/utils.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/util/utils.ts.ejs
@@ -53,8 +53,10 @@ export const waitUntilCount = async (elementArrayFinder: ElementArrayFinder, exp
     `Failed while waiting for "${elementArrayFinder.locator()}" to have ${expectedCount} elements.`
   );
 };
+<%_ if (databaseType !== 'cassandra') { _%>
 
 export const getModifiedDateSortButton = (): ElementFinder => element(by.id('modified-date-sort'));
+<%_ } _%>
 
 export const getUserDeactivatedButtonByLogin = (login: string): ElementFinder =>
   element(by.css('table > tbody')).element(by.id(login)).element(by.buttonText('Deactivated'));


### PR DESCRIPTION
As Cassandra doesn't have the audit code, that button does not exist

@pascalgrimaud this should solve one error in the hipster lab builds

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
