### PR TITLE
Enable blueprint to define custom subgenerator

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -18,10 +18,11 @@
  */
 
 let customCommands = {};
-if (process.argv.indexOf('--blueprint') > -1) {
+const indexOfBlueprintArgv = process.argv.indexOf('--blueprint');
+if (indexOfBlueprintArgv > -1) {
     /* eslint-disable import/no-dynamic-require */
     /* eslint-disable global-require */
-    customCommands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/cli/commands`);
+    customCommands = require(`generator-jhipster-${process.argv[indexOfBlueprintArgv + 1]}/cli/commands`);
 }
 
 const defaultCommands = {

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -16,7 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-module.exports = {
+let commands = {};
+if (process.argv.indexOf('--blueprint') > -1) {
+    commands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/commands`);
+}
+
+const defaultCommands = {
     app: {
         default: true,
         desc: 'Create a new JHipster application based on the selected options'
@@ -103,3 +108,4 @@ Example:
         desc: 'Upgrade the JHipster version, and upgrade the generated application'
     }
 };
+module.exports = Object.assign(defaultCommands, commands);

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -17,11 +17,11 @@
  * limitations under the License.
  */
 
-let commands = {};
+let customCommands = {};
 if (process.argv.indexOf('--blueprint') > -1) {
     /* eslint-disable import/no-dynamic-require */
     /* eslint-disable global-require */
-    commands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/commands`);
+    customCommands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/commands`);
 }
 
 const defaultCommands = {
@@ -111,4 +111,8 @@ Example:
         desc: 'Upgrade the JHipster version, and upgrade the generated application'
     }
 };
-module.exports = Object.assign(defaultCommands, commands);
+
+module.exports = {
+    ...defaultCommands,
+    ...customCommands
+};

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -21,7 +21,7 @@ let customCommands = {};
 if (process.argv.indexOf('--blueprint') > -1) {
     /* eslint-disable import/no-dynamic-require */
     /* eslint-disable global-require */
-    customCommands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/commands`);
+    customCommands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/cli/commands`);
 }
 
 const defaultCommands = {

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -16,8 +16,11 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
 let commands = {};
 if (process.argv.indexOf('--blueprint') > -1) {
+    /* eslint-disable import/no-dynamic-require */
+    /* eslint-disable global-require */
     commands = require(`generator-jhipster-${process.argv[process.argv.indexOf('--blueprint') + 1]}/commands`);
 }
 

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -188,7 +188,11 @@ const createYeomanEnv = () => {
     Object.keys(SUB_GENERATORS)
         .filter(command => !SUB_GENERATORS[command].cliOnly)
         .forEach(generator => {
-            env.register(require.resolve(`../generators/${generator}`), `${CLI_NAME}:${generator}`);
+            if (SUB_GENERATORS[generator].blueprint) {
+                env.register(require.resolve(`../node_modules/${SUB_GENERATORS[generator].blueprint}/generators/${generator}`), `${CLI_NAME}:${generator}`);
+            } else {
+                env.register(require.resolve(`../generators/${generator}`), `${CLI_NAME}:${generator}`);
+            }
         });
     return env;
 };

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -190,7 +190,7 @@ const createYeomanEnv = () => {
         .forEach(generator => {
             if (SUB_GENERATORS[generator].blueprint) {
                 /* eslint-disable prettier/prettier */
-                env.register(require.resolve(`../node_modules/${SUB_GENERATORS[generator].blueprint}/generators/${generator}`), `${CLI_NAME}:${generator}`);
+                env.register(require.resolve(`${SUB_GENERATORS[generator].blueprint}/generators/${generator}`), `${CLI_NAME}:${generator}`);
             } else {
                 env.register(require.resolve(`../generators/${generator}`), `${CLI_NAME}:${generator}`);
             }

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -189,6 +189,7 @@ const createYeomanEnv = () => {
         .filter(command => !SUB_GENERATORS[command].cliOnly)
         .forEach(generator => {
             if (SUB_GENERATORS[generator].blueprint) {
+                /* eslint-disable prettier/prettier */
                 env.register(require.resolve(`../node_modules/${SUB_GENERATORS[generator].blueprint}/generators/${generator}`), `${CLI_NAME}:${generator}`);
             } else {
                 env.register(require.resolve(`../generators/${generator}`), `${CLI_NAME}:${generator}`);

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -45,7 +45,7 @@ describe('jhipster cli test', () => {
             expect(error).to.not.be.null;
             expect(error.code).to.equal(1);
             /* eslint-disable prettier/prettier */
-            expect(stderr.includes('Cannot find module \'generator-jhipster-bar/commands\'')).to.be.true;
+            expect(stderr.includes('Cannot find module \'generator-jhipster-bar/cli/commands\'')).to.be.true;
             done();
         });
     });

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -36,4 +36,17 @@ describe('jhipster cli test', () => {
             done();
         });
     });
+
+    it('should delegate to blueprint on blueprint command but will not find it', function(done) {
+        this.timeout(4000);
+
+        exec(`${cmd} foo --blueprint bar`, (error, stdout, stderr) => {
+            console.log(error);
+            expect(error).to.not.be.null;
+            expect(error.code).to.equal(1);
+            /* eslint-disable prettier/prettier */
+            expect(stderr.includes('Cannot find module \'generator-jhipster-bar/commands\'')).to.be.true;
+            done();
+        });
+    });
 });


### PR DESCRIPTION
Blueprints can easily modify main generator behavior, however, quickly grows the need to define custom subgenerator for specific tasks.

To ensure that possibility, this PR enables to define a subgenerator in a blueprint using a simple file formatted as such:
*generator-jhipster-testblueprint/commands.js*
```
module.exports = {
    foo: {
        desc: 'bar', // A little description that will be displayed using --help
        blueprint: 'generator-jhipster-testblueprint' // This is required to determine the blueprint issuing the custom command
    }
};
```

When using `jhipster foo --blueprint testblueprint`, the foo subgenerator from the blueprint will be called directly.

I'd like some reviews on this one, as on the feature itself as on the code. This will clearly enable users to define specific stuff on their own enjoying all JHipster cli mechanism.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
