### PR TITLE
CI: migrate jhipster/jhipster to test-integration folder [ci skip]

### DIFF
--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -30,7 +30,7 @@ else
     fi
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
-    travis/scripts/00-replace-version-jhipster.sh
+    test-integration/scripts/10-replace-version-jhipster.sh
 
     ./mvnw clean install -Dgpg.skip=true
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-framework/


### PR DESCRIPTION
Related to https://github.com/jhipster/jhipster/pull/124
No impact here, as we only use release version -> that's why I put `[ci skip]`

@DanielFran : same comment, I'll cherry pick to spring boot 2.1, unless you're not OK

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
