### PR TITLE
Add react SCSS needle public API

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -577,6 +577,29 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add new scss style to the react application in "app.scss".
+     *
+     * @param {string} style - css to add in the file
+     * @param {string} comment - comment to add before css code
+     *
+     * example:
+     *
+     * style = '.jhipster {\n     color: #baa186;\n}'
+     * comment = 'New JHipster color'
+     *
+     * * ==========================================================================
+     * New JHipster color
+     * ========================================================================== *
+     * .jhipster {
+     *     color: #baa186;
+     * }
+     *
+     */
+    addAppSCSSStyle(style, comment) {
+        this.needleApi.clientReact.addAppSCSSStyle(style, comment);
+    }
+
+    /**
      * Copy third-party library resources path.
      *
      * @param {string} sourceFolder - third-party library resources source path

--- a/test/needle-api/needle-client-react.spec.js
+++ b/test/needle-api/needle-client-react.spec.js
@@ -42,8 +42,8 @@ const mockBlueprintSubGen = class extends ClientGenerator {
         const customPhaseSteps = {
             addAppCssStep() {
                 // please change this to public API when it will be available see https://github.com/jhipster/generator-jhipster/issues/9234
-                this.needleApi.clientReact.addAppSCSSStyle('@import without-comment');
-                this.needleApi.clientReact.addAppSCSSStyle('@import with-comment', 'my comment');
+                this.addAppSCSSStyle('@import without-comment');
+                this.addAppSCSSStyle('@import with-comment', 'my comment');
             },
             addEntityToMenuStep() {
                 this.addEntityToMenu('routerName', false, 'react', false);


### PR DESCRIPTION
related to #9234
When I added the needle API I figured out that we did not have a working public API for React. I added a needle API for both React and Angular but only Angular had a Public API.

First I thought doing this PR on demand only but since we have a needle api and unit tests added method in public API seems to be very easy and takes no times.

I added 2 methods for both React CSS and SCSS case. Updated the unit tests to test public API instead of needle API.

With this addition people will be able to add their own style even if they have a react application.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
