### PR TITLE
Fix Angular codelyzer rule name

### DIFF
--- a/generators/client/templates/angular/tslint.json.ejs
+++ b/generators/client/templates/angular/tslint.json.ejs
@@ -128,7 +128,7 @@
         "no-host-metadata-property": true,
         "no-input-rename": true,
         "no-output-rename": true,
-        "use-life-cycle-interface": true,
+        "use-lifecycle-interface": true,
         "use-pipe-transform-interface": false,
         "component-class-suffix": true,
         "directive-class-suffix": true


### PR DESCRIPTION
Codelyzer rule `use-life-cycle-interface` has been renamed to `use-lifecycle-interface` at version [5.0.0
](https://github.com/mgechev/codelyzer/releases/tag/5.0.0)

There is an error emitted when building although it does not fail:
```
[INFO] > travis-psql-es-noi-18-n-maps-id-with-ngx@0.0.0 webpack /home/pav/Development/temp/jhipster-java/ngx-psql-es-noi18n-mapsid
[INFO] > node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js "--config" "webpack/webpack.dev.js" "--env.stats=minimal"
[INFO] 
[INFO] Webpack: Starting ...
[INFO] Starting type checking service...
Webpack: Starting ...
[INFO] 
[INFO]    ✔ Compile modules
[INFO]    ❯ Build modules (33%)
[INFO]      → 5 of 7 modules :: src/main/webapp/app/app.main.ts ~ internal
[ERROR] 
[ERROR] Could not find implementations for the following rules specified in the configuration:
[ERROR]     use-life-cycle-interface
[ERROR] Try upgrading TSLint and/or ensuring that you have all necessary custom rules installed.
[ERROR] If TSLint was recently upgraded, you may have old rules configured which need to be cleaned up.
[ERROR]         
[ERROR] 

``

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed