### PR TITLE
fix exported entity module class name

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -62,7 +62,7 @@ const ENTITY_STATES = [
     <%_ } _%>
     schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
-export class <%= angularXAppName %><%= entityAngularName %>Module {
+export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {
     <%_ if (enableTranslation) { _%>
     constructor(private languageService: JhiLanguageService, private languageHelper: JhiLanguageHelper) {
         this.languageHelper.language.subscribe((languageKey: string) => {

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -529,6 +529,10 @@ describe('JHipster generator for entity', () => {
                 assert.file(expectedFiles.clientNg2GatewayMicroserviceEntity);
                 assert.noFile(expectedFiles.gatling);
                 assert.fileContent(`${CLIENT_MAIN_SRC_DIR}app/entities/sampleMicroservice/bar/bar.service.ts`, 'samplemicroservice');
+                assert.fileContent(
+                    `${CLIENT_MAIN_SRC_DIR}app/entities/sampleMicroservice/bar/bar.module.ts`,
+                    'SampleMicroserviceBarModule'
+                );
                 assert.noFile(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/BarResource.java`);
             });
         });


### PR DESCRIPTION
This exported name must match the name set [in the lazy-loaded entity module needle](https://github.com/jhipster/generator-jhipster/blob/55f76b4a656cac7592534080f2aed6add73b000e/generators/generator-base.js#L297-L299).  This only affects Angular Microservice entities since it uses a different module name in that case.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
