### PR TITLE
Blueprint base api : parent class for generator extendable through a blueprint

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -19,7 +19,7 @@
 /* eslint-disable consistent-return */
 const chalk = require('chalk');
 const _ = require('lodash');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const prompts = require('./prompts');
 const writeAngularFiles = require('./files-angular').writeFiles;
 const writeReactFiles = require('./files-react').writeFiles;
@@ -29,7 +29,7 @@ const statistics = require('../statistics');
 
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -17,14 +17,14 @@
  * limitations under the License.
  */
 /* eslint-disable consistent-return */
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const writeFiles = require('./files').writeFiles;
 const packagejs = require('../../package.json');
 const constants = require('../generator-constants');
 
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
@@ -132,16 +132,6 @@ module.exports = class extends BaseGenerator {
     }
 
     // Public API method used by the getter and also by Blueprints
-    _prompting() {
-        return {};
-    }
-
-    get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
-    }
-
-    // Public API method used by the getter and also by Blueprints
     _configuring() {
         return {
             setSharedConfigOptions() {
@@ -191,24 +181,5 @@ module.exports = class extends BaseGenerator {
     get writing() {
         if (useBlueprint) return;
         return this._writing();
-    }
-
-    _install() {
-        return {};
-    }
-
-    get install() {
-        if (useBlueprint) return;
-        return this._install();
-    }
-
-    // Public API method used by the getter and also by Blueprints
-    _end() {
-        return {};
-    }
-
-    get end() {
-        if (useBlueprint) return;
-        return this._end();
     }
 };

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -20,11 +20,11 @@
 const chalk = require('chalk');
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, this.options.context);

--- a/generators/entity-i18n/files.js
+++ b/generators/entity-i18n/files.js
@@ -38,7 +38,7 @@ function writeFiles() {
                     if (!this.skipClient && this.enableTranslation) {
                         const languages = this.languages || this.getAllInstalledLanguages();
                         languages.forEach(language => {
-                            this.copyEnumI18n(language, enumInfo);
+                            this.copyEnumI18n(language, enumInfo, this.fetchFromInstalledJHipster('entity-i18n/templates'));
                         });
                     }
                 }
@@ -52,7 +52,7 @@ function writeFiles() {
             if (this.enableTranslation) {
                 const languages = this.languages || this.getAllInstalledLanguages();
                 languages.forEach(language => {
-                    this.copyI18n(language);
+                    this.copyI18n(language, this.fetchFromInstalledJHipster('entity-i18n/templates'));
                 });
             }
         }

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -19,12 +19,12 @@
 /* eslint-disable consistent-return */
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
 /* constants used throughout */
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, this.options.context);

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -19,12 +19,12 @@
 /* eslint-disable consistent-return */
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 
 /* constants used throughout */
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, opts.context);

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -23,7 +23,7 @@ const shelljs = require('shelljs');
 const pluralize = require('pluralize');
 const jhiCore = require('jhipster-core');
 const prompts = require('./prompts');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
 
@@ -31,7 +31,7 @@ const statistics = require('../statistics');
 const SUPPORTED_VALIDATION_RULES = constants.SUPPORTED_VALIDATION_RULES;
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -1,0 +1,62 @@
+/**
+ * Copyright 2013-2018 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable consistent-return */
+const BaseGenerator = require('./generator-base');
+
+/**
+ * This is the base class for a generator that can be extended through a blueprint.
+ *
+ * The method signatures in public API should not be changed without a major version change
+ */
+module.exports = class extends BaseGenerator {
+    // Public API method used by the getter and also by Blueprints
+    _initializing() {
+        return {};
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _prompting() {
+        return {};
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _configuring() {
+        return {};
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _default() {
+        return {};
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _writing() {
+        return {};
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _install() {
+        return {};
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _end() {
+        return {};
+    }
+};

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -22,7 +22,7 @@ const _ = require('lodash');
 const crypto = require('crypto');
 const os = require('os');
 const prompts = require('./prompts');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const writeFiles = require('./files').writeFiles;
 const packagejs = require('../../package.json');
 const constants = require('../generator-constants');
@@ -30,7 +30,7 @@ const statistics = require('../statistics');
 
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -19,7 +19,7 @@
 /* eslint-disable consistent-return */
 const _ = require('lodash');
 const chalk = require('chalk');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const constants = require('../generator-constants');
 const prompts = require('./prompts');
 const statistics = require('../statistics');
@@ -29,7 +29,7 @@ const SERVER_TEST_SRC_DIR = constants.SERVER_TEST_SRC_DIR;
 
 let useBlueprint;
 
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         this.argument('name', { type: String, required: true });

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -19,14 +19,14 @@
 /* eslint-disable consistent-return */
 const _ = require('lodash');
 const chalk = require('chalk');
-const BaseGenerator = require('../generator-base');
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
 
 const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
 
 let useBlueprint;
-module.exports = class extends BaseGenerator {
+module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         this.argument('name', { type: String, required: true });

--- a/test/blueprint/client-blueprint.spec.js
+++ b/test/blueprint/client-blueprint.spec.js
@@ -90,4 +90,31 @@ describe('JHipster client generator with blueprint', () => {
             });
         });
     });
+
+    describe('generate client with dummy blueprint overriding everything', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/client'))
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'myblueprint',
+                    skipChecks: true
+                })
+                .withGenerators([[helpers.createDummyGenerator(), 'jhipster-myblueprint:client']])
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    useSass: false,
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr']
+                })
+                .on('end', done);
+        });
+
+        it("doesn't create any expected files from jhipster client generator", () => {
+            assert.noFile(expectedFiles.client);
+        });
+    });
 });

--- a/test/blueprint/common-blueprint.spec.js
+++ b/test/blueprint/common-blueprint.spec.js
@@ -81,4 +81,26 @@ describe('JHipster common generator with blueprint', () => {
             });
         });
     });
+
+    describe('generate common with dummy blueprint overriding everything', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/common'))
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'myblueprint',
+                    skipChecks: true
+                })
+                .withGenerators([[helpers.createDummyGenerator(), 'jhipster-myblueprint:common']])
+                .withPrompts({
+                    baseName: 'jhipster'
+                })
+                .on('end', done);
+        });
+
+        it("doesn't create any expected files from jhipster common generator", () => {
+            assert.noFile(expectedFiles.common);
+        });
+    });
 });

--- a/test/blueprint/entity-blueprint.spec.js
+++ b/test/blueprint/entity-blueprint.spec.js
@@ -3,7 +3,11 @@ const fse = require('fs-extra');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const expectedFiles = require('../utils/expected-files').entity;
+const createBlueprintMockForSubgen = require('../utils/utils').createBlueprintMockForSubgen;
 const EntityGenerator = require('../../generators/entity');
+const EntityClientGenerator = require('../../generators/entity-client');
+const EntityServerGenerator = require('../../generators/entity-server');
+const EntityI18nGenerator = require('../../generators/entity-i18n');
 const constants = require('../../generators/generator-constants');
 
 const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
@@ -79,7 +83,12 @@ describe('JHipster entity generator with blueprint', () => {
                         blueprint: blueprintName,
                         skipChecks: true
                     })
-                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:entity']])
+                    .withGenerators([
+                        [mockBlueprintSubGen, 'jhipster-myblueprint:entity'],
+                        [createBlueprintMockForSubgen(EntityClientGenerator), 'jhipster-myblueprint:entity-client'],
+                        [createBlueprintMockForSubgen(EntityServerGenerator), 'jhipster-myblueprint:entity-server'],
+                        [createBlueprintMockForSubgen(EntityI18nGenerator), 'jhipster-myblueprint:entity-i18n']
+                    ])
                     .withPrompts({
                         fieldAdd: false,
                         relationshipAdd: false,

--- a/test/blueprint/entity-blueprint.spec.js
+++ b/test/blueprint/entity-blueprint.spec.js
@@ -37,13 +37,15 @@ const mockBlueprintSubGen = class extends EntityGenerator {
     }
 
     get prompting() {
-        // Here we are not overriding this phase and hence its being handled by JHipster
         return super._prompting();
     }
 
     get configuring() {
-        // Here we are not overriding this phase and hence its being handled by JHipster
         return super._configuring();
+    }
+
+    get default() {
+        return super._default();
     }
 
     get writing() {
@@ -51,8 +53,11 @@ const mockBlueprintSubGen = class extends EntityGenerator {
     }
 
     get install() {
-        // Here we are not overriding this phase and hence its being handled by JHipster
         return super._install();
+    }
+
+    get end() {
+        return super._end();
     }
 };
 

--- a/test/blueprint/entity-blueprint.spec.js
+++ b/test/blueprint/entity-blueprint.spec.js
@@ -27,8 +27,7 @@ const mockBlueprintSubGen = class extends EntityGenerator {
         const phaseFromJHipster = super._initializing();
         const customPhaseSteps = {
             changeProperty() {
-                // TODO check why this doesnt work
-                // this.context.name = 'newBaseName';
+                this.context.angularAppName = 'awesomeAngularAppName';
             }
         };
         return {
@@ -66,9 +65,9 @@ describe('JHipster entity generator with blueprint', () => {
                 helpers
                     .run(path.join(__dirname, '../../generators/entity'))
                     .inTmpDir(dir => {
-                        fse.copySync(path.join(__dirname, '../../test/templates/default-ng2'), dir);
+                        fse.copySync(path.join(__dirname, '../../test/templates/ngx-blueprint'), dir);
                     })
-                    .withArguments('foo')
+                    .withArguments(['foo'])
                     .withOptions({
                         'from-cli': true,
                         skipInstall: true,
@@ -92,10 +91,41 @@ describe('JHipster entity generator with blueprint', () => {
                 assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`);
             });
 
-            // TODO check why this doesnt work
-            // it('contains the specific change added by the blueprint', () => {
-            //     assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`, /dummyBlueprintProperty/);
-            // });
+            it('contains the specific change added by the blueprint', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`, /awesomeAngularAppName/);
+            });
+        });
+    });
+
+    describe('generate entity with dummy blueprint overriding everything', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/entity'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, '../../test/templates/ngx-blueprint'), dir);
+                })
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'myblueprint',
+                    skipChecks: true
+                })
+                .withGenerators([[helpers.createDummyGenerator(), 'jhipster-myblueprint:entity']])
+                .withArguments(['foo'])
+                .withPrompts({
+                    fieldAdd: false,
+                    relationshipAdd: false,
+                    dto: 'no',
+                    service: 'no',
+                    pagination: 'no'
+                })
+                .on('end', done);
+        });
+
+        it("doesn't create any expected files from jhipster entity generator", () => {
+            assert.noFile(expectedFiles.server);
+            assert.noFile(expectedFiles.clientNg2);
+            assert.noFile(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`);
         });
     });
 });

--- a/test/blueprint/server-blueprint.spec.js
+++ b/test/blueprint/server-blueprint.spec.js
@@ -42,6 +42,10 @@ const mockBlueprintSubGen = class extends ServerGenerator {
         return { ...phaseFromJHipster, ...customPhaseSteps };
     }
 
+    get install() {
+        return super._install();
+    }
+
     get end() {
         return super._end();
     }

--- a/test/blueprint/server-blueprint.spec.js
+++ b/test/blueprint/server-blueprint.spec.js
@@ -94,4 +94,41 @@ describe('JHipster server generator with blueprint', () => {
             });
         });
     });
+
+    describe('generate server with dummy blueprint overriding everything', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/server'))
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    blueprint: 'myblueprint',
+                    skipChecks: true
+                })
+                .withGenerators([[helpers.createDummyGenerator(), 'jhipster-myblueprint:server']])
+                .withPrompts({
+                    baseName: 'jhipster',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    cacheProvider: 'ehcache',
+                    enableHibernateCache: true,
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Memory',
+                    prodDatabaseType: 'mysql',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr'],
+                    buildTool: 'maven',
+                    rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                    serverSideOptions: []
+                })
+                .on('end', done);
+        });
+
+        it("doesn't create any expected files from jhipster server generator", () => {
+            assert.noFile(expectedFiles.server);
+        });
+    });
 });

--- a/test/templates/ngx-blueprint/.yo-rc.json
+++ b/test/templates/ngx-blueprint/.yo-rc.json
@@ -1,0 +1,48 @@
+{
+    "generator-jhipster-myblueprint": {
+        "promptValues": {
+            "packageName": "com.mycompany.myapp"
+        },
+        "applicationType": "monolith",
+        "baseName": "myblueprint",
+        "packageName": "com.mycompany.myapp",
+        "packageFolder": "com/mycompany/myapp",
+        "serverPort": "8080",
+        "authenticationType": "jwt",
+        "cacheProvider": "ehcache",
+        "enableHibernateCache": true,
+        "websocket": false,
+        "databaseType": "sql",
+        "devDatabaseType": "h2Disk",
+        "prodDatabaseType": "mysql",
+        "searchEngine": false,
+        "messageBroker": false,
+        "serviceDiscoveryType": false,
+        "buildTool": "maven",
+        "enableSwaggerCodegen": false,
+        "jwtSecretKey": "147e04cf224f52908a60d7a2902e19e0648d0a8c52503b4624f1708478dd29ba2885a9bb823c85873a76b27964a90e22f1e8",
+        "clientFramework": "angularX",
+        "useSass": false,
+        "clientPackageManager": "npm"
+    },
+    "generator-jhipster": {
+        "promptValues": {
+            "nativeLanguage": "en"
+        },
+        "applicationType": "monolith",
+        "baseName": "myblueprint",
+        "testFrameworks": [
+            "gatling",
+            "protractor"
+        ],
+        "jhiPrefix": "jhi",
+        "enableTranslation": true,
+        "clientPackageManager": "npm",
+        "nativeLanguage": "en",
+        "languages": [
+            "en",
+            "fr"
+        ],
+        "blueprint": "generator-jhipster-myblueprint"
+    }
+}

--- a/test/utils/utils.js
+++ b/test/utils/utils.js
@@ -11,6 +11,7 @@ module.exports = {
     getFilesForOptions,
     shouldBeV3DockerfileCompatible,
     getJHipsterCli,
+    createBlueprintMockForSubgen,
     testInTempDir
 };
 
@@ -59,4 +60,45 @@ function testInTempDir(cb) {
     process.chdir(cwd);
     /* eslint-disable-next-line no-console */
     console.log(`current cwd: ${process.cwd()}`);
+}
+
+function createBlueprintMockForSubgen(parentSubGenerator) {
+    return class extends parentSubGenerator {
+        constructor(args, opts) {
+            super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+            const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+            if (!jhContext) {
+                this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint ...')}");
+            }
+            this.configOptions = jhContext.configOptions || {};
+        }
+
+        get initializing() {
+            return super._initializing();
+        }
+
+        get prompting() {
+            return super._prompting();
+        }
+
+        get configuring() {
+            return super._configuring();
+        }
+
+        get default() {
+            return super._default();
+        }
+
+        get writing() {
+            return super._writing();
+        }
+
+        get install() {
+            return super._install();
+        }
+
+        get end() {
+            return super._end();
+        }
+    };
 }


### PR DESCRIPTION
This parent class holds the public API that can be used for developers of blueprint.
See [this discussion](https://github.com/jhipster/generator-jhipster/pull/8623#discussion_r226876596) for the rationale.

This PR replaces #8677 : I've given up the factorization for now since it introduced regressions, but I've added more unit tests and fixed entity-i18n subgenerator and related entity-blueprint test.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
