### PR TITLE
Fix Docker elasticsearch settings

### DIFF
--- a/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
+++ b/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-version: '2.2'
+version: '2'
 services:
     <%= baseName.toLowerCase() %>-elasticsearch:
         image: <%= DOCKER_ELASTICSEARCH %>
@@ -25,6 +25,6 @@ services:
         ports:
             - 9200:9200
             - 9300:9300
-        command: -Enetwork.host=0.0.0.0 -Ediscovery.type=single-node
         environment:
             - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
+            - discovery.type=single-node


### PR DESCRIPTION
Revert to version 2 otherwise it does not start
Remove command network.host deprecated (it seems that we don't need it anymore)
Move command discovery.type to environment (-e command is no longer recognized)

#8683

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
