### PR TITLE
Upgrade yarn and fix test:watch script in angular

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -180,7 +180,7 @@
     "serve": "<%= clientPackageManager %> run start",
     "build": "<%= clientPackageManager %> run webpack:prod",
     "test": "<%= clientPackageManager %> run lint && jest --coverage --logHeapUsage -w=2 --config src/test/javascript/jest.conf.js",
-    "test:watch": "<%= clientPackageManager %> test <%= optionsForwarder %>--watch --clearCache",
+    "test:watch": "<%= clientPackageManager %> run test <%= optionsForwarder %>--watch",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server <%= optionsForwarder %>--config webpack/webpack.dev.js --inline --hot --port=9060 --watch-content-base --env.stats=minimal",
     "webpack:dev-verbose": "<%= clientPackageManager %> run webpack-dev-server <%= optionsForwarder %>--config webpack/webpack.dev.js --inline --hot --port=9060 --watch-content-base --profile --progress --env.stats=normal",
     "webpack:build:main": "<%= clientPackageManager %> run webpack <%= optionsForwarder %>--config webpack/webpack.dev.js --env.stats=minimal",

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -59,7 +59,7 @@ const SCALA_VERSION = '2.12.6';
 
 // version of Node, Yarn, NPM
 const NODE_VERSION = '8.12.0';
-const YARN_VERSION = '1.10.1';
+const YARN_VERSION = '1.12.1';
 const NPM_VERSION = '6.4.1';
 
 // all constants used throughout all generators


### PR DESCRIPTION


- Upgrade yarn to `v1.12.1`
- Fix `test:watch` script in angular. If we pass `--clearCache` option to Jest, then, that would clear the cache, but, wouldn't execute the tests. I also checked equivalent script in react and don't see usage of `--clearCache`. If we have any specific reason to support this, then, we should support it as separate script. I didn't use `&&` to execute test script twice (one with `--clearCache` and other with `--watch`) as that would also execute `lint` script twice (again not sure why lint is executed along with test script)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
