### PR TITLE
Remove AngularJs method in generator API

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -448,33 +448,6 @@ module.exports = class extends PrivateBase {
     }
 
     /**
-     * Add a new http interceptor to the angular application in "blocks/config/http.config.js".
-     * The interceptor should be in its own .js file inside app/blocks/interceptor folder
-     * @param {string} interceptorName - angular name of the interceptor
-     *
-     */
-    addAngularJsInterceptor(interceptorName) {
-        const fullPath = `${CLIENT_MAIN_SRC_DIR}app/blocks/config/http.config.js`;
-        try {
-            jhipsterUtils.rewriteFile(
-                {
-                    file: fullPath,
-                    needle: 'jhipster-needle-angularjs-add-interceptor',
-                    splicable: [`$httpProvider.interceptors.push('${interceptorName}');`]
-                },
-                this
-            );
-        } catch (e) {
-            this.log(
-                chalk.yellow('\nUnable to find ') +
-                    fullPath +
-                    chalk.yellow(' or missing required jhipster-needle. Interceptor not added to JHipster app.\n')
-            );
-            this.debug('Error:', e);
-        }
-    }
-
-    /**
      * Add a new entity to Ehcache, for the 2nd level cache of an entity and its relationships.
      *
      * @param {string} entityClass - the entity to cache


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

When I did the needle API refactoring I found this AngularJS method. Because we don't support AngularJS  anymore we should remove it from the generator API.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [X] Tests are added where necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
