### PR TITLE
Change configuration of BOM import to platform to allow version overriding

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -249,7 +249,7 @@ repositories {
 
 dependencies {
     // import JHipster dependencies BOM
-    implementation enforcedPlatform("io.github.jhipster:jhipster-dependencies:${jhipster_dependencies_version}" )
+    implementation platform("io.github.jhipster:jhipster-dependencies:${jhipster_dependencies_version}" )
 
     // Use ", version: jhipster_dependencies_version, changing: true" if you want
     // to use a SNAPSHOT release instead of a stable release


### PR DESCRIPTION
The correct configuration for the BOM is 'platform' in order to allow for version overriding.

This is needed at least in the Kotlin blueprint where Kotlin version used is different from the one declared by Spring Boot and probably will be a problem for other users as well who want to override versions manually.

The distinction is clear in the [documentation](https://docs.gradle.org/5.0/userguide/managing_transitive_dependencies.html#sec:bom_import) but I misunderstood it when implementing the Gradle native BOM support at #9385  

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed