### PR TITLE
Fix gradle webpackBuildDev task to not fail when package-lock.json or `yarn.lock is missing

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -46,9 +46,9 @@ bootRun {
 <%_ if (!skipClient) { _%>
 task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
     <%_ if (clientPackageManager==='npm') { _%>
-    inputs.file("package-lock.json")
+    inputs.files("package-lock.json")
     <%_ } else { _%>
-    inputs.file("yarn.lock")
+    inputs.files("yarn.lock")
     <%_ } _%>
     inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
 


### PR DESCRIPTION
Fix Gradle `webpackBuildDev` task to not fail when either `package-lock.json` or `yarn.lock` is missing when using either npm or  yarn respectively.

When using `inputs.file(file)` and the referenced file is missing then gradle will throw an error and fail. Instead when using `inputs.files(file)`(mind the s) gradle considers it as a collection of paths and if any is missing it is simply ignored. We should not fail when the `package-lock.json` is missing but instead continue to execute `npm install` when `./gradlew` is executed.

This is another regression after merging #9389.

-   Please make sure the below checklist is followed for Pull Requests.

-   [] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed