### PR TITLE
initial create of kiali (service mesh observability) and istio prompt refactoring

### DIFF
--- a/generators/kubernetes-helm/index.js
+++ b/generators/kubernetes-helm/index.js
@@ -57,7 +57,6 @@ module.exports = class extends BaseDockerGenerator {
                 this.kubernetesServiceType = this.config.get('kubernetesServiceType');
                 this.ingressDomain = this.config.get('ingressDomain');
                 this.istio = this.config.get('istio');
-                this.istioRoute = this.config.get('istioRoute');
                 this.jhipsterVersion = packagejs.version;
                 this.dbRandomPassword = Math.random()
                     .toString(36)
@@ -79,7 +78,6 @@ module.exports = class extends BaseDockerGenerator {
             askForDockerRepositoryName: prompts.askForDockerRepositoryName,
             askForDockerPushCommand: prompts.askForDockerPushCommand,
             askForIstioSupport: prompts.askForIstioSupport,
-            askForIstioRouteFiles: prompts.askForIstioRouteFiles,
             askForKubernetesServiceType: prompts.askForKubernetesServiceType,
             askForIngressDomain: prompts.askForIngressDomain
         };
@@ -118,8 +116,7 @@ module.exports = class extends BaseDockerGenerator {
                     kubernetesServiceType: this.kubernetesServiceType,
                     ingressDomain: this.ingressDomain,
                     monitoring: this.monitoring,
-                    istio: this.istio,
-                    istioRoute: this.istioRoute
+                    istio: this.istio
                 });
             }
         };

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -40,8 +40,8 @@ function writeFiles() {
                     (this.app.applicationType === 'gateway' || this.app.applicationType === 'monolith') &&
                     this.kubernetesServiceType === 'Ingress'
                 ) {
-                    if (this.istio !== 'no') {
-                        this.template('gateway.yml.ejs', `${appName}/${appName}-gateway.yml`);
+                    if (this.istio) {
+                        this.template('istio/gateway.yml.ejs', `${appName}/${appName}-gateway.yml`);
                     } else {
                         this.template('ingress.yml.ejs', `${appName}/${appName}-ingress.yml`);
                     }
@@ -52,7 +52,7 @@ function writeFiles() {
                 if (this.monitoring === 'prometheus') {
                     this.template('monitoring/jhipster-prometheus-sm.yml.ejs', `${appName}/${appName}-prometheus-sm.yml`);
                 }
-                if (this.istioRoute === true) {
+                if (this.istio) {
                     this.template('istio/destination-rule.yml.ejs', `${appName}/${appName}-destination-rule.yml`);
                     this.template('istio/virtual-service.yml.ejs', `${appName}/${appName}-virtual-service.yml`);
                 }
@@ -83,6 +83,9 @@ function writeFiles() {
                 if (this.deploymentApplicationType === 'microservice') {
                     this.template('console/jhipster-zipkin.yml.ejs', 'console/jhipster-zipkin.yml');
                 }
+                if (this.kubernetesServiceType === 'Ingress' && this.istio) {
+                    this.template('istio/gateway/jhipster-console-gateway.yml.ejs', 'console/jhipster-console-gateway.yml');
+                }
             }
         },
 
@@ -92,6 +95,9 @@ function writeFiles() {
                 this.template('monitoring/jhipster-prometheus-cr.yml.ejs', 'monitoring/jhipster-prometheus-cr.yml');
                 this.template('monitoring/jhipster-grafana.yml.ejs', 'monitoring/jhipster-grafana.yml');
                 this.template('monitoring/jhipster-grafana-dashboard.yml.ejs', 'monitoring/jhipster-grafana-dashboard.yml');
+                if (this.kubernetesServiceType === 'Ingress' && this.istio) {
+                    this.template('istio/gateway/jhipster-grafana-gateway.yml.ejs', 'monitoring/jhipster-grafana-gateway.yml');
+                }
             }
         },
 
@@ -111,8 +117,9 @@ function writeFiles() {
         },
 
         writeObservabilityGatewayFiles() {
-            if (this.istio === 'no') return;
+            if (!this.istio) return;
             if (this.kubernetesServiceType === 'Ingress') {
+                this.template('k8s-addons.sh.ejs', 'k8s-addons.sh');
                 this.template('istio/gateway/grafana-gateway.yml.ejs', 'istio/grafana-gateway.yml');
                 this.template('istio/gateway/jaeger-gateway.yml.ejs', 'istio/jaeger-gateway.yml');
                 this.template('istio/gateway/kiali-gateway.yml.ejs', 'istio/kiali-gateway.yml');

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -108,6 +108,15 @@ function writeFiles() {
 
         writeConfigRunFile() {
             this.template('kubectl-apply.sh.ejs', 'kubectl-apply.sh');
+        },
+
+        writeObservabilityGatewayFiles() {
+            if (this.istio === 'no') return;
+            if (this.kubernetesServiceType === 'Ingress') {
+                this.template('istio/gateway/grafana-gateway.yml.ejs', 'istio/grafana-gateway.yml');
+                this.template('istio/gateway/jaeger-gateway.yml.ejs', 'istio/jaeger-gateway.yml');
+                this.template('istio/gateway/kiali-gateway.yml.ejs', 'istio/kiali-gateway.yml');
+            }
         }
     };
 }

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -56,7 +56,6 @@ module.exports = class extends BaseDockerGenerator {
                 this.kubernetesServiceType = this.config.get('kubernetesServiceType');
                 this.ingressDomain = this.config.get('ingressDomain');
                 this.istio = this.config.get('istio');
-                this.istioRoute = this.config.get('istioRoute');
                 this.dbRandomPassword = Math.random()
                     .toString(36)
                     .slice(-8);
@@ -77,7 +76,6 @@ module.exports = class extends BaseDockerGenerator {
             askForDockerRepositoryName: prompts.askForDockerRepositoryName,
             askForDockerPushCommand: prompts.askForDockerPushCommand,
             askForIstioSupport: prompts.askForIstioSupport,
-            askForIstioRouteFiles: prompts.askForIstioRouteFiles,
             askForKubernetesServiceType: prompts.askForKubernetesServiceType,
             askForIngressDomain: prompts.askForIngressDomain
         };
@@ -116,8 +114,7 @@ module.exports = class extends BaseDockerGenerator {
                     kubernetesServiceType: this.kubernetesServiceType,
                     ingressDomain: this.ingressDomain,
                     monitoring: this.monitoring,
-                    istio: this.istio,
-                    istioRoute: this.istioRoute
+                    istio: this.istio
                 });
             }
         };
@@ -151,7 +148,7 @@ module.exports = class extends BaseDockerGenerator {
         }
 
         this.log('\nYou can deploy all your apps by running the following script:');
-        this.log(`  ${chalk.cyan('./kubectl-apply.sh')}`);
+        this.log(`  ${chalk.cyan('bash kubectl-apply.sh')}`);
         if (this.gatewayNb + this.monolithicNb >= 1) {
             const namespaceSuffix = this.kubernetesNamespace === 'default' ? '' : ` -n ${this.kubernetesNamespace}`;
             this.log("\nUse these commands to find your application's IP addresses:");

--- a/generators/kubernetes/prompts.js
+++ b/generators/kubernetes/prompts.js
@@ -23,7 +23,6 @@ module.exports = {
     askForKubernetesServiceType,
     askForIngressDomain,
     askForIstioSupport,
-    askForIstioRouteFiles,
     ...dockerPrompts
 };
 
@@ -93,7 +92,7 @@ function askForIngressDomain() {
             message:
                 'What is the root FQDN for your ingress services (e.g. example.com, sub.domain.co, www.10.10.10.10.xip.io, [namespace.ip]...)?',
             // default to minikube ip
-            default: this.ingressDomain ? this.ingressDomain : `${this.kubernetesNamespace}.192.168.99.100.nip.io`,
+            default: this.ingressDomain ? this.ingressDomain : '192.168.99.100.nip.io',
             validate: input => {
                 if (input.length === 0) {
                     return 'domain name cannot be empty';
@@ -119,7 +118,7 @@ function askForIngressDomain() {
 function askForIstioSupport() {
     if (this.regenerate) return;
     if (this.deploymentApplicationType === 'monolith') {
-        this.istio = 'no';
+        this.istio = false;
         return;
     }
     const done = this.async();
@@ -128,44 +127,7 @@ function askForIstioSupport() {
         {
             type: 'list',
             name: 'istio',
-            message: 'Do you want to configure Istio?',
-            choices: [
-                {
-                    value: 'no',
-                    name: 'Not required'
-                },
-                {
-                    value: 'manualInjection',
-                    name: 'Manual sidecar injection (ensure istioctl in $PATH)'
-                },
-                {
-                    value: 'autoInjection',
-                    name: 'Label tag namespace as automatic injection is already configured'
-                }
-            ],
-            default: this.istio ? this.istio : 'no'
-        }
-    ];
-
-    this.prompt(prompts).then(props => {
-        this.istio = props.istio;
-        done();
-    });
-}
-
-function askForIstioRouteFiles() {
-    if (this.regenerate) return;
-    if (this.istio === 'no') {
-        this.istioRoute = false;
-        return;
-    }
-    const done = this.async();
-
-    const prompts = [
-        {
-            type: 'list',
-            name: 'istioRoute',
-            message: 'Do you want to generate Istio route files?',
+            message: 'Do you want to enable Istio?',
             choices: [
                 {
                     value: false,
@@ -176,12 +138,12 @@ function askForIstioRouteFiles() {
                     name: 'Yes'
                 }
             ],
-            default: this.istioRoute
+            default: this.istio
         }
     ];
 
     this.prompt(prompts).then(props => {
-        this.istioRoute = props.istioRoute;
+        this.istio = props.istio;
         done();
     });
 }

--- a/generators/kubernetes/prompts.js
+++ b/generators/kubernetes/prompts.js
@@ -83,6 +83,7 @@ function askForIngressDomain() {
     if (this.regenerate) return;
     const done = this.async();
     const kubernetesServiceType = this.kubernetesServiceType;
+    this.ingressDomain = this.ingressDomain && this.ingressDomain.startsWith('.') ? this.ingressDomain.substring(1) : this.ingressDomain;
 
     const prompts = [
         {
@@ -110,7 +111,7 @@ function askForIngressDomain() {
     ];
 
     this.prompt(prompts).then(props => {
-        this.ingressDomain = props.ingressDomain;
+        this.ingressDomain = props.ingressDomain ? '.'.concat(props.ingressDomain) : '';
         done();
     });
 }

--- a/generators/kubernetes/templates/console/jhipster-console.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-console.yml.ejs
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels:
         app: jhipster-console
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - image: <%= DOCKER_JHIPSTER_CONSOLE %>
@@ -55,7 +59,7 @@ spec:
   selector:
     app: jhipster-console
 ---
-<%_ if (kubernetesServiceType === 'Ingress') { _%>
+<%_ if (kubernetesServiceType === 'Ingress' && !istio) { _%>
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -63,7 +67,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 spec:
   rules:
-  - host: jhipster-console<%= ingressDomain %>
+  - host: jhipster-console.<%= kubernetesNamespace %><%= ingressDomain %>
     http:
       paths:
       - path: /

--- a/generators/kubernetes/templates/console/jhipster-console.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-console.yml.ejs
@@ -63,7 +63,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 spec:
   rules:
-  - host: jhipster-console.<%= ingressDomain %>
+  - host: jhipster-console<%= ingressDomain %>
     http:
       paths:
       - path: /

--- a/generators/kubernetes/templates/console/jhipster-dashboard-console.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-dashboard-console.yml.ejs
@@ -30,6 +30,9 @@ spec:
         job: jhipster-import-dashboards
       annotations:
         "helm.sh/hook": post-install
+     <%_ if (istio) { _%>
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
         - name: init-dependent-service-check

--- a/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
@@ -49,6 +49,10 @@ spec:
       labels:
         component: jhipster-elasticsearch
         role: master
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
       - name: init-sysctl
@@ -195,6 +199,10 @@ spec:
       labels:
         component: jhipster-elasticsearch
         role: data
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
       - name: init-sysctl
@@ -336,6 +344,10 @@ spec:
       labels:
         component: jhipster-elasticsearch
         role: client
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
       - name: init-sysctl

--- a/generators/kubernetes/templates/console/jhipster-logstash.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-logstash.yml.ejs
@@ -45,6 +45,10 @@ spec:
     metadata:
       labels:
         app: jhipster-logstash
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
         - name: init-es-check

--- a/generators/kubernetes/templates/console/jhipster-zipkin.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-zipkin.yml.ejs
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels:
         app: jhipster-zipkin
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - name: jhipster-zipkin

--- a/generators/kubernetes/templates/db/couchbase.yml.ejs
+++ b/generators/kubernetes/templates/db/couchbase.yml.ejs
@@ -41,6 +41,10 @@ spec:
     metadata:
       labels:
         app: <%= app.baseName.toLowerCase() %>-couchbase
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - name: <%= app.baseName.toLowerCase() %>-couchbase

--- a/generators/kubernetes/templates/db/elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/db/elasticsearch.yml.ejs
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels:
         app: <%= app.baseName.toLowerCase() %>-elasticsearch
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       volumes:
       - name: data

--- a/generators/kubernetes/templates/db/mariadb.yml.ejs
+++ b/generators/kubernetes/templates/db/mariadb.yml.ejs
@@ -38,6 +38,10 @@ spec:
     metadata:
       labels:
         app: <%= app.baseName.toLowerCase() %>-mariadb
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       volumes:
       - name: data

--- a/generators/kubernetes/templates/db/mongodb.yml.ejs
+++ b/generators/kubernetes/templates/db/mongodb.yml.ejs
@@ -180,7 +180,10 @@ spec:
     metadata:
       labels:
         app: <%= app.baseName.toLowerCase() %>-mongodb
+     <%_ if (istio) { _%>
       annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
         - name: config

--- a/generators/kubernetes/templates/db/mysql.yml.ejs
+++ b/generators/kubernetes/templates/db/mysql.yml.ejs
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels:
         app: <%= app.baseName.toLowerCase() %>-mysql
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       volumes:
       - name: data

--- a/generators/kubernetes/templates/db/postgresql.yml.ejs
+++ b/generators/kubernetes/templates/db/postgresql.yml.ejs
@@ -38,6 +38,10 @@ spec:
     metadata:
       labels:
         app: <%= app.baseName.toLowerCase() %>-postgresql
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       volumes:
       - name: data

--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -80,7 +80,7 @@ spec:
               key: registry-admin-password
         - name: EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE
           value: http://admin:${jhipster.registry.password}@jhipster-registry.<%= kubernetesNamespace %>.svc.cluster.local:8761/eureka/
-          <%_ if (istio !== 'no') { _%>
+          <%_ if (istio) { _%>
         - name: EUREKA_INSTANCE_PREFER_IP_ADDRESS
           value: "false"
         - name: EUREKA_INSTANCE_HOSTNAME
@@ -92,7 +92,7 @@ spec:
           value: consul.<%= kubernetesNamespace %>.svc.cluster.local
         - name: SPRING_CLOUD_CONSUL_PORT
           value: "8500"
-          <%_ if (istio !== 'no') { _%>
+          <%_ if (istio) { _%>
         - name: SPRING_CLOUD_CONSUL_DISCOVERY_PREFER_IP_ADDRESS
           value: "false"
         - name: SPRING_CLOUD_CONSUL_DISCOVERY_HOSTNAME

--- a/generators/kubernetes/templates/ingress.yml.ejs
+++ b/generators/kubernetes/templates/ingress.yml.ejs
@@ -23,7 +23,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 spec:
   rules:
-  - host: <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+  - host: <%= app.baseName.toLowerCase() %>.<%= kubernetesNamespace %><%= ingressDomain %>
     http:
       paths:
       - path: /.*

--- a/generators/kubernetes/templates/ingress.yml.ejs
+++ b/generators/kubernetes/templates/ingress.yml.ejs
@@ -23,7 +23,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 spec:
   rules:
-  - host: <%= app.baseName.toLowerCase() %>.<%= ingressDomain %>
+  - host: <%= app.baseName.toLowerCase() %><%= ingressDomain %>
     http:
       paths:
       - path: /.*

--- a/generators/kubernetes/templates/istio/gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway.yml.ejs
@@ -1,0 +1,72 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-gateway
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    gateway: <%= app.baseName.toLowerCase() %>-gateway
+    istio: ingressgateway
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - <%= app.baseName.toLowerCase() %>.<%= kubernetesNamespace %><%= ingressDomain %>
+  - port:
+      number: 80
+      name: http2
+      protocol: HTTP2
+    hosts:
+    - <%= app.baseName.toLowerCase() %>.<%= kubernetesNamespace %><%= ingressDomain %>
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-gw-virtualservice
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    service: <%= app.baseName.toLowerCase() %>-gw-virtualservice
+spec:
+  hosts:
+  - <%= app.baseName.toLowerCase() %>.<%= kubernetesNamespace %><%= ingressDomain %>
+  gateways:
+  - <%= app.baseName.toLowerCase() %>-gateway
+  http:
+  <%_ if (!app.serviceDiscoveryType) { _%>
+    <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(function(config) { _%>
+  - match:
+    - uri:
+        prefix: /<%= config.baseName.toLowerCase() %>/
+    route:
+    - destination:
+        host: <%= config.baseName.toLowerCase() %>
+    <%_ }); _%>
+  <%_ } _%>
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: <%= app.baseName.toLowerCase() %>

--- a/generators/kubernetes/templates/istio/gateway/grafana-gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway/grafana-gateway.yml.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2019 the original author or authors from the JHipster project.
+ Copyright 2013-2018 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -19,8 +19,8 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gateway
-  namespace: <%= kubernetesNamespace %>
+  name: grafana-observability-gateway
+  namespace: istio-system
 spec:
   selector:
     istio: ingressgateway
@@ -30,44 +30,28 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - grafana.istio-system<%= ingressDomain %>
   - port:
       number: 80
       name: http2
       protocol: HTTP2
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
-#  - port:
-#      number: 443
-#      name: https
-#      protocol: HTTPS
-#    hosts:
-#    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - grafana.istio-system<%= ingressDomain %>
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gw-virtualservice
-  namespace: <%= kubernetesNamespace %>
+  name: grafana-gw-virtualservice
+  namespace: istio-system
 spec:
   hosts:
-  - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+  - grafana.istio-system<%= ingressDomain %>
   gateways:
-  - <%= app.baseName.toLowerCase() %>-gateway
+  - grafana-observability-gateway
   http:
-  <%_ if (!app.serviceDiscoveryType) { _%>
-    <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(function(config) { _%>
-  - match:
-    - uri:
-        prefix: /<%= config.baseName.toLowerCase() %>/
-    route:
-    - destination:
-        host: <%= config.baseName.toLowerCase() %>
-    <%_ }); _%>
-  <%_ } _%>
   - match:
     - uri:
         prefix: /
     route:
     - destination:
-        host: <%= app.baseName.toLowerCase() %>
+        host: grafana

--- a/generators/kubernetes/templates/istio/gateway/jaeger-gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway/jaeger-gateway.yml.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2019 the original author or authors from the JHipster project.
+ Copyright 2013-2018 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -19,8 +19,8 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gateway
-  namespace: <%= kubernetesNamespace %>
+  name: jaeger-observability-gateway
+  namespace: istio-system
 spec:
   selector:
     istio: ingressgateway
@@ -30,44 +30,28 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - jaeger.istio-system<%= ingressDomain %>
   - port:
       number: 80
       name: http2
       protocol: HTTP2
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
-#  - port:
-#      number: 443
-#      name: https
-#      protocol: HTTPS
-#    hosts:
-#    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - jaeger.istio-system<%= ingressDomain %>
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gw-virtualservice
-  namespace: <%= kubernetesNamespace %>
+  name: jaeger-gw-virtualservice
+  namespace: istio-system
 spec:
   hosts:
-  - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+  - jaeger.istio-system<%= ingressDomain %>
   gateways:
-  - <%= app.baseName.toLowerCase() %>-gateway
+  - jaeger-observability-gateway
   http:
-  <%_ if (!app.serviceDiscoveryType) { _%>
-    <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(function(config) { _%>
-  - match:
-    - uri:
-        prefix: /<%= config.baseName.toLowerCase() %>/
-    route:
-    - destination:
-        host: <%= config.baseName.toLowerCase() %>
-    <%_ }); _%>
-  <%_ } _%>
   - match:
     - uri:
         prefix: /
     route:
     - destination:
-        host: <%= app.baseName.toLowerCase() %>
+        host: jaeger-query

--- a/generators/kubernetes/templates/istio/gateway/jhipster-console-gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway/jhipster-console-gateway.yml.ejs
@@ -1,0 +1,57 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+apiVersion: networking.istio.io/v1alpha3
+kind: Gateway
+metadata:
+  name: jhipster-console-gateway
+  namespace: <%= kubernetesNamespace %>
+spec:
+  selector:
+    istio: ingressgateway
+  servers:
+  - port:
+      number: 80
+      name: http
+      protocol: HTTP
+    hosts:
+    - jhipster-console<%= ingressDomain %>
+  - port:
+      number: 80
+      name: http2
+      protocol: HTTP2
+    hosts:
+    - jhipster-console<%= ingressDomain %>
+---
+apiVersion: networking.istio.io/v1alpha3
+kind: VirtualService
+metadata:
+  name: jhipster-console-gw-virtualservice
+  namespace: <%= kubernetesNamespace %>
+spec:
+  hosts:
+  - jhipster-console<%= ingressDomain %>
+  gateways:
+  - jhipster-console-gateway
+  http:
+  - match:
+    - uri:
+        prefix: /
+    route:
+    - destination:
+        host: jhipster-console

--- a/generators/kubernetes/templates/istio/gateway/jhipster-grafana-gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway/jhipster-grafana-gateway.yml.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2019 the original author or authors from the JHipster project.
+ Copyright 2013-2018 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -19,7 +19,7 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gateway
+  name: jhipster-grafana-gateway
   namespace: <%= kubernetesNamespace %>
 spec:
   selector:
@@ -30,44 +30,28 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - jhipster-grafana<%= ingressDomain %>
   - port:
       number: 80
       name: http2
       protocol: HTTP2
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
-#  - port:
-#      number: 443
-#      name: https
-#      protocol: HTTPS
-#    hosts:
-#    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - jhipster-grafana<%= ingressDomain %>
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gw-virtualservice
+  name: jhipster-grafana-gw-virtualservice
   namespace: <%= kubernetesNamespace %>
 spec:
   hosts:
-  - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+  - jhipster-grafana<%= ingressDomain %>
   gateways:
-  - <%= app.baseName.toLowerCase() %>-gateway
+  - jhipster-grafana-gateway
   http:
-  <%_ if (!app.serviceDiscoveryType) { _%>
-    <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(function(config) { _%>
-  - match:
-    - uri:
-        prefix: /<%= config.baseName.toLowerCase() %>/
-    route:
-    - destination:
-        host: <%= config.baseName.toLowerCase() %>
-    <%_ }); _%>
-  <%_ } _%>
   - match:
     - uri:
         prefix: /
     route:
     - destination:
-        host: <%= app.baseName.toLowerCase() %>
+        host: grafana

--- a/generators/kubernetes/templates/istio/gateway/kiali-gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway/kiali-gateway.yml.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2019 the original author or authors from the JHipster project.
+ Copyright 2013-2018 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -19,8 +19,8 @@
 apiVersion: networking.istio.io/v1alpha3
 kind: Gateway
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gateway
-  namespace: <%= kubernetesNamespace %>
+  name: kiali-observability-gateway
+  namespace: istio-system
 spec:
   selector:
     istio: ingressgateway
@@ -30,44 +30,28 @@ spec:
       name: http
       protocol: HTTP
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - kiali.istio-system<%= ingressDomain %>
   - port:
       number: 80
       name: http2
       protocol: HTTP2
     hosts:
-    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
-#  - port:
-#      number: 443
-#      name: https
-#      protocol: HTTPS
-#    hosts:
-#    - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+    - kiali.istio-system<%= ingressDomain %>
 ---
 apiVersion: networking.istio.io/v1alpha3
 kind: VirtualService
 metadata:
-  name: <%= app.baseName.toLowerCase() %>-gw-virtualservice
-  namespace: <%= kubernetesNamespace %>
+  name: kiali-gw-virtualservice
+  namespace: istio-system
 spec:
   hosts:
-  - <%= app.baseName.toLowerCase() %><%= ingressDomain %>
+  - kiali.istio-system<%= ingressDomain %>
   gateways:
-  - <%= app.baseName.toLowerCase() %>-gateway
+  - kiali-observability-gateway
   http:
-  <%_ if (!app.serviceDiscoveryType) { _%>
-    <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(function(config) { _%>
-  - match:
-    - uri:
-        prefix: /<%= config.baseName.toLowerCase() %>/
-    route:
-    - destination:
-        host: <%= config.baseName.toLowerCase() %>
-    <%_ }); _%>
-  <%_ } _%>
   - match:
     - uri:
         prefix: /
     route:
     - destination:
-        host: <%= app.baseName.toLowerCase() %>
+        host: kiali

--- a/generators/kubernetes/templates/k8s-addons.sh.ejs
+++ b/generators/kubernetes/templates/k8s-addons.sh.ejs
@@ -1,0 +1,68 @@
+#!/bin/bash
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+# Files are ordered in proper order with needed wait for the dependent custom resource definitions to get initialized.
+# kiali - istio service mesh observability
+export GRAFANA_URL="http://grafana.${ISTIO_SYSTEM}<%= ingressDomain %>"
+export JAEGER_URL="http://jaeger.${ISTIO_SYSTEM}<%= ingressDomain %>"
+export IMAGE_NAME="${IMAGE_NAME:-kiali/kiali}"
+export IMAGE_VERSION=
+export VERSION_LABEL=
+export IMAGE_PULL_POLICY_TOKEN="${IMAGE_PULL_POLICY_TOKEN:-imagePullPolicy: Always}"
+export NAMESPACE=istio-system
+export ISTIO_NAMESPACE="${NAMESPACE}"
+export VERBOSE_MODE="${VERBOSE_MODE:-3}"
+export KIALI_USERNAME_BASE64="YWRtaW4K"
+export KIALI_PASSPHRASE_BASE64="YWRtaW4K"
+
+if ! which 'envsubst' > /dev/null 2>&1 ; then
+  echo "ERROR: You do not have 'envsubst' in your PATH. Please install it and retry."
+  echo "If you are on MacOS, you can get this by installing the gettext package"
+  exit 1
+fi
+
+IMAGE_VERSION=$(curl https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null | grep  "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
+VERSION_LABEL=${IMAGE_VERSION}
+
+get_downloader() {
+  if [ ! "$downloader" ] ; then
+    # Use wget command if available, otherwise try curl
+    if which wget > /dev/null ; then
+      downloader="wget -q -O -"
+    fi
+    if [ ! "$downloader" ] ; then
+      if which curl > /dev/null ; then
+        downloader="curl -s"
+      fi
+    fi
+    if [ ! "$downloader" ] ; then
+      echo "ERROR: You must install either curl or wget to allow downloading"
+      exit 1
+    fi
+  fi
+}
+
+for yaml in secret configmap serviceaccount clusterrole clusterrolebinding deployment service ingress
+do
+    get_downloader
+    yaml_url="https://raw.githubusercontent.com/kiali/kiali/${VERSION_LABEL}/deploy/kubernetes/${yaml}.yaml"
+    ${downloader} ${yaml_url} | envsubst | kubectl apply -n ${NAMESPACE} -f -
+done
+
+kubectl apply -f istio/

--- a/generators/kubernetes/templates/kubectl-apply.sh.ejs
+++ b/generators/kubernetes/templates/kubectl-apply.sh.ejs
@@ -19,12 +19,38 @@
 -%>
 # Files are ordered in proper order with needed wait for the dependent custom resource definitions to get initialized.
 # Usage: bash kubectl-apply.sh
-<%_ if (istio === 'manualInjection') { _%>
-loopDir(){
-  for entry in "$1"/*
-  do
-    kubectl apply -f <(istioctl kube-inject -f ${entry})
-  done
+
+logSummary(){
+    echo ""
+    echo "#####################################################"
+    echo "Please find the below useful endpoints,"
+    <%_ if (monitoring === 'elk') { _%>
+    echo "JHipster Console - http://jhipster-console.<%= kubernetesNamespace %><%= ingressDomain %>"
+    <%_ } _%>
+    <%_ if (monitoring === 'prometheus') { _%>
+    echo "JHipster Grafana - http://jhipster-grafana.<%= kubernetesNamespace %><%= ingressDomain %>"
+    <%_ } _%>
+    <%_ if (kubernetesServiceType === 'Ingress') { _%>
+    <%_ appConfigs.forEach((appConfig) =>  { _%>
+    <%_ if (appConfig.applicationType === 'gateway') {_%>
+    echo "Gateway - http://<%= appConfig.baseName.toLowerCase() %>.<%= kubernetesNamespace %><%= ingressDomain %>"
+    <%_ } _%><%_ if (appConfig.applicationType === 'monolith') {_%>
+    echo "<%= appConfig.baseName %> - http://<%= appConfig.baseName.toLowerCase() %>.<%= kubernetesNamespace %><%= ingressDomain %>"
+    <%_ } _%>
+    <%_ }) _%>
+    <%_ if (istio) { _%>
+    echo "Jaeger - http://jaeger.${ISTIO_SYSTEM}<%= ingressDomain %>"
+    echo "Grafana - http://grafana.${ISTIO_SYSTEM}<%= ingressDomain %>"
+    echo "Kiali - http://kiali.${ISTIO_SYSTEM}<%= ingressDomain %>"
+    <%_ } _%>
+    <%_ } _%>
+    echo "#####################################################"
+}
+
+<%_ if (istio && kubernetesServiceType === 'Ingress') { _%>
+execAddons(){
+    chmod +x k8s-addons.sh
+    bash k8s-addons.sh
 }
 <%_ } _%>
 
@@ -32,16 +58,12 @@ loopDir(){
 kubectl apply -f namespace.yml
 <%_ } _%> <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
 kubectl apply -f registry/
-<%_ } _%> <%_ if (istio === 'autoInjection') { _%>
-kubectl label namespace <%-kubernetesNamespace%> istio-injection=enabled
-<%_ } _%> <%_ if (istio === 'manualInjection') { _%>
-<%_ appConfigs.forEach((appConfig, index) =>  { _%>
-loopDir "<%- appConfig.baseName.toLowerCase() %>"
-<%_ }) _%>
-<%_ } else {_%>
-<%_ appConfigs.forEach((appConfig, index) =>  { _%>
+<%_ } _%> <%_ if (istio) { _%>
+kubectl label namespace <%-kubernetesNamespace%> istio-injection=enabled --overwrite=true
+<%_ } _%> <%_ appConfigs.forEach((appConfig, index) =>  { _%>
 kubectl apply -f <%- appConfig.baseName.toLowerCase() %>/
-<%_ }) _%> <%_ } _%> <%_ if (useKafka === true) { _%>
+<%_ }) _%>
+<%_ if (useKafka === true) { _%>
 kubectl apply -f messagebroker/
 <%_ } _%> <%_ if (monitoring === 'elk') { _%>
 kubectl apply -f console/
@@ -56,53 +78,8 @@ kubectl apply -f monitoring/jhipster-grafana.yml
 kubectl apply -f monitoring/jhipster-grafana-dashboard.yml
 <%_ } _%>
 
-<%_ if (istio !== 'no' && kubernetesServiceType === 'Ingress') { _%>
-export GRAFANA_URL="http://grafana.istio-system<%= ingressDomain %>"
-export JAEGER_URL="http://jaeger.istio-system<%= ingressDomain %>"
-export IMAGE_NAME="${IMAGE_NAME:-kiali/kiali}"
-export IMAGE_VERSION=
-export VERSION_LABEL=
-export IMAGE_PULL_POLICY_TOKEN="${IMAGE_PULL_POLICY_TOKEN:-imagePullPolicy: Always}"
-export NAMESPACE=istio-system
-export ISTIO_NAMESPACE="${NAMESPACE}"
-export VERBOSE_MODE="${VERBOSE_MODE:-3}"
-export KIALI_USERNAME_BASE64="YWRtaW4K"
-export KIALI_PASSPHRASE_BASE64="YWRtaW4K"
-
-if ! which 'envsubst' > /dev/null 2>&1 ; then
-  echo "ERROR: You do not have 'envsubst' in your PATH. Please install it and retry."
-  echo "If you are on MacOS, you can get this by installing the gettext package"
-  exit 1
-fi
-
-IMAGE_VERSION=$(curl https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null | grep  "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
-VERSION_LABEL=${IMAGE_VERSION}
-
-get_downloader() {
-  if [ ! "$downloader" ] ; then
-    # Use wget command if available, otherwise try curl
-    if which wget > /dev/null ; then
-      downloader="wget -q -O -"
-    fi
-    if [ ! "$downloader" ] ; then
-      if which curl > /dev/null ; then
-        downloader="curl -s"
-      fi
-    fi
-    if [ ! "$downloader" ] ; then
-      echo "ERROR: You must install either curl or wget to allow downloading"
-      exit 1
-    fi
-  fi
-}
-
-for yaml in secret configmap serviceaccount clusterrole clusterrolebinding deployment service ingress
-do
-    get_downloader
-    yaml_url="https://raw.githubusercontent.com/kiali/kiali/${VERSION_LABEL}/deploy/kubernetes/${yaml}.yaml"
-    ${downloader} ${yaml_url} | envsubst | kubectl apply -n ${NAMESPACE} -f -
-done
-
-kubectl apply -f istio/
+<%_ if (istio && kubernetesServiceType === 'Ingress') { _%>
+export ISTIO_SYSTEM=istio-system
+execAddons
 <%_ } _%>
-
+logSummary

--- a/generators/kubernetes/templates/kubectl-apply.sh.ejs
+++ b/generators/kubernetes/templates/kubectl-apply.sh.ejs
@@ -55,3 +55,54 @@ kubectl apply -f monitoring/jhipster-prometheus-cr.yml
 kubectl apply -f monitoring/jhipster-grafana.yml
 kubectl apply -f monitoring/jhipster-grafana-dashboard.yml
 <%_ } _%>
+
+<%_ if (istio !== 'no' && kubernetesServiceType === 'Ingress') { _%>
+export GRAFANA_URL="http://grafana.istio-system<%= ingressDomain %>"
+export JAEGER_URL="http://jaeger.istio-system<%= ingressDomain %>"
+export IMAGE_NAME="${IMAGE_NAME:-kiali/kiali}"
+export IMAGE_VERSION=
+export VERSION_LABEL=
+export IMAGE_PULL_POLICY_TOKEN="${IMAGE_PULL_POLICY_TOKEN:-imagePullPolicy: Always}"
+export NAMESPACE=istio-system
+export ISTIO_NAMESPACE="${NAMESPACE}"
+export VERBOSE_MODE="${VERBOSE_MODE:-3}"
+export KIALI_USERNAME_BASE64="YWRtaW4K"
+export KIALI_PASSPHRASE_BASE64="YWRtaW4K"
+
+if ! which 'envsubst' > /dev/null 2>&1 ; then
+  echo "ERROR: You do not have 'envsubst' in your PATH. Please install it and retry."
+  echo "If you are on MacOS, you can get this by installing the gettext package"
+  exit 1
+fi
+
+IMAGE_VERSION=$(curl https://api.github.com/repos/kiali/kiali/releases/latest 2> /dev/null | grep  "tag_name" | sed -e 's/.*://' -e 's/ *"//' -e 's/",//')
+VERSION_LABEL=${IMAGE_VERSION}
+
+get_downloader() {
+  if [ ! "$downloader" ] ; then
+    # Use wget command if available, otherwise try curl
+    if which wget > /dev/null ; then
+      downloader="wget -q -O -"
+    fi
+    if [ ! "$downloader" ] ; then
+      if which curl > /dev/null ; then
+        downloader="curl -s"
+      fi
+    fi
+    if [ ! "$downloader" ] ; then
+      echo "ERROR: You must install either curl or wget to allow downloading"
+      exit 1
+    fi
+  fi
+}
+
+for yaml in secret configmap serviceaccount clusterrole clusterrolebinding deployment service ingress
+do
+    get_downloader
+    yaml_url="https://raw.githubusercontent.com/kiali/kiali/${VERSION_LABEL}/deploy/kubernetes/${yaml}.yaml"
+    ${downloader} ${yaml_url} | envsubst | kubectl apply -n ${NAMESPACE} -f -
+done
+
+kubectl apply -f istio/
+<%_ } _%>
+

--- a/generators/kubernetes/templates/messagebroker/kafka.yml.ejs
+++ b/generators/kubernetes/templates/messagebroker/kafka.yml.ejs
@@ -27,6 +27,10 @@ spec:
     metadata:
       labels:
         app: jhipster-kafka
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - name: kafka
@@ -65,6 +69,10 @@ spec:
     metadata:
       labels:
         app: jhipster-zookeeper
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - name: zookeeper

--- a/generators/kubernetes/templates/monitoring/jhipster-grafana-dashboard.yml.ejs
+++ b/generators/kubernetes/templates/monitoring/jhipster-grafana-dashboard.yml.ejs
@@ -2311,6 +2311,10 @@ spec:
     metadata:
       labels:
         job: jhipster-grafana-dashboard
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       initContainers:
         - name: init-dependent-services-check

--- a/generators/kubernetes/templates/monitoring/jhipster-grafana.yml.ejs
+++ b/generators/kubernetes/templates/monitoring/jhipster-grafana.yml.ejs
@@ -100,7 +100,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 spec:
   rules:
-  - host: jhipster-grafana.<%= ingressDomain %>
+  - host: jhipster-grafana<%= ingressDomain %>
     http:
       paths:
       - path: /

--- a/generators/kubernetes/templates/monitoring/jhipster-grafana.yml.ejs
+++ b/generators/kubernetes/templates/monitoring/jhipster-grafana.yml.ejs
@@ -36,6 +36,10 @@ spec:
     metadata:
       labels:
         app: jhipster-grafana
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - name: jhipster-grafana
@@ -92,7 +96,7 @@ spec:
   selector:
     app: jhipster-grafana
 ---
-<%_ if (kubernetesServiceType === 'Ingress') { _%>
+<%_ if (kubernetesServiceType === 'Ingress' && !istio ) { _%>
 apiVersion: extensions/v1beta1
 kind: Ingress
 metadata:
@@ -100,7 +104,7 @@ metadata:
   namespace: <%= kubernetesNamespace %>
 spec:
   rules:
-  - host: jhipster-grafana<%= ingressDomain %>
+  - host: jhipster-grafana.<%= kubernetesNamespace %><%= ingressDomain %>
     http:
       paths:
       - path: /

--- a/generators/kubernetes/templates/monitoring/jhipster-prometheus-crd.yml.ejs
+++ b/generators/kubernetes/templates/monitoring/jhipster-prometheus-crd.yml.ejs
@@ -102,6 +102,10 @@ spec:
     metadata:
       labels:
         k8s-app: prometheus-operator
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       containers:
       - args:

--- a/generators/kubernetes/templates/registry/consul.yml.ejs
+++ b/generators/kubernetes/templates/registry/consul.yml.ejs
@@ -90,6 +90,10 @@ spec:
       name: consul
       labels:
         app: consul
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
     spec:
       securityContext:
         fsGroup: 1000

--- a/generators/kubernetes/templates/registry/jhipster-registry.yml.ejs
+++ b/generators/kubernetes/templates/registry/jhipster-registry.yml.ejs
@@ -73,7 +73,7 @@ spec:
       labels:
         app: jhipster-registry
         version: "1.0"
-     <%_ if (istio !== 'no') { _%>
+     <%_ if (istio) { _%>
       annotations:
         sidecar.istio.io/inject: "false"
      <%_ } _%>
@@ -94,7 +94,7 @@ spec:
             secretKeyRef:
               name: registry-secret
               key: registry-admin-password
-        <%_ if (istio !== 'no') { _%>
+        <%_ if (istio) { _%>
         - name: EUREKA_INSTANCE_PREFER_IP_ADDRESS
           value: "false"
         <%_ } _%>

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -399,8 +399,7 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesServiceType: 'Ingress',
                     ingressDomain: 'example.com',
                     clusteredDbApps: [],
-                    istio: 'manualInjection',
-                    istioRoute: true
+                    istio: true
                 })
                 .on('end', done);
         });


### PR DESCRIPTION
- initial creation of kiali (kiali is for service mesh observability to understand the mesh composition and connectivity)
- refactor istio prompt (manual inject option is removed as auto inject is the default post 1.9)
- Envoy sidecars for microservices alone (db, elastic etc. are excluded)