### PR TITLE
align openapi plugin with current gradle implementation [ci-skip]

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -107,7 +107,7 @@
         <scala-maven-plugin.version>3.4.2</scala-maven-plugin.version>
         <sonar-maven-plugin.version>3.5.0.1254</sonar-maven-plugin.version>
         <%_ if (enableSwaggerCodegen) { _%>
-        <openapi-generator-maven-plugin.version>3.2.3</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>3.3.0</openapi-generator-maven-plugin.version>
         <%_ } _%>
         <git-commit-id-plugin.version>2.2.5</git-commit-id-plugin.version>
 
@@ -1058,6 +1058,7 @@
                             <apiPackage><%= packageName %>.web.api</apiPackage>
                             <modelPackage><%= packageName %>.web.api.model</modelPackage>
                             <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
+                            <validateSpec>true</validateSpec>
                             <configOptions>
                                 <delegatePattern>true</delegatePattern>
                             </configOptions>


### PR DESCRIPTION
Sorry, forgot to update the maven plugins when I did the same for gradle.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
