### PR TITLE
Fix regression with prettier transform after the move to common subgen in 5.7.1

### DIFF
--- a/generators/common/files.js
+++ b/generators/common/files.js
@@ -21,12 +21,18 @@
  * The default is to use a file path string. It implies use of the template method.
  * For any other config an object { file:.., method:.., template:.. } can be used
  */
+const prettierConfigFiles = {
+    global: [
+        {
+            templates: ['.prettierrc', '.prettierignore']
+        }
+    ]
+};
+
 const commonFiles = {
     global: [
         {
             templates: [
-                '.prettierrc', // this needs to be the first file for prettier transform to work
-                '.prettierignore',
                 'README.md',
                 {
                     file: 'gitignore',
@@ -57,5 +63,6 @@ function writeFiles() {
 
 module.exports = {
     writeFiles,
+    prettierConfigFiles,
     commonFiles
 };

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -19,6 +19,7 @@
 /* eslint-disable consistent-return */
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const writeFiles = require('./files').writeFiles;
+const prettierConfigFiles = require('./files').prettierConfigFiles;
 const constants = require('../generator-constants');
 
 let useBlueprint;
@@ -81,16 +82,6 @@ module.exports = class extends BaseBlueprintGenerator {
     }
 
     // Public API method used by the getter and also by Blueprints
-    _prompting() {
-        return {};
-    }
-
-    get prompting() {
-        if (useBlueprint) return;
-        return this._prompting();
-    }
-
-    // Public API method used by the getter and also by Blueprints
     _default() {
         return {
             getSharedConfigOptions() {
@@ -102,6 +93,10 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.useSass = this.configOptions.useSass;
                 this.protractorTests = this.testFrameworks.includes('protractor');
                 this.gatlingTests = this.testFrameworks.includes('gatling');
+            },
+            writePrettierConfig() {
+                // Prettier configuration needs to be the first written files - all subgenerators considered - for prettier transform to work
+                this.writeFilesToDisk(prettierConfigFiles, this, false, this.fetchFromInstalledJHipster('common/templates'));
             }
         };
     }

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -73,6 +73,11 @@ describe('JHipster generator', () => {
             it('generates a README with no undefined value', () => {
                 assert.noFileContent('README.md', /undefined/);
             });
+            it('uses correct prettier formatting', () => {
+                // tabWidth = 4 (see generators/common/templates/.prettierrc.ejs)
+                assert.fileContent('webpack/webpack.dev.js', / {4}devtool:/);
+                assert.fileContent('tsconfig.json', / {4}"compilerOptions":/);
+            });
         });
 
         describe('React', () => {
@@ -131,6 +136,11 @@ describe('JHipster generator', () => {
             });
             it('contains clientFramework with react value', () => {
                 assert.fileContent('.yo-rc.json', /"clientFramework": "react"/);
+            });
+            it('uses correct prettier formatting', () => {
+                // tabWidth = 2 (see generators/common/templates/.prettierrc.ejs)
+                assert.fileContent('webpack/webpack.dev.js', / {2}devtool:/);
+                assert.fileContent('tsconfig.json', / {2}"compilerOptions":/);
             });
         });
 


### PR DESCRIPTION
Prettier configuration needs to be written before all other files, all subgenerators considered

This regression is (re)formatting all javascript, typescript, json, ... with 2 spaces tab with, instead of 4 spaces.
See e.g. https://github.com/jhipster/jhipster-sample-app/commit/f4758950c6a14f107040c6167232bad6330fafba#diff-9f0810dd246846b72b1e562d738464d4

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
