### PR TITLE
Change EhCache creation logic to fix Cucumber test failures

### DIFF
--- a/generators/server/needle-api/needle-server-cache.js
+++ b/generators/server/needle-api/needle-server-cache.js
@@ -44,7 +44,7 @@ module.exports = class extends needleServer {
 
         if (cacheProvider === 'ehcache') {
             const needle = 'jhipster-needle-ehcache-add-entry';
-            const content = `cm.createCache(${entry}, jcacheConfiguration);`;
+            const content = `createCache(cm, ${entry});`;
 
             this._doAddBlockContentToFile(cachePath, needle, content, errorMessage);
         } else if (cacheProvider === 'infinispan') {

--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -165,23 +165,31 @@ public class CacheConfiguration<% if (cacheProvider === 'hazelcast') { %> implem
     public JCacheManagerCustomizer cacheManagerCustomizer() {
         return cm -> {
             <%_ if (authenticationType === 'oauth2' && applicationType === 'microservice') { _%>
-            cm.createCache("oAuth2Authentication", jcacheConfiguration);
+            createCache(cm, "oAuth2Authentication");
             <%_ } _%>
             <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
-            cm.createCache(<%=packageName%>.repository<% if (reactive) { %>.reactive<% } %>.UserRepository.USERS_BY_LOGIN_CACHE, jcacheConfiguration);
-            cm.createCache(<%=packageName%>.repository<% if (reactive) { %>.reactive<% } %>.UserRepository.USERS_BY_EMAIL_CACHE, jcacheConfiguration);
+            createCache(cm, <%=packageName%>.repository<% if (reactive) { %>.reactive<% } %>.UserRepository.USERS_BY_LOGIN_CACHE);
+            createCache(cm, <%=packageName%>.repository<% if (reactive) { %>.reactive<% } %>.UserRepository.USERS_BY_EMAIL_CACHE);
                 <%_ if (enableHibernateCache) { _%>
-            cm.createCache(<%=packageName%>.domain.<%= asEntity('User') %>.class.getName(), jcacheConfiguration);
-            cm.createCache(<%=packageName%>.domain.Authority.class.getName(), jcacheConfiguration);
-            cm.createCache(<%=packageName%>.domain.<%= asEntity('User') %>.class.getName() + ".authorities", jcacheConfiguration);
+            createCache(cm, <%=packageName%>.domain.<%= asEntity('User') %>.class.getName());
+            createCache(cm, <%=packageName%>.domain.Authority.class.getName());
+            createCache(cm, <%=packageName%>.domain.<%= asEntity('User') %>.class.getName() + ".authorities");
                     <%_ if (authenticationType === 'session') { _%>
-            cm.createCache(<%=packageName%>.domain.PersistentToken.class.getName(), jcacheConfiguration);
-            cm.createCache(<%=packageName%>.domain.<%= asEntity('User') %>.class.getName() + ".persistentTokens", jcacheConfiguration);
+            createCache(cm, <%=packageName%>.domain.PersistentToken.class.getName());
+            createCache(cm, <%=packageName%>.domain.<%= asEntity('User') %>.class.getName() + ".persistentTokens");
                     <%_ } _%>
                 <%_ } _%>
             <%_ } _%>
             // jhipster-needle-ehcache-add-entry
         };
+    }
+
+    private void createCache(javax.cache.CacheManager cm, String cacheName) {
+        javax.cache.Cache<Object, Object> cache = cm.getCache(cacheName);
+        if (cache != null) {
+            cm.destroyCache(cacheName);
+        }
+        cm.createCache(cacheName, jcacheConfiguration);
     }
     <%_ } _%>
     <%_ if (cacheProvider === 'hazelcast') { _%>

--- a/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
@@ -21,13 +21,11 @@ package <%=packageName%>.cucumber;
 import <%=packageName%>.<%= mainClass %>;
 import cucumber.api.java.Before;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.web.WebAppConfiguration;
 
 @SpringBootTest
 @WebAppConfiguration
-@DirtiesContext
 @ContextConfiguration(classes = <%= mainClass %>.class)
 public class CucumberContextConfiguration {
 

--- a/test/needle-api/needle-server-cache.spec.js
+++ b/test/needle-api/needle-server-cache.spec.js
@@ -111,24 +111,21 @@ describe('needle API server cache: JHipster server generator with blueprint', ()
             });
 
             it('Assert ehCache configuration has entry added', () => {
-                assert.fileContent(
-                    `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
-                    'cm.createCache(entry, jcacheConfiguration);'
-                );
+                assert.fileContent(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`, 'createCache(cm, entry);');
             });
 
             it('Assert ehCache configuration has entity added', () => {
                 assert.fileContent(
                     `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
-                    'cm.createCache(com.mycompany.myapp.domain.entityClass.class.getName(), jcacheConfiguration);'
+                    'createCache(cm, com.mycompany.myapp.domain.entityClass.class.getName());'
                 );
                 assert.fileContent(
                     `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
-                    'cm.createCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesOneToMany", jcacheConfiguration);'
+                    'createCache(cm, com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesOneToMany");'
                 );
                 assert.fileContent(
                     `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
-                    'cm.createCache(com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesManoToMany", jcacheConfiguration);'
+                    'createCache(cm, com.mycompany.myapp.domain.entityClass.class.getName() + ".entitiesManoToMany");'
                 );
             });
         });


### PR DESCRIPTION
This PR reverts #9404 and instead uses a different approach where it first deletes a previously configured cache with the same name if it already exists before trying to create it.

Usage of '@DirtiesContext' creates other issues when using Infinispan instead of EhCache as mentioned by @pascalgrimaud in comment https://github.com/jhipster/generator-jhipster/pull/9404#issuecomment-475850157 and can bee seen at https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=1721.

**NOTE:** I have chosen to delete previous cache instead of ignoring creation as in theory the `jcacheConfiguration` could be different, although under normal circumstances the `CacheConfiguration ` is a singleton and would only be instantiated once hence the `JCacheManagerCustomizer` only created once.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed