### PR TITLE
Use SDKMan to provision Open JDK 11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -78,10 +78,6 @@ before_install:
         else
             echo '*** Using OpenJDK 8 by default'
         fi
-    - curl -s get.sdkman.io | bash
-    - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-    - source "$HOME/.sdkman/bin/sdkman-init.sh"
-    - sdk install java 11.0.2-open
     - java --version
     - export TZ=Australia/Canberra
     - date

--- a/.travis.yml
+++ b/.travis.yml
@@ -70,18 +70,19 @@ before_install:
     - |
         if [[ $JHI_JDK = '11' ]]; then
             echo '*** Using OpenJDK 11'
-            sudo add-apt-repository ppa:openjdk-r/ppa
-            sudo apt-get update
-            sudo apt-get install -y openjdk-11-jdk
-            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+            curl -s get.sdkman.io | bash
+            echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+            source "$HOME/.sdkman/bin/sdkman-init.sh"
+            sdk install java 11.0.2-open
+            java --version
         else
             echo '*** Using OpenJDK 8 by default'
         fi
-    - sudo add-apt-repository ppa:openjdk-r/ppa -y
-    - sudo apt-get update
-    - sudo apt-get install -y openjdk-11-jdk
-    - sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
-    - java -version
+    - curl -s get.sdkman.io | bash
+    - echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+    - source "$HOME/.sdkman/bin/sdkman-init.sh"
+    - sdk install java 11.0.2-open
+    - java --version
     - export TZ=Australia/Canberra
     - date
     - sudo /etc/init.d/mysql stop

--- a/.travis.yml
+++ b/.travis.yml
@@ -74,11 +74,10 @@ before_install:
             echo sdkman_auto_answer=true > ~/.sdkman/etc/config
             source "$HOME/.sdkman/bin/sdkman-init.sh"
             sdk install java 11.0.2-open
-            java --version
         else
             echo '*** Using OpenJDK 8 by default'
         fi
-    - java --version
+    - java -version
     - export TZ=Australia/Canberra
     - date
     - sudo /etc/init.d/mysql stop

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,9 +6,11 @@ RUN \
   useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
   echo 'jhipster:jhipster' |chpasswd && \
   mkdir /home/jhipster/app && \
-  # install open-jdk 8
-  apt-get update && \
-  apt-get install -y openjdk-11-jdk && \
+  # install open-jdk 8 using SDKMAN
+  curl -s get.sdkman.io | bash && \
+  echo sdkman_auto_answer=true > ~/.sdkman/etc/config && \
+  source "$HOME/.sdkman/bin/sdkman-init.sh" && \
+  sdk install java 11.0.2-open && \
   # install utilities
   apt-get install -y \
     wget \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,11 +94,9 @@ jobs:
           - script: |
                 if [[ $JHI_JDK = '11' ]]; then
                     echo '*** Using OpenJDK 11'
-                    echo '*** Installing SDKMAN!'
                     curl -s get.sdkman.io | bash
                     echo sdkman_auto_answer=true > ~/.sdkman/etc/config
                     source "$HOME/.sdkman/bin/sdkman-init.sh"
-                    echo '*** Installing OpenJDK 11'
                     sdk install java 11.0.2-open
                     java --version
                 else

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,10 +94,13 @@ jobs:
           - script: |
                 if [[ $JHI_JDK = '11' ]]; then
                     echo '*** Using OpenJDK 11'
-                    sudo add-apt-repository ppa:openjdk-r/ppa
-                    sudo apt-get update
-                    sudo apt-get install -y openjdk-11-jdk
-                    sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+                    echo '*** Installing SDKMAN!'
+                    curl -s get.sdkman.io | bash
+                    echo sdkman_auto_answer=true > ~/.sdkman/etc/config
+                    source "$HOME/.sdkman/bin/sdkman-init.sh"
+                    echo '*** Installing OpenJDK 11'
+                    sdk install java 11.0.2-open
+                    java --version
                 else
                     echo '*** Using OpenJDK 8 by default'
                 fi


### PR DESCRIPTION
Use SDKMAN to provision Open JDK 11 in Azure build

Fixes #9513 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed