### PR TITLE
Multiple travis builds with jdk8 and jdk11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ language: node_js
 node_js:
     - '10.15.3'
 jdk:
+    - oraclejdk8
     - openjdk11
 addons:
     apt:
@@ -67,7 +68,6 @@ env:
 # Install all tools and check configuration
 #----------------------------------------------------------------------
 before_install:
-    - jdk_switcher use oraclejdk8
     - java -version
     - export TZ=Australia/Canberra
     - date
@@ -94,6 +94,7 @@ install:
 # Launch tests
 #----------------------------------------------------------------------
 script:
+    - java -version
     - $JHI_SCRIPTS/20-docker-compose.sh
     - $JHI_SCRIPTS/21-tests-backend.sh
     - $JHI_SCRIPTS/22-tests-frontend.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,7 @@ os:
     - linux
 services:
     - docker
-language: node_js
-node_js:
-    - '10.15.3'
+language: java
 jdk:
     - oraclejdk8
     - openjdk11
@@ -39,6 +37,7 @@ cache:
         - $HOME/.gradle
 env:
     global:
+        - NODE_VERSION=10.15.2
         - JHI_PROFILE=dev
         - JHI_RUN_APP=1
         - JHI_PROTRACTOR=0
@@ -68,6 +67,8 @@ env:
 # Install all tools and check configuration
 #----------------------------------------------------------------------
 before_install:
+    - nvm install $NODE_VERSION
+    - nvm use $NODE_VERSION
     - java -version
     - export TZ=Australia/Canberra
     - date

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,9 +21,10 @@ os:
     - linux
 services:
     - docker
-language: java
+language: node_js
+node_js:
+    - '10.15.3'
 jdk:
-    - oraclejdk8
     - openjdk11
 addons:
     apt:
@@ -37,7 +38,6 @@ cache:
         - $HOME/.gradle
 env:
     global:
-        - NODE_VERSION=10.15.2
         - JHI_PROFILE=dev
         - JHI_RUN_APP=1
         - JHI_PROTRACTOR=0
@@ -53,8 +53,10 @@ env:
         - JHI_DISABLE_WEBPACK_LOGS=true
         - JHI_E2E_HEADLESS=true
         - JHI_SCRIPTS=$TRAVIS_BUILD_DIR/test-integration/scripts
+        - JHI_JDK=11
     matrix:
         - JHI_APP=jdl-default JHI_ENTITY=jdl JHI_PROFILE=prod JHI_PROTRACTOR=1
+        - JHI_APP=jdl-default JHI_ENTITY=jdl JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_JDK=8
         - JHI_APP=ngx-default JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_SONAR=1
         - JHI_APP=ngx-psql-es-noi18n JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sqlfull
         - JHI_APP=ngx-gradle-fr JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_WAR=1
@@ -67,8 +69,9 @@ env:
 # Install all tools and check configuration
 #----------------------------------------------------------------------
 before_install:
-    - nvm install $NODE_VERSION
-    - nvm use $NODE_VERSION
+    - sudo add-apt-repository ppa:openjdk-r/ppa -y
+    - sudo apt-get update
+    - sudo apt-get install -y openjdk-11-jdk
     - java -version
     - export TZ=Australia/Canberra
     - date
@@ -95,7 +98,6 @@ install:
 # Launch tests
 #----------------------------------------------------------------------
 script:
-    - java -version
     - $JHI_SCRIPTS/20-docker-compose.sh
     - $JHI_SCRIPTS/21-tests-backend.sh
     - $JHI_SCRIPTS/22-tests-frontend.sh

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -117,6 +117,7 @@
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.0</maven-compiler-plugin.version>
+        <maven-javadoc-plugin.version>3.1.0</maven-javadoc-plugin.version>
         <maven-eclipse-plugin.version>2.10</maven-eclipse-plugin.version>
         <!-- We can't go to 3.0.0-M2 as it has a regression. See https://issues.apache.org/jira/browse/MENFORCER-306 -->
         <maven-enforcer-plugin.version>3.0.0-M1</maven-enforcer-plugin.version>
@@ -770,6 +771,14 @@
                     </annotationProcessorPaths>
                 </configuration>
             </plugin>
+            <plugin> 
+                <groupId>org.apache.maven.plugins</groupId> 
+                <artifactId>maven-javadoc-plugin</artifactId> 
+                <version>${maven-javadoc-plugin.version}</version>
+                <configuration> 
+                  <source>8</source> 
+                </configuration> 
+              </plugin> 
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-eclipse-plugin</artifactId>


### PR DESCRIPTION
Change travis image to java. This makes building with multiple jdks easier. The travis java image comes with nvm. The node version can be set with nvm in "before_install". Install node version via nvm and remove node_js key in travis.yml.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
See https://github.com/jhipster/generator-jhipster/issues/9145