### PR TITLE
upgrade jest for v5.x

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -27,27 +27,27 @@
     "node_modules"
   ],
   "dependencies": {
-    "@angular/common": "7.2.2",
-    "@angular/compiler": "7.2.2",
-    "@angular/core": "7.2.2",
-    "@angular/forms": "7.2.2",
-    "@angular/platform-browser": "7.2.2",
-    "@angular/platform-browser-dynamic": "7.2.2",
-    "@angular/router": "7.2.2",
+    "@angular/common": "7.2.4",
+    "@angular/compiler": "7.2.4",
+    "@angular/core": "7.2.4",
+    "@angular/forms": "7.2.4",
+    "@angular/platform-browser": "7.2.4",
+    "@angular/platform-browser-dynamic": "7.2.4",
+    "@angular/router": "7.2.4",
     "@fortawesome/angular-fontawesome": "0.3.0",
-    "@fortawesome/fontawesome-svg-core": "1.2.12",
-    "@fortawesome/free-solid-svg-icons": "5.6.3",
-    "@ng-bootstrap/ng-bootstrap": "4.0.1",
+    "@fortawesome/fontawesome-svg-core": "1.2.14",
+    "@fortawesome/free-solid-svg-icons": "5.7.1",
+    "@ng-bootstrap/ng-bootstrap": "4.0.2",
     "@ngx-translate/core": "11.0.1",
     "@ngx-translate/http-loader": "4.0.0",
     "bootstrap": "4.2.1",
-    "core-js": "2.6.3",
+    "core-js": "2.6.4",
     "moment": "2.24.0",
     "ng-jhipster": "0.9.1",
     "ngx-cookie": "2.0.1",
     "ngx-infinite-scroll": "7.0.1",
     "ngx-webstorage": "2.0.1",
-    "rxjs": "6.3.3",
+    "rxjs": "6.4.0",
     "swagger-ui": "2.2.10",
     <%_ if (websocket === 'spring-websocket') { _%>
     "sockjs-client": "1.3.0",
@@ -57,24 +57,24 @@
     "zone.js": "0.8.29"
   },
   "devDependencies": {
-    "@angular/cli": "7.2.3",
-    "@angular/compiler-cli": "7.2.2",
-    "@ngtools/webpack": "7.2.3",
+    "@angular/cli": "7.3.1",
+    "@angular/compiler-cli": "7.2.4",
+    "@ngtools/webpack": "7.3.1",
     <%_ if (protractorTests) { _%>
     "@types/chai": "4.1.7",
     "@types/chai-string": "1.4.1",
     <%_ } _%>
-    "@types/jest": "23.3.13",
+    "@types/jest": "24.0.0",
     <%_ if (protractorTests) { _%>
     "@types/mocha": "5.2.5",
     <%_ } _%>
-    "@types/node": "10.12.18",
+    "@types/node": "10.12.24",
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "3.0.14",
     <%_ } _%>
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",
-    "autoprefixer": "9.4.6",
+    "autoprefixer": "9.4.7",
     "browser-sync": "2.26.3",
     "browser-sync-webpack-plugin": "2.2.2",
     "cache-loader": "2.0.1",
@@ -95,12 +95,12 @@
     <%_ if (!skipCommitHook) { _%>
     "husky": "1.3.1",
     <%_ } _%>
-    "jest": "23.6.0",
-    "jest-junit": "6.1.0",
+    "jest": "24.1.0",
+    "jest-junit": "6.2.1",
     "jest-preset-angular": "6.0.2",
     "jest-sonar-reporter": "2.0.0",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "8.1.0",
+    "lint-staged": "8.1.3",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.18",
@@ -111,7 +111,7 @@
     "mini-css-extract-plugin": "0.5.0",
     "moment-locales-webpack-plugin": "1.0.7",
     "optimize-css-assets-webpack-plugin": "5.0.1",
-    "prettier": "1.16.1",
+    "prettier": "1.16.4",
     <%_ if (protractorTests) { _%>
     "protractor": "5.4.2",
     <%_ } _%>
@@ -119,19 +119,19 @@
     "rimraf": "2.6.3",
     "simple-progress-webpack-plugin": "1.1.2",
     "style-loader": "0.23.1",
-    "terser-webpack-plugin": "1.2.1",
-    "thread-loader": "2.1.1",
+    "terser-webpack-plugin": "1.2.2",
+    "thread-loader": "2.1.2",
     "to-string-loader": "1.1.5",
     <%_ if (protractorTests) { _%>
-    "ts-node": "8.0.1",
+    "ts-node": "8.0.2",
     <%_ } _%>
     "ts-loader": "5.3.3",
     "tslint": "5.12.1",
-    "tslint-config-prettier": "1.17.0",
+    "tslint-config-prettier": "1.18.0",
     "tslint-loader": "3.6.0",
-    "typescript": "3.2.2",
+    "typescript": "3.3.3",
     <%_ if (useSass) { _%>
-    "sass": "1.16.1",
+    "sass": "1.17.0",
     "sass-loader": "7.1.0",
     <%_ } _%>
     "postcss-loader": "3.0.0",
@@ -141,8 +141,8 @@
     <%_ otherModules.forEach(module => { _%>
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
-    "webpack": "4.29.0",
-    "webpack-cli": "3.2.1",
+    "webpack": "4.29.3",
+    "webpack-cli": "3.2.3",
     "webpack-dev-server": "3.1.14",
     "webpack-merge": "4.2.1",
     "webpack-notifier": "1.7.0",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -129,7 +129,7 @@
     "tslint": "5.12.1",
     "tslint-config-prettier": "1.18.0",
     "tslint-loader": "3.6.0",
-    "typescript": "3.3.3",
+    "typescript": "3.2.4",
     <%_ if (useSass) { _%>
     "sass": "1.17.0",
     "sass-loader": "7.1.0",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -68,7 +68,7 @@ limitations under the License.
     "@types/chai": "4.1.4",
     <%_ } _%>
     "@types/enzyme": "3.1.13",
-    "@types/jest": "23.3.1",
+    "@types/jest": "24.0.0",
     "@types/lodash": "4.14.116",
     <%_ if (protractorTests) { _%>
     "@types/mocha": "5.2.5",
@@ -107,8 +107,8 @@ limitations under the License.
     "husky": "1.1.0",
     <%_ } _%>
     "identity-obj-proxy": "3.0.0",
-    "jest": "23.5.0",
-    "jest-junit": "5.1.0",
+    "jest": "24.1.0",
+    "jest-junit": "6.2.1",
     "jest-sonar-reporter": "2.0.0",
     "json-loader": "0.5.7",
     <%_ if (!skipCommitHook) { _%>


### PR DESCRIPTION
Fix #9298 (Windows + Jest issue)  by upgrading Jest to v24.1.0

I cherrypicked @DanielFran's Angular dependency update from master (which had this change), upgraded React's Jest for on its own.

I can open another PR for master React, but I'll probably leave it for #9285

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
