### PR TITLE
use promise to parallelise protractor input

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -63,6 +63,7 @@
     "@ngtools/webpack": "6.0.0",
     <%_ if (protractorTests) { _%>
     "@types/chai": "4.1.4",
+    "@types/chai-string": "1.4.1",
     <%_ } _%>
     "@types/jest": "22.2.3",
     <%_ if (protractorTests) { _%>
@@ -80,6 +81,7 @@
     <%_ if (protractorTests) { _%>
     "chai": "4.1.2",
     "chai-as-promised": "7.1.1",
+    "chai-string": "1.5.0",
     <%_ } _%>
     "codelyzer": "4.2.1",
     "copy-webpack-plugin": "4.5.1",

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -65,6 +65,8 @@ exports.config = {
         const chai = require('chai');
         const chaiAsPromised = require('chai-as-promised');
         chai.use(chaiAsPromised);
+        const chaiString = require('chai-string');
+        chai.use(chaiString);
         // @ts-ignore
         global.chai = chai;
     },

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 /* tslint:disable no-unused-expression */
-import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor<% } %> } from 'protractor';
+import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor, <% } %>promise } from 'protractor';
 import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
 
 import { <%= entityClass %>ComponentsPage, <%= entityClass %>DeleteDialog, <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
@@ -49,7 +49,8 @@ describe('<%= entityClass %> e2e test', () => {
     let <%= entityInstance %>ComponentsPage: <%= entityClass %>ComponentsPage;
     <%= openBlockComment %>let <%= entityInstance %>DeleteDialog: <%= entityClass %>DeleteDialog;<%= closeBlockComment %>
     <%_ if (fieldsContainBlobOrImage) { _%>
-    const fileToUpload = '../../../../../<%= entityParentPathAddition %>main/webapp/content/images/logo-jhipster.png';
+    const fileNameToUpload = 'logo-jhipster.png';
+    const fileToUpload = '../../../../../<%= entityParentPathAddition %>main/webapp/content/images/' + fileNameToUpload;
     const absolutePath = path.resolve(__dirname, fileToUpload);
     <%_ } _%>
 
@@ -94,23 +95,56 @@ describe('<%= entityClass %> e2e test', () => {
         const nbButtonsBeforeCreate = await <%= entityInstance %>ComponentsPage.countDeleteButtons();
 
         await <%= entityInstance %>ComponentsPage.clickOnCreateButton();
+        await promise.all([
         <%_ fields.forEach((field) => {
             const fieldName = field.fieldName;
             const fieldNameCapitalized = field.fieldNameCapitalized;
             const fieldType = field.fieldType;
             const fieldTypeBlobContent = field.fieldTypeBlobContent;
             const fieldIsEnum = field.fieldIsEnum;
-        _%>
-        <%_ if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5');
+            if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5'),
+            <%_ } else if (fieldType === 'LocalDate') { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('2000-12-31'),
+            <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('01/01/2001' + protractor.Key.TAB + '02:30AM'),
+            <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>'),
+            <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath),
+            <%_ } else if (fieldIsEnum) { _%>
+            <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption(),
+            <%_ } else if (fieldType === 'UUID'){ _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974'),
+            <%_ } else if (fieldType !== 'Boolean') { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>'),
+            <%_ } _%>
+            <%_ }); _%>
+            <%_ relationships.forEach((relationship) => {
+                const relationshipType = relationship.relationshipType;
+                const ownerSide = relationship.ownerSide;
+                const relationshipName = relationship.relationshipName;
+                const relationshipFieldName = relationship.relationshipFieldName;
+                if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+            <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption(),
+            <%_ } else if ((relationshipType === 'many-to-many' && ownerSide === true)) { _%>
+            // <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption(),
+            <%_ } _%>
+        <%_ }); _%>
+        ]);
+        <%_ fields.forEach((field) => {
+            const fieldName = field.fieldName;
+            const fieldNameCapitalized = field.fieldNameCapitalized;
+            const fieldType = field.fieldType;
+            const fieldTypeBlobContent = field.fieldTypeBlobContent;
+            const fieldIsEnum = field.fieldIsEnum;
+            if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('5');
-        <%_ } else if (fieldType === 'LocalDate') { _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('2000-12-31');
+            <%_ } else if (fieldType === 'LocalDate') { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('2000-12-31');
-        <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('01/01/2001' + protractor.Key.TAB + '02:30AM');
+            <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('2001-01-01T02:30');
-        <%_ } else if (fieldType === 'Boolean') { _%>
+            <%_ } else if (fieldType === 'Boolean') { _%>
         const selected<%= fieldNameCapitalized %> = <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input();
         if (await selected<%= fieldNameCapitalized %>.isSelected()) {
             await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
@@ -119,31 +153,15 @@ describe('<%= entityClass %> e2e test', () => {
             await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
             expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected()).to.be.true;
         }
-        <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
+            <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>');
-        <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath);
-        <%_ } else if (fieldIsEnum) { _%>
-        await <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption();
-        <%_ } else if (fieldType === 'UUID'){ _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
+            <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.endsWith(fileNameToUpload);
+            <%_ } else if (fieldType === 'UUID'){ _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('64c99148-3908-465d-8c4a-e510e3ade974');
-        <%_ } else { _%>
-        await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
+            <%_ } else if (!fieldIsEnum) { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>');
-        <%_ } _%>
-        <%_ }); _%>
-        <%_ relationships.forEach((relationship) => {
-            const relationshipType = relationship.relationshipType;
-            const ownerSide = relationship.ownerSide;
-            const relationshipName = relationship.relationshipName;
-            const relationshipFieldName = relationship.relationshipFieldName; _%>
-        <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-        await <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
-        <%_ } else if ((relationshipType === 'many-to-many' && ownerSide === true)) { _%>
-        // <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption();
-        <%_ } _%>
+            <%_ } _%>
         <%_ }); _%>
         await <%= entityInstance %>UpdatePage.save();
         expect(await <%= entityInstance %>UpdatePage.getSaveButton().isPresent()).to.be.false;


### PR DESCRIPTION
Wip: Use promise.all to parallelize protractor inputs.
This as reduced the time of our build by two on a big project!

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

