### PR TITLE
react: upgrade: remove menu components from layout/headers directory

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -181,5 +181,13 @@ function cleanupOldServerFiles(generator, javaDir, testDir, mainResourceDir, tes
         generator.removeFile(`${testDir}web/rest/util/PaginationUtilUnitTest.java`);
         generator.removeFile(`${javaDir}config/OAuth2Configuration.java`);
         generator.removeFile(`${javaDir}security/OAuth2AuthenticationSuccessHandler.java`);
+
+        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/index.ts`);
+        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/account.tsx`);
+        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/admin.tsx`);
+        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/entities.tsx`);
+        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/locale.tsx`);
+
+        generator.removeFile(`${CLIENT_TEST_SRC_DIR}spec/app/shared/layout/header/menus/account.spec.tsx`);
     }
 }

--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -182,12 +182,7 @@ function cleanupOldServerFiles(generator, javaDir, testDir, mainResourceDir, tes
         generator.removeFile(`${javaDir}config/OAuth2Configuration.java`);
         generator.removeFile(`${javaDir}security/OAuth2AuthenticationSuccessHandler.java`);
 
-        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/index.ts`);
-        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/account.tsx`);
-        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/admin.tsx`);
-        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/entities.tsx`);
-        generator.removeFile(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus/locale.tsx`);
-
-        generator.removeFile(`${CLIENT_TEST_SRC_DIR}spec/app/shared/layout/header/menus/account.spec.tsx`);
+        generator.removeFolder(`${CLIENT_MAIN_SRC_DIR}app/shared/layout/header/menus`);
+        generator.removeFolder(`${CLIENT_TEST_SRC_DIR}spec/app/shared/layout/header/menus`);
     }
 }


### PR DESCRIPTION
Menu components are now directly present under `layout/menus` directory

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
