### PR TITLE
Remove deps in favor of injectable for http interceptors

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -18,12 +18,11 @@
 -%>
 import './vendor.ts';
 
-import { NgModule, Injector } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
-import { Ng2Webstorage<% if (authenticationType === 'jwt') { %>, LocalStorageService, SessionStorageService <% } %> } from 'ngx-webstorage';
-import { JhiEventManager } from 'ng-jhipster';
+import { Ng2Webstorage } from 'ngx-webstorage';
 
 <%_ if (authenticationType === 'jwt') { _%>
 import { AuthInterceptor } from './blocks/interceptor/auth.interceptor';
@@ -39,9 +38,6 @@ import { <%=angularXAppName%>HomeModule } from './home/home.module';
 import { <%=angularXAppName%>AccountModule } from './account/account.module';
 <%_ } _%>
 import { <%=angularXAppName%>EntityModule } from './entities/entity.module';
-<%_ if (['session', 'oauth2'].includes(authenticationType)) { _%>
-import { StateStorageService } from 'app/core/auth/state-storage.service';
-<%_ } _%>
 import * as moment from 'moment';
 // jhipster-needle-angular-add-module-import JHipster will add new module here
 import {
@@ -84,39 +80,23 @@ import {
         {
             provide: HTTP_INTERCEPTORS,
             useClass: AuthInterceptor,
-            multi: true,
-            deps: [
-                LocalStorageService,
-                SessionStorageService
-            ]
+            multi: true
         },
         <%_ } _%>
         {
             provide: HTTP_INTERCEPTORS,
             useClass: AuthExpiredInterceptor,
-            multi: true,
-            deps: [
-                <%_ if (['session', 'oauth2'].includes(authenticationType)) { _%>
-                StateStorageService,
-                <%_ } _%>
-                Injector
-            ]
+            multi: true
         },
         {
             provide: HTTP_INTERCEPTORS,
             useClass: ErrorHandlerInterceptor,
-            multi: true,
-            deps: [
-                JhiEventManager
-            ]
+            multi: true
         },
         {
             provide: HTTP_INTERCEPTORS,
             useClass: NotificationInterceptor,
-            multi: true,
-            deps: [
-                Injector
-            ]
+            multi: true
         }
     ],
     bootstrap: [ <%=jhiPrefixCapitalized%>MainComponent ]

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent, HttpErrorResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
@@ -37,13 +37,26 @@ import { LoginModalService } from 'app/core/login/login-modal.service';
 import { StateStorageService } from 'app/core/auth/state-storage.service';
 <%_ } _%>
 
+@Injectable()
 export class AuthExpiredInterceptor implements HttpInterceptor {
 
     constructor(
-        <%_ if (['session', 'oauth2'].includes(authenticationType)) { _%>
-        private stateStorageService: StateStorageService,
+        <%_ if (authenticationType === 'session') { _%>
+        private loginModalService: LoginModalService,
+        private authServerProvider: AuthServerProvider,
+        private stateStorageService: StateStorageService
         <%_ } _%>
-        private injector: Injector
+        <%_ if (['oauth2', 'jwt', 'uaa'].includes(authenticationType)) { _%>
+            <%_ if (authenticationType === 'uaa') { _%>
+        private loginModalService: LoginModalService,
+        private principal: Principal,
+        private router: Router,
+            <%_ } _%>
+            <%_ if (authenticationType === 'oauth2') { _%>
+        private stateStorageService: StateStorageService,
+            <%_ } _%>
+        private loginService: LoginService
+        <%_ } _%>
     ) {}
 
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
@@ -52,20 +65,14 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
             if (err instanceof HttpErrorResponse) {
                 if (err.status === 401) {
 <%_ if (authenticationType === 'jwt') { _%>
-                    const loginService: LoginService = this.injector.get(LoginService);
-                    loginService.logout();
+                    this.loginService.logout();
 <% } if (authenticationType === 'uaa') { %>
-                    const principal = this.injector.get(Principal);
-
-                    if (principal.isAuthenticated()) {
-                        principal.authenticate(null);
-                        const loginModalService: LoginModalService = this.injector.get(LoginModalService);
-                        loginModalService.open();
+                    if (this.principal.isAuthenticated()) {
+                        this.principal.authenticate(null);
+                        this.loginModalService.open();
                     } else {
-                        const loginService: LoginService = this.injector.get(LoginService);
-                        loginService.logout();
-                        const router = this.injector.get(Router);
-                        router.navigate(['/']);
+                        this.loginService.logout();
+                        this.router.navigate(['/']);
                     }
 <%_ } _%>
                 }
@@ -88,13 +95,10 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
                         this.stateStorageService.storeUrl('/');
                     }
 <% if (authenticationType === 'session') { %>
-                    const authServer: AuthServerProvider = this.injector.get(AuthServerProvider);
-                    authServer.logout();
-                    const loginModalService: LoginModalService = this.injector.get(LoginModalService);
-                    loginModalService.open();
+                    this.authServerProvider.logout();
+                    this.loginModalService.open();
 <% } else { %>
-                    const loginService: LoginService = this.injector.get(LoginService);
-                    loginService.login();
+                    this.loginService.login();
 <% } %>
                 }
             }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth.interceptor.ts.ejs
@@ -16,12 +16,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
 
 import { SERVER_API_URL } from 'app/app.constants';
 
+@Injectable()
 export class AuthInterceptor implements HttpInterceptor {
 
     constructor(

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
@@ -16,11 +16,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+import { Injectable } from '@angular/core';
 import { JhiEventManager } from 'ng-jhipster';
 import { HttpInterceptor, HttpRequest, HttpErrorResponse, HttpHandler, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
+@Injectable()
 export class ErrorHandlerInterceptor implements HttpInterceptor {
 
     constructor(private eventManager: JhiEventManager) {
@@ -30,9 +32,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
         return next.handle(request).pipe(tap((event: HttpEvent<any>) => {}, (err: any) => {
             if (err instanceof HttpErrorResponse) {
                 if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('/api/account'))))) {
-                    if (this.eventManager !== undefined) {
-                        this.eventManager.broadcast({name: '<%=angularAppName%>.httpError', content: err});
-                    }
+                    this.eventManager.broadcast({name: '<%=angularAppName%>.httpError', content: err});
                 }
             }
         }));

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
@@ -18,18 +18,14 @@
 -%>
 import { JhiAlertService } from 'ng-jhipster';
 import { HttpInterceptor, HttpRequest, HttpResponse, HttpHandler, HttpEvent } from '@angular/common/http';
-import { Injector } from '@angular/core';
+import { Injectable } from '@angular/core';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
+@Injectable()
 export class NotificationInterceptor implements HttpInterceptor {
 
-    private alertService: JhiAlertService;
-
-    // tslint:disable-next-line: no-unused-variable
-    constructor(private injector: Injector) {
-        setTimeout(() => this.alertService = injector.get(JhiAlertService));
-    }
+    constructor(private alertService: JhiAlertService) {}
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(tap((event: HttpEvent<any>) => {
@@ -48,13 +44,11 @@ export class NotificationInterceptor implements HttpInterceptor {
                 });
                 if (alert) {
                     if (typeof alert === 'string') {
-                        if (this.alertService) {
-                            <%_ if (enableTranslation) { _%>
-                            this.alertService.success(alert, { param : alertParams }, null);
-                            <%_ } else { _%>
-                            this.alertService.success(alert, null, null);
-                            <%_ } _%>
-                        }
+                        <%_ if (enableTranslation) { _%>
+                        this.alertService.success(alert, { param : alertParams }, null);
+                        <%_ } else { _%>
+                        this.alertService.success(alert, null, null);
+                        <%_ } _%>
                     }
                 }
             }


### PR DESCRIPTION
Since Angular 5.2.3 we can use @Injectable for classes which implement HttpInterceptor (without the cyclic dependency error)

Angular thread: https://github.com/angular/angular/pull/19809

I tested it and it seems working fine.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
