### PR TITLE
WIP: Update java to jdk-11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ env:
 # Install all tools and check configuration
 #----------------------------------------------------------------------
 before_install:
-    - jdk_switcher use oraclejdk8
+    - jdk_switcher use openjdk11
     - java -version
     - export TZ=Australia/Canberra
     - date

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:cosmic
 
 RUN \
   # configure the "jhipster" user
@@ -8,7 +8,7 @@ RUN \
   mkdir /home/jhipster/app && \
   # install open-jdk 8
   apt-get update && \
-  apt-get install -y openjdk-8-jdk && \
+  apt-get install -y openjdk-11-jdk && \
   # install utilities
   apt-get install -y \
     wget \

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -54,7 +54,7 @@ const DOCKER_PROMETHEUS_OPERATOR = 'quay.io/coreos/prometheus-operator:v0.28.0';
 const DOCKER_GRAFANA_WATCHER = 'quay.io/coreos/grafana-watcher:v0.0.8';
 
 // Version of Java, Scala
-const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
+const JAVA_VERSION = '11'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
 const SCALA_VERSION = '2.12.6';
 
 // version of Node, Yarn, NPM


### PR DESCRIPTION
related to: https://github.com/jhipster/generator-jhipster/issues/9145

Setting the JAVA_VERSION to 11 to make the jdk11 the default jdk. I also updated the jhipster Dockerfile to use the openjdk11 under ubuntu-cosmic.

Still a WIP. I want to test some more generated applications. In fact that this is my first pull-request to jhipster i want to figure out, how to build jdk-11 versions via Azure/Travis.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->