### PR TITLE
Db identifiers length

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2374,18 +2374,18 @@ module.exports = class extends PrivateBase {
             constraintName = `${constraintNamePrefix}${this.getTableName(entityName)}_${this.getTableName(columnOrRelationName)}`;
         }
         let limit = 0;
-        if (prodDatabaseType === 'oracle' && constraintName.length >= 27 && !this.skipCheckLengthOfIdentifier) {
+        if (prodDatabaseType === 'oracle' && constraintName.length > 27 && !this.skipCheckLengthOfIdentifier) {
             this.warning(
                 `The generated constraint name "${constraintName}" is too long for Oracle (which has a 30 characters limit). It will be truncated!`
             );
 
-            limit = 28;
-        } else if (prodDatabaseType === 'mysql' && constraintName.length >= 61 && !this.skipCheckLengthOfIdentifier) {
+            limit = 27;
+        } else if (prodDatabaseType === 'mysql' && constraintName.length > 61 && !this.skipCheckLengthOfIdentifier) {
             this.warning(
                 `The generated constraint name "${constraintName}" is too long for MySQL (which has a 64 characters limit). It will be truncated!`
             );
 
-            limit = 62;
+            limit = 61;
         }
         if (limit > 0) {
             const halfLimit = Math.floor(limit / 2);

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2386,6 +2386,12 @@ module.exports = class extends PrivateBase {
             );
 
             limit = 61;
+        } else if (prodDatabaseType === 'postgresql' && constraintName.length > 60 && !this.skipCheckLengthOfIdentifier) {
+            this.warning(
+                `The generated constraint name "${constraintName}" is too long for PostgreSQL (which has a 63 characters limit). It will be truncated!`
+            );
+
+            limit = 60;
         }
         if (limit > 0) {
             const halfLimit = Math.floor(limit / 2);

--- a/test-integration/samples/.jhipster/SuperMegaLargeTestEntity.json
+++ b/test-integration/samples/.jhipster/SuperMegaLargeTestEntity.json
@@ -2,47 +2,41 @@
     "fluentMethods": true,
     "relationships": [
         {
-            "relationshipName": "testManyToOne",
+            "relationshipName": "superMegaLargeTestManyToOne",
             "otherEntityName": "testManyToOne",
             "relationshipType": "one-to-many",
-            "otherEntityRelationshipName": "testCustomTableName"
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         },
         {
-            "relationshipName": "testManyToMany",
+            "relationshipName": "superMegaLargeTestManyToMany",
             "otherEntityName": "testManyToMany",
             "relationshipType": "many-to-many",
             "ownerSide": false,
-            "otherEntityRelationshipName": "testCustomTableName"
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         },
         {
-            "relationshipName": "testOneToOne",
+            "relationshipName": "superMegaLargeTestOneToOne",
             "otherEntityName": "testOneToOne",
             "relationshipType": "one-to-one",
             "ownerSide": false,
-            "otherEntityRelationshipName": "testCustomTableName"
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         },
         {
-            "relationshipName": "testEntity",
-            "otherEntityName": "testEntity",
-            "relationshipType": "many-to-one",
-            "relationshipValidateRules": "required",
-            "otherEntityField": "id"
-        },
-        {
-            "relationshipName": "userOneToMany",
+            "relationshipName": "superMegaLargeUserOneToMany",
             "otherEntityName": "user",
             "relationshipType": "many-to-one",
+            "relationshipValidateRules": "required",
             "otherEntityField": "login"
         },
         {
-            "relationshipName": "userManyToMany",
+            "relationshipName": "superMegaLargeUserManyToMany",
             "otherEntityName": "user",
             "relationshipType": "many-to-many",
             "otherEntityField": "login",
             "ownerSide": true
         },
         {
-            "relationshipName": "userOneToOne",
+            "relationshipName": "superMegaLargeUserOneToOne",
             "otherEntityName": "user",
             "relationshipType": "one-to-one",
             "otherEntityField": "login",
@@ -50,17 +44,17 @@
             "otherEntityRelationshipName": "parent"
         },
         {
-            "relationshipName": "superMegaLargeTestEntity",
-            "otherEntityName": "superMegaLargeTestEntity",
-            "relationshipType": "many-to-one",
-            "relationshipValidateRules": "required",
-            "otherEntityField": "id"
+            "relationshipName": "superMegaLargeTestCustomTableName",
+            "otherEntityName": "testCustomTableName",
+            "relationshipType": "one-to-many",
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         }
     ],
     "fields": [],
-    "changelogDate": "20160208210109",
+    "changelogDate": "20181120190609",
     "dto": "no",
     "service": "no",
-    "entityTableName": "test_custom_table_name_entity",
+    "jpaMetamodelFiltering": true,
+    "angularJSSuffix": "mySuffixAlt",
     "pagination": "no"
 }

--- a/test-integration/samples/.jhipster/TestManyToMany.json
+++ b/test-integration/samples/.jhipster/TestManyToMany.json
@@ -56,6 +56,13 @@
             "relationshipType": "many-to-many",
             "otherEntityField": "id",
             "ownerSide": true
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "id",
+            "ownerSide": true
         }
     ],
     "fields": [],

--- a/test-integration/samples/.jhipster/TestManyToOne.json
+++ b/test-integration/samples/.jhipster/TestManyToOne.json
@@ -48,6 +48,12 @@
             "otherEntityName": "testCustomTableName",
             "relationshipType": "many-to-one",
             "otherEntityField": "id"
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "id"
         }
     ],
     "fields": [],

--- a/test-integration/samples/.jhipster/TestOneToOne.json
+++ b/test-integration/samples/.jhipster/TestOneToOne.json
@@ -64,6 +64,14 @@
             "otherEntityField": "id",
             "ownerSide": true,
             "otherEntityRelationshipName": "testOneToOne"
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "one-to-one",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "superMegaLargeTestOneToOne"
         }
     ],
     "fields": [],

--- a/test-integration/scripts/11-generate-entities.sh
+++ b/test-integration/scripts/11-generate-entities.sh
@@ -96,6 +96,7 @@ elif [[ "$JHI_ENTITY" == "sqlfull" ]]; then
     moveEntity TestOneToOne
     moveEntity TestCustomTableName
     moveEntity TestTwoRelationshipsSameEntity
+    moveEntity SuperMegaLargeTestEntity
 
     moveEntity EntityWithDTO
     moveEntity EntityWithPagination

--- a/travis/samples/.jhipster/SuperMegaLargeTestEntity.json
+++ b/travis/samples/.jhipster/SuperMegaLargeTestEntity.json
@@ -2,47 +2,41 @@
     "fluentMethods": true,
     "relationships": [
         {
-            "relationshipName": "testManyToOne",
+            "relationshipName": "superMegaLargeTestManyToOne",
             "otherEntityName": "testManyToOne",
             "relationshipType": "one-to-many",
-            "otherEntityRelationshipName": "testCustomTableName"
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         },
         {
-            "relationshipName": "testManyToMany",
+            "relationshipName": "superMegaLargeTestManyToMany",
             "otherEntityName": "testManyToMany",
             "relationshipType": "many-to-many",
             "ownerSide": false,
-            "otherEntityRelationshipName": "testCustomTableName"
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         },
         {
-            "relationshipName": "testOneToOne",
+            "relationshipName": "superMegaLargeTestOneToOne",
             "otherEntityName": "testOneToOne",
             "relationshipType": "one-to-one",
             "ownerSide": false,
-            "otherEntityRelationshipName": "testCustomTableName"
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         },
         {
-            "relationshipName": "testEntity",
-            "otherEntityName": "testEntity",
-            "relationshipType": "many-to-one",
-            "relationshipValidateRules": "required",
-            "otherEntityField": "id"
-        },
-        {
-            "relationshipName": "userOneToMany",
+            "relationshipName": "superMegaLargeUserOneToMany",
             "otherEntityName": "user",
             "relationshipType": "many-to-one",
+            "relationshipValidateRules": "required",
             "otherEntityField": "login"
         },
         {
-            "relationshipName": "userManyToMany",
+            "relationshipName": "superMegaLargeUserManyToMany",
             "otherEntityName": "user",
             "relationshipType": "many-to-many",
             "otherEntityField": "login",
             "ownerSide": true
         },
         {
-            "relationshipName": "userOneToOne",
+            "relationshipName": "superMegaLargeUserOneToOne",
             "otherEntityName": "user",
             "relationshipType": "one-to-one",
             "otherEntityField": "login",
@@ -50,17 +44,17 @@
             "otherEntityRelationshipName": "parent"
         },
         {
-            "relationshipName": "superMegaLargeTestEntity",
-            "otherEntityName": "superMegaLargeTestEntity",
-            "relationshipType": "many-to-one",
-            "relationshipValidateRules": "required",
-            "otherEntityField": "id"
+            "relationshipName": "superMegaLargeTestCustomTableName",
+            "otherEntityName": "testCustomTableName",
+            "relationshipType": "one-to-many",
+            "otherEntityRelationshipName": "superMegaLargeTestEntity"
         }
     ],
     "fields": [],
-    "changelogDate": "20160208210109",
+    "changelogDate": "20181120190609",
     "dto": "no",
     "service": "no",
-    "entityTableName": "test_custom_table_name_entity",
+    "jpaMetamodelFiltering": true,
+    "angularJSSuffix": "mySuffixAlt",
     "pagination": "no"
 }

--- a/travis/samples/.jhipster/TestCustomTableName.json
+++ b/travis/samples/.jhipster/TestCustomTableName.json
@@ -48,6 +48,13 @@
             "otherEntityField": "login",
             "ownerSide": true,
             "otherEntityRelationshipName": "parent"
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "many-to-one",
+            "relationshipValidateRules": "required",
+            "otherEntityField": "id"
         }
     ],
     "fields": [],

--- a/travis/samples/.jhipster/TestManyToMany.json
+++ b/travis/samples/.jhipster/TestManyToMany.json
@@ -56,6 +56,13 @@
             "relationshipType": "many-to-many",
             "otherEntityField": "id",
             "ownerSide": true
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "many-to-many",
+            "otherEntityField": "id",
+            "ownerSide": true
         }
     ],
     "fields": [],

--- a/travis/samples/.jhipster/TestManyToOne.json
+++ b/travis/samples/.jhipster/TestManyToOne.json
@@ -48,6 +48,12 @@
             "otherEntityName": "testCustomTableName",
             "relationshipType": "many-to-one",
             "otherEntityField": "id"
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "many-to-one",
+            "otherEntityField": "id"
         }
     ],
     "fields": [],

--- a/travis/samples/.jhipster/TestOneToOne.json
+++ b/travis/samples/.jhipster/TestOneToOne.json
@@ -64,6 +64,14 @@
             "otherEntityField": "id",
             "ownerSide": true,
             "otherEntityRelationshipName": "testOneToOne"
+        },
+        {
+            "relationshipName": "superMegaLargeTestEntity",
+            "otherEntityName": "superMegaLargeTestEntity",
+            "relationshipType": "one-to-one",
+            "otherEntityField": "id",
+            "ownerSide": true,
+            "otherEntityRelationshipName": "superMegaLargeTestOneToOne"
         }
     ],
     "fields": [],

--- a/travis/scripts/01-generate-entities.sh
+++ b/travis/scripts/01-generate-entities.sh
@@ -110,6 +110,7 @@ elif [[ ( "$JHIPSTER" == *"mysql"* ) || ( "$JHIPSTER" == *"psql"* ) ]]; then
     moveEntity TestOneToOne
     moveEntity TestCustomTableName
     moveEntity TestTwoRelationshipsSameEntity
+    moveEntity SuperMegaLargeTestEntity
 
     moveEntity EntityWithDTO
     moveEntity EntityWithPagination


### PR DESCRIPTION
This pull request contains two fixes:

- Fix constraint name limit length for oracle and mysql
As '_id' is appended limit is maxlength-3 (not maxlength-2)

- [PostgreSQL] Add constraint name length limit
PostgreSQL has 63 byte identifier length limit. (I think that "really"
is 64 -empirical check- but let's trust doc.)
See: https://www.postgresql.org/docs/current/sql-syntax-lexical.html#SQL-SYNTAX-IDENTIFIERS
"The system uses no more than NAMEDATALEN-1 bytes of an identifier;
longer names can be written in commands, but they will be truncated. By
default, NAMEDATALEN is 64 so the maximum identifier length is 63
bytes."


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
