### PR TITLE
Use Gradle 5 native BOM support

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -751,18 +751,6 @@ module.exports = class extends PrivateBase {
      * @param {string} name - maven ArtifactId
      * @param {string} version - (optional) explicit dependency version number
      */
-    addGradleDependencyManagement(scope, group, name, version) {
-        this.needleApi.serverGradle.addDependencyManagement(scope, group, name, version);
-    }
-
-    /**
-     * A new dependency to build.gradle file.
-     *
-     * @param {string} scope - scope of the new dependency, e.g. compile
-     * @param {string} group - maven GroupId
-     * @param {string} name - maven ArtifactId
-     * @param {string} version - (optional) explicit dependency version number
-     */
     addGradleDependency(scope, group, name, version) {
         this.addGradleDependencyInDirectory('.', scope, group, name, version);
     }

--- a/generators/server/needle-api/needle-server-gradle.js
+++ b/generators/server/needle-api/needle-server-gradle.js
@@ -54,21 +54,6 @@ module.exports = class extends needleServer {
         this.addBlockContentToFile(rewriteFileModel, errorMessage);
     }
 
-    addDependencyManagement(scope, group, name, version) {
-        const errorMessage = `${chalk.yellow('Reference to ') + group}:${name}:${version}${chalk.yellow(' not added.')}`;
-        let dependency = `${group}:${name}`;
-        if (version) {
-            dependency += `:${version}`;
-        }
-        const rewriteFileModel = this.generateFileModel(
-            buildGradlePath,
-            'jhipster-needle-gradle-dependency-management',
-            `${scope} "${dependency}"`
-        );
-
-        this.addBlockContentToFile(rewriteFileModel, errorMessage);
-    }
-
     addDependencyInDirectory(directory, scope, group, name, version) {
         const errorMessage = `${chalk.yellow('Reference to ') + group}:${name}:${version}${chalk.yellow(' not added.')}`;
         let dependency = `${group}:${name}`;

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -46,7 +46,6 @@ plugins {
     <%_ if (!skipClient) { _%>
     id "com.moowork.node" version "1.2.0"
     <%_ } _%>
-    id "io.spring.dependency-management" version "1.0.7.RELEASE"
     id "net.ltgt.apt-eclipse" version "0.21"
     id "net.ltgt.apt-idea" version "0.21"
     id "net.ltgt.apt" version "0.21"
@@ -86,13 +85,6 @@ if (project.hasProperty('zipkin')) {
 idea {
   module {
     excludeDirs += files('node_modules')
-  }
-}
-
-dependencyManagement {
-  imports {
-    mavenBom 'io.github.jhipster:jhipster-dependencies:' + jhipster_dependencies_version
-    //jhipster-needle-gradle-dependency-management - JHipster will add additional dependencies management here
   }
 }
 
@@ -256,6 +248,9 @@ repositories {
 }
 
 dependencies {
+    // import JHipster dependencies BOM
+    implementation enforcedPlatform("io.github.jhipster:jhipster-dependencies:${jhipster_dependencies_version}" )
+
     // Use ", version: jhipster_dependencies_version, changing: true" if you want
     // to use a SNAPSHOT release instead of a stable release
     implementation group: "io.github.jhipster", name: "jhipster-framework"<% if (reactive) { %>, {
@@ -458,11 +453,11 @@ dependencies {
     implementation "org.mapstruct:mapstruct:${mapstruct_version}"
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstruct_version}"
     <%_ if (databaseType === 'sql') { _%>
-    annotationProcessor "org.hibernate:hibernate-jpamodelgen"
+    annotationProcessor "org.hibernate:hibernate-jpamodelgen:${hibernate_version}"
     annotationProcessor "javax.xml.bind:jaxb-api:${jaxb_api_version}"
     annotationProcessor "com.sun.xml.bind:jaxb-impl:${jaxb_impl_version}"
     <%_ } _%>
-    annotationProcessor ("org.springframework.boot:spring-boot-configuration-processor") {
+    annotationProcessor ("org.springframework.boot:spring-boot-configuration-processor:${spring_boot_version}") {
         exclude group: 'com.vaadin.external.google', module: 'android-json'
     }
     testImplementation "com.jayway.jsonpath:json-path"

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 dependencies {
-    implementation "org.springframework.boot:spring-boot-devtools"
+    runtimeOnly "org.springframework.boot:spring-boot-devtools"
     <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
     implementation "com.h2database:h2"
     <%_ } _%>

--- a/test/needle-api/needle-server-gradle.spec.js
+++ b/test/needle-api/needle-server-gradle.spec.js
@@ -41,8 +41,6 @@ const mockBlueprintSubGen = class extends ServerGenerator {
                 this.addGradleProperty('name', 'value');
                 this.addGradlePlugin('group', 'name', 'version');
                 this.addGradlePluginToPluginsBlock('id', 'version');
-                this.addGradleDependencyManagement('scope1', 'group1', 'name1', 'version1');
-                this.addGradleDependencyManagement('scope2', 'group2', 'name2');
                 this.addGradleDependency('scope3', 'group3', 'name3', 'version3');
                 this.addGradleDependency('scope4', 'group4', 'name4');
                 this.addGradleDependencyInDirectory('.', 'scope5', 'group5', 'name5', 'version5');
@@ -101,14 +99,6 @@ describe('needle API server gradle: JHipster server generator with blueprint', (
 
             it('Assert gradle.properties has the PluginToPluginsBlock added', () => {
                 assert.fileContent('build.gradle', 'id "id" version "version"');
-            });
-
-            it('Assert gradle.properties has the DependencyManagement with version added', () => {
-                assert.fileContent('build.gradle', 'scope1 "group1:name1:version1"');
-            });
-
-            it('Assert gradle.properties has the DependencyManagement without version added', () => {
-                assert.fileContent('build.gradle', 'scope2 "group2:name2"');
             });
 
             it('Assert gradle.properties has the Dependency with version added', () => {


### PR DESCRIPTION
Gradle 5 now supports [Maven BOMs natively](https://docs.gradle.org/current/userguide/upgrading_version_4.html#rel5.0:bom_import)

The following changes have been made which **break** compatibility:
1. Switch to Gradle 5 native BOM support and remove `io.spring.dependency-management` plugin
2. Remove method `addGradleDependencyManagement() ` as the `dependencyManagement` block is no longer available. Code can use the [Gradle's native BOM support instead](https://docs.gradle.org/5.0/userguide/managing_transitive_dependencies.html#sec:bom_import)

Relates to  #9081 

Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed