### PR TITLE
Switch Main(S)CSS to Global(S)CSS

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/css/global.css.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/css/global.css.ejs
@@ -238,4 +238,4 @@ ui bootstrap tweaks
     white-space: nowrap;
 }
 
-/* jhipster-needle-css-add-main JHipster will add new css style */
+/* jhipster-needle-css-add-global JHipster will add new css style */

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -236,4 +236,4 @@ ui bootstrap tweaks
     white-space: nowrap;
 }
 
-/* jhipster-needle-scss-add-main JHipster will add new css style */
+/* jhipster-needle-scss-add-global JHipster will add new css style */

--- a/generators/client/templates/react/src/main/webapp/app/app.css.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.css.ejs
@@ -251,4 +251,4 @@ ui bootstrap tweaks
   white-space: nowrap;
 }
 
-/* jhipster-needle-css-add-main JHipster will add new css style */
+/* jhipster-needle-css-add-app JHipster will add new css style */

--- a/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
@@ -336,4 +336,4 @@ http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
   margin-top: -0.5rem;
 }
 
-/* jhipster-needle-css-add-main JHipster will add new css style */
+/* jhipster-needle-scss-add-app JHipster will add new css style */

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1072,7 +1072,7 @@ module.exports = class extends PrivateBase {
      *
      */
     addGlobalSCSSStyle(style, comment) {
-        const fullPath = `${CLIENT_MAIN_SRC_DIR}scss/global.scss`;
+        const fullPath = `${CLIENT_MAIN_SRC_DIR}content/scss/global.scss`;
         let styleBlock = '';
         if (comment) {
             styleBlock += '/* ==========================================================================\n';

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1148,6 +1148,106 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add new css style to the react application in "app.css".
+     *
+     * @param {boolean} isUseSass - flag indicating if sass should be used
+     * @param {string} style - css to add in the file
+     * @param {string} comment - comment to add before css code
+     *
+     * example:
+     *
+     * style = '.jhipster {\n     color: #baa186;\n}'
+     * comment = 'New JHipster color'
+     *
+     * * ==========================================================================
+     * New JHipster color
+     * ========================================================================== *
+     * .jhipster {
+     *     color: #baa186;
+     * }
+     *
+     */
+    addAppCSSStyle(isUseSass, style, comment) {
+        if (isUseSass) {
+            this.addAppSCSSStyle(style, comment);
+        }
+
+        const fullPath = `${CLIENT_MAIN_SRC_DIR}app/app.css`;
+        let styleBlock = '';
+        if (comment) {
+            styleBlock += '/* ==========================================================================\n';
+            styleBlock += `${comment}\n`;
+            styleBlock += '========================================================================== */\n';
+        }
+        styleBlock += `${style}\n`;
+        try {
+            jhipsterUtils.rewriteFile(
+                {
+                    file: fullPath,
+                    needle: 'jhipster-needle-css-add-app',
+                    splicable: [styleBlock]
+                },
+                this
+            );
+        } catch (e) {
+            this.log(
+                chalk.yellow('\nUnable to find ') +
+                fullPath +
+                chalk.yellow(' or missing required jhipster-needle. Style not added to JHipster app.\n')
+            );
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
+     * Add new scss style to the react application in "app.scss".
+     *
+     * @param {string} style - scss to add in the file
+     * @param {string} comment - comment to add before css code
+     *
+     * example:
+     *
+     * style = '.success {\n     @extend .message;\n    border-color: green;\n}'
+     * comment = 'Message'
+     *
+     * * ==========================================================================
+     * Message
+     * ========================================================================== *
+     * .success {
+     *     @extend .message;
+     *     border-color: green;
+     * }
+     *
+     */
+    addAppSCSSStyle(style, comment) {
+        const fullPath = `${CLIENT_MAIN_SRC_DIR}app/app.scss`;
+        let styleBlock = '';
+        if (comment) {
+            styleBlock += '/* ==========================================================================\n';
+            styleBlock += `${comment}\n`;
+            styleBlock += '========================================================================== */\n';
+        }
+        styleBlock += `${style}\n`;
+        try {
+            jhipsterUtils.rewriteFile(
+                {
+                    file: fullPath,
+                    needle: 'jhipster-needle-scss-add-app',
+                    splicable: [styleBlock]
+                },
+                this
+            );
+        } catch (e) {
+            this.log(
+                chalk.yellow('\nUnable to find ') +
+                fullPath +
+                chalk.yellow(' or missing required jhipster-needle. Style not added to JHipster app.\n')
+            );
+            this.debug('Error:', e);
+        }
+    }
+
+    /**
      * Copy third-party library resources path.
      *
      * @param {string} sourceFolder - third-party library resources source path

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1000,7 +1000,7 @@ module.exports = class extends PrivateBase {
     }
 
     /**
-     * Add new css style to the angular application in "main.css".
+     * Add new css style to the angular application in "global.css".
      *
      * @param {boolean} isUseSass - flag indicating if sass should be used
      * @param {string} style - css to add in the file
@@ -1019,12 +1019,12 @@ module.exports = class extends PrivateBase {
      * }
      *
      */
-    addMainCSSStyle(isUseSass, style, comment) {
+    addGlobalCSSStyle(isUseSass, style, comment) {
         if (isUseSass) {
-            this.addMainSCSSStyle(style, comment);
+            this.addGlobalSCSSStyle(style, comment);
         }
 
-        const fullPath = `${CLIENT_MAIN_SRC_DIR}content/css/main.css`;
+        const fullPath = `${CLIENT_MAIN_SRC_DIR}content/css/global.css`;
         let styleBlock = '';
         if (comment) {
             styleBlock += '/* ==========================================================================\n';
@@ -1036,7 +1036,7 @@ module.exports = class extends PrivateBase {
             jhipsterUtils.rewriteFile(
                 {
                     file: fullPath,
-                    needle: 'jhipster-needle-css-add-main',
+                    needle: 'jhipster-needle-css-add-global',
                     splicable: [styleBlock]
                 },
                 this
@@ -1052,7 +1052,7 @@ module.exports = class extends PrivateBase {
     }
 
     /**
-     * Add new scss style to the angular application in "main.scss".
+     * Add new scss style to the angular application in "global.scss".
      *
      * @param {string} style - scss to add in the file
      * @param {string} comment - comment to add before css code
@@ -1071,8 +1071,8 @@ module.exports = class extends PrivateBase {
      * }
      *
      */
-    addMainSCSSStyle(style, comment) {
-        const fullPath = `${CLIENT_MAIN_SRC_DIR}scss/main.scss`;
+    addGlobalSCSSStyle(style, comment) {
+        const fullPath = `${CLIENT_MAIN_SRC_DIR}scss/global.scss`;
         let styleBlock = '';
         if (comment) {
             styleBlock += '/* ==========================================================================\n';
@@ -1084,7 +1084,7 @@ module.exports = class extends PrivateBase {
             jhipsterUtils.rewriteFile(
                 {
                     file: fullPath,
-                    needle: 'jhipster-needle-scss-add-main',
+                    needle: 'jhipster-needle-scss-add-global',
                     splicable: [styleBlock]
                 },
                 this


### PR DESCRIPTION
The JHipster API provide functions to add style to css and scss files. 
But the files targeted are named main.css and main.scss.

As I can see 'main.css' and 'main.scss' is no longer existing and are replaces by 'global.css' and 'global.scss'.

I suggest to switch all 'main' references to 'global'. (needle, files references and needles).

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
