### PR TITLE
remove not required check for executing npm/yarn_install tasks

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -47,7 +47,7 @@ before_script:
         <%_ if (clientPackageManager === 'yarn') { _%>
     - ./gradlew yarn_install -PnodeInstall --no-daemon
         <%_ } else if (clientPackageManager === 'npm') { _%>
-    - ./gradlew npmInstall -PnodeInstall --no-daemon
+    - ./gradlew npm_install -PnodeInstall --no-daemon
         <%_ } _%>
     <%_ } _%>
 

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -85,10 +85,4 @@ processResources {
 processResources.dependsOn webpackBuildDev
 copyIntoStatic.dependsOn processResources
 bootJar.dependsOn copyIntoStatic
-
-<%= clientPackageManager %>_install.onlyIf { shouldWebpackRun() == true }
-
-def shouldWebpackRun() {
-    project.hasProperty('webpack')
-}
 <%_ } _%>


### PR DESCRIPTION
we don't need the additional check it is basically useless.

closes #8626

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
