### PR TITLE
override UAA specific beans in test phase

### DIFF
--- a/generators/server/templates/src/test/java/package/config/timezone/HibernateTimeZoneTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/timezone/HibernateTimeZoneTest.java.ejs
@@ -19,7 +19,7 @@
 package <%= packageName %>.config.timezone;
 
 import <%= packageName %>.<%= mainClass %>;
-<%_ if (authenticationType === 'uaa') { _%>
+<%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
 import <%= packageName %>.config.SecurityBeanOverrideConfiguration;
 <%_ } _%>
 import <%= packageName %>.repository.timezone.DateTimeWrapper;
@@ -44,7 +44,11 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for the UTC Hibernate configuration.
  */
 @RunWith(SpringRunner.class)
+<%_ if (authenticationType === 'uaa' && applicationType !== 'uaa') { _%>
 @SpringBootTest(classes = {SecurityBeanOverrideConfiguration.class, <%= mainClass %>.class})
+<%_ } else { _%>
+@SpringBootTest(classes = <%= mainClass %>.class)
+<%_ } _%>
 public class HibernateTimeZoneTest {
 
     @Autowired

--- a/generators/server/templates/src/test/java/package/config/timezone/HibernateTimeZoneTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/timezone/HibernateTimeZoneTest.java.ejs
@@ -19,6 +19,9 @@
 package <%= packageName %>.config.timezone;
 
 import <%= packageName %>.<%= mainClass %>;
+<%_ if (authenticationType === 'uaa') { _%>
+import <%= packageName %>.config.SecurityBeanOverrideConfiguration;
+<%_ } _%>
 import <%= packageName %>.repository.timezone.DateTimeWrapper;
 import <%= packageName %>.repository.timezone.DateTimeWrapperRepository;
 import org.junit.Before;
@@ -41,7 +44,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Unit tests for the UTC Hibernate configuration.
  */
 @RunWith(SpringRunner.class)
-@SpringBootTest(classes = <%= mainClass %>.class)
+@SpringBootTest(classes = {SecurityBeanOverrideConfiguration.class, <%= mainClass %>.class})
 public class HibernateTimeZoneTest {
 
     @Autowired


### PR DESCRIPTION
Fix #8790

UAA settings need to be bypassed at testing phase so they do not interfere testing. For that SecurityBeanOverrideConfiguration class needs to be included in @SpringBootTest which is missing in HibernateTimeZoneTest class.