### PR TITLE
Adding pluginRepositories Needle in maven Pom.xml

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1267,6 +1267,40 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add a remote Maven Plugin Repository to the Maven build.
+     *
+     * @param {string} id - id of the repository
+     * @param {string} url - url of the repository
+     */
+    addMavenPluginRepository(id, url) {
+        const fullPath = 'pom.xml';
+        try {
+            // prettier-ignore
+            const repository = `${'<pluginRepository>\n'
+                + '            <id>'}${id}</id>\n`
+                + `            <url>${url}</url>\n`
+                + '        </pluginRepository>';
+            jhipsterUtils.rewriteFile(
+                {
+                    file: fullPath,
+                    needle: 'jhipster-needle-maven-plugin-repository',
+                    splicable: [repository]
+                },
+                this
+            );
+        } catch (e) {
+            this.log(
+                `${chalk.yellow('\nUnable to find ') +
+                fullPath +
+                chalk.yellow(
+                    ' or missing required jhipster-needle. Reference to '
+                )}maven plugin repository (id: ${id}, url:${url})${chalk.yellow(' not added.\n')}`
+            );
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
      * Add a distributionManagement to the Maven build.
      *
      * @param {string} id - id of the repository

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -43,6 +43,10 @@
         <!-- jhipster-needle-maven-repository -->
     </repositories>
 
+    <pluginRepositories>
+        <!-- jhipster-needle-maven-plugin-repository -->
+    </pluginRepositories>
+
     <!-- jhipster-needle-distribution-management -->
 
     <properties>


### PR DESCRIPTION
I currently working on a JHipster blueprint and I want to add maven specific configuration like repositories, plugin repositories and distribution management.

In the main generator we don't already have a function to add Maven plugin repositories as we have for repositories.
I suggest to add this function and the related needle in the Pom.xml.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
