### PR TITLE
Singularize JoinColumn names in ManyToMany

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -272,8 +272,8 @@ public class <%= entityClass %> implements Serializable {
     <%- include relationship_validators -%>
         <%_ } _%>
     @JoinTable(name = "<%= joinTableName %>",
-               joinColumns = @JoinColumn(name = "<%= getPluralColumnName(name) %>_id", referencedColumnName = "id"),
-               inverseJoinColumns = @JoinColumn(name = "<%= getPluralColumnName(relationships[idx].relationshipName) %>_id", referencedColumnName = "id"))
+               joinColumns = @JoinColumn(name = "<%= getColumnName(name) %>_id", referencedColumnName = "id"),
+               inverseJoinColumns = @JoinColumn(name = "<%= getColumnName(relationships[idx].relationshipName) %>_id", referencedColumnName = "id"))
         <%_ }
         } else if (databaseType === 'mongodb') { _%>
     @DBRef

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -154,15 +154,15 @@
           _%>
 
         <createTable tableName="<%= joinTableName %>">
-            <column name="<%= getPluralColumnName(relationshipName) %>_id" type="bigint">
+            <column name="<%= getColumnName(relationshipName) %>_id" type="bigint">
                 <constraints nullable="false"/>
             </column>
-            <column name="<%= getPluralColumnName(name) %>_id" type="bigint">
+            <column name="<%= getColumnName(name) %>_id" type="bigint">
                 <constraints nullable="false"/>
             </column>
         </createTable>
 
-        <addPrimaryKey columnNames="<%= getPluralColumnName(name) %>_id, <%= getPluralColumnName(relationshipName) %>_id" tableName="<%= joinTableName %>"/>
+        <addPrimaryKey columnNames="<%= getColumnName(name) %>_id, <%= getColumnName(relationshipName) %>_id" tableName="<%= joinTableName %>"/>
         <% } %><% } %>
     </changeSet>
     <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity_constraints.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity_constraints.xml.ejs
@@ -38,19 +38,19 @@
                                  referencedColumnNames="id"
                                  referencedTableName="<%= otherEntityTableName %>"/>
         <%_ } else if (relationshipType === 'many-to-many' && ownerSide) {
-                const joinTableName = getJoinTableName(entityTableName, relationshipName, prodDatabaseType);
-                const constraintName = getFKConstraintName(joinTableName, getPluralColumnName(entityTableName), prodDatabaseType, true);
-                const otherEntityConstraintName = getFKConstraintName(joinTableName, getPluralColumnName(relationshipName), prodDatabaseType, true);
+                const joinTableName = getJoinTableName(name, relationshipName, prodDatabaseType);
+                const constraintName = getFKConstraintName(joinTableName, getColumnName(name), prodDatabaseType, true);
+                const otherEntityConstraintName = getFKConstraintName(joinTableName, getColumnName(relationshipName), prodDatabaseType, true);
           _%>
 
-        <addForeignKeyConstraint baseColumnNames="<%= getPluralColumnName(name) %>_id"
+        <addForeignKeyConstraint baseColumnNames="<%= getColumnName(name) %>_id"
                                  baseTableName="<%= joinTableName %>"
                                  constraintName="<%= constraintName %>"
                                  referencedColumnNames="id"
                                  referencedTableName="<%= entityTableName %>"/>
-        <addForeignKeyConstraint baseColumnNames="<%= getPluralColumnName(relationshipName) %>_id"
+        <addForeignKeyConstraint baseColumnNames="<%= getColumnName(relationshipName) %>_id"
                                  baseTableName="<%= joinTableName %>"
-                                 constraintName="<%= otherEntityConstraintName %>"
+                                 constraintName="<%= getColumnName(otherEntityConstraintName) %>"
                                  referencedColumnNames="id"
                                  referencedTableName="<%= otherEntityTableName %>"/>
         <%  } %><% } %>


### PR DESCRIPTION
fix #8447

This issue suggests to singularize `JoinColumn` names in ManyToMany relationships, actually I also think it would be better logic to use singular here.
The author of the issue gives also some articles that shows this is considered as a "best practice".

ps: this might annoy people with jhipster migration 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
