### PR TITLE
Spring Boot 2: Sonar: no use of jq

### DIFF
--- a/test-integration/scripts/25-sonar-analyze.sh
+++ b/test-integration/scripts/25-sonar-analyze.sh
@@ -22,7 +22,7 @@ elif [[ $JHI_SONAR = 1 ]]; then
     sleep 30
     docker-compose -f src/main/docker/sonar.yml logs
     echo "*** Sonar results:"
-    curl 'http://localhost:9001/api/measures/component?componentKey=JHipsterSonar&metricKeys=bugs%2Ccoverage%2Cvulnerabilities%2Cduplicated_lines_density%2Ccode_smells' | jq
+    curl 'http://localhost:9001/api/measures/component?componentKey=JHipsterSonar&metricKeys=bugs%2Ccoverage%2Cvulnerabilities%2Cduplicated_lines_density%2Ccode_smells'
 
 else
     echo "*** No sonar analyze"


### PR DESCRIPTION
Quick fix for now. 
I'll put jq back when I'll start to work on Sonar analyze which will failed the build if the coverage is under a specific percentage


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
