### PR TITLE
Fallback clientFramework=angular to the angularX

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -182,7 +182,7 @@ module.exports = class extends BaseGenerator {
                     /* for backward compatibility */
                     this.clientFramework = 'angularX';
                 }
-                if (this.clientFramework === 'angular2') {
+                if (this.clientFramework === 'angular' || this.clientFramework === 'angular2') {
                     /* for backward compatibility */
                     this.clientFramework = 'angularX';
                 }


### PR DESCRIPTION
With @jdubois we had the problem today because we mistakenly used `angular` instead of `angularX` in our app JDL, which caused the app to not generate entities. So I'm adding a fallback to convert **angular** to **angularX**.

Example app:
```
application {
  config {
    baseName store,
    applicationType gateway,
    packageName com.jhipster.demo.store,
    serviceDiscoveryType eureka,
    authenticationType jwt,
    prodDatabaseType mysql,
    cacheProvider hazelcast,
    buildTool maven,
    messageBroker kafka,
    clientFramework angular,
    testFrameworks [protractor]
  }
  entities *
}
```



-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
