### PR TITLE
Add basic auth config to secure management endpoints

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -331,6 +331,10 @@ const serverFiles = {
                 {
                     file: 'package/security/package-info.java',
                     renameTo: generator => `${generator.javaDir}security/package-info.java`
+                },
+                {
+                    file: 'package/config/ManagementSecurityConfiguration.java',
+                    renameTo: generator => `${generator.javaDir}config/ManagementSecurityConfiguration.java`
                 }
             ]
         },

--- a/generators/server/templates/src/main/java/package/config/ManagementSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ManagementSecurityConfiguration.java.ejs
@@ -1,0 +1,86 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.config;
+
+import <%= packageName %>.security.AuthoritiesConstants;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.security.SecurityProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.annotation.Order;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.WebSecurityConfigurerAdapter;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.provisioning.InMemoryUserDetailsManager;
+
+@Order(1)
+@ConditionalOnProperty({"spring.security.user.name", "spring.security.user.password", "spring.security.user.roles"})
+@Configuration
+public class ManagementSecurityConfiguration extends WebSecurityConfigurerAdapter {
+
+    private final Logger log = LoggerFactory.getLogger(ManagementSecurityConfiguration.class);
+
+    private static final String MANAGEMENT_REALM_NAME = "management";
+
+    private final SecurityProperties securityProperties;
+
+    @Value("${management.endpoints.web.base-path:management}")
+    private String managementBasePath;
+
+    public ManagementSecurityConfiguration(SecurityProperties securityProperties) {
+        this.securityProperties = securityProperties;
+    }
+
+    @Override
+    protected void configure(HttpSecurity http) throws Exception {
+        http
+            .antMatcher(managementBasePath + "/**")
+            .authorizeRequests()
+            .antMatchers(managementBasePath + "/health").permitAll()
+            .antMatchers(managementBasePath + "/info").permitAll()
+            .antMatchers(managementBasePath +"/**").hasAnyAuthority(AuthoritiesConstants.ADMIN)
+        .and()
+            .httpBasic()
+            .realmName(MANAGEMENT_REALM_NAME)
+        .and()
+            .userDetailsService(managementUserDetailsService())
+            .sessionManagement()
+            .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            .and().csrf().disable();
+    }
+
+    @Bean
+    public UserDetailsService managementUserDetailsService() {
+        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
+        SecurityProperties.User user = securityProperties.getUser();
+        boolean isUserPasswordGenerated = user.isPasswordGenerated();
+        String[] userRoles = user.getRoles().toArray(new String[0]);
+        manager.createUser(User.builder()
+            .username(user.getName())
+            .password(user.getPassword())
+            .roles(userRoles).build());
+        log.info("Securing endpoints under {} with Basic Authentication", managementBasePath);
+        return manager;
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -36,6 +36,7 @@ import org.springframework.beans.factory.InitializingBean;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
+import org.springframework.core.annotation.Order;
 <%_ if (authenticationType !== 'uaa' && !(applicationType === 'microservice' && authenticationType === 'oauth2')) { _%>
 import org.springframework.http.HttpMethod;
 <%_ } _%>
@@ -89,6 +90,7 @@ import org.springframework.web.filter.CorsFilter;
 <%_ } _%>
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 
+@Order(2)
 @Configuration
 <%_ if (authenticationType === 'oauth2') { _%>
     <%_ if (['monolith', 'gateway'].includes(applicationType)) { _%>
@@ -266,9 +268,11 @@ public class SecurityConfiguration extends <% if (authenticationType === 'oauth2
             .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/websocket/**").permitAll()
             <%_ } _%>
+            .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/info").permitAll()
-            .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)<% if (authenticationType === 'jwt') { %>
+            .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN);
+            <% if (authenticationType === 'jwt') { %>
         .and()
             .apply(securityConfigurerAdapter())<% } %>;
 
@@ -318,6 +322,7 @@ import org.springframework.web.filter.CorsFilter;
 <%_ } _%>
 import org.springframework.web.client.RestTemplate;
 
+@Order(2)
 @Configuration
 @EnableResourceServer
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true)
@@ -355,10 +360,12 @@ public class SecurityConfiguration extends ResourceServerConfigurerAdapter {
             .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
         .and()
             .authorizeRequests()
+
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/info").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN);
+            .antMatchers("/api/**").authenticated();
     }
 
     @Bean

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -235,6 +235,13 @@ spring:
             discovery:
                 enabled: true
 <%_ } _%>
+    # Set Basic Authentication credentials for accessing management endpoints
+    security:
+        user:
+            name: admin
+            # BCrypt encrypted "admin"
+            password: "$2a$10$irth1Grc1faFEXNFcmHFyeLYM4IkoIAhqxA5HGOl1a/0I1N4vKuqy"
+            roles: ADMIN
 
 server:
     port: <%= serverPort %>

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -203,6 +203,12 @@ spring:
             discovery:
                 enabled: true
 <%_ } _%>
+    # Set Basic Authentication credentials for accessing management endpoints
+    #security:
+    #    user:
+    #       name: admin
+    #       password: admin
+    #       roles: ADMIN
 
 # ===================================================================
 # To enable TLS in production, generate a certificate using:


### PR DESCRIPTION
fix #8946

With this PR, endpoints under /management can be accessed with basic auth. The user/password/roles used is taken from the default spring security properties (`spring.security.user.name/password/roles).

⚠️ When not set those properties will default to : 
- name: user
- password: a random UUID

This is why I'm printing the credentials in the logs at startup. I'm not sure if everyone is OK with this.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
