### PR TITLE
update gatling scripts to be compatible with gatling 3.x

### DIFF
--- a/generators/entity-server/templates/src/test/gatling/user-files/simulations/EntityGatlingTest.scala.ejs
+++ b/generators/entity-server/templates/src/test/gatling/user-files/simulations/EntityGatlingTest.scala.ejs
@@ -41,7 +41,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
     val baseURL = Option(System.getProperty("baseURL")) getOrElse """http://localhost:8080"""
 
     val httpConf = http
-        .baseURL(baseURL)
+        .baseUrl(baseURL)
         .inferHtmlResources()
         .acceptHeader("*/*")
         .acceptEncodingHeader("gzip, deflate")
@@ -167,7 +167,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
 <%_ } else if (authenticationType === 'jwt') { _%>
         .post("/api/authenticate")
         .headers(headers_http_authentication)
-        .body(StringBody("""{"username":"admin", "password":"admin"}""")).asJSON
+        .body(StringBody("""{"username":"admin", "password":"admin"}""")).asJson
         .check(header.get("Authorization").saveAs("access_token"))).exitHereIfFailed
 <%_ } _%>
         .pause(2)
@@ -190,7 +190,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
                 <%_ for (idx in fields) { _%>
                 , "<%= fields[idx].fieldName %>":<% if (fields[idx].fieldType === 'String') { %>"SAMPLE_TEXT"<% } else if (['Integer', 'BigDecimal'].includes(fields[idx].fieldType)) { %>"0"<% } else if (['Instant', 'ZonedDateTime', 'LocalDate'].includes(fields[idx].fieldType)) { %>"2020-01-01T00:00:00.000Z"<% } else if (fields[idx].fieldIsEnum) { %>"<%= fields[idx].fieldValues.split(',')[0] %>"<% } else { %>null<% } %>
                 <%_ } _%>
-                }""")).asJSON
+                }""")).asJson
             .check(status.is(201))
             .check(headerRegex("Location", "(.*)").saveAs("new_<%= entityInstance %>_url"))).exitHereIfFailed
             .pause(10)
@@ -209,6 +209,6 @@ class <%= entityClass %>GatlingTest extends Simulation {
     val users = scenario("Users").exec(scn)
 
     setUp(
-        users.inject(rampUsers(Integer.getInteger("users", 100)) over (Integer.getInteger("ramp", 1) minutes))
+        users.inject(rampUsers(Integer.getInteger("users", 100)) during (Integer.getInteger("ramp", 1) minutes))
     ).protocols(httpConf)
 }

--- a/generators/entity-server/templates/src/test/gatling/user-files/simulations/EntityGatlingTest.scala.ejs
+++ b/generators/entity-server/templates/src/test/gatling/user-files/simulations/EntityGatlingTest.scala.ejs
@@ -168,7 +168,7 @@ class <%= entityClass %>GatlingTest extends Simulation {
         .post("/api/authenticate")
         .headers(headers_http_authentication)
         .body(StringBody("""{"username":"admin", "password":"admin"}""")).asJson
-        .check(header.get("Authorization").saveAs("access_token"))).exitHereIfFailed
+        .check(header("Authorization").saveAs("access_token"))).exitHereIfFailed
 <%_ } _%>
         .pause(2)
         .exec(http("Authenticated request")


### PR DESCRIPTION
The generated gatling scripts are now compatible with gatling 3. I will update the documentation accordingly and how to call gatling. This is a breaking change as the scripts won't work with gatling 2.x anymore.

Tested with jwt and oauth. Will do it for session auth later, but I don't see why that should not work.

closes #9080

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
