### PR TITLE
Make the Spring services extendable

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/common/inject_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/inject_template.ejs
@@ -39,7 +39,7 @@
     }
 _%>
 
-    <%= beans.map(bean => `private final ${bean.class} ${bean.instance};`).join('\n\n    ') %>
+    <%= beans.map(bean => `protected final ${bean.class} ${bean.instance};`).join('\n\n    ') %>
 
     public <%= constructorName %>(<%= beans.map(bean => `${bean.class} ${bean.instance}`).join(', ') %>) {
         <%= beans.map(bean => `this.${bean.instance} = ${bean.instance};`).join('\n        ') %>


### PR DESCRIPTION
Make the Spring services extendable by changing the beans from `private` to `protected`, so the extending service will be able to use the extend service beans

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
