### PR TITLE
use underscore syntax to access command

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -60,7 +60,7 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
 
     outputs.files(fileTree("<%= CLIENT_DIST_DIR %>"))
 
-    dependsOn <%= clientPackageManager %>Install
+    dependsOn <%= clientPackageManager %>_install
 
     args = ["run", "webpack:build"]
 }


### PR DESCRIPTION
Use underscore syntax to run `npm install` and `yarn install` as documented in https://github.com/srs/gradle-node-plugin/blob/master/docs/node.md.
