### PR TITLE
Apply npm lint before npm test

### DIFF
--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -557,9 +557,12 @@ module.exports = class extends BaseGenerator {
 
                 const name = this.gcpCloudSqlInstanceName;
                 // for mysql keep default options, set specific option for pg
-                const dbVersionFlag = this.prodDatabaseType === 'postgresql' ? ' --database-version="POSTGRES_9_6" --tier="db-g1-small"' : '';
+                const dbVersionFlag =
+                    this.prodDatabaseType === 'postgresql' ? ' --database-version="POSTGRES_9_6" --tier="db-g1-small"' : '';
 
-                const cmd = `gcloud sql instances create "${name}" --region='${this.gaeLocation}' --project=${this.gcpProjectId}${dbVersionFlag}`;
+                const cmd = `gcloud sql instances create "${name}" --region='${this.gaeLocation}' --project=${
+                    this.gcpProjectId
+                }${dbVersionFlag}`;
                 this.log(chalk.bold(`\n... Running: ${cmd}`));
 
                 exec(cmd, (err, stdout, stderr) => {

--- a/package.json
+++ b/package.json
@@ -43,8 +43,7 @@
         "eslint": "eslint .",
         "ejs-lint": "npm run test:unit -- test/ejslint.js",
         "ejslint": "ejslint",
-        "pretest": "npm run lint-fix",
-        "prepublish": "npm run lint-fix",
+        "pretest": "npm run lint",
         "test": "npm run test:unit -- test/**/*.spec.js test/*.spec.js --no-insight",
         "test:unit": "mocha --timeout 20000 --slow 0 --reporter spec",
         "jsdoc": "jsdoc --configure jsdoc-conf.json"


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/commit/c7fb5c6108487be127c4e8da4b05625e521bd06c#r32293602 and fix https://github.com/jhipster/generator-jhipster/issues/9290

With this change:
- if the code is not well formated, the `npm test` will fail :

```
07:46:08 in projects/jhipster/generator-jhipster on  master [⇡!] 
➜ npm test

> generator-jhipster@5.8.1 pretest /home/pgrimaud/projects/jhipster/generator-jhipster
> npm run lint


> generator-jhipster@5.8.1 lint /home/pgrimaud/projects/jhipster/generator-jhipster
> npm run eslint && npm run ejs-lint


> generator-jhipster@5.8.1 eslint /home/pgrimaud/projects/jhipster/generator-jhipster
> eslint .


/home/pgrimaud/projects/jhipster/generator-jhipster/generators/gae/index.js
  560:38   error  Insert `⏎···················`                                                               prettier/prettier
  562:111  error  Replace `this.gcpProjectId` with `⏎····················this.gcpProjectId⏎················`  prettier/prettier

✖ 2 problems (2 errors, 0 warnings)
  2 errors and 0 warnings potentially fixable with the `--fix` option.

npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! generator-jhipster@5.8.1 eslint: `eslint .`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the generator-jhipster@5.8.1 eslint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pgrimaud/.npm/_logs/2019-02-20T06_46_22_905Z-debug.log
npm ERR! code ELIFECYCLE
npm ERR! errno 1
npm ERR! generator-jhipster@5.8.1 lint: `npm run eslint && npm run ejs-lint`
npm ERR! Exit status 1
npm ERR! 
npm ERR! Failed at the generator-jhipster@5.8.1 lint script.
npm ERR! This is probably not a problem with npm. There is likely additional logging output above.

npm ERR! A complete log of this run can be found in:
npm ERR!     /home/pgrimaud/.npm/_logs/2019-02-20T06_46_22_927Z-debug.log
npm ERR! Test failed.  See above for more details.
```

- The `npm ci && npm link` won't launch full prettier:format so it will speed up the builds:

```
07:46:23 in projects/jhipster/generator-jhipster on  master [⇡!] took 12s 
➜ npm ci && npm link
npm WARN prepare removing existing node_modules/ before installation

> spawn-sync@1.0.15 postinstall /home/pgrimaud/projects/jhipster/generator-jhipster/node_modules/spawn-sync
> node postinstall

added 711 packages in 6.973s
audited 6642 packages in 5.934s
found 0 vulnerabilities

/home/pgrimaud/.npm-global/bin/jhipster -> /home/pgrimaud/.npm-global/lib/node_modules/generator-jhipster/cli/jhipster.js
/home/pgrimaud/.npm-global/lib/node_modules/generator-jhipster -> /home/pgrimaud/projects/jhipster/generator-jhipster
```


_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
