### PR TITLE
fix-issue-for-PR#8525

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/settings/settings.reducer.ts.ejs
@@ -17,11 +17,10 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-import { translate } from 'react-jhipster';
+<% if (enableTranslation) { %>import { translate, Storage } from 'react-jhipster';<% } %>
 
 import { REQUEST, SUCCESS, FAILURE } from 'app/shared/reducers/action-type.util';
 import { getSession } from 'app/shared/reducers/authentication';
- <% if (enableTranslation) { %>import { setLocale } from 'app/shared/reducers/locale';<% } %>
 
 export const ACTION_TYPES = {
   UPDATE_ACCOUNT: 'account/UPDATE_ACCOUNT',
@@ -81,6 +80,11 @@ export const saveAccountSettings = account => async <% if (enableTranslation) { 
       successMessage: translate('settings.messages.success')
     }
   });
+  <% if (enableTranslation) { %>
+    if (Storage.session.get(`locale`)) {
+      Storage.session.remove(`locale`);
+    }
+    <% } %>  
   await dispatch(getSession());
 };
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import axios from 'axios';
-<%_ if (authenticationType === 'jwt') { _%>
+<%_ if (authenticationType === 'jwt' || enableTranslation) { _%>
 import { Storage } from 'react-jhipster';
 <%_ } _%>
 

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
@@ -28,7 +28,7 @@ import configureStore from 'redux-mock-store';
 import promiseMiddleware from 'redux-promise-middleware';
 
 import authentication, { ACTION_TYPES, getSession<% if (authenticationType !== 'oauth2') { %>, login<% } %>, clearAuthentication, logout<% if (authenticationType === 'jwt') { %>, clearAuthToken<% } %> } from 'app/shared/reducers/authentication';
-<% if (enableTranslation && authenticationType !== 'oauth2') { %>import { ACTION_TYPES as localeActionTypes } from 'app/shared/reducers/locale';<% } %>
+<% if (enableTranslation) { %>import { ACTION_TYPES as localeActionTypes } from 'app/shared/reducers/locale';<% } %>
 
 describe('Authentication reducer tests', () => {
   function isAccountEmpty(state): boolean {


### PR DESCRIPTION
In the #8525 , there is a issue for the Storage, previour we only import it for JWT. but now since we add the language logic to the getSession, the Storage will be imported when the enableTranslation is true.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
