### PR TITLE
Fix undefined version in documentation

### DIFF
--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -70,9 +70,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
                 // Make documentation URL available in templates
                 this.DOCUMENTATION_URL = constants.JHIPSTER_DOCUMENTATION_URL;
-                this.DOCUMENTATION_ARCHIVE_URL = `${constants.JHIPSTER_DOCUMENTATION_URL + constants.JHIPSTER_DOCUMENTATION_ARCHIVE_PATH}v${
-                    this.jhipsterVersion
-                }`;
+                this.DOCUMENTATION_ARCHIVE_PATH = constants.JHIPSTER_DOCUMENTATION_ARCHIVE_PATH;
             }
         };
     }

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -28,6 +28,7 @@ if (clientPackageManager === 'yarn') {
     clientPackageMngrAdd = 'add --exact';
     clientPackageMngrAddDev = 'add --dev --exact';
 }
+let DOCUMENTATION_ARCHIVE_URL = `${DOCUMENTATION_URL + DOCUMENTATION_ARCHIVE_PATH}v${jhipsterVersion}`;
 _%>
 This application was generated using JHipster <%= jhipsterVersion %>, you can find documentation and help at [<%= DOCUMENTATION_ARCHIVE_URL %>](<%= DOCUMENTATION_ARCHIVE_URL %>).
 <%_ if (applicationType === 'gateway' || applicationType === 'microservice' || applicationType === 'uaa') { _%>

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -70,6 +70,9 @@ describe('JHipster generator', () => {
             it('contains correct custom prefix when specified', () => {
                 assert.fileContent('angular.json', /"prefix": "test"/);
             });
+            it('generates a README with no undefined value', () => {
+                assert.noFileContent('README.md', /undefined/);
+            });
         });
 
         describe('React', () => {
@@ -1319,6 +1322,47 @@ describe('JHipster generator', () => {
         });
     });
 
+    context('App with skip server', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../generators/app'))
+                .withOptions({ 'from-cli': true, skipInstall: true, skipServer: true, db: 'mysql', auth: 'jwt', skipChecks: true })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    useSass: false,
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr'],
+                    rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277'
+                })
+                .on('end', done);
+        });
+
+        it('creates expected files for default configuration with skip server option enabled', () => {
+            assert.file(expectedFiles.common);
+            assert.noFile(expectedFiles.server);
+            assert.noFile(expectedFiles.userManagementServer);
+            assert.noFile(expectedFiles.maven);
+            assert.file(
+                getFilesForOptions(angularFiles, {
+                    useSass: false,
+                    enableTranslation: true,
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    testFrameworks: []
+                })
+            );
+        });
+        it('generates a README with no undefined value', () => {
+            assert.noFileContent('README.md', /undefined/);
+        });
+    });
+
     context('App with skip client', () => {
         describe('Maven', () => {
             before(done => {
@@ -1365,6 +1409,9 @@ describe('JHipster generator', () => {
                         ['package.json']
                     )
                 );
+            });
+            it('generates a README with no undefined value', () => {
+                assert.noFileContent('README.md', /undefined/);
             });
         });
 

--- a/test/blueprint/common-blueprint.spec.js
+++ b/test/blueprint/common-blueprint.spec.js
@@ -26,7 +26,7 @@ const mockBlueprintSubGen = class extends CommonGenerator {
         const phaseFromJHipster = super._configuring();
         const customPhaseSteps = {
             overridesDocumentationUrl() {
-                this.DOCUMENTATION_ARCHIVE_URL = 'https://myenterprise.intranet';
+                this.DOCUMENTATION_URL = 'https://myenterprise.intranet';
             }
         };
         return { ...phaseFromJHipster, ...customPhaseSteps };


### PR DESCRIPTION
DOCUMENTATION_ARCHIVE_URL variable - using jhipsterVersion - was defined before jhipsterVersion was set.
Added tests to check everything is OK in the 3 scenarios where common subgenerator can be invoked:
- standard monolith (server + client)
- microservice (server only)
- monolith with skipServer (client only)

Fix #8955

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
