### PR TITLE
Elasticsearch: limit memory to 1024m

### DIFF
--- a/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
+++ b/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
@@ -27,4 +27,4 @@ services:
             - 9300:9300
         command: -Enetwork.host=0.0.0.0 -Ediscovery.type=single-node
         environment:
-            - "ES_JAVA_OPTS=-Xms512m -Xmx512m"
+            - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"


### PR DESCRIPTION
Following this PR https://github.com/jhipster/generator-jhipster/pull/8264
I'm working on using Azure Pipelines (https://github.com/jhipster/generator-jhipster/issues/8337)

512m is not enough, and I have a lot of random failures.
Increasing to 1024m seems to solve my issues. Hope you're ok with this change, @ndywicki

Here the logs:

```
2018-10-04T04:28:15.6246473Z 04:28:15.615 [main] ERROR org.springframework.boot.SpringApplication - Application run failed
2018-10-04T04:28:15.6248413Z org.springframework.beans.factory.UnsatisfiedDependencyException: Error creating bean with name 'entityWithPaginationAndDTOResource' defined in URL [jar:file:/home/vsts/app/app.war!/WEB-INF/classes!/com/mycompany/myapp/web/rest/EntityWithPaginationAndDTOResource.class]: Unsatisfied dependency expressed through constructor parameter 2; nested exception is org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityWithPaginationAndDTOSearchRepository': Invocation of init method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.data.elasticsearch.repository.support.NumberKeyedRepository]: Constructor threw exception; nested exception is org.springframework.data.elasticsearch.ElasticsearchException: failed to execute action
2018-10-04T04:28:15.6249110Z 	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:732) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6249703Z 	at org.springframework.beans.factory.support.ConstructorResolver.autowireConstructor(ConstructorResolver.java:197) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6250335Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.autowireConstructor(AbstractAutowireCapableBeanFactory.java:1267) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6251203Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBeanInstance(AbstractAutowireCapableBeanFactory.java:1124) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6252877Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:535) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6253273Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6254113Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6254945Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6255462Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6256206Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6256670Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.preInstantiateSingletons(DefaultListableBeanFactory.java:759) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6257189Z 	at org.springframework.context.support.AbstractApplicationContext.finishBeanFactoryInitialization(AbstractApplicationContext.java:869) ~[spring-context-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6257675Z 	at org.springframework.context.support.AbstractApplicationContext.refresh(AbstractApplicationContext.java:550) ~[spring-context-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6258308Z 	at org.springframework.boot.web.servlet.context.ServletWebServerApplicationContext.refresh(ServletWebServerApplicationContext.java:140) ~[spring-boot-2.0.5.RELEASE.jar!/:2.0.5.RELEASE]
2018-10-04T04:28:15.6258694Z 	at org.springframework.boot.SpringApplication.refresh(SpringApplication.java:780) [spring-boot-2.0.5.RELEASE.jar!/:2.0.5.RELEASE]
2018-10-04T04:28:15.6259013Z 	at org.springframework.boot.SpringApplication.refreshContext(SpringApplication.java:412) [spring-boot-2.0.5.RELEASE.jar!/:2.0.5.RELEASE]
2018-10-04T04:28:15.6259368Z 	at org.springframework.boot.SpringApplication.run(SpringApplication.java:333) [spring-boot-2.0.5.RELEASE.jar!/:2.0.5.RELEASE]
2018-10-04T04:28:15.6259474Z 	at com.mycompany.myapp.TravisPsqlEsNoi18NApp.main(TravisPsqlEsNoi18NApp.java:63) [classes!/:?]
2018-10-04T04:28:15.6259601Z 	at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method) ~[?:1.8.0_181]
2018-10-04T04:28:15.6259685Z 	at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62) ~[?:1.8.0_181]
2018-10-04T04:28:15.6259936Z 	at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43) ~[?:1.8.0_181]
2018-10-04T04:28:15.6260074Z 	at java.lang.reflect.Method.invoke(Method.java:498) ~[?:1.8.0_181]
2018-10-04T04:28:15.6260161Z 	at org.springframework.boot.loader.MainMethodRunner.run(MainMethodRunner.java:48) [app.war:?]
2018-10-04T04:28:15.6260369Z 	at org.springframework.boot.loader.Launcher.launch(Launcher.java:87) [app.war:?]
2018-10-04T04:28:15.6260462Z 	at org.springframework.boot.loader.Launcher.launch(Launcher.java:50) [app.war:?]
2018-10-04T04:28:15.6260581Z 	at org.springframework.boot.loader.WarLauncher.main(WarLauncher.java:58) [app.war:?]
2018-10-04T04:28:15.6261230Z Caused by: org.springframework.beans.factory.BeanCreationException: Error creating bean with name 'entityWithPaginationAndDTOSearchRepository': Invocation of init method failed; nested exception is org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.data.elasticsearch.repository.support.NumberKeyedRepository]: Constructor threw exception; nested exception is org.springframework.data.elasticsearch.ElasticsearchException: failed to execute action
2018-10-04T04:28:15.6262251Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1699) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6263020Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:573) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6263481Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6263896Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6264288Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6265503Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6266008Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6266456Z 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:251) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6266963Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1135) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6267433Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1062) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6267945Z 	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:818) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6268513Z 	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:724) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6268613Z 	... 25 more
2018-10-04T04:28:15.6268975Z Caused by: org.springframework.beans.BeanInstantiationException: Failed to instantiate [org.springframework.data.elasticsearch.repository.support.NumberKeyedRepository]: Constructor threw exception; nested exception is org.springframework.data.elasticsearch.ElasticsearchException: failed to execute action
2018-10-04T04:28:15.6269818Z 	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:182) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6270980Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.lambda$getTargetRepositoryViaReflection$3(RepositoryFactorySupport.java:512) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6271117Z 	at java.util.Optional.map(Optional.java:215) ~[?:1.8.0_181]
2018-10-04T04:28:15.6271536Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getTargetRepositoryViaReflection(RepositoryFactorySupport.java:512) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6280444Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getTargetRepositoryViaReflection(RepositoryFactorySupport.java:497) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6281292Z 	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactory.getTargetRepository(ElasticsearchRepositoryFactory.java:73) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6282752Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getRepository(RepositoryFactorySupport.java:304) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6283643Z 	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.lambda$afterPropertiesSet$4(RepositoryFactoryBeanSupport.java:290) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6284235Z 	at org.springframework.data.util.Lazy.getNullable(Lazy.java:141) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6285172Z 	at org.springframework.data.util.Lazy.get(Lazy.java:63) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6285885Z 	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.afterPropertiesSet(RepositoryFactoryBeanSupport.java:293) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6286720Z 	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactoryBean.afterPropertiesSet(ElasticsearchRepositoryFactoryBean.java:67) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6287658Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1758) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6288525Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1695) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6291744Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:573) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6292297Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6292821Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6293194Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6293510Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6293864Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6294178Z 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:251) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6295373Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1135) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6295797Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1062) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6296256Z 	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:818) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6296650Z 	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:724) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6296788Z 	... 25 more
2018-10-04T04:28:15.6296862Z Caused by: org.springframework.data.elasticsearch.ElasticsearchException: failed to execute action
2018-10-04T04:28:15.6297481Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.execute(JestElasticsearchTemplate.java:1223) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6297887Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.executeWithAcknowledge(JestElasticsearchTemplate.java:1228) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6298320Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndex(JestElasticsearchTemplate.java:196) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6298985Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndexWithSettings(JestElasticsearchTemplate.java:1438) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6299717Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndexIfNotCreated(JestElasticsearchTemplate.java:1423) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6300409Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndex(JestElasticsearchTemplate.java:177) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6301532Z 	at org.springframework.data.elasticsearch.repository.support.AbstractElasticsearchRepository.createIndex(AbstractElasticsearchRepository.java:96) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6302272Z 	at org.springframework.data.elasticsearch.repository.support.AbstractElasticsearchRepository.<init>(AbstractElasticsearchRepository.java:87) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6302989Z 	at org.springframework.data.elasticsearch.repository.support.NumberKeyedRepository.<init>(NumberKeyedRepository.java:36) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6303197Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_181]
2018-10-04T04:28:15.6303514Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_181]
2018-10-04T04:28:15.6303628Z 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_181]
2018-10-04T04:28:15.6304258Z 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_181]
2018-10-04T04:28:15.6304985Z 	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:170) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6305495Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.lambda$getTargetRepositoryViaReflection$3(RepositoryFactorySupport.java:512) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6305605Z 	at java.util.Optional.map(Optional.java:215) ~[?:1.8.0_181]
2018-10-04T04:28:15.6306080Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getTargetRepositoryViaReflection(RepositoryFactorySupport.java:512) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6306541Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getTargetRepositoryViaReflection(RepositoryFactorySupport.java:497) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6307063Z 	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactory.getTargetRepository(ElasticsearchRepositoryFactory.java:73) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6307531Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getRepository(RepositoryFactorySupport.java:304) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6307981Z 	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.lambda$afterPropertiesSet$4(RepositoryFactoryBeanSupport.java:290) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6308903Z 	at org.springframework.data.util.Lazy.getNullable(Lazy.java:141) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6309206Z 	at org.springframework.data.util.Lazy.get(Lazy.java:63) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6309910Z 	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.afterPropertiesSet(RepositoryFactoryBeanSupport.java:293) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6310354Z 	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactoryBean.afterPropertiesSet(ElasticsearchRepositoryFactoryBean.java:67) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6310812Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1758) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6311439Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1695) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6312328Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:573) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6312972Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6313349Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6313775Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6314194Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6315013Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6315543Z 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:251) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6315997Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1135) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6316543Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1062) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6317050Z 	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:818) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6317531Z 	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:724) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6317705Z 	... 25 more
2018-10-04T04:28:15.6318082Z Caused by: java.net.SocketTimeoutException: Read timed out
2018-10-04T04:28:15.6318383Z 	at java.net.SocketInputStream.socketRead0(Native Method) ~[?:1.8.0_181]
2018-10-04T04:28:15.6318492Z 	at java.net.SocketInputStream.socketRead(SocketInputStream.java:116) ~[?:1.8.0_181]
2018-10-04T04:28:15.6318627Z 	at java.net.SocketInputStream.read(SocketInputStream.java:171) ~[?:1.8.0_181]
2018-10-04T04:28:15.6318718Z 	at java.net.SocketInputStream.read(SocketInputStream.java:141) ~[?:1.8.0_181]
2018-10-04T04:28:15.6319471Z 	at org.apache.http.impl.io.SessionInputBufferImpl.streamRead(SessionInputBufferImpl.java:137) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6320128Z 	at org.apache.http.impl.io.SessionInputBufferImpl.fillBuffer(SessionInputBufferImpl.java:153) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6320645Z 	at org.apache.http.impl.io.SessionInputBufferImpl.readLine(SessionInputBufferImpl.java:282) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6320977Z 	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:138) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6321318Z 	at org.apache.http.impl.conn.DefaultHttpResponseParser.parseHead(DefaultHttpResponseParser.java:56) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6321800Z 	at org.apache.http.impl.io.AbstractMessageParser.parse(AbstractMessageParser.java:259) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6322155Z 	at org.apache.http.impl.DefaultBHttpClientConnection.receiveResponseHeader(DefaultBHttpClientConnection.java:163) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6322453Z 	at org.apache.http.impl.conn.CPoolProxy.receiveResponseHeader(CPoolProxy.java:165) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6322901Z 	at org.apache.http.protocol.HttpRequestExecutor.doReceiveResponse(HttpRequestExecutor.java:273) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6323190Z 	at org.apache.http.protocol.HttpRequestExecutor.execute(HttpRequestExecutor.java:125) ~[httpcore-4.4.10.jar!/:4.4.10]
2018-10-04T04:28:15.6323516Z 	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:272) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6323790Z 	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:185) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6324125Z 	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:89) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6324777Z 	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6325278Z 	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:185) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6325683Z 	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:83) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6330739Z 	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:108) ~[httpclient-4.5.6.jar!/:4.5.6]
2018-10-04T04:28:15.6331049Z 	at io.searchbox.client.http.JestHttpClient.executeRequest(JestHttpClient.java:133) ~[jest-5.3.4.jar!/:?]
2018-10-04T04:28:15.6331383Z 	at io.searchbox.client.http.JestHttpClient.execute(JestHttpClient.java:67) ~[jest-5.3.4.jar!/:?]
2018-10-04T04:28:15.6331650Z 	at io.searchbox.client.http.JestHttpClient.execute(JestHttpClient.java:60) ~[jest-5.3.4.jar!/:?]
2018-10-04T04:28:15.6332017Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.execute(JestElasticsearchTemplate.java:1215) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6332518Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.executeWithAcknowledge(JestElasticsearchTemplate.java:1228) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6332920Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndex(JestElasticsearchTemplate.java:196) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6333252Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndexWithSettings(JestElasticsearchTemplate.java:1438) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6333661Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndexIfNotCreated(JestElasticsearchTemplate.java:1423) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6334016Z 	at com.github.vanroy.springdata.jest.JestElasticsearchTemplate.createIndex(JestElasticsearchTemplate.java:177) ~[spring-data-jest-3.1.5.RELEASE.jar!/:?]
2018-10-04T04:28:15.6334937Z 	at org.springframework.data.elasticsearch.repository.support.AbstractElasticsearchRepository.createIndex(AbstractElasticsearchRepository.java:96) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6335692Z 	at org.springframework.data.elasticsearch.repository.support.AbstractElasticsearchRepository.<init>(AbstractElasticsearchRepository.java:87) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6336190Z 	at org.springframework.data.elasticsearch.repository.support.NumberKeyedRepository.<init>(NumberKeyedRepository.java:36) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6336349Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method) ~[?:1.8.0_181]
2018-10-04T04:28:15.6336441Z 	at sun.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:62) ~[?:1.8.0_181]
2018-10-04T04:28:15.6336582Z 	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45) ~[?:1.8.0_181]
2018-10-04T04:28:15.6336733Z 	at java.lang.reflect.Constructor.newInstance(Constructor.java:423) ~[?:1.8.0_181]
2018-10-04T04:28:15.6337139Z 	at org.springframework.beans.BeanUtils.instantiateClass(BeanUtils.java:170) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6337714Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.lambda$getTargetRepositoryViaReflection$3(RepositoryFactorySupport.java:512) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6337881Z 	at java.util.Optional.map(Optional.java:215) ~[?:1.8.0_181]
2018-10-04T04:28:15.6338649Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getTargetRepositoryViaReflection(RepositoryFactorySupport.java:512) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6339038Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getTargetRepositoryViaReflection(RepositoryFactorySupport.java:497) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6339489Z 	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactory.getTargetRepository(ElasticsearchRepositoryFactory.java:73) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6339873Z 	at org.springframework.data.repository.core.support.RepositoryFactorySupport.getRepository(RepositoryFactorySupport.java:304) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6340302Z 	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.lambda$afterPropertiesSet$4(RepositoryFactoryBeanSupport.java:290) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6340616Z 	at org.springframework.data.util.Lazy.getNullable(Lazy.java:141) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6340951Z 	at org.springframework.data.util.Lazy.get(Lazy.java:63) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6341482Z 	at org.springframework.data.repository.core.support.RepositoryFactoryBeanSupport.afterPropertiesSet(RepositoryFactoryBeanSupport.java:293) ~[spring-data-commons-2.0.10.RELEASE.jar!/:2.0.10.RELEASE]
2018-10-04T04:28:15.6342553Z 	at org.springframework.data.elasticsearch.repository.support.ElasticsearchRepositoryFactoryBean.afterPropertiesSet(ElasticsearchRepositoryFactoryBean.java:67) ~[spring-data-elasticsearch-3.0.10.RELEASE.jar!/:3.0.10.RELEASE]
2018-10-04T04:28:15.6342981Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.invokeInitMethods(AbstractAutowireCapableBeanFactory.java:1758) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6343354Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.initializeBean(AbstractAutowireCapableBeanFactory.java:1695) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6343750Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.doCreateBean(AbstractAutowireCapableBeanFactory.java:573) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6344247Z 	at org.springframework.beans.factory.support.AbstractAutowireCapableBeanFactory.createBean(AbstractAutowireCapableBeanFactory.java:495) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6345446Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.lambda$doGetBean$0(AbstractBeanFactory.java:317) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6345859Z 	at org.springframework.beans.factory.support.DefaultSingletonBeanRegistry.getSingleton(DefaultSingletonBeanRegistry.java:222) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6346299Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.doGetBean(AbstractBeanFactory.java:315) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6346678Z 	at org.springframework.beans.factory.support.AbstractBeanFactory.getBean(AbstractBeanFactory.java:199) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6347132Z 	at org.springframework.beans.factory.config.DependencyDescriptor.resolveCandidate(DependencyDescriptor.java:251) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6347673Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.doResolveDependency(DefaultListableBeanFactory.java:1135) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6348143Z 	at org.springframework.beans.factory.support.DefaultListableBeanFactory.resolveDependency(DefaultListableBeanFactory.java:1062) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6348866Z 	at org.springframework.beans.factory.support.ConstructorResolver.resolveAutowiredArgument(ConstructorResolver.java:818) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6349212Z 	at org.springframework.beans.factory.support.ConstructorResolver.createArgumentArray(ConstructorResolver.java:724) ~[spring-beans-5.0.9.RELEASE.jar!/:5.0.9.RELEASE]
2018-10-04T04:28:15.6349342Z 	... 25 more
```
