### PR TITLE
[skip ci] add missing $ in docker-build for gradle in gitlab-ci gener…

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -130,7 +130,7 @@ gradle-package:
 #        - docker info
 #        - cp build/libs/*.war src/main/docker
 #    script:
-#        - docker login -u "gitlab-ci-token" -p "$CI_BUILD_TOKEN" REGISTRY_URL
+#        - docker login -u "gitlab-ci-token" -p "$CI_BUILD_TOKEN" $REGISTRY_URL
 #        - docker build -f src/main/docker/Dockerfile -t $IMAGE_TAG src/main/docker
 #        - docker push $IMAGE_TAG
 


### PR DESCRIPTION
Add a missing $ in the docker-build template provided for Gradle (not missing for Maven)