### PR TITLE
pin react-router version to v4.3.1 to fix transitive deps

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -44,6 +44,7 @@ limitations under the License.
     "react-loadable": "5.5.0",
     "react-redux": "6.0.1",
     "react-redux-loading-bar": "4.2.0",
+    "react-router": "4.3.1",
     "react-router-dom": "4.3.1",
     "react-toastify": "4.5.2",
     "react-transition-group": "2.5.3",


### PR DESCRIPTION
React Router Dom uses `^` to specify the React Router version, so it pulls in v4.4.0 even though we are using v4.3.1.

This should also be cherry-picked to the v5 maintenance branch.

Fix #9438
Fix #9436

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
