### PR TITLE
Fix Cucumber tests to use @DirtiesContext to have a clean context for each scenario

### DIFF
--- a/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
@@ -21,11 +21,13 @@ package <%=packageName%>.cucumber;
 import <%=packageName%>.<%= mainClass %>;
 import cucumber.api.java.Before;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest
 @WebAppConfiguration
+@DirtiesContext
 @ContextConfiguration(classes = <%= mainClass %>.class)
 public class CucumberContextConfiguration {
 

--- a/generators/server/templates/src/test/java/package/cucumber/CucumberIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/CucumberIT.java.ejs
@@ -20,8 +20,9 @@ package <%=packageName%>.cucumber;
 
 import org.junit.runner.RunWith;
 
-<% if (databaseType === 'cassandra') { %>
-import <%=packageName%>.AbstractCassandraTest;<% } %>
+<%_ if (databaseType === 'cassandra') { _%>
+import <%=packageName%>.AbstractCassandraTest;
+<%_ } _%>
 import cucumber.api.CucumberOptions;
 import cucumber.api.junit.Cucumber;
 


### PR DESCRIPTION
This fixes the failing integration tests for Cucumber in the `ngx-mongodb-kafka-cucumber` sample.

Example logs: also https://travis-ci.org/jhipster/generator-jhipster/jobs/503656883

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed