### PR TITLE
[WIP] Add error message when the backend is not started

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, OnDestroy } from '@angular/core';
+import { Component, Input, OnDestroy } from '@angular/core';
 <%_ if (enableTranslation) { _%>
 import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
@@ -38,8 +38,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
 
     alerts: any[];
     cleanHttpErrorListener: Subscription;
-    defaultTimeout = 5000;
-    noTimeout = 0;
+    @Input() timeout = 5000;
     /* tslint:disable */
     constructor(private alertService: JhiAlertService, private eventManager: JhiEventManager<% if (enableTranslation) { %>, private translateService: TranslateService<% } %>) {
     /* tslint:enable */
@@ -67,7 +66,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                     });
                     if (errorHeader) {
                         const entityName = <% if (enableTranslation) { %>translateService.instant('global.menu.entities.' + entityKey)<% }else{ %>entityKey<% } %>;
-                        this.addErrorAlert(errorHeader, errorHeader, this.defaultTimeout, { entityName });
+                        this.addErrorAlert(errorHeader, errorHeader, { entityName });
                     } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.fieldErrors) {
                         const fieldErrors = httpErrorResponse.error.fieldErrors;
                         for (i = 0; i < fieldErrors.length; i++) {
@@ -81,15 +80,10 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                                 fieldError.objectName + '.' + convertedField)<% } else { %>convertedField.charAt(0).toUpperCase() +
                                 convertedField.slice(1)<% } %>;
                             this.addErrorAlert(
-                                'Error on field "' + fieldName + '"', 'error.' + fieldError.message, this.defaultTimeout, { fieldName });
+                                'Error on field "' + fieldName + '"', 'error.' + fieldError.message, { fieldName });
                         }
                     } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-                        this.addErrorAlert(
-                            httpErrorResponse.error.message,
-                            httpErrorResponse.error.message,
-                            this.defaultTimeout,
-                            httpErrorResponse.error.params
-                        );
+                        this.addErrorAlert(httpErrorResponse.error.message, httpErrorResponse.error.message, httpErrorResponse.error.params);
                     } else {
                         this.addErrorAlert(httpErrorResponse.error);
                     }
@@ -99,8 +93,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                     if (httpErrorResponse.url && httpErrorResponse.url.includes('/api/authenticate')) {
                         this.addErrorAlert(
                             '<strong>Failed to sign in!</strong> Please check your credentials and try again.',
-                            'login.messages.error.authentication',
-                            this.noTimeout
+                            'login.messages.error.authentication'
                         );
                     }
                     break;
@@ -111,7 +104,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
 
                 case 504:
                     if (httpErrorResponse.url && httpErrorResponse.url.includes('/api/authenticate')) {
-                        this.addErrorAlert('The backend is not started yet', 'error.backend.notStarted', this.noTimeout);
+                        this.addErrorAlert('The backend is not started yet', 'error.backend.notStarted');
                     }
                     break;
 
@@ -139,7 +132,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
         }
     }
 
-    addErrorAlert(message, key?, t = this.defaultTimeout, data?) {
+    addErrorAlert(message, key?, data?) {
         <%_ if (enableTranslation) { _%>
         const info = (key && key !== null) ? key : message;
         <%_ } else { _%>
@@ -152,7 +145,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
             <%_ if (enableTranslation) { _%>
             params: data,
             <%_ } _%>
-            timeout: t,
+            timeout: this.timeout,
             toast: this.alertService.isToast(),
             scoped: true
         };

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -29,7 +29,11 @@ import { Subscription } from 'rxjs';
         <div class="alerts" role="alert">
             <div *ngFor="let alert of alerts" [ngClass]="setClasses(alert)">
                 <ngb-alert *ngIf="alert && alert.type && alert.msg" [type]="alert.type" (close)="alert.close(alerts)">
-                    <span [innerHTML]="alert.msg"></span>
+                    <%_ if (enableTranslation) { _%>
+                    <span jhiTranslate="{{alert.msg}}">{{alert.msg}}</span>
+                    <%_ } else { _%>
+                    <span>{{alert.msg}}</span>
+                    <%_ } _%>
                 </ngb-alert>
             </div>
         </div>`
@@ -158,7 +162,8 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
         <%_ } _%>
 
         if (!alertsMessage.includes(newAlertMessage) || newAlert.timeout !== 0) {
-            this.alerts.push(this.alertService.addAlert(newAlert, this.alerts));
+            // this.alerts.push(this.alertService.addAlert(newAlert, this.alerts));
+            this.alerts.push(newAlert); // WIP for e2e tests
         }
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -29,7 +29,7 @@ import { Subscription } from 'rxjs';
         <div class="alerts" role="alert">
             <div *ngFor="let alert of alerts" [ngClass]="setClasses(alert)">
                 <ngb-alert *ngIf="alert && alert.type && alert.msg" [type]="alert.type" (close)="alert.close(alerts)">
-                    <pre [innerHTML]="alert.msg"></pre>
+                    <span [innerHTML]="alert.msg"></span>
                 </ngb-alert>
             </div>
         </div>`

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -20,7 +20,7 @@ import { Component, OnDestroy } from '@angular/core';
 <%_ if (enableTranslation) { _%>
 import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
-import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
+import { JhiEventManager, JhiAlert, JhiAlertService } from 'ng-jhipster';
 import { Subscription } from 'rxjs';
 
 @Component({
@@ -38,6 +38,8 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
 
     alerts: any[];
     cleanHttpErrorListener: Subscription;
+    defaultTimeout = 5000;
+    noTimeout = 0;
     /* tslint:disable */
     constructor(private alertService: JhiAlertService, private eventManager: JhiEventManager<% if (enableTranslation) { %>, private translateService: TranslateService<% } %>) {
     /* tslint:enable */
@@ -65,7 +67,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                     });
                     if (errorHeader) {
                         const entityName = <% if (enableTranslation) { %>translateService.instant('global.menu.entities.' + entityKey)<% }else{ %>entityKey<% } %>;
-                        this.addErrorAlert(errorHeader, errorHeader, { entityName });
+                        this.addErrorAlert(errorHeader, errorHeader, this.defaultTimeout, { entityName });
                     } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.fieldErrors) {
                         const fieldErrors = httpErrorResponse.error.fieldErrors;
                         for (i = 0; i < fieldErrors.length; i++) {
@@ -79,17 +81,38 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                                 fieldError.objectName + '.' + convertedField)<% } else { %>convertedField.charAt(0).toUpperCase() +
                                 convertedField.slice(1)<% } %>;
                             this.addErrorAlert(
-                                'Error on field "' + fieldName + '"', 'error.' + fieldError.message, { fieldName });
+                                'Error on field "' + fieldName + '"', 'error.' + fieldError.message, this.defaultTimeout, { fieldName });
                         }
                     } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-                        this.addErrorAlert(httpErrorResponse.error.message, httpErrorResponse.error.message, httpErrorResponse.error.params);
+                        this.addErrorAlert(
+                            httpErrorResponse.error.message,
+                            httpErrorResponse.error.message,
+                            this.defaultTimeout,
+                            httpErrorResponse.error.params
+                        );
                     } else {
                         this.addErrorAlert(httpErrorResponse.error);
                     }
                     break;
 
+                case 401:
+                    if (httpErrorResponse.url && httpErrorResponse.url.includes('/api/authenticate')) {
+                        this.addErrorAlert(
+                            '<strong>Failed to sign in!</strong> Please check your credentials and try again.',
+                            'login.messages.error.authentication',
+                            this.noTimeout
+                        );
+                    }
+                    break;
+
                 case 404:
                     this.addErrorAlert('Not found', 'error.url.not.found');
+                    break;
+
+                case 504:
+                    if (httpErrorResponse.url && httpErrorResponse.url.includes('/api/authenticate')) {
+                        this.addErrorAlert('The backend is not started yet', 'error.backend.notStarted', this.noTimeout);
+                    }
                     break;
 
                 default:
@@ -116,35 +139,33 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
         }
     }
 
-    addErrorAlert(message, key?, data?) {
+    addErrorAlert(message, key?, t = this.defaultTimeout, data?) {
         <%_ if (enableTranslation) { _%>
-        key = (key && key !== null) ? key : message;
-        this.alerts.push(
-            this.alertService.addAlert(
-                {
-                    type: 'danger',
-                    msg: key,
-                    params: data,
-                    timeout: 5000,
-                    toast: this.alertService.isToast(),
-                    scoped: true
-                },
-                this.alerts
-            )
-        );
+        const info = (key && key !== null) ? key : message;
         <%_ } else { _%>
-        this.alerts.push(
-            this.alertService.addAlert(
-                {
-                    type: 'danger',
-                    msg: message,
-                    timeout: 5000,
-                    toast: this.alertService.isToast(),
-                    scoped: true
-                },
-                this.alerts
-            )
-        );
+        const info = message;
         <%_ } _%>
+
+        const newAlert: JhiAlert = {
+            type: 'danger',
+            msg: info,
+            <%_ if (enableTranslation) { _%>
+            params: data,
+            <%_ } _%>
+            timeout: t,
+            toast: this.alertService.isToast(),
+            scoped: true
+        };
+
+        const alertsMessage: string[] = this.alerts.map(alert => alert.msg);
+        <%_ if (enableTranslation) { _%>
+        const newAlertMessage = this.translateService.instant(newAlert.msg);
+        <%_ } else { _%>
+        const newAlertMessage = newAlert.msg;
+        <%_ } _%>
+
+        if (!alertsMessage.includes(newAlertMessage) || newAlert.timeout !== 0) {
+            this.alerts.push(this.alertService.addAlert(newAlert, this.alerts));
+        }
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
@@ -24,7 +24,7 @@
 <div class="modal-body">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <jhi-alert-error></jhi-alert-error>
+            <jhi-alert-error [timeout]=0></jhi-alert-error>
         </div>
         <div class="col-md-8">
             <form class="form" role="form" (ngSubmit)="login()">

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
@@ -24,9 +24,7 @@
 <div class="modal-body">
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <div class="alert alert-danger" *ngIf="authenticationError" jhiTranslate="login.messages.error.authentication">
-                <strong>Failed to sign in!</strong> Please check your credentials and try again.
-            </div>
+            <jhi-alert-error></jhi-alert-error>
         </div>
         <div class="col-md-8">
             <form class="form" role="form" (ngSubmit)="login()">

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -29,7 +29,6 @@ import { StateStorageService } from 'app/core/auth/state-storage.service';
     templateUrl: './login.component.html'
 })
 export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewInit {
-    authenticationError: boolean;
     password: string;
     rememberMe: boolean;
     username: string;
@@ -57,7 +56,6 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
             password: null,
             rememberMe: true
         };
-        this.authenticationError = false;
         this.activeModal.dismiss('cancel');
     }
 
@@ -67,7 +65,6 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
             password: this.password,
             rememberMe: this.rememberMe
         }).then(() => {
-            this.authenticationError = false;
             this.activeModal.dismiss('login success');
             if (this.router.url === '/register' || (/^\/activate\//.test(this.router.url)) ||
                 (/^\/reset\//.test(this.router.url))) {
@@ -80,14 +77,12 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
             });
 
             // previousState was set in the authExpiredInterceptor before being redirected to login modal.
-            // since login is succesful, go to stored previousState and clear previousState
+            // since login is successful, go to stored previousState and clear previousState
             const redirect = this.stateStorageService.getUrl();
             if (redirect) {
                 this.stateStorageService.storeUrl(null);
                 this.router.navigate([redirect]);
             }
-        }).catch(() => {
-            this.authenticationError = true;
         });
     }
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -51,18 +51,21 @@ describe('account', () => {
         expect(value1).to.eq(expect1);
     <%_ if (authenticationType !== 'oauth2') { _%>
         signInPage = await navBarPage.getSignInPage();
-        await signInPage.autoSignInUsing('admin', 'foo');
+        await signInPage.autoSignInUsing('admin', 'foo bar');
 
         <%_ if (enableTranslation) { _%>
         const expect2 = 'login.messages.error.authentication';
+        const value2 = await element(by.css('.alert-danger > span')).getAttribute('ng-reflect-jhi-translate'); // trim to 30 characters
+        expect(expect2).to.contain(value2);
         <%_ } else { _%>
-        const expect2 = 'Failed to sign in! Please check your credentials and try again.';
-        <%_ } _%>
-        const value2 = await element(by.css('.alert-danger')).<%- elementGetter %>;
+        const expect2 = '<strong>Failed to sign in!</strong> Please check your credentials and try again.';
+        const value2 = await element(by.css('.alert-danger > span')).<%- elementGetter %>;
         expect(value2).to.eq(expect2);
+        <%_ } _%>
+
     <%_ } else { _%>
         signInPage = await navBarPage.getSignInPage();
-        await signInPage.loginWithOAuth('admin', 'foo');
+        await signInPage.loginWithOAuth('admin', 'foo bar');
 
         // Keycloak
         const alert = element(by.css('.alert-error'));

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
@@ -90,7 +90,6 @@ describe('Component Tests', () => {
                     tick(); // simulate async
 
                     // THEN
-                    expect(comp.authenticationError).toEqual(false);
                     expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('login success');
                     expect(mockEventManager.broadcastSpy).toHaveBeenCalledTimes(1);
                     expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
@@ -122,7 +121,6 @@ describe('Component Tests', () => {
                     tick(); // simulate async
 
                     // THEN
-                    expect(comp.authenticationError).toEqual(false);
                     expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('login success');
                     expect(mockEventManager.broadcastSpy).toHaveBeenCalledTimes(1);
                     expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
@@ -153,7 +151,6 @@ describe('Component Tests', () => {
             comp.cancel();
 
             // THEN
-            expect(comp.authenticationError).toEqual(false);
             expect(comp.credentials).toEqual(expected);
             expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('cancel');
         });

--- a/generators/languages/templates/src/main/webapp/i18n/en/error.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/error.json
@@ -8,6 +8,9 @@
             "500": "Internal server error."
         },
         "concurrencyFailure": "Another user modified this data at the same time as you. Your changes were rejected.",
-        "validation": "Validation error on the server."
+        "validation": "Validation error on the server.",
+        "backend": {
+            "notStarted": "The backend is not started yet"
+        }
     }
 }

--- a/generators/languages/templates/src/main/webapp/i18n/fr/error.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/error.json
@@ -8,6 +8,9 @@
             "500": "Erreur interne du serveur."
         },
         "concurrencyFailure": "Un autre utilisateur a modifié ces données en même temps que vous. Vos changements n'ont pas été sauvegardés.",
-        "validation": "Erreur de validation côté serveur."
+        "validation": "Erreur de validation côté serveur.",
+        "backend": {
+            "notStarted": "Le serveur n'est pas démarré"
+        }
     }
 }


### PR DESCRIPTION
Fix #8565 

My solution relies on HTTP code status. I'm not sure if this approach is really good.

Left TODO
-   [x] Improve timeout customization for jhi-alert-error component (@Input)
-   [ ] Improve multi lines customization for jhi-alert-error component (@Input)
-   [ ] Add translations for all languages
-   [ ] Fix e2e tests

Screenshot (only `npm|yarn start` is running)
![not-started-crop](https://user-images.githubusercontent.com/9569081/47102068-01827e00-d23c-11e8-9df7-0723a66f150b.png)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
