### PR TITLE
fix invalid open api spec

### DIFF
--- a/generators/server/templates/gradle/swagger.gradle.ejs
+++ b/generators/server/templates/gradle/swagger.gradle.ejs
@@ -32,7 +32,7 @@ openApiGenerate {
     modelFilesConstrainedTo = [""]
     supportingFilesConstrainedTo = ["ApiUtil.java"]
     configOptions = [delegatePattern: "true"]
-    validateSpec = false
+    validateSpec = true
 }
 
 sourceSets {

--- a/generators/server/templates/src/main/resources/swagger/api.yml.ejs
+++ b/generators/server/templates/src/main/resources/swagger/api.yml.ejs
@@ -19,7 +19,7 @@
 # API-first development with OpenAPI
 # This file will be used at compile time to generate Spring-MVC endpoint stubs using openapi-generator
 openapi: "3.0.1"
-title: "<%= baseName %>"
 info:
+  title: "<%= baseName %>"
   version: 0.0.1
 paths: {}


### PR DESCRIPTION
Fixed invalid openapi spec (title must be in info object) and enabled validation explicitly (which is the default for the latest gradle plugin)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
