### PR TITLE
Change to jaxb-runtime and explicitly include it when using UAA

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -436,6 +436,7 @@ dependencies {
     <%_ if (authenticationType === 'uaa') { _%>
     implementation "org.springframework.security.oauth:spring-security-oauth2"
     implementation "org.springframework.security:spring-security-jwt"
+    <% if (databaseType === 'sql') { %>implementation<% } else { %>runtimeOnly<% } %>> "org.glassfish.jaxb:jaxb-runtime:${jaxb_runtime_version}"
     <%_ } _%>
     <%_ if (databaseType === 'mongodb') { _%>
     implementation "com.github.mongobee:mongobee"
@@ -473,8 +474,9 @@ dependencies {
     annotationProcessor "org.mapstruct:mapstruct-processor:${mapstruct_version}"
     <%_ if (databaseType === 'sql') { _%>
     annotationProcessor "org.hibernate:hibernate-jpamodelgen:${hibernate_version}"
-    annotationProcessor "javax.xml.bind:jaxb-api:${jaxb_api_version}"
-    annotationProcessor "com.sun.xml.bind:jaxb-impl:${jaxb_impl_version}"
+        <%_ if (authenticationType !== 'uaa') { _%>
+    annotationProcessor "org.glassfish.jaxb:jaxb-runtime:${jaxb_runtime_version}"
+        <%_ } _%>
     <%_ } _%>
     annotationProcessor ("org.springframework.boot:spring-boot-configuration-processor:${spring_boot_version}") {
         exclude group: "com.vaadin.external.google", module: "android-json"

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -36,9 +36,10 @@ mapstruct_version=1.3.0.Final
 
 liquibase_hibernate5_version=3.6
 liquibaseTaskPrefix=liquibase
+<%_ if (databaseType === 'sql' || authenticationType === 'uaa') { _%>
 
-jaxb_api_version=2.3.1
-jaxb_impl_version=2.3.2
+jaxb_runtime_version=2.3.2
+<%_ } _%>
 
 # jhipster-needle-gradle-property - JHipster will add additional properties here
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -101,15 +101,14 @@
         <!-- The javassist version should match the one managed by
         https://mvnrepository.com/artifact/org.hibernate/hibernate-core/${hibernate.version} -->
         <javassist.version>3.23.1-GA</javassist.version>
-        <%_ if (databaseType === 'sql') { _%>
-        <jaxb-api.version>2.3.1</jaxb-api.version>
-        <jaxb-impl.version>2.3.2</jaxb-impl.version>
         <!-- The liquibase version should match the one managed by
         https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${spring-boot.version} -->
         <liquibase.version>3.6.3</liquibase.version>
         <liquibase-hibernate5.version>3.6</liquibase-hibernate5.version>
-        <%_ } _%>
         <validation-api.version>2.0.1.Final</validation-api.version>
+        <%_ } _%>
+        <%_ if (databaseType === 'sql' || authenticationType === 'uaa') { _%>
+        <jaxb-runtime.version>2.3.2</jaxb-runtime.version>
         <%_ } _%>
         <mapstruct.version>1.3.0.Final</mapstruct.version>
 
@@ -607,6 +606,15 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-jwt</artifactId>
         </dependency>
+        <dependency>
+            <groupId>org.glassfish.jaxb</groupId>
+            <artifactId>jaxb-runtime</artifactId>
+            <version>${jaxb-runtime.version}</version>
+            <%_ if (databaseType !== 'sql') { _%>
+            <scope>runtime</scope>
+            <%_ } _%>
+        </dependency>
+
         <%_ } _%>
         <%_ if (databaseType === 'cassandra') { _%>
         <!-- DataStax driver -->
@@ -755,16 +763,13 @@
                             <artifactId>hibernate-jpamodelgen</artifactId>
                             <version>${hibernate.version}</version>
                         </path>
+    <%_ if (authenticationType !== 'uaa') { _%>
                         <path>
-                            <groupId>javax.xml.bind</groupId>
-                            <artifactId>jaxb-api</artifactId>
-                            <version>${jaxb-api.version}</version>
+                            <groupId>org.glassfish.jaxb</groupId>
+                            <artifactId>jaxb-runtime</artifactId>
+                            <version>${jaxb-runtime.version}</version>
                         </path>
-                        <path>
-                            <groupId>com.sun.xml.bind</groupId>
-                            <artifactId>jaxb-impl</artifactId>
-                            <version>${jaxb-impl.version}</version>
-                        </path>
+    <%_ } _%>
 <%_ } _%>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
This PR fixes the problem of missing JAXB implementation at runtime when using JDK 11.
It includes the following changes:
- Dependency changed to [org.glassfish.jaxb:jaxb-runtime](https://search.maven.org/artifact/org.glassfish.jaxb/jaxb-runtime/2.3.2/jar) as is also recommended by the Spring team [here]( https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-with-Java-9-and-above#jaxb)
- The dependency is explicitly included when using UAA as authentication type as it is also required by `spring-security-oauth2` at runtime.
- Fix has been applied for both Maven and Gradle

Fix #9514 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed