### PR TITLE
Update jdk version in docker image to openjdk-11

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic
+FROM ubuntu:cosmic
 
 RUN \
   # configure the "jhipster" user
@@ -8,7 +8,7 @@ RUN \
   mkdir /home/jhipster/app && \
   # install open-jdk 8
   apt-get update && \
-  apt-get install -y openjdk-8-jdk && \
+  apt-get install -y openjdk-11-jdk && \
   # install utilities
   apt-get install -y \
     wget \


### PR DESCRIPTION
Need to update the base container from ubuntu:bionic to ubuntu:cosmic. The open jdk in ubuntu-bionic is in fact a jdk 10.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
See https://github.com/jhipster/generator-jhipster/issues/9145