### PR TITLE
Add a parent class for generator extendable through a blueprint

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -19,7 +19,7 @@
 /* eslint-disable consistent-return */
 const chalk = require('chalk');
 const _ = require('lodash');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const prompts = require('./prompts');
 const writeAngularFiles = require('./files-angular').writeFiles;
 const writeReactFiles = require('./files-react').writeFiles;
@@ -27,9 +27,7 @@ const packagejs = require('../../package.json');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
 
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
@@ -65,14 +63,12 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.options.blueprint || this.configOptions.blueprint || this.config.get('blueprint');
         // use global variable since getters dont have access to instance property
         if (!opts.fromBlueprint) {
-            useBlueprint = this.composeBlueprint(blueprint, 'client', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'client', {
                 'skip-install': this.options['skip-install'],
                 'from-cli': this.options['from-cli'],
                 configOptions: this.configOptions,
                 force: this.options.force
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -180,8 +176,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get initializing() {
-        if (useBlueprint) return;
-        return this._initializing();
+        return super.initializing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -200,8 +195,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
+        return super.prompting();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -266,8 +260,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get configuring() {
-        if (useBlueprint) return;
-        return this._configuring();
+        return super.configuring();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -352,8 +345,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get default() {
-        if (useBlueprint) return;
-        return this._default();
+        return super.default();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -362,17 +354,16 @@ module.exports = class extends BaseGenerator {
             write() {
                 switch (this.clientFramework) {
                     case 'react':
-                        return writeReactFiles.call(this, useBlueprint);
+                        return writeReactFiles.call(this, this.useBlueprint);
                     default:
-                        return writeAngularFiles.call(this, useBlueprint);
+                        return writeAngularFiles.call(this, this.useBlueprint);
                 }
             }
         };
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -402,8 +393,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get install() {
-        if (useBlueprint) return;
-        return this._install();
+        return super.install();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -423,7 +413,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get end() {
-        if (useBlueprint) return;
-        return this._end();
+        return super.end();
     }
 };

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -17,14 +17,12 @@
  * limitations under the License.
  */
 /* eslint-disable consistent-return */
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const writeFiles = require('./files').writeFiles;
 const packagejs = require('../../package.json');
 const constants = require('../generator-constants');
 
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
@@ -40,13 +38,11 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.options.blueprint || this.configOptions.blueprint || this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'common', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'common', {
                 'from-cli': this.options['from-cli'],
                 configOptions: this.configOptions,
                 force: this.options.force
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -127,18 +123,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get initializing() {
-        if (useBlueprint) return;
-        return this._initializing();
-    }
-
-    // Public API method used by the getter and also by Blueprints
-    _prompting() {
-        return {};
-    }
-
-    get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
+        return super.initializing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -157,8 +142,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get configuring() {
-        if (useBlueprint) return;
-        return this._configuring();
+        return super.configuring();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -179,8 +163,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get default() {
-        if (useBlueprint) return;
-        return this._default();
+        return super.default();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -189,26 +172,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
-    }
-
-    _install() {
-        return {};
-    }
-
-    get install() {
-        if (useBlueprint) return;
-        return this._install();
-    }
-
-    // Public API method used by the getter and also by Blueprints
-    _end() {
-        return {};
-    }
-
-    get end() {
-        if (useBlueprint) return;
-        return this._end();
+        return super.writing();
     }
 };

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -20,26 +20,22 @@
 const chalk = require('chalk');
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, this.options.context);
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'entity-client', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'entity-client', {
                 context: opts.context,
                 force: opts.force,
                 debug: opts.context.isDebugEnabled,
                 'skip-install': opts.context.options['skip-install'],
                 'from-cli': opts.context.options['from-cli']
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -49,8 +45,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -66,7 +61,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get end() {
-        if (useBlueprint) return;
-        return this._end();
+        return super.end();
     }
 };

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -19,27 +19,22 @@
 /* eslint-disable consistent-return */
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
-/* constants used throughout */
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, this.options.context);
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'entity-i18n', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'entity-i18n', {
                 context: opts.context,
                 force: opts.force,
                 debug: opts.context.isDebugEnabled,
                 'skip-install': opts.context.options['skip-install'],
                 'from-cli': opts.context.options['from-cli']
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -49,7 +44,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 };

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -19,12 +19,9 @@
 /* eslint-disable consistent-return */
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
-/* constants used throughout */
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, opts.context);
@@ -34,14 +31,12 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'entity-server', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'entity-server', {
                 context: opts.context,
                 force: opts.force,
                 debug: opts.context.isDebugEnabled,
                 'from-cli': opts.context.options['from-cli']
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -51,7 +46,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 };

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -23,15 +23,14 @@ const shelljs = require('shelljs');
 const pluralize = require('pluralize');
 const jhiCore = require('jhipster-core');
 const prompts = require('./prompts');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
 
 /* constants used throughout */
 const SUPPORTED_VALIDATION_RULES = constants.SUPPORTED_VALIDATION_RULES;
-let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
@@ -125,14 +124,12 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'entity', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'entity', {
                 'skip-install': this.options['skip-install'],
                 'from-cli': this.options['from-cli'],
                 force: this.options.force,
                 arguments: [this.context.name]
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -317,8 +314,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get initializing() {
-        if (useBlueprint) return;
-        return this._initializing();
+        return super.initializing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -341,8 +337,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
+        return super.prompting();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -1036,8 +1031,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get configuring() {
-        if (useBlueprint) return;
-        return this._configuring();
+        return super.configuring();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -1089,8 +1083,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -1128,7 +1121,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get install() {
-        if (useBlueprint) return;
-        return this._install();
+        return super.install();
     }
 };

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2013-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable consistent-return */
+const BaseGenerator = require('./generator-base');
+
+/**
+ * This is the base class for a generator that can be extended through a blueprint.
+ *
+ * The method signatures in public API should not be changed without a major version change
+ */
+module.exports = class extends BaseGenerator {
+    constructor(args, opts) {
+        super(args, opts);
+        this.useBlueprint = false;
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _initializing() {
+        return {};
+    }
+
+    initializing() {
+        if (this.useBlueprint) return;
+        return this._initializing();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _prompting() {
+        return {};
+    }
+
+    prompting() {
+        if (this.useBlueprint) return;
+        return this._prompting();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _configuring() {
+        return {};
+    }
+
+    configuring() {
+        if (this.useBlueprint) return;
+        return this._configuring();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _default() {
+        return {};
+    }
+
+    default() {
+        if (this.useBlueprint) return;
+        return this._default();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _writing() {
+        return {};
+    }
+
+    writing() {
+        if (this.useBlueprint) return;
+        return this._writing();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _install() {
+        return {};
+    }
+
+    install() {
+        if (this.useBlueprint) return;
+        return this._install();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _end() {
+        return {};
+    }
+
+    end() {
+        if (this.useBlueprint) return;
+        return this._end();
+    }
+};

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -22,15 +22,13 @@ const _ = require('lodash');
 const crypto = require('crypto');
 const os = require('os');
 const prompts = require('./prompts');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const writeFiles = require('./files').writeFiles;
 const packagejs = require('../../package.json');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
 
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
@@ -60,14 +58,12 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.options.blueprint || this.configOptions.blueprint || this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'server', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'server', {
                 'client-hook': !this.skipClient,
                 'from-cli': this.options['from-cli'],
                 configOptions: this.configOptions,
                 force: this.options.force
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -287,8 +283,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get initializing() {
-        if (useBlueprint) return;
-        return this._initializing();
+        return super.initializing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -328,8 +323,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
+        return super.prompting();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -407,8 +401,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get configuring() {
-        if (useBlueprint) return;
-        return this._configuring();
+        return super.configuring();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -445,8 +438,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get default() {
-        if (useBlueprint) return;
-        return this._default();
+        return super.default();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -455,8 +447,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 
     _install() {
@@ -478,8 +469,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get install() {
-        if (useBlueprint) return;
-        return this._install();
+        return super.install();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -510,7 +500,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get end() {
-        if (useBlueprint) return;
-        return this._end();
+        return super.end();
     }
 };

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -19,7 +19,7 @@
 /* eslint-disable consistent-return */
 const _ = require('lodash');
 const chalk = require('chalk');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const constants = require('../generator-constants');
 const prompts = require('./prompts');
 const statistics = require('../statistics');
@@ -27,9 +27,7 @@ const statistics = require('../statistics');
 const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
 const SERVER_TEST_SRC_DIR = constants.SERVER_TEST_SRC_DIR;
 
-let useBlueprint;
-
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         this.argument('name', { type: String, required: true });
@@ -50,14 +48,12 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'spring-controller', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'spring-controller', {
                 'from-cli': this.options['from-cli'],
                 force: this.options.force,
                 arguments: [this.name],
                 default: this.options.default
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -91,8 +87,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get initializing() {
-        if (useBlueprint) return;
-        return this._initializing();
+        return super.initializing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -103,8 +98,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
+        return super.prompting();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -117,8 +111,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get default() {
-        if (useBlueprint) return;
-        return this._default();
+        return super.default();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -180,7 +173,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 };

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -19,14 +19,13 @@
 /* eslint-disable consistent-return */
 const _ = require('lodash');
 const chalk = require('chalk');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
 
 const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
 
-let useBlueprint;
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         this.argument('name', { type: String, required: true });
@@ -47,14 +46,12 @@ module.exports = class extends BaseGenerator {
         const blueprint = this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
-            useBlueprint = this.composeBlueprint(blueprint, 'spring-service', {
+            this.useBlueprint = this.composeBlueprint(blueprint, 'spring-service', {
                 'from-cli': this.options['from-cli'],
                 force: this.options.force,
                 arguments: [this.name],
                 default: this.options.default
             });
-        } else {
-            useBlueprint = false;
         }
     }
 
@@ -83,8 +80,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get initializing() {
-        if (useBlueprint) return;
-        return this._initializing();
+        return super.initializing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -113,8 +109,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
+        return super.prompting();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -127,8 +122,7 @@ module.exports = class extends BaseGenerator {
     }
 
     get default() {
-        if (useBlueprint) return;
-        return this._default();
+        return super.default();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -156,7 +150,6 @@ module.exports = class extends BaseGenerator {
     }
 
     get writing() {
-        if (useBlueprint) return;
-        return this._writing();
+        return super.writing();
     }
 };

--- a/test/blueprint/entity-blueprint.spec.js
+++ b/test/blueprint/entity-blueprint.spec.js
@@ -38,13 +38,15 @@ const mockBlueprintSubGen = class extends EntityGenerator {
     }
 
     get prompting() {
-        // Here we are not overriding this phase and hence its being handled by JHipster
         return super._prompting();
     }
 
     get configuring() {
-        // Here we are not overriding this phase and hence its being handled by JHipster
         return super._configuring();
+    }
+
+    get default() {
+        return super._default();
     }
 
     get writing() {
@@ -52,8 +54,11 @@ const mockBlueprintSubGen = class extends EntityGenerator {
     }
 
     get install() {
-        // Here we are not overriding this phase and hence its being handled by JHipster
         return super._install();
+    }
+
+    get end() {
+        return super._end();
     }
 };
 

--- a/test/blueprint/server-blueprint.spec.js
+++ b/test/blueprint/server-blueprint.spec.js
@@ -42,6 +42,10 @@ const mockBlueprintSubGen = class extends ServerGenerator {
         return { ...phaseFromJHipster, ...customPhaseSteps };
     }
 
+    get install() {
+        return super._install();
+    }
+
     get end() {
         return super._end();
     }


### PR DESCRIPTION
This parent class holds the public API that can be used for developers of blueprint.
See [this discussion](https://github.com/jhipster/generator-jhipster/pull/8623#discussion_r226876596) for the rationale.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
