### PR TITLE
Reorganize entity tests: reorder, regroup by context, reword

### DIFF
--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -9,220 +9,280 @@ const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
 
 describe('JHipster generator for entity', () => {
-    describe('search, no dto, no service, no pagination', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-elasticsearch'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'no',
-                    service: 'no',
-                    pagination: 'no'
-                })
-                .on('end', done);
-        });
+    context('monolith with elasticsearch', () => {
+        describe('search, no dto, no service, no pagination', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-elasticsearch'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
 
-        it('does creates search files', () => {
-            assert.file(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/search/FooSearchRepository.java`);
-            assert.file(expectedFiles.gatling);
-        });
-    });
-});
-
-describe('JHipster generator entity for angularX', () => {
-    describe('no dto, no service, no pagination', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'no',
-                    service: 'no',
-                    pagination: 'no'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2);
-            assert.file(expectedFiles.gatling);
+            it('does creates search files', () => {
+                assert.file(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/search/FooSearchRepository.java`);
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.gatling);
+            });
         });
     });
 
-    describe('no dto, no service, with pagination', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'no',
-                    service: 'no',
-                    pagination: 'pagination'
-                })
-                .on('end', done);
+    context('monolith with angularX', () => {
+        describe('no dto, no service, no pagination', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+            });
         });
 
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2);
-            assert.file(expectedFiles.gatling);
+        describe('no dto, no service, with pagination', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'pagination'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+            });
+        });
+
+        describe('no dto, no service, with infinite-scroll', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'infinite-scroll'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+            });
+        });
+
+        describe('no dto, with serviceImpl, no pagination', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'serviceImpl',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+                assert.file([
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/FooService.java`,
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/impl/FooServiceImpl.java`
+                ]);
+            });
+        });
+
+        describe('with dto, service, no pagination', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'mapstruct',
+                        service: 'serviceClass',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+                assert.file([
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/dto/FooDTO.java`,
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/mapper/FooMapper.java`,
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/FooService.java`
+                ]);
+            });
+        });
+
+        describe('with angular suffix', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({ 'angular-suffix': 'management' })
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'yes',
+                        service: 'serviceImpl',
+                        pagination: 'infinite-scroll'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2WithSuffix);
+                assert.file(expectedFiles.gatling);
+                assert.fileContent('.jhipster/Foo.json', 'angularJSSuffix');
+            });
+        });
+
+        describe('with client-root-folder', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({ 'client-root-folder': 'test-root' })
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'yes',
+                        service: 'serviceImpl',
+                        pagination: 'infinite-scroll'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2WithRootFolder);
+                assert.file(expectedFiles.gatling);
+                assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
+            });
+        });
+
+        describe('with client-root-folder and angular-suffix', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({ 'client-root-folder': 'test-root' })
+                    .withOptions({ 'angular-suffix': 'management' })
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'yes',
+                        service: 'serviceImpl',
+                        pagination: 'infinite-scroll'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2WithRootFolderAndSuffix);
+                assert.file(expectedFiles.gatling);
+                assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
+            });
         });
     });
 
-    describe('no dto, no service, with infinite-scroll', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'no',
-                    service: 'no',
-                    pagination: 'infinite-scroll'
-                })
-                .on('end', done);
-        });
+    context('no i18n', () => {
+        describe('with dto, serviceImpl, with hazelcast, elasticsearch', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/noi18n'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'yes',
+                        service: 'serviceImpl',
+                        pagination: 'infinite-scroll'
+                    })
+                    .on('end', done);
+            });
 
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2);
-            assert.file(expectedFiles.gatling);
-        });
-    });
-
-    describe('no dto, with serviceImpl, no pagination', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'no',
-                    service: 'serviceImpl',
-                    pagination: 'no'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2);
-            assert.file(expectedFiles.gatling);
-            assert.file([
-                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/FooService.java`,
-                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/impl/FooServiceImpl.java`
-            ]);
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+                assert.noFile([`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`, `${CLIENT_MAIN_SRC_DIR}i18n/fr/foo.json`]);
+            });
         });
     });
 
-    describe('with dto, service, no pagination', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'mapstruct',
-                    service: 'serviceClass',
-                    pagination: 'no'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2);
-            assert.file(expectedFiles.gatling);
-            assert.file([
-                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/dto/FooDTO.java`,
-                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/mapper/FooMapper.java`,
-                `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/service/FooService.java`
-            ]);
-        });
-    });
-
-    describe('with dto, serviceImpl, with hazelcast, elasticsearch and no i18n', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/noi18n'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'yes',
-                    service: 'serviceImpl',
-                    pagination: 'infinite-scroll'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2);
-            assert.file(expectedFiles.gatling);
-            assert.noFile([`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`, `${CLIENT_MAIN_SRC_DIR}i18n/fr/foo.json`]);
-        });
-    });
-
-    describe('with angular suffix', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withOptions({ 'angular-suffix': 'management' })
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'yes',
-                    service: 'serviceImpl',
-                    pagination: 'infinite-scroll'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2WithSuffix);
-            assert.file(expectedFiles.gatling);
-            assert.fileContent('.jhipster/Foo.json', 'angularJSSuffix');
-        });
-    });
-
-    describe('JHipster generator entity with all languages', () => {
+    context('all languages', () => {
         describe('no dto, no service, no pagination', () => {
             before(done => {
                 helpers
@@ -247,172 +307,8 @@ describe('JHipster generator entity for angularX', () => {
                 });
             });
         });
-    });
 
-    describe('with client-root-folder', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withOptions({ 'client-root-folder': 'test-root' })
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'yes',
-                    service: 'serviceImpl',
-                    pagination: 'infinite-scroll'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2WithRootFolder);
-            assert.file(expectedFiles.gatling);
-            assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
-        });
-    });
-
-    describe('with client-root-folder and angular-suffix', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                })
-                .withArguments(['foo'])
-                .withOptions({ 'client-root-folder': 'test-root' })
-                .withOptions({ 'angular-suffix': 'management' })
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'yes',
-                    service: 'serviceImpl',
-                    pagination: 'infinite-scroll'
-                })
-                .on('end', done);
-        });
-
-        it('creates expected default files', () => {
-            assert.file(expectedFiles.server);
-            assert.file(expectedFiles.clientNg2WithRootFolderAndSuffix);
-            assert.file(expectedFiles.gatling);
-            assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
-        });
-    });
-
-    describe('with client-root-folder microservice', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-microservice'), dir);
-                })
-                .withArguments(['foo'])
-                .withOptions({ 'client-root-folder': 'test-root' })
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'yes',
-                    service: 'serviceImpl',
-                    pagination: 'infinite-scroll'
-                })
-                .on('end', done);
-        });
-
-        it('sets expected custom clientRootFolder', () => {
-            assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
-            assert.file(expectedFiles.server);
-            assert.noFile(expectedFiles.clientNg2WithRootFolder);
-        });
-    });
-
-    describe('with default microservice', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-microservice'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    fieldAdd: false,
-                    relationshipAdd: false,
-                    dto: 'yes',
-                    service: 'serviceImpl',
-                    pagination: 'pagination'
-                })
-                .on('end', done);
-        });
-
-        it('sets expected default clientRootFolder', () => {
-            assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'sampleMicroservice' });
-        });
-        it('generates expected files', () => {
-            assert.file(expectedFiles.server);
-            assert.noFile(expectedFiles.gatling);
-            assert.noFile(expectedFiles.clientNg2WithRootFolder);
-        });
-    });
-
-    describe('with default gateway entity from microservice', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-gateway'), dir);
-                })
-                .withPrompts({
-                    useMicroserviceJson: true,
-                    microservicePath: '../'
-                })
-                .withArguments(['bar'])
-                .on('end', done);
-        });
-
-        it('sets expected default clientRootFolder', () => {
-            assert.jsonFileContent('.jhipster/Bar.json', { clientRootFolder: 'sampleMicroservice' });
-        });
-        it('generates expected files', () => {
-            assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/sampleMicroserviceBar.json`);
-            assert.file(expectedFiles.clientNg2GatewayMicroserviceEntity);
-            assert.noFile(expectedFiles.gatling);
-            assert.fileContent(`${CLIENT_MAIN_SRC_DIR}app/entities/sampleMicroservice/bar/bar.service.ts`, 'samplemicroservice');
-            assert.noFile(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/BarResource.java`);
-        });
-    });
-
-    describe('with default gateway entity from microservice with custom client-root-folder', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/entity'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, '../test/templates/default-gateway'), dir);
-                })
-                .withArguments(['foo'])
-                .withPrompts({
-                    useMicroserviceJson: true,
-                    microservicePath: '../'
-                })
-                .on('end', done);
-        });
-
-        it('sets expected custom clientRootFolder', () => {
-            assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
-        });
-        it('generates expected files', () => {
-            assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/testRootFoo.json`);
-            assert.file(expectedFiles.clientNg2WithRootFolder);
-            assert.noFile(expectedFiles.gatling);
-            assert.noFile(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`);
-        });
-    });
-
-    describe('with all languages and client-root-folder', () => {
-        describe('no dto, no service, no pagination', () => {
+        describe('no dto, no service, no pagination with client-root-folder', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/entity'))
@@ -436,6 +332,117 @@ describe('JHipster generator entity for angularX', () => {
                     assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/${language.value}/testRootFoo.json`);
                 });
                 assert.file(expectedFiles.clientNg2WithRootFolder);
+            });
+        });
+    });
+
+    context('microservice', () => {
+        describe('with client-root-folder microservice', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-microservice'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({ 'client-root-folder': 'test-root' })
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'yes',
+                        service: 'serviceImpl',
+                        pagination: 'infinite-scroll'
+                    })
+                    .on('end', done);
+            });
+
+            it('sets expected custom clientRootFolder', () => {
+                assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
+                assert.file(expectedFiles.server);
+                assert.noFile(expectedFiles.clientNg2WithRootFolder);
+            });
+        });
+
+        describe('with default microservice', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-microservice'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'yes',
+                        service: 'serviceImpl',
+                        pagination: 'pagination'
+                    })
+                    .on('end', done);
+            });
+
+            it('sets expected default clientRootFolder', () => {
+                assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'sampleMicroservice' });
+            });
+            it('generates expected files', () => {
+                assert.file(expectedFiles.server);
+                assert.noFile(expectedFiles.gatling);
+                assert.noFile(expectedFiles.clientNg2WithRootFolder);
+            });
+        });
+    });
+
+    context('gateway', () => {
+        describe('with entity from microservice', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-gateway'), dir);
+                    })
+                    .withPrompts({
+                        useMicroserviceJson: true,
+                        microservicePath: '../'
+                    })
+                    .withArguments(['bar'])
+                    .on('end', done);
+            });
+
+            it('sets expected default clientRootFolder', () => {
+                assert.jsonFileContent('.jhipster/Bar.json', { clientRootFolder: 'sampleMicroservice' });
+            });
+            it('generates expected files', () => {
+                assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/sampleMicroserviceBar.json`);
+                assert.file(expectedFiles.clientNg2GatewayMicroserviceEntity);
+                assert.noFile(expectedFiles.gatling);
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}app/entities/sampleMicroservice/bar/bar.service.ts`, 'samplemicroservice');
+                assert.noFile(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/BarResource.java`);
+            });
+        });
+
+        describe('with entity from microservice and custom client-root-folder', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-gateway'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withPrompts({
+                        useMicroserviceJson: true,
+                        microservicePath: '../'
+                    })
+                    .on('end', done);
+            });
+
+            it('sets expected custom clientRootFolder', () => {
+                assert.jsonFileContent('.jhipster/Foo.json', { clientRootFolder: 'test-root' });
+            });
+            it('generates expected files', () => {
+                assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/testRootFoo.json`);
+                assert.file(expectedFiles.clientNg2WithRootFolder);
+                assert.noFile(expectedFiles.gatling);
+                assert.noFile(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`);
             });
         });
     });


### PR DESCRIPTION
Before:
![image](https://user-images.githubusercontent.com/155828/50053136-bdbece80-012f-11e9-9ff9-ad23e220b905.png)

After:
![image](https://user-images.githubusercontent.com/155828/50053125-99fb8880-012f-11e9-94d5-b1fe4282ee78.png)

Excepted the addition of `assert.file(expectedFiles.server);` in the test with elastisearch, there's no other changes than reordering, adding context, rewording.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
