### PR TITLE
Fix display of endpoints requests in new metrics implementation in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -38,7 +38,7 @@
 
     <jhi-metrics-request [updating]="updatingMetrics" [requestMetrics]="metrics['http.server.requests']"></jhi-metrics-request>
 
-    <jhi-metrics-endpoints-requests [updating]="updatingMetrics" [endpointsRequestsMetrics]="metrics.endpointsRequests"></jhi-metrics-endpoints-requests>
+    <jhi-metrics-endpoints-requests [updating]="updatingMetrics" [endpointsRequestsMetrics]="metrics.services"></jhi-metrics-endpoints-requests>
 
     <jhi-metrics-cache [updating]="updatingMetrics" [cacheMetrics]="metrics.cache"></jhi-metrics-cache>
 


### PR DESCRIPTION
The endpoint returns json with metrics.services instead of metrics.endpoints.
With this little change, the endpoint requests are displayed properly

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
