### PR TITLE
update spring connector auto-config - Fix for #8518 #8169 

### DIFF
--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -63,16 +63,6 @@ module.exports = class extends BaseGenerator {
                 this.template('application-cloudfoundry.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}config/application-cloudfoundry.yml`);
             },
 
-            addCloudFoundryDependencies() {
-                if (this.buildTool === 'maven') {
-                    this.addMavenDependency('org.springframework.cloud', 'spring-cloud-localconfig-connector');
-                    this.addMavenDependency('org.springframework.cloud', 'spring-cloud-cloudfoundry-connector');
-                } else if (this.buildTool === 'gradle') {
-                    this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-localconfig-connector');
-                    this.addGradleDependency('compile', 'org.springframework.cloud', 'spring-cloud-cloudfoundry-connector');
-                }
-            },
-
             checkInstallation() {
                 if (this.abort) return;
                 const done = this.async();

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -384,7 +384,7 @@ dependencies {
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || applicationType === 'uaa') { _%>
     compile "org.springframework.cloud:spring-cloud-starter-openfeign"
     <%_ } _%>
-    compile "org.springframework.cloud:spring-cloud-spring-service-connector"
+    compile "org.springframework.boot:spring-boot-starter-cloud-connectors"
     compile "org.springframework.security:spring-security-config"
     compile "org.springframework.security:spring-security-data"
     compile "org.springframework.security:spring-security-web"

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -721,8 +721,8 @@
         </dependency>
         <%_ } _%>
         <dependency>
-            <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-spring-service-connector</artifactId>
+            <groupId>org.springframework.boot</groupId>
+            <artifactId>spring-boot-starter-cloud-connectors</artifactId>
         </dependency>
         <!-- Security -->
         <dependency>

--- a/generators/server/templates/src/main/java/package/config/CloudDatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CloudDatabaseConfiguration.java.ejs
@@ -57,12 +57,15 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 <%_ if (databaseType === 'sql') { _%>
 
 import javax.sql.DataSource;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import static <%=packageName%>.config.Constants.CLOUD_CONFIGURATION_PREFIX;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
 
 import java.util.ArrayList;
 import java.util.List;
 <%_ } _%>
+
 
 @Configuration
 <%_ if (databaseType === 'mongodb') { _%>
@@ -77,6 +80,7 @@ public class CloudDatabaseConfiguration extends AbstractCloudConfig {
     <%_ if (databaseType === 'sql') { _%>
 
     @Bean
+    @ConfigurationProperties(CLOUD_CONFIGURATION_PREFIX)
     public DataSource dataSource(<% if (cacheProvider === 'hazelcast') { %>CacheManager cacheManager<% } %>) {
         log.info("Configuring JDBC datasource from a cloud provider");
         return connectionFactory().dataSource();

--- a/generators/server/templates/src/main/java/package/config/CloudDatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CloudDatabaseConfiguration.java.ejs
@@ -58,7 +58,6 @@ import org.springframework.validation.beanvalidation.LocalValidatorFactoryBean;
 
 import javax.sql.DataSource;
 import org.springframework.boot.context.properties.ConfigurationProperties;
-import static <%=packageName%>.config.Constants.CLOUD_CONFIGURATION_PREFIX;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
 
@@ -78,9 +77,11 @@ public class CloudDatabaseConfiguration extends AbstractCloudConfig {
     private final Logger log = LoggerFactory.getLogger(CloudDatabaseConfiguration.class);
     <%_ } _%>
     <%_ if (databaseType === 'sql') { _%>
+    
+    private final String CLOUD_CONFIGURATION_HIKARI_PREFIX = "spring.datasource.hikari";
 
     @Bean
-    @ConfigurationProperties(CLOUD_CONFIGURATION_PREFIX)
+    @ConfigurationProperties(CLOUD_CONFIGURATION_HIKARI_PREFIX)
     public DataSource dataSource(<% if (cacheProvider === 'hazelcast') { %>CacheManager cacheManager<% } %>) {
         log.info("Configuring JDBC datasource from a cloud provider");
         return connectionFactory().dataSource();

--- a/generators/server/templates/src/main/java/package/config/Constants.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/Constants.java.ejs
@@ -32,7 +32,6 @@ public final class Constants {
     <% if (databaseType === 'couchbase') { %>
     public static final String ID_DELIMITER = "__";
     <% } %>
-    public static final String CLOUD_CONFIGURATION_PREFIX = "spring.datasource.hikari";
     private Constants() {
     }
 }

--- a/generators/server/templates/src/main/java/package/config/Constants.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/Constants.java.ejs
@@ -32,6 +32,7 @@ public final class Constants {
     <% if (databaseType === 'couchbase') { %>
     public static final String ID_DELIMITER = "__";
     <% } %>
+    public static final String CLOUD_CONFIGURATION_PREFIX = "spring.datasource.hikari";
     private Constants() {
     }
 }


### PR DESCRIPTION
Fix #8518 #8169 

#8169 
First time deployment would have failed, because the updated pom.xml (with cf connectors) from the CF sub-generator would have been written to the file system after the build that got triggered from the same sub-generator. So the build would have had happened not with the updated pom.xml. When the subsequent re-deployment happens, pom.xml was already updated (in the previous run) and hence the service binding would have gone through without any issues.

I noticed spring-cloud-spring-service-connector in the main pom.xml and in CF sub-generator cf specific connectors are being added. I've replaced everything with spring-boot-starter-cloud-connectors in the main pom.xml that includes both service and cloud specific connectors. There is no harm keeping it in the main pom.xml/build.gradle as this would come into effect only when it discovers those cloud specific env variables like VCAP_SERVICES etc.

#8518
When using service connectors, can't configure the custom datasource using boot properties. These two are sort of mutually exclusive. It's always recommended to initialise the custom/cloud specific datasource using cloud connectors so that it would do its best to do the binding in 'any cloud' and manually force the boot specific properties through @ConfigurationProperties. 