### PR TITLE
[v5 maintenance] add needle api unit tests

### DIFF
--- a/generators/internal/needle-api/needle-base.js
+++ b/generators/internal/needle-api/needle-base.js
@@ -26,14 +26,7 @@ module.exports = class {
 
     addBlockContentToFile(rewriteFileModel, errorMessage) {
         try {
-            jhipsterUtils.rewriteFile(
-                {
-                    file: rewriteFileModel.file,
-                    needle: rewriteFileModel.needle,
-                    splicable: rewriteFileModel.splicable
-                },
-                this.generator
-            );
+            jhipsterUtils.rewriteFile(rewriteFileModel, this.generator);
         } catch (e) {
             this.logNeedleNotFound(e, errorMessage, rewriteFileModel.file);
         }

--- a/generators/internal/needle-api/needle-server-maven.js
+++ b/generators/internal/needle-api/needle-server-maven.js
@@ -36,7 +36,7 @@ module.exports = class extends needleServer {
             dependency += `                <type>${type}</type>\n`;
         }
         if (scope) {
-            dependency += `                <scope>${version}</scope>\n`;
+            dependency += `                <scope>${scope}</scope>\n`;
         }
         if (other) {
             dependency += `${other}\n`;

--- a/test/needle-api/needle-client-i18n.spec.js
+++ b/test/needle-api/needle-client-i18n.spec.js
@@ -1,0 +1,118 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const fse = require('fs-extra');
+const LanguagesGenerator = require('../../generators/languages');
+const constants = require('../../generators/generator-constants');
+
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+
+const mockBlueprintSubGen = class extends LanguagesGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupEntityOptions(this, jhContext, this);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            addElementInTranslation() {
+                this.addElementTranslationKey('my_key', 'My value', 'en');
+                this.addElementTranslationKey('ma_cle', 'Ma valeur', 'fr');
+            },
+            addAdminElementTranslationKey() {
+                this.addAdminElementTranslationKey('my_admin_key', 'my admin value', 'en');
+                this.addAdminElementTranslationKey('ma_cle_admin', 'ma valeur admin', 'fr');
+            },
+            addEntityTranslationKey() {
+                this.addEntityTranslationKey('my_entity_key', 'my entity value', 'en');
+                this.addEntityTranslationKey('ma_cle_entite', 'ma valeur entite', 'fr');
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API i18n: JHipster language generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate client with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/languages'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../../test/templates/ngx-blueprint'), dir);
+                    })
+                    .withOptions({
+                        'from-cli': true,
+                        build: 'maven',
+                        auth: 'jwt',
+                        db: 'mysql',
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:languages']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        clientFramework: 'angularX',
+                        useSass: true,
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['en', 'fr']
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert english global.json contain the new key', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/en/global.json`, '"my_key": "My Value",');
+            });
+
+            it('Assert french global.json contain the new key', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/fr/global.json`, '"ma_cle": "Ma Valeur",');
+            });
+
+            it('Assert english admin global.json contain the new key', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/en/global.json`, '"my_admin_key": "My Admin Value",');
+            });
+
+            it('Assert french admin global.json contain the new key', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/fr/global.json`, '"ma_cle_admin": "Ma Valeur Admin",');
+            });
+
+            it('Assert english entity global.json contain the new key', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/en/global.json`, '"my_entity_key": "My Entity Value",');
+            });
+
+            it('Assert french entity global.json contain the new key', () => {
+                assert.fileContent(`${CLIENT_MAIN_SRC_DIR}i18n/fr/global.json`, '"ma_cle_entite": "Ma Valeur Entite",');
+            });
+        });
+    });
+});

--- a/test/needle-api/needle-client-webpack.spec.js
+++ b/test/needle-api/needle-client-webpack.spec.js
@@ -1,0 +1,97 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ClientGenerator = require('../../generators/client');
+const constants = require('../../generators/generator-constants');
+
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+const CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
+const microserviceName = 'myMicroService';
+const assetFrom = 'source';
+const assetTo = 'target';
+
+const mockBlueprintSubGen = class extends ClientGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupEntityOptions(this, jhContext, this);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            webpackPhase() {
+                this.addEntityToWebpack(microserviceName);
+                this.copyExternalAssetsInWebpack(assetFrom, assetTo);
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API Webpack: JHipster client generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate client with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/client'))
+                    .withOptions({
+                        'from-cli': true,
+                        build: 'maven',
+                        auth: 'jwt',
+                        db: 'mysql',
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:client']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        clientFramework: 'angularX',
+                        useSass: true,
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['en', 'fr']
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert microservice name is added to webpack.dev.js in lowercase', () => {
+                assert.fileContent(`${CLIENT_WEBPACK_DIR}/webpack.dev.js`, `'/${microserviceName.toLowerCase()}',`);
+            });
+
+            it('Assert external asset is added to webpack.common.js', () => {
+                const from = `${CLIENT_MAIN_SRC_DIR}content/${assetFrom}/`;
+                const to = `content/${assetTo}/`;
+
+                assert.fileContent(`${CLIENT_WEBPACK_DIR}/webpack.common.js`, `{ from: './${from}', to: '${to}' },`);
+            });
+        });
+    });
+});

--- a/test/needle-api/needle-server-cache.spec.js
+++ b/test/needle-api/needle-server-cache.spec.js
@@ -1,0 +1,205 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ServerGenerator = require('../../generators/server');
+const constants = require('../../generators/generator-constants');
+
+const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
+
+const mockBlueprintSubGen = class extends ServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupServerOptions(this, jhContext);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            ehCacheStep() {
+                if (this.cacheProvider === 'ehcache') {
+                    this.addEntryToEhcache('entry', 'com/mycompany/myapp');
+                    this.addEntityToEhcache(
+                        'entityClass',
+                        [
+                            { relationshipType: 'one-to-many', relationshipFieldNamePlural: 'entitiesOneToMany' },
+                            { relationshipType: 'many-to-many', relationshipFieldNamePlural: 'entitiesManoToMany' }
+                        ],
+                        'com.mycompany.myapp',
+                        'com/mycompany/myapp'
+                    );
+                }
+            },
+            infinispanCacheStep() {
+                if (this.cacheProvider === 'infinispan') {
+                    this.addEntryToCache('entry', 'com/mycompany/myapp', 'infinispan');
+                    this.addEntityToCache(
+                        'entityClass',
+                        [
+                            { relationshipType: 'one-to-many', relationshipFieldNamePlural: 'entitiesOneToMany' },
+                            { relationshipType: 'many-to-many', relationshipFieldNamePlural: 'entitiesManoToMany' }
+                        ],
+                        'com.mycompany.myapp',
+                        'com/mycompany/myapp',
+                        'infinispan'
+                    );
+                }
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API server cache: JHipster server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/server'))
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:server']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'ehcache',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert ehCache configuration has entry added', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    'cm.createCache(entry, jcacheConfiguration);'
+                );
+            });
+
+            it('Assert ehCache configuration has entity added', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    'cm.createCache(com.mycompany.myapp.domain.entityClass.class.getName(), jcacheConfiguration);'
+                );
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    'cm.createCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesOneToMany", jcacheConfiguration);'
+                );
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    'cm.createCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesManoToMany", jcacheConfiguration);'
+                );
+            });
+        });
+    });
+});
+
+describe('needle API server cache: JHipster server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/server'))
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:server']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'infinispan',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert Infinispan configuration has entity added', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    '            registerPredefinedCache(entry, new JCache<Object, Object>(\n' +
+                        '                cacheManager.getCache(entry).getAdvancedCache(), this,\n' +
+                        '                ConfigurationAdapter.create()));'
+                );
+            });
+
+            it('Assert Infinispan configuration has entity added', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    '            registerPredefinedCache(com.mycompany.myapp.domain.entityClass.class.getName(), new JCache<Object, Object>(\n' +
+                        '                cacheManager.getCache(com.mycompany.myapp.domain.entityClass.class.getName()).getAdvancedCache(), this,\n' +
+                        '                ConfigurationAdapter.create()));'
+                );
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    '            registerPredefinedCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesOneToMany", new JCache<Object, Object>(\n' +
+                        '                cacheManager.getCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesOneToMany").getAdvancedCache(), this,\n' +
+                        '                ConfigurationAdapter.create()));'
+                );
+                assert.fileContent(
+                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
+                    '            registerPredefinedCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesManoToMany", new JCache<Object, Object>(\n' +
+                        '                cacheManager.getCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesManoToMany").getAdvancedCache(), this,\n' +
+                        '                ConfigurationAdapter.create()));'
+                );
+            });
+        });
+    });
+});

--- a/test/needle-api/needle-server-gradle.spec.js
+++ b/test/needle-api/needle-server-gradle.spec.js
@@ -1,0 +1,148 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ServerGenerator = require('../../generators/server');
+
+const mockBlueprintSubGen = class extends ServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupServerOptions(this, jhContext);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            gradleStep() {
+                this.addGradleProperty('name', 'value');
+                this.addGradlePlugin('group', 'name', 'version');
+                this.addGradlePluginToPluginsBlock('id', 'version');
+                this.addGradleDependencyManagement('scope1', 'group1', 'name1', 'version1');
+                this.addGradleDependencyManagement('scope2', 'group2', 'name2');
+                this.addGradleDependency('scope3', 'group3', 'name3', 'version3');
+                this.addGradleDependency('scope4', 'group4', 'name4');
+                this.addGradleDependencyInDirectory('.', 'scope5', 'group5', 'name5', 'version5');
+                this.addGradleDependencyInDirectory('.', 'scope6', 'group6', 'name6');
+                this.applyFromGradleScript('name');
+                this.addGradleMavenRepository('url', 'username', 'password');
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API server gradle: JHipster server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/server'))
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:server']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'ehcache',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'gradle',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert gradle.properties has the property added', () => {
+                assert.fileContent('gradle.properties', 'name=value');
+            });
+
+            it('Assert gradle.properties has the plugin added', () => {
+                assert.fileContent('build.gradle', 'classpath "group:name:version"');
+            });
+
+            it('Assert gradle.properties has the PluginToPluginsBlock added', () => {
+                assert.fileContent('build.gradle', 'id "id" version "version"');
+            });
+
+            it('Assert gradle.properties has the DependencyManagement with version added', () => {
+                assert.fileContent('build.gradle', 'scope1 "group1:name1:version1"');
+            });
+
+            it('Assert gradle.properties has the DependencyManagement without version added', () => {
+                assert.fileContent('build.gradle', 'scope2 "group2:name2"');
+            });
+
+            it('Assert gradle.properties has the Dependency with version added', () => {
+                assert.fileContent('build.gradle', 'scope3 "group3:name3:version3"');
+            });
+
+            it('Assert gradle.properties has the Dependency without version added', () => {
+                assert.fileContent('build.gradle', 'scope4 "group4:name4"');
+            });
+
+            it('Assert gradle.properties has the Dependency in directory with version added', () => {
+                assert.fileContent('build.gradle', 'scope5 "group5:name5:version5"');
+            });
+
+            it('Assert gradle.properties has the Dependency without version added', () => {
+                assert.fileContent('build.gradle', 'scope6 "group6:name6"');
+            });
+
+            it('Assert gradle.properties has the apply gradle script added', () => {
+                assert.fileContent('build.gradle', "apply from: 'name.gradle'");
+            });
+
+            it('Assert gradle.properties has the maven repository added', () => {
+                assert.fileContent(
+                    'build.gradle',
+                    '    maven {\n' +
+                        '        url "url"\n' +
+                        '        credentials {\n' +
+                        '            username = "username"\n' +
+                        '            password = "password"\n' +
+                        '        }\n' +
+                        '    }'
+                );
+            });
+        });
+    });
+});

--- a/test/needle-api/needle-server-liquibase.spec.js
+++ b/test/needle-api/needle-server-liquibase.spec.js
@@ -1,0 +1,175 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const fse = require('fs-extra');
+const ServerGenerator = require('../../generators/server');
+const constants = require('../../generators/generator-constants');
+
+const SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
+
+const serverFiles = {
+    serverResource: [
+        {
+            path: `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/`,
+            templates: [
+                {
+                    file: 'dummy_changelog.xml'
+                }
+            ]
+        }
+    ]
+};
+
+const mockBlueprintSubGen = class extends ServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupServerOptions(this, jhContext);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            writeTestFiles() {
+                this.writeFilesToDisk(serverFiles, this, false);
+            },
+            addChangelogStep() {
+                this.addChangelogToLiquibase('aNewChangeLog');
+                this.addConstraintsChangelogToLiquibase('aNewConstraintsChangeLog');
+                this.addLiquibaseChangelogToMaster('aNewChangeLogWithNeedle', 'jhipster-needle-liquibase-add-changelog');
+            },
+            addColumnStep() {
+                this.addColumnToLiquibaseEntityChangeset(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
+                    '            <column name="test" type="varchar(255)">\n' +
+                        '                <constraints nullable="false" />\n' +
+                        '            </column>'
+                );
+
+                this.addChangesetToLiquibaseEntityChangelog(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
+                    '    <changeSet id="20180328000000-2" author="jhipster">\n' +
+                    '        <createTable tableName="test">\n' +
+                        '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
+                        '                <constraints primaryKey="true" nullable="false"/>\n' +
+                        '            </column>\n' +
+                        '        </createTable>\n' +
+                        '    </changeSet>'
+                );
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API server liquibase: JHipster server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/server'))
+                    .inTmpDir(dir => {
+                        fse.copySync(
+                            path.join(__dirname, 'templates/src/main/resources/config/liquibase/changelog/'),
+                            `${dir}/templates/src/main/resources/config/liquibase/changelog/`
+                        );
+                    })
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:server']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'ehcache',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert changelog is added to master.xml', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/master.xml`,
+                    '<include file="config/liquibase/changelog/aNewChangeLog.xml" relativeToChangelogFile="false"/>'
+                );
+            });
+
+            it('Assert constraints changelog is added to master.xml', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/master.xml`,
+                    '<include file="config/liquibase/changelog/aNewConstraintsChangeLog.xml" relativeToChangelogFile="false"/>'
+                );
+            });
+
+            it('Assert constraints with needle changelog is added to master.xml', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/master.xml`,
+                    '<include file="config/liquibase/changelog/aNewChangeLogWithNeedle.xml" relativeToChangelogFile="false"/>'
+                );
+            });
+
+            it('Assert that column is added to an existing changelog', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
+                    '            <column name="test" type="varchar(255)">\n' +
+                        '                <constraints nullable="false" />\n' +
+                        '            </column>'
+                );
+            });
+
+            it('Assert that changeSet is added to an existing changelog', () => {
+                assert.fileContent(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
+                    '    <changeSet id="20180328000000-2" author="jhipster">\n' +
+                    '        <createTable tableName="test">\n' +
+                        '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
+                        '                <constraints primaryKey="true" nullable="false"/>\n' +
+                        '            </column>\n' +
+                        '        </createTable>\n' +
+                        '    </changeSet>'
+                );
+            });
+        });
+    });
+});

--- a/test/needle-api/needle-server-maven.spec.js
+++ b/test/needle-api/needle-server-maven.spec.js
@@ -1,0 +1,232 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ServerGenerator = require('../../generators/server');
+
+const mockBlueprintSubGen = class extends ServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupServerOptions(this, jhContext);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            mavenStep() {
+                this.addMavenDependencyManagement(
+                    'groupId',
+                    'artifactId',
+                    'version',
+                    'type',
+                    'scope',
+                    '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>'
+                );
+
+                this.addMavenRepository('id', 'url');
+                this.addMavenPluginRepository('id', 'url');
+                this.addMavenDistributionManagement('snapshotsId', 'snapshotsUrl', 'releasesId', 'releasesUrl');
+                this.addMavenProperty('name', 'value');
+                this.addMavenDependency(
+                    'groupId',
+                    'artifactId',
+                    'version',
+                    '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>'
+                );
+                this.addMavenDependencyInDirectory(
+                    '.',
+                    'groupId2',
+                    'artifactId2',
+                    'version2',
+                    '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>'
+                );
+                this.addMavenPlugin(
+                    'groupId',
+                    'artifactId',
+                    'version',
+                    '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>'
+                );
+                this.addMavenProfile('profileId', '            <other>other</other>');
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API server maven: JHipster server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/server'))
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:server']])
+                    .withPrompts({
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        serviceDiscoveryType: false,
+                        authenticationType: 'jwt',
+                        cacheProvider: 'ehcache',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('Assert pom.xml has the dependency management added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '            <dependency>\n' +
+                        '                <groupId>groupId</groupId>\n' +
+                        '                <artifactId>artifactId</artifactId>\n' +
+                        '                <version>version</version>\n' +
+                        '                <type>type</type>\n' +
+                        '                <scope>scope</scope>\n' +
+                        '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>\n' +
+                        '             </dependency>'
+                );
+            });
+
+            it('Assert pom.xml has the repository added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '        <repository>\n            <id>id</id>\n            <url>url</url>\n        </repository>'
+                );
+            });
+
+            it('Assert pom.xml has the plugin repository added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '        <pluginRepository>\n' +
+                        '            <id>id</id>\n' +
+                        '            <url>url</url>\n' +
+                        '        </pluginRepository>'
+                );
+            });
+
+            it('Assert pom.xml has the distributionManagement added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '        <repository>\n' +
+                        '            <id>releasesId</id>\n' +
+                        '            <url>releasesUrl</url>\n' +
+                        '        </repository>'
+                );
+            });
+
+            it('Assert pom.xml has the property added', () => {
+                assert.fileContent('pom.xml', '<name>value</name>');
+            });
+
+            it('Assert pom.xml has the dependencyManagement added', () => {
+                assert.fileContent('pom.xml', '');
+            });
+
+            it('Assert pom.xml has the dependency added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '        <dependency>\n' +
+                        '            <groupId>groupId</groupId>\n' +
+                        '            <artifactId>artifactId</artifactId>\n' +
+                        '            <version>version</version>\n' +
+                        '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>\n' +
+                        '        </dependency>'
+                );
+            });
+
+            it('Assert pom.xml has the dependency in directory added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '        <dependency>\n' +
+                        '            <groupId>groupId2</groupId>\n' +
+                        '            <artifactId>artifactId2</artifactId>\n' +
+                        '            <version>version2</version>\n' +
+                        '            <exclusions>\n' +
+                        '                <exclusion>\n' +
+                        '                    <groupId>aGroupId</groupId>\n' +
+                        '                    <artifactId>anArtifactId</artifactId>\n' +
+                        '                </exclusion>\n' +
+                        '            </exclusions>\n' +
+                        '        </dependency>'
+                );
+            });
+
+            it('Assert pom.xml has the profile added', () => {
+                assert.fileContent(
+                    'pom.xml',
+                    '        <profile>\n            <id>profileId</id>\n            <other>other</other>\n        </profile>'
+                );
+            });
+        });
+    });
+});

--- a/test/needle-api/templates/src/main/resources/config/liquibase/changelog/dummy_changelog.xml.ejs
+++ b/test/needle-api/templates/src/main/resources/config/liquibase/changelog/dummy_changelog.xml.ejs
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.5.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+
+    <property name="now" value="now()" dbms="h2"/>
+
+    <property name="now" value="now()" dbms="mysql"/>
+    <property name="autoIncrement" value="true"/>
+
+    <property name="floatType" value="float4" dbms="postgresql, h2"/>
+    <property name="floatType" value="float" dbms="mysql, oracle, mssql"/>
+
+    <!--
+        Added the entity Jdl.
+    -->
+    <changeSet id="20180328000000-1" author="jhipster">
+        <createTable tableName="jdl">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+
+            <column name="content" type="mediumtext">
+                <constraints nullable="true" />
+            </column>
+
+            <column name="jdl_metadata_id" type="varchar(255)">
+                <constraints nullable="false" />
+            </column>
+
+            <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
+        </createTable>
+
+        <addForeignKeyConstraint baseColumnNames="jdl_metadata_id"
+                                 baseTableName="jdl"
+                                 constraintName="fk_jdl_jdl_metadata_id"
+                                 referencedColumnNames="id"
+                                 referencedTableName="jdl_metadata"/>
+    </changeSet>
+    <changeSet id="20180328000000-2" author="jhipster">
+        <createTable tableName="test">
+            <column name="id" type="bigint" autoIncrement="${autoIncrement}">
+                <constraints primaryKey="true" nullable="false"/>
+            </column>
+            <!-- jhipster-needle-liquibase-add-column - JHipster will add columns here, do not remove-->
+        </createTable>
+    </changeSet>
+    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
+</databaseChangeLog>


### PR DESCRIPTION
same as #9254 but for v5 maintenance

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
