### PR TITLE
Switch to OpenJDK11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -70,10 +70,11 @@ before_install:
     - |
         if [[ $JHI_JDK = '11' ]]; then
             echo '*** Using OpenJDK 11'
-            curl -s get.sdkman.io | bash
-            echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-            source "$HOME/.sdkman/bin/sdkman-init.sh"
-            sdk install java 11.0.2-open
+            sudo add-apt-repository ppa:openjdk-r/ppa
+            sudo apt-get update
+            sudo apt-get install -y openjdk-11-jdk
+            sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+            java -version
         else
             echo '*** Using OpenJDK 8 by default'
         fi

--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,13 @@ RUN \
     g++ \
     libpng-dev \
     build-essential \
+    software-properties-common \
     sudo && \
+  # install OpenJDK 11
+  add-apt-repository ppa:openjdk-r/ppa && \
+  apt-get update && \
+  apt-get install -y openjdk-11-jdk && \
+  update-java-alternatives -s java-1.11.0-openjdk-amd64 && \
   # install node.js
   wget https://nodejs.org/dist/v10.15.3/node-v10.15.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
   tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
@@ -62,12 +68,6 @@ RUN \
 
 # expose the working directory, the Tomcat port, the BrowserSync ports
 USER jhipster
-
-# install open-jdk 11 using SDKMAN
-RUN curl -s get.sdkman.io | bash && \
-    echo sdkman_auto_answer=true > /home/jhipster/.sdkman/etc/config && \
-    /bin/bash -c "source /home/jhipster/.sdkman/bin/sdkman-init.sh ; sdk install java 11.0.2-open"
-
 ENV PATH $PATH:/usr/bin:/home/jhipster/.yarn-global/bin:/home/jhipster/.yarn/bin:/home/jhipster/.config/yarn/global/node_modules/.bin
 WORKDIR "/home/jhipster/app"
 VOLUME ["/home/jhipster/app"]

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -94,11 +94,11 @@ jobs:
           - script: |
                 if [[ $JHI_JDK = '11' ]]; then
                     echo '*** Using OpenJDK 11'
-                    curl -s get.sdkman.io | bash
-                    echo sdkman_auto_answer=true > ~/.sdkman/etc/config
-                    source "$HOME/.sdkman/bin/sdkman-init.sh"
-                    sdk install java 11.0.2-open
-                    java --version
+                    sudo add-apt-repository ppa:openjdk-r/ppa
+                    sudo apt-get update
+                    sudo apt-get install -y openjdk-11-jdk
+                    sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
+                    java -version
                 else
                     echo '*** Using OpenJDK 8 by default'
                 fi


### PR DESCRIPTION
We discussed with @jdubois during our last JHipster day, and I think we should stick with a more classic installation of OpenJDK, instead of using SDKMAN.

@pvliss: do you agree with that ?
@PierreBesson : what do you think too ?

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
