### PR TITLE
Fixes for the upgrade subgenerator

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -124,7 +124,7 @@ module.exports = class extends BaseGenerator {
                     : shelljs.exec('npm bin', { silent: this.silent }).stdout;
             generatorCommand = `"${generatorDir.replace('\n', '')}/jhipster"`;
         }
-        const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --no-insight`;
+        const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --skip-git --no-insight`;
         this.info(regenerateCmd);
         shelljs.exec(regenerateCmd, { silent: this.silent }, (code, msg, err) => {
             if (code === 0) this.success(`Successfully regenerated application with JHipster ${version}`);

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -278,7 +278,8 @@ module.exports = class extends BaseGenerator {
                 const installJhipsterLocally = (version, callback) => {
                     this.log(`Installing JHipster ${version} locally`);
                     const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
-                    const generatorCommand = `${commandPrefix} ${GENERATOR_JHIPSTER}@${version} --dev --no-lockfile --ignore-scripts`;
+                    const devDependencyParam = this.clientPackageManager === 'yarn' ? '--dev' : '--save-dev';
+                    const generatorCommand = `${commandPrefix} ${GENERATOR_JHIPSTER}@${version} ${devDependencyParam} --no-lockfile --ignore-scripts`;
                     this.info(generatorCommand);
                     shelljs.exec(generatorCommand, { silent: this.silent }, (code, msg, err) => {
                         if (code === 0) this.success(`Installed ${GENERATOR_JHIPSTER}@${version}`);
@@ -330,9 +331,10 @@ module.exports = class extends BaseGenerator {
                 this.log(chalk.yellow(`Updating ${GENERATOR_JHIPSTER} to ${this.latestVersion} . This might take some time...`));
                 const done = this.async();
                 const commandPrefix = this.clientPackageManager === 'yarn' ? 'yarn add' : 'npm install';
+                const devDependencyParam = this.clientPackageManager === 'yarn' ? '--dev' : '--save-dev';
                 const generatorCommand = `${commandPrefix} ${GENERATOR_JHIPSTER}@${
                     this.latestVersion
-                } --dev --no-lockfile --ignore-scripts`;
+                } ${devDependencyParam} --no-lockfile --ignore-scripts`;
                 this.info(generatorCommand);
                 shelljs.exec(generatorCommand, { silent: this.silent }, (code, msg, err) => {
                     if (code === 0) this.success(`Updated ${GENERATOR_JHIPSTER} to version ${this.latestVersion}`);

--- a/test/upgrade.spec.js
+++ b/test/upgrade.spec.js
@@ -1,0 +1,73 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const shelljs = require('shelljs');
+const expect = require('chai').expect;
+const expectedFiles = require('./utils/expected-files');
+
+describe('JHipster upgrade generator', function() {
+    this.timeout(200000);
+    describe('default application', () => {
+        before(done => {
+            let workingDirectory;
+            helpers
+                .run(path.join(__dirname, '../generators/app'))
+                .withOptions({ skipInstall: true, skipChecks: true, 'from-cli': true })
+                .inTmpDir(dir => {
+                    console.log(`Generating JHipster application in directory: ${dir}`);
+                    // Save directory, in order to run the upgrade generator in the same directory
+                    workingDirectory = dir;
+                })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    cacheProvider: 'ehcache',
+                    enableHibernateCache: true,
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Memory',
+                    prodDatabaseType: 'mysql',
+                    useSass: false,
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr'],
+                    buildTool: 'maven',
+                    rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                    skipClient: false,
+                    skipUserManagement: false,
+                    serverSideOptions: []
+                })
+                .on('end', () => {
+                    helpers
+                        .run(path.join(__dirname, '../generators/upgrade'))
+                        .withOptions({ 'from-cli': true, force: true, silent: true })
+                        .inTmpDir(() => {
+                            console.log('Upgrading the JHipster application');
+                            process.chdir(workingDirectory);
+                        })
+                        .on('end', done);
+                });
+        });
+
+        it('creates expected files for default configuration', () => {
+            assert.file(expectedFiles.common);
+            assert.file(expectedFiles.server);
+            assert.file(expectedFiles.maven);
+            assert.file(expectedFiles.client);
+        });
+
+        it('generates expected number of commits', () => {
+            const commitsCount = shelljs.exec('git rev-list --count HEAD', { silent: false }).stdout.replace('\n', '');
+            // Expecting 5 commits in history (because we used `force` option):
+            //   - master: initial commit
+            //   - jhipster_upgrade; initial generation
+            //   - master: block-merge commit of jhipster_upgrade
+            //   - jhipster_upgrade: new generation in jhipster_upgrade
+            //   - master: merge commit of jhipster_upgrade
+            expect(commitsCount).to.equal('5');
+        });
+    });
+});


### PR DESCRIPTION
2 fixes:
- incorrect npm syntax for installing dev dependency
- extraneous commits were generated

I've created a unit test for this subgenerator, that is bit long to run since it generates a new application, and then run the upgrade process. This is not perfect, but it's still better than nothing.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
