### PR TITLE
Switch gradle node plugin and fix webpackBuildDev task to not execute if no client file has changed

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -44,7 +44,7 @@ plugins {
     id "com.google.cloud.tools.jib" version "0.9.11"
     id "com.gorylenko.gradle-git-properties" version "2.0.0"
     <%_ if (!skipClient) { _%>
-    id "com.moowork.node" version "1.2.0"
+    id "com.github.node-gradle.node" version "1.3.0"
     <%_ } _%>
     id "net.ltgt.apt-eclipse" version "0.21"
     id "net.ltgt.apt-idea" version "0.21"

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -45,15 +45,16 @@ bootRun {
 
 <%_ if (!skipClient) { _%>
 task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
-    inputs.files(fileTree("<%= CLIENT_MAIN_SRC_DIR %>"))
+    inputs.file("package-lock.json")
+    inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
 
     def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>/")
     webpackDevFiles.exclude("webpack.prod.js")
     inputs.files(webpackDevFiles)
 
-    outputs.files(fileTree("<%= CLIENT_DIST_DIR %>"))
+    outputs.dir("<%= CLIENT_DIST_DIR %>")
 
-    dependsOn <%= clientPackageManager %>_install
+    dependsOn <%= clientPackageManager %>Install
 
     args = ["run", "webpack:build"]
 }

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -40,11 +40,11 @@ bootRun {
 }
 
 <%_ if (!skipClient) { _%>
-task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %>_install") {
+task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %>Install") {
     args = ["run", "webpack:test"]
 }
 
-task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %>_install") {
+task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %>Install") {
     args = ["run", "webpack:prod"]
 }
 <%_ } _%>


### PR DESCRIPTION
As discussed in #9081 this PR switches the gradle plugin used for client tasks to https://github.com/node-gradle/gradle-node-plugin which is more active than the one currently used.

It also contains a fix to avoid constantly re-running webpack when nothing has changed.

**NOTE:** This PR is based on the branches of #9385 and #9388 to avoid conflicts, hence they should be merge first. Will do a rebase if needed.

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
