### PR TITLE
Fix install task and lock file used for yarn

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -58,7 +58,7 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
 
     outputs.dir("<%= CLIENT_DIST_DIR %>")
 
-    dependsOn <%= clientPackageManager %><%_ if (clientPackageManager==='npm') { _%>Install<%_ } _%>
+    dependsOn <%= clientPackageManager %><%_ if (clientPackageManager === 'npm') { _%>Install<%_ } _%>
 
     args = ["run", "webpack:build"]
 }

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -45,7 +45,11 @@ bootRun {
 
 <%_ if (!skipClient) { _%>
 task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
+    <%_ if (clientPackageManager==='npm') { _%>
     inputs.file("package-lock.json")
+    <%_ } else { _%>
+    inputs.file("yarn.lock")
+    <%_ } _%>
     inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
 
     def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>/")
@@ -54,7 +58,7 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
 
     outputs.dir("<%= CLIENT_DIST_DIR %>")
 
-    dependsOn <%= clientPackageManager %>Install
+    dependsOn <%= clientPackageManager %>_install
 
     args = ["run", "webpack:build"]
 }

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -58,7 +58,7 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
 
     outputs.dir("<%= CLIENT_DIST_DIR %>")
 
-    dependsOn <%= clientPackageManager %>_install
+    dependsOn <%= clientPackageManager %><%_ if (clientPackageManager==='npm') { _%>Install<%_ } _%>
 
     args = ["run", "webpack:build"]
 }

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -40,11 +40,11 @@ bootRun {
 }
 
 <%_ if (!skipClient) { _%>
-task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager==='npm') { _%>Install<%_ } _%>") {
+task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager === 'npm') { _%>Install<%_ } _%>") {
     args = ["run", "webpack:test"]
 }
 
-task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager==='npm') { _%>Install<%_ } _%>") {
+task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager === 'npm') { _%>Install<%_ } _%>") {
     args = ["run", "webpack:prod"]
 }
 <%_ } _%>

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -40,11 +40,11 @@ bootRun {
 }
 
 <%_ if (!skipClient) { _%>
-task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %>Install") {
+task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager==='npm') { _%>Install<%_ } _%>") {
     args = ["run", "webpack:test"]
 }
 
-task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %>Install") {
+task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager==='npm') { _%>Install<%_ } _%>") {
     args = ["run", "webpack:prod"]
 }
 <%_ } _%>


### PR DESCRIPTION
This PR contains the following fixes

1. Switched back to the synthetic tasks, i.e `npm_install` and `yarn_install` as there is no `yarnInstall` task.
2. Fix input file for yarn is `yarn.lock`

Fixes #9451

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
