### PR TITLE
Fix loading of variables in common subgen

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -327,15 +327,6 @@ module.exports = class extends BaseGenerator {
             //     this.composeWith(require.resolve('../link-account'));
             // },
 
-            composeCommon() {
-                this.composeWith(require.resolve('../common'), {
-                    'from-cli': this.options['from-cli'],
-                    configOptions: this.configOptions,
-                    force: this.options.force,
-                    debug: this.isDebugEnabled
-                });
-            },
-
             composeServer() {
                 if (this.skipServer) return;
 
@@ -354,6 +345,16 @@ module.exports = class extends BaseGenerator {
                 this.composeWith(require.resolve('../client'), {
                     'skip-install': this.options['skip-install'],
                     'skip-commit-hook': this.options['skip-commit-hook'],
+                    'from-cli': this.options['from-cli'],
+                    configOptions: this.configOptions,
+                    force: this.options.force,
+                    debug: this.isDebugEnabled
+                });
+            },
+
+            composeCommon() {
+                this.composeWith(require.resolve('../common'), {
+                    'client-hook': !this.skipClient,
                     'from-cli': this.options['from-cli'],
                     configOptions: this.configOptions,
                     force: this.options.force,

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -331,11 +331,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 }
 
                 // Make dist dir available in templates
-                if (this.configOptions.buildTool === 'maven') {
-                    this.BUILD_DIR = 'target/';
-                } else {
-                    this.BUILD_DIR = 'build/';
-                }
+                this.BUILD_DIR = this.getBuildDirectoryForBuildTool(this.configOptions.buildTool);
 
                 this.styleSheetExt = this.useSass ? 'scss' : 'css';
                 this.pkType = this.getPkType(this.databaseType);

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -19,7 +19,6 @@
 /* eslint-disable consistent-return */
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const writeFiles = require('./files').writeFiles;
-const packagejs = require('../../package.json');
 const constants = require('../generator-constants');
 
 let useBlueprint;
@@ -37,6 +36,7 @@ module.exports = class extends BaseBlueprintGenerator {
         });
 
         this.setupServerOptions(this);
+        this.setupClientOptions(this);
         const blueprint = this.options.blueprint || this.configOptions.blueprint || this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
@@ -62,60 +62,15 @@ module.exports = class extends BaseBlueprintGenerator {
             setupConsts() {
                 // Make constants available in templates
                 this.TEST_DIR = constants.TEST_DIR;
-                this.CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
                 this.SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
-
-                this.packagejs = packagejs;
-                const configuration = this.getAllJhipsterConfig(this, true);
-                this.applicationType = configuration.get('applicationType') || this.configOptions.applicationType;
-                if (!this.applicationType) {
-                    this.applicationType = 'monolith';
-                }
-                this.serverPort = configuration.get('serverPort');
-                if (this.serverPort === undefined) {
-                    this.serverPort = '8080';
-                }
-
-                this.enableSwaggerCodegen = configuration.get('enableSwaggerCodegen');
-
-                this.serviceDiscoveryType =
-                    configuration.get('serviceDiscoveryType') === 'no' ? false : configuration.get('serviceDiscoveryType');
-                if (this.serviceDiscoveryType === undefined) {
-                    this.serviceDiscoveryType = false;
-                }
-
-                this.databaseType = configuration.get('databaseType');
-                if (this.databaseType === 'mongodb') {
-                    this.prodDatabaseType = 'mongodb';
-                } else if (this.databaseType === 'couchbase') {
-                    this.prodDatabaseType = 'couchbase';
-                } else if (this.databaseType === 'cassandra') {
-                    this.prodDatabaseType = 'cassandra';
-                } else if (this.databaseType === 'no') {
-                    // no database, only available for microservice applications
-                    this.prodDatabaseType = 'no';
+                this.CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+                this.CLIENT_TEST_SRC_DIR = constants.CLIENT_TEST_SRC_DIR;
+                if (this.buildTool === 'maven') {
+                    this.BUILD_DIR = 'target/';
                 } else {
-                    // sql
-                    this.prodDatabaseType = configuration.get('prodDatabaseType');
+                    this.BUILD_DIR = 'build/';
                 }
-
-                this.buildTool = configuration.get('buildTool');
-                this.jhipsterVersion = packagejs.version;
-                if (this.jhipsterVersion === undefined) {
-                    this.jhipsterVersion = configuration.get('jhipsterVersion');
-                }
-                this.authenticationType = configuration.get('authenticationType');
-                this.clientFramework = configuration.get('clientFramework');
-                const testFrameworks = configuration.get('testFrameworks');
-                if (testFrameworks) {
-                    this.testFrameworks = testFrameworks;
-                }
-
-                const baseName = configuration.get('baseName');
-                if (baseName) {
-                    // to avoid overriding name from configOptions
-                    this.baseName = baseName;
-                }
+                this.CLIENT_DIST_DIR = this.BUILD_DIR + constants.CLIENT_DIST_DIR;
 
                 // Make documentation URL available in templates
                 this.DOCUMENTATION_URL = constants.JHIPSTER_DOCUMENTATION_URL;
@@ -132,36 +87,25 @@ module.exports = class extends BaseBlueprintGenerator {
     }
 
     // Public API method used by the getter and also by Blueprints
-    _configuring() {
-        return {
-            setSharedConfigOptions() {
-                // Make dist dir available in templates
-                if (this.buildTool === 'maven') {
-                    this.BUILD_DIR = 'target/';
-                } else {
-                    this.BUILD_DIR = 'build/';
-                }
-                this.CLIENT_DIST_DIR = this.BUILD_DIR + constants.CLIENT_DIST_DIR;
-            }
-        };
+    _prompting() {
+        return {};
     }
 
-    get configuring() {
+    get prompting() {
         if (useBlueprint) return;
-        return this._configuring();
+        return this._prompting();
     }
 
     // Public API method used by the getter and also by Blueprints
     _default() {
         return {
             getSharedConfigOptions() {
-                if (this.configOptions.clientFramework) {
-                    this.clientFramework = this.configOptions.clientFramework;
-                }
-                this.testFrameworks = [];
-                if (this.configOptions.testFrameworks) {
-                    this.testFrameworks = this.configOptions.testFrameworks;
-                }
+                this.jhipsterVersion = this.config.get('jhipsterVersion');
+                this.applicationType = this.config.get('applicationType') || this.configOptions.applicationType;
+                this.enableSwaggerCodegen = this.configOptions.enableSwaggerCodegen;
+                this.serverPort = this.configOptions.serverPort;
+                this.clientFramework = this.configOptions.clientFramework;
+                this.useSass = this.configOptions.useSass;
                 this.protractorTests = this.testFrameworks.includes('protractor');
                 this.gatlingTests = this.testFrameworks.includes('gatling');
             }

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -65,11 +65,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
                 this.CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
                 this.CLIENT_TEST_SRC_DIR = constants.CLIENT_TEST_SRC_DIR;
-                if (this.buildTool === 'maven') {
-                    this.BUILD_DIR = 'target/';
-                } else {
-                    this.BUILD_DIR = 'build/';
-                }
+                this.BUILD_DIR = this.getBuildDirectoryForBuildTool(this.buildTool);
                 this.CLIENT_DIST_DIR = this.BUILD_DIR + constants.CLIENT_DIST_DIR;
 
                 // Make documentation URL available in templates

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1099,6 +1099,14 @@ module.exports = class extends Generator {
     }
 
     /**
+     * Get build directory used by buildTool
+     * @param {string} buildTool - buildTool
+     */
+    getBuildDirectoryForBuildTool(buildTool) {
+        return buildTool === 'maven' ? 'target/' : 'build/';
+    }
+
+    /**
      * @returns generated JDL from entities
      */
     generateJDLFromEntities() {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2848,6 +2848,8 @@ module.exports = class extends PrivateBase {
      * @param {any} dest - destination context to use default is context
      */
     setupSharedOptions(generator, context = generator, dest = context) {
+        dest.skipClient = !context.options['client-hook'] || context.configOptions.skipClient || context.config.get('skipClient');
+        dest.skipServer = context.configOptions.skipServer || context.config.get('skipServer');
         dest.skipUserManagement =
             context.configOptions.skipUserManagement || context.options['skip-user-management'] || context.config.get('skipUserManagement');
         dest.otherModules = context.configOptions.otherModules || [];
@@ -2869,7 +2871,6 @@ module.exports = class extends PrivateBase {
      */
     setupClientOptions(generator, context = generator, dest = context) {
         this.setupSharedOptions(generator, context, dest);
-        dest.skipServer = context.configOptions.skipServer || context.config.get('skipServer');
         dest.skipCommitHook = context.options['skip-commit-hook'] || context.config.get('skipCommitHook');
         dest.authenticationType =
             context.options.auth || context.configOptions.authenticationType || context.config.get('authenticationType');
@@ -2877,7 +2878,7 @@ module.exports = class extends PrivateBase {
             dest.skipUserManagement = true;
         }
         const uaaBaseName = context.configOptions.uaaBaseName || context.config.get('uaaBaseName');
-        if (dest.authenticationType === 'uaa' && _.isNil(uaaBaseName)) {
+        if (!dest.skipClient && dest.authenticationType === 'uaa' && _.isNil(uaaBaseName)) {
             generator.error('when using --auth uaa, a UAA basename must be provided with --uaa-base-name');
         }
         dest.uaaBaseName = uaaBaseName;
@@ -2915,7 +2916,6 @@ module.exports = class extends PrivateBase {
      */
     setupServerOptions(generator, context = generator, dest = context) {
         this.setupSharedOptions(generator, context, dest);
-        dest.skipClient = !context.options['client-hook'] || context.configOptions.skipClient || context.config.get('skipClient');
         dest.enableTranslation = context.configOptions.enableTranslation || context.config.get('enableTranslation');
         dest.testFrameworks = context.configOptions.testFrameworks;
     }

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -114,11 +114,7 @@ module.exports = class extends BaseGenerator {
         this.clientFramework = this.config.get('clientFramework');
         this.serviceDiscoveryType = this.config.get('serviceDiscoveryType') === 'no' ? false : this.config.get('serviceDiscoveryType');
         // Make dist dir available in templates
-        if (this.config.get('buildTool') === 'maven') {
-            this.BUILD_DIR = 'target/';
-        } else {
-            this.BUILD_DIR = 'build/';
-        }
+        this.BUILD_DIR = this.getBuildDirectoryForBuildTool(this.config.get('buildTool'));
     }
 
     prompting() {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -317,11 +317,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.configOptions.serverPort = this.serverPort;
 
                 // Make dist dir available in templates
-                if (this.buildTool === 'maven') {
-                    this.BUILD_DIR = 'target/';
-                } else {
-                    this.BUILD_DIR = 'build/';
-                }
+                this.BUILD_DIR = this.getBuildDirectoryForBuildTool(this.buildTool);
                 this.CLIENT_DIST_DIR = this.BUILD_DIR + constants.CLIENT_DIST_DIR;
             }
         };

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -537,6 +537,9 @@ describe('JHipster generator', () => {
             it('creates expected files with authenticationType "oauth2"', () => {
                 assert.file(expectedFiles.oauth2);
             });
+            it('generates README with instructions for OAuth', () => {
+                assert.fileContent('README.md', 'OAuth 2.0');
+            });
         });
 
         describe('oauth2 + elasticsearch', () => {
@@ -830,6 +833,9 @@ describe('JHipster generator', () => {
                 assert.file(expectedFiles.jwtServer);
                 assert.file(expectedFiles.gatling);
                 assert.file(expectedFiles.swaggerCodegen);
+            });
+            it('generates README with instructions for OpenAPI generator', () => {
+                assert.fileContent('README.md', 'OpenAPI-Generator');
             });
         });
 
@@ -1339,6 +1345,9 @@ describe('JHipster generator', () => {
                     )
                 );
                 assert.noFile(['gradle/yeoman.gradle']);
+            });
+            it('generates README with instructions for Gradle', () => {
+                assert.fileContent('README.md', './gradlew');
             });
         });
     });


### PR DESCRIPTION
Composed common subgen after client and server, since they're defining and prompring their own options that common will uses, and add missing `'client-hook'` parameter.
Changed the way common subgen loads its variables: mainly from `this.config` and `this.configOptions`.
Fixes #8783.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
