### PR TITLE
CI: reduce logs during e2e [ci skip] ***NO_CI***

### DIFF
--- a/test-integration/scripts/24-tests-e2e.sh
+++ b/test-integration/scripts/24-tests-e2e.sh
@@ -82,6 +82,7 @@ if [ "$JHI_RUN_APP" == 1 ]; then
         --spring.profiles.active="$JHI_PROFILE" \
         --logging.level.ROOT=OFF \
         --logging.level.org.zalando=OFF \
+        --logging.level.org.springframework.web=ERROR \
         --logging.level.io.github.jhipster=OFF \
         --logging.level.io.github.jhipster.sample=OFF \
         --logging.level.io.github.jhipster.travis=OFF &


### PR DESCRIPTION
Avoid displaying: WARN 8551 --- [ XNIO-2 task-11] .m.m.a.ExceptionHandlerExceptionResolver : Resolved [org.springframework.security.authentication.InsufficientAuthenticationException: Full authentication is required to access this resource]

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
