### PR TITLE
react: fix logout reducer to handle success logout event

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -98,10 +98,10 @@ export default (state: AuthenticationState = initialState, action): Authenticati
         loginSuccess: true
       };
     <%_ } _%>
-    <%_ if (authenticationType === 'oauth2') { _%>
-    case SUCCESS(ACTION_TYPES.LOGOUT):
-    <%_ } else { _%>
+    <%_ if (authenticationType === 'jwt') { _%>
     case ACTION_TYPES.LOGOUT:
+    <%_ } else { _%>
+    case SUCCESS(ACTION_TYPES.LOGOUT):
     <%_ } _%>
       return {
         ...initialState,
@@ -219,21 +219,12 @@ export const logout = () => dispatch => {
     type: ACTION_TYPES.LOGOUT
   });
 };
-<%_ } else if (authenticationType === 'uaa') { _%>
-export const logout = () => async dispatch => {
-  await dispatch({
-    type: ACTION_TYPES.LOGOUT,
-    payload: axios.post('auth/logout', {})
-  });
-  dispatch(getSession());
-};
 <%_ } else { _%>
 export const logout = () => async dispatch => {
   await dispatch({
     type: ACTION_TYPES.LOGOUT,
-    payload: axios.post('api/logout', {})
+    payload: axios.post(<%_ if (authenticationType === 'uaa') { _%>'auth/logout'<%_ } else { _%>'api/logout'<%_ } _%>, {})
   });
-  dispatch(getSession());
 };
 <%_ } _%>
 

--- a/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/reducers/authentication.ts.ejs
@@ -225,6 +225,9 @@ export const logout = () => async dispatch => {
     type: ACTION_TYPES.LOGOUT,
     payload: axios.post(<%_ if (authenticationType === 'uaa') { _%>'auth/logout'<%_ } else { _%>'api/logout'<%_ } _%>, {})
   });
+
+  // fetch new csrf token
+  dispatch(getSession());
 };
 <%_ } _%>
 

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
@@ -135,7 +135,7 @@ describe('Authentication reducer tests', () => {
 
   describe('Other cases', () => {
     it('should properly reset the current state when a logout is requested', () => {
-      const toTest = authentication(undefined, { type: ACTION_TYPES.LOGOUT });
+      const toTest = authentication(undefined, { type: <%_ if (authenticationType === 'jwt') { _%> ACTION_TYPES.LOGOUT <%_ } else { _%>SUCCESS(ACTION_TYPES.LOGOUT)<%_ } _%> });
       expect(toTest).toMatchObject({
         loading: false,
         isAuthenticated: false,
@@ -223,13 +223,6 @@ describe('Authentication reducer tests', () => {
         {
          "payload": {},
          type: SUCCESS(ACTION_TYPES.LOGOUT),
-        },
-        {
-         type: REQUEST(ACTION_TYPES.GET_SESSION),
-        },
-        {
-         "payload": resolvedObject,
-         type: SUCCESS(ACTION_TYPES.GET_SESSION),
         }
         <%_ } _%>
       ];

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/reducers/authentication.spec.ts.ejs
@@ -223,6 +223,13 @@ describe('Authentication reducer tests', () => {
         {
          "payload": {},
          type: SUCCESS(ACTION_TYPES.LOGOUT),
+        },
+        {
+         type: REQUEST(ACTION_TYPES.GET_SESSION),
+        },
+        {
+         "payload": resolvedObject,
+         type: SUCCESS(ACTION_TYPES.GET_SESSION),
         }
         <%_ } _%>
       ];


### PR DESCRIPTION
- Closes #9297 
~~I have also removed the dispatch to `getSession()` in logout action as I couldn't think about a reason to justify that. Post successful logout, that call should always fail with `401`. If anyone sees a valid reason to have that, I will be happy to add that back.~~

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
