### PR TITLE
handle 404 errors for angular entities

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, OnInit } from '@angular/core';
-import { Router, ActivatedRouteSnapshot, NavigationEnd } from '@angular/router';
+import { Router, ActivatedRouteSnapshot, NavigationEnd, NavigationError } from '@angular/router';
 
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageHelper } from 'app/core';
@@ -56,6 +56,9 @@ export class <%=jhiPrefixCapitalized%>MainComponent implements OnInit {
                 <%_ } else { _%>
                 this.titleService.setTitle(this.getPageTitle(this.router.routerState.snapshot.root));
                 <%_ } _%>
+            }
+            if (event instanceof NavigationError && event.error.status === 404) {
+                this.router.navigate(['/404']);
             }
         });
     }


### PR DESCRIPTION
Fix #8801

There's still a blank page when you go to non-existant entities, such as http://localhost:8080/foo/3/view when you only have one Foo entity.  I didn't want to force any HTTP 404 to send to `/404` since a developer may be integrating an external API, so I handled the NavigationError that is thrown.

![screen shot 2019-01-25 at 10 00 21 am](https://user-images.githubusercontent.com/4294623/51763764-26329100-2088-11e9-8035-f8d2324df580.png)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
