### PR TITLE
Angular: remove rxjs-compat and bump ngx-infinite-scroll

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -44,11 +44,10 @@
     "moment": "2.22.2",
     "ng-jhipster": "0.5.4",
     "ngx-cookie": "2.0.1",
-    "ngx-infinite-scroll": "0.5.1",
+    "ngx-infinite-scroll": "6.0.1",
     "ngx-webstorage": "2.0.1",
     "reflect-metadata": "0.1.12",
     "rxjs": "6.1.0",
-    "rxjs-compat": "6.1.0",
     "swagger-ui": "2.2.10",
     <%_ if (websocket === 'spring-websocket') { _%>
     "sockjs-client": "1.1.4",


### PR DESCRIPTION
We should remove `rxjs-compat` as it is provided for migration between rxjs 5.5 and rxjs 6. Now all of our dependencies uses rxjs6 we can safely remove it.
It also allow to do tree-shaking on rxjs operators which save some kB (27 to be precise) 🎉 

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
