### PR TITLE
enhancement for using webpack proxy via oauth

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -50,10 +50,7 @@ export class LoginService {
 
     <%_ if (authenticationType === 'oauth2') { _%>
     login() {
-        let port = (location.port ? ':' + location.port : '');
-        if (port === ':9000') {
-            port = ':<%= serverPort %>';
-        }
+        const port = (location.port ? ':' + location.port : '');
         location.href = '//' + location.hostname + port + location.pathname + 'login';
     }
     <%_ } else { _%>

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -46,7 +46,8 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                 '/management',
                 '/swagger-resources',
                 '/v2/api-docs',
-                '/h2-console',
+                '/h2-console',<% if (authenticationType === 'oauth2') { %>
+                '/login',<% } %>
                 '/auth'
             ],
             target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,

--- a/generators/client/templates/react/src/main/webapp/app/shared/util/url-utils.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/util/url-utils.ts.ejs
@@ -18,10 +18,7 @@
 -%>
 <%_ if (authenticationType === 'oauth2') { _%>
 export const getLoginUrl = () => {
-  let port = location.port ? `:${location.port}` : '';
-  if (port === ':9000') {
-    port = ':8080';
-  }
+  const port = location.port ? `:${location.port}` : '';
   return `//${location.hostname}${port}/login`;
 }
 <%_ } _%>

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -76,7 +76,8 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         '/management',
         '/swagger-resources',
         '/v2/api-docs',
-        '/h2-console',
+        '/h2-console',<% if (authenticationType === 'oauth2') { %>
+        '/login',<% } %>        
         '/auth'
       ],
       target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,


### PR DESCRIPTION
### Issue
The `webpack proxy` is really useful for frontend dev only. We can test and debug the frontend without to build it again and deploy it again. We can simply do a `yarn start` or `npm start`. of cause, we need to setup the proxy in the `webpack.dev.js`.
when we create a a new gateway microserivce with oauth2. it will have some issue with the `webpack proxy`.
> case 1:  we generate the gateway with 8080 port, we build the image, and run container with a 8080:8080 port mapping. we can do easily do a `yarn start` (or `npm start`) for frontend dev only. 

> case 2: we generate the gateway with 8080 port, we build the image, and run the container with 8081:8080 port mapping,  the `yarn start`(or `npm start`) **will not work**. 

> case 3: we generate the gateway with 8080 port, we build the image, and deploy the gateway to 
a remote server with 80:8080 port mapping,  the `yarn start`(or `npm start`) **will not work**. 

### Issue Analysis
when we use the `yarn start` or `npm start`, we are seting up the proxy for the backend call. 

1. In the current `webpack.dev.js`, we are not setting up the proxy for `login` url.  (for oauth setting, we will call `/login` ), it will cause a `404` error since it is not being proxied. 
1. In the current `login.service.ts` (it is `url-utils.ts` for react). we will hard-code it to the port when we generate the project. if when we run the image with a different port mapping. it will have a error.
```
        let port = (location.port ? ':' + location.port : '');	        const port = (location.port ? ':' + location.port : '');
        if (port === ':9000') {	
            port = ':<%= serverPort %>';	
        }
```
### Issue Fix

1.  set the proxy for `/login` when using the `oauth2`
2.  remove the hardcoded logic to get the url

when we using the `yarn start` (or `npm start`) with the oauth2 setting , it will proxy the `/login` to the backend according the proxy we are setting.



-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
