### PR TITLE
Fix resolution problem for @types/react dep when using yarn

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -172,6 +172,11 @@ limitations under the License.
     "write-file-webpack-plugin": "4.5.0"<% if (buildTool === 'maven') { %>,
     "xml2js": "0.4.19"<% } %>
   },
+<%_ if (clientPackageManager === 'yarn') { _%>
+  "resolutions": {
+    "@types/react": "16.8.10"
+  },
+<%_ } _%>
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
     "yarn": ">=1.3.2"<% } %>


### PR DESCRIPTION
This PR restores usage of `resolutions` feature for yarn to avoid dep resolution problem for `@types/react`.

This was removed in https://github.com/jhipster/generator-jhipster/pull/9508/commits/abfe4175a5d9f88c7bd2e5aa29efd15214c84df1 but problem reappeared in https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=2176 as reported by @pascalgrimaud in comment https://github.com/jhipster/generator-jhipster/pull/9508#issuecomment-480573655.

I believe the problem is related to old dependencies of https://github.com/jhipster/react-jhipster and could be solved when https://github.com/jhipster/react-jhipster/issues/24 is implemented

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed