### PR TITLE
Angular: use default parameter in CSRF service

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/csrf.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/csrf.service.ts.ejs
@@ -24,8 +24,7 @@ export class CSRFService {
 
     constructor(private cookieService: CookieService) {}
 
-    getCSRF(name?: string) {
-        name = `${name ? name : 'XSRF-TOKEN'}`;
+    getCSRF(name = 'XSRF-TOKEN') {
         return this.cookieService.get(name);
     }
 }


### PR DESCRIPTION
It's better to use the default parameter than checking manually in the code 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
