### PR TITLE
fix metrics_path in Prometheus configuration file (with Docker)

### DIFF
--- a/generators/server/templates/src/main/docker/prometheus/prometheus.yml.ejs
+++ b/generators/server/templates/src/main/docker/prometheus/prometheus.yml.ejs
@@ -37,7 +37,7 @@ scrape_configs:
     scrape_interval: 5s
 
     # scheme defaults to 'http'.
-    metrics_path: /management/prometheus
+    metrics_path: <% if ((applicationType === 'microservice' || applicationType === 'uaa') && !serviceDiscoveryType) { %>/services/<%= baseName %><% } %>/management/prometheus
     static_configs:
       - targets:
           # On MacOS, replace localhost by host.docker.internal


### PR DESCRIPTION
Update prometheus metrics route if no service discovery is used with microservices or uaa

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
