### PR TITLE
fixing some cves

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -333,8 +333,8 @@ dependencies {
         exclude module: 'commons-logging'
     }
     // log4j needed to create embedded elasticsearch instance
-    runtime "org.apache.logging.log4j:log4j-api:2.7"
-    runtime "org.apache.logging.log4j:log4j-core:2.7"
+    runtime "org.apache.logging.log4j:log4j-api:2.8.1"
+    runtime "org.apache.logging.log4j:log4j-core:2.8.1"
     // end of Spring Data Jest dependencies
     <%_ } _%>
     <%_ if (['mongodb', 'cassandra', 'couchbase'].includes(databaseType)) { _%>
@@ -422,8 +422,8 @@ dependencies {
     compile "io.springfox:springfox-bean-validators"
     <%_ } _%>
     <%_ if (devDatabaseType === 'mysql' || prodDatabaseType === 'mysql') { _%>
-    compile "mysql:mysql-connector-java"
-    liquibaseRuntime "mysql:mysql-connector-java"
+    compile "mysql:mysql-connector-java:5.1.47"
+    liquibaseRuntime "mysql:mysql-connector-java:5.1.47"
     <%_ } _%>
     <%_ if (devDatabaseType === 'postgresql' || prodDatabaseType === 'postgresql') { _%>
     compile "org.postgresql:postgresql"

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -374,6 +374,7 @@
         <dependency>
             <groupId>mysql</groupId>
             <artifactId>mysql-connector-java</artifactId>
+            <version>5.1.47</version>
         </dependency>
         <%_ } _%>
         <%_ if (devDatabaseType === 'mariadb' || prodDatabaseType === 'mariadb') { _%>
@@ -525,12 +526,12 @@
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-api</artifactId>
-            <version>2.7</version>
+            <version>2.8.1</version>
         </dependency>
         <dependency>
             <groupId>org.apache.logging.log4j</groupId>
             <artifactId>log4j-core</artifactId>
-            <version>2.7</version>
+            <version>2.8.1</version>
         </dependency>
         <!-- end of Spring Data Jest dependencies -->
         <%_ } _%>

--- a/generators/server/templates/src/main/resources/h2.server.properties.ejs
+++ b/generators/server/templates/src/main/resources/h2.server.properties.ejs
@@ -5,6 +5,6 @@
 <%_ if (devDatabaseType === 'h2Disk') { _%>
 0=JHipster H2 (Disk)|org.h2.Driver|jdbc\:h2\:file\:./<%= BUILD_DIR %>h2db/db/<%= lowercaseBaseName %>|<%= baseName %>
 <%_ } _%>
-webAllowOthers=true
+webAllowOthers=false
 webPort=8082
 webSSL=false


### PR DESCRIPTION
I tried randomly some configurations to find some more valid cves. Nearly all of them where false positives (with low confidence), e.g. it complained about a `spring-framework 1.0.0` cve because of `spring-tuple-1.0.0.RELEASE` on the classpath. I fixed the mysql and found some reagrding log4j (couldn't update to 2.9+ as it doesn't work at all). I also disallowed to be connected to the web console from somewhere else (or is that required by e.g. the jhipster console, was not sure).

closes #8248 if no one has any more current cve (docker is fixed as we now use jib).

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
