### PR TITLE
Fix bug on needle value for (s)css

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -236,4 +236,4 @@ ui bootstrap tweaks
     white-space: nowrap;
 }
 
-/* jhipster-needle-scss-add-global JHipster will add new css style */
+/* jhipster-needle-scss-add-main JHipster will add new css style */

--- a/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/app.scss.ejs
@@ -336,4 +336,4 @@ http://stackoverflow.com/questions/23436430/bootstrap-3-input-group-100-width */
   margin-top: -0.5rem;
 }
 
-/* jhipster-needle-css-add-main JHipster will add new css style */
+/* jhipster-needle-scss-add-main JHipster will add new css style */

--- a/generators/internal/needle-api/needle-client-angular.js
+++ b/generators/internal/needle-api/needle-client-angular.js
@@ -27,12 +27,12 @@ const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 module.exports = class extends needleClientBase {
     addGlobalCSSStyle(style, comment) {
         const filePath = `${CLIENT_MAIN_SRC_DIR}content/css/global.css`;
-        this.addStyle(style, comment, filePath, 'jhipster-needle-css-add-global');
+        this.addStyle(style, comment, filePath, 'jhipster-needle-css-add-main');
     }
 
     addGlobalSCSSStyle(style, comment) {
         const filePath = `${CLIENT_MAIN_SRC_DIR}content/scss/global.scss`;
-        this.addStyle(style, comment, filePath, 'jhipster-needle-scss-add-global');
+        this.addStyle(style, comment, filePath, 'jhipster-needle-scss-add-main');
     }
 
     addVendorSCSSStyle(style, comment) {

--- a/generators/internal/needle-api/needle-client-react.js
+++ b/generators/internal/needle-api/needle-client-react.js
@@ -27,12 +27,12 @@ const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 module.exports = class extends needleClientBase {
     addAppCSSStyle(style, comment) {
         const filePath = `${CLIENT_MAIN_SRC_DIR}app/app.css`;
-        this.addStyle(style, comment, filePath, 'jhipster-needle-css-add-app');
+        this.addStyle(style, comment, filePath, 'jhipster-needle-css-add-main');
     }
 
     addAppSCSSStyle(style, comment) {
         const filePath = `${CLIENT_MAIN_SRC_DIR}app/app.scss`;
-        this.addStyle(style, comment, filePath, 'jhipster-needle-scss-add-app');
+        this.addStyle(style, comment, filePath, 'jhipster-needle-scss-add-main');
     }
 
     addEntityToMenu(routerName, enableTranslation, entityTranslationKeyMenu) {


### PR DESCRIPTION
Hi,
We recently merge a modification on needle API. A bug has come with it because needles in files and in the method do not match.

To fix I opened a PR #9151 but it breaks the ne public API by modifying the method signature.
This is planned for the v6. To be fix quickly the bug I've just cherry pick the commit which fix the needle value bug.

@deepu105 
I think we can merge this one to first fix the bug and then, for the v6, decide if we revert public API method or not. Is it ok for you ? 

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [X] Tests are added where necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
