### PR TITLE
Prevent wrong http code on empty body response

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -234,7 +234,7 @@ public class <%= entityClass %>Resource {
     public ResponseEntity<Void> delete<%= entityClass %>(@PathVariable <%= pkType %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);
 <%- include('../../common/delete_template', {viaService: viaService}); -%>
-        return ResponseEntity.ok().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (pkType !== 'String') { %>.toString()<% } %>)).build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (pkType !== 'String') { %>.toString()<% } %>)).build();
     }<% if (searchEngine === 'elasticsearch') { %>
 
     /**

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -228,7 +228,7 @@ public class <%= entityClass %>Resource {
      * DELETE  /<%= entityApiUrl %>/:id : delete the "id" <%= entityInstance %>.
      *
      * @param id the id of the <%= instanceName %> to delete
-     * @return the ResponseEntity with status 200 (OK)
+     * @return the ResponseEntity with status 204 (NO_CONTENT)
      */
     @DeleteMapping("/<%= entityApiUrl %>/{id}")
     public ResponseEntity<Void> delete<%= entityClass %>(@PathVariable <%= pkType %> id) {

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -954,7 +954,7 @@ _%>
         // Delete the <%= entityInstance %>
         rest<%= entityClass %>MockMvc.perform(delete("/api/<%= entityApiUrl %>/{id}", <%= asEntity(entityInstance) %>.getId())
             .accept(TestUtil.APPLICATION_JSON_UTF8))
-            .andExpect(status().isOk());
+            .andExpect(status().isNoContent());
 
         // Validate the database is empty
         List<<%= asEntity(entityClass) %>> <%= entityInstance %>List = <%= entityInstance %>Repository.findAll();

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -344,7 +344,7 @@ public class UserResource {
     public Mono<ResponseEntity<Void>> deleteUser(@PathVariable String login) {
         log.debug("REST request to delete User: {}", login);
         return userService.deleteUser(login)
-            .map(it -> ResponseEntity.ok().headers(HeaderUtil.createAlert( applicationName, "userManagement.deleted", login)).build());
+            .map(it -> ResponseEntity.noContent().headers(HeaderUtil.createAlert( applicationName, "userManagement.deleted", login)).build());
     <%_ } _%>
     }
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -339,7 +339,7 @@ public class UserResource {
     public ResponseEntity<Void> deleteUser(@PathVariable String login) {
         log.debug("REST request to delete User: {}", login);
         userService.deleteUser(login);
-        return ResponseEntity.ok().headers(HeaderUtil.createAlert(applicationName, <% if (enableTranslation) {%> "userManagement.deleted"<% } else { %> "A user is deleted with identifier " + login<% } %>, login)).build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createAlert(applicationName, <% if (enableTranslation) {%> "userManagement.deleted"<% } else { %> "A user is deleted with identifier " + login<% } %>, login)).build();
     <%_ } else { _%>
     public Mono<ResponseEntity<Void>> deleteUser(@PathVariable String login) {
         log.debug("REST request to delete User: {}", login);

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -331,7 +331,7 @@ public class UserResource {
      * DELETE /users/:login : delete the "login" User.
      *
      * @param login the login of the user to delete
-     * @return the ResponseEntity with status 200 (OK)
+     * @return the ResponseEntity with status 204 (NO_CONTENT)
      */
     @DeleteMapping("/users/{login:" + Constants.LOGIN_REGEX + "}")
     @PreAuthorize("hasRole(\"" + AuthoritiesConstants.ADMIN + "\")")

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -341,6 +341,7 @@ public class UserResource {
         userService.deleteUser(login);
         return ResponseEntity.noContent().headers(HeaderUtil.createAlert(applicationName, <% if (enableTranslation) {%> "userManagement.deleted"<% } else { %> "A user is deleted with identifier " + login<% } %>, login)).build();
     <%_ } else { _%>
+    @ResponseStatus(code = HttpStatus.NO_CONTENT)
     public Mono<ResponseEntity<Void>> deleteUser(@PathVariable String login) {
         log.debug("REST request to delete User: {}", login);
         return userService.deleteUser(login)

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -838,12 +838,12 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         <%_ if (!reactive) { _%>
         restUserMockMvc.perform(delete("/api/users/{login}", user.getLogin())
             .accept(TestUtil.APPLICATION_JSON_UTF8))
-            .andExpect(status().isOk());
+            .andExpect(status().isNoContent());
         <%_ } else { _%>
         webTestClient.delete().uri("/api/users/{login}", user.getLogin())
             .accept(TestUtil.APPLICATION_JSON_UTF8)
             .exchange()
-            .expectStatus().isOk();
+            .expectStatus().isNoContent();
         <%_ } _%>
         <%_ if (cacheManagerIsAvailable === true) { _%>
 


### PR DESCRIPTION
This is mentionned here https://github.com/jhipster/jhipster-vuejs/issues/180.
To be more consistent with good practices, we should return correct HTTP codes when using DELETE Request and thus use 204 instead of 200.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
