### PR TITLE
add custom MappingElasticsearchConverter to ElasticsearchConfiguration

### DIFF
--- a/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
@@ -33,6 +33,15 @@ import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
 import org.springframework.data.elasticsearch.core.EntityMapper;
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+<%_ if (databaseType === 'mongodb') { _%>
+import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentProperty;
+import org.springframework.data.mapping.PersistentEntity;
+import org.springframework.data.mapping.model.Property;
+import org.springframework.data.mapping.model.SimpleTypeHolder;
+import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
+import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentEntity;
+<%_ } _%>
 
 import java.io.IOException;
 
@@ -59,7 +68,11 @@ public class ElasticsearchConfiguration {
                                                          EntityMapper mapper) {
         return new JestElasticsearchTemplate(
             jestClient,
+            <%_ if (databaseType === 'mongodb') { _%>
+            new MappingElasticsearchConverter(new CustomElasticsearchMappingContext()),
+            <%_ } else { _%>
             elasticsearchConverter,
+            <%_ } _%>
             new DefaultJestResultsMapper(simpleElasticsearchMappingContext, mapper));
     }
 
@@ -88,3 +101,22 @@ public class ElasticsearchConfiguration {
     }
 
 }
+<%_ if (databaseType === 'mongodb') { _%>
+class CustomElasticsearchMappingContext extends SimpleElasticsearchMappingContext {
+    @Override
+    protected ElasticsearchPersistentProperty createPersistentProperty(Property property, SimpleElasticsearchPersistentEntity owner, SimpleTypeHolder simpleTypeHolder) {
+        return new CustomElasticsearchPersistentProperty(property, owner, simpleTypeHolder);
+    }
+}
+class CustomElasticsearchPersistentProperty extends SimpleElasticsearchPersistentProperty {
+
+    public CustomElasticsearchPersistentProperty(Property property, PersistentEntity owner, SimpleTypeHolder simpleTypeHolder) {
+        super(property, owner, simpleTypeHolder);
+    }
+
+    @Override
+    public boolean isAssociation() {
+        return false;
+    }
+}
+<%_ } _%>


### PR DESCRIPTION
Custom MappingElasticsearchConverter to support mongodb relations
Based on https://github.com/deshetti/mongo-es-issue/commit/2c54dec25ced959cf0faac3930cecdfdb082a3d7

Fix #8666

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
