### PR TITLE
Clean eslint oriented instructions in tests, declare global mocha env

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,5 +29,11 @@
         "no-multi-assign": "off",
         "no-param-reassign": "off",
         "no-shadow": "off"
-    }
+    },
+    "overrides": [
+        {
+            "files": ["test/**/*.js"],
+            "env": { "mocha": true }
+        }
+    ]
 }

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -1,5 +1,3 @@
-/* global describe, context, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/blueprint/client-blueprint.spec.js
+++ b/test/blueprint/client-blueprint.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/blueprint/entity-blueprint.spec.js
+++ b/test/blueprint/entity-blueprint.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 const path = require('path');
 const fse = require('fs-extra');
 const assert = require('yeoman-assert');

--- a/test/blueprint/server-blueprint.spec.js
+++ b/test/blueprint/server-blueprint.spec.js
@@ -1,5 +1,3 @@
-/* eslint-env mocha */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -1,5 +1,3 @@
-/* global describe, context, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/docker-compose.spec.js
+++ b/test/docker-compose.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/ejslint.js
+++ b/test/ejslint.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const assert = require('assert');
 const ejslint = require('ejs-lint');
 const fs = require('fs');

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/export-jdl.spec.js
+++ b/test/export-jdl.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/generator-base-private.spec.js
+++ b/test/generator-base-private.spec.js
@@ -1,5 +1,3 @@
-/* global describe, before, it */
-
 const expect = require('chai').expect;
 // using base generator which extends the private base
 const BaseGenerator = require('../generators/generator-base').prototype;

--- a/test/generator-base.spec.js
+++ b/test/generator-base.spec.js
@@ -1,5 +1,3 @@
-/* global describe, before, it */
-
 const expect = require('chai').expect;
 const jhiCore = require('jhipster-core');
 const expectedFiles = require('./utils/expected-files');

--- a/test/heroku.spec.js
+++ b/test/heroku.spec.js
@@ -1,5 +1,3 @@
-/* global describe, context, before, beforeEach, after, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/languages.spec.js
+++ b/test/languages.spec.js
@@ -1,5 +1,3 @@
-/* global describe, context, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/load.spec.js
+++ b/test/load.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const assert = require('assert');
 
 describe('JHipster generator', () => {

--- a/test/openshift.spec.js
+++ b/test/openshift.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/rancher-compose.spec.js
+++ b/test/rancher-compose.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/server.spec.js
+++ b/test/server.spec.js
@@ -1,5 +1,3 @@
-/* global describe, context, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/service.spec.js
+++ b/test/service.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/spring-controller.spec.js
+++ b/test/spring-controller.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,5 +1,3 @@
-/* global describe, beforeEach, it */
-
 const assert = require('yeoman-assert');
 const utils = require('../generators/utils');
 

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -1,4 +1,3 @@
-/* global describe, beforeEach, it */
 const path = require('path');
 const os = require('os');
 const shelljs = require('shelljs');


### PR DESCRIPTION
Rather than using global instructions in the header of each test, declares mocha environment globally for tests in .eslintrc.json.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
