### PR TITLE
exclude node_modules dir for idea(maven) project

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -100,6 +100,7 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <maven-idea-plugin.version>2.2.1</maven-idea-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
         <maven-war-plugin.version>3.2.2</maven-war-plugin.version>
@@ -769,6 +770,10 @@
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-idea-plugin</artifactId>
+            </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-resources-plugin</artifactId>
             </plugin>
             <plugin>
@@ -1004,6 +1009,14 @@
                                 <version>[1.8,1.9)</version>
                             </requireJavaVersion>
                         </rules>
+                    </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-idea-plugin</artifactId>
+                    <version>${maven-idea-plugin.version}</version>
+                    <configuration>
+                        <exclude>node_modules</exclude>
                     </configuration>
                 </plugin>
                 <plugin>


### PR DESCRIPTION
@jdubois maven can exclude dir.

@pvliss I using `JHipster v5.7.2` create `Monolithic application`, idea don't auto  exclude `node_modules` dir. but idea can auto exclude directories containing `package.json`.
my test idea is 2018.3.2.

---
After the `node_modules` directory is added and excluded, the maven/gradle configuration is removed from the exclusion. idea cannot restore the exclusion status.  only click `Cancel Exclusion` on the right-click menu.😇