### PR TITLE
rename the `-original.war` to `.war.original` to have only one war file

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -523,7 +523,7 @@ if (project.hasProperty('nodeInstall')) {
 task renameWarFile (type: Copy) {
     from ("$buildDir/libs/")
     include "$project.name-$version-original.war"
-    destinationDir file("$buildDir/libs/"")
+    destinationDir file("$buildDir/libs/")
     rename "$project.name-$version-original.war", "$project.name-{$version}.war.original"
 }
 

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -520,7 +520,20 @@ if (project.hasProperty('nodeInstall')) {
 }
 <%_ } _%>
 
-bootWar.dependsOn war
+task renameWarFile (type: Copy) {
+    from ("$buildDir/libs/")
+    include "$project.name-$version-original.war"
+    destinationDir file("$buildDir/libs/"")
+    rename "$project.name-$version-original.war", "$project.name-{$version}.war.original"
+}
+
+task deleteWarFile(type: Delete) {
+  delete "$buildDir/libs/$project.name-$version-original.war"
+}
+
+renameWarFile.dependsOn war
+bootWar.dependsOn war,renameWarFile,deleteWarFile
 compileJava.dependsOn processResources
 processResources.dependsOn cleanResources,bootBuildInfo
 bootBuildInfo.mustRunAfter cleanResources
+deleteWarFile.mustRunAfter renameWarFile


### PR DESCRIPTION
pretty simple, we rename the `-original.war` to `.war.original` and delete the `-original.war` file. So now when executing `./gradlew bootWar` we will have the executable war file and the `.original` file similar to what maven generates.

closes #8972

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
