### PR TITLE
CI: add generate sample script

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,7 +90,7 @@ Before you submit your pull request consider the following guidelines:
     mvn spring-boot:run
     ```
 
--   You can also run our travis build locally by following [this](#local-travis-build)
+-   You can generate our Continuous Integration (with Travis CI and Azure Pipelines) by following [this](#local-build)
 
 -   Commit your changes using a descriptive commit message that follows our
     [commit message conventions](#commit-message-format).
@@ -243,24 +243,20 @@ To start debugging JHipster with **VSCode**, open the generator code in your wor
 
 It is also possible to debug sub generators by selecting one of the other debug options (for example `jhipster entity`). Those debug configurations are specified in the `.vscode/launch.json` file.
 
-## Local Travis Build
+## Local Build
 
-You can run the travis builds locally by following below commands
+You can run the builds locally by following below commands
 
-CD into the travis folder `cd travis` from the generator source code root folder
+Go into the `test-integration` folder with `cd test-integration` from the generator source code root folder
 
-Run `./build-samples.sh [command_name] [sample_name:optional]`
+Run `./generate-sample.sh <command_name> [folder] [sample_name:optional] [type of entity]`
 
-This will create the travis sample project under the `travis/samples` folder with folder name `[sample_name]-sample`. You can open this application in your editor or IDE to check it further. You can also run tests locally on the project to verify
-
-Sample name is optional and can be any of the folder name in the `travis/samples` folder. If not specified the it will mean all samples
+This will create a folder with configuration and entities. Then, you can generate manually a JHipster project and test it.
 
 Command name can be as below
 
     `list`: List all sample names
-    `generate`: Generate the sample if specified else generate all samples
-    `build` : Generate and test the sample if specified else generate and test all samples
-    `clean` : Clean the generated code for the sample if specified else clean all samples
+    `generate`: Generate the sample
 
 ## <a name="rules"></a> Coding Rules
 

--- a/test-integration/generate-sample.sh
+++ b/test-integration/generate-sample.sh
@@ -1,0 +1,74 @@
+#!/bin/bash
+
+set -e
+
+trap ctrl_c INT
+
+function ctrl_c() {
+    exit 1
+}
+
+function usage() {
+    me=$(basename "$0")
+    echo
+    echo "Usage: $me generate <destination> <sample_name> [sql|sqlfull|micro|uaa|mongodb|cassandra|couchbase] | list"
+    echo 
+    echo "Examples:"
+    echo "$me generate /tmp/ngx-default/ ngx-default sql"
+    echo "$me generate /tmp/ngx-default/ ngx-session-cassandra-fr cassandra"
+    echo
+    exit 2
+}
+
+function generateProject() {
+    cd "$mydir"
+
+    echo "JHI_FOLDER_APP=$JHI_FOLDER_APP"
+    echo "JHI_APP=$JHI_APP"
+    echo "JHI_ENTITY=$JHI_ENTITY"
+    
+    if [ ! -d "$JHI_FOLDER_APP" ]; then
+        echo "*** Create $JHI_FOLDER_APP"
+        mkdir -p "$JHI_FOLDER_APP"
+    fi
+    if [ ! -z "$(ls -A $JHI_FOLDER_APP)" ]; then
+        echo "*** The folder is not empty: $JHI_FOLDER_APP"
+        exit 1
+    else
+        mkdir -p "$JHI_FOLDER_APP"/.jhipster/
+        echo "*** Empty folder, let's generate JHipster project in: $JHI_FOLDER_APP"
+    fi
+
+    pushd scripts/
+    echo "*********************** Copying entities for $JHI_APP"
+    source ./11-generate-entities.sh
+    popd
+
+    echo "*********************** Copy configuration"
+    cp -f "$JHI_SAMPLES"/"$JHI_APP"/.yo-rc.json "$JHI_FOLDER_APP"/
+    ls -al "$JHI_FOLDER_APP"/
+}
+
+mydir="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
+JHI_SAMPLES="$mydir/samples"
+
+if [ "$1" = "list" ]; then
+    for dir in $(ls -1 "$JHI_SAMPLES"); do
+        if [ -f "$JHI_SAMPLES/$dir/.yo-rc.json" ] && [[ $dir != *-sample ]]; then
+            echo "$dir"
+        fi
+    done
+
+elif [ "$1" = "generate" ]; then
+    if [ "$3" != "" ]; then
+        JHI_FOLDER_APP=$2
+        JHI_APP=$3
+        JHI_ENTITY=$4
+        generateProject
+    else
+        usage
+    fi
+
+else
+    usage
+fi

--- a/test-integration/scripts/00-init-env.sh
+++ b/test-integration/scripts/00-init-env.sh
@@ -17,16 +17,26 @@ JHI_REPO=$(init_var "$BUILD_REPOSITORY_URI" "$TRAVIS_REPO_SLUG")
 JHI_HOME=$(init_var "$BUILD_REPOSITORY_LOCALPATH" "$TRAVIS_BUILD_DIR")
 
 # folder for test-integration
-JHI_INTEG="$JHI_HOME"/test-integration
+if [[ "$JHI_INTEG" == "" ]]; then
+    JHI_INTEG="$JHI_HOME"/test-integration
+fi
 
 # folder for samples
-JHI_SAMPLES="$JHI_INTEG"/samples
+if [[ "$JHI_SAMPLES" == "" ]]; then
+    JHI_SAMPLES="$JHI_INTEG"/samples
+fi
 
 # folder for scripts
-JHI_SCRIPTS="$JHI_INTEG"/scripts
+if [[ "$JHI_SCRIPTS" == "" ]]; then
+    JHI_SCRIPTS="$JHI_INTEG"/scripts
+fi
 
 # folder for app
-JHI_FOLDER_APP="$HOME"/app
+if [[ "$JHI_FOLDER_APP" == "" ]]; then
+    JHI_FOLDER_APP="$HOME"/app
+fi
 
 # folder for uaa app
-JHI_FOLDER_UAA="$HOME"/uaa
+if [[ "$JHI_FOLDER_UAA" == "" ]]; then
+    JHI_FOLDER_UAA="$HOME"/uaa
+fi

--- a/test-integration/scripts/11-generate-entities.sh
+++ b/test-integration/scripts/11-generate-entities.sh
@@ -1,7 +1,11 @@
 #!/bin/bash
 
 set -e
-source $(dirname $0)/00-init-env.sh
+if [[ -a $(dirname $0)/00-init-env.sh ]]; then
+    source $(dirname $0)/00-init-env.sh
+else
+    echo "*** 00-init-env.sh not found"
+fi
 
 #-------------------------------------------------------------------------------
 # Functions
@@ -11,12 +15,17 @@ moveEntity() {
     cp "$JHI_SAMPLES"/.jhipster/"$entity".json "$JHI_FOLDER_APP"/.jhipster/
 }
 
+prepareFolder() {
+    rm -rf "$JHI_FOLDER_APP"
+    mkdir -p "$JHI_FOLDER_APP"/.jhipster/
+}
 #-------------------------------------------------------------------------------
 # Copy entities json
 #-------------------------------------------------------------------------------
 
-rm -rf "$JHI_FOLDER_APP"
-mkdir -p "$JHI_FOLDER_APP"/.jhipster/
+if [[ $JHI_REPO != "" ]]; then
+    prepareFolder
+fi
 
 if [[ ("$JHI_ENTITY" == "mongodb") || ("$JHI_ENTITY" == "couchbase") ]]; then
     moveEntity DocumentBankAccount
@@ -125,3 +134,9 @@ elif [[ "$JHI_ENTITY" == "sql" ]]; then
     moveEntity EntityWithServiceImplAndPagination
     moveEntity EntityWithServiceImplPaginationAndDTO
 fi
+
+#-------------------------------------------------------------------------------
+# Copy entities json
+#-------------------------------------------------------------------------------
+echo "*** Entities:"
+ls -al "$JHI_FOLDER_APP"/.jhipster/


### PR DESCRIPTION
Last steps before deleting old `travis/` folder.
Currently, we have `build-samples.sh` which can:
- list
- generate
- build
- clean

I change it to this new `generate-sample.sh`, which will only:
- list all samples
- generate: it will copy the `.yo-rc.json` and all entities

This new script won't generate any more a new JHipster project, either won't launch test.
The reason is the new shell scripts are compatible with Travis and Azure, not locally. A non-set variable could delete all your folders (I delete accidently my `~/app/`, so I don't want it happened to our users).

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
