### PR TITLE
fix docker start with jib : added a sync before starting /entrypoint.sh

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1021,7 +1021,7 @@
                         <entrypoint>
                             <shell>sh</shell>
                             <option>-c</option>
-                            <arg>chmod +x /entrypoint.sh &amp;&amp; /entrypoint.sh</arg>
+                            <arg>chmod +x /entrypoint.sh &amp;&amp; sync &amp;&amp; /entrypoint.sh</arg>
                         </entrypoint>
                         <ports>
                             <port><%= serverPort %></port>


### PR DESCRIPTION
When running pod ok k8s, I have an error : (on my local docker it's fine)
   sh: /entrypoint.sh : Text file busy

![image](https://user-images.githubusercontent.com/11631430/46528289-c8d5c280-c893-11e8-99f9-e2328d0b5fc2.png)

Looking in https://github.com/moby/moby/issues/9547,  it seems that the script can't start because the file is still busy with chmod.
I added a sync between the chmod and the script startup.
After that, all my microservices started correctly on kubernetes.

Changed in the pom.xml : 
`chmod +x /entrypoint.sh && /entrypoint.sh`
with
`chmod +x /entrypoint.sh && sync && /entrypoint.sh`
