### PR TITLE
CI: use default build for Gradle and copy the non original war

### DIFF
--- a/test-integration/scripts/23-package.sh
+++ b/test-integration/scripts/23-package.sh
@@ -28,8 +28,8 @@ if [ -f "mvnw" ]; then
     ./mvnw verify -DskipTests -P"$JHI_PROFILE"
     mv target/*.war app.war
 elif [ -f "gradlew" ]; then
-    ./gradlew bootWar -P"$JHI_PROFILE" -x test -x war
-    mv build/libs/*.war app.war
+    ./gradlew bootWar -P"$JHI_PROFILE" -x test
+    mv build/libs/*SNAPSHOT.war app.war
 else
     echo "*** no mvnw or gradlew"
     exit 0


### PR DESCRIPTION
Following https://github.com/jhipster/generator-jhipster/pull/8866

I'd prefer to keep `./gradlew bootWar -P"$JHI_PROFILE" -x test` so it is similar to what our end users will use. Are you ok with that @atomfrede ?

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
