### PR TITLE
fix decimal fake-data column type

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -180,7 +180,7 @@
             <%_ for (idx in fields) {
                 let loadColumnType = 'string';
                 let columnType = fields[idx].columnType;
-                if (columnType === 'integer' || columnType === 'bigint' || columnType === 'double' || columnType === 'decimal(10,2)' || columnType === '${floatType}') {
+                if (columnType === 'integer' || columnType === 'bigint' || columnType === 'double' || columnType === 'decimal(21,2)' || columnType === '${floatType}') {
                     loadColumnType = 'numeric';
                 } else if (columnType === 'date' || columnType === 'datetime') {
                     loadColumnType = 'date';


### PR DESCRIPTION
The precision was changed from (10,2) to (21,2) in #9338, so the condition no longer matched.

Related to [this StackOverflow post](https://stackoverflow.com/questions/55787123/error-column-own-amount-is-of-type-numeric-but-expression-is-of-type-characte), I couldn't reproduce the error message myself but this should fix it.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
