### PR TITLE
Correct spell of settings in Farsi

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/fa/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/global.json.ejs
@@ -29,7 +29,7 @@
             },
             "account": {
                 "main": "حساب",
-                "settings": "تنضیمات",
+                "settings": "تنظیمات",
                 "password": "رمزعبور",
                 "sessions": "نشست ها",
                 "login": "ورود",


### PR DESCRIPTION
The correct Spell of settings in Farsi is "تنظیمات"

Fix #8918