### PR TITLE
rename Integration tests to *IT.java

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -157,7 +157,7 @@ function cleanupOldServerFiles(generator, javaDir, testDir, mainResourceDir, tes
         generator.removeFile(`${mainResourceDir}mails/passwordResetEmail.html`);
         generator.removeFile(`${mainResourceDir}mails/socialRegistrationValidationEmail.html`);
         generator.removeFile(`${testResourceDir}mail/testEmail.html`);
-        generator.removeFile(`${testDir}web/rest/ProfileInfoResourceIntTest.java`);
+        generator.removeFile(`${testDir}web/rest/ProfileInfoResourceIT.java`);
         generator.removeFile('gradle/mapstruct.gradle');
     }
     if (generator.isJhipsterVersionLessThan('5.2.2')) {

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -174,7 +174,7 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/EntityResourceIntTest.java',
+                    file: 'package/web/rest/EntityResourceIT.java',
                     options: {
                         context: {
                             randexp,
@@ -184,7 +184,7 @@ const serverFiles = {
                             SERVER_TEST_SRC_DIR
                         }
                     },
-                    renameTo: generator => `${generator.packageFolder}/web/rest/${generator.entityClass}ResourceIntTest.java`
+                    renameTo: generator => `${generator.packageFolder}/web/rest/${generator.entityClass}ResourceIT.java`
                 }
             ]
         },

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -150,11 +150,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>
-public class <%= entityClass %>ResourceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 <%_
     let oldSource = '';
     try {
-        oldSource = this.fs.readFileSync(this.SERVER_TEST_SRC_DIR + packageFolder + '/web/rest/' + entityClass + 'ResourceIntTest.java', 'utf8');
+        oldSource = this.fs.readFileSync(this.SERVER_TEST_SRC_DIR + packageFolder + '/web/rest/' + entityClass + 'ResourceIT.java', 'utf8');
     } catch (e) {}
 _%>
     <%_ for (idx in fields) {
@@ -245,7 +245,7 @@ _%>
                 updatedTextString = updatedTextString + "B";
                 log(this.chalkRed('Randomly generated first and second test values for entity "' + entityClass +
                     '" field "' + fields[idx].fieldName + '" with pattern "' + fields[idx].fieldValidateRulesPattern +
-                    '" in file "' + entityClass + 'ResourceIntTest" where equal, added symbol "B" to second value.'));
+                    '" in file "' + entityClass + 'ResourceIT" where equal, added symbol "B" to second value.'));
             }
         }_%>
 
@@ -428,7 +428,7 @@ _%>
             if ((relationshipValidate !== null && relationshipValidate === true) || mapsIdUse === true) { _%>
         // Add required entity
             <%_ if (alreadyGeneratedEntities.indexOf(otherEntityName) == -1) { _%>
-        <%= asEntity(otherEntityNameCapitalized) %> <%= otherEntityName %> = <%= otherEntityNameCapitalized %>ResourceIntTest.createEntity(<% if (databaseType === 'sql') { %>em<% } %>);
+        <%= asEntity(otherEntityNameCapitalized) %> <%= otherEntityName %> = <%= otherEntityNameCapitalized %>ResourceIT.createEntity(<% if (databaseType === 'sql') { %>em<% } %>);
                 <%_ if (databaseType === 'sql') { _%>
         em.persist(<%= otherEntityName %>);
         em.flush();
@@ -734,7 +734,7 @@ _%>
     @Transactional<% } %>
     public void getAll<%= entityClassPlural %>By<%= relationship.relationshipNameCapitalized %>IsEqualToSomething() throws Exception {
         // Initialize the database
-        <%= asEntity(relationship.otherEntityNameCapitalized) %> <%= relationship.relationshipFieldName %> = <%= relationship.otherEntityNameCapitalized %>ResourceIntTest.createEntity(em);
+        <%= asEntity(relationship.otherEntityNameCapitalized) %> <%= relationship.relationshipFieldName %> = <%= relationship.otherEntityNameCapitalized %>ResourceIT.createEntity(em);
         em.persist(<%= relationship.relationshipFieldName %>);
         em.flush();
 <%_ if (relationship.relationshipType === 'many-to-many' || relationship.relationshipType === 'one-to-many') { _%>

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1162,13 +1162,13 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/CassandraKeyspaceUnitTest.java',
-                    renameTo: generator => `${generator.testDir}CassandraKeyspaceUnitTest.java`
+                    file: 'package/CassandraKeyspaceIT.java',
+                    renameTo: generator => `${generator.testDir}CassandraKeyspaceIT.java`
                 },
                 { file: 'package/AbstractCassandraTest.java', renameTo: generator => `${generator.testDir}AbstractCassandraTest.java` },
                 {
-                    file: 'package/config/CassandraTestConfiguration.java',
-                    renameTo: generator => `${generator.testDir}config/CassandraTestConfiguration.java`
+                    file: 'package/config/CassandraConfigurationIT.java',
+                    renameTo: generator => `${generator.testDir}config/CassandraConfigurationIT.java`
                 }
             ]
         },
@@ -1182,8 +1182,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/config/DatabaseTestConfiguration.java',
-                    renameTo: generator => `${generator.testDir}config/DatabaseTestConfiguration.java`
+                    file: 'package/config/DatabaseConfigurationIT.java',
+                    renameTo: generator => `${generator.testDir}config/DatabaseConfigurationIT.java`
                 }
             ]
         },
@@ -1192,12 +1192,12 @@ const serverFiles = {
             templates: [
                 { file: 'package/web/rest/TestUtil.java', renameTo: generator => `${generator.testDir}web/rest/TestUtil.java` },
                 {
-                    file: 'package/web/rest/LogsResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/LogsResourceIntTest.java`
+                    file: 'package/web/rest/LogsResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/LogsResourceIT.java`
                 },
                 {
-                    file: 'package/web/rest/errors/ExceptionTranslatorIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/errors/ExceptionTranslatorIntTest.java`
+                    file: 'package/web/rest/errors/ExceptionTranslatorIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/errors/ExceptionTranslatorIT.java`
                 },
                 {
                     file: 'package/web/rest/errors/ExceptionTranslatorTestController.java',
@@ -1214,8 +1214,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/config/timezone/HibernateTimeZoneTest.java',
-                    renameTo: generator => `${generator.testDir}config/timezone/HibernateTimeZoneTest.java`
+                    file: 'package/config/timezone/HibernateTimeZoneIT.java',
+                    renameTo: generator => `${generator.testDir}config/timezone/HibernateTimeZoneIT.java`
                 },
                 {
                     file: 'package/repository/timezone/DateTimeWrapper.java',
@@ -1305,8 +1305,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/LogoutResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/LogoutResourceIntTest.java`
+                    file: 'package/web/rest/LogoutResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/LogoutResourceIT.java`
                 }
             ]
         },
@@ -1332,7 +1332,7 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 // Create Cucumber test files
-                { file: 'package/cucumber/CucumberTest.java', renameTo: generator => `${generator.testDir}cucumber/CucumberTest.java` },
+                { file: 'package/cucumber/CucumberIT.java', renameTo: generator => `${generator.testDir}cucumber/CucumberIT.java` },
                 {
                     file: 'package/cucumber/stepdefs/StepDefs.java',
                     renameTo: generator => `${generator.testDir}cucumber/stepdefs/StepDefs.java`
@@ -1350,8 +1350,8 @@ const serverFiles = {
             templates: [
                 // Create auth config test files
                 {
-                    file: 'package/security/DomainUserDetailsServiceIntTest.java',
-                    renameTo: generator => `${generator.testDir}security/DomainUserDetailsServiceIntTest.java`
+                    file: 'package/security/DomainUserDetailsServiceIT.java',
+                    renameTo: generator => `${generator.testDir}security/DomainUserDetailsServiceIT.java`
                 }
             ]
         }
@@ -1435,16 +1435,16 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/service/UserServiceIntTest.java',
-                    renameTo: generator => `${generator.testDir}service/UserServiceIntTest.java`
+                    file: 'package/service/UserServiceIT.java',
+                    renameTo: generator => `${generator.testDir}service/UserServiceIT.java`
                 },
                 {
-                    file: 'package/service/mapper/UserMapperTest.java',
-                    renameTo: generator => `${generator.testDir}service/mapper/UserMapperTest.java`
+                    file: 'package/service/mapper/UserMapperIT.java',
+                    renameTo: generator => `${generator.testDir}service/mapper/UserMapperIT.java`
                 },
                 {
-                    file: 'package/web/rest/UserResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/UserResourceIntTest.java`
+                    file: 'package/web/rest/UserResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/UserResourceIT.java`
                 }
             ]
         },
@@ -1456,8 +1456,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/AccountResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/AccountResourceIntTest.java`
+                    file: 'package/web/rest/AccountResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/AccountResourceIT.java`
                 }
             ]
         },
@@ -1517,12 +1517,12 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/repository/CustomAuditEventRepositoryIntTest.java',
-                    renameTo: generator => `${generator.testDir}repository/CustomAuditEventRepositoryIntTest.java`
+                    file: 'package/repository/CustomAuditEventRepositoryIT.java',
+                    renameTo: generator => `${generator.testDir}repository/CustomAuditEventRepositoryIT.java`
                 },
                 {
-                    file: 'package/web/rest/AuditResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/AuditResourceIntTest.java`
+                    file: 'package/web/rest/AuditResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/AuditResourceIT.java`
                 }
             ]
         },
@@ -1652,8 +1652,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/UserJWTControllerIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/UserJWTControllerIntTest.java`
+                    file: 'package/web/rest/UserJWTControllerIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/UserJWTControllerIT.java`
                 }
             ]
         },
@@ -1664,8 +1664,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/AuditResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/AuditResourceIntTest.java`
+                    file: 'package/web/rest/AuditResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/AuditResourceIT.java`
                 }
             ]
         },
@@ -1674,8 +1674,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/repository/CustomAuditEventRepositoryIntTest.java',
-                    renameTo: generator => `${generator.testDir}repository/CustomAuditEventRepositoryIntTest.java`
+                    file: 'package/repository/CustomAuditEventRepositoryIT.java',
+                    renameTo: generator => `${generator.testDir}repository/CustomAuditEventRepositoryIT.java`
                 }
             ]
         },
@@ -1704,24 +1704,24 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/service/MailServiceIntTest.java',
-                    renameTo: generator => `${generator.testDir}service/MailServiceIntTest.java`
+                    file: 'package/service/MailServiceIT.java',
+                    renameTo: generator => `${generator.testDir}service/MailServiceIT.java`
                 },
                 {
-                    file: 'package/service/UserServiceIntTest.java',
-                    renameTo: generator => `${generator.testDir}service/UserServiceIntTest.java`
+                    file: 'package/service/UserServiceIT.java',
+                    renameTo: generator => `${generator.testDir}service/UserServiceIT.java`
                 },
                 {
-                    file: 'package/service/mapper/UserMapperTest.java',
-                    renameTo: generator => `${generator.testDir}service/mapper/UserMapperTest.java`
+                    file: 'package/service/mapper/UserMapperIT.java',
+                    renameTo: generator => `${generator.testDir}service/mapper/UserMapperIT.java`
                 },
                 {
-                    file: 'package/web/rest/AccountResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/AccountResourceIntTest.java`
+                    file: 'package/web/rest/AccountResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/AccountResourceIT.java`
                 },
                 {
-                    file: 'package/web/rest/UserResourceIntTest.java',
-                    renameTo: generator => `${generator.testDir}web/rest/UserResourceIntTest.java`
+                    file: 'package/web/rest/UserResourceIT.java',
+                    renameTo: generator => `${generator.testDir}web/rest/UserResourceIT.java`
                 }
             ]
         }

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -127,7 +127,7 @@ if (OperatingSystem.current().isWindows()) {
 }
 
 test {
-    exclude '**/CucumberTest*'
+    exclude '**/*CucumberIT*'
 
     // uncomment if the tests reports are not generated
     // see https://github.com/jhipster/generator-jhipster/pull/2771 and https://github.com/jhipster/generator-jhipster/pull/4484
@@ -139,7 +139,7 @@ test {
 task cucumberTest(type: Test) {
     description = "Execute cucumber BDD tests."
     group = "verification"
-    include '**/CucumberTest*'
+    include '**/*CucumberIT*'
 
     // uncomment if the tests reports are not generated
     // see https://github.com/jhipster/generator-jhipster/pull/2771 and https://github.com/jhipster/generator-jhipster/pull/4484

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -106,7 +106,6 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
-        <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
         <maven-idea-plugin.version>2.2.1</maven-idea-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
@@ -788,10 +787,6 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-failsafe-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
@@ -1087,6 +1082,30 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
+                    <%_ if (cucumberTests) { _%>
+                    <executions>
+                        <execution>
+                            <id>default-test</id>
+                            <configuration>
+                                <excludes>
+                                    <exclude>**/Abstract*.java</exclude>
+                                    <exclude>**/*Cucumber*.java</exclude>
+                                </excludes>
+                            </configuration>
+                        </execution>
+                        <execution>
+                            <id>without-cucumber</id>
+                            <goals>
+                                <goal>test</goal>
+                            </goals>
+                            <configuration>
+                                <includes>
+                                    <include>**/*Cucumber*.java</include>
+                                </includes>
+                            </configuration>
+                        </execution>
+                    </executions>
+                    <%_ } _%>
                     <configuration>
                         <!-- Force alphabetical order to have a reproducible build -->
                         <runOrder>alphabetical</runOrder>
@@ -1095,19 +1114,6 @@
                         <useSystemClassLoader>false</useSystemClassLoader>
                         <outputDirectory>${sonar.junit.reportsPath}</outputDirectory>
                     </configuration>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-failsafe-plugin</artifactId>
-                    <version>${maven-failsafe-plugin.version}</version>
-                    <executions>
-                        <execution>
-                            <goals>
-                                <goal>integration-test</goal>
-                                <goal>verify</goal>
-                            </goals>
-                        </execution>
-                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -106,6 +106,7 @@
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <maven-enforcer-plugin.version>3.0.0-M2</maven-enforcer-plugin.version>
+        <maven-failsafe-plugin.version>3.0.0-M3</maven-failsafe-plugin.version>
         <maven-idea-plugin.version>2.2.1</maven-idea-plugin.version>
         <maven-resources-plugin.version>3.1.0</maven-resources-plugin.version>
         <maven-surefire-plugin.version>2.22.1</maven-surefire-plugin.version>
@@ -787,6 +788,10 @@
                 <artifactId>maven-surefire-plugin</artifactId>
             </plugin>
             <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-failsafe-plugin</artifactId>
+            </plugin>
+            <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
             </plugin>
@@ -1082,30 +1087,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
-                    <%_ if (cucumberTests) { _%>
-                    <executions>
-                        <execution>
-                            <id>default-test</id>
-                            <configuration>
-                                <excludes>
-                                    <exclude>**/Abstract*.java</exclude>
-                                    <exclude>**/*Cucumber*.java</exclude>
-                                </excludes>
-                            </configuration>
-                        </execution>
-                        <execution>
-                            <id>without-cucumber</id>
-                            <goals>
-                                <goal>test</goal>
-                            </goals>
-                            <configuration>
-                                <includes>
-                                    <include>**/*Cucumber*.java</include>
-                                </includes>
-                            </configuration>
-                        </execution>
-                    </executions>
-                    <%_ } _%>
                     <configuration>
                         <!-- Force alphabetical order to have a reproducible build -->
                         <runOrder>alphabetical</runOrder>
@@ -1114,6 +1095,19 @@
                         <useSystemClassLoader>false</useSystemClassLoader>
                         <outputDirectory>${sonar.junit.reportsPath}</outputDirectory>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-failsafe-plugin</artifactId>
+                    <version>${maven-failsafe-plugin.version}</version>
+                    <executions>
+                        <execution>
+                            <goals>
+                                <goal>integration-test</goal>
+                                <goal>verify</goal>
+                            </goals>
+                        </execution>
+                    </executions>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>

--- a/generators/server/templates/src/test/java/package/CassandraKeyspaceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/CassandraKeyspaceIT.java.ejs
@@ -32,7 +32,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class CassandraKeyspaceUnitTest extends AbstractCassandraTest {
+public class CassandraKeyspaceIT extends AbstractCassandraTest {
 
     protected final Logger log = LoggerFactory.getLogger(this.getClass().getCanonicalName());
 

--- a/generators/server/templates/src/test/java/package/config/CassandraConfigurationIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/CassandraConfigurationIT.java.ejs
@@ -31,9 +31,9 @@ import org.springframework.context.annotation.Profile;
 
 @Configuration
 @Profile(JHipsterConstants.SPRING_PROFILE_TEST)
-public class CassandraTestConfiguration extends CassandraConfiguration {
+public class CassandraConfigurationIT extends CassandraConfiguration {
 
-    private final Logger log = LoggerFactory.getLogger(CassandraTestConfiguration.class);
+    private final Logger log = LoggerFactory.getLogger(CassandraConfigurationIT.class);
 
     /**
      * Override how to get the port to connect to the Cassandra cluster

--- a/generators/server/templates/src/test/java/package/config/DatabaseConfigurationIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/DatabaseConfigurationIT.java.ejs
@@ -34,13 +34,13 @@ import org.testcontainers.couchbase.CouchbaseContainer;
 import java.util.List;
 
 @Configuration
-public class DatabaseTestConfiguration extends AbstractCouchbaseConfiguration {
+public class DatabaseConfigurationIT extends AbstractCouchbaseConfiguration {
 
     private CouchbaseProperties couchbaseProperties;
 
     private static CouchbaseContainer<? extends CouchbaseContainer<?>> couchbaseContainer;
 
-    public DatabaseTestConfiguration(CouchbaseProperties couchbaseProperties) {
+    public DatabaseConfigurationIT(CouchbaseProperties couchbaseProperties) {
         this.couchbaseProperties = couchbaseProperties;
     }
 

--- a/generators/server/templates/src/test/java/package/config/timezone/HibernateTimeZoneIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/timezone/HibernateTimeZoneIT.java.ejs
@@ -49,7 +49,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>
-public class HibernateTimeZoneTest {
+public class HibernateTimeZoneIT {
 
     @Autowired
     private DateTimeWrapperRepository dateTimeWrapperRepository;

--- a/generators/server/templates/src/test/java/package/cucumber/CucumberIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/CucumberIT.java.ejs
@@ -27,6 +27,6 @@ import cucumber.api.junit.Cucumber;
 
 @RunWith(Cucumber.class)
 @CucumberOptions(plugin = "pretty", features = "<%= TEST_DIR %>features")
-public class CucumberTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest<% } %> {
+public class CucumberIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest<% } %> {
 
 }

--- a/generators/server/templates/src/test/java/package/repository/CustomAuditEventRepositoryIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/repository/CustomAuditEventRepositoryIT.java.ejs
@@ -54,7 +54,7 @@ import static <%=packageName%>.repository.CustomAuditEventRepository.EVENT_DATA_
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)<% if (databaseType === 'sql') { %>
 @Transactional<% } %>
-public class CustomAuditEventRepositoryIntTest {
+public class CustomAuditEventRepositoryIT {
 
     @Autowired
     private PersistenceAuditEventRepository persistenceAuditEventRepository;

--- a/generators/server/templates/src/test/java/package/security/DomainUserDetailsServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/DomainUserDetailsServiceIT.java.ejs
@@ -69,7 +69,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 <%_ if (databaseType === 'couchbase') { _%>
 @WithMockUser("test-user-one")
 <%_ } _%>
-public class DomainUserDetailsServiceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class DomainUserDetailsServiceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     private static final String USER_ONE_LOGIN = "test-user-one";
     private static final String USER_ONE_EMAIL = "test-user-one@localhost";

--- a/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
@@ -50,7 +50,7 @@ import static org.mockito.Mockito.*;
 
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class MailServiceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class MailServiceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     @Autowired
     private JHipsterProperties jHipsterProperties;

--- a/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
@@ -126,7 +126,7 @@ import static org.mockito.Mockito.when;
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)<% if (databaseType === 'sql') { %>
 @Transactional<% } %>
-public class UserServiceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class UserServiceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     <%_ if ((databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') && authenticationType === 'session') { _%>
     @Autowired

--- a/generators/server/templates/src/test/java/package/service/mapper/UserMapperIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/mapper/UserMapperIT.java.ejs
@@ -29,7 +29,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class UserMapperTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class UserMapperIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     private static final String DEFAULT_LOGIN = "johndoe";
 

--- a/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
@@ -61,7 +61,7 @@ import org.springframework.web.context.WebApplicationContext;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class AccountResourceIntTest<% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     @Autowired
     private UserRepository userRepository;
@@ -248,7 +248,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class AccountResourceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     @Autowired
     private UserRepository userRepository;

--- a/generators/server/templates/src/test/java/package/web/rest/AuditResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AuditResourceIT.java.ejs
@@ -56,7 +56,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)<% if (databaseType === 'sql') { %>
 @Transactional<% } %>
-public class AuditResourceIntTest {
+public class AuditResourceIT {
 
     private static final String SAMPLE_PRINCIPAL = "SAMPLE_PRINCIPAL";
     private static final String SAMPLE_TYPE = "SAMPLE_TYPE";

--- a/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
@@ -49,7 +49,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class LogoutResourceIntTest {
+public class LogoutResourceIT {
 
     @Autowired
     private MappingJackson2HttpMessageConverter jacksonMessageConverter;

--- a/generators/server/templates/src/test/java/package/web/rest/LogsResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/LogsResourceIT.java.ejs
@@ -61,7 +61,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>
-public class LogsResourceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class LogsResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     <%_ if (reactive) { _%>
     private WebTestClient webTestClient;

--- a/generators/server/templates/src/test/java/package/web/rest/UserJWTControllerIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserJWTControllerIT.java.ejs
@@ -65,7 +65,7 @@ import static org.hamcrest.Matchers.not;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class UserJWTControllerIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class UserJWTControllerIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     @Autowired
     private TokenProvider tokenProvider;

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -106,7 +106,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class UserResourceIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     private static final String DEFAULT_LOGIN = "johndoe";
     <%_ if (authenticationType !== 'oauth2') { _%>

--- a/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/errors/ExceptionTranslatorIT.java.ejs
@@ -54,7 +54,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>
-public class ExceptionTranslatorIntTest <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class ExceptionTranslatorIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     @Autowired
     private ExceptionTranslatorTestController controller;
@@ -199,7 +199,7 @@ import java.util.List;
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class ExceptionTranslatorIntTest {
+public class ExceptionTranslatorIT {
 
     @Autowired
     private ExceptionTranslatorTestController controller;

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -166,8 +166,8 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.template(
                     `${this.fetchFromInstalledJHipster(
                         'spring-controller/templates'
-                    )}/${SERVER_TEST_SRC_DIR}package/web/rest/ResourceIntTest.java.ejs`,
-                    `${SERVER_TEST_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}IntTest.java`
+                    )}/${SERVER_TEST_SRC_DIR}package/web/rest/ResourceIT.java.ejs`,
+                    `${SERVER_TEST_SRC_DIR}${this.packageFolder}/web/rest/${this.controllerClass}IT.java`
                 );
             }
         };

--- a/generators/spring-controller/templates/src/test/java/package/web/rest/ResourceIT.java.ejs
+++ b/generators/spring-controller/templates/src/test/java/package/web/rest/ResourceIT.java.ejs
@@ -39,7 +39,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
  */
 @RunWith(SpringRunner.class)
 @SpringBootTest(classes = <%= mainClass %>.class)
-public class <%= controllerClass %>IntTest {
+public class <%= controllerClass %>IT {
 
     private MockMvc restMockMvc;
 

--- a/test/spring-controller.spec.js
+++ b/test/spring-controller.spec.js
@@ -25,7 +25,7 @@ describe('JHipster generator spring-controller', () => {
         it('creates controller files', () => {
             assert.file([`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`]);
 
-            assert.file([`${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIntTest.java`]);
+            assert.file([`${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIT.java`]);
         });
     });
 
@@ -44,7 +44,7 @@ describe('JHipster generator spring-controller', () => {
         it('creates controller files', () => {
             assert.file([`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`]);
 
-            assert.file([`${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIntTest.java`]);
+            assert.file([`${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIT.java`]);
         });
     });
 });

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -125,7 +125,7 @@ const expectedFiles = {
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/FooRepository.java`,
             `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/FooResource.java`,
             // SERVER_MAIN_RES_DIR + 'config/liquibase/changelog/20160120213555_added_entity_Foo.xml',
-            `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIntTest.java`
+            `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIT.java`
         ],
         gatling: [`${TEST_DIR}gatling/user-files/simulations/FooGatlingTest.scala`]
     },
@@ -201,7 +201,7 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/package-info.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/LogsResource.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/security/SecurityUtilsUnitTest.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/LogsResourceIntTest.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/LogsResourceIT.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/TestUtil.java`,
         `${SERVER_TEST_RES_DIR}config/application.yml`,
         `${SERVER_TEST_RES_DIR}logback.xml`
@@ -234,10 +234,10 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/UserResource.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/vm/KeyAndPasswordVM.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/vm/ManagedUserVM.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/AccountResourceIntTest.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/AuditResourceIntTest.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/UserResourceIntTest.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/service/UserServiceIntTest.java`
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/AccountResourceIT.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/AuditResourceIT.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/UserResourceIT.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/service/UserServiceIT.java`
     ],
 
     infinispan: [`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheFactoryConfiguration.java`],
@@ -642,7 +642,7 @@ const expectedFiles = {
     couchbase: [
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/N1qlCouchbaseRepository.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/repository/CustomN1qlCouchbaseRepository.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/config/DatabaseTestConfiguration.java`,
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/config/DatabaseConfigurationIT.java`,
         `${SERVER_MAIN_RES_DIR}config/couchmove/changelog/V0__create_indexes.n1ql`,
         `${SERVER_MAIN_RES_DIR}config/couchmove/changelog/V0.1__initial_setup/ROLE_ADMIN.json`,
         `${SERVER_MAIN_RES_DIR}config/couchmove/changelog/V0.1__initial_setup/ROLE_USER.json`,
@@ -682,7 +682,7 @@ const expectedFiles = {
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberContextConfiguration.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/UserStepDefs.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/stepdefs/StepDefs.java`,
-        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberTest.java`
+        `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/cucumber/CucumberIT.java`
     ],
 
     eureka: [


### PR DESCRIPTION
currently JHipster mix unit tests and integration tests, this change allows to run unit test via `mvn test` and unit+integration via `mvn verify`

Fixes #8868

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->

Currently in WIP until all discussions are resolved in #8868 