### PR TITLE
Change ts compilation target to es6 as default

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -29,7 +29,7 @@ import { ITEMS_PER_PAGE } from 'app/shared';
 import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
 <%_ } _%>
 import { AccountService, UserService, User } from 'app/core';
-import { UserMgmtDeleteDialogComponent } from 'app/admin';
+import { UserMgmtDeleteDialogComponent } from './user-management-delete-dialog.component';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-user-mgmt',

--- a/generators/client/templates/angular/tsconfig-aot.json.ejs
+++ b/generators/client/templates/angular/tsconfig-aot.json.ejs
@@ -18,7 +18,7 @@
 -%>
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "es2015",
         "moduleResolution": "node",
         "sourceMap": false,

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -18,7 +18,7 @@
 -%>
 {
     "compilerOptions": {
-        "target": "es5",
+        "target": "es6",
         "module": "commonjs",
         "moduleResolution": "node",
         "sourceMap": true,

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -113,7 +113,10 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                 parallel: true,
                 cache: true,
                 terserOptions: {
+                    ecma: 6,
                     ie8: false,
+                    toplevel: true,
+                    module: true,
                     // sourceMap: true, // Enable source maps. Please note that this will slow down the build
                     compress: {
                         dead_code: true,
@@ -127,12 +130,20 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                         toplevel: true,
                         if_return: true,
                         inline: true,
-                        join_vars: true
+                        join_vars: true,
+                        ecma: 6,
+                        module: true,
+                        toplevel: true
                     },
                     output: {
                         comments: false,
                         beautify: false,
-                        indent_level: 2
+                        indent_level: 2,
+                        ecma: 6
+                    },
+                    mangle: {
+                        module: true,
+                        toplevel: true
                     }
                 }
             }),

--- a/generators/client/templates/react/tsconfig.json.ejs
+++ b/generators/client/templates/react/tsconfig.json.ejs
@@ -19,7 +19,7 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "target": "es5",
+    "target": "es6",
     "module": "esnext",
     "moduleResolution": "node",
     "sourceMap": true,

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -77,13 +77,27 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         parallel: true,
         // sourceMap: true, // Enable source maps. Please note that this will slow down the build
         terserOptions: {
+          ecma: 6,
+          toplevel: true,
+          module: true,
           beautify: false,
           comments: false,
           compress: {
-            warnings: false
+            warnings: false,
+            ecma: 6,
+            module: true,
+            toplevel: true
+          },
+          output: {
+              comments: false,
+              beautify: false,
+              indent_level: 2,
+              ecma: 6
           },
           mangle: {
-            keep_fnames: true
+            keep_fnames: true,
+            module: true,
+            toplevel: true
           }
         }
       }),


### PR DESCRIPTION
Considering evergreen browsers support almost all ES6 features, we should enable it as default (reference: https://kangax.github.io/compat-table/es6/). It will reduce bundle size by few KiB.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
