### PR TITLE
add workaround for oracle maven repo. 

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -240,7 +240,14 @@ repositories {
     jcenter()
     <%_ if (devDatabaseType === 'oracle' || prodDatabaseType === 'oracle') { _%>
     // more information at https://blogs.oracle.com/dev2dev/entry/how_to_get_oracle_jdbc
-    maven { url "https://maven.oracle.com" }
+    // https://discuss.gradle.org/t/support-for-maven-repositories-that-use-realm-based-sso/14456/5
+    maven {
+        url "https://www.oracle.com/content/secure/maven/content"
+        credentials {
+            username ''
+            password ''
+        }
+    }
     <%_ } _%>
     // TODO To remove after final JHipster release
     maven { url "http://oss.sonatype.org/content/repositories/snapshots" }


### PR DESCRIPTION
Just add the workaround mentioned in gradle forum/example. Linking to the repository in the build file. Of course a user should use e.g. a project property in order not to hard code credentials in the build file.

Closes #8731

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
