### PR TITLE
Add a flag to auto-configure Gitlab

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -46,6 +46,13 @@ module.exports = class extends BaseGenerator {
             defaults: false,
             description: 'Automatically configure Jenkins'
         });
+
+        // Automatically configure Gitlab
+        this.argument('autoconfigure-gitlab', {
+            type: Boolean,
+            defaults: false,
+            description: 'Automatically configure Gitlab'
+        });
     }
 
     get initializing() {
@@ -77,6 +84,7 @@ module.exports = class extends BaseGenerator {
                 this.testFrameworks = this.config.get('testFrameworks');
                 this.autoconfigureTravis = this.options['autoconfigure-travis'];
                 this.autoconfigureJenkins = this.options['autoconfigure-jenkins'];
+                this.autoconfigureGitlab = this.options['autoconfigure-gitlab'];
                 this.abort = false;
             },
             initConstants() {

--- a/generators/ci-cd/prompts.js
+++ b/generators/ci-cd/prompts.js
@@ -37,6 +37,15 @@ function askPipeline() {
         this.insideDocker = false;
         return;
     }
+
+    if (this.autoconfigureGitlab) {
+        this.log('Auto-configuring Gitlab');
+        this.pipeline = 'gitlab';
+        this.sendBuildToGitlab = true;
+        this.insideDocker = true;
+        return;
+    }
+
     const done = this.async();
     const prompts = [
         {
@@ -69,6 +78,14 @@ function askIntegrations() {
         this.insideDocker = false;
         return;
     }
+
+    if (this.autoconfigureGitlab) {
+        this.cicdIntegrations = [];
+        this.sendBuildToGitlab = true;
+        this.insideDocker = true;
+        return;
+    }
+
     const done = this.async();
     const prompts = [
         {

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -357,6 +357,26 @@ describe('JHipster CI-CD Sub Generator', () => {
         });
     });
 
+    describe('GitLab: maven AngularX Yarn inside Docker Autoconfigure', () => {
+        beforeEach(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-yarn'), dir);
+                })
+                .withOptions({ autoconfigureGitlab: true })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.gitlab);
+        });
+        it('contains image: jhipster, Sonar, Heroku', () => {
+            assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
+            assert.noFileContent('.gitlab-ci.yml', /sonar/);
+            assert.noFileContent('.gitlab-ci.yml', /heroku/);
+        });
+    });
+
     //--------------------------------------------------
     // Travis CI tests
     //--------------------------------------------------


### PR DESCRIPTION
That PR is to update the Gitlab to include autogeneration option, like Travis and Jenkins.

The motivation is the issue in jhipster/jhipster-online#80


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [X] Tests are added where necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
