### PR TITLE
use jdk 11 via update-java-alternatives

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -72,6 +72,7 @@ before_install:
     - sudo add-apt-repository ppa:openjdk-r/ppa -y
     - sudo apt-get update
     - sudo apt-get install -y openjdk-11-jdk
+    - sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
     - java -version
     - export TZ=Australia/Canberra
     - date


### PR DESCRIPTION
The java version is still 1.8. Forget to set jdk11 as default.
The post from https://www.linuxuprising.com/2019/01/how-to-install-openjdk-11-in-ubuntu.html says: "After the installation, your Java version should now be 11:"
But this seems not to bee the case in travis.

Now it is set to jdk 11.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
Follow up from: https://github.com/jhipster/generator-jhipster/pull/9410