### PR TITLE
rewrite Entity equals and hashCode to fix #8656

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -440,19 +440,15 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof <%= asEntity(entityClass) %>)) {
             return false;
         }
-        <%= asEntity(entityClass) %> <%= entityInstance %> = (<%= asEntity(entityClass) %>) o;
-        if (<%= entityInstance %>.getId() == null || getId() == null) {
-            return false;
-        }
-        return Objects.equals(getId(), <%= entityInstance %>.getId());
+        return id != null && id.equals(((<%= asEntity(entityClass) %>) o).id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getId());
+        return 31;
     }
 
     @Override

--- a/generators/server/templates/src/main/java/package/domain/Authority.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/Authority.java.ejs
@@ -35,6 +35,7 @@ import javax.persistence.Column;
 import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 import java.io.Serializable;
+import java.util.Objects;
 
 /**
  * An authority (a security role) used by Spring Security.
@@ -79,18 +80,15 @@ public class Authority implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof Authority)) {
             return false;
         }
-
-        Authority authority = (Authority) o;
-
-        return !(name != null ? !name.equals(authority.name) : authority.name != null);
+        return Objects.equals(name, ((Authority) o).name);
     }
 
     @Override
     public int hashCode() {
-        return name != null ? name.hashCode() : 0;
+        return Objects.hashCode(name);
     }
 
     @Override

--- a/generators/server/templates/src/main/java/package/domain/PersistentAuditEvent.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/PersistentAuditEvent.java.ejs
@@ -149,17 +149,15 @@ public class PersistentAuditEvent implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof PersistentAuditEvent)) {
             return false;
         }
-
-        PersistentAuditEvent persistentAuditEvent = (PersistentAuditEvent) o;
-        return !(persistentAuditEvent.getId() == null || getId() == null) && Objects.equals(getId(), persistentAuditEvent.getId());
+        return id != null && id.equals(((PersistentAuditEvent) o).id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getId());
+        return 31;
     }
 
     @Override

--- a/generators/server/templates/src/main/java/package/domain/PersistentToken.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/PersistentToken.java.ejs
@@ -46,6 +46,7 @@ import javax.validation.constraints.NotNull;
 import javax.validation.constraints.Size;
 
 import java.io.Serializable;
+import java.util.Objects;
 <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
 import java.time.LocalDate;
 <%_ } _%>
@@ -223,22 +224,15 @@ public class PersistentToken implements Serializable {
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof PersistentToken)) {
             return false;
         }
-
-        PersistentToken that = (PersistentToken) o;
-
-        if (!series.equals(that.series)) {
-            return false;
-        }
-
-        return true;
+        return Objects.equals(series, ((PersistentToken) o).series);
     }
 
     @Override
     public int hashCode() {
-        return series.hashCode();
+        return Objects.hashCode(series);
     }
 
     @Override

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -316,17 +316,15 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
         if (this == o) {
             return true;
         }
-        if (o == null || getClass() != o.getClass()) {
+        if (!(o instanceof <%= asEntity('User') %>)) {
             return false;
         }
-
-        <%= asEntity('User') %> user = (<%= asEntity('User') %>) o;
-        return !(user.getId() == null || getId() == null) && Objects.equals(getId(), user.getId());
+        return id != null && id.equals(((<%= asEntity('User') %>) o).id);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hashCode(getId());
+        return 31;
     }
 
     @Override


### PR DESCRIPTION
accept subclasses as parameter to equals to avoid problems with proxies, and provide consistent hashCode with database generated identifiers

fix #8656

this is the most reliable equals and hashCode implementation when using database generated identifiers with JPA and Hibernate (and still compatible with anything else).
As explained in https://vladmihalcea.com/the-best-way-to-implement-equals-hashcode-and-tostring-with-jpa-and-hibernate/, the constant hashCode provides consistency but can decrease performance when using huge sets and maps.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
