### PR TITLE
Add missing jhipster.clientApp.name to application.yml used for tests.

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -288,7 +288,7 @@ info:
 
 jhipster:
     clientApp:
-        name: <%= angularAppName %>
+        name: "<%= angularAppName %>"
     # By default CORS is disabled. Uncomment to enable.
     #cors:
         #allowed-origins: "*"

--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -163,6 +163,8 @@ server:
 # ===================================================================
 
 jhipster:
+    clientApp:
+        name: "<%= angularAppName %>"
     # To test logstash appender
     logging:
         logstash:


### PR DESCRIPTION
The following PR fixes issue reported by @cbornet at https://github.com/jhipster/generator-jhipster/pull/9283#issuecomment-465360644 caused by merge of #9283 

It contains the following changes:
- Add missing `jhipster.clientApp.name` to `application.yml` used for tests.
- Enclose `jhipster.clientApp.name` within double quotes

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
