### PR TITLE
CI: add websocket to Azure builds

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -40,11 +40,6 @@ jobs:
 
   strategy:
     matrix:
-      jdl-default:
-        JHI_APP: jdl-default
-        JHI_PROFILE: prod
-        JHI_PROTRACTOR: 1
-        JHI_ENTITY: jdl
       react-default:
         JHI_APP: react-default
         JHI_PROFILE: prod
@@ -67,6 +62,9 @@ jobs:
       ms-micro-consul:
         JHI_APP: ms-micro-consul
         JHI_ENTITY: micro
+      ngx-h2mem-ws-nol2:
+        JHI_APP: ngx-h2mem-ws-nol2
+        JHI_ENTITY: sql
       ngx-session-cassandra-fr:
         JHI_APP: ngx-session-cassandra-fr
         JHI_ENTITY: cassandra

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { SERVER_API_URL } from 'app/app.constants';
-import { AccountService } from 'app/core';
+import { AccountService<% if (websocket === 'spring-websocket') { %>, JhiTrackerService <% } %> } from 'app/core';
 import { JhiDateUtils
 <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
     ,JhiLanguageService
@@ -10,6 +10,9 @@ import { JhiDateUtils
 import { SessionStorageService } from 'ngx-webstorage';
 <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
 import { MockLanguageService } from '../../../helpers/mock-language.service';
+<%_ } _%>
+<%_ if (websocket === 'spring-websocket') { _%>
+import { MockTrackerService } from '../../../helpers/mock-tracker.service';
 <%_ } _%>
 
 describe('Service Tests', () => {
@@ -27,6 +30,12 @@ describe('Service Tests', () => {
                     {
                         provide: JhiLanguageService,
                         useClass: MockLanguageService
+                    },
+                    <%_ } _%>
+                    <%_ if (websocket === 'spring-websocket') { _%>
+                    {
+                        provide: JhiTrackerService,
+                        useClass: MockTrackerService
                     }
                     <%_ } _%>
                 ]

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -1,7 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 import { SERVER_API_URL } from 'app/app.constants';
-import { AccountService<% if (websocket === 'spring-websocket') { %>, JhiTrackerService <% } %> } from 'app/core';
+import { AccountService<% if (websocket === 'spring-websocket') { %>, <%= jhiPrefixCapitalized %>TrackerService <% } %> } from 'app/core';
 import { JhiDateUtils
 <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
     ,JhiLanguageService
@@ -34,7 +34,7 @@ describe('Service Tests', () => {
                     <%_ } _%>
                     <%_ if (websocket === 'spring-websocket') { _%>
                     {
-                        provide: JhiTrackerService,
+                        provide: <%= jhiPrefixCapitalized %>TrackerService,
                         useClass: MockTrackerService
                     }
                     <%_ } _%>


### PR DESCRIPTION
Following this merge https://github.com/jhipster/generator-jhipster/pull/8513
There are some nightly failed builds, related to Websocket:
- https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=209&view=logs
- https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=211&view=logs

So I found that I removed accidentaly the build with Websocket.

1st commit is to put back the build with Websocket.
2nd commit is for the fix.
_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
