### PR TITLE
Remove extra arg lines arguments used for surefire and failsafe and

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -173,9 +173,6 @@
         <sonar.testExecutionReportPaths>${project.testresult.directory}/jest/TESTS-results-sonar.xml</sonar.testExecutionReportPaths>
         <sonar.typescript.lcov.reportPaths>${project.testresult.directory}/lcov.info</sonar.typescript.lcov.reportPaths>
         <%_ } _%>
-        <!-- Used to keep correct jacoco report filename for the surefire/failsafe arg line. Therefore we set this empty property here -->
-        <surefireArgLine />
-        <failsafeArgLine />
 
         <!-- jhipster-needle-maven-property -->
     </properties>
@@ -923,8 +920,6 @@
                             <configuration>
                                 <!-- Sets the path to the file which contains the execution data. -->
                                 <destFile>${sonar.jacoco.utReportFile}</destFile>
-                                <!-- Sets the name of the property containing the settings for JaCoCo runtime agent. -->
-                                <propertyName>surefireArgLine</propertyName>
                             </configuration>
                         </execution>
                         <!-- Ensures that the code coverage report for unit tests is created after unit tests have been run -->
@@ -947,8 +942,6 @@
                             <configuration>
                                 <!-- Sets the path to the file which contains the execution data. -->
                                 <destFile>${sonar.jacoco.itReportFile}</destFile>
-                                <!-- Sets the name of the property containing the settings for JaCoCo runtime agent. -->
-                                <propertyName>failsafeArgLine</propertyName>
                             </configuration>
                         </execution>
                         <!-- Ensures that the code coverage report for integration tests is created after integration tests have been run -->
@@ -1131,10 +1124,6 @@
                     <artifactId>maven-surefire-plugin</artifactId>
                     <version>${maven-surefire-plugin.version}</version>
                     <configuration>
-                        <!-- To get jacoco report we need to set argLine in surefire, without this snippet the jacoco argLine is lost.
-                             The property must be prefixed with @ and not $. The reason for this is the usage of late binding of variables
-                             by other plugins (jacoco in this case) -->
-                        <argLine>@{surefireArgLine}</argLine>
                         <!-- Force alphabetical order to have a reproducible build -->
                         <runOrder>alphabetical</runOrder>
                         <reportsDirectory>${sonar.junit.utReportFolder}</reportsDirectory>
@@ -1150,10 +1139,6 @@
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven-failsafe-plugin.version}</version>
                     <configuration>
-                        <!-- To get jacoco report we need to set argLine in failsafe, without this snippet the jacoco argLine is lost.
-                             The property must be prefixed with @ and not $. The reason for this is the usage of late binding of variables
-                             by other plugins (jacoco in this case) -->
-                        <argLine>@{failsafeArgLine}</argLine>
                         <!-- Due to spring-boot repackage, without adding this property test classes are not found
                              See https://github.com/spring-projects/spring-boot/issues/6254 -->
                         <classesDirectory>${project.build.outputDirectory}</classesDirectory>


### PR DESCRIPTION
Remove extra arg lines arguments used for surefire and failsafe and use only `argLine` as a property.

`argLine` is automatically picked up by all three plugins:
`maven-surefire-plugin`, `maven-failsafe-plugin` and `jacoco-maven-plugin`

See also https://www.eclemma.org/jacoco/trunk/doc/prepare-agent-mojo.html

I have tested it with IDEA and command line and it works and generates proper sonar reports at least locally.

Fixes #9393 

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed