### PR TITLE
fixes #9529 "Can't use OAuth2 in dev with start-tls"

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -53,7 +53,8 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         stats: options.stats,
         watchOptions: {
             ignored: /node_modules/
-        }
+        },
+        https: options.tls
     },
     entry: {
         polyfills: './<%= MAIN_SRC_DIR %>app/polyfills',
@@ -128,10 +129,11 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         new FriendlyErrorsWebpackPlugin(),
         new ForkTsCheckerWebpackPlugin(),
         new BrowserSyncPlugin({
+            https: options.tls,
             host: 'localhost',
             port: 9000,
             proxy: {
-                target: 'http://localhost:9060'<% if (websocket === 'spring-websocket') { %>,
+                target: `http${options.tls ? 's' : ''}://localhost:9060`<% if (websocket === 'spring-websocket') { %>,
                 ws: true<% } %>,
                 proxyOptions: {
                     changeOrigin: false  //pass the Host header to the backend unchanged  https://github.com/Browsersync/browser-sync/issues/430

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -74,7 +74,8 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     }<% } %>],
     watchOptions: {
       ignored: /node_modules/
-    }
+    },
+    https: options.tls
   },
   stats: process.env.JHI_DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
   plugins: [
@@ -85,10 +86,11 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         }),
     new FriendlyErrorsWebpackPlugin(),
     new BrowserSyncPlugin({
+      https: options.tls,
       host: 'localhost',
       port: 9000,
       proxy: {
-        target: 'http://localhost:9060'<% if (websocket === 'spring-websocket') { %>,
+        target: `http${options.tls ? 's' : ''}://localhost:9060`<% if (websocket === 'spring-websocket') { %>,
           ws: true<% } %>,
           proxyOptions: {
               changeOrigin: false  //pass the Host header to the backend unchanged  https://github.com/Browsersync/browser-sync/issues/430


### PR DESCRIPTION
One should also update [the TLS documentation](/jhipster/jhipster.github.io/blob/master/pages/tls.md) in order to tell the developer to go to https://localhost:9000 instead http address

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
