### PR TITLE
refactor: use strong instead of b tag

### DIFF
--- a/generators/languages/templates/src/main/webapp/i18n/en/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/en/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "Password for [<b>{{username}}</b>]",
+        "title": "Password for [<strong>{{username}}</strong>]",
         "form": {
             "button": "Save"
         },


### PR DESCRIPTION
Follow dev best practices, see sonar analysis message:

The `<strong>/<b>` and `<em>/<i>` tags have exactly the same effect in most web browsers, but there is a fundamental difference between them: `<strong>` and `<em>` have a semantic meaning whereas `<b>` and `<i>` only convey styling information like CSS.

While `<b>` can have simply no effect on a some devices with limited display or when a screen reader software is used by a blind person, `<strong>` will:

Display the text bold in normal browsers
Speak with lower tone when using a screen reader such as Jaws
Consequently:

in order to convey semantics, the `<b>` and `<i>` tags shall never be used,
in order to convey styling information, the `<b>` and `<i>` should be avoided and CSS should be used instead.

Noncompliant Code Example

~~~html
<i>car</i>             <!-- Noncompliant -->
<b>train</b>         <!-- Noncompliant -->
~~~

Compliant Solution

~~~html
<em>car</em>
<strong>train</strong>
~~~

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
