### PR TITLE
CI: fix condition for launching npm test by default

### DIFF
--- a/test-integration/scripts/22-tests-frontend.sh
+++ b/test-integration/scripts/22-tests-frontend.sh
@@ -8,9 +8,9 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 cd "$JHI_FOLDER_APP"
 if [ -f "tsconfig.json" ]; then
-    if [ -f "angular.json" ]; then
-        npm test
-    else # for react
+    if [ -f "src/main/webapp/app/app.tsx" ]; then
         npm run test-ci
+    else
+        npm test
     fi
 fi


### PR DESCRIPTION
Thanks @sahbi-ktifa for reporting me this

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
