### PR TITLE
Update condition when applying prettierTransform

### DIFF
--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -31,9 +31,9 @@ const prettierOptions = {
 
 const prettierTransform = function(defaultOptions) {
     const transform = (file, encoding, callback) => {
-        if(file.state !== 'deleted') {
-            /* resolve from the projects config */
-            prettier.resolveConfig(file.relative).then(options => {
+        /* resolve from the projects config */
+        prettier.resolveConfig(file.relative).then(options => {
+            if(file.state !== 'deleted') {
                 const str = file.contents.toString('utf8');
                 if (!options || Object.keys(options).length === 0) {
                     options = defaultOptions;
@@ -42,9 +42,9 @@ const prettierTransform = function(defaultOptions) {
                 options.filepath = file.relative;
                 const data = prettier.format(str, options);
                 file.contents = Buffer.from(data);
-                callback(null, file);
-            });
-        }
+            }
+            callback(null, file);
+        });
     };
     return through.obj(transform);
 };


### PR DESCRIPTION
We need to always call callback(null, file) otherwise the program
is stopped prematurely

My first fix was not totally good because this could stop the program before it was really finished.
The callback is not called and the generator finish like this, before handling all files: 

>     force src/main/webapp/app/admin/configuration/configuration.component.ts
>     force src/main/webapp/app/admin/configuration/configuration.service.ts
>     force src/main/webapp/app/admin/docs/docs.route.ts
>     force src/main/webapp/app/admin/docs/docs.component.ts
>     force src/main/webapp/app/admin/health/health.route.ts
>     force src/main/webapp/app/admin/health/health.component.ts
>     force src/main/webapp/app/admin/health/health-modal.component.ts
>     force src/main/webapp/app/admin/health/health.service.ts
> 
> Process finished with exit code 0

Could you please, @murdos, merge this in the v5 maintenance and add it to your #9215 PR?

thanks so much !


-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
