### PR TITLE
fix: mongo return empty databases object

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
@@ -118,7 +118,7 @@ export class MetricsPage extends React.Component<IMetricsPageProps, IMetricsPage
           ''
         )}
 
-        {metrics.databases ? (
+        {(metrics.databases && JSON.stringify(metrics.databases) !== '{}') ? (
           <Row>
             <Col sm="12">
               <DatasourceMetrics datasourceMetrics={metrics.databases}


### PR DESCRIPTION
```json
{
    "jvm": {
        "PS Eden Space": {
            "committed": 664272896,
            "max": 664272896,
            "used": 50715328
        },
        "Code Cache": {
            "committed": 13238272,
            "max": 251658240,
            "used": 13201664
        },
        "Compressed Class Space": {
            "committed": 10665984,
            "max": 1073741824,
            "used": 9928464
        },
        "PS Survivor Space": {
            "committed": 22544384,
            "max": 22544384,
            "used": 22225336
        },
        "PS Old Gen": {
            "committed": 105381888,
            "max": 1431830528,
            "used": 37493560
        },
        "Metaspace": {
            "committed": 73818112,
            "max": -1,
            "used": 69989576
        }
    },
    "databases": {},
    "http.server.requests": {
        "all": {
            "count": 7
        },
        "percode": {
            "200": {
                "max": 0,
                "mean": 262.8261046,
                "count": 5
            },
            "401": {
                "max": 0,
                "mean": 60.9113105,
                "count": 2
            }
        }
    },
    "cache": {},
    "garbageCollector": {
        "jvm.gc.max.data.size": 1431830528,
        "jvm.gc.pause": {
            "0.0": 0,
            "1.0": 0,
            "max": 0,
            "totalTime": 238,
            "mean": 238,
            "0.5": 0,
            "count": 1,
            "0.99": 0,
            "0.75": 0,
            "0.95": 0
        },
        "jvm.gc.memory.promoted": 23422992,
        "jvm.gc.memory.allocated": 1611822376,
        "classesLoaded": 15902,
        "jvm.gc.live.data.size": 37477176,
        "classesUnloaded": 10
    },
    "services": {
        "/api/users": {
            "GET": {
                "max": 0,
                "mean": 98.703928,
                "count": 1
            }
        },
        "/management/threaddump": {
            "GET": {
                "max": 0,
                "mean": 218.472587,
                "count": 1
            }
        },
        "/api/authenticate": {
            "POST": {
                "max": 0,
                "mean": 752.185877,
                "count": 1
            }
        },
        "root": {
            "GET": {
                "max": 0,
                "mean": 60.9113105,
                "count": 2
            }
        },
        "/management/jhi-metrics": {
            "GET": {
                "max": 0,
                "mean": 203.976306,
                "count": 1
            }
        },
        "/api/account": {
            "GET": {
                "max": 0,
                "mean": 40.791825,
                "count": 1
            }
        }
    },
    "processMetrics": {
        "system.load.average.1m": 3.48388671875,
        "system.cpu.usage": 0.1983824928639391,
        "system.cpu.count": 8,
        "process.start.time": 1548661581518,
        "process.files.open": 237,
        "process.cpu.usage": 0.0022837495444923846,
        "process.uptime": 58687,
        "process.files.max": 10240
    }
}
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
