### PR TITLE
Fix JIB integration www folder issue

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -49,7 +49,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         main: './<%= MAIN_SRC_DIR %>app/app.main'
     },
     output: {
-        path: utils.root('<%= BUILD_DIR %><% if (buildTool === 'maven') { %>classes/public<% } %><% if (buildTool === 'gradle'){ %>resources/main/public<% } %>'),
+        path: utils.root('<%= BUILD_DIR %>www'),
         filename: 'app/[name].[hash].bundle.js',
         chunkFilename: 'app/[id].[hash].chunk.js'
     },

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -40,7 +40,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
     main: './<%= MAIN_SRC_DIR %>app/index'
   },
   output: {
-    path: utils.root('<%= BUILD_DIR %><% if (buildTool === 'maven') { %>classes/public<% } %><% if (buildTool === 'gradle'){ %>resources/main/public<% } %>'),
+    path: utils.root('<%= BUILD_DIR %>www'),
     filename: 'app/[name].[hash].bundle.js',
     chunkFilename: 'app/[name].[hash].chunk.js'
   },

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -292,7 +292,7 @@ To stop it and remove the container, run:
 You can also fully dockerize your application and all the services that it depends on.
 To achieve this, first build a docker image of your app by running:
 
-    <% if (buildTool === 'maven') { %>./mvnw package -Pprod jib:dockerBuild<% } %><% if (buildTool === 'gradle') { %>./gradlew bootWar -Pprod jibDockerBuild<% } %>
+    <% if (buildTool === 'maven') { %>./mvnw package -Pprod verify jib:dockerBuild<% } %><% if (buildTool === 'gradle') { %>./gradlew bootWar -Pprod jibDockerBuild<% } %>
 
 Then run:
 

--- a/generators/docker-base.js
+++ b/generators/docker-base.js
@@ -46,7 +46,7 @@ function checkImages() {
         const appConfig = this.appConfigs[index];
         if (appConfig.buildTool === 'maven') {
             imagePath = this.destinationPath(`${this.directoryPath + appsFolder}/target/jib-cache`);
-            runCommand = './mvnw package -Pprod jib:dockerBuild';
+            runCommand = './mvnw package -Pprod verify jib:dockerBuild';
         } else {
             imagePath = this.destinationPath(`${this.directoryPath + appsFolder}/build/jib-cache`);
             runCommand = './gradlew bootWar -Pprod jibDockerBuild';

--- a/generators/docker-utils.js
+++ b/generators/docker-utils.js
@@ -85,7 +85,7 @@ function checkImageExist(opts = { cwd: './', appConfig: null }) {
     this.warningMessage = 'To generate the missing Docker image(s), please run:\n';
     if (opts.appConfig.buildTool === 'maven') {
         imagePath = this.destinationPath(`${opts.cwd + opts.cwd}/target/docker`);
-        this.dockerBuildCommand = './mvnw package -Pprod jib:dockerBuild';
+        this.dockerBuildCommand = './mvnw package -Pprod verify jib:dockerBuild';
     } else {
         imagePath = this.destinationPath(`${opts.cwd + opts.cwd}/build/docker`);
         this.dockerBuildCommand = './gradlew bootWar -Pprod jibDockerBuild';

--- a/generators/server/templates/gradle/docker.gradle.ejs
+++ b/generators/server/templates/gradle/docker.gradle.ejs
@@ -27,11 +27,6 @@ buildscript {
 
 apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
 
-task copyWwwIntoStatic (type: Copy) {
-    from 'build/www/'
-    into 'build/resources/main/static'
-}
-
 jib {
     from {
         image = '<%= DOCKER_JAVA_JRE %>'
@@ -51,4 +46,11 @@ jib {
     }
 }
 
+<%_ if (!skipClient) { _%>
+task copyWwwIntoStatic (type: Copy) {
+    from '<%= CLIENT_DIST_DIR %>'
+    into 'build/resources/main/static'
+}
+
 jibDockerBuild.dependsOn copyWwwIntoStatic
+<%_ } _%>

--- a/generators/server/templates/gradle/docker.gradle.ejs
+++ b/generators/server/templates/gradle/docker.gradle.ejs
@@ -27,6 +27,11 @@ buildscript {
 
 apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
 
+task copyWwwIntoStatic (type: Copy) {
+    from 'build/www/'
+    into 'build/resources/main/static'
+}
+
 jib {
     from {
         image = '<%= DOCKER_JAVA_JRE %>'
@@ -45,3 +50,5 @@ jib {
         useCurrentTimestamp = true
     }
 }
+
+jibDockerBuild.dependsOn copyWwwIntoStatic

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1075,13 +1075,13 @@
                             </configuration>
                         </execution>
                         <execution>
-                            <id>docker-resources</id>
+                            <id>jib-www-resources</id>
                             <phase>verify</phase>
                             <goals>
                                 <goal>copy-resources</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>target/classes/static/</outputDirectory>
+                                <outputDirectory>target/classes/public/</outputDirectory>
                                 <resources>
                                     <resource>
                                         <directory>target/www</directory>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1081,7 +1081,7 @@
                                 <goal>copy-resources</goal>
                             </goals>
                             <configuration>
-                                <outputDirectory>target/classes/public/</outputDirectory>
+                                <outputDirectory>target/classes/static/</outputDirectory>
                                 <resources>
                                     <resource>
                                         <directory>target/www</directory>


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
This PR is a WIP to fix #8586.

When introducing JIB, the static assets were generated to a standard Spring MVC static location ( `classpath:/public`) to then be integrated into the JIB resource layer.
This feature broke the webserver compatibility of JHipster (Tomcat, Undertow, etc.)

The main action is to rollback to the standard `www` folder for static assets (and be compliant again with webservers) and update the JIB integration with a pre-build step to copy the static files to be compliant to Spring MVC.