### PR TITLE
Updated @types/react to 16.8.10 and aligned versions in devDependencies and resolutions

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -76,7 +76,7 @@ limitations under the License.
     "@types/mocha": "5.2.6",
     <%_ } _%>
     "@types/node": "10.14.3",
-    "@types/react": "16.8.8",
+    "@types/react": "16.8.10",
     "@types/react-dom": "16.8.3",
     "@types/react-redux": "6.0.6",
     "@types/react-router-dom": "4.3.1",
@@ -173,7 +173,7 @@ limitations under the License.
     "xml2js": "0.4.19"<% } %>
   },
   "resolutions": {
-    "@types/react": "16.8.4"
+    "@types/react": "16.8.10"
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -172,9 +172,6 @@ limitations under the License.
     "write-file-webpack-plugin": "4.5.0"<% if (buildTool === 'maven') { %>,
     "xml2js": "0.4.19"<% } %>
   },
-  "resolutions": {
-    "@types/react": "16.8.10"
-  },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
     "yarn": ">=1.3.2"<% } %>


### PR DESCRIPTION
Updated `@types/react` to 16.8.10 and aligned versions in `devDependencies` and `resolutions`.

The misalignment of versions was causing yarn build to fail as reported by @pascalgrimaud in comment https://github.com/jhipster/generator-jhipster/pull/9444#issuecomment-477910992

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed