### PR TITLE
fix maven warning regarding webpack profile activation

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1200,7 +1200,7 @@
             <id>webpack</id>
             <activation>
                 <file>
-                    <missing>${project.build.directory}/www/app/main.bundle.js</missing>
+                    <missing>${basedir}/target/www/app/main.bundle.js</missing>
                 </file>
             </activation>
             <dependencies>


### PR DESCRIPTION
Fixes #9054

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
