### PR TITLE
Bump version to 5.8.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-jhipster",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {
@@ -39,28 +39,34 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
         },
         "@sinonjs/commons": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.0.tgz",
-            "integrity": "sha512-j4ZwhaHmwsCb4DlDOIWnI5YyKDNMoNThsmwEpfHx6a1EpsGZ9qYLxP++LMlmBRjtGptGHFsGItJ768snllFWpA==",
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.3.1.tgz",
+            "integrity": "sha512-rgmZk5CrBGAMATk0HlHOFvo8V44/r+On6cKS80tqid0Eljd+fFBWBOXZp9H2/EB3faxdNdzXTx6QZIKLkbJ7mA==",
             "dev": true,
             "requires": {
                 "type-detect": "4.0.8"
             }
         },
         "@sinonjs/formatio": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
-            "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.0.tgz",
+            "integrity": "sha512-hskkZG4qB0HgsxrPUlnk2EiIyBwntM+ETIxCha/gidl172MCfdosNezB5706ciS5P2VhueM7MoACWwMc4A4gMQ==",
             "dev": true,
             "requires": {
-                "samsam": "1.3.0"
+                "@sinonjs/commons": "^1",
+                "@sinonjs/samsam": "^3.1.0"
             }
         },
         "@sinonjs/samsam": {
-            "version": "2.1.3",
-            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-2.1.3.tgz",
-            "integrity": "sha512-8zNeBkSKhU9a5cRNbpCKau2WWPfan+Q2zDlcXvXyhn9EsMqgYs4qzo0XHNVlXC6ABQL8fT6nV+zzo5RTHJzyXw==",
-            "dev": true
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.2.0.tgz",
+            "integrity": "sha512-j5F1rScewLtx6pbTK0UAjA3jJj4RYiSKOix53YWv+Jzy/AZ69qHxUpU8fwVLjyKbEEud9QrLpv6Ggs7WqTimYw==",
+            "dev": true,
+            "requires": {
+                "@sinonjs/commons": "^1.0.2",
+                "array-from": "^2.1.1",
+                "lodash": "^4.17.11"
+            }
         },
         "@sinonjs/text-encoding": {
             "version": "0.7.1",
@@ -69,9 +75,9 @@
             "dev": true
         },
         "acorn": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.0.tgz",
-            "integrity": "sha512-MW/FjM+IvU9CgBzjO3UIPCE2pyEwUsoFl+VGdczOPEdxfGFjuKny/gN54mOuX7Qxmb9Rg9MCn2oKiSUeW+pjrw==",
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/acorn/-/acorn-6.1.1.tgz",
+            "integrity": "sha512-jPTiwtOxaHNaAPg/dmrJ/beuzLRnXtB0kQPQ8JpotKJgTB6rX6c8mlf315941pyjBSaPg8NHXS9fhP4u17DpGA==",
             "dev": true
         },
         "acorn-dynamic-import": {
@@ -1269,19 +1275,6 @@
                     "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
                     "dev": true
                 },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -1622,16 +1615,6 @@
                 "p-finally": "^1.0.0",
                 "signal-exit": "^3.0.0",
                 "strip-eof": "^1.0.0"
-            },
-            "dependencies": {
-                "get-stream": {
-                    "version": "4.1.0",
-                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
-                    "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
-                    "requires": {
-                        "pump": "^3.0.0"
-                    }
-                }
             }
         },
         "exit-hook": {
@@ -1986,7 +1969,6 @@
             "version": "7.0.1",
             "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
             "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-            "dev": true,
             "requires": {
                 "graceful-fs": "^4.1.2",
                 "jsonfile": "^4.0.0",
@@ -2041,9 +2023,12 @@
             "dev": true
         },
         "get-stream": {
-            "version": "3.0.0",
-            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
-            "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-4.1.0.tgz",
+            "integrity": "sha512-GMat4EJ5161kIy2HevLlr4luNjBgvmj413KaQA7jt4V8B4RDsfpHk7WQ9GVqfYyyx8OS/L66Kox+rJRNklLK7w==",
+            "requires": {
+                "pump": "^3.0.0"
+            }
         },
         "get-value": {
             "version": "2.0.6",
@@ -2175,6 +2160,13 @@
                 "timed-out": "^4.0.0",
                 "url-parse-lax": "^1.0.0",
                 "url-to-options": "^1.0.1"
+            },
+            "dependencies": {
+                "get-stream": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-3.0.0.tgz",
+                    "integrity": "sha1-jpQ9E1jcN1VQVOy+LtsFqhdO3hQ="
+                }
             }
         },
         "graceful-fs": {
@@ -2441,10 +2433,9 @@
             "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw=="
         },
         "invert-kv": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
-            "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
-            "dev": true
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
+            "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -2697,18 +2688,6 @@
                 "fs-extra": "7.0.1",
                 "lodash": "4.17.11",
                 "winston": "3.2.1"
-            },
-            "dependencies": {
-                "fs-extra": {
-                    "version": "7.0.1",
-                    "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
-                    "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
-                    "requires": {
-                        "graceful-fs": "^4.1.2",
-                        "jsonfile": "^4.0.0",
-                        "universalify": "^0.1.0"
-                    }
-                }
             }
         },
         "js-object-pretty-print": {
@@ -2839,12 +2818,11 @@
             }
         },
         "lcid": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
-            "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-            "dev": true,
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
+            "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
             "requires": {
-                "invert-kv": "^1.0.0"
+                "invert-kv": "^2.0.0"
             }
         },
         "levn": {
@@ -2939,9 +2917,9 @@
             }
         },
         "lolex": {
-            "version": "2.7.5",
-            "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
-            "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
+            "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
             "dev": true
         },
         "loud-rejection": {
@@ -3281,15 +3259,6 @@
                         "wrap-ansi": "^2.0.0"
                     }
                 },
-                "debug": {
-                    "version": "3.2.6",
-                    "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
-                    "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
-                    "dev": true,
-                    "requires": {
-                        "ms": "^2.1.1"
-                    }
-                },
                 "find-up": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/find-up/-/find-up-3.0.0.tgz",
@@ -3318,12 +3287,6 @@
                         "p-locate": "^3.0.0",
                         "path-exists": "^3.0.0"
                     }
-                },
-                "ms": {
-                    "version": "2.1.1",
-                    "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
-                    "integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
-                    "dev": true
                 },
                 "p-limit": {
                     "version": "2.1.0",
@@ -3488,14 +3451,11 @@
                 "path-to-regexp": "^1.7.0"
             },
             "dependencies": {
-                "@sinonjs/formatio": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-                    "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/samsam": "^2 || ^3"
-                    }
+                "lolex": {
+                    "version": "2.7.5",
+                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+                    "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+                    "dev": true
                 }
             }
         },
@@ -3679,21 +3639,6 @@
                 "execa": "^1.0.0",
                 "lcid": "^2.0.0",
                 "mem": "^4.0.0"
-            },
-            "dependencies": {
-                "invert-kv": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
-                    "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
-                },
-                "lcid": {
-                    "version": "2.0.0",
-                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-2.0.0.tgz",
-                    "integrity": "sha512-avPEb8P8EGnwXKClwsNUgryVjllcRqtMYa49NTsbQagYuT1DcXnl1915oxWjoyGrXR6zH/Y0Zc96xWsPcoDKeA==",
-                    "requires": {
-                        "invert-kv": "^2.0.0"
-                    }
-                }
             }
         },
         "os-name": {
@@ -4399,34 +4344,6 @@
                 "lolex": "^3.1.0",
                 "nise": "^1.4.10",
                 "supports-color": "^5.5.0"
-            },
-            "dependencies": {
-                "@sinonjs/formatio": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.1.0.tgz",
-                    "integrity": "sha512-ZAR2bPHOl4Xg6eklUGpsdiIJ4+J1SNag1DHHrG/73Uz/nVwXqjgUtRPLoS+aVyieN9cSbc0E4LsU984tWcDyNg==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/samsam": "^2 || ^3"
-                    }
-                },
-                "@sinonjs/samsam": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.1.1.tgz",
-                    "integrity": "sha512-ILlwvQUwAiaVBzr3qz8oT1moM7AIUHqUc2UmEjQcH9lLe+E+BZPwUMuc9FFojMswRK4r96x5zDTTrowMLw/vuA==",
-                    "dev": true,
-                    "requires": {
-                        "@sinonjs/commons": "^1.0.2",
-                        "array-from": "^2.1.1",
-                        "lodash": "^4.17.11"
-                    }
-                },
-                "lolex": {
-                    "version": "3.1.0",
-                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-3.1.0.tgz",
-                    "integrity": "sha512-zFo5MgCJ0rZ7gQg69S4pqBsLURbFw11X68C18OcJjJQbqaXm2NoTrGl1IMM3TIz0/BnN1tIs2tzmmqvCsOMMjw==",
-                    "dev": true
-                }
             }
         },
         "slash": {
@@ -5413,9 +5330,9 @@
             },
             "dependencies": {
                 "readable-stream": {
-                    "version": "3.1.1",
-                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.1.1.tgz",
-                    "integrity": "sha512-DkN66hPyqDhnIQ6Jcsvx9bFjhw214O4poMBcIMgPVpQvNy9a0e0Uhg5SqySyDKAmUlwt8LonTBz1ezOnM8pUdA==",
+                    "version": "3.2.0",
+                    "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.2.0.tgz",
+                    "integrity": "sha512-RV20kLjdmpZuTF1INEb9IA3L68Nmi+Ri7ppZqo78wj//Pn62fCoJyV9zalccNzDD/OuJpMG4f+pfMl8+L6QdGw==",
                     "requires": {
                         "inherits": "^2.0.3",
                         "string_decoder": "^1.1.1",
@@ -5587,6 +5504,12 @@
                         "pinkie-promise": "^2.0.0"
                     }
                 },
+                "invert-kv": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-1.0.0.tgz",
+                    "integrity": "sha1-EEqOSqym09jNFXqO+L+rLXo//bY=",
+                    "dev": true
+                },
                 "is-fullwidth-code-point": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
@@ -5594,6 +5517,15 @@
                     "dev": true,
                     "requires": {
                         "number-is-nan": "^1.0.0"
+                    }
+                },
+                "lcid": {
+                    "version": "1.0.0",
+                    "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
+                    "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
+                    "dev": true,
+                    "requires": {
+                        "invert-kv": "^1.0.0"
                     }
                 },
                 "load-json-file": {
@@ -5869,18 +5801,6 @@
                     "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
                     "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
                 },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
                 "external-editor": {
                     "version": "3.0.3",
                     "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
@@ -5963,18 +5883,6 @@
                 "yeoman-environment": "^2.0.5"
             },
             "dependencies": {
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
-                },
                 "debug": {
                     "version": "4.1.1",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
@@ -6034,15 +5942,6 @@
                         "find-up": "^3.0.0",
                         "read-pkg": "^3.0.0"
                     }
-                },
-                "through2": {
-                    "version": "3.0.0",
-                    "resolved": "https://registry.npmjs.org/through2/-/through2-3.0.0.tgz",
-                    "integrity": "sha512-8B+sevlqP4OiCjonI1Zw03Sf8PuV1eRsYQgLad5eonILOdyeRsY27A/2Ze8IlvlMvq31OH+3fz/styI7Ya62yQ==",
-                    "requires": {
-                        "readable-stream": "2 || 3",
-                        "xtend": "~4.0.1"
-                    }
                 }
             }
         },
@@ -6062,6 +5961,15 @@
                 "yeoman-generator": "^2.0.5"
             },
             "dependencies": {
+                "@sinonjs/formatio": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
+                    "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
+                    "dev": true,
+                    "requires": {
+                        "samsam": "1.3.0"
+                    }
+                },
                 "clone": {
                     "version": "2.1.2",
                     "resolved": "https://registry.npmjs.org/clone/-/clone-2.1.2.tgz",
@@ -6073,19 +5981,6 @@
                     "resolved": "https://registry.npmjs.org/clone-stats/-/clone-stats-1.0.0.tgz",
                     "integrity": "sha1-s3gt/4u1R04Yuba/D9/ngvh3doA=",
                     "dev": true
-                },
-                "cross-spawn": {
-                    "version": "6.0.5",
-                    "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
-                    "integrity": "sha512-eTVLrBSt7fjbDygz805pMnstIs2VTBNkRm0qxZd+M7A5XDdxVRWO5MxGBXZhjY4cqLYLdtrGqRf8mBPmzwSpWQ==",
-                    "dev": true,
-                    "requires": {
-                        "nice-try": "^1.0.4",
-                        "path-key": "^2.0.1",
-                        "semver": "^5.5.0",
-                        "shebang-command": "^1.2.0",
-                        "which": "^1.2.9"
-                    }
                 },
                 "dargs": {
                     "version": "5.1.0",
@@ -6107,6 +6002,12 @@
                         "slash": "^1.0.0"
                     }
                 },
+                "lolex": {
+                    "version": "2.7.5",
+                    "resolved": "https://registry.npmjs.org/lolex/-/lolex-2.7.5.tgz",
+                    "integrity": "sha512-l9x0+1offnKKIzYVjyXU2SiwhXDLekRzKyhnbyldPHvC7BvLPVpdNUNR2KeMAiCN2D/kLNttZgQD5WjSxuBx3Q==",
+                    "dev": true
+                },
                 "mem-fs-editor": {
                     "version": "4.0.3",
                     "resolved": "https://registry.npmjs.org/mem-fs-editor/-/mem-fs-editor-4.0.3.tgz",
@@ -6124,18 +6025,6 @@
                         "rimraf": "^2.2.8",
                         "through2": "^2.0.0",
                         "vinyl": "^2.0.1"
-                    },
-                    "dependencies": {
-                        "through2": {
-                            "version": "2.0.5",
-                            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-                            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": "~2.3.6",
-                                "xtend": "~4.0.1"
-                            }
-                        }
                     }
                 },
                 "minimist": {
@@ -6179,6 +6068,16 @@
                         "nise": "^1.3.3",
                         "supports-color": "^5.4.0",
                         "type-detect": "^4.0.8"
+                    }
+                },
+                "through2": {
+                    "version": "2.0.5",
+                    "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
+                    "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
+                    "dev": true,
+                    "requires": {
+                        "readable-stream": "~2.3.6",
+                        "xtend": "~4.0.1"
                     }
                 },
                 "vinyl": {
@@ -6226,18 +6125,6 @@
                         "text-table": "^0.2.0",
                         "through2": "^2.0.0",
                         "yeoman-environment": "^2.0.5"
-                    },
-                    "dependencies": {
-                        "through2": {
-                            "version": "2.0.5",
-                            "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
-                            "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
-                            "dev": true,
-                            "requires": {
-                                "readable-stream": "~2.3.6",
-                                "xtend": "~4.0.1"
-                            }
-                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-jhipster",
-    "version": "5.8.1",
+    "version": "5.8.2",
     "description": "Spring Boot + Angular/React in one handy generator",
     "files": [
         "cli",


### PR DESCRIPTION
After release of 5.8.2 we need to bump the version in master as well otherwise `npm test` fails for the upgrade sub-gen.

Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed