### PR TITLE
React: fix delete e2e tests

### DIFF
--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 /* tslint:disable no-unused-expression */
-import { browser<% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>, protractor<% } %> } from 'protractor';
+import { browser, element, by<% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>, protractor<% } %> } from 'protractor';
 
 import NavBarPage from './../../<%= entityParentPathAddition %>page-objects/navbar-page';
 import SignInPage from './../../<%= entityParentPathAddition %>page-objects/signin-page';
@@ -159,6 +159,9 @@ describe('<%= entityClass %> e2e test', () => {
         await <%= entityInstance %>ComponentsPage.waitUntilLoaded();
         const nbButtonsBeforeDelete = await <%= entityInstance %>ComponentsPage.countDeleteButtons();
         await <%= entityInstance %>ComponentsPage.clickOnLastDeleteButton();
+
+        const deleteModal = element(by.className('modal'));
+        await waitUntilDisplayed(deleteModal);
 
         <%= entityInstance %>DeleteDialog = new <%= entityClass %>DeleteDialog();
         expect(await <%= entityInstance %>DeleteDialog.getDialogTitle().getAttribute('id')).to.match(/<%= i18nKeyPrefix %>.delete.question/);


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/8379

Here a full builds with React+Protractor, using my code:
https://travis-ci.org/hipster-labs/jhipster-travis-build/builds/444291196

_____


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
