### PR TITLE
Speed up gradle build

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -90,6 +90,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.TEST_DIR = constants.TEST_DIR;
                 this.CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
                 this.CLIENT_TEST_SRC_DIR = constants.CLIENT_TEST_SRC_DIR;
+                this.CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
                 this.SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
                 this.SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
                 this.SERVER_TEST_SRC_DIR = constants.SERVER_TEST_SRC_DIR;

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -88,11 +88,15 @@ version = '0.0.1-SNAPSHOT'
 description = ''
 
 bootWar {
-   mainClassName = '<%= packageName %>.<%= mainClass %>'
+    mainClassName = '<%= packageName %>.<%= mainClass %>'
+}
+
+war {
     <%_ if (!skipClient) { _%>
     webAppDirName = '<%= CLIENT_DIST_DIR %>'
     <%_ } _%>
     enabled = true
+    extension = 'war.original'
 }
 
 springBoot {

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -89,19 +89,14 @@ description = ''
 
 bootWar {
    mainClassName = '<%= packageName %>.<%= mainClass %>'
-}
-
-war {
     <%_ if (!skipClient) { _%>
     webAppDirName = '<%= CLIENT_DIST_DIR %>'
     <%_ } _%>
     enabled = true
-    classifier = 'original'
 }
 
 springBoot {
     mainClassName = '<%= packageName %>.<%= mainClass %>'
-    buildInfo()
 }
 
 if (OperatingSystem.current().isWindows()) {
@@ -515,21 +510,3 @@ if (project.hasProperty('nodeInstall')) {
     }
 }
 <%_ } _%>
-
-task renameWarFile (type: Copy) {
-    from ("$buildDir/libs/")
-    include "$project.name-$version-original.war"
-    destinationDir file("$buildDir/libs/")
-    rename "$project.name-$version-original.war", "$project.name-{$version}.war.original"
-}
-
-task deleteWarFile(type: Delete) {
-  delete "$buildDir/libs/$project.name-$version-original.war"
-}
-
-renameWarFile.dependsOn war
-bootWar.dependsOn war,renameWarFile,deleteWarFile
-compileJava.dependsOn processResources
-processResources.dependsOn cleanResources,bootBuildInfo
-bootBuildInfo.mustRunAfter cleanResources
-deleteWarFile.mustRunAfter renameWarFile

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -38,16 +38,30 @@ if (project.hasProperty('tls')) {
     profiles += ',tls'
 }
 
+springBoot {
+    buildInfo {
+		properties {
+			time = null
+		}
+	}
+}
+
 bootRun {
     args = []
 }
 
 <%_ if (!skipClient) { _%>
-task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: '<%= clientPackageManager %>_install') {
-    inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
+task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
     inputs.files(fileTree('<%= CLIENT_MAIN_SRC_DIR %>'))
-    outputs.dir("<%= CLIENT_DIST_DIR %>")
-    outputs.file("<%= CLIENT_DIST_DIR %>app/main.bundle.js")
+
+    def webpackDevFiles = fileTree('<%= CLIENT_WEBPACK_DIR %>/')
+    webpackDevFiles.exclude('webpack.prod.js')
+    inputs.files(webpackDevFiles)
+
+    outputs.files(fileTree("<%= CLIENT_DIST_DIR %>"))
+
+    dependsOn <%= clientPackageManager %>Install
+
     args = ["run", "webpack:build"]
 }
 

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -37,6 +37,10 @@ if (project.hasProperty('swagger')) {
     profiles += ',swagger'
 }
 
+springBoot {
+    buildInfo()
+}
+
 bootRun {
     args = []
 }


### PR DESCRIPTION
- Define separate logic for the creation of SpringBoot `buildInfo` for the dev and pro profiles. For prod it remains the same but for dev we do not generate a build timestamp as it is not really needed and it triggers constant re-compilation, etc. Also removed clean of resources as it is not needed and always triggers a full re-build regardless if anything has changed or not
- Fix duplicate war creation. The `bootWar` task is actually extending the `war` task hence defining it again and with a separate name was causing the duplication. Removed tasks for renaming and deleting the war file as they are no longer necessary
- Fix the `webpackBuildDev` task to execute `npm install` only when needed. Moved the dependency within the task and now also checking for changes of the webpack config files excluding the prod

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
