### PR TITLE
Fix source map generation for webpack prod

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -35,7 +35,7 @@ const sass = require('sass');
 
 module.exports = webpackMerge(commonConfig({ env: ENV }), {
     // Enable source maps. Please note that this will slow down the build.
-    // You have to enable it in UglifyJSPlugin config below and in tsconfig-aot.json as well
+    // You have to enable it in Terser config below and in tsconfig-aot.json as well
     // devtool: 'source-map',
     entry: {
         polyfills: './<%= MAIN_SRC_DIR %>app/polyfills',
@@ -111,12 +111,12 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
             new TerserPlugin({
                 parallel: true,
                 cache: true,
+                // sourceMap: true, // Enable source maps. Please note that this will slow down the build
                 terserOptions: {
                     ecma: 6,
                     ie8: false,
                     toplevel: true,
                     module: true,
-                    // sourceMap: true, // Enable source maps. Please note that this will slow down the build
                     compress: {
                         dead_code: true,
                         warnings: false,


### PR DESCRIPTION
I think this was a small typo leftover from the webpack upgrade, but source maps aren't being generated the way it is now

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
