### PR TITLE
Improve npm/yarn scripts to run jest tests

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -129,13 +129,10 @@ module.exports = class extends BaseGenerator {
                 this.gitLabIndent = this.sendBuildToGitlab ? '    ' : '';
                 this.indent = this.insideDocker ? '    ' : '';
                 this.indent += this.gitLabIndent;
-                this.frontTests = '';
                 if (this.clientFramework === 'react') {
-                    if (this.clientPackageManager === 'yarn') {
-                        this.frontTests = ' -u';
-                    } else if (this.clientPackageManager === 'npm') {
-                        this.frontTests = ' -- -u';
-                    }
+                    this.frontTestCommand = 'test-ci';
+                } else {
+                    this.frontTestCommand = 'test';
                 }
             }
         };

--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -73,10 +73,7 @@ gradle-test:
 frontend-test:
     stage: test
     script:
-        # You should use default run instead: <%= clientPackageManager %>_test 
-        # See documentation at https://www.jhipster.tech/setting-up-ci/
-        # - ./gradlew <%= clientPackageManager %>_test -PnodeInstall --no-daemon
-        - ./gradlew <%= clientPackageManager %>_run_test-ci -PnodeInstall --no-daemon
+        - ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
     artifacts:
         reports:
             junit: build/test-results/jest/TESTS-*.xml
@@ -177,9 +174,6 @@ maven-test:
 frontend-test:
     stage: test
     script:
-        # You should use default argument instead: 'test'
-        # See documentation at https://www.jhipster.tech/setting-up-ci/
-        # - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='test' -Dmaven.repo.local=$MAVEN_USER_HOME
         - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='<%= frontTestCommand %>' -Dmaven.repo.local=$MAVEN_USER_HOME
     artifacts:
         reports:

--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -180,7 +180,7 @@ frontend-test:
         # You should use default argument instead: 'test'
         # See documentation at https://www.jhipster.tech/setting-up-ci/
         # - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='test' -Dmaven.repo.local=$MAVEN_USER_HOME
-        - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='test<%= frontTests%>' -Dmaven.repo.local=$MAVEN_USER_HOME
+        - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='<%= frontTestCommand %>' -Dmaven.repo.local=$MAVEN_USER_HOME
     artifacts:
         reports:
             junit: target/test-results/jest/TESTS-*.xml

--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -60,8 +60,8 @@ jobs:
       ./gradlew clean test
   <%_ } _%>
     displayName: 'TESTS: backend'
-<%_ if (applicationType !== 'microservice') { _%>
-  - script: <%= clientPackageManager %> test<%= frontTests %>
+<%_ if (!skipClient) { _%>
+  - script: <%= clientPackageManager %> run <%= frontTestCommand %>
     displayName: 'TESTS: frontend'
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>

--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -61,7 +61,11 @@ jobs:
   <%_ } _%>
     displayName: 'TESTS: backend'
 <%_ if (!skipClient) { _%>
-  - script: <%= clientPackageManager %> run <%= frontTestCommand %>
+  <%_ if (buildTool === 'maven') { _%>
+    - script: ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='run <%= frontTestCommand %>'
+  <%_ } else if (buildTool === 'gradle') { _%>
+    - script: ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
+  <%_ } _%>
     displayName: 'TESTS: frontend'
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>

--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -62,9 +62,9 @@ jobs:
     displayName: 'TESTS: backend'
 <%_ if (!skipClient) { _%>
   <%_ if (buildTool === 'maven') { _%>
-    - script: ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='run <%= frontTestCommand %>'
+  - script: ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='run <%= frontTestCommand %>'
   <%_ } else if (buildTool === 'gradle') { _%>
-    - script: ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
+  - script: ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
   <%_ } _%>
     displayName: 'TESTS: frontend'
 <%_ } _%>

--- a/generators/ci-cd/templates/circle.yml.ejs
+++ b/generators/ci-cd/templates/circle.yml.ejs
@@ -58,12 +58,8 @@ test:
         - chmod +x gradlew
         - ./gradlew clean test --no-daemon
 <%_ } _%>
-<%_ if (applicationType !== 'microservice') { _%>
-    <%_ if (clientPackageManager === 'yarn') { _%>
-        - yarn test
-    <%_ } else if (clientPackageManager === 'npm') { _%>
-        - npm test
-    <%_ } _%>
+<%_ if (!skipClient) { _%>
+        - <%= clientPackageManager %> run <%= frontTestCommand %>
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
     <%_ if (cicdIntegrations.includes('circle')) { _%>

--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -73,11 +73,7 @@ node {
     <%_ if (!skipClient) { _%>
 <%= indent %>    stage('frontend tests') {
 <%= indent %>        try {
-        <%_ if (clientPackageManager === 'yarn') { _%>
-<%= indent %>            sh "./mvnw com.github.eirslett:frontend-maven-plugin:yarn -Dfrontend.yarn.arguments='test<%= frontTests%>'"
-        <%_ } else if (clientPackageManager === 'npm') { _%>
-<%= indent %>            sh "./mvnw com.github.eirslett:frontend-maven-plugin:npm -Dfrontend.npm.arguments='test<%= frontTests%>'"
-        <%_ } _%>
+<%= indent %>            sh "./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='run <%= frontTestCommand %>'"
 <%= indent %>        } catch(err) {
 <%= indent %>            throw err
 <%= indent %>        } finally {

--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -116,9 +116,6 @@ node {
     <%_ if (!skipClient) { _%>
 <%= indent %>    stage('frontend tests') {
 <%= indent %>        try {
-<%= indent %>            // You should use default run instead: <%= clientPackageManager %>_test 
-<%= indent %>            // See documentation at https://www.jhipster.tech/setting-up-ci/
-<%= indent %>            // sh "./gradlew <%= clientPackageManager %>_test -PnodeInstall --no-daemon"
 <%= indent %>            sh "./gradlew <%= clientPackageManager %>_run_test-ci -PnodeInstall --no-daemon"
 <%= indent %>        } catch(err) {
 <%= indent %>            throw err

--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -70,8 +70,8 @@ script:
   - chmod +x gradlew
   - ./gradlew clean test
 <%_ } _%>
-<%_ if (applicationType !== 'microservice') { _%>
-  - <%= clientPackageManager %> test<%= frontTests%>
+<%_ if (!skipClient) { _%>
+  - <%= clientPackageManager %> run <%= frontTestCommand %>
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
   <%_ if (cicdIntegrations.includes('sonar')) { _%>

--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -71,7 +71,11 @@ script:
   - ./gradlew clean test
 <%_ } _%>
 <%_ if (!skipClient) { _%>
-  - <%= clientPackageManager %> run <%= frontTestCommand %>
+  <%_ if (buildTool === 'maven') { _%>
+    - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='<%= frontTestCommand %>' -Dmaven.repo.local=$MAVEN_USER_HOME
+  <%_ } else if (buildTool === 'gradle') { _%>
+    - ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
+  <%_ } _%>
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>
   <%_ if (cicdIntegrations.includes('sonar')) { _%>

--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -72,9 +72,9 @@ script:
 <%_ } _%>
 <%_ if (!skipClient) { _%>
   <%_ if (buildTool === 'maven') { _%>
-    - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='<%= frontTestCommand %>' -Dmaven.repo.local=$MAVEN_USER_HOME
+  - ./mvnw com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='run <%= frontTestCommand %>' -Dmaven.repo.local=$MAVEN_USER_HOME
   <%_ } else if (buildTool === 'gradle') { _%>
-    - ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
+  - ./gradlew <%= clientPackageManager %>_run_<%= frontTestCommand %> -PnodeInstall --no-daemon
   <%_ } _%>
 <%_ } _%>
 <%_ if (buildTool === 'maven') { _%>

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -194,8 +194,10 @@ limitations under the License.
     <%_ } _%>
     "start": "<%= clientPackageManager %> run webpack:dev",
     "start-tls": "<%= clientPackageManager %> run webpack:dev <%= optionsForwarder %>--env.tls",
-    "test": "<%= clientPackageManager %> run lint && jest --coverage --logHeapUsage -w=2 --config src/test/javascript/jest.conf.js",
-    "test-ci": "<%= clientPackageManager %> run lint && jest --coverage --logHeapUsage --updateSnapshot -w=2 --config src/test/javascript/jest.conf.js",
+    "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config src/test/javascript/jest.conf.js",
+    "jest:update": "<%= clientPackageManager %> run jest <%= optionsForwarder %>--updateSnapshot",
+    "test": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest",
+    "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
     "test:watch": "<%= clientPackageManager %> test <%= optionsForwarder %>--watch",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server <%= optionsForwarder %>--config webpack/webpack.dev.js --inline --port=9060 --env.stats=minimal",
     "webpack:dev-verbose": "<%= clientPackageManager %> run webpack-dev-server <%= optionsForwarder %>--config webpack/webpack.dev.js --inline --port=9060 --profile --progress --env.stats=normal",

--- a/test-integration/scripts/22-tests-frontend.sh
+++ b/test-integration/scripts/22-tests-frontend.sh
@@ -8,5 +8,9 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 cd "$JHI_FOLDER_APP"
 if [ -f "tsconfig.json" ]; then
-    npm test -- -u
+    if [ -f "angular.json" ]; then
+        npm test
+    else # for react
+        npm run test-ci
+    fi
 fi


### PR DESCRIPTION
Following https://github.com/jhipster/generator-jhipster/pull/8816, this simply cleans up the script and add a new script to run `jest --updateSnapshot` by itself.

