### PR TITLE
Facilitate troubleshooting failed CI builds

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -92,7 +92,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                 {
                     loader: 'thread-loader',
                     options: {
-                        // there should be 1 cpu for the fork-ts-checker-webpack-plugin
+                        // There should be 1 cpu for the fork-ts-checker-webpack-plugin.
+                        // The value may need to be adjusted (e.g. to 1) in some CI environments,
+                        // as cpus() may report more cores than what are available to the build.
                         workers: require('os').cpus().length - 1
                     }
                 },

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -38,7 +38,9 @@ const getTsLoaderRule = env => {
     {
       loader: 'thread-loader',
       options: {
-        // there should be 1 cpu for the fork-ts-checker-webpack-plugin
+        // There should be 1 cpu for the fork-ts-checker-webpack-plugin.
+        // The value may need to be adjusted (e.g. to 1) in some CI environments,
+        // as cpus() may report more cores than what are available to the build.
         workers: require('os').cpus().length - 1
       }
     },


### PR DESCRIPTION
`requires('os').cpus().length` reports an inaccurate value in certain CI environments that use virtualization (e.g. CircleCI). This can result in usage of resources that exceeds what is available to a CI build.


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->