### PR TITLE
Prevent error while looking for custom command within blueprint

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -16,13 +16,22 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const chalk = require('chalk');
 
 let customCommands = {};
 const indexOfBlueprintArgv = process.argv.indexOf('--blueprint');
 if (indexOfBlueprintArgv > -1) {
     /* eslint-disable import/no-dynamic-require */
     /* eslint-disable global-require */
-    customCommands = require(`generator-jhipster-${process.argv[indexOfBlueprintArgv + 1]}/cli/commands`);
+
+    const blueprint = process.argv[indexOfBlueprintArgv + 1];
+    try {
+        customCommands = require(`generator-jhipster-${blueprint}/cli/commands`);
+    } catch (e) {
+        const msg = `No custom command found within blueprint: generator-jhipster-${blueprint}`;
+        /* eslint-disable no-console */
+        console.info(`${chalk.green.bold('INFO!')} ${msg}`);
+    }
 }
 
 const defaultCommands = {

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -45,7 +45,8 @@ describe('jhipster cli test', () => {
             expect(error).to.not.be.null;
             expect(error.code).to.equal(1);
             /* eslint-disable prettier/prettier */
-            expect(stderr.includes('Cannot find module \'generator-jhipster-bar/cli/commands\'')).to.be.true;
+            expect(stdout.includes('No custom command found within blueprint')).to.be.true;
+            expect(stderr.includes('is not a known command')).to.be.true;
             done();
         });
     });


### PR DESCRIPTION
This finalize #9574 as it prevents generator to throw errors using blueprint.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
