### PR TITLE
enable original war packaging 

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -86,7 +86,11 @@ bootWar {
 }
 
 war {
-
+    <%_ if (!skipClient) { _%>
+    webAppDirName = '<%= CLIENT_DIST_DIR %>'
+    <%_ } _%>
+    enabled = true
+    classifier = 'original'
 }
 
 springBoot {
@@ -516,6 +520,7 @@ if (project.hasProperty('nodeInstall')) {
 }
 <%_ } _%>
 
+bootWar.dependsOn war
 compileJava.dependsOn processResources
 processResources.dependsOn cleanResources,bootBuildInfo
 bootBuildInfo.mustRunAfter cleanResources

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -51,10 +51,6 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task, depend
     args = ["run", "webpack:build"]
 }
 
-war {
-    webAppDirName = '<%= CLIENT_DIST_DIR %>'
-}
-
 task copyIntoStatic (type: Copy) {
     from '<%= CLIENT_DIST_DIR %>'
     into 'build/resources/main/static'

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -50,10 +50,6 @@ task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: '<%
     args = ["run", "webpack:prod"]
 }
 
-war {
-    webAppDirName = '<%= CLIENT_DIST_DIR %>'
-}
-
 task copyIntoStatic (type: Copy) {
     from '<%= CLIENT_DIST_DIR %>'
     into 'build/resources/main/static'

--- a/test-integration/scripts/23-package.sh
+++ b/test-integration/scripts/23-package.sh
@@ -28,7 +28,7 @@ if [ -f "mvnw" ]; then
     ./mvnw verify -DskipTests -P"$JHI_PROFILE"
     mv target/*.war app.war
 elif [ -f "gradlew" ]; then
-    ./gradlew bootWar -P"$JHI_PROFILE" -x test
+    ./gradlew bootWar -P"$JHI_PROFILE" -x test -x war
     mv build/libs/*.war app.war
 else
     echo "*** no mvnw or gradlew"


### PR DESCRIPTION
the original war is now also created when building an executable war via `bootWar` task.

closes #8811
closes #8860

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
