### PR TITLE
Fix for Create User dialog pre-filling data from previously viewed/edited user 

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -25,7 +25,7 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 
 import { APP_DATE_FORMAT } from 'app/config/constants';
 <% if (enableTranslation) { %>import { languages } from 'app/config/translation';<% } %>
-import { getUser } from './user-management.reducer';
+import { getUser, reset } from './user-management.reducer';
 import { IRootState } from 'app/shared/reducers';
 
 export interface IUserManagementDetailProps extends StateProps, DispatchProps, RouteComponentProps<{login: string}> {}
@@ -33,6 +33,10 @@ export interface IUserManagementDetailProps extends StateProps, DispatchProps, R
 export class UserManagementDetail extends React.Component<IUserManagementDetailProps> {
   componentDidMount() {
     this.props.getUser(this.props.match.params.login);
+  }
+
+  componentWillUnmount() {
+    this.props.reset();
   }
 
   render() {
@@ -103,7 +107,7 @@ const mapStateToProps = (storeState: IRootState) => ({
   user: storeState.userManagement.user
 });
 
-const mapDispatchToProps = { getUser };
+const mapDispatchToProps = { getUser, reset };
 
 type StateProps = ReturnType<typeof mapStateToProps>;
 type DispatchProps = typeof mapDispatchToProps;

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -85,7 +85,6 @@ export default (state: UserManagementState = initialState, action): UserManageme
     case SUCCESS(ACTION_TYPES.FETCH_ROLES):
       return {
         ...state,
-        loading: false,
         authorities: action.payload.data
       };
     case SUCCESS(ACTION_TYPES.FETCH_USERS):

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.ts.ejs
@@ -107,7 +107,7 @@ export default (state: UserManagementState = initialState, action): UserManageme
         ...state,
         updating: false,
         updateSuccess: true,
-        user: action.payload.data
+        user: {}
       };
     case SUCCESS(ACTION_TYPES.DELETE_USER):
       return {

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
@@ -161,9 +161,9 @@ describe('User management reducer tests', () => {
       testMultipleTypes([SUCCESS(ACTION_TYPES.CREATE_USER), SUCCESS(ACTION_TYPES.UPDATE_USER)], { data: 'some handsome user' }, types => {
         expect(types).toMatchObject({
           updating: false,
-          updateSuccess: true,
-          user: 'some handsome user'
+          updateSuccess: true
         });
+        expect(isEmpty(types.user))
       });
     });
 

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
@@ -152,7 +152,6 @@ describe('User management reducer tests', () => {
       const toTest = userManagement(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_ROLES), payload });
 
       expect(toTest).toMatchObject({
-        loading: false,
         authorities: payload.data
       });
     });


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed


Fix for issue #8302 React: "Create a new user" dialog incorrectly prefills properties with data from a previously edited or detailed user

Fixed the following issues:
- Issue of create user dialog pre-filling user data from previously visited user detail or user update pages. 
- Intermittent issue with activation checkbox not being set in user detail dialog, and deactivating user when data is saved.


