### PR TITLE
Fix creationEmail link for react

### DIFF
--- a/generators/server/templates/src/main/resources/templates/mail/creationEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/creationEmail.html.ejs
@@ -13,13 +13,8 @@
             Your JHipster account has been created, please click on the URL below to access it:
         </p>
         <p>
-          <% if (clientFramework === 'react') { %>
-            <a th:with="url=(@{|${baseUrl}/#/reset/finish/${user.resetKey}|})" th:href="${url}"
-            th:text="${url}">Login link</a>
-            <% } else { %>
             <a th:with="url=(@{|${baseUrl}/#/reset/finish?key=${user.resetKey}|})" th:href="${url}"
             th:text="${url}">Login link</a>
-            <% } %>
         </p>
         <p>
             <span th:text="#{email.activation.text2}">Regards, </span>


### PR DESCRIPTION
It will also align URLs for both react and angular apps.
It has already been done for other thymeleaf templates

Fix #8522 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
