### PR TITLE
fixes #9086 'Wrong login URL when using OAuth2 and TLS'

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -50,7 +50,7 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                 '/login',<% } %>
                 '/auth'
             ],
-            target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,
+            target: `http${options.tls ? 's' : ''}://localhost:<%= serverPort %>`,
             secure: false,
             changeOrigin: options.tls,
             headers: { host: 'localhost:9000' }

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -80,7 +80,7 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         '/login',<% } %>        
         '/auth'
       ],
-      target: `http${options.tls ? 's' : ''}://127.0.0.1:<%= serverPort %>`,
+      target: `http${options.tls ? 's' : ''}://localhost:<%= serverPort %>`,
       secure: false,
       changeOrigin: options.tls,
       headers: { host: 'localhost:9000' }

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -76,7 +76,7 @@ module.exports = class extends BaseDockerGenerator {
 
             setAppsYaml() {
                 this.appsYaml = [];
-                this.keycloakRedirectUri = '';
+                this.keycloakRedirectUris = '';
                 let portIndex = 8080;
                 this.serverPort = portIndex;
                 this.appsFolders.forEach((appsFolder, index) => {
@@ -90,7 +90,7 @@ module.exports = class extends BaseDockerGenerator {
                     if (this.gatewayType === 'traefik' && appConfig.applicationType === 'gateway') {
                         delete yamlConfig.ports; // Do not export the ports as Traefik is the gateway
                     } else if (appConfig.applicationType === 'gateway' || appConfig.applicationType === 'monolith') {
-                        this.keycloakRedirectUri += `"http://localhost:${portIndex}/*", `;
+                        this.keycloakRedirectUris += `"http://localhost:${portIndex}/*", "https://localhost:${portIndex}/*", `;
                         const ports = yamlConfig.ports[0].split(':');
                         ports[0] = portIndex;
                         yamlConfig.ports[0] = ports.join(':');

--- a/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
+++ b/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
@@ -740,13 +740,13 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "web_app",
       "redirectUris": [
-        <%- keycloakRedirectUri %>
+        <%- keycloakRedirectUris %>
         "http://localhost:8100/*",
         "http://127.0.0.1:8761/*",
         "http://localhost:9000/*"
       ],
       "webOrigins": [
-        <%- keycloakRedirectUri %>
+        <%- keycloakRedirectUris %>
         "http://localhost:8100/*",
         "http://127.0.0.1:8761/*",
         "http://localhost:9000/*"

--- a/generators/server/templates/src/main/docker/config/realm-config/jhipster-realm.json.ejs
+++ b/generators/server/templates/src/main/docker/config/realm-config/jhipster-realm.json.ejs
@@ -741,6 +741,7 @@
       "secret": "web_app",
       "redirectUris": [
         "http://localhost:<%= serverPort %>/*",
+        "https://localhost:<%= serverPort %>/*",
         "http://localhost:8100/*",
         "http://127.0.0.1:8761/*",
         "http://localhost:9000/*"


### PR DESCRIPTION
Fix #9086 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

I tried to test these patches, but didn't manage to generate a correct `jhipster-realm.json` with `"redirectUris": ["http://localhost:8080/*", "https://localhost:8080/*"` (I don't have the second url in the generated app).
But I'm not sure if I'm doing `npm link` correctly... could somebody check if this really fixes #9086 please?