### PR TITLE
Fix call to the wrong stripMargin method

### DIFF
--- a/generators/internal/needle-api/needle-client-angular.js
+++ b/generators/internal/needle-api/needle-client-angular.js
@@ -111,7 +111,7 @@ module.exports = class extends needleClientBase {
     _generateRewriteFileModelWithImportStatement(appName, angularName, folderName, fileName, modulePath, needle) {
         const importStatement = this._generateImportStatement(appName, angularName, folderName, fileName);
 
-        return this.generateFileModel(modulePath, needle, this.stripMargin(importStatement));
+        return this.generateFileModel(modulePath, needle, this.generator.stripMargin(importStatement));
     }
 
     _generateImportStatement(appName, angularName, folderName, fileName) {
@@ -127,7 +127,7 @@ module.exports = class extends needleClientBase {
     }
 
     _generateRewriteFileModelAddModule(appName, angularName, modulePath, needle) {
-        return this.generateFileModel(modulePath, needle, this.stripMargin(`|${appName}${angularName}Module,`));
+        return this.generateFileModel(modulePath, needle, this.generator.stripMargin(`|${appName}${angularName}Module,`));
     }
 
     addEntityToMenu(routerName, enableTranslation, entityTranslationKeyMenu) {


### PR DESCRIPTION
In the angular needle Api we are calling a this.stripMargin() method that does not exist. 'stripMargin()' belongs to generator-base.js so I changed it to this.generator.stripMargin().

@murdos 
I don't use to handle maintenance branch with JHipster. I open a new PR and close the other one. I hope this is what you wanted me to do ;).

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
