### PR TITLE
Use Prettier for Json for lint-staged

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -129,7 +129,7 @@
     <%_ } _%>
     "ts-loader": "4.5.0",
     "tslint": "5.11.0",
-    "tslint-config-prettier": "1.9.0",
+    "tslint-config-prettier": "1.15.0",
     "tslint-loader": "3.6.0",
     "typescript": "3.1.3",
     <%_ if (useSass) { _%>
@@ -158,7 +158,7 @@
   },
   <%_ if(!skipCommitHook) { _%>
   "lint-staged": {
-    "src/**/*.{ts,css,scss}": [
+    "src/**/*.{json,ts,css,scss}": [
       "prettier --write",
       "git add"
     ]

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -179,7 +179,7 @@ limitations under the License.
   },
   <%_ if(!skipCommitHook) { _%>
   "lint-staged": {
-    "src/**/*.{ts,tsx,css,scss}": [
+    "src/**/*.{json,ts,tsx,css,scss}": [
       "prettier --write",
       "git add"
     ]


### PR DESCRIPTION
Related to #8709. Sorry I just realised that I didn't also update `lint-staged` to apply changes to JSON files and `tslint-config-prettier` should be updated to work with the latest prettier. I'm still learning how this all fits together.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed