### PR TITLE
Upgrade to jib 0.10.0

### DIFF
--- a/generators/server/templates/gradle/docker.gradle.ejs
+++ b/generators/server/templates/gradle/docker.gradle.ejs
@@ -21,21 +21,18 @@ buildscript {
         gradlePluginPortal()
     }
     dependencies {
-        classpath "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:0.9.11"
+        classpath "gradle.plugin.com.google.cloud.tools:jib-gradle-plugin:0.10.0"
     }
 }
 
 apply plugin: com.google.cloud.tools.jib.gradle.JibPlugin
 
 jib {
-    from {
-        image = '<%= DOCKER_JAVA_JRE %>'
-    }
     to {
         image = '<%= baseName.toLowerCase() %>:latest'
     }
     container {
-        entrypoint = ['sh', '-c', 'chmod +x /entrypoint.sh && sync && /entrypoint.sh']
+        entrypoint = ['/entrypoint.sh']
         ports = ['<%= serverPort %>'<% if (cacheProvider === 'hazelcast') { %>, '5701/udp' <% } %>]
         environment = [
             <%_ if (cacheProvider === 'infinispan') { _%>JAVA_OPTS: '-Djgroups.tcp.address=NON_LOOPBACK -Djava.net.preferIPv4Stack=true',<%_ } _%>
@@ -43,6 +40,9 @@ jib {
             JHIPSTER_SLEEP: '0'
         ]
         useCurrentTimestamp = true
+    }
+    extraDirectory {
+        permissions = ['/entrypoint.sh': '700']
     }
 }
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -99,7 +99,7 @@
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
-        <jib-maven-plugin.version>0.9.11</jib-maven-plugin.version>
+        <jib-maven-plugin.version>0.10.0</jib-maven-plugin.version>
         <%_ if (!skipClient) { _%>
         <frontend-maven-plugin.version>1.6</frontend-maven-plugin.version>
         <%_ } _%>
@@ -937,9 +937,7 @@
                       </to>
                       <container>
                           <entrypoint>
-                              <shell>sh</shell>
-                              <option>-c</option>
-                              <arg>chmod +x /entrypoint.sh &amp;&amp; sync &amp;&amp; /entrypoint.sh</arg>
+                              <script>/entrypoint.sh</script>
                           </entrypoint>
                           <ports>
                               <port><%= serverPort %></port>
@@ -954,6 +952,14 @@
                           </environment>
                           <useCurrentTimestamp>true</useCurrentTimestamp>
                       </container>
+                      <extraDirectory>
+                        <permissions>
+                            <permission>
+                              <file>/entrypoint.sh</file>
+                              <mode>700</mode>
+                            </permission>
+                        </permissions>
+                      </extraDirectory>
                   </configuration>
                 </plugin>
 <%_ if (databaseType === 'sql') { _%>

--- a/generators/server/templates/src/main/jib/entrypoint.sh.ejs
+++ b/generators/server/templates/src/main/jib/entrypoint.sh.ejs
@@ -1,4 +1,4 @@
 #!/bin/sh
 
 echo "The application will start in ${JHIPSTER_SLEEP}s..." && sleep ${JHIPSTER_SLEEP}
-exec java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -cp /app/resources/:/app/classes/:/app/libs/* "<%= packageName %>.<%= mainClass %>"  "$@"
+exec java ${JAVA_OPTS} -Djava.security.egd=file:/dev/./urandom -jar /jetty/start.jar


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->

---
The upgrade to version 0.10.0 introduce couple of changes for us...

**TL;DR: we can't containerize an executable WARs**

Jib detects the usage of the `war` packaging/plugin and force the usage of a servlet container vs an executable war. 
https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#war-projects
As explained in the above doc, jib copies the expanded war into `/jetty/webapps/ROOT` by default even if you use a *jre only* base image.

I raised an issue on the the jib project
https://github.com/GoogleContainerTools/jib/issues/1281

**Experiment with `gcr.io/distroless/java/jetty`**
Another issue appeared... the lack of shell commands, that's why they have a `:debug` flavor
https://github.com/GoogleContainerTools/distroless#debug-images
Long story short, we can't trigger the `entrypoint.sh` script with *official* distroless images.

**Proposals**
1- Use the `jetty:jre8-alpine` as base image to be compliant with the jib behavior about WAR packaging and use the shell tools to trigger the `entrypoint.sh`
2- Remove the `sleep ${JHIPSTER_SLEEP}` to have the app startup managed by the image entrypoint
3- Define an official JHipster base image with the `sleep ${JHIPSTER_SLEEP}`  included
4- Stay with the current version of jib because so far it works

Thoughts?