### PR TITLE
Use Spring security default auth form param names

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
@@ -32,8 +32,8 @@ export class AuthServerProvider {
 <%_ if (authenticationType !== 'oauth2') { _%>
 
     login(credentials): Observable<any> {
-        const data = 'j_username=' + encodeURIComponent(credentials.username) +
-            '&j_password=' + encodeURIComponent(credentials.password) +
+        const data = 'username=' + encodeURIComponent(credentials.username) +
+            '&password=' + encodeURIComponent(credentials.password) +
             '&remember-me=' + credentials.rememberMe + '&submit=Login';
         const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
@@ -32,9 +32,11 @@ export class AuthServerProvider {
 <%_ if (authenticationType !== 'oauth2') { _%>
 
     login(credentials): Observable<any> {
-        const data = 'username=' + encodeURIComponent(credentials.username) +
-            '&password=' + encodeURIComponent(credentials.password) +
-            '&remember-me=' + credentials.rememberMe + '&submit=Login';
+        const data =
+            `username=${encodeURIComponent(credentials.username)}` +
+            `&password=${encodeURIComponent(credentials.password)}` +
+            `&remember-me=${credentials.rememberMe}` +
+            `&submit=Login`;
         const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
 
         return this.http.post(SERVER_API_URL + 'api/authentication', data, { headers });

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -169,7 +169,7 @@ export const getSession = () => async (dispatch, getState) => {
 
 <%_ if (authenticationType === 'session') { _%>
 export const login = (username, password, rememberMe = false) => async (dispatch, getState) => {
-  const data = `j_username=${encodeURIComponent(username)}&j_password=${encodeURIComponent(password)}&remember-me=${rememberMe}&submit=Login`;
+  const data = `username=${encodeURIComponent(username)}&password=${encodeURIComponent(password)}&remember-me=${rememberMe}&submit=Login`;
   await dispatch({
     type: ACTION_TYPES.LOGIN,
     payload: axios.post('api/authentication', data, { headers: { 'Content-Type': 'application/x-www-form-urlencoded' } })

--- a/generators/entity-server/templates/src/test/gatling/user-files/simulations/EntityGatlingTest.scala.ejs
+++ b/generators/entity-server/templates/src/test/gatling/user-files/simulations/EntityGatlingTest.scala.ejs
@@ -117,8 +117,8 @@ class <%= entityClass %>GatlingTest extends Simulation {
 <%_ if (authenticationType === 'session') { _%>
         .post("/api/authentication")
         .headers(headers_http_authenticated)
-        .formParam("j_username", "admin")
-        .formParam("j_password", "admin")
+        .formParam("username", "admin")
+        .formParam("password", "admin")
         .formParam("remember-me", "true")
         .formParam("submit", "Login")
         .check(headerRegex("Set-Cookie", "XSRF-TOKEN=(.*);[\\s]").saveAs("xsrf_token"))).exitHereIfFailed

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -240,8 +240,6 @@ public class SecurityConfiguration extends <% if (authenticationType === 'oauth2
             .loginProcessingUrl("/api/authentication")
             .successHandler(ajaxAuthenticationSuccessHandler())
             .failureHandler(ajaxAuthenticationFailureHandler())
-            .usernameParameter("j_username")
-            .passwordParameter("j_password")
             .permitAll()<% } %><% if (authenticationType === 'session') { %>
         .and()
             .logout()


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Because:
* [Policy 1](https://www.jhipster.tech/policies/)
* The reactive version currently doesn't support custom param names