### PR TITLE
complete the logout request before fetching account

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -104,8 +104,7 @@ export class LoginService {
             window.location.href = logoutUrl;
         });
         <%_ } else { _%>
-        this.authServerProvider.logout().subscribe();
-        this.accountService.authenticate(null);
+        this.authServerProvider.logout().subscribe(() => this.accountService.authenticate(null));
         <%_ } _%>
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -104,7 +104,7 @@ export class LoginService {
             window.location.href = logoutUrl;
         });
         <%_ } else { _%>
-        this.authServerProvider.logout().subscribe(() => this.accountService.authenticate(null));
+        this.authServerProvider.logout().subscribe(null, null, () => this.accountService.authenticate(null));
         <%_ } _%>
     }
 }


### PR DESCRIPTION
Fix #9349

Session auth makes a logout request, then requests the account.  It needs to wait for the logout request to finish before requesting the account, or the home page and navbar show as if the user is logged in.  This causes the Protractor test to fail because it looks for the "Login" link.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
