### PR TITLE
Move the waituntilcount function so it is available everywhere

### DIFF
--- a/generators/client/templates/react/src/test/javascript/e2e/util/utils.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/util/utils.ts.ejs
@@ -41,7 +41,6 @@ export const waitUntilHidden = async (selector: ElementFinder, classname = '', t
   );
 };
 
-<%_ if (authenticationType !== 'oauth2') { _%>
 export const waitForCount = (elementArrayFinder: ElementArrayFinder, expectedCount: number) => () => {
   return elementArrayFinder.count().then(actualCount => expectedCount === actualCount);
 };
@@ -53,10 +52,11 @@ export const waitUntilCount = async (elementArrayFinder: ElementArrayFinder, exp
     `Failed while waiting for "${elementArrayFinder.locator()}" to have ${expectedCount} elements.`
   );
 };
-<%_ if (databaseType !== 'cassandra') { _%>
+<%_ if (authenticationType !== 'oauth2') { _%>
+    <%_ if (databaseType !== 'cassandra') { _%>
 
 export const getModifiedDateSortButton = (): ElementFinder => element(by.id('modified-date-sort'));
-<%_ } _%>
+    <%_ } _%>
 
 export const getUserDeactivatedButtonByLogin = (login: string): ElementFinder =>
   element(by.css('table > tbody')).element(by.id(login)).element(by.buttonText('Deactivated'));


### PR DESCRIPTION
@pascalgrimaud this should fix the oauth2+react issue in hipster-labs

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
