### PR TITLE
ensure only one glue class configures the Spring context

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1314,8 +1314,8 @@ const serverFiles = {
                     renameTo: generator => `${generator.testDir}cucumber/stepdefs/StepDefs.java`
                 },
                 {
-                    file: 'package/cucumber/stepdefs/CucumberContextConfiguration.java',
-                    renameTo: generator => `${generator.testDir}cucumber/stepdefs/CucumberContextConfiguration.java`
+                    file: 'package/cucumber/CucumberContextConfiguration.java',
+                    renameTo: generator => `${generator.testDir}cucumber/CucumberContextConfiguration.java`
                 },
                 { file: '../features/gitkeep', noEjs: true }
             ]

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1313,6 +1313,10 @@ const serverFiles = {
                     file: 'package/cucumber/stepdefs/StepDefs.java',
                     renameTo: generator => `${generator.testDir}cucumber/stepdefs/StepDefs.java`
                 },
+                {
+                    file: 'package/cucumber/stepdefs/CucumberContextConfiguration.java',
+                    renameTo: generator => `${generator.testDir}cucumber/stepdefs/CucumberContextConfiguration.java`
+                },
                 { file: '../features/gitkeep', noEjs: true }
             ]
         },

--- a/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
@@ -20,12 +20,12 @@ package <%=packageName%>.cucumber.stepdefs;
 
 import <%=packageName%>.<%= mainClass %>;
 import cucumber.api.java.Before;
-import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest
-@AutoConfigureMockMvc
+@WebAppConfiguration
 @ContextConfiguration(classes = <%= mainClass %>.class)
 public class CucumberContextConfiguration {
 

--- a/generators/server/templates/src/test/java/package/cucumber/stepdefs/CucumberContextConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/stepdefs/CucumberContextConfiguration.java.ejs
@@ -18,10 +18,21 @@
 -%>
 package <%=packageName%>.cucumber.stepdefs;
 
-import org.springframework.test.web.servlet.ResultActions;
+import <%=packageName%>.<%= mainClass %>;
+import cucumber.api.java.Before;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ContextConfiguration;
 
-public abstract class StepDefs {
+@SpringBootTest
+@AutoConfigureMockMvc
+@ContextConfiguration(classes = <%= mainClass %>.class)
+public class CucumberContextConfiguration {
 
-    protected ResultActions actions;
+    @Before
+    public void setup_cucumber_spring_context(){
+        // Dummy method so cucumber will recognize this class as glue
+        // and use its context configuration.
+    }
 
 }

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -660,7 +660,7 @@ const expectedFiles = {
     cucumber: [
         `${TEST_DIR}features/user/user.feature`,
         `${TEST_DIR}features/gitkeep`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/CucumberContextConfiguration.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberContextConfiguration.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/UserStepDefs.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/StepDefs.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberTest.java`

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -660,6 +660,7 @@ const expectedFiles = {
     cucumber: [
         `${TEST_DIR}features/user/user.feature`,
         `${TEST_DIR}features/gitkeep`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/CucumberContextConfiguration.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/UserStepDefs.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/StepDefs.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberTest.java`


### PR DESCRIPTION
Cucumber no longer allows multiple classes to configure the Spring context
see https://github.com/cucumber/cucumber-jvm/issues/1420

Fix #9043 