### PR TITLE
Add 'unique = true' to the @Column when needed

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -165,7 +165,6 @@ public class <%= entityClass %> implements Serializable {
         if (fieldValidateRules.includes('unique')) {
             unique = true;
         }
-    }_%>
     <%- include ../common/field_validators -%>
     <%_ } _%>
     <%_ if (typeof fields[idx].javadoc != 'undefined') { _%>

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -159,14 +159,13 @@ public class <%= entityClass %> implements Serializable {
     const fieldNameUnderscored = fields[idx].fieldNameUnderscored;
     const fieldNameAsDatabaseColumn = fields[idx].fieldNameAsDatabaseColumn;
     if (fieldValidate === true) {
-        if (fieldValidate === true) {
-            if (fieldValidateRules.includes('required')) {
-                required = true;
-            }
-            if (fieldValidateRules.includes('unique')) {
-                unique = true;
-            }
-        }_%>
+        if (fieldValidateRules.includes('required')) {
+            required = true;
+        }
+        if (fieldValidateRules.includes('unique')) {
+            unique = true;
+        }
+    }_%>
     <%- include ../common/field_validators -%>
     <%_ } _%>
     <%_ if (typeof fields[idx].javadoc != 'undefined') { _%>

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -164,7 +164,7 @@ public class <%= entityClass %> implements Serializable {
         }
         if (fieldValidateRules.includes('unique')) {
             unique = true;
-        }
+        } _%>
     <%- include ../common/field_validators -%>
     <%_ } _%>
     <%_ if (typeof fields[idx].javadoc != 'undefined') { _%>

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -149,6 +149,7 @@ public class <%= entityClass %> implements Serializable {
 <%- formatAsFieldJavadoc(fields[idx].javadoc) %>
     <%_ }
     let required = false;
+    let unique = false;
     const fieldValidate = fields[idx].fieldValidate;
     const fieldValidateRules = fields[idx].fieldValidateRules;
     const fieldValidateRulesMaxlength = fields[idx].fieldValidateRulesMaxlength;
@@ -158,9 +159,14 @@ public class <%= entityClass %> implements Serializable {
     const fieldNameUnderscored = fields[idx].fieldNameUnderscored;
     const fieldNameAsDatabaseColumn = fields[idx].fieldNameAsDatabaseColumn;
     if (fieldValidate === true) {
-        if (fieldValidate === true && fieldValidateRules.includes('required')) {
-            required = true;
-        } _%>
+        if (fieldValidate === true) {
+            if (fieldValidateRules.includes('required')) {
+                required = true;
+            }
+            if (fieldValidateRules.includes('unique')) {
+                unique = true;
+            }
+        }_%>
     <%- include ../common/field_validators -%>
     <%_ } _%>
     <%_ if (typeof fields[idx].javadoc != 'undefined') { _%>
@@ -174,11 +180,11 @@ public class <%= entityClass %> implements Serializable {
     @Lob
         <%_ }
         if (['Instant', 'ZonedDateTime', 'LocalDate'].includes(fieldType)) { _%>
-    @Column(name = "<%-fieldNameAsDatabaseColumn %>"<% if (required) { %>, nullable = false<% } %>)
+    @Column(name = "<%-fieldNameAsDatabaseColumn %>"<% if (required) { %>, nullable = false<% } %><% if (unique) { %>, unique = true<% } %>)
         <%_ } else if (fieldType === 'BigDecimal') { _%>
-    @Column(name = "<%-fieldNameAsDatabaseColumn %>", precision = 10, scale = 2<% if (required) { %>, nullable = false<% } %>)
+    @Column(name = "<%-fieldNameAsDatabaseColumn %>", precision = 10, scale = 2<% if (required) { %>, nullable = false<% } %><% if (unique) { %>, unique = true<% } %>)
         <%_ } else { _%>
-    @Column(name = "<%-fieldNameAsDatabaseColumn %>"<% if (fieldValidate === true) { %><% if (fieldValidateRules.includes('maxlength')) { %>, length = <%= fieldValidateRulesMaxlength %><% } %><% if (required) { %>, nullable = false<% } %><% } %>)
+    @Column(name = "<%-fieldNameAsDatabaseColumn %>"<% if (fieldValidate === true) { %><% if (fieldValidateRules.includes('maxlength')) { %>, length = <%= fieldValidateRulesMaxlength %><% } %><% if (required) { %>, nullable = false<% } %><% if (unique) { %>, unique = true<% } %><% } %>)
         <%_ }
     } _%>
     <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>


### PR DESCRIPTION
Add 'unique = true' to the @Column if the field validate rule is "unique"

Before:
`@Column(name = "just_a_test", nullable = false, unique = true)`

After:
`@Column(name = "just_a_test", nullable = false)`

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
