### PR TITLE
several relationship fixes for Angular forms

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -236,8 +236,8 @@ _%>
                 </div>
                 <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
                 <div class="form-group">
-                    <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
-                    <select class="form-control" id="field_<%= relationshipName %>" multiple name="<%= relationshipName %>" formControlName="<%=relationshipName %>">
+                    <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipFieldNamePlural %>"><%= relationshipNameHumanized %></label>
+                    <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" multiple name="<%= relationshipFieldNamePlural %>" formControlName="<%=relationshipFieldNamePlural %>">
                         <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>').value, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: track<%=otherEntityNameCapitalized %>ById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
                 </div>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -264,46 +264,48 @@ _%>
     }
 
     private createFromForm(): I<%= entityAngularName %> {
-        const entity = new <%= entityAngularName %>()
-        entity.id = this.editForm.get(['id']).value
-<%_ for (idx in fields) {
-    const fieldName = fields[idx].fieldName;
-    const fieldType = fields[idx].fieldType;
-    const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
-_%>
-    <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-        entity.<%= fieldName %> = this.editForm.get(['<%= fieldName %>']).value != null ? moment(this.editForm.get(['<%= fieldName %>']).value, DATE_TIME_FORMAT) : undefined,
-    <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
-        entity.<%= fieldName %>ContentType = this.editForm.get(['<%= fieldName %>ContentType']).value
-        entity.<%= fieldName %> = this.editForm.get(['<%= fieldName %>']).value
-    <%_ } else { _%>
-        entity.<%= fieldName %> = this.editForm.get(['<%= fieldName %>']).value
-    <%_ } _%>
-<%_ } _%>
-<%_ for (idx in relationships) {
-    const relationshipType = relationships[idx].relationshipType;
-    const ownerSide = relationships[idx].ownerSide;
-    const otherEntityName = relationships[idx].otherEntityName;
-    const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-    const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-    const relationshipName = relationships[idx].relationshipName;
-    const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
-    const relationshipFieldName = relationships[idx].relationshipFieldName;
-    const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-    const otherEntityField = relationships[idx].otherEntityField;
-    const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
-    const relationshipRequired = relationships[idx].relationshipRequired;
-    const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
-    <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-        <%_ if (dto === 'no') { _%>
-        entity.<%= relationshipName %> = this.editForm.get(['<%= relationshipName %>']).value
+        const entity = {
+                       ...new <%= entityAngularName %>(),
+            id: this.editForm.get(['id']).value,
+    <%_ for (idx in fields) {
+        const fieldName = fields[idx].fieldName;
+        const fieldType = fields[idx].fieldType;
+        const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
+    _%>
+        <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+            <%= fieldName %>: this.editForm.get(['<%= fieldName %>']).value != null ? moment(this.editForm.get(['<%= fieldName %>']).value, DATE_TIME_FORMAT) : undefined,
+        <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
+            <%= fieldName %>ContentType: this.editForm.get(['<%= fieldName %>ContentType']).value,
+            <%= fieldName %>: this.editForm.get(['<%= fieldName %>']).value,
         <%_ } else { _%>
-        entity.<%= relationshipName %>Id = this.editForm.get(['<%= relationshipName %>Id']).value
+            <%= fieldName %>: this.editForm.get(['<%= fieldName %>']).value,
         <%_ } _%>
-    <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
-        entity.<%= relationshipFieldNamePlural %> = this.editForm.get(['<%= relationshipFieldNamePlural %>']).value
     <%_ } _%>
+    <%_ for (idx in relationships) {
+        const relationshipType = relationships[idx].relationshipType;
+        const ownerSide = relationships[idx].ownerSide;
+        const otherEntityName = relationships[idx].otherEntityName;
+        const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
+        const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
+        const relationshipName = relationships[idx].relationshipName;
+        const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
+        const relationshipFieldName = relationships[idx].relationshipFieldName;
+        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+        const otherEntityField = relationships[idx].otherEntityField;
+        const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+        const relationshipRequired = relationships[idx].relationshipRequired;
+        const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
+        <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+            <%_ if (dto === 'no') { _%>
+            <%= relationshipName %>: this.editForm.get(['<%= relationshipName %>']).value,
+            <%_ } else { _%>
+            <%= relationshipName %>Id: this.editForm.get(['<%= relationshipName %>Id']).value,
+            <%_ } _%>
+        <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
+            <%= relationshipFieldNamePlural %>: this.editForm.get(['<%= relationshipFieldNamePlural %>']).value,
+        <%_ } _%>
 <%_ } _%>
+        }
         return entity;
     }
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -264,20 +264,20 @@ _%>
     }
 
     private createFromForm(): I<%= entityAngularName %> {
-        return new <%= entityAngularName %>(
-            this.editForm.get(['id']).value,
+        const entity = new <%= entityAngularName %>()
+        entity.id = this.editForm.get(['id']).value
 <%_ for (idx in fields) {
     const fieldName = fields[idx].fieldName;
     const fieldType = fields[idx].fieldType;
     const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
 _%>
     <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-    this.editForm.get(['<%= fieldName %>']).value != null ? moment(this.editForm.get(['<%= fieldName %>']).value, DATE_TIME_FORMAT) : undefined,
+        entity.<%= fieldName %> = this.editForm.get(['<%= fieldName %>']).value != null ? moment(this.editForm.get(['<%= fieldName %>']).value, DATE_TIME_FORMAT) : undefined,
     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
-    this.editForm.get(['<%= fieldName %>ContentType']).value,
-    this.editForm.get(['<%= fieldName %>']).value,
+        entity.<%= fieldName %>ContentType = this.editForm.get(['<%= fieldName %>ContentType']).value
+        entity.<%= fieldName %> = this.editForm.get(['<%= fieldName %>']).value
     <%_ } else { _%>
-    this.editForm.get(['<%= fieldName %>']).value,
+        entity.<%= fieldName %> = this.editForm.get(['<%= fieldName %>']).value
     <%_ } _%>
 <%_ } _%>
 <%_ for (idx in relationships) {
@@ -296,16 +296,15 @@ _%>
     const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
         <%_ if (dto === 'no') { _%>
-    this.editForm.get(['<%= relationshipName %>']).value,
+        entity.<%= relationshipName %> = this.editForm.get(['<%= relationshipName %>']).value
         <%_ } else { _%>
-    this.editForm.get(['<%= relationshipName %>Id']).value,
+        entity.<%= relationshipName %>Id = this.editForm.get(['<%= relationshipName %>Id']).value
         <%_ } _%>
     <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
-    this.editForm.get(['<%= relationshipFieldNamePlural %>']).value,
+        entity.<%= relationshipFieldNamePlural %> = this.editForm.get(['<%= relationshipFieldNamePlural %>']).value
     <%_ } _%>
 <%_ } _%>
-
-        );
+        return entity;
     }
 
     protected subscribeToSaveResponse(result: Observable<HttpResponse<I<%= entityAngularName %>>>) {

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -91,7 +91,7 @@ describe('Service Tests', () => {
             )
         });
 
-        describe('Service methods', async () => {
+        describe('Service methods', () => {
             it('should find an element', async () => {
                 const returnedFromService = Object.assign({
 <%_ fields.forEach((field) => {

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/data/table.csv.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/data/table.csv.ejs
@@ -123,7 +123,11 @@ for (lineNb = 1; lineNb <= 10; lineNb++) {
     }
     for (idx in relationships) {
         if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
-            line.push(this.faker.random.number({min: 1, max: 10}));
+            if (relationships[idx].otherEntityNameCapitalized === 'User') {
+                line.push(this.faker.random.number({min: 1, max: 2}));
+            } else {
+                line.push(this.faker.random.number({min: 1, max: 10}));
+            }
         }
     }
     table.push(line);


### PR DESCRIPTION
- entity form should use relationshipFieldNamePlural for many-to-many relationships to match the entity fields to the form fields
- mapping form data to entity can't use model constructor as some fields should not be sent in request but are in the constructor (such as `many-to-one` relations) 
- faker data can only have a max userId of 2 (oauth doesn't have > 2)

Fix #9347

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
