### PR TITLE
Force lowercase for consul microservice application names

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -169,7 +169,8 @@ spring:
         consul:
             discovery:
                 healthCheckPath: /management/health
-                instanceId: ${spring.application.name}:${spring.application.instance-id:${random.value}}
+                instanceId: <%= baseName.toLowerCase() %>:${spring.application.instance-id:${random.value}}
+                service-name: <%= baseName.toLowerCase() %>
             config:
                 watch:
                     enabled: false


### PR DESCRIPTION
This fixes gateway routes for consul microservices with uppercase in their names
fix #9435

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
