### PR TITLE
Remove duplicated property in editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,5 +13,4 @@ insert_final_newline = true
 trim_trailing_whitespace = false
 
 [package.json]
-indent_style = space
 indent_size = 2


### PR DESCRIPTION
The property `indent_style = space` is already defined in the parent `[*]` and could be removed in `[package.json]`.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
