### PR TITLE
Fix junit stacktrace displayed in junit with uaa

### DIFF
--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -122,7 +122,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 <%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
-@SpringBootTest(classes = {SecurityBeanOverrideConfiguration.class, <%= mainClass %>.class})
+@SpringBootTest(classes = {<%= mainClass %>.class}, SecurityBeanOverrideConfiguration.class)
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIntTest.java.ejs
@@ -122,7 +122,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 <%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
-@SpringBootTest(classes = {<%= mainClass %>.class}, SecurityBeanOverrideConfiguration.class)
+@SpringBootTest(classes = {<%= mainClass %>.class, SecurityBeanOverrideConfiguration.class})
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
@@ -32,6 +32,7 @@ import org.springframework.security.oauth2.common.exceptions.InvalidClientExcept
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestTemplate;
 
+import javax.annotation.Nullable;
 import java.util.Map;
 
 /**

--- a/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
@@ -43,7 +43,7 @@ public class UaaSignatureVerifierClient implements OAuth2SignatureVerifierClient
     private final RestTemplate restTemplate;
     protected final OAuth2Properties oAuth2Properties;
 
-    public UaaSignatureVerifierClient(DiscoveryClient discoveryClient, @Qualifier("loadBalancedRestTemplate") RestTemplate restTemplate,
+    public UaaSignatureVerifierClient(DiscoveryClient discoveryClient, @Nullable @Qualifier("loadBalancedRestTemplate") RestTemplate restTemplate,
                                   OAuth2Properties oAuth2Properties) {
         this.restTemplate = restTemplate;
         this.oAuth2Properties = oAuth2Properties;

--- a/generators/server/templates/src/test/java/package/web/rest/LogsResourceIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/LogsResourceIntTest.java.ejs
@@ -57,7 +57,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 <%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
-@SpringBootTest(classes = {SecurityBeanOverrideConfiguration.class, <%= mainClass %>.class})
+@SpringBootTest(classes = {<%= mainClass %>.class, SecurityBeanOverrideConfiguration.class})
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>

--- a/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIntTest.java.ejs
@@ -50,7 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 <%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
-@SpringBootTest(classes = {<%= mainClass %>.class}, SecurityBeanOverrideConfiguration.class)
+@SpringBootTest(classes = {<%= mainClass %>.class, SecurityBeanOverrideConfiguration.class})
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>

--- a/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIntTest.java.ejs
@@ -50,7 +50,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 <%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
-@SpringBootTest(classes = {SecurityBeanOverrideConfiguration.class, <%= mainClass %>.class})
+@SpringBootTest(classes = {<%= mainClass %>.class}, SecurityBeanOverrideConfiguration.class)
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>


### PR DESCRIPTION
When junit microservices configured with uaa, I get stacktrace error in the console.  The test pass but this stacktrace doesn't look good.

With junit, when we mock a remote server, UaaSignatureVerifierClient constructor receive a null value for the restTemplate.
So we first need to accept null in that case.

Then we need to change the order of the @SpringBootTest classes.
We need to set the SecurityBeanOverrideConfiguration.class as the second in the list so it's initialized first.

You will find attached the tests for LogsResourceIntTest before and after the patch.

[juni-LogsResourceIntTest-BAD.txt](https://github.com/jhipster/generator-jhipster/files/2449878/juni-LogsResourceIntTest-BAD.txt)
[juni-LogsResourceIntTest-GOOD.txt](https://github.com/jhipster/generator-jhipster/files/2449879/juni-LogsResourceIntTest-GOOD.txt)


