### PR TITLE
Fix cassandra unit tests with java 8

### DIFF
--- a/generators/server/templates/src/test/java/package/AbstractCassandraTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/AbstractCassandraTest.java.ejs
@@ -41,8 +41,6 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 
-import static org.cassandraunit.utils.EmbeddedCassandraServerHelper.getNativeTransportPort;
-
 /**
  * Base class for starting/stopping Cassandra during tests.
  */
@@ -58,7 +56,7 @@ public class AbstractCassandraTest {
     public static void startServer() throws TTransportException, ConfigurationException, IOException, URISyntaxException  {
         if (! started) {
             EmbeddedCassandraServerHelper.startEmbeddedCassandra(CASSANDRA_UNIT_RANDOM_PORT_YAML, CASSANDRA_TIMEOUT);
-            Cluster cluster = new Cluster.Builder().addContactPoints("127.0.0.1").withPort(getNativeTransportPort()).build();
+            Cluster cluster = EmbeddedCassandraServerHelper.getCluster();
             Session session = cluster.connect();
             String createQuery = "CREATE KEYSPACE " + CASSANDRA_UNIT_KEYSPACE + " WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1}";
             session.execute(createQuery);


### PR DESCRIPTION
Fixes NoClassDefFoundError: com/codahale/metrics/JmxReporter 
Change benefits from the fix done for https://github.com/jsevellec/cassandra-unit/issues/255

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
