### PR TITLE
Heroku: set ${JHIPSTER_REGISTRY_URL} only for eureka apps

### DIFF
--- a/generators/heroku/templates/application-heroku.yml.ejs
+++ b/generators/heroku/templates/application-heroku.yml.ejs
@@ -35,9 +35,11 @@ eureka:
         non-secure-port: 80
         prefer-ip-address: false
 <%_ } _%>
+<%_ if (serviceDiscoveryType === 'eureka') { _%>
     client:
         service-url:
             defaultZone: ${JHIPSTER_REGISTRY_URL}/eureka/
+<%_ } _%>
 
 spring:
 <%_ if (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb') { _%>

--- a/generators/heroku/templates/bootstrap-heroku.yml.ejs
+++ b/generators/heroku/templates/bootstrap-heroku.yml.ejs
@@ -20,8 +20,10 @@
 # Spring Cloud Config bootstrap configuration for the "heroku" profile
 # ===================================================================
 
+<%_ if (serviceDiscoveryType === 'eureka') { _%>
 spring:
     cloud:
         config:
             fail-fast: true
             uri: ${JHIPSTER_REGISTRY_URL}/config
+<%_ } _%>


### PR DESCRIPTION
Non eureka apps don't require ${JHIPSTER_REGISTRY_URL}

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
