### PR TITLE
Fix elastic docker for azure ci

### DIFF
--- a/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
+++ b/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-version: '2'
+version: '2.2'
 services:
     <%= baseName.toLowerCase() %>-elasticsearch:
         image: <%= DOCKER_ELASTICSEARCH %>
@@ -27,4 +27,4 @@ services:
             - 9300:9300
         environment:
             - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
-            - discovery.type=single-node
+            - "discovery.type=single-node"


### PR DESCRIPTION
I think that adding `discovery.type=single-node` within double quotes should fix the problem for Azure CI build and allow for upgrade to version 2.2 as per example at https://www.elastic.co/guide/en/elasticsearch/reference/current/docker.html
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
