### PR TITLE
Inverse logic for blueprint composition logging and improve wording and formatting

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -730,7 +730,6 @@ module.exports = class extends Generator {
         if (blueprint) {
             blueprint = this.normalizeBlueprintName(blueprint);
             this.checkBlueprint(blueprint, subGen);
-            this.log(`Trying to use blueprint ${blueprint}`);
             try {
                 const finalOptions = {
                     ...options,
@@ -738,10 +737,11 @@ module.exports = class extends Generator {
                 };
                 this.useBlueprint = true;
                 this.composeExternalModule(blueprint, subGen, finalOptions);
+                this.info(`Using blueprint ${chalk.yellow(blueprint)} for ${chalk.yellow(subGen)} subgenerator`);
                 return true;
             } catch (e) {
+                this.debug(`No blueprint found for ${chalk.yellow(subGen)} subgenerator: falling back to default generator`);
                 this.debug('Error', e);
-                this.info(`No blueprint found for ${subGen} falling back to default generator`);
                 return false;
             }
         }


### PR DESCRIPTION
- info logging when composition worked (subgen found)
- debug logging when composition failed (subgen not found), but this is an expected error since blueprint usually overrides only a few subgenerators .

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
