### PR TITLE
refactor: use strong instead of b tag

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
@@ -19,7 +19,7 @@
 <div>
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <h2 jhiTranslate="password.title" [translateValues]="{username: account.login}" *ngIf="account">Password for [<b>{{account.login}}</b>]</h2>
+            <h2 jhiTranslate="password.title" [translateValues]="{username: account.login}" *ngIf="account">Password for [<strong>{{account.login}}</strong>]</h2>
 
             <div class="alert alert-success" *ngIf="success" jhiTranslate="password.messages.success">
                 <strong>Password changed!</strong>

--- a/generators/languages/templates/src/main/webapp/i18n/al/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/al/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Fjalëkalimi për [<b>{{username}}</b>]",
+        "title": "Fjalëkalimi për [<strong>{{username}}</strong>]",
         "form": {
             "button": "Ruaj"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/al/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/al/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Seksione aktive për [<b>{{username}}</b>]",
+        "title": "Seksione aktive për [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Adresa e IP",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/al/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/al/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Mjedisi për përdoruesin [<b>{{username}}</b>]",
+        "title": "Mjedisi për përdoruesin [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Emri",
             "firstname.placeholder": "Emri juar",

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "كلمة السر ل [<b>{{username}}</b>]",
+        "title": "كلمة السر ل [<strong>{{username}}</strong>]",
         "form": {
             "button": "حفظ"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "جلسات العمل النشطة ل [<b>{{username}}</b>]",
+        "title": "جلسات العمل النشطة ل [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP عنوان",
             "useragent": "وكيل المستخدم",

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "إعدادات المستخدم ل [<b>{{username}}</b>]",
+        "title": "إعدادات المستخدم ل [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "الاسم الاول",
             "firstname.placeholder": "اسمك الأول",

--- a/generators/languages/templates/src/main/webapp/i18n/bn/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] এর পাসওয়ার্ড",
+        "title": "[<strong>{{username}}</strong>] এর পাসওয়ার্ড",
         "form": {
             "button": "সেইভ"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/bn/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "চলতি সেশন [<b>{{username}}</b>] এর জন্য",
+        "title": "চলতি সেশন [<strong>{{username}}</strong>] এর জন্য",
         "table": {
             "ipaddress": "আই পি অ্যাড্রেস",
             "useragent": "ইউজার এজেন্ট",

--- a/generators/languages/templates/src/main/webapp/i18n/bn/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "ইউজার সেটিংস [<b>{{username}}</b>] এর জন্য",
+        "title": "ইউজার সেটিংস [<strong>{{username}}</strong>] এর জন্য",
         "form": {
             "firstname": "নামের প্রথম অংশ",
             "firstname.placeholder": "নামের প্রথম অংশ",

--- a/generators/languages/templates/src/main/webapp/i18n/by/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/by/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Пароль для [<b>{{username}}</b>]",
+        "title": "Пароль для [<strong>{{username}}</strong>]",
         "form": {
             "button": "Захаваць"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/by/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/by/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Актыўныя сесіі для [<b>{{username}}</b>]",
+        "title": "Актыўныя сесіі для [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP адрас",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/by/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/by/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Налады карыстальніка для [<b>{{username}}</b>]",
+        "title": "Налады карыстальніка для [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Імя",
             "firstname.placeholder": "Ваше імя",

--- a/generators/languages/templates/src/main/webapp/i18n/ca/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Contrasenya per [<b>{{username}}</b>]",
+        "title": "Contrasenya per [<strong>{{username}}</strong>]",
         "form": {
             "button": "Desa"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ca/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sessions actives per [<b>{{username}}</b>]",
+        "title": "Sessions actives per [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Adreça IP",
             "useragent": "Agent d'usuari",

--- a/generators/languages/templates/src/main/webapp/i18n/ca/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Ajustos d'usuari per [<b>{{username}}</b>]",
+        "title": "Ajustos d'usuari per [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Nom",
             "firstname.placeholder": "El seu nom",

--- a/generators/languages/templates/src/main/webapp/i18n/cs/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Heslo pro [<b>{{username}}</b>]",
+        "title": "Heslo pro [<strong>{{username}}</strong>]",
         "form": {
             "button": "Uložit"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/cs/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktivní sezení uživatele [<b>{{username}}</b>]",
+        "title": "Aktivní sezení uživatele [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP adresa",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/cs/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Nastavení uživatele [<b>{{username}}</b>]",
+        "title": "Nastavení uživatele [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Křestní jméno",
             "firstname.placeholder": "Vaše křestní jméno",

--- a/generators/languages/templates/src/main/webapp/i18n/da/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/da/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Kodeord for [<b>{{username}}</b>]",
+        "title": "Kodeord for [<strong>{{username}}</strong>]",
         "form": {
             "button": "Gem"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/da/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/da/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktive sessioner for [<b>{{username}}</b>]",
+        "title": "Aktive sessioner for [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP-adresse",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/da/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/da/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Brugerindstillinger for [<b>{{username}}</b>]",
+        "title": "Brugerindstillinger for [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Fornavn",
             "firstname.placeholder": "Dit fornavn",

--- a/generators/languages/templates/src/main/webapp/i18n/de/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/de/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Passwort für [<b>{{username}}</b>]",
+        "title": "Passwort für [<strong>{{username}}</strong>]",
         "form": {
             "button": "Speichern"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/de/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/de/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktive Sitzungen für [<b>{{username}}</b>]",
+        "title": "Aktive Sitzungen für [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP Adresse",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/de/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/de/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Einstellungen für Benutzer [<b>{{username}}</b>]",
+        "title": "Einstellungen für Benutzer [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Vorname",
             "firstname.placeholder": "Ihr Vorname",

--- a/generators/languages/templates/src/main/webapp/i18n/el/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/el/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Κωδικός για τον χρηστη: [<b>{{username}}</b>]",
+        "title": "Κωδικός για τον χρηστη: [<strong>{{username}}</strong>]",
         "form": {
             "button": "Αποθήκευση"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/el/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/el/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Ενεργές συνεδρίες για τον χρηστη [<b>{{username}}</b>]",
+        "title": "Ενεργές συνεδρίες για τον χρηστη [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Διεύθυνση IP",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/el/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/el/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Ρυθμίσεις για τον χρηστη [<b>{{username}}</b>]",
+        "title": "Ρυθμίσεις για τον χρηστη [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "First Name",
             "firstname.placeholder": "Το μικρό σας όνομα",

--- a/generators/languages/templates/src/main/webapp/i18n/en/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Password for [<b>{{username}}</b>]",
+        "title": "Password for [<strong>{{username}}</strong>]",
         "form": {
             "button": "Save"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/en/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Active sessions for [<b>{{username}}</b>]",
+        "title": "Active sessions for [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP address",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/en/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "User settings for [<b>{{username}}</b>]",
+        "title": "User settings for [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "First Name",
             "firstname.placeholder": "Your first name",

--- a/generators/languages/templates/src/main/webapp/i18n/es/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/es/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Contraseña de [<b>{{username}}</b>]",
+        "title": "Contraseña de [<strong>{{username}}</strong>]",
         "form": {
             "button": "Guardar"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/es/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/es/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sesiones activas para [<b>{{username}}</b>]",
+        "title": "Sesiones activas para [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Dirección IP",
             "useragent": "Agente de usuario",

--- a/generators/languages/templates/src/main/webapp/i18n/es/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/es/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Ajustes del usuario [<b>{{username}}</b>]",
+        "title": "Ajustes del usuario [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Nombre",
             "firstname.placeholder": "Su nombre",

--- a/generators/languages/templates/src/main/webapp/i18n/et/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/et/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Salasõna kasutajale [<b>{{username}}</b>]",
+        "title": "Salasõna kasutajale [<strong>{{username}}</strong>]",
         "form": {
             "button": "Salvesta"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/et/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/et/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Kasutaja [<b>{{username}}</b>] aktiivsed sessioonid",
+        "title": "Kasutaja [<strong>{{username}}</strong>] aktiivsed sessioonid",
         "table": {
             "ipaddress": "IP aadress",
             "useragent": "Veebilehitseja",

--- a/generators/languages/templates/src/main/webapp/i18n/et/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/et/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Kasutaja [<b>{{username}}</b>] sätted",
+        "title": "Kasutaja [<strong>{{username}}</strong>] sätted",
         "form": {
             "firstname": "Eesnimi",
             "firstname.placeholder": "Teie eesnimi",

--- a/generators/languages/templates/src/main/webapp/i18n/fa/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "رمزعبور برای [<b>{{username}}</b>]",
+        "title": "رمزعبور برای [<strong>{{username}}</strong>]",
         "form": {
             "button": "ذخیره"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/fa/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "نشست های فعال برای [<b>{{username}}</b>]",
+        "title": "نشست های فعال برای [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP آدرس",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/fa/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "تنظیمات کاربر برای [<b>{{username}}</b>]",
+        "title": "تنظیمات کاربر برای [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "نام",
             "firstname.placeholder": "نام شما",

--- a/generators/languages/templates/src/main/webapp/i18n/fr/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Changer le mot de passe pour [<b>{{username}}</b>]",
+        "title": "Changer le mot de passe pour [<strong>{{username}}</strong>]",
         "form": {
             "button": "Sauvegarder"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/fr/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sessions actives de [<b>{{username}}</b>]",
+        "title": "Sessions actives de [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Adresse IP",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/fr/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Profil de l'utilisateur [<b>{{username}}</b>]",
+        "title": "Profil de l'utilisateur [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Prénom",
             "firstname.placeholder": "Votre prénom",

--- a/generators/languages/templates/src/main/webapp/i18n/gl/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Contrasinal de [<b>{{username}}</b>]",
+        "title": "Contrasinal de [<strong>{{username}}</strong>]",
         "form": {
             "button": "Gardar"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/gl/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sesións activas para [<b>{{username}}</b>]",
+        "title": "Sesións activas para [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Dirección IP",
             "useragent": "Axente de usuario",

--- a/generators/languages/templates/src/main/webapp/i18n/gl/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Axustes do usuario para [<b>{{username}}</b>]",
+        "title": "Axustes do usuario para [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Nome",
             "firstname.placeholder": "O seu nome",

--- a/generators/languages/templates/src/main/webapp/i18n/hi/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] के लिए पासवर्ड",
+        "title": "[<strong>{{username}}</strong>] के लिए पासवर्ड",
         "form": {
             "button": "सहेजें"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/hi/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>] के सक्रिय सत्र",
+        "title": "[<strong>{{username}}</strong>] के सक्रिय सत्र",
         "table": {
             "ipaddress": "IP address",
             "useragent": "उपयोगकर्ता एजेंट",

--- a/generators/languages/templates/src/main/webapp/i18n/hi/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] के लिए User सेटिंग्स",
+        "title": "[<strong>{{username}}</strong>] के लिए User सेटिंग्स",
         "form": {
             "firstname": "प्रथम नाम",
             "firstname.placeholder": "प्रथम नाम",

--- a/generators/languages/templates/src/main/webapp/i18n/hu/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Jelszó [<b>{{username}}</b>]-nak",
+        "title": "Jelszó [<strong>{{username}}</strong>]-nak",
         "form": {
             "button": "Mentés"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/hu/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>]-hoz tartozó aktív munkamenetek",
+        "title": "[<strong>{{username}}</strong>]-hoz tartozó aktív munkamenetek",
         "table": {
             "ipaddress": "IP cím",
             "useragent": "Böngésző típusa",

--- a/generators/languages/templates/src/main/webapp/i18n/hu/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Felhasználói beállítások [<b>{{username}}</b>]-nak",
+        "title": "Felhasználói beállítások [<strong>{{username}}</strong>]-nak",
         "form": {
             "firstname": "Keresztnév",
             "firstname.placeholder": "Az Ön keresztneve",

--- a/generators/languages/templates/src/main/webapp/i18n/hy/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Գաղտնաբառ [<b>{{username}}</b>] համար",
+        "title": "Գաղտնաբառ [<strong>{{username}}</strong>] համար",
         "form": {
             "button": "Պահպանել "
         },

--- a/generators/languages/templates/src/main/webapp/i18n/hy/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Ակտիվ  միացումներ [<b>{{username}}</b>] համար",
+        "title": "Ակտիվ  միացումներ [<strong>{{username}}</strong>] համար",
         "table": {
             "ipaddress": "IP հասցե",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/hy/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Օգտվողի կարգավորումներ [<b>{{username}}</b>]",
+        "title": "Օգտվողի կարգավորումներ [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Անուն",
             "firstname.placeholder": "Ձեր անունը",

--- a/generators/languages/templates/src/main/webapp/i18n/id/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/id/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Password untuk [<b>{{username}}</b>]",
+        "title": "Password untuk [<strong>{{username}}</strong>]",
         "form": {
             "button": "Simpan"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/id/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/id/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sesi aktif untuk [<b>{{username}}</b>]",
+        "title": "Sesi aktif untuk [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Alamat IP",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/id/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/id/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Pengaturan pengguna untuk [<b>{{username}}</b>]",
+        "title": "Pengaturan pengguna untuk [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Nama depan",
             "firstname.placeholder": "Nama depan anda",

--- a/generators/languages/templates/src/main/webapp/i18n/it/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/it/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Password per [<b>{{username}}</b>]",
+        "title": "Password per [<strong>{{username}}</strong>]",
         "form": {
             "button": "Salva"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/it/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/it/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sessioni attive per [<b>{{username}}</b>]",
+        "title": "Sessioni attive per [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Indirizzo IP",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/it/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/it/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Impostazioni per l'utente [<b>{{username}}</b>]",
+        "title": "Impostazioni per l'utente [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Nome",
             "firstname.placeholder": "Il tuo nome",

--- a/generators/languages/templates/src/main/webapp/i18n/ja/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ja/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>]のパスワード",
+        "title": "[<strong>{{username}}</strong>]のパスワード",
         "form": {
             "button": "保存"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ja/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ja/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>]のアクティブセッション",
+        "title": "[<strong>{{username}}</strong>]のアクティブセッション",
         "table": {
             "ipaddress": "IPアドレス",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/ja/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ja/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>]の設定",
+        "title": "[<strong>{{username}}</strong>]の設定",
         "form": {
             "firstname": "名",
             "firstname.placeholder": "名",

--- a/generators/languages/templates/src/main/webapp/i18n/ko/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] 비밀번호",
+        "title": "[<strong>{{username}}</strong>] 비밀번호",
         "form": {
             "button": "저장"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ko/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>] Active 세션",
+        "title": "[<strong>{{username}}</strong>] Active 세션",
         "table": {
             "ipaddress": "IP 주소",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/ko/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] 사용자 설정",
+        "title": "[<strong>{{username}}</strong>] 사용자 설정",
         "form": {
             "firstname": "이름",
             "firstname.placeholder": "이름",

--- a/generators/languages/templates/src/main/webapp/i18n/mr/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "पासवर्ड  [<b>{{username}}</b>]",
+        "title": "पासवर्ड  [<strong>{{username}}</strong>]",
         "form": {
             "button": "जतन करा"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/mr/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "सक्रिय सत्र [<b>{{username}}</b>]",
+        "title": "सक्रिय सत्र [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP address",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/mr/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "वापरकर्ता सेटिंग्ज [<b>{{username}}</b>]",
+        "title": "वापरकर्ता सेटिंग्ज [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "नाव",
             "firstname.placeholder": "आपले नाव",

--- a/generators/languages/templates/src/main/webapp/i18n/my/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/my/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] အတွက် လျှို့ဝှက်ကုဒ်",
+        "title": "[<strong>{{username}}</strong>] အတွက် လျှို့ဝှက်ကုဒ်",
         "form": {
             "button": "သိမ်းမည်"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/my/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/my/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Active sessions for [<b>{{username}}</b>]",
+        "title": "Active sessions for [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP address",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/my/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/my/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "အသုံးပြုသူ [<b>{{username}}</b>] ၏ settings",
+        "title": "အသုံးပြုသူ [<strong>{{username}}</strong>] ၏ settings",
         "form": {
             "firstname": "အမည်",
             "firstname.placeholder": "သင်၏အမည်",

--- a/generators/languages/templates/src/main/webapp/i18n/nl/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Wachtwoord voor [<b>{{username}}</b>]",
+        "title": "Wachtwoord voor [<strong>{{username}}</strong>]",
         "form": {
             "button": "Opslaan"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/nl/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Actieve sessies voor [<b>{{username}}</b>]",
+        "title": "Actieve sessies voor [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP adres",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/nl/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Gebruikersinstellingen voor [<b>{{username}}</b>]",
+        "title": "Gebruikersinstellingen voor [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Voornaam",
             "firstname.placeholder": "Uw voornaam",

--- a/generators/languages/templates/src/main/webapp/i18n/pl/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Hasło dla [<b>{{username}}</b>]",
+        "title": "Hasło dla [<strong>{{username}}</strong>]",
         "form": {
             "button": "Zapisz"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/pl/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktywne sesje dla użytkownika [<b>{{username}}</b>]",
+        "title": "Aktywne sesje dla użytkownika [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Adres IP",
             "useragent": "Przeglądarka użytkownika",

--- a/generators/languages/templates/src/main/webapp/i18n/pl/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Ustawienia dla użytkownika [<b>{{username}}</b>]",
+        "title": "Ustawienia dla użytkownika [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Imię",
             "firstname.placeholder": "Twoje imię",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Senha para [<b>{{username}}</b>]",
+        "title": "Senha para [<strong>{{username}}</strong>]",
         "form": {
             "button": "Salvar"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sessões ativas para [<b>{{username}}</b>]",
+        "title": "Sessões ativas para [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP",
             "useragent": "Agente",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Configurações para o usuário [<b>{{username}}</b>]",
+        "title": "Configurações para o usuário [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Primeiro nome",
             "firstname.placeholder": "Seu primeiro nome",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Palavra-passe para [<b>{{username}}</b>]",
+        "title": "Palavra-passe para [<strong>{{username}}</strong>]",
         "form": {
             "button": "Guardar"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sessões ativas para [<b>{{username}}</b>]",
+        "title": "Sessões ativas para [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP",
             "useragent": "Agente",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Configurações para o utilizador [<b>{{username}}</b>]",
+        "title": "Configurações para o utilizador [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Nome",
             "firstname.placeholder": "O seu primeiro nome",

--- a/generators/languages/templates/src/main/webapp/i18n/ro/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Parola pentru [<b>{{username}}</b>]",
+        "title": "Parola pentru [<strong>{{username}}</strong>]",
         "form": {
             "button": "Salvare"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ro/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Sesiuni active pentru [<b>{{username}}</b>]",
+        "title": "Sesiuni active pentru [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Adresa IP",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/ro/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Setări pentru [<b>{{username}}</b>]",
+        "title": "Setări pentru [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Prenume",
             "firstname.placeholder": "Prenumele dumneavoastră",

--- a/generators/languages/templates/src/main/webapp/i18n/ru/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Пароль для [<b>{{username}}</b>]",
+        "title": "Пароль для [<strong>{{username}}</strong>]",
         "form": {
             "button": "Сохранить"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ru/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Активные сессии для [<b>{{username}}</b>]",
+        "title": "Активные сессии для [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP адрес",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/ru/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Настройки пользователя для [<b>{{username}}</b>]",
+        "title": "Настройки пользователя для [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Имя",
             "firstname.placeholder": "Ваше имя",

--- a/generators/languages/templates/src/main/webapp/i18n/sk/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Heslo pre [<b>{{username}}</b>]",
+        "title": "Heslo pre [<strong>{{username}}</strong>]",
         "form": {
             "button": "Uložiť"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/sk/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktívne sedenia používateľa [<b>{{username}}</b>]",
+        "title": "Aktívne sedenia používateľa [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP adresa",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/sk/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Nastavenia používateľa [<b>{{username}}</b>]",
+        "title": "Nastavenia používateľa [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Krstné meno",
             "firstname.placeholder": "Vaše krstné meno meno",

--- a/generators/languages/templates/src/main/webapp/i18n/sr/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Lozinka za [<b>{{username}}</b>]",
+        "title": "Lozinka za [<strong>{{username}}</strong>]",
         "form": {
             "button": "Sačuvaj"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/sr/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktivne sesije za [<b>{{username}}</b>]",
+        "title": "Aktivne sesije za [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP adresa",
             "useragent": "Pretraživač",

--- a/generators/languages/templates/src/main/webapp/i18n/sr/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Podešavanja za [<b>{{username}}</b>]",
+        "title": "Podešavanja za [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Ime",
             "firstname.placeholder": "Vaše ime",

--- a/generators/languages/templates/src/main/webapp/i18n/sv/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Lösenord för [<b>{{username}}</b>]",
+        "title": "Lösenord för [<strong>{{username}}</strong>]",
         "form": {
             "button": "Spara"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/sv/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktiva sessioner för [<b>{{username}}</b>]",
+        "title": "Aktiva sessioner för [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP-adress",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/sv/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Användarinställningar för [<b>{{username}}</b>]",
+        "title": "Användarinställningar för [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Förnamn",
             "firstname.placeholder": "Ditt förnamn",

--- a/generators/languages/templates/src/main/webapp/i18n/ta/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] -யின் கடவுச்சொல்",
+        "title": "[<strong>{{username}}</strong>] -யின் கடவுச்சொல்",
         "form": {
             "button": "சேமி"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ta/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "தற்போதைய வேளைகள் [<b>{{username}}</b>]",
+        "title": "தற்போதைய வேளைகள் [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "ஐ.பி முகவரி",
             "useragent": "பிரெளஸர்",

--- a/generators/languages/templates/src/main/webapp/i18n/ta/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "User settings for [<b>{{username}}</b>]",
+        "title": "User settings for [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "முதற்பெயர்",
             "firstname.placeholder": "முதற்பெயர்",

--- a/generators/languages/templates/src/main/webapp/i18n/te/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/te/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] యొక్క రహస్య సంకేత పదం",
+        "title": "[<strong>{{username}}</strong>] యొక్క రహస్య సంకేత పదం",
         "form": {
             "button": "భద్రపరుచు"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/te/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/te/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>] యొక్క క్రియాశీల సెషన్స్",
+        "title": "[<strong>{{username}}</strong>] యొక్క క్రియాశీల సెషన్స్",
         "table": {
             "ipaddress": "ఇపి అడ్రస్",
             "useragent": "యూజర్ ఏజెంట్",

--- a/generators/languages/templates/src/main/webapp/i18n/te/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/te/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] యొక్క యూజర్ సెట్టింగులు",
+        "title": "[<strong>{{username}}</strong>] యొక్క యూజర్ సెట్టింగులు",
         "form": {
             "firstname": "పేరు",
             "firstname.placeholder": "మీ పేరు",

--- a/generators/languages/templates/src/main/webapp/i18n/th/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/th/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "รหัสผ่านสำหรับ [<b>{{username}}</b>]",
+        "title": "รหัสผ่านสำหรับ [<strong>{{username}}</strong>]",
         "form": {
             "button": "บันทึก"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/th/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/th/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Active sessions for [<b>{{username}}</b>]",
+        "title": "Active sessions for [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP address",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/th/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/th/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "การตั้งค่าสำหรับ [<b>{{username}}</b>]",
+        "title": "การตั้งค่าสำหรับ [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "ชื่อ",
             "firstname.placeholder": "ใส่ชื่อของคุณ",

--- a/generators/languages/templates/src/main/webapp/i18n/tr/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] kullanıcısı için şifre",
+        "title": "[<strong>{{username}}</strong>] kullanıcısı için şifre",
         "form": {
             "button": "Kaydet"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/tr/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>] kullanıcısı için aktif oturumlar",
+        "title": "[<strong>{{username}}</strong>] kullanıcısı için aktif oturumlar",
         "table": {
             "ipaddress": "IP adresi",
             "useragent": "Kullanıcı Bilgisi",

--- a/generators/languages/templates/src/main/webapp/i18n/tr/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Kullanıcı ayarları [<b>{{username}}</b>]",
+        "title": "Kullanıcı ayarları [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "İsim",
             "firstname.placeholder": "Adınız",

--- a/generators/languages/templates/src/main/webapp/i18n/ua/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Пароль для [<b>{{username}}</b>]",
+        "title": "Пароль для [<strong>{{username}}</strong>]",
         "form": {
             "button": "Зберегти"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/ua/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Активні сесії для [<b>{{username}}</b>]",
+        "title": "Активні сесії для [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP адреса",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/ua/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Налаштування користувача для [<b>{{username}}</b>]",
+        "title": "Налаштування користувача для [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Ім'я",
             "firstname.placeholder": "Ваше ім'я",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-lat/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-lat/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] uchun parol",
+        "title": "[<strong>{{username}}</strong>] uchun parol",
         "form": {
             "button": "Saqlash"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/uz-lat/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-lat/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>] uchun faol sessiyalar",
+        "title": "[<strong>{{username}}</strong>] uchun faol sessiyalar",
         "table": {
             "ipaddress": "IP manzil",
             "useragent": "User Agent",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-lat/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-lat/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] sozlamalari",
+        "title": "[<strong>{{username}}</strong>] sozlamalari",
         "form": {
             "firstname": "Ism",
             "firstname.placeholder": "Ismingiz",

--- a/generators/languages/templates/src/main/webapp/i18n/vi/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Mật khẩu cho tài khoản [<b>{{username}}</b>]",
+        "title": "Mật khẩu cho tài khoản [<strong>{{username}}</strong>]",
         "form": {
             "button": "Lưu"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/vi/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Các phiên đăng nhập hiện tại của [<b>{{username}}</b>]",
+        "title": "Các phiên đăng nhập hiện tại của [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "Địa chỉ IP",
             "useragent": "Trình duyệt",

--- a/generators/languages/templates/src/main/webapp/i18n/vi/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "Cài đặt người dùng của [<b>{{username}}</b>]",
+        "title": "Cài đặt người dùng của [<strong>{{username}}</strong>]",
         "form": {
             "firstname": "Tên",
             "firstname.placeholder": "Nhập tên của bạn",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] 的密码",
+        "title": "[<strong>{{username}}</strong>] 的密码",
         "form": {
             "button": "保存"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] 的用户设置",
+        "title": "[<strong>{{username}}</strong>] 的用户设置",
         "form": {
             "firstname": "名字",
             "firstname.placeholder": "您的名字",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] 的密碼",
+        "title": "[<strong>{{username}}</strong>] 的密碼",
         "form": {
             "button": "儲存"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] 使用者設定",
+        "title": "[<strong>{{username}}</strong>] 使用者設定",
         "form": {
             "firstname": "名字",
             "firstname.placeholder": "您的名字",


### PR DESCRIPTION
Follow dev best practices, see sonar analysis message:

The strong/b and em/i tags have exactly the same effect in most web browsers, but there is a fundamental difference between them: strong and em have a semantic meaning whereas b and i only convey styling information like CSS.

While b can have simply no effect on a some devices with limited display or when a screen reader software is used by a blind person, strong will:

Display the text bold in normal browsers
Speak with lower tone when using a screen reader such as Jaws
Consequently:

in order to convey semantics, the <b> and <i> tags shall never be used,
in order to convey styling information, the <b> and <i> should be avoided and CSS should be used instead.
Noncompliant Code Example
```
<i>car</i>             <!-- Noncompliant -->
<b>train</b>         <!-- Noncompliant -->
```
Compliant Solution
```
<em>car</em>
<strong>train</strong>
```
-   Please make sure the below checklist is followed for Pull Requests.
-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
