### PR TITLE
Revert "Use Webpack IgnorePlugin to ignore @nguniversal/express-engine"

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -111,7 +111,6 @@ module.exports = (options) => ({
             chunks: ['vendors', 'polyfills', 'main', 'global'],
             chunksSortMode: 'manual',
             inject: 'body'
-        }),
-        new webpack.IgnorePlugin(/express-engine\/tokens/)
+        })
     ]
 });


### PR DESCRIPTION
This reverts commit 8115e8cb as it was meant to make upgrade of `ngx-cookie` work in #9354 . Since `ngx-cookie` was been reverted back to 4.0.2 this is no longer needed and I forgot to revert it.

Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
