### PR TITLE
Feature/enhancement translation for oauth

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-<%_ if (enableTranslation && authenticationType !== 'oauth2' && authenticationType !== 'uaa') { _%>
+<%_ if (enableTranslation && authenticationType !== 'uaa') { _%>
 import { JhiLanguageService } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
@@ -38,7 +38,7 @@ export class AccountService  {
 
 
     constructor(
-        <%_ if (enableTranslation && authenticationType !== 'oauth2' && authenticationType !== 'uaa') { _%>
+        <%_ if (enableTranslation && authenticationType !== 'uaa') { _%>
         private languageService: JhiLanguageService,
         private sessionStorage: SessionStorageService,
         <%_ } _%>
@@ -105,7 +105,7 @@ export class AccountService  {
                 <%_ if (websocket === 'spring-websocket') { _%>
                 this.trackerService.connect();
                 <%_ } _%>
-                <%_ if (enableTranslation && authenticationType !== 'oauth2' && authenticationType !== 'uaa') { _%>
+                <%_ if (enableTranslation && authenticationType !== 'uaa') { _%>
                 // After retrieve the account info, the language will be changed to
                 // the user's preferred language configured in the account setting
                 const langKey = this.sessionStorage.retrieve('locale') || this.userIdentity.langKey;

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -3,12 +3,12 @@ import { TestBed } from '@angular/core/testing';
 import { SERVER_API_URL } from 'app/app.constants';
 import { AccountService<% if (websocket === 'spring-websocket') { %>, <%= jhiPrefixCapitalized %>TrackerService <% } %> } from 'app/core';
 import { JhiDateUtils
-<%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
+<%_ if (enableTranslation) { _%>
     ,JhiLanguageService
 <%_ } _%>
 } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
-<%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
+<%_ if (enableTranslation) { _%>
 import { MockLanguageService } from '../../../helpers/mock-language.service';
 <%_ } _%>
 <%_ if (websocket === 'spring-websocket') { _%>
@@ -26,7 +26,7 @@ describe('Service Tests', () => {
                 providers: [
                     JhiDateUtils,
                     SessionStorageService,
-                    <%_ if (enableTranslation && authenticationType !== 'oauth2') { _%>
+                    <%_ if (enableTranslation) { _%>
                     {
                         provide: JhiLanguageService,
                         useClass: MockLanguageService

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -823,14 +823,14 @@ public class UserService {
         if (details.get("langKey") != null) {
             user.setLangKey((String) details.get("langKey"));
         } else if (details.get("locale") != null) {
+            // for the locale issue, we suggest you should adjust the format based on the oauth server. here we can't cater for all the cases
+            // https://github.com/jhipster/generator-jhipster/issues/7866 
+            // for the en_US or en_** issue. since jhipter only have one "en" language, we will handle it here, for other language, please handle it accordingly. 
             String locale = (String) details.get("locale");
-            if (locale.contains("-")) {
-              String langKey = locale.substring(0, locale.indexOf('-'));
-              user.setLangKey(langKey);
-            } else if (locale.contains("_")) {
-              String langKey = locale.substring(0, locale.indexOf('_'));
-              user.setLangKey(langKey);
+            if(locale.startsWith("en_") || locale.startsWith("en-")) {
+                locale = "en";
             }
+            user.setLangKey(locale.toLowerCase());
         }
         if (details.get("picture") != null) {
             user.setImageUrl((String) details.get("picture"));

--- a/generators/server/templates/src/test/java/package/service/UserServiceIntTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIntTest.java.ejs
@@ -421,7 +421,7 @@ public class UserServiceIntTest <% if (databaseType === 'cassandra') { %>extends
 
         userDTO = userService.getUserFromAuthentication(authentication);
 
-        assertThat(userDTO.getLangKey()).isEqualTo("it");
+        assertThat(userDTO.getLangKey()).isEqualTo("it-it");
     }
 
     private OAuth2Authentication createMockOAuth2AuthenticationWithDetails(Map<String, Object> userDetails) {


### PR DESCRIPTION
in the PR #8525 , we fix the language issue for the normal JWT cases. 
Actually for the oauth case, we should apply the same flow, the logic will be:
- when get the account info (when refresh the page or login), update the lang to the user preferred lang
- if use set the lang via the nav bar. this setting will persist into the sessionStorage, it will apply for current page only. 

 Extra things,  the Okta and KeyCloak will return the language with the key `locale`. but the value is different with our jhipster lang key.  
> in the #7866 ,  and [#7923](https://github.com/jhipster/generator-jhipster/pull/7923)  we fix the `en-US` -> `en` mapping for the Okta,  but it donesn't work for Keycloak.
Even for KeyCloak, they are have a lang key `zh-CN`, but in jhipster side, we are using `zh-cn`. 

there is no way for jhipster to cater all the lang keys.  here is the new logic for us:

- if the lang key start with `en-` or `en_`, we will set it to `en`, since in Jhipster, we only one en lang.
- otherwise, we will use lowercase of the lang-key from the oauth side. since in Jhipster, we only use lowercase for lang-key. 
- for the other case, the developer should mapping it accordingly. 

 
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
