### PR TITLE
All generator end() methods not getting called when project is not a git repo

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -466,6 +466,7 @@ module.exports = class extends BaseGenerator {
                             this.warning(
                                 'The generated application could not be committed to Git, as a Git repository could not be initialized.'
                             );
+                            done();
                         }
                     });
                 }


### PR DESCRIPTION
Need to call done() when the project is not a git repo otherwise other generator end() methods won't be called.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
