### PR TITLE
do not prepend SERVER_API_URL when fetching i18n

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/config/axios-interceptor.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/axios-interceptor.ts.ejs
@@ -22,6 +22,9 @@ import { getBasePath, Storage } from 'react-jhipster';
 import { SERVER_API_URL } from 'app/config/constants';
 
 const TIMEOUT = 1000000; // 10000
+axios.defaults.timeout = TIMEOUT;
+axios.defaults.baseURL = SERVER_API_URL;
+
 const setupAxiosInterceptors = onUnauthenticated => {
   const onRequestSuccess = config => {
     <%_ if (authenticationType === 'jwt') { _%>
@@ -30,8 +33,6 @@ const setupAxiosInterceptors = onUnauthenticated => {
       config.headers.Authorization = `Bearer ${token}`;
     }
     <%_ } _%>
-    config.timeout = TIMEOUT;
-    config.url = `${SERVER_API_URL}${config.url}`;
     return config;
   };
   const onResponseSuccess = response => response;

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/locale.ts.ejs
@@ -47,7 +47,7 @@ export default (state: LocaleState = initialState, action): LocaleState => {
 
 export const setLocale = locale => async dispatch => {
   if (!Object.keys(TranslatorContext.context.translations).includes(locale)) {
-    const response = await axios.get(`i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`);
+    const response = await axios.get(`i18n/${locale}.json?buildTimestamp=${process.env.BUILD_TIMESTAMP}`, { baseURL: '' });
     TranslatorContext.registerTranslations(locale, response.data);
   }
   dispatch({

--- a/generators/client/templates/react/src/test/javascript/spec/app/config/axios-interceptor.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/config/axios-interceptor.spec.ts.ejs
@@ -29,8 +29,7 @@ describe('Axios Interceptor', () => {
 
     it('onRequestSuccess is called on fulfilled request', () => {
       expect((client.interceptors.request as any).handlers[0].fulfilled({ data: 'foo', url: '/test' })).toMatchObject({
-        data: 'foo',
-        timeout: 1000000
+        data: 'foo'
       });
     });
     it('onResponseSuccess is called on fulfilled response', () => {


### PR DESCRIPTION
Set the axios defaults the correct way, which allows overriding them in the request

If you deploy the server and client separately and set the `SERVER_API_URL`, the axios.interceptor prepends the `SERVER_API_URL` to all requests.  By setting the axios default baseURL instead, it allows us to override the baseURL, such as in locale.ts when fetching the i18n.

Fix #8662

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
