### PR TITLE
use gradles build in up-to-date checking

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -44,12 +44,15 @@ bootRun {
 
 <%_ if (!skipClient) { _%>
 task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: '<%= clientPackageManager %>_install') {
-    onlyIf { shouldWebpackRun() == true }
+    inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
+    inputs.files(fileTree('<%= CLIENT_MAIN_SRC_DIR %>'))
+    outputs.dir("<%= CLIENT_DIST_DIR %>")
+    outputs.file("<%= CLIENT_DIST_DIR %>app/main.bundle.js")
     args = ["run", "webpack:build"]
 }
 
 war {
-    webAppDirName = '<%= CLIENT_MAIN_SRC_DIR %>'
+    webAppDirName = '<%= CLIENT_DIST_DIR %>'
 }
 
 task copyIntoStatic (type: Copy) {
@@ -83,9 +86,9 @@ processResources.dependsOn webpackBuildDev
 copyIntoStatic.dependsOn processResources
 bootJar.dependsOn copyIntoStatic
 
-yarn_install.onlyIf { shouldWebpackRun() == true }
+<%= clientPackageManager %>_install.onlyIf { shouldWebpackRun() == true }
 
 def shouldWebpackRun() {
-    file('build/www/app/main.bundle.js').exists() == false || project.hasProperty('webpack')
+    project.hasProperty('webpack')
 }
 <%_ } _%>

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -47,6 +47,10 @@ task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn
 }
 
 task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: '<%= clientPackageManager %>_install') {
+    inputs.dir("CLIENT_MAIN_SRC_DIR")
+    inputs.files(fileTree('CLIENT_MAIN_SRC_DIRp'))
+    outputs.dir("<%= CLIENT_DIST_DIR %>")
+    outputs.file("<%= CLIENT_DIST_DIR %>app/main.bundle.js")
     args = ["run", "webpack:prod"]
 }
 


### PR DESCRIPTION
We have build some special handling to decided when to run the frontend build (I guess because we need to do something similar in maven). With gradle we can use the build in up-to-date check mechanism. So basically we can rely on `Task has outputs and inputs and they have not change`. It works quite well. As an example you can also have look at this (incomplete) guide: https://guides.gradle.org/running-webpack-with-gradle/

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

