### PR TITLE
enable html5-mode for angular and react

### DIFF
--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -310,6 +310,7 @@ const files = {
                 { file: 'shared/auth/private-route.tsx', method: 'processJsx' },
                 { file: 'shared/error/error-boundary.tsx', method: 'processJsx' },
                 { file: 'shared/error/error-boundary-route.tsx', method: 'processJsx' },
+                { file: 'shared/error/page-not-found.tsx', method: 'processJsx' },
                 // model
                 'shared/model/user.model.ts'
             ]

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -75,6 +75,7 @@
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",
     "autoprefixer": "9.4.7",
+    "base-href-webpack-plugin": "2.0.0",
     "browser-sync": "2.26.3",
     "browser-sync-webpack-plugin": "2.2.2",
     "cache-loader": "2.0.1",

--- a/generators/client/templates/angular/src/main/webapp/app/app-routing.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app-routing.module.ts.ejs
@@ -36,7 +36,7 @@ const LAYOUT_ROUTES = [
                 },
                 ...LAYOUT_ROUTES
             ],
-            { useHash: true , enableTracing: DEBUG_INFO_ENABLED }
+            { enableTracing: DEBUG_INFO_ENABLED }
         )
     ],
     exports: [

--- a/generators/client/templates/angular/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/index.html.ejs
@@ -19,7 +19,7 @@
 <!doctype html>
 <html class="no-js" lang="<% if (enableTranslation) { %><%= nativeLanguage %><% } else { %>en<% } %>" dir="ltr">
 <head>
-    <base href="./" />
+    <base href="/" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>

--- a/generators/client/templates/angular/src/main/webapp/manifest.webapp.ejs
+++ b/generators/client/templates/angular/src/main/webapp/manifest.webapp.ejs
@@ -25,7 +25,7 @@
   ],
   "theme_color": "#000000",
   "background_color": "#e0e0e0",
-  "start_url": "/index.html",
+  "start_url": ".",
   "display": "standalone",
   "orientation": "portrait"
 }

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -40,7 +40,6 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         contentBase: './<%= DIST_DIR %>',
         proxy: [{
             context: [
-                /* jhipster-needle-add-entity-to-webpack - JHipster will add entity api paths here */
                 '/'
             ],
             target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -39,16 +39,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     devServer: {
         contentBase: './<%= DIST_DIR %>',
         proxy: [{
-            context: [<% if (authenticationType === 'uaa') { %>
-                '/<%= uaaBaseName.toLowerCase() %>',<% } %>
+            context: [
                 /* jhipster-needle-add-entity-to-webpack - JHipster will add entity api paths here */
-                '/api',
-                '/management',
-                '/swagger-resources',
-                '/v2/api-docs',
-                '/h2-console',<% if (authenticationType === 'oauth2') { %>
-                '/login',<% } %>
-                '/auth'
+                '/'
             ],
             target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,
             secure: false,

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -18,6 +18,7 @@
 -%>
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
+const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const Visualizer = require('webpack-visualizer-plugin');
@@ -164,7 +165,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         new WorkboxPlugin.GenerateSW({
           clientsClaim: true,
           skipWaiting: true,
-        })
+        }),
+        new BaseHrefWebpackPlugin({ baseHref: '/' })
     ],
     mode: 'production'
 });

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -84,6 +84,7 @@ limitations under the License.
     <%_ } _%>
     "@types/webpack-env": "1.13.6",
     "autoprefixer": "9.2.0",
+    "base-href-webpack-plugin": "2.0.0",
     "browser-sync": "2.26.3",
     "browser-sync-webpack-plugin": "2.2.2",
     "cache-loader": "1.2.2",

--- a/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.tsx.ejs
@@ -22,7 +22,7 @@ import './app.<%= styleSheetExt %>';
 import React from 'react';
 import { connect } from 'react-redux';
 import { Card } from 'reactstrap';
-import { HashRouter as Router } from 'react-router-dom';
+import { BrowserRouter as Router } from 'react-router-dom';
 import { ToastContainer, ToastPosition, toast } from 'react-toastify';
 
 import { IRootState } from 'app/shared/reducers';

--- a/generators/client/templates/react/src/main/webapp/app/routes.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/routes.tsx.ejs
@@ -51,10 +51,10 @@ const Admin = Loadable({
 
 const Routes = () => (
   <div className="view-routes">
-    <%_ if (authenticationType !== 'oauth2') { _%>
-    <ErrorBoundaryRoute path="/login" component={Login} />
-    <%_ } _%>
     <Switch>
+    <%_ if (authenticationType !== 'oauth2') { _%>
+      <ErrorBoundaryRoute path="/login" component={Login} />
+    <%_ } _%>
       <ErrorBoundaryRoute path="/logout" component={Logout} />
     <%_ if (authenticationType !== 'oauth2') { _%>
       <ErrorBoundaryRoute path="/register" component={Register} />

--- a/generators/client/templates/react/src/main/webapp/app/routes.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/routes.tsx.ejs
@@ -32,6 +32,7 @@ import Home from 'app/modules/home/home';
 import Entities from 'app/entities';
 import PrivateRoute from 'app/shared/auth/private-route';
 import ErrorBoundaryRoute from 'app/shared/error/error-boundary-route';
+import PageNotFound from 'app/shared/error/page-not-found';
 import { AUTHORITIES } from 'app/config/constants';
 
 // tslint:disable:space-in-parens
@@ -66,7 +67,8 @@ const Routes = () => (
       <PrivateRoute path="/account" component={Account} hasAnyAuthorities={[AUTHORITIES.ADMIN, AUTHORITIES.USER]}/>
     <%_ } _%>
       <PrivateRoute path="/entity" component={Entities} hasAnyAuthorities={[AUTHORITIES.USER]}/>
-      <ErrorBoundaryRoute path="/" component={Home}/>
+      <ErrorBoundaryRoute path="/" exact component={Home}/>
+      <ErrorBoundaryRoute component={PageNotFound} />
     </Switch>
   </div>
 );

--- a/generators/client/templates/react/src/main/webapp/app/shared/error/page-not-found.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/error/page-not-found.tsx.ejs
@@ -1,0 +1,19 @@
+import React from 'react';
+import { Translate } from 'react-jhipster';
+import { Row, Col, Alert } from 'reactstrap';
+
+class PageNotFound extends React.Component {
+  render() {
+    return (
+      <div>
+        <Alert color="danger">
+          <Translate contentKey="error.http.404">
+            The page does not exist.
+          </Translate>
+        </Alert>
+      </div>
+    );
+  }
+}
+
+export default PageNotFound;

--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -19,7 +19,7 @@
 <!doctype html>
 <html class="no-js" lang="<%= nativeLanguage %>" dir="ltr">
 <head>
-    <base href="./" />
+    <base href="/" />
     <meta charset="utf-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>

--- a/generators/client/templates/react/src/main/webapp/manifest.webapp.ejs
+++ b/generators/client/templates/react/src/main/webapp/manifest.webapp.ejs
@@ -25,7 +25,7 @@
   ],
   "theme_color": "#000000",
   "background_color": "#e0e0e0",
-  "start_url": "/index.html",
+  "start_url": ".",
   "display": "standalone",
   "orientation": "portrait"
 }

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -335,7 +335,7 @@ describe('Account', () => {
   });
 
   it('should delete previously created fake user', async () => {
-    await browser.get('#/admin/user-management/user_test/delete');
+    await browser.get('/admin/user-management/user_test/delete');
     const deleteModal = element(by.className('modal'));
     await waitUntilDisplayed(deleteModal);
 

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/navbar-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/navbar-page.ts.ejs
@@ -38,7 +38,7 @@ export default class NavBarPage extends BasePage {
 
   async getRegisterPage() {
     await this.clickOnAccountMenu();
-    await this.clickOnTabMenu('#/register');
+    await this.clickOnTabMenu('/register');
     return new RegisterPage();
   }
   <%_ } _%>
@@ -46,7 +46,7 @@ export default class NavBarPage extends BasePage {
   async getSignInPage() {
     await this.clickOnAccountMenu();
     <%_ if (authenticationType !== 'oauth2') { _%>
-    await this.clickOnTabMenu('#/login');
+    await this.clickOnTabMenu('/login');
     <%_ } else { _%>
     await this.loginItem.click();
     <%_ } _%>
@@ -71,12 +71,12 @@ export default class NavBarPage extends BasePage {
 
   async clickOnAccountMenuItem(item: string) {
     await this.accountMenu.click();
-    await this.selector.$(`.dropdown-item[href="#/account/${item}"`).click();
+    await this.selector.$(`.dropdown-item[href="/account/${item}"`).click();
   }
 
   async clickOnAdminMenuItem(item: string) {
     await this.adminMenu.click();
-    await this.selector.$(`.dropdown-item[href="#/admin/${item}"]`).click();
+    await this.selector.$(`.dropdown-item[href="/admin/${item}"]`).click();
   }
 
   async clickOnEntityMenu() {
@@ -84,7 +84,7 @@ export default class NavBarPage extends BasePage {
   }
 
   async clickOnEntity(entityName: string) {
-    await this.selector.$(`.dropdown-item[href="#/entity/${entityName}"]`).click();
+    await this.selector.$(`.dropdown-item[href="/entity/${entityName}"]`).click();
   }
 
   async autoSignIn() {
@@ -97,6 +97,7 @@ export default class NavBarPage extends BasePage {
   }
 
   async autoSignOut() {
-    await this.signInPage.autoSignOut();
+    await this.accountMenu.click();
+    await this.selector.$(`.dropdown-item[href="/logout"`).click();
   }
 }

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/password-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/password-page.ts.ejs
@@ -17,7 +17,7 @@ export default class PasswordPage extends BasePage {
   }
 
   async get() {
-    await browser.get('#/account/password');
+    await browser.get('/account/password');
     await this.waitUntilDisplayed();
   }
 

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/register-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/register-page.ts.ejs
@@ -18,7 +18,7 @@ export default class RegisterPage extends BasePage {
   }
 
   async get() {
-    await browser.get('#/register');
+    await browser.get('/register');
     await this.waitUntilDisplayed();
   }
 

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/settings-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/settings-page.ts.ejs
@@ -18,7 +18,7 @@ export default class SettingsPage extends BasePage {
   }
 
   async get() {
-    await browser.get('#/account/settings');
+    await browser.get('/account/settings');
     await this.waitUntilDisplayed();
   }
 

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -22,7 +22,7 @@ export default class SignInPage extends BasePage {
   }
 
   async get() {
-    await browser.get('#/login');
+    await browser.get('/login');
     await this.waitUntilDisplayed();
   }
 
@@ -63,7 +63,7 @@ export default class SignInPage extends BasePage {
   <%_ } _%>
 
   async autoSignOut() {
-    await browser.get('#/logout');
+    await browser.get('/logout');
   }
 
   async login() {

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -69,16 +69,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     hot: true,
     contentBase: './<%= DIST_DIR %>',
     proxy: [{
-      context: [<% if (authenticationType === 'uaa') { %>
-        '/<%= uaaBaseName.toLowerCase() %>',<% } %>
+      context: [
         /* jhipster-needle-add-entity-to-webpack - JHipster will add entity api paths here */
-        '/api',
-        '/management',
-        '/swagger-resources',
-        '/v2/api-docs',
-        '/h2-console',<% if (authenticationType === 'oauth2') { %>
-        '/login',<% } %>        
-        '/auth'
+        '/'
       ],
       target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,
       secure: false,

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -70,7 +70,6 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     contentBase: './<%= DIST_DIR %>',
     proxy: [{
       context: [
-        /* jhipster-needle-add-entity-to-webpack - JHipster will add entity api paths here */
         '/'
       ],
       target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -18,6 +18,7 @@
 -%>
 const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
+const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
@@ -124,6 +125,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
     new WorkboxPlugin.GenerateSW({
       clientsClaim: true,
       skipWaiting: true,
-    })
+    }),
+    new BaseHrefWebpackPlugin({ baseHref: '/' })
   ]
 });

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -266,9 +266,6 @@ function writeFiles() {
                     this.clientFramework
                 );
             }
-            if (this.applicationType === 'gateway' && !_.isUndefined(this.microserviceName)) {
-                this.addEntityToWebpack(this.microserviceName, this.clientFramework);
-            }
             this.addEntityToMenu(this.entityStateName, this.enableTranslation, this.clientFramework, this.entityTranslationKeyMenu);
         }
     };

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const _ = require('lodash');
 const constants = require('../generator-constants');
 
 /* Constants use throughout */

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -116,15 +116,6 @@ module.exports = class extends PrivateBase {
     }
 
     /**
-     * Add a new entity route path to webpacks config
-     *
-     * @param {string} microserviceName - The name of the microservice to put into the url
-     */
-    addEntityToWebpack(microserviceName) {
-        this.needleApi.clientWebpack.addEntity(microserviceName);
-    }
-
-    /**
      * Add a new entity in the "entities" menu.
      *
      * @param {string} routerName - The name of the Angular router (which by default is the name of the entity).

--- a/generators/internal/needle-api/needle-client-webpack.js
+++ b/generators/internal/needle-api/needle-client-webpack.js
@@ -25,18 +25,6 @@ const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 const CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
 
 module.exports = class extends needleClient {
-    addEntity(microserviceName) {
-        const errorMessage = `${chalk.yellow(' Reference to ') + microserviceName} ${chalk.yellow('not added to menu.')}`;
-        const webpackDevPath = `${CLIENT_WEBPACK_DIR}/webpack.dev.js`;
-        const rewriteFileModel = this.generateFileModel(
-            webpackDevPath,
-            'jhipster-needle-add-entity-to-webpack',
-            `'/${microserviceName.toLowerCase()}',`
-        );
-
-        this.addBlockContentToFile(rewriteFileModel, errorMessage);
-    }
-
     copyExternalAssets(sourceFolder, targetFolder) {
         const errorMessage = 'Resource path not added to JHipster app.';
         const from = `${CLIENT_MAIN_SRC_DIR}content/${sourceFolder}/`;

--- a/generators/internal/needle-api/needle-client-webpack.js
+++ b/generators/internal/needle-api/needle-client-webpack.js
@@ -16,8 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const chalk = require('chalk');
-
 const needleClient = require('./needle-client');
 const constants = require('../../generator-constants');
 

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1235,6 +1235,16 @@ const serverFiles = {
             ]
         },
         {
+            condition: generator => !generator.skipClient,
+            path: SERVER_TEST_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/web/rest/ClientForwardControllerIntTest.java',
+                    renameTo: generator => `${generator.testDir}web/rest/ClientForwardControllerIntTest.java`
+                }
+            ]
+        },
+        {
             condition: generator => generator.databaseType === 'sql',
             path: SERVER_TEST_SRC_DIR,
             templates: [

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1239,8 +1239,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/ClientForwardControllerIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/ClientForwardControllerIntTest.java`
+                    file: 'package/web/rest/ClientForwardControllerIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/ClientForwardControllerIT.java`
                 }
             ]
         },

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1148,7 +1148,13 @@ const serverFiles = {
                 },
                 { file: 'package/web/rest/package-info.java', renameTo: generator => `${generator.javaDir}web/rest/package-info.java` },
 
-                { file: 'package/web/rest/LogsResource.java', renameTo: generator => `${generator.javaDir}web/rest/LogsResource.java` },
+                { file: 'package/web/rest/LogsResource.java', renameTo: generator => `${generator.javaDir}web/rest/LogsResource.java` }
+            ]
+        },
+        {
+            condition: generator => !generator.skipClient,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
                 {
                     file: 'package/web/rest/ClientForwardController.java',
                     renameTo: generator => `${generator.javaDir}web/rest/ClientForwardController.java`

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1148,7 +1148,11 @@ const serverFiles = {
                 },
                 { file: 'package/web/rest/package-info.java', renameTo: generator => `${generator.javaDir}web/rest/package-info.java` },
 
-                { file: 'package/web/rest/LogsResource.java', renameTo: generator => `${generator.javaDir}web/rest/LogsResource.java` }
+                { file: 'package/web/rest/LogsResource.java', renameTo: generator => `${generator.javaDir}web/rest/LogsResource.java` },
+                {
+                    file: 'package/web/rest/ClientForwardController.java',
+                    renameTo: generator => `${generator.javaDir}web/rest/ClientForwardController.java`
+                }
             ]
         }
     ],

--- a/generators/server/templates/src/main/java/package/web/rest/ClientForwardController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/ClientForwardController.java.ejs
@@ -1,0 +1,30 @@
+<%#
+Copyright 2013-2019 the original author or authors from the JHipster project.
+
+This file is part of the JHipster project, see https://www.jhipster.tech/
+for more information.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+     http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-%>
+package <%=packageName%>.web.rest;
+
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+
+@Controller
+public class ClientForwardController {
+    @GetMapping(value = "/**/{path:[^\\.]*}")
+    public String redirect() {
+        return "forward:/";
+    }
+}

--- a/generators/server/templates/src/main/java/package/web/rest/ClientForwardController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/ClientForwardController.java.ejs
@@ -23,8 +23,11 @@ import org.springframework.web.bind.annotation.GetMapping;
 
 @Controller
 public class ClientForwardController {
+    /**
+     * Forwards any unmapped paths (except those containing a period) to the client index.html
+     */
     @GetMapping(value = "/**/{path:[^\\.]*}")
-    public String redirect() {
+    public String forward() {
         return "forward:/";
     }
 }

--- a/generators/server/templates/src/main/resources/templates/mail/activationEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/activationEmail.html.ejs
@@ -13,7 +13,7 @@
             Your JHipster account has been created, please click on the URL below to activate it:
         </p>
         <p>
-            <a th:with="url=(@{|${baseUrl}/#/activate?key=${user.activationKey}|})" th:href="${url}"
+            <a th:with="url=(@{|${baseUrl}/activate?key=${user.activationKey}|})" th:href="${url}"
             th:text="${url}">Activation link</a>
         </p>
         <p>

--- a/generators/server/templates/src/main/resources/templates/mail/creationEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/creationEmail.html.ejs
@@ -13,7 +13,7 @@
             Your JHipster account has been created, please click on the URL below to access it:
         </p>
         <p>
-            <a th:with="url=(@{|${baseUrl}/#/reset/finish?key=${user.resetKey}|})" th:href="${url}"
+            <a th:with="url=(@{|${baseUrl}/reset/finish?key=${user.resetKey}|})" th:href="${url}"
             th:text="${url}">Login link</a>
         </p>
         <p>

--- a/generators/server/templates/src/main/resources/templates/mail/passwordResetEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/passwordResetEmail.html.ejs
@@ -13,7 +13,7 @@
             For your JHipster account a password reset was requested, please click on the URL below to reset it:
         </p>
         <p>
-            <a th:with="url=(@{|${baseUrl}/#/reset/finish?key=${user.resetKey}|})" th:href="${url}"
+            <a th:with="url=(@{|${baseUrl}/reset/finish?key=${user.resetKey}|})" th:href="${url}"
             th:text="${url}">Login link</a>
         </p>
         <p>

--- a/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerIT.java.ejs
@@ -44,7 +44,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class ClientForwardControllerIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class ClientForwardControllerIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     private MockMvc restMockMvc;
 

--- a/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerIntTest.java.ejs
@@ -1,0 +1,81 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.rest;
+
+<%_ if (databaseType === 'cassandra') { _%>
+import <%= packageName %>.AbstractCassandraTest;
+<%_ } _%>
+import <%=packageName%>.<%= mainClass %>;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultActions;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.forwardedUrl;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Test class for the ClientForwardController REST controller.
+ *
+ * @see ClientForwardController
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = <%= mainClass %>.class)
+public class ClientForwardControllerIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+
+    private MockMvc restMockMvc;
+
+    @Before
+    public void setup() {
+        ClientForwardController clientForwardController = new ClientForwardController();
+        LogsResource logsResource = new LogsResource();
+        this.restMockMvc = MockMvcBuilders
+            .standaloneSetup(clientForwardController, logsResource)
+            .build();
+    }
+
+    @Test
+    public void getBackendEndpoint() throws Exception {
+        restMockMvc.perform(get("/management/logs"))
+            .andExpect(status().isOk())
+            .andExpect(content().contentType(MediaType.APPLICATION_JSON_UTF8_VALUE));
+    }
+
+    @Test
+    public void getClientEndpoint() throws Exception {
+        ResultActions perform = restMockMvc.perform(get("/non-existant-mapping"));
+        perform
+            .andExpect(status().isOk())
+            .andExpect(forwardedUrl("/"));
+    }
+
+    @Test
+    public void getNestedClientEndpoint() throws Exception {
+        restMockMvc.perform(get("/admin/user-management"))
+            .andExpect(status().isOk())
+            .andExpect(forwardedUrl("/"));
+    }
+}


### PR DESCRIPTION
Fix #8462

Removes the `#` from the URL. Also handles non-existing client pages for React, similar to how Angular handles it in https://github.com/jhipster/generator-jhipster/pull/8909

Tested manually:
-  [x] OAuth2
-  [x] JWT
-  [x] UAA
-  [x] React default
-  [x] Angular default
-  [x] Angular Microservices
-  [x] Email links
-  [x] Heroku https://html-5-mode.herokuapp.com/
-  [x] Traefik

Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
