### PR TITLE
Pass 'client-hook' option to common blueprint

### DIFF
--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -41,6 +41,7 @@ module.exports = class extends BaseBlueprintGenerator {
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property
             useBlueprint = this.composeBlueprint(blueprint, 'common', {
+                'client-hook': !this.skipClient,
                 'from-cli': this.options['from-cli'],
                 configOptions: this.configOptions,
                 force: this.options.force


### PR DESCRIPTION
Missing option that needs to be transmitted to blueprint generator too