### PR TITLE
change language after retrieve the account info instead of login

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
@@ -17,6 +17,9 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
+<%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
+import { JhiLanguageService } from 'ng-jhipster';
+<%_ } _%>
 import { Observable, Subject } from 'rxjs';
 import { AccountService } from './account.service';
 <%_ if (websocket === 'spring-websocket') { _%>
@@ -30,6 +33,9 @@ export class Principal {
     private authenticationState = new Subject<any>();
 
     constructor(
+        <%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
+        private languageService: JhiLanguageService,
+        <%_ } _%>
         private account: AccountService<% if (websocket === 'spring-websocket') { %>,
         private trackerService: <%=jhiPrefixCapitalized%>TrackerService<% } %>
     ) {}
@@ -90,6 +96,13 @@ export class Principal {
                 <%_ if (websocket === 'spring-websocket') { _%>
                 this.trackerService.connect();
                 <%_ } _%>
+
+                <%_ if (enableTranslation) { _%>
+                // After retrieve the account info, the language will be changed to
+                // the user's preferred language configured in the account setting
+                this.languageService.changeLanguage(this.userIdentity.langKey);
+                <%_ } _%>
+
             } else {
                 this.userIdentity = null;
                 this.authenticated = false;

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-<%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
+<%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
 import { JhiLanguageService } from 'ng-jhipster';
 <%_ } _%>
 import { Observable, Subject } from 'rxjs';
@@ -33,7 +33,7 @@ export class Principal {
     private authenticationState = new Subject<any>();
 
     constructor(
-        <%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
+        <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
         private languageService: JhiLanguageService,
         <%_ } _%>
         private account: AccountService<% if (websocket === 'spring-websocket') { %>,
@@ -97,7 +97,7 @@ export class Principal {
                 this.trackerService.connect();
                 <%_ } _%>
 
-                <%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
+                <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
                 // After retrieve the account info, the language will be changed to
                 // the user's preferred language configured in the account setting
                 this.languageService.changeLanguage(this.userIdentity.langKey);

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
@@ -19,6 +19,7 @@
 import { Injectable } from '@angular/core';
 <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
 import { JhiLanguageService } from 'ng-jhipster';
+import { SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
 import { Observable, Subject } from 'rxjs';
 import { AccountService } from './account.service';
@@ -35,6 +36,7 @@ export class Principal {
     constructor(
         <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
         private languageService: JhiLanguageService,
+        private sessionStorage: SessionStorageService,
         <%_ } _%>
         private account: AccountService<% if (websocket === 'spring-websocket') { %>,
         private trackerService: <%=jhiPrefixCapitalized%>TrackerService<% } %>
@@ -100,7 +102,8 @@ export class Principal {
                 <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
                 // After retrieve the account info, the language will be changed to
                 // the user's preferred language configured in the account setting
-                this.languageService.changeLanguage(this.userIdentity.langKey);
+                const langKey = this.sessionStorage.retrieve('local') || this.userIdentity.langKey;
+                this.languageService.changeLanguage(langKey);
                 <%_ } _%>
 
             } else {

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/principal.service.ts.ejs
@@ -97,7 +97,7 @@ export class Principal {
                 this.trackerService.connect();
                 <%_ } _%>
 
-                <%_ if (enableTranslation) { _%>
+                <%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
                 // After retrieve the account info, the language will be changed to
                 // the user's preferred language configured in the account setting
                 this.languageService.changeLanguage(this.userIdentity.langKey);

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -17,9 +17,6 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-<%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
-import { JhiLanguageService } from 'ng-jhipster';
-<%_ } _%>
 
 import { Principal } from '../auth/principal.service';
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
@@ -35,9 +32,6 @@ import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.serv
 export class LoginService {
 
     constructor(
-        <%_ if (enableTranslation && !(authenticationType === 'oauth2')) { _%>
-        private languageService: JhiLanguageService,
-        <%_ } _%>
         private principal: Principal,
         <%_ if (websocket === 'spring-websocket') { _%>
         private trackerService: <%=jhiPrefixCapitalized%>TrackerService,
@@ -60,13 +54,6 @@ export class LoginService {
         return new Promise((resolve, reject) => {
             this.authServerProvider.login(credentials).subscribe((data) => {
                 this.principal.identity(true).then((account) => {
-                    <%_ if (enableTranslation) { _%>
-                    // After the login the language will be changed to
-                    // the language selected by the user during his registration
-                    if (account !== null) {
-                        this.languageService.changeLanguage(account.langKey);
-                    }
-                    <%_ } _%>
                     <%_ if (websocket === 'spring-websocket') { _%>
                     this.trackerService.sendActivity();
                     <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
@@ -25,6 +25,9 @@ import { JhiLanguageService } from 'ng-jhipster';
 
 import { VERSION } from 'app/app.constants';
 import { <% if (enableTranslation) { %>JhiLanguageHelper, <% } %>Principal, <% if (authenticationType !== 'oauth2') { %>LoginModalService, <% } %>LoginService } from 'app/core';
+<%_ if (enableTranslation) { _%>
+import { SessionStorageService } from 'ngx-webstorage';
+<%_ } _%>
 import { ProfileService } from '../profiles/profile.service';
 
 @Component({
@@ -53,6 +56,7 @@ export class NavbarComponent implements OnInit {
         <%_ if (enableTranslation) { _%>
         private languageService: JhiLanguageService,
         private languageHelper: JhiLanguageHelper,
+        private sessionStorage: SessionStorageService,
         <%_ } _%>
         private principal: Principal,
         <%_ if (authenticationType !== 'oauth2') { _%>
@@ -80,7 +84,8 @@ export class NavbarComponent implements OnInit {
 
     <%_ if (enableTranslation) { _%>
     changeLanguage(languageKey: string) {
-      this.languageService.changeLanguage(languageKey);
+        this.sessionStorage.store('local', languageKey);
+        this.languageService.changeLanguage(languageKey);
     }
 
     <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
@@ -81,16 +81,7 @@ export const saveAccountSettings = account => async <% if (enableTranslation) { 
       successMessage: translate('settings.messages.success')
     }
   });
-  <%_ if (enableTranslation) { _%>
   await dispatch(getSession());
-
-  const accountState = getState().authentication.account;
-  if (accountState && accountState.langKey) {
-    await dispatch(setLocale(accountState.langKey));
-  }
-  <%_ } else { _%>
-  dispatch(getSession());
-  <%_ } _%>
 };
 
 export const reset = () => ({

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/header/header.tsx.ejs
@@ -19,7 +19,7 @@
 import './header.<%= styleSheetExt %>';
 
 import React from 'react';
-import { Translate<% if (enableI18nRTL) { %>, Storage<% } %> } from 'react-jhipster';
+import { Translate<% if (enableTranslation) { %>, Storage<% } %> } from 'react-jhipster';
 import {
   Navbar,
   Nav,
@@ -67,6 +67,7 @@ export default class Header extends React.Component<IHeaderProps, IHeaderState> 
 
   <%_ if (enableTranslation) { _%>
   handleLocaleChange = event => {
+    Storage.session.set('locale', event.target.value);
     this.props.onLocaleChange(event.target.value);
     <%_ if (enableI18nRTL) { _%>
     document.querySelector('html').setAttribute('dir', isRTL(event.target.value) ? 'rtl' : 'ltr');

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -147,7 +147,7 @@ export const getSession = () => async (dispatch, getState) => {
   
     const account = getState().authentication.account;
     if (account && account.langKey) {
-      await dispatch(setLocale(account.langKey));
+      dispatch(setLocale(account.langKey));
     }
     <%_ } else { _%>
     dispatch({

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -197,7 +197,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
     await dispatch(setLocale(account.langKey));
   }
   <%_ } else { _%>
-  dispatch(getSession());
+  await dispatch(getSession());
   <%_ } _%>
 };
 <%_ } _%>

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -147,7 +147,7 @@ export const getSession = () => async (dispatch, getState) => {
   
     const account = getState().authentication.account;
     if (account && account.langKey) {
-      dispatch(setLocale(account.langKey));
+      await dispatch(setLocale(account.langKey));
     }
     <%_ } else { _%>
     dispatch({

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -181,7 +181,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
       Storage.session.set(AUTH_TOKEN_KEY, jwt);
     }
   }
-  dispatch(getSession());
+  await dispatch(getSession());
 };
 <%_ } else if (authenticationType === 'uaa') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
@@ -189,16 +189,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
     type: ACTION_TYPES.LOGIN,
     payload: axios.post('auth/login', { username, password })
   });
- <%_ if (enableTranslation) { _%>
   await dispatch(getSession());
-
-  const account = getState().authentication.account;
-  if (account && account.langKey) {
-    await dispatch(setLocale(account.langKey));
-  }
-  <%_ } else { _%>
-  await dispatch(getSession());
-  <%_ } _%>
 };
 <%_ } _%>
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -147,7 +147,9 @@ export const getSession = () => async (dispatch, getState) => {
   
     const account = getState().authentication.account;
     if (account && account.langKey) {
-      await dispatch(setLocale(account.langKey));
+      const langKey = Storage.session.get('locale', account.langKey);
+      Storage.session.set('locale', langKey);
+      await dispatch(setLocale(langKey));
     }
     <%_ } else { _%>
     dispatch({

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -181,7 +181,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
       Storage.session.set(AUTH_TOKEN_KEY, jwt);
     }
   }
-  await dispatch(getSession());
+  dispatch(getSession());
 };
 <%_ } else if (authenticationType === 'uaa') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
@@ -189,7 +189,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
     type: ACTION_TYPES.LOGIN,
     payload: axios.post('auth/login', { username, password })
   });
-  await dispatch(getSession());
+  dispatch(getSession());
 };
 <%_ } _%>
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -148,7 +148,6 @@ export const getSession = () => async (dispatch, getState) => {
     const account = getState().authentication.account;
     if (account && account.langKey) {
       const langKey = Storage.session.get('locale', account.langKey);
-      Storage.session.set('locale', langKey);
       await dispatch(setLocale(langKey));
     }
     <%_ } else { _%>

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -138,10 +138,24 @@ export default (state: AuthenticationState = initialState, action): Authenticati
 
 export const displayAuthError = message => ({ type: ACTION_TYPES.ERROR_MESSAGE, message });
 
-export const getSession = () => dispatch => dispatch({
-  type: ACTION_TYPES.GET_SESSION,
-  payload: axios.get('<%= apiUaaPath %>api/account')
-});
+export const getSession = () => async (dispatch, getState) => {
+    <%_ if (enableTranslation) { _%>
+    await dispatch({
+      type: ACTION_TYPES.GET_SESSION,
+      payload: axios.get('<%= apiUaaPath %>api/account')
+    });
+  
+    const account = getState().authentication.account;
+    if (account && account.langKey) {
+      dispatch(setLocale(account.langKey));
+    }
+    <%_ } else { _%>
+    dispatch({
+      type: ACTION_TYPES.GET_SESSION,
+      payload: axios.get('<%= apiUaaPath %>api/account')
+    });
+    <%_ } _%>
+}
 
 <%_ if (authenticationType === 'session') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
@@ -150,16 +164,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
     type: ACTION_TYPES.LOGIN,
     payload: axios.post('api/authentication', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } })
   });
- <%_ if (enableTranslation) { _%>
-  await dispatch(getSession());
-
-  const account = getState().authentication.account;
-  if (account && account.langKey) {
-    dispatch(setLocale(account.langKey));
-  }
-  <%_ } else { _%>
   dispatch(getSession());
-  <%_ } _%>
 };
 <%_ } else if (authenticationType === 'jwt') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -164,7 +164,11 @@ export const login = (username, password, rememberMe = false) => async (dispatch
     type: ACTION_TYPES.LOGIN,
     payload: axios.post('api/authentication', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } })
   });
+  <%_ if (enableTranslation) { _%>
+  await dispatch(getSession());
+  <%_ } else { _%>
   dispatch(getSession());
+  <%_ } _%>
 };
 <%_ } else if (authenticationType === 'jwt') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
@@ -181,7 +185,11 @@ export const login = (username, password, rememberMe = false) => async (dispatch
       Storage.session.set(AUTH_TOKEN_KEY, jwt);
     }
   }
+  <%_ if (enableTranslation) { _%>
+  await dispatch(getSession());
+  <%_ } else { _%>
   dispatch(getSession());
+  <%_ } _%>
 };
 <%_ } else if (authenticationType === 'uaa') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
@@ -189,7 +197,11 @@ export const login = (username, password, rememberMe = false) => async (dispatch
     type: ACTION_TYPES.LOGIN,
     payload: axios.post('auth/login', { username, password })
   });
+  <%_ if (enableTranslation) { _%>
+  await dispatch(getSession());
+  <%_ } else { _%>
   dispatch(getSession());
+  <%_ } _%>
 };
 <%_ } _%>
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -147,7 +147,7 @@ export const getSession = () => async (dispatch, getState) => {
   
     const account = getState().authentication.account;
     if (account && account.langKey) {
-      dispatch(setLocale(account.langKey));
+      await dispatch(setLocale(account.langKey));
     }
     <%_ } else { _%>
     dispatch({
@@ -181,16 +181,7 @@ export const login = (username, password, rememberMe = false) => async (dispatch
       Storage.session.set(AUTH_TOKEN_KEY, jwt);
     }
   }
- <%_ if (enableTranslation) { _%>
-  await dispatch(getSession());
-
-  const account = getState().authentication.account;
-  if (account && account.langKey) {
-    await dispatch(setLocale(account.langKey));
-  }
-  <%_ } else { _%>
   dispatch(getSession());
-  <%_ } _%>
 };
 <%_ } else if (authenticationType === 'uaa') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -35,7 +35,6 @@ export default (state: LocaleState = initialState, action): LocaleState => {
     case ACTION_TYPES.SET_LOCALE:
       const currentLocale = action.locale;
       if (state.currentLocale !== currentLocale) {
-        Storage.session.set('locale', currentLocale);
         TranslatorContext.setLocale(currentLocale);
       }
       return {

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
@@ -198,11 +198,7 @@ describe('Authentication reducer tests', () => {
         {
           type: SUCCESS(ACTION_TYPES.GET_SESSION),
           payload: resolvedObject
-        }<% if (enableTranslation) { %>,
-          {
-            type: localeActionTypes.SET_LOCALE,
-            locale: '<%= nativeLanguage %>'
-          }<% } %>
+        }
       ];
       await store.dispatch(getSession()).then(() => expect(store.getActions()).toEqual(expectedActions));
     });

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
@@ -198,7 +198,11 @@ describe('Authentication reducer tests', () => {
         {
           type: SUCCESS(ACTION_TYPES.GET_SESSION),
           payload: resolvedObject
-        }
+        }<% if (enableTranslation) { %>,
+          {
+            type: localeActionTypes.SET_LOCALE,
+            locale: '<%= nativeLanguage %>'
+          }<% } %>
       ];
       await store.dispatch(getSession()).then(() => expect(store.getActions()).toEqual(expectedActions));
     });


### PR DESCRIPTION
### Current Logic
 the current multiple language. there is 2 place we will change it

1. we will load it during the login process. if login success, we retrieve the account info, and change the laguage based on the user setting, (we keep it in a something like a globle variable)
```
            this.authServerProvider.login(credentials).subscribe(
                data => {
                    this.principal.identity(true).then(account => {
                        // After the login the language will be changed to
                        // the language selected by the user during his registration
                        if (account !== null) {
                            this.languageService.changeLanguage(account.langKey);
                        }
                        this.trackerService.sendActivity();
                        resolve(data);
```
1. when user choose the language temporarily, we change the language 
### Issue

- if the use set the `remember` me to true, we will save the JWT token in to the localStorage, if use close the brower and open again, the login process will be skipped,  we won't able to get the user preferred language, so we will display en as default.
- even user set the `remember` me to false, we still save the JWT token into sessionStorage, if user login succeed, it will display the user preferred language, but if in the same time, we open a new tap and load the gateway again, it will display the en as default (even the user set other langage as preferred).
### New Logic
change the `languageService.changeLanguage` when load the account info. so
- when first time login, it will display the user preferred lang
- when close and open the browser, it will display the user preferred lang
- when refresh the page, it will display the user preferred lang
- for the temporarily language user choosed, it will valid for the current window.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
