### PR TITLE
angular: add ngx-translate as dependency

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -45,7 +45,7 @@
     "bootstrap": "4.1.3",
     "core-js": "2.5.7",
     "moment": "2.22.2",
-    "ng-jhipster": "0.6.0",
+    "ng-jhipster": "0.7.0",
     "ngx-cookie": "2.0.1",
     "ngx-infinite-scroll": "6.0.1",
     "ngx-webstorage": "2.0.1",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -27,21 +27,19 @@
     "node_modules"
   ],
   "dependencies": {
-    "@angular/common": "7.1.0",
-    "@angular/compiler": "7.1.0",
-    "@angular/core": "7.1.0",
-    "@angular/forms": "7.1.0",
-    "@angular/platform-browser": "7.1.0",
-    "@angular/platform-browser-dynamic": "7.1.0",
-    "@angular/router": "7.1.0",
+    "@angular/common": "7.2.0",
+    "@angular/compiler": "7.2.0",
+    "@angular/core": "7.2.0",
+    "@angular/forms": "7.2.0",
+    "@angular/platform-browser": "7.2.0",
+    "@angular/platform-browser-dynamic": "7.2.0",
+    "@angular/router": "7.2.0",
     "@fortawesome/angular-fontawesome": "0.3.0",
     "@fortawesome/fontawesome-svg-core": "1.2.8",
     "@fortawesome/free-solid-svg-icons": "5.5.0",
     "@ng-bootstrap/ng-bootstrap": "4.0.0",
-    <%_ if (enableTranslation) { _%>
     "@ngx-translate/core": "11.0.1",
     "@ngx-translate/http-loader": "4.0.0",
-    <%_ } _%>
     "bootstrap": "4.1.3",
     "core-js": "2.5.7",
     "moment": "2.22.2",
@@ -60,7 +58,7 @@
   },
   "devDependencies": {
     "@angular/cli": "7.0.6",
-    "@angular/compiler-cli": "7.1.0",
+    "@angular/compiler-cli": "7.2.0",
     "@ngtools/webpack": "7.0.6",
     <%_ if (protractorTests) { _%>
     "@types/chai": "4.1.7",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -43,7 +43,7 @@
     "bootstrap": "4.1.3",
     "core-js": "2.5.7",
     "moment": "2.22.2",
-    "ng-jhipster": "0.7.0",
+    "ng-jhipster": "0.8.0",
     "ngx-cookie": "2.0.1",
     "ngx-infinite-scroll": "6.0.1",
     "ngx-webstorage": "2.0.1",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -38,6 +38,10 @@
     "@fortawesome/fontawesome-svg-core": "1.2.8",
     "@fortawesome/free-solid-svg-icons": "5.5.0",
     "@ng-bootstrap/ng-bootstrap": "4.0.0",
+    <%_ if (enableTranslation) { _%>
+    "@ngx-translate/core": "11.0.1",
+    "@ngx-translate/http-loader": "4.0.0",
+    <%_ } _%>
     "bootstrap": "4.1.3",
     "core-js": "2.5.7",
     "moment": "2.22.2",


### PR DESCRIPTION
Due to https://github.com/jhipster/ng-jhipster/pull/84

We need to add ngx-translate dependencies in order to have a working JHipster app.

It wasn't a good practice to embed some dependencies in our lib as it can result into duplicated dependencies versions if our end users install ngx-translate on their JHipster app.
cf: https://github.com/ng-packagr/ng-packagr/blob/master/docs/dependencies.md

**Warning:** Please wait the 0.7.0 (or 1.0) version of `ng-jhipster` to be available before merging this.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
