### PR TITLE
fix issue with skipClient

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2161,7 +2161,7 @@ module.exports = class extends PrivateBase {
         context.jhiPrefix = context.fileData.jhiPrefix || context.jhiPrefix;
         context.skipCheckLengthOfIdentifier = context.fileData.skipCheckLengthOfIdentifier || context.skipCheckLengthOfIdentifier;
         context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
-        context.skipClient = context.fileData.skipClient;
+        context.skipClient = context.fileData.skipClient || context.skipClient;
         this.copyFilteringFlag(context.fileData, context, context);
         if (_.isUndefined(context.entityTableName)) {
             this.warning(`entityTableName is missing in .jhipster/${context.name}.json, using entity name as fallback`);


### PR DESCRIPTION
### Issue
In the PR #8632 , we read the `skipClient` from the .json file. But if the `skipClient` is not in the .json file. the value will be `undifined`. As a result, the `skipClient` will be overwrite to `undefined`, when we update the entity in the microservice app, it will generate the frontend code. 

### How to reproduce.

1.  use any generator v5.6.0 or v5.6.1
1.  generate a microservice app
1.  generate any entity (first it will succeed): `jhipster entity book`
1.  rerun the command  `jhipster entity book` to regenerate the entity, it will generate the frontend code.


![step1](https://user-images.githubusercontent.com/17842462/48139658-fc1bcf00-e2e1-11e8-942a-d8ffe18699fc.JPG)
![step2](https://user-images.githubusercontent.com/17842462/48139665-ffaf5600-e2e1-11e8-973a-bca329ac2d97.JPG)
![step3](https://user-images.githubusercontent.com/17842462/48139672-0211b000-e2e2-11e8-9692-1bf683293af9.JPG)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
