### PR TITLE
Prevent routes in entity.module.ts to be duplicated upon reimporting JDL

### DIFF
--- a/generators/internal/needle-api/needle-client-angular.js
+++ b/generators/internal/needle-api/needle-client-angular.js
@@ -193,18 +193,19 @@ module.exports = class extends needleClientBase {
                 : `${appName}${entityAngularName}Module`;
 
             const splicable = isEntityAlreadyGenerated
-                ? `|,{
+                ? `|,
+                        |{
                         |                path: '${entityUrl}',
                         |                loadChildren: '${modulePath}#${moduleName}'
                         |            }`
                 : `|{
-                            |                path: '${entityUrl}',
-                            |                loadChildren: '${modulePath}#${moduleName}'
-                            |            }`;
+                        |                path: '${entityUrl}',
+                        |                loadChildren: '${modulePath}#${moduleName}'
+                        |            }`;
             const rewriteFileModel = this.generateFileModel(
                 entityModulePath,
                 'jhipster-needle-add-entity-route',
-                this.generator.stripMargin(splicable)
+                ...this.generator.stripMargin(splicable).split(/\n/)
             );
 
             this.addBlockContentToFile(rewriteFileModel, errorMessage);

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -90,6 +90,25 @@ function escapeRegExp(str) {
 }
 
 /**
+ * Escape leading comma in case the splicable is like a JSON array entry. This
+ * will allow it to match the first element of the list, in case that element is
+ * the same.
+ *
+ * @param {string} line the parsed line
+ * @param {number} idx the current line index
+ * @returns {string} a regex representing an optional comma if needed, or the
+ * common escaped regexp
+ */
+function escapeJsonArray(line, idx) {
+    if (idx === 0 && line === ',') {
+        // ignore the leading comma in order to allow the first element
+        // to match if the output is like a JSON array
+        return ',?';
+    }
+    return `\\s*${escapeRegExp(line)}`;
+}
+
+/**
  * Rewrite using the passed argument object.
  *
  * @param {object} args arguments object (containing splicable, haystack, needle properties) to be used
@@ -97,7 +116,7 @@ function escapeRegExp(str) {
  */
 function rewrite(args) {
     // check if splicable is already in the body text
-    const re = new RegExp(args.splicable.map(line => `\\s*${escapeRegExp(line)}`).join('\n'));
+    const re = new RegExp(args.splicable.map((line, idx) => escapeJsonArray(line, idx)).join('\n'));
 
     if (re.test(args.haystack)) {
         return args.haystack;


### PR DESCRIPTION
The generator fails to detect already existing routes because the template
was broken (missed a line separator after the comma), and the template
would not splitted into multiple lignes. This led to non-matching regex
in the utils.rewrite funtion.

closes #9178

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
