### PR TITLE
only import OAuth2 user-management files for OAuth2

### DIFF
--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -393,7 +393,7 @@ const files = {
             templates: ['spec/app/shared/reducers/locale.spec.ts']
         },
         {
-            condition: generator => generator.skipUserManagement,
+            condition: generator => generator.skipUserManagement && generator.authenticationType === 'oauth2',
             path: TEST_SRC_DIR,
             templates: ['spec/app/shared/reducers/user-management.spec.ts']
         },

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/index.ts.ejs
@@ -28,7 +28,7 @@ import applicationProfile, { ApplicationProfileState } from './application-profi
 import administration, { AdministrationState } from 'app/modules/administration/administration.reducer';
 <%_ if (!skipUserManagement) { _%>
 import userManagement, { UserManagementState } from 'app/modules/administration/user-management/user-management.reducer';
-<%_ } else { _%>
+<%_ } else if (authenticationType === 'oauth2') { _%>
 import userManagement, { UserManagementState } from './user-management';
 <%_ } _%>
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -50,7 +50,9 @@ export interface IRootState {
   <%_ } _%>
   readonly applicationProfile: ApplicationProfileState;
   readonly administration: AdministrationState;
+  <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
   readonly userManagement: UserManagementState;
+  <%_ } _%>
   <%_ if (authenticationType !== 'oauth2') { _%>
   readonly register: RegisterState;
   readonly activate: ActivateState;
@@ -72,7 +74,9 @@ const rootReducer = combineReducers<IRootState>({
   <%_ } _%>
   applicationProfile,
   administration,
+  <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
   userManagement,
+  <%_ } _%>
   <%_ if (authenticationType !== 'oauth2') { _%>
   register,
   activate,


### PR DESCRIPTION
fixes non-OAuth2 React apps with `skipUserManagement = true`

`skipUserManagement` is set to true for OAuth2 apps [here](https://github.com/jhipster/generator-jhipster/blob/50df54efe80d1127c6ebd816e2de86f1379150ec/generators/generator-base.js#L2856-L2858), using just an `else` breaks it for other auth types

Fix jhipster/jhipster-core#268
Fix #8549

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
