### PR TITLE
Revert "Use fixed dependency: terser 3.14.1"

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -119,7 +119,6 @@
     "rimraf": "2.6.3",
     "simple-progress-webpack-plugin": "1.1.2",
     "style-loader": "0.23.1",
-    "terser": "3.14.1",
     "terser-webpack-plugin": "1.2.1",
     "thread-loader": "2.1.1",
     "to-string-loader": "1.1.5",
@@ -150,9 +149,6 @@
     "webpack-visualizer-plugin": "0.1.11",
     "workbox-webpack-plugin": "3.6.3",
     "write-file-webpack-plugin": "4.5.0"
-  },
-  "resolutions": {
-    "terser": "3.14.1"
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -145,7 +145,6 @@ limitations under the License.
     <%_ otherModules.forEach(module => { _%>
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
-    "terser": "3.14.1",
     "terser-webpack-plugin": "1.0.2",
     "thread-loader": "1.2.0",
     "to-string-loader": "1.1.5",
@@ -170,8 +169,7 @@ limitations under the License.
     "xml2js": "0.4.19"<% } %>
   },
   "resolutions": {
-    "@types/react": "16.4.12",
-    "terser": "3.14.1"
+    "@types/react": "16.4.12"
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,


### PR DESCRIPTION
This reverts commit 11594152ff54275bec7427e54c4b558efed16444.

I'm reverting my previous PR as it is already fixed by terser project: https://github.com/terser-js/terser/releases

@DanielFran : so, no need to report this fix in v5 maintenance branch

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
