### PR TITLE
Force user id to be considered as numeric value when loadData with postgresql and Liquibase

### DIFF
--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -147,6 +147,9 @@
                   identityInsertEnabled="true"
                   <%_ } _%>
                   tableName="<%= jhiTablePrefix %>_user">
+            <%_ if (prodDatabaseType === 'postgresql') { _%>
+            <column name="id" type="numeric"/>
+            <%_ } _%>
             <column name="activated" type="boolean"/>
             <column name="created_date" type="timestamp"/>
         </<% if (devDatabaseType === 'mssql' || prodDatabaseType === 'mssql') { %>ext:<% } %>loadData>


### PR DESCRIPTION
1. Postgres Exception @ users loadData
In case of postgresql the id is considered as varying value
instead of numeric. The loadData failed. We have to force the type when load data.
It seems to be a regression but don't any information about it.

> Reason: liquibase.exception.DatabaseException: java.sql.BatchUpdateException: Batch entry 0 INSERT INTO public.jhi_user(id, login, password_hash, first_name, last_name, email, image_url, activated, lang_key, created_by, last_modified_by) VALUES('1', 'system', '$2a$10$mE.qmcV0mFU5NcKh73TZx.z4ueI/.bDWbj0T1BYyqP481kGGarKLG', 'System', 'System', 'system@localhost', '', 'TRUE', 'en', 'system', 'system') was aborted: ERROR: column "id" is of type bigint but expression is of type character varying


-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
