### PR TITLE
fix issue with relationship.otherEntityRelationshipName and entity generation

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -265,7 +265,9 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     @DBRef
     @Field("<%= relationshipFieldName %>")
     <%_ } _%>
+    <%_ if (otherEntityRelationshipNamePlural !== undefined && otherEntityRelationshipNamePlural !== '') { _%>
     @JsonIgnoreProperties("<%= otherEntityRelationshipNamePlural %>")
+    <%_ } _%>
     private <%= asEntity(otherEntityNameCapitalized) %> <%= relationshipFieldName %>;
 
     <%_ } else if (relationshipType === 'many-to-many') {
@@ -408,7 +410,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         this.<%= relationshipFieldNamePlural %>.add(<%= otherEntityName %>);
             <%_ if (relationshipType === 'one-to-many') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(this);
-            <%_ } else if (otherEntityRelationshipNameCapitalizedPlural !== '' && relationshipType === 'many-to-many') {
+            <%_ } else if (otherEntityRelationshipNameCapitalizedPlural !== '' && asEntity(otherEntityNameCapitalized)!=='User' && relationshipType === 'many-to-many') {
                 // JHipster version < 3.6.0 didn't ask for this relationship name _%>
         <%= otherEntityName %>.get<%= otherEntityRelationshipNameCapitalizedPlural %>().add(this);
             <%_ } _%>
@@ -419,7 +421,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         this.<%= relationshipFieldNamePlural %>.remove(<%= otherEntityName %>);
             <%_ if (relationshipType === 'one-to-many') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(null);
-            <%_ } else if (otherEntityRelationshipNameCapitalizedPlural !== '' && relationshipType === 'many-to-many') {
+            <%_ } else if (otherEntityRelationshipNameCapitalizedPlural !== '' && asEntity(otherEntityNameCapitalized)!=='User' && relationshipType === 'many-to-many') {
                 // JHipster version < 3.6.0 didn't ask for this relationship name _%>
         <%= otherEntityName %>.get<%= otherEntityRelationshipNameCapitalizedPlural %>().remove(this);
             <%_ } _%>

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -518,22 +518,21 @@ module.exports = class extends BaseBlueprintGenerator {
                             )
                         );
                     }
+                    relationship.otherEntityRelationshipNameUndefined = _.isUndefined(relationship.otherEntityRelationshipName);
 
-                    if (_.isUndefined(relationship.otherEntityRelationshipName)) {
-                        if (
-                            relationship.relationshipType === 'one-to-many' ||
-                            (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === false) ||
-                            relationship.relationshipType === 'one-to-one'
-                        ) {
-                            relationship.otherEntityRelationshipName = _.lowerFirst(entityName);
-                            this.warning(
-                                `otherEntityRelationshipName is missing in .jhipster/${entityName}.json for relationship ${JSON.stringify(
-                                    relationship,
-                                    null,
-                                    4
-                                )}, using ${_.lowerFirst(entityName)} as fallback`
-                            );
-                        }
+                    if (
+                        relationship.otherEntityRelationshipNameUndefined &&
+                        _.isUndefined(relationship.relationshipType) === false &&
+                        relationship.relationshipType !== ''
+                    ) {
+                        relationship.otherEntityRelationshipName = _.lowerFirst(entityName);
+                        this.warning(
+                            `otherEntityRelationshipName is missing in .jhipster/${entityName}.json for relationship ${JSON.stringify(
+                                relationship,
+                                null,
+                                4
+                            )}, using ${_.lowerFirst(entityName)} as fallback`
+                        );
                     }
 
                     if (
@@ -857,9 +856,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
                     if (
                         _.isUndefined(relationship.otherEntityRelationshipNamePlural) &&
-                        (relationship.relationshipType === 'one-to-many' ||
-                            (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === false) ||
-                            (relationship.relationshipType === 'one-to-one' && relationship.otherEntityName.toLowerCase() !== 'user'))
+                        _.isUndefined(relationship.otherEntityRelationshipName) === false
                     ) {
                         relationship.otherEntityRelationshipNamePlural = pluralize(relationship.otherEntityRelationshipName);
                     }
@@ -922,17 +919,29 @@ module.exports = class extends BaseBlueprintGenerator {
                         relationship.otherEntityNameCapitalized = _.upperFirst(relationship.otherEntityName);
                     }
 
-                    if (_.isUndefined(relationship.otherEntityRelationshipNamePlural)) {
-                        if (relationship.relationshipType === 'many-to-one') {
+                    if (
+                        _.isUndefined(relationship.otherEntityRelationshipNamePlural) ||
+                        relationship.otherEntityRelationshipNameUndefined
+                    ) {
+                        if (relationship.relationshipType === 'many-to-one' || relationship.relationshipType === 'many-to-many') {
                             if (otherEntityData && otherEntityData.relationships) {
                                 otherEntityData.relationships.forEach(otherRelationship => {
                                     if (
                                         _.upperFirst(otherRelationship.otherEntityName) === entityName &&
                                         otherRelationship.otherEntityRelationshipName === relationship.relationshipName &&
-                                        otherRelationship.relationshipType === 'one-to-many'
+                                        ((relationship.relationshipType === 'many-to-one' &&
+                                            otherRelationship.relationshipType === 'one-to-many') ||
+                                            (relationship.relationshipType === 'many-to-many' &&
+                                                otherRelationship.relationshipType === 'many-to-many'))
                                     ) {
                                         relationship.otherEntityRelationshipName = otherRelationship.relationshipName;
                                         relationship.otherEntityRelationshipNamePlural = pluralize(otherRelationship.relationshipName);
+                                        relationship.otherEntityRelationshipNameCapitalized = _.upperFirst(
+                                            otherRelationship.relationshipName
+                                        );
+                                        relationship.otherEntityRelationshipNameCapitalizedPlural = pluralize(
+                                            _.upperFirst(otherRelationship.relationshipName)
+                                        );
                                     }
                                 });
                             }


### PR DESCRIPTION
- initialize relationship.otherEntityRelationshipName properly
- do not generate @JsonIgnoreProperties when
  otherEntityRelationshipNamePlural is undefined or empty
- fix add/remove for @ManyToMany for the owner side

Fix #8991

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
