### PR TITLE
angular: send objects instead of strings

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
@@ -19,7 +19,7 @@
 <div>
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <h2 jhiTranslate="password.title" translateValues="{username: '{{account.login}}'}" *ngIf="account">Password for [<b>{{account.login}}</b>]</h2>
+            <h2 jhiTranslate="password.title" [translateValues]="{username: account.login}" *ngIf="account">Password for [<b>{{account.login}}</b>]</h2>
 
             <div class="alert alert-success" *ngIf="success" jhiTranslate="password.messages.success">
                 <strong>Password changed!</strong>

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div>
-    <h2 jhiTranslate="sessions.title" translateValues="{username: '{{account.login}}'}" *ngIf="account">Active sessions for [<b>{{account.login}}</b>]</h2>
+    <h2 jhiTranslate="sessions.title" [translateValues]="{username: account.login}" *ngIf="account">Active sessions for [<b>{{account.login}}</b>]</h2>
 
     <div class="alert alert-success" *ngIf="success" jhiTranslate="sessions.messages.success">
         <strong>Session invalidated!</strong>

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
@@ -19,7 +19,7 @@
 <div>
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <h2 jhiTranslate="settings.title" translateValues="{username: '{{settingsAccount.login}}'}" *ngIf="settingsAccount">User settings for [<b>{{settingsAccount.login}}</b>]</h2>
+            <h2 jhiTranslate="settings.title" [translateValues]="{username: settingsAccount.login}" *ngIf="settingsAccount">User settings for [<b>{{settingsAccount.login}}</b>]</h2>
 
             <div class="alert alert-success" *ngIf="success" jhiTranslate="settings.messages.success">
                 <strong>Settings saved!</strong>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -19,7 +19,7 @@
 <div class="table-responsive" *ngIf="loggers">
     <h2 id="logs-page-heading" jhiTranslate="logs.title">Logs</h2>
 
-    <p jhiTranslate="logs.nbloggers" translateValues="{total: '{{ loggers.length }}'}">There are {{ loggers.length }} loggers.</p>
+    <p jhiTranslate="logs.nbloggers" [translateValues]="{total: loggers.length}">There are {{ loggers.length }} loggers.</p>
 
     <span jhiTranslate="logs.filter">Filter</span> <input type="text" [(ngModel)]="filter" class="form-control">
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
@@ -24,7 +24,7 @@
     </div>
     <div class="modal-body">
         <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
-        <p jhiTranslate="userManagement.delete.question" translateValues="{login: '{{user.login}}'}">Are you sure you want to delete this User?</p>
+        <p jhiTranslate="userManagement.delete.question" [translateValues]="{login: user.login}">Are you sure you want to delete this User?</p>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
@@ -43,7 +43,7 @@
 
                         <small class="form-text text-danger"
                         *ngIf="loginInput.errors.maxlength" jhiTranslate="entity.validation.maxlength"
-                        translateValues="{max: 50}">
+                        [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
 
@@ -61,7 +61,7 @@
                     <div *ngIf="firstNameInput.dirty && firstNameInput.invalid">
                         <small class="form-text text-danger"
                         *ngIf="firstNameInput.errors.maxlength" jhiTranslate="entity.validation.maxlength"
-                        translateValues="{max: 50}">
+                        [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
                     </div>
@@ -74,7 +74,7 @@
                     <div *ngIf="lastNameInput.dirty && lastNameInput.invalid">
                         <small class="form-text text-danger"
                         *ngIf="lastNameInput.errors.maxlength" jhiTranslate="entity.validation.maxlength"
-                        translateValues="{max: 50}">
+                        [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
                     </div>
@@ -92,13 +92,13 @@
 
                         <small class="form-text text-danger"
                         *ngIf="emailInput.errors.maxlength" jhiTranslate="entity.validation.maxlength"
-                        translateValues="{max: 100}">
+                        [translateValues]="{max: 100}">
                             This field cannot be longer than 100 characters.
                         </small>
 
                         <small class="form-text text-danger"
                         *ngIf="emailInput.errors.minlength" jhiTranslate="entity.validation.minlength"
-                        translateValues="{min: 5}">
+                        [translateValues]="{min: 5}">
                             This field is required to be at least 5 characters.
                         </small>
 

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
@@ -27,7 +27,7 @@
         <div [ngSwitch]="isAuthenticated()">
             <div class="alert alert-success" *ngSwitchCase="true">
                 <span id="home-logged-message" *ngIf="account" jhiTranslate="home.logged.message"
-                    translateValues="{username: '{{account.login}}'}"> You are logged in as user "{{account.login}}". </span>
+                    [translateValues]="{username: account.login}"> You are logged in as user "{{account.login}}". </span>
             </div>
 
             <div class="alert alert-warning" *ngSwitchCase="false">

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
@@ -24,7 +24,7 @@
     </div>
     <div class="modal-body">
         <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
-        <p id="<%= jhiPrefixDashed %>-delete-<%= entityInstance %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.delete.question" translateValues="{id: '{{<%= entityInstance %>.id}}'}">Are you sure you want to delete this <%= entityClassHumanized %>?</p>
+        <p id="<%= jhiPrefixDashed %>-delete-<%= entityInstance %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.delete.question" [translateValues]="{id: <%= entityInstance %>.id}">Are you sure you want to delete this <%= entityClassHumanized %>?</p>
     </div>
     <div class="modal-footer">
         <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -119,43 +119,43 @@
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('minlength')) { _%>
                         <small class="form-text text-danger"
-                        [hidden]="!editForm.controls.<%= fieldName %>?.errors?.minlength" jhiTranslate="entity.validation.minlength" translateValues="{ min: <%= fields[idx].fieldValidateRulesMinlength %> }">
+                        [hidden]="!editForm.controls.<%= fieldName %>?.errors?.minlength" jhiTranslate="entity.validation.minlength" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinlength %> }">
                         This field is required to be at least <%= fields[idx].fieldValidateRulesMinlength %> characters.
                         </small>
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('maxlength')) { _%>
                         <small class="form-text text-danger"
-                        [hidden]="!editForm.controls.<%= fieldName %>?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" translateValues="{ max: <%= fields[idx].fieldValidateRulesMaxlength %> }">
+                        [hidden]="!editForm.controls.<%= fieldName %>?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxlength %> }">
                         This field cannot be longer than <%= fields[idx].fieldValidateRulesMaxlength %> characters.
                         </small>
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('min')) { _%>
                         <small class="form-text text-danger"
-                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.min" jhiTranslate="entity.validation.min" translateValues="{ min: <%= fields[idx].fieldValidateRulesMin %> }">
+                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.min" jhiTranslate="entity.validation.min" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMin %> }">
                             This field should be at least <%= fields[idx].fieldValidateRulesMin %>.
                         </small>
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('max')) { _%>
                         <small class="form-text text-danger"
-                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.max" jhiTranslate="entity.validation.max" translateValues="{ max: <%= fields[idx].fieldValidateRulesMax %> }">
+                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.max" jhiTranslate="entity.validation.max" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMax %> }">
                             This field cannot be more than <%= fields[idx].fieldValidateRulesMax %>.
                         </small>
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('minbytes')) { _%>
                         <small class="form-text text-danger"
-                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.minbytes" jhiTranslate="entity.validation.minbytes" translateValues="{ min: <%= fields[idx].fieldValidateRulesMinbytes %> }">
+                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.minbytes" jhiTranslate="entity.validation.minbytes" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinbytes %> }">
                             This field should be at least <%= fields[idx].fieldValidateRulesMinbytes %>.
                         </small>
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('maxbytes')) { _%>
                         <small class="form-text text-danger"
-                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.maxbytes" jhiTranslate="entity.validation.maxbytes" translateValues="{ max: <%= fields[idx].fieldValidateRulesMaxbytes %> }">
+                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.maxbytes" jhiTranslate="entity.validation.maxbytes" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxbytes %> }">
                             This field cannot be more than <%= fields[idx].fieldValidateRulesMaxbytes %>.
                         </small>
                         <%_ } _%>
                         <%_ if (fields[idx].fieldValidateRules.includes('pattern')) { _%>
                         <small class="form-text text-danger"
-                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.pattern" jhiTranslate="entity.validation.pattern" translateValues="{ pattern: '<%= fieldNameHumanized %>' }">
+                            [hidden]="!editForm.controls.<%= fieldName %>?.errors?.pattern" jhiTranslate="entity.validation.pattern" [translateValues]="{ pattern: '<%= fieldNameHumanized %>' }">
                             This field should follow pattern for "<%= fieldNameHumanized %>".
                         </small>
                         <%_ } _%>

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1764,7 +1764,7 @@ module.exports = class extends PrivateBase {
                 regex = new RegExp(
                     [
                         /( (data-t|jhiT)ranslate="([a-zA-Z0-9 +{}'_](\.)?)+")/, // data-translate or jhiTranslate
-                        /( translate(-v|V)alues="\{([a-zA-Z]|\d|:|\{|\}|\[|\]|-|'|\s|\.|_)*?\}")/, // translate-values or translateValues
+                        /( \[translate(-v|V)alues\]="\{([a-zA-Z]|\d|:|\{|\}|\[|\]|-|'|\s|\.|_)*?\}")/, // translate-values or translateValues
                         /( translate-compile)/, // translate-compile
                         /( translate-value-max="[0-9{}()|]*")/ // translate-value-max
                     ]


### PR DESCRIPTION
In order to start fixing #9048, I need to have proper objects sent as parameter and not as strings.
So i use the `[ ]` notation to send object in the `jhiTranslate` directive.

This needs https://github.com/jhipster/ng-jhipster/pull/87  to be merged before.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
