### PR TITLE
Fix elastic docker compose error for azure ci

### DIFF
--- a/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
+++ b/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-version: '2'
+version: '2.2'
 services:
     <%= baseName.toLowerCase() %>-elasticsearch:
         image: <%= DOCKER_ELASTICSEARCH %>
@@ -27,4 +27,4 @@ services:
             - 9300:9300
         environment:
             - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
-            - discovery.type=single-node
+            - "discovery.type=single-node"

--- a/test-integration/scripts/20-no-memory-limit-elasticsearch.sh
+++ b/test-integration/scripts/20-no-memory-limit-elasticsearch.sh
@@ -5,7 +5,6 @@ source $(dirname $0)/00-init-env.sh
 
 cd "$JHI_FOLDER_APP"
 if [ -a src/main/docker/elasticsearch.yml ]; then
-    #sed -i -e 's/        environment:/        # environment:/1;' src/main/docker/elasticsearch.yml
     sed -i -e 's/            - \"ES_JAVA_OPTS=-Xms1024m -Xmx1024m\"/        #     - \"ES_JAVA_OPTS=-Xms1024m -Xmx1024m\"/1;' src/main/docker/elasticsearch.yml
     cat src/main/docker/elasticsearch.yml
 fi

--- a/test-integration/scripts/20-no-memory-limit-elasticsearch.sh
+++ b/test-integration/scripts/20-no-memory-limit-elasticsearch.sh
@@ -5,7 +5,7 @@ source $(dirname $0)/00-init-env.sh
 
 cd "$JHI_FOLDER_APP"
 if [ -a src/main/docker/elasticsearch.yml ]; then
-    sed -i -e 's/        environment:/        # environment:/1;' src/main/docker/elasticsearch.yml
+    #sed -i -e 's/        environment:/        # environment:/1;' src/main/docker/elasticsearch.yml
     sed -i -e 's/            - \"ES_JAVA_OPTS=-Xms1024m -Xmx1024m\"/        #     - \"ES_JAVA_OPTS=-Xms1024m -Xmx1024m\"/1;' src/main/docker/elasticsearch.yml
     cat src/main/docker/elasticsearch.yml
 fi


### PR DESCRIPTION
So the real problem seemed to be at `test-integration/scripts/20-no-memory-limit-elasticsearch.sh` which was commenting out `environment` and the fact that `discovery.type` was moved out of `commands` group and within `environment`.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed