### PR TITLE
change action from `dismiss` to `close`

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
@@ -45,7 +45,7 @@ export class UserMgmtDeleteDialogComponent {
         this.userService.delete(login).subscribe((response) => {
             this.eventManager.broadcast({ name: 'userListModification',
                 content: 'Deleted a user'});
-            this.activeModal.dismiss(true);
+            this.activeModal.close(true);
         });
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
@@ -64,7 +64,7 @@ describe('Component Tests', () => {
 
                         // THEN
                         expect(service.delete).toHaveBeenCalledWith('user');
-                        expect(mockActiveModal.dismissSpy).toHaveBeenCalled();
+                        expect(mockActiveModal.closeSpy).toHaveBeenCalled();
                         expect(mockEventManager.broadcastSpy).toHaveBeenCalled();
                     })
                 )

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-active-modal.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-active-modal.service.ts.ejs
@@ -23,9 +23,11 @@ import Spy = jasmine.Spy;
 export class MockActiveModal extends SpyObject {
 
     dismissSpy: Spy;
+    closeSpy: Spy;
 
     constructor() {
         super(NgbActiveModal);
         this.dismissSpy = this.spy('dismiss').andReturn(this);
+        this.closeSpy = this.spy('close').andReturn(this);
     }
 }


### PR DESCRIPTION
change action of the modal when confirmation on user
delete is provided

Fix #9421

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
