### PR TITLE
Add initialize phase when call sonar:sonar

### DIFF
--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -280,8 +280,7 @@ Sonar is used to analyse code quality. You can start a local Sonar server (acces
 docker-compose -f src/main/docker/sonar.yml up -d
 ```
 
-You can both run Sonar with maven or gradle but also with a sonar-scanner.
-In this case you must install it before.
+You can run a Sonar analysis with using the [sonar-scanner](https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner)<% if (buildTool) { %> or by using the <% if (buildTool === 'maven') { %>maven<% } %><% if (buildTool === 'gradle') { %>gradle<% } %> plugin<% } %>.
 
 Then, run a Sonar analysis:
 
@@ -301,12 +300,6 @@ or
 ./gradlew -Pprod clean check sonarqube
 ```
 <%_ } _%>
-
-You can, now, run analysis with [sonar-scanner](https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) if you already have installed it.
-
-```
-sonar-scanner
-```
 
 For more information, refer to the [Code quality page][].
 

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -280,7 +280,7 @@ Sonar is used to analyse code quality. You can start a local Sonar server (acces
 docker-compose -f src/main/docker/sonar.yml up -d
 ```
 
-You can both run sonar with maven or gradle but also with a sonar-scanner.
+You can both run Sonar with maven or gradle but also with a sonar-scanner.
 In this case you must install it before.
 
 Then, run a Sonar analysis:
@@ -290,7 +290,7 @@ Then, run a Sonar analysis:
 ./mvnw -Pprod clean verify sonar:sonar
 ```
 
-If you need to re-run the sonar phase, please be sure to specify at least the `initialize` phase since sonar properties are loaded from the sonar-project.properties file.
+If you need to re-run the Sonar phase, please be sure to specify at least the `initialize` phase since Sonar properties are loaded from the sonar-project.properties file.
 
 ```
 ./mvnw initialize sonar:sonar

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -301,6 +301,12 @@ or
 sonar-scanner
 ```
 
+If you need to re-run the sonar phase, please be sur to specify at least the `initialize` phase since sonar properties are loaded from the sonar-project.properties file.
+
+```
+./mvnw initialize sonar:sonar
+```
+
 For more information, refer to the [Code quality page][].
 
 ## Using Docker to simplify development (optional)

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -289,7 +289,8 @@ Then, run a Sonar analysis:
 ```
 ./mvnw -Pprod clean verify sonar:sonar
 ```
-If you need to re-run the sonar phase, please be sur to specify at least the `initialize` phase since sonar properties are loaded from the sonar-project.properties file.
+
+If you need to re-run the sonar phase, please be sure to specify at least the `initialize` phase since sonar properties are loaded from the sonar-project.properties file.
 
 ```
 ./mvnw initialize sonar:sonar
@@ -299,8 +300,9 @@ or
 ```
 ./gradlew -Pprod clean check sonarqube
 ```
-or
 <%_ } _%>
+
+You can, now, run analysis with [sonar-scanner](https://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) if you already have installed it.
 
 ```
 sonar-scanner

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -289,6 +289,11 @@ Then, run a Sonar analysis:
 ```
 ./mvnw -Pprod clean verify sonar:sonar
 ```
+If you need to re-run the sonar phase, please be sur to specify at least the `initialize` phase since sonar properties are loaded from the sonar-project.properties file.
+
+```
+./mvnw initialize sonar:sonar
+```
 or
 <%_ } else if(buildTool === 'gradle') { _%>
 ```
@@ -299,12 +304,6 @@ or
 
 ```
 sonar-scanner
-```
-
-If you need to re-run the sonar phase, please be sur to specify at least the `initialize` phase since sonar properties are loaded from the sonar-project.properties file.
-
-```
-./mvnw initialize sonar:sonar
 ```
 
 For more information, refer to the [Code quality page][].

--- a/test-integration/scripts/25-sonar-analyze.sh
+++ b/test-integration/scripts/25-sonar-analyze.sh
@@ -9,16 +9,16 @@ cd "$JHI_FOLDER_APP"
 
 if [[ "$JHI_APP" = "ngx-default" && "$TRAVIS_REPO_SLUG" = "jhipster/generator-jhipster" && "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     echo "*** Sonar analyze for master branch"
-    ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+    ./mvnw initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.login=$SONAR_TOKEN
 
 elif [[ $JHI_SONAR = 1 ]]; then
     echo "*** Sonar analyze locally"
-    ./mvnw org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+    ./mvnw initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=http://localhost:9001 \
         -Dsonar.projectKey=JHipsterSonar
-    
+        
     sleep 30
     docker-compose -f src/main/docker/sonar.yml logs
     echo "*** Sonar results:"


### PR DESCRIPTION
Fix the test-integrations scripts for sonar analysis.
With the properties maven plugin we need to have, at least, an initialize phase to load sonar-project.properties.

related to #9423

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
