### PR TITLE
Add the main java application class to sonarqube exclusions

### DIFF
--- a/generators/server/templates/gradle/sonar.gradle.ejs
+++ b/generators/server/templates/gradle/sonar.gradle.ejs
@@ -29,7 +29,12 @@ jacocoTestReport {
 sonarqube {
     properties {
         property "sonar.host.url", "http://localhost:9001"
-        property "sonar.exclusions", "<%= CLIENT_MAIN_SRC_DIR %>content/**/*.*,<%= CLIENT_MAIN_SRC_DIR %>i18n/*.js, <%= CLIENT_DIST_DIR %>**/*.*"
+        property("sonar.exclusions", [
+            "<%= CLIENT_MAIN_SRC_DIR %>content/**/*.*",
+            "<%= CLIENT_MAIN_SRC_DIR %>i18n/*.js",
+            "<%= CLIENT_DIST_DIR %>**/*.*",
+            "<%= SERVER_MAIN_SRC_DIR %><%= javaDir %><%= mainClass %>.java"
+        ])
 
         property "sonar.issue.ignore.multicriteria", "S3437,<% if (authenticationType === 'jwt') { %>S4502,<% } %>S4684,UndocumentedApi,BoldAndItalicTagsCheck"
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -140,7 +140,7 @@
 
         <!-- Sonar properties -->
         <sonar.host.url>http://localhost:9001</sonar.host.url>
-        <sonar.exclusions><%= CLIENT_MAIN_SRC_DIR %>content/**/*.*, <%= CLIENT_MAIN_SRC_DIR %>i18n/*.js, <%= CLIENT_DIST_DIR %>**/*.*</sonar.exclusions>
+        <sonar.exclusions><%= CLIENT_MAIN_SRC_DIR %>content/**/*.*, <%= CLIENT_MAIN_SRC_DIR %>i18n/*.js, <%= CLIENT_DIST_DIR %>**/*.*, <%= SERVER_MAIN_SRC_DIR %><%= javaDir %><%= mainClass %>.java</sonar.exclusions>
         <sonar.issue.ignore.multicriteria>S3437,<% if (authenticationType === 'jwt') { %>S4502,<% } %>S4684,UndocumentedApi,BoldAndItalicTagsCheck</sonar.issue.ignore.multicriteria>
         <!-- Rule https://sonarcloud.io/coding_rules?open=Web%3ABoldAndItalicTagsCheck&rule_key=Web%3ABoldAndItalicTagsCheck is ignored. Even if we agree that using the "i" tag is an awful practice, this is what is recommended by http://fontawesome.io/examples/ -->
         <sonar.issue.ignore.multicriteria.BoldAndItalicTagsCheck.resourceKey><%= CLIENT_MAIN_SRC_DIR %>app/**/*.*</sonar.issue.ignore.multicriteria.BoldAndItalicTagsCheck.resourceKey>


### PR DESCRIPTION
This class is typically ignored when evaluating code coverage due to it being very difficult or impossible to test.

I also took the liberty of reformatting the exclusion block in `sonar.gradle` so it is easier to read.

Fix #9408

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
