### PR TITLE
CI: update JDK8 / JDK11 builds

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,8 +24,6 @@ services:
 language: node_js
 node_js:
     - '10.15.3'
-jdk:
-    - openjdk11
 addons:
     apt:
         sources:
@@ -41,6 +39,7 @@ env:
         - JHI_PROFILE=dev
         - JHI_RUN_APP=1
         - JHI_PROTRACTOR=0
+        - JHI_JDK=8
         # if JHI_LIB_BRANCH value is release, use the release from Maven
         - JHI_LIB_REPO=https://github.com/jhipster/jhipster.git
         - JHI_LIB_BRANCH=master
@@ -53,22 +52,31 @@ env:
         - JHI_DISABLE_WEBPACK_LOGS=true
         - JHI_E2E_HEADLESS=true
         - JHI_SCRIPTS=$TRAVIS_BUILD_DIR/test-integration/scripts
-        - JHI_JDK=11
     matrix:
-        - JHI_APP=jdl-default JHI_ENTITY=jdl JHI_PROFILE=prod JHI_PROTRACTOR=1
-        - JHI_APP=jdl-default JHI_ENTITY=jdl JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_JDK=8
         - JHI_APP=ngx-default JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_SONAR=1
         - JHI_APP=ngx-psql-es-noi18n JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sqlfull
         - JHI_APP=ngx-gradle-fr JHI_PROFILE=prod JHI_PROTRACTOR=1 JHI_ENTITY=sql JHI_WAR=1
-        - JHI_APP=ngx-mariadb-oauth2-sass-infinispan JHI_PROTRACTOR=1 JHI_ENTITY=sql
         - JHI_APP=ms-ngx-gateway-eureka JHI_ENTITY=sql JHI_WAR=1
         - JHI_APP=ms-micro-eureka JHI_ENTITY=micro JHI_WAR=1
+        - JHI_APP=ms-micro-consul JHI_ENTITY=micro
         - JHI_APP=ngx-mongodb-kafka-cucumber JHI_ENTITY=mongodb
+        - JHI_APP=ngx-session-cassandra-fr JHI_ENTITY=cassandra
+        - JHI_APP=ngx-couchbase JHI_PROFILE=prod JHI_ENTITY=couchbase
 
 #----------------------------------------------------------------------
 # Install all tools and check configuration
 #----------------------------------------------------------------------
 before_install:
+    - |
+        if [[ $JHI_JDK = '11' ]]; then
+            echo '*** Using OpenJDK 11'
+            sudo add-apt-repository ppa:openjdk-r/ppa
+            sudo apt-get update
+            sudo apt-get install -y openjdk-11-jdk
+            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+        else
+            echo '*** Using OpenJDK 8 by default'
+        fi
     - sudo add-apt-repository ppa:openjdk-r/ppa -y
     - sudo apt-get update
     - sudo apt-get install -y openjdk-11-jdk

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -25,6 +25,7 @@ jobs:
           JHI_PROFILE: dev
           JHI_RUN_APP: 1
           JHI_PROTRACTOR: 0
+          JHI_JDK: 11
           # if JHI_LIB_BRANCH value is release, use the release from Maven
           JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
           JHI_LIB_BRANCH: master
@@ -40,6 +41,17 @@ jobs:
 
       strategy:
           matrix:
+              jdl-default:
+                  JHI_APP: jdl-default
+                  JHI_ENTITY: jdl
+                  JHI_PROFILE: prod
+                  JHI_PROTRACTOR: 1
+              jdl-default-jdk8:
+                  JHI_APP: jdl-default
+                  JHI_ENTITY: jdl
+                  JHI_PROFILE: prod
+                  JHI_PROTRACTOR: 1
+                  JHI_JDK: 8
               react-default:
                   JHI_APP: react-default
                   JHI_PROFILE: prod
@@ -60,19 +72,13 @@ jobs:
               ms-ngx-gateway-uaa:
                   JHI_APP: ms-ngx-gateway-uaa
                   JHI_ENTITY: uaa
-              ms-micro-consul:
-                  JHI_APP: ms-micro-consul
-                  JHI_ENTITY: micro
+              ngx-mariadb-oauth2-sass-infinispan:
+                  JHI_APP: ngx-mariadb-oauth2-sass-infinispan
+                  JHI_PROTRACTOR: 1
+                  JHI_ENTITY: sql
               ngx-h2mem-ws-nol2:
                   JHI_APP: ngx-h2mem-ws-nol2
                   JHI_ENTITY: sql
-              ngx-session-cassandra-fr:
-                  JHI_APP: ngx-session-cassandra-fr
-                  JHI_ENTITY: cassandra
-              ngx-couchbase:
-                  JHI_APP: ngx-couchbase
-                  JHI_PROFILE: prod
-                  JHI_ENTITY: couchbase
               webflux-mongodb:
                   JHI_APP: webflux-mongodb
                   JHI_ENTITY: mongodb
@@ -85,6 +91,17 @@ jobs:
             inputs:
                 versionSpec: '10.15.3'
             displayName: 'TOOLS: install Node.js'
+          - script: |
+                if [[ $JHI_JDK = '11' ]]; then
+                    echo '*** Using OpenJDK 11'
+                    sudo add-apt-repository ppa:openjdk-r/ppa
+                    sudo apt-get update
+                    sudo apt-get install -y openjdk-11-jdk
+                    sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+                else
+                    echo '*** Using OpenJDK 8 by default'
+                fi
+            displayName: 'TOOLS: configuring OpenJDK'
           - script: |
                 wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | sudo apt-key add -
                 sudo sh -c 'echo "deb [arch=amd64] http://dl.google.com/linux/chrome/deb/ stable main" >> /etc/apt/sources.list.d/google.list'


### PR DESCRIPTION
Following this PR https://github.com/jhipster/generator-jhipster/pull/9507 by @cremich

- Travis: use JDK8 by default, as downloading JDK11 is too long
- Azure: use JDK11 by default and add 1 build with JDK8
- switch jdl, infinispan builds to Azure

2 builds will fail, because of JDK11 :
- infinispan
- uaa

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
