### PR TITLE
Fix how pk's type is checked for a gateway using React

### DIFF
--- a/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
@@ -276,7 +276,7 @@ describe('Entities reducer tests', () => {
         }
         <%_ } _%>
       ];
-      await store.dispatch(createEntity({ id: <% if (databaseType === 'sql') { %>1<%} else {%>'1'<%}%> })).then(() => expect(store.getActions()).toEqual(expectedActions));
+      await store.dispatch(createEntity({ id: <% if (pkType === 'Long') { %>1<%} else {%>'1'<%}%> })).then(() => expect(store.getActions()).toEqual(expectedActions));
     });
 
     it('dispatches ACTION_TYPES.UPDATE_<%= entityActionName %> actions', async () => {
@@ -297,7 +297,7 @@ describe('Entities reducer tests', () => {
         }
         <%_ } _%>
       ];
-      await store.dispatch(updateEntity({ id: <% if (databaseType === 'sql') { %>1<%} else {%>'1'<%}%> })).then(() => expect(store.getActions()).toEqual(expectedActions));
+      await store.dispatch(updateEntity({ id: <% if (pkType === 'Long') { %>1<%} else {%>'1'<%}%> })).then(() => expect(store.getActions()).toEqual(expectedActions));
     });
 
     it('dispatches ACTION_TYPES.DELETE_<%= entityActionName %> actions', async () => {


### PR DESCRIPTION
Fix #8441 

A gateway with React, UAA and no database was generating a wrong pk's value when generating an entity from a microservice using a SQL db.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
