### PR TITLE
fix maven elasticsearch missing dependencies

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -531,16 +531,16 @@
                 </exclusion>
             </exclusions>
         </dependency>
-        <!-- log4j needed to create embedded elasticsearch instance -->	
-        <dependency>	
-            <groupId>org.apache.logging.log4j</groupId>	
-            <artifactId>log4j-api</artifactId>	
-            <version>2.7</version>	
-        </dependency>	
-        <dependency>	
-            <groupId>org.apache.logging.log4j</groupId>	
-            <artifactId>log4j-core</artifactId>	
-            <version>2.7</version>	
+        <!-- log4j needed to create embedded elasticsearch instance -->
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>2.7</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>2.7</version>
         </dependency>
         <!-- end of Spring Data Jest dependencies -->
         <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -531,6 +531,17 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <!-- log4j needed to create embedded elasticsearch instance -->	
+        <dependency>	
+            <groupId>org.apache.logging.log4j</groupId>	
+            <artifactId>log4j-api</artifactId>	
+            <version>2.7</version>	
+        </dependency>	
+        <dependency>	
+            <groupId>org.apache.logging.log4j</groupId>	
+            <artifactId>log4j-core</artifactId>	
+            <version>2.7</version>	
+        </dependency>
         <!-- end of Spring Data Jest dependencies -->
         <%_ } _%>
         <%_ if (['mongodb', 'cassandra', 'couchbase'].includes(databaseType)) { _%>


### PR DESCRIPTION
Maven projects using Elasticsearch fail to start without these dependencies.

Pinging @Tcharl since they may know a better way to fix this (these dependencies were removed in #8475).  I don't notice anything wrong when adding these dependencies back to the pom.xml.

related to #8739 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
