### PR TITLE
angular: simplify entity route adding

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/entities/entity.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/entities/entity.module.ts.ejs
@@ -19,6 +19,7 @@
 import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
+// prettier-ignore
 @NgModule({
     imports: [
         RouterModule.forChild([

--- a/generators/internal/needle-api/needle-client-angular.js
+++ b/generators/internal/needle-api/needle-client-angular.js
@@ -20,7 +20,6 @@ const chalk = require('chalk');
 const _ = require('lodash');
 const needleClientBase = require('./needle-client');
 const constants = require('../../generator-constants');
-const jhipsterUtils = require('../../utils');
 
 const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 
@@ -186,21 +185,16 @@ module.exports = class extends needleClientBase {
 
         try {
             const appName = this.generator.getAngularXAppName();
-            const isEntityAlreadyGenerated = jhipsterUtils.checkStringInFile(entityModulePath, 'loadChildren', this.generator);
             const modulePath = `./${entityFolderName}/${entityFileName}.module`;
             const moduleName = microServiceName
                 ? `${this.generator.upperFirstCamelCase(microServiceName)}${entityAngularName}Module`
                 : `${appName}${entityAngularName}Module`;
 
-            const splicable = isEntityAlreadyGenerated
-                ? `|,{
-                        |                path: '${entityUrl}',
-                        |                loadChildren: '${modulePath}#${moduleName}'
-                        |            }`
-                : `|{
+            const splicable = `|{
                             |                path: '${entityUrl}',
                             |                loadChildren: '${modulePath}#${moduleName}'
-                            |            }`;
+                            |            },`;
+
             const rewriteFileModel = this.generateFileModel(
                 entityModulePath,
                 'jhipster-needle-add-entity-route',


### PR DESCRIPTION
As discussed in #9179 

We know make use of `prettier-ignore` in order to prevent prettier from removing trailing commas.
Thus, it simplifies the entity route generation as we always add a trailing comma after each route.

closes #9178 
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
