### PR TITLE
Use deferred mode for JPA repositories, to speed up start up

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -153,6 +153,10 @@ spring:
         active: #spring.profiles.active#
     <%_ } _%>
     <%_ if (databaseType === 'sql') { _%>
+    data:
+        jpa:
+            repositories:
+                bootstrap-mode: deferred
     jpa:
         open-in-view: false
         properties:


### PR DESCRIPTION
Use deferred mode for JPA repositories, to speed up start up.

See #8954