### PR TITLE
#9194 Fix paging link headers for use all query parameters.

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
@@ -23,14 +23,14 @@
     const entityListToDtoListReference = mapper + '.' + 'toDto';
     const entityToDtoReference = mapper + '::'+ 'toDto';
     if (jpaMetamodelFiltering) {  %>
-    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(<%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>, Pageable pageable<% } %>) {
+    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(<%= entityClass %>Criteria criteria<% if (pagination != 'no') { %>, Pageable pageable, HttpServletRequest request<% } %>) {
         log.debug("REST request to get <%= entityClassPlural %> by criteria: {}", criteria);
     <%_ if (pagination === 'no') { _%>
         List<<%= instanceType %>> entityList = <%= entityInstance %>QueryService.findByCriteria(criteria);
         return ResponseEntity.ok().body(entityList);
     <%_ } else { _%>
         Page<<%= instanceType %>> page = <%= entityInstance %>QueryService.findByCriteria(criteria, pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityApiUrl %>");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         return ResponseEntity.ok().headers(headers).body(page.getContent());
     <%_ } _%>
     }
@@ -55,7 +55,7 @@
         return <%= entityListToDtoListReference %>(<%= entityInstancePlural %>);<% } else { %>
         return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>();<% } %>
     <%_ } if (pagination !== 'no') { _%>
-    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(Pageable pageable<% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @RequestParam(required = false, defaultValue = "false") boolean eagerload<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+    public ResponseEntity<List<<%= instanceType %>>> getAll<%= entityClassPlural %>(Pageable pageable, HttpServletRequest request<% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @RequestParam(required = false, defaultValue = "false") boolean eagerload<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get a page of <%= entityClassPlural %>");
     <%_ if (viaService) { _%>
         <%_ if (fieldsContainOwnerManyToMany) { _%>
@@ -65,10 +65,10 @@
         } else {
             page = <%= entityInstance %>Service.findAll(pageable);
         }
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, String.format("/api/<%= entityApiUrl %>?eagerload=%b", eagerload));
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         <%_ } else { _%>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.findAll(pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityApiUrl %>");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         <%_ } _%>
     <%_ } else { _%>
         <%_ if (fieldsContainOwnerManyToMany) { _%>
@@ -78,10 +78,10 @@
         } else {
             page = <%= entityInstance %>Repository.findAll(pageable)<% if (dto !== 'mapstruct') { %>;<% } else { %>.map(<%= entityToDtoReference %>);<% } %>
         }
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, String.format("/api/<%= entityApiUrl %>?eagerload=%b", eagerload));
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         <%_ } else { _%>
         Page<<%= instanceType %>> page = <%= entityInstance %>Repository.findAll(pageable)<% if (dto !== 'mapstruct') { %>;<% } else { %>.map(<%= entityToDtoReference %>);<% } %>
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/<%= entityApiUrl %>");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         <%_ } _%>
     <%_ } _%>
         return ResponseEntity.ok().headers(headers).body(page.getContent());

--- a/generators/entity-server/templates/src/main/java/package/common/search_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/search_template.ejs
@@ -26,11 +26,11 @@
     public List<<%= instanceType %>> search<%= entityClassPlural %>(@RequestParam String query) {
         log.debug("REST request to search <%= entityClassPlural %> for query {}", query);<%- include('search_stream_template', {viaService: viaService}); -%>
     <% } if (pagination !== 'no') { %>
-    public ResponseEntity<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable) {
+    public ResponseEntity<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable, HttpServletRequest request) {
         log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
         Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
         Page<<%= asEntity(entityClass) %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>
-        HttpHeaders headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, "/api/_search/<%= entityApiUrl %>");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         return ResponseEntity.ok().headers(headers).body(<% if (!viaService && dto === 'mapstruct') { %><%= entityListToDtoListReference %>(<% } %>page.getContent()<% if (!viaService && dto === 'mapstruct') { %>)<% } %>);
     <% } -%>
 }

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -68,6 +68,7 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
+import javax.servlet.http.HttpServletRequest;
 <%_ } _%>
 <%_ if (reactiveRepositories) { _%>
 import org.springframework.http.MediaType;

--- a/generators/server/templates/src/main/java/package/web/rest/AuditResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AuditResource.java.ejs
@@ -29,6 +29,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import javax.servlet.http.HttpServletRequest;
 
 import java.time.LocalDate;
 import java.time.ZoneId;
@@ -54,9 +55,9 @@ public class AuditResource {
      * @return the ResponseEntity with status 200 (OK) and the list of AuditEvents in body
      */
     @GetMapping
-    public ResponseEntity<List<AuditEvent>> getAll(Pageable pageable) {
+    public ResponseEntity<List<AuditEvent>> getAll(HttpServletRequest request, Pageable pageable) {
         Page<AuditEvent> page = auditEventService.findAll(pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/management/audits");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }
 
@@ -72,13 +73,14 @@ public class AuditResource {
     public ResponseEntity<List<AuditEvent>> getByDates(
         @RequestParam(value = "fromDate") LocalDate fromDate,
         @RequestParam(value = "toDate") LocalDate toDate,
+        HttpServletRequest request,
         Pageable pageable) {
 
         Page<AuditEvent> page = auditEventService.findByDates(
             fromDate.atStartOfDay(ZoneId.systemDefault()).toInstant(),
             toDate.atStartOfDay(ZoneId.systemDefault()).plusDays(1).toInstant(),
             pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/management/audits");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
     }
 

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -59,6 +59,7 @@ import org.springframework.data.domain.Pageable;
     <%_ if (!reactive) { _%>
 import org.springframework.http.HttpHeaders;
     <%_ } _%>
+import javax.servlet.http.HttpServletRequest;
 <%_ } _%>
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -271,15 +272,15 @@ public class UserResource {
     @GetMapping("/users")
     <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
         <%_ if (!reactive) { _%>
-    public ResponseEntity<List<<%= asDto('User') %>>> getAllUsers(Pageable pageable) {
+    public ResponseEntity<List<<%= asDto('User') %>>> getAllUsers(HttpServletRequest request, Pageable pageable) {
         final Page<<%= asDto('User') %>> page = userService.getAllManagedUsers(pageable);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, "/api/users");
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(request, page);
         return new ResponseEntity<>(page.getContent(), headers, HttpStatus.OK);
         <%_ } else { _%>
-    public Mono<ResponseEntity<Flux<<%= asDto('User') %>>>> getAllUsers(Pageable pageable) {
+    public Mono<ResponseEntity<Flux<<%= asDto('User') %>>>> getAllUsers(HttpServletRequest request, Pageable pageable) {
         return userService.countManagedUsers()
             .map(total -> new PageImpl<>(new ArrayList<>(), pageable, total))
-            .map(page -> PaginationUtil.generatePaginationHttpHeaders(page, "/api/users"))
+            .map(page -> PaginationUtil.generatePaginationHttpHeaders(request, page))
             .map(headers -> ResponseEntity.ok().headers(headers).body(userService.getAllManagedUsers(pageable)));
         <%_ } _%>
     }

--- a/generators/server/templates/src/main/java/package/web/rest/util/PaginationUtil.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/util/PaginationUtil.java.ejs
@@ -20,12 +20,15 @@ package <%=packageName%>.web.rest.util;
 
 import org.springframework.data.domain.Page;
 import org.springframework.http.HttpHeaders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
 import org.springframework.web.util.UriComponentsBuilder;
-<%_ if (searchEngine === 'elasticsearch') { _%>
 
+import javax.servlet.http.HttpServletRequest;
 import java.io.UnsupportedEncodingException;
 import java.net.URLEncoder;
-<%_ } _%>
+import java.text.MessageFormat;
+import java.util.Arrays;
 
 /**
  * Utility class for handling pagination.
@@ -36,9 +39,57 @@ import java.net.URLEncoder;
  */
 public final class PaginationUtil {
 
+    private static final String HEADER_X_TOTAL_COUNT = "X-Total-Count";
+    private static final String HEADER_LINK_FORMAT = "<{0}>; rel=\"{1}\"";
+
     private PaginationUtil() {
     }
 
+    public static <T> HttpHeaders generatePaginationHttpHeaders(HttpServletRequest request, Page<T> page) {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add(HEADER_X_TOTAL_COUNT, Long.toString(page.getTotalElements()));
+        int pageNumber = page.getNumber();
+        int pageSize = page.getSize();
+        StringBuilder link = new StringBuilder();
+        if (pageNumber < page.getTotalPages() - 1) {
+            link.append(prepareLink(request, pageNumber + 1, pageSize, "next"))
+                .append(",");
+        }
+        if (pageNumber > 0) {
+            link.append(prepareLink(request, pageNumber - 1, pageSize, "prev"))
+                .append(",");
+        }
+        link.append(prepareLink(request, page.getTotalPages() - 1, pageSize, "last"))
+            .append(",")
+            .append(prepareLink(request, 0, pageSize, "first"));
+        headers.add(HttpHeaders.LINK, link.toString());
+        return headers;
+    }
+
+    private static String prepareLink(HttpServletRequest request, int pageNumber, int pageSize, String relType) {
+        return MessageFormat.format(HEADER_LINK_FORMAT, preparePageUri(request, pageNumber, pageSize), relType);
+    }
+
+    private static String preparePageUri(HttpServletRequest request, int pageNumber, int pageSize) {
+        MultiValueMap<String, String> parameters = new LinkedMultiValueMap<>();
+        parameters.set("page", Integer.toString(pageNumber));
+        parameters.set("size", Integer.toString(pageSize));
+        request.getParameterMap().entrySet().stream()
+            .filter(map -> !"page".equalsIgnoreCase(map.getKey()) && !"size".equalsIgnoreCase(map.getKey()))
+            .forEach(map -> Arrays.asList(map.getValue()).forEach(value -> {
+                    try {
+                        parameters.add(map.getKey(), URLEncoder.encode(value, "UTF-8"));
+                    } catch (UnsupportedEncodingException e) {
+                        throw new RuntimeException(e);
+                    }
+                })
+            );
+        return UriComponentsBuilder.fromUriString(request.getRequestURI())
+            .queryParams(parameters).build(false)
+            .toUriString();
+    }
+
+    @Deprecated
     public static <T> HttpHeaders generatePaginationHttpHeaders(Page<T> page, String baseUrl) {
 
         HttpHeaders headers = new HttpHeaders();
@@ -66,7 +117,7 @@ public final class PaginationUtil {
         return UriComponentsBuilder.fromUriString(baseUrl).queryParam("page", page).queryParam("size", size).toUriString();
     }
     <%_ if (searchEngine === 'elasticsearch') { _%>
-
+    @Deprecated
     public static <T> HttpHeaders generateSearchPaginationHttpHeaders(String query, Page<T> page, String baseUrl) {
         String escapedQuery;
         try {

--- a/generators/server/templates/src/test/java/package/web/rest/util/PaginationUtilUnitTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/util/PaginationUtilUnitTest.java.ejs
@@ -22,14 +22,17 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.UnsupportedEncodingException;
 import java.util.ArrayList;
 import java.util.List;
 
+import org.junit.Before;
 import org.junit.Test;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpHeaders;
+import org.springframework.mock.web.MockHttpServletRequest;
 
 /**
  * Tests based on parsing algorithm in app/components/util/pagination-util.service.js
@@ -38,12 +41,21 @@ import org.springframework.http.HttpHeaders;
  */
 public class PaginationUtilUnitTest {
 
+    private static final String BASE_URL = "/api/_search/example";
+
+    private MockHttpServletRequest mockRequest;
+
+    @Before
+    public void init() {
+        mockRequest  = new MockHttpServletRequest();
+        mockRequest.setRequestURI(BASE_URL);
+    }
+
     @Test
     public void generatePaginationHttpHeadersTest() {
-        String baseUrl = "/api/_search/example";
         List<String> content = new ArrayList<>();
         Page<String> page = new PageImpl<>(content, PageRequest.of(6, 50), 400L);
-        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(page, baseUrl);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         List<String> strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -59,14 +71,12 @@ public class PaginationUtilUnitTest {
         assertTrue(Long.valueOf(xTotalCountHeaders.get(0)).equals(400L));
     }
 
-    <%_ if (searchEngine === 'elasticsearch') { _%>
     @Test
-    public void commaTest() {
-        String baseUrl = "/api/_search/example";
+    public void commaTest() throws UnsupportedEncodingException {
+        mockRequest.setParameter("query", "Test1, test2");
         List<String> content = new ArrayList<>();
         Page<String> page = new PageImpl<>(content);
-        String query = "Test1, test2";
-        HttpHeaders headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, baseUrl);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         List<String> strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -82,13 +92,11 @@ public class PaginationUtilUnitTest {
 
     @Test
     public void multiplePagesTest() {
-        String baseUrl = "/api/_search/example";
+        mockRequest.setParameter("query", "Test1, test2");
         List<String> content = new ArrayList<>();
-
         // Page 0
         Page<String> page = new PageImpl<>(content, PageRequest.of(0, 50), 400L);
-        String query = "Test1, test2";
-        HttpHeaders headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, baseUrl);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         List<String> strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -103,9 +111,9 @@ public class PaginationUtilUnitTest {
         assertTrue(Long.valueOf(xTotalCountHeaders.get(0)).equals(400L));
 
         // Page 1
+        mockRequest.setParameter("page", "1");
         page = new PageImpl<>(content, PageRequest.of(1, 50), 400L);
-        query = "Test1, test2";
-        headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, baseUrl);
+        headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -121,8 +129,9 @@ public class PaginationUtilUnitTest {
         assertTrue(Long.valueOf(xTotalCountHeaders.get(0)).equals(400L));
 
         // Page 6
+        mockRequest.setParameter("page", "6");
         page = new PageImpl<>(content, PageRequest.of(6, 50), 400L);
-        headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, baseUrl);
+        headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -138,8 +147,9 @@ public class PaginationUtilUnitTest {
         assertTrue(Long.valueOf(xTotalCountHeaders.get(0)).equals(400L));
 
         // Page 7
+        mockRequest.setParameter("page", "7");
         page = new PageImpl<>(content, PageRequest.of(7, 50), 400L);
-        headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, baseUrl);
+        headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -153,11 +163,10 @@ public class PaginationUtilUnitTest {
 
     @Test
     public void greaterSemicolonTest() {
-        String baseUrl = "/api/_search/example";
+        mockRequest.setParameter("query", "Test>;test");
         List<String> content = new ArrayList<>();
         Page<String> page = new PageImpl<>(content);
-        String query = "Test>;test";
-        HttpHeaders headers = PaginationUtil.generateSearchPaginationHttpHeaders(query, page, baseUrl);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
         List<String> strHeaders = headers.get(HttpHeaders.LINK);
         assertNotNull(strHeaders);
         assertTrue(strHeaders.size() == 1);
@@ -174,5 +183,22 @@ public class PaginationUtilUnitTest {
         assertTrue(xTotalCountHeaders.size() == 1);
         assertTrue(Long.valueOf(xTotalCountHeaders.get(0)).equals(0L));
     }
-    <%_ }  _%>
+
+    @Test
+    public void sortAndCriteriaTest() {
+        mockRequest.setRequestURI("/api/users");
+        mockRequest.addParameter("login.contains","adm");
+        mockRequest.addParameter("name","name,asc");
+        List<String> content = new ArrayList<>();
+        Page<String> page = new PageImpl<>(content, PageRequest.of(0, 50), 400L);
+        HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(mockRequest, page);
+        List<String>  strHeaders = headers.get(HttpHeaders.LINK);
+        String expectedData = "</api/users?page=1&size=50&login.contains=adm&name=name%2Casc>; rel=\"next\"," +
+            "</api/users?page=7&size=50&login.contains=adm&name=name%2Casc>; rel=\"last\"," +
+            "</api/users?page=0&size=50&login.contains=adm&name=name%2Casc>; rel=\"first\"";
+        assertNotNull(strHeaders);
+        assertEquals(1, strHeaders.size());
+        String headerData = strHeaders.get(0);
+        assertEquals(expectedData, headerData);
+    }
 }


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/9194

1. Created universal single method PaginationUtil.generatePaginationHttpHeaders(HttpServletRequest request, Page<T> page). HttpServletRequest need for get URI and query params.
2. Tests adapted for new method calls. Assets not changed.
3. New test for sort and criteria params
4. Change templates for new call
5. Previous methods marks as deprecated.
  


-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
