### PR TITLE
add UAA environment var for JHipster Registry in docker-compose

### DIFF
--- a/generators/docker-compose/templates/jhipster-registry.yml.ejs
+++ b/generators/docker-compose/templates/jhipster-registry.yml.ejs
@@ -54,5 +54,9 @@ services:
             - SECURITY_OAUTH2_CLIENT_CLIENT_SECRET=jhipster-registry
             - SECURITY_OAUTH2_RESOURCE_USER_INFO_URI=http://keycloak:9080/auth/realms/jhipster/protocol/openid-connect/userinfo
             <%_ } _%>
+            <%_ if (authenticationType === 'uaa') { _%>
+            # change the name of UAA server here, if needed
+            - JHIPSTER_SECURITY_CLIENT_AUTHORIZATION_TOKEN_SERVICE_ID=uaa
+            <%_ } _%>
         ports:
             - 8761:8761


### PR DESCRIPTION
With this PR I will give users a hint on how to tune the registry to use with a custom named UAA server (see https://github.com/jhipster/jhipster-registry/pull/314)

It doesn't change the default behavior but is helpful if the user will search for how to change that.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
