### PR TITLE
SB2 branch: fix CI

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -26,9 +26,9 @@ jobs:
     JHI_RUN_APP: 1
     JHI_PROTRACTOR: 0
     JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
-    JHI_LIB_BRANCH: release
+    JHI_LIB_BRANCH: spring-boot_2.1.0
     JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
-    JHI_GEN_BRANCH: release
+    JHI_GEN_BRANCH: spring-boot_2.1.0
     SPRING_OUTPUT_ANSI_ENABLED: NEVER
     SPRING_JPA_SHOW_SQL: false
     JHI_DISABLE_WEBPACK_LOGS: true

--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -29,7 +29,7 @@ else
     fi
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
-    "$JHI_SCRIPTS"/13-replace-version-generated-project.sh
+    travis/scripts/00-replace-version-jhipster.sh
 
     ./mvnw clean install -Dgpg.skip=true
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-framework/


### PR DESCRIPTION
I fixed the CI for the spring boot 2 branch, and customized the Azure too.
But there are a lot of failures dependencies.
Here some logs:

```
[ERROR] /home/travis/app/src/main/java/io/github/jhipster/travis/config/MetricsConfiguration.java:[5,28] cannot find symbol
[ERROR]   symbol:   class JmxReporter
[ERROR]   location: package com.codahale.metrics
[ERROR] /home/travis/app/src/main/java/io/github/jhipster/travis/config/MetricsConfiguration.java:[6,28] cannot find symbol
[ERROR]   symbol:   class JvmAttributeGaugeSet
[ERROR]   location: package com.codahale.metrics
```

```
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'dependencies.dependency.version' for org.hibernate:hibernate-infinispan:jar is missing. @ line 182, column 21
 @ 
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]   
[ERROR]   The project io.github.jhipster.travis:travis-oauth-2-sass-infinispan:0.0.1-SNAPSHOT (/home/travis/app/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.version' for org.hibernate:hibernate-infinispan:jar is missing. @ line 182, column 21
[ERROR] 
```

Thanks for your hard work @DanielFran !
