### PR TITLE
Fix prettier:format script

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
         "url": "git://github.com/jhipster/generator-jhipster.git"
     },
     "scripts": {
-        "prettier:format": "prettier --write '{,**/}*.{js,json,md}'",
+        "prettier:format": "prettier --write \"{,**/}*.{js,json,md}\"",
         "completion": "tabtab install --name jhipster --auto",
         "lint": "npm run eslint && npm run ejs-lint",
         "lint-fix": "npm run eslint -- --fix",


### PR DESCRIPTION
Currently running `npm prettier:format` generates the following error : 
```
[error] No matching files. Patterns tried: '{,**/}*.{js,json,md}' !**/node_modules/** !./node_modules/**
npm ERR! code ELIFECYCLE
npm ERR! errno 2
npm ERR! generator-jhipster@5.7.0 prettier:format: `prettier --write '{,**/}*.{js,json,md}'`
npm ERR! Exit status 2
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
