### PR TITLE
Add title configOption to openapi generator plugin

### DIFF
--- a/generators/server/templates/gradle/swagger.gradle.ejs
+++ b/generators/server/templates/gradle/swagger.gradle.ejs
@@ -31,7 +31,7 @@ openApiGenerate {
     apiFilesConstrainedTo = [""]
     modelFilesConstrainedTo = [""]
     supportingFilesConstrainedTo = ["ApiUtil.java"]
-    configOptions = [delegatePattern: "true"]
+    configOptions = [delegatePattern: "true", "title": <%= dasherizedBaseName %>]
     validateSpec = true
 }
 

--- a/generators/server/templates/gradle/swagger.gradle.ejs
+++ b/generators/server/templates/gradle/swagger.gradle.ejs
@@ -31,7 +31,7 @@ openApiGenerate {
     apiFilesConstrainedTo = [""]
     modelFilesConstrainedTo = [""]
     supportingFilesConstrainedTo = ["ApiUtil.java"]
-    configOptions = [delegatePattern: "true", "title": <%= dasherizedBaseName %>]
+    configOptions = [delegatePattern: "true", title: "<%= dasherizedBaseName %>"]
     validateSpec = true
 }
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1194,6 +1194,7 @@
                                     <reactive>true</reactive>
                                     <%_ } _%>
                                     <delegatePattern>true</delegatePattern>
+                                    <title><%= dasherizedBaseName %></title>
                                 </configOptions>
                             </configuration>
                         </execution>


### PR DESCRIPTION
Fixes #9555 by adding `title` property both in maven and gradle 

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->

