### PR TITLE
Change addGradlePlugin method to use double instead of single quotes to allow for string interpolation

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1492,7 +1492,7 @@ module.exports = class extends PrivateBase {
                 {
                     file: fullPath,
                     needle: 'jhipster-needle-gradle-buildscript-dependency',
-                    splicable: [`classpath '${group}:${name}:${version}'`]
+                    splicable: [`classpath "${group}:${name}:${version}"`]
                 },
                 this
             );


### PR DESCRIPTION
Change addGradlePlugin method to use double instead of single quotes to allow for string interpolation

Fix #9017

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
