### PR TITLE
oauth2: navigate to stored url post successful authentication

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -476,6 +476,11 @@ const files = {
                 'e2e/page-objects/jhi-page-objects.ts',
                 'protractor.conf.js'
             ]
+        },
+        {
+            condition: generator => generator.authenticationType === 'oauth2',
+            path: TEST_SRC_DIR,
+            templates: ['spec/app/layouts/main/main.component.spec.ts']
         }
     ]
 };

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -42,7 +42,14 @@ export class LoginService {
     <%_ if (authenticationType === 'oauth2') { _%>
     login() {
         const port = (location.port ? ':' + location.port : '');
-        location.href = '//' + location.hostname + port + location.pathname + 'authorize';
+        let contextPath = location.pathname;
+        if (contextPath.endsWith('accessdenied')) {
+            contextPath = contextPath.substring(0, contextPath.indexOf('accessdenied'));
+        }
+        if (!contextPath.endsWith('/')) {
+            contextPath = contextPath + '/';
+        }
+        location.href = `//${location.hostname}${port}${contextPath}authorize`;
     }
     <%_ } else { _%>
     login(credentials, callback?) {

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -16,12 +16,19 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, OnInit } from '@angular/core';
+import { Component,<%_ if (authenticationType === 'oauth2') { _%> OnDestroy,<%_ } _%> OnInit } from '@angular/core';
 import { Router, ActivatedRouteSnapshot, NavigationEnd, NavigationError } from '@angular/router';
+<%_ if (authenticationType === 'oauth2') { _%>
+import { Subject } from 'rxjs';
+import { takeUntil } from 'rxjs/operators';
+<%_ } _%>
 
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageHelper } from 'app/core';
+import { JhiLanguageHelper<%_ if (authenticationType === 'oauth2') { _%>, Account, AccountService, StateStorageService<%_ } _%> } from 'app/core';
 <%_ } else { _%>
+<%_ if (authenticationType === 'oauth2') { _%>
+import { Account, AccountService, StateStorageService } from 'app/core';
+<%_ } _%>
 import { Title } from '@angular/platform-browser';
 <%_ } _%>
 
@@ -29,9 +36,16 @@ import { Title } from '@angular/platform-browser';
     selector: '<%= jhiPrefixDashed %>-main',
     templateUrl: './main.component.html'
 })
-export class <%=jhiPrefixCapitalized%>MainComponent implements OnInit {
+export class <%=jhiPrefixCapitalized%>MainComponent implements OnInit<%_ if (authenticationType === 'oauth2') { _%>, OnDestroy<%_ } _%> {
+    <%_ if (authenticationType === 'oauth2') { _%>
+    _cleanup: Subject<any> = new Subject<any>();
+    <%_ } _%>
 
     constructor(
+        <%_ if (authenticationType === 'oauth2') { _%>
+        private accountService: AccountService,
+        private stateStorageService: StateStorageService,
+        <%_ } _%>
         <%_ if (enableTranslation) { _%>
         private jhiLanguageHelper: JhiLanguageHelper,
         <%_ } else { _%>
@@ -61,5 +75,34 @@ export class <%=jhiPrefixCapitalized%>MainComponent implements OnInit {
                 this.router.navigate(['/404']);
             }
         });
+        <%_ if (authenticationType === 'oauth2') { _%>
+        this.subscribeToLoginEvents();
+        <%_ } _%>
     }
+    <%_ if (authenticationType === 'oauth2') { _%>
+
+    ngOnDestroy() {
+        this._cleanup.next();
+        this._cleanup.complete();
+      }
+
+    private subscribeToLoginEvents() {
+        this.accountService
+            .getAuthenticationState()
+            .pipe(takeUntil(this._cleanup))
+            .subscribe((account: Account) => {
+                if (account) {
+                    this.navigateToStoredUrl();
+                }
+            });
+      }
+
+    private navigateToStoredUrl() {
+        const previousUrl = this.stateStorageService.getUrl();
+        if (previousUrl) {
+            this.stateStorageService.storeUrl(null);
+            this.router.navigateByUrl(previousUrl);
+        }
+    }
+    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -86,7 +86,7 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
             const redirect = this.stateStorageService.getUrl();
             if (redirect) {
                 this.stateStorageService.storeUrl(null);
-                this.router.navigate([redirect]);
+                this.router.navigateByUrl(redirect);
             }
         }).catch(() => {
             this.authenticationError = true;

--- a/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
@@ -1,0 +1,99 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { NavigationCancel, Router } from '@angular/router';
+
+import { AccountService, StateStorageService } from 'app/core';
+import { <%=jhiPrefixCapitalized%>MainComponent } from 'app/layouts';
+import { MockStateStorageService } from '../../../helpers/mock-state-storage.service';
+import { <%=angularXAppName%>TestModule } from '../../../test.module';
+
+describe('Component Tests', () => {
+  describe('MainComponent', () => {
+    let comp: <%=jhiPrefixCapitalized%>MainComponent;
+    let fixture: ComponentFixture<<%=jhiPrefixCapitalized%>MainComponent>;
+    let accountService: any;
+    let storageService: any;
+    let router: any;
+
+    beforeEach(async(() => {
+      TestBed.configureTestingModule({
+        imports: [<%=angularXAppName%>TestModule],
+        declarations: [<%=jhiPrefixCapitalized%>MainComponent],
+        providers: [
+          {
+            provide: StateStorageService,
+            useClass: MockStateStorageService
+          }
+        ]
+      })
+        .overrideTemplate(<%=jhiPrefixCapitalized%>MainComponent, '')
+        .compileComponents();
+    }));
+
+    beforeEach(() => {
+      fixture = TestBed.createComponent(<%=jhiPrefixCapitalized%>MainComponent);
+      comp = fixture.componentInstance;
+      accountService = fixture.debugElement.injector.get(AccountService);
+      storageService = fixture.debugElement.injector.get(StateStorageService);
+      router = fixture.debugElement.injector.get(Router);
+    });
+
+    it('should navigate to the previous stored url post successful authentication', () => {
+      accountService.setIdentityResponse({ firstName: 'John' });
+      storageService.setResponse('admin/users?page=0');
+      router.setRouterEvent(new NavigationCancel(0, 'http://localhost:9000', 'cancel'));
+
+      // WHEN/
+      comp.ngOnInit();
+
+      // THEN
+      expect(storageService.getUrlSpy).toHaveBeenCalledTimes(1);
+      expect(storageService.storeUrlSpy).toHaveBeenCalledWith(null);
+      expect(router.navigateByUrlSpy).toHaveBeenCalledWith('admin/users?page=0');
+    });
+
+    it('should not navigate to the previous stored url when authentication fails', () => {
+      accountService.setIdentityResponse();
+      router.setRouterEvent(new NavigationCancel(0, 'http://localhost:9000', 'cancel'));
+
+      // WHEN/
+      comp.ngOnInit();
+
+      // THEN
+      expect(storageService.getUrlSpy).not.toHaveBeenCalled();
+      expect(storageService.storeUrlSpy).not.toHaveBeenCalled();
+      expect(router.navigateByUrlSpy).not.toHaveBeenCalled();
+    });
+
+    it('should not navigate to the previous stored url when no such url exists post successful authentication', () => {
+      accountService.setIdentityResponse({ firstName: 'John' });
+      storageService.setResponse(undefined);
+      router.setRouterEvent(new NavigationCancel(0, 'http://localhost:9000', 'cancel'));
+
+      // WHEN/
+      comp.ngOnInit();
+
+      // THEN
+      expect(storageService.getUrlSpy).toHaveBeenCalledTimes(1);
+      expect(storageService.storeUrlSpy).not.toHaveBeenCalled();
+      expect(router.navigateByUrlSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
@@ -87,7 +87,7 @@ describe('Component Tests', () => {
                         rememberMe: true
                     });
                     mockLoginService.setResponse({});
-                    mockStateStorageService.setResponse({redirect: 'dummy'});
+                    mockStateStorageService.setResponse('admin/users?page=0');
 
                     // WHEN/
                     comp.login();
@@ -100,7 +100,7 @@ describe('Component Tests', () => {
                     expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
                     expect(mockStateStorageService.getUrlSpy).toHaveBeenCalledTimes(1);
                     expect(mockStateStorageService.storeUrlSpy).toHaveBeenCalledWith(null);
-                    expect(mockRouter.navigateSpy).toHaveBeenCalledWith([{redirect: 'dummy'}]);
+                    expect(mockRouter.navigateByUrlSpy).toHaveBeenCalledWith('admin/users?page=0');
                 })
             )
         );

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-account.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-account.service.ts.ejs
@@ -16,6 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+import { of } from 'rxjs';
+
 import { SpyObject } from './spyobject';
 import { AccountService } from 'app/core/auth/account.service';
 import Spy = jasmine.Spy;
@@ -26,6 +28,7 @@ export class MockAccountService extends SpyObject {
     saveSpy: Spy;
     fakeResponse: any;
     identitySpy: Spy;
+    getAuthenticationStateSpy: Spy;
 
     constructor() {
         super(AccountService);
@@ -50,5 +53,6 @@ export class MockAccountService extends SpyObject {
 
     setIdentityResponse(json: any): void {
         this.setIdentitySpy(json);
+        this.getAuthenticationStateSpy = this.spy('getAuthenticationState').andReturn(of(json));
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
@@ -37,9 +37,11 @@ export class MockActivatedRoute extends ActivatedRoute {
 
 export class MockRouter extends SpyObject {
     navigateSpy: Spy;
+    navigateByUrlSpy: Spy;
 
     constructor() {
         super(Router);
         this.navigateSpy = this.spy('navigate');
+        this.navigateByUrlSpy = this.spy('navigateByUrl');
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
@@ -38,10 +38,15 @@ export class MockActivatedRoute extends ActivatedRoute {
 export class MockRouter extends SpyObject {
     navigateSpy: Spy;
     navigateByUrlSpy: Spy;
+    events: Observable<any>;
 
     constructor() {
         super(Router);
         this.navigateSpy = this.spy('navigate');
         this.navigateByUrlSpy = this.spy('navigateByUrl');
+    }
+
+    setRouterEvent(event: any) {
+        this.events = of(event);
     }
 }


### PR DESCRIPTION
- Closes #9446 
- Fix redirection issue to the `/login` resource if you directly try to access protected view.
- Correctly navigate to stored url in `jwt`/`uaa` flow.


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
