### PR TITLE
Handle all blueprint name variants when searching for blueprint custo…

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 const chalk = require('chalk');
+const jhipsterUtils = require('../generators/utils');
 
 let customCommands = {};
 const indexOfBlueprintArgv = process.argv.indexOf('--blueprint');
@@ -24,11 +25,11 @@ if (indexOfBlueprintArgv > -1) {
     /* eslint-disable import/no-dynamic-require */
     /* eslint-disable global-require */
 
-    const blueprint = process.argv[indexOfBlueprintArgv + 1];
+    const blueprint = jhipsterUtils.normalizeBlueprintName(process.argv[indexOfBlueprintArgv + 1]);
     try {
-        customCommands = require(`generator-jhipster-${blueprint}/cli/commands`);
+        customCommands = require(`${blueprint}/cli/commands`);
     } catch (e) {
-        const msg = `No custom command found within blueprint: generator-jhipster-${blueprint}`;
+        const msg = `No custom command found within blueprint: ${blueprint}`;
         /* eslint-disable no-console */
         console.info(`${chalk.green.bold('INFO!')} ${msg}`);
     }

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -23,6 +23,7 @@ const cleanup = require('../cleanup');
 const prompts = require('./prompts');
 const packagejs = require('../../package.json');
 const statistics = require('../statistics');
+const jhipsterUtils = require('../utils');
 
 module.exports = class extends BaseGenerator {
     constructor(args, opts) {
@@ -188,7 +189,7 @@ module.exports = class extends BaseGenerator {
 
         this.withEntities = this.options['with-entities'];
         this.skipChecks = this.options['skip-checks'];
-        const blueprint = this.normalizeBlueprintName(this.options.blueprint || this.config.get('blueprint'));
+        const blueprint = jhipsterUtils.normalizeBlueprintName(this.options.blueprint || this.config.get('blueprint'));
         this.blueprint = this.configOptions.blueprint = blueprint;
         this.useNpm = this.configOptions.useNpm = !this.options.yarn;
         this.useYarn = !this.useNpm;

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -715,20 +715,6 @@ module.exports = class extends Generator {
     }
 
     /**
-     * Normalize blueprint name: prepend 'generator-jhipster-' if needed
-     * @param {string} blueprint - name of the blueprint
-     */
-    normalizeBlueprintName(blueprint) {
-        if (blueprint && blueprint.startsWith('@')) {
-            return blueprint;
-        }
-        if (blueprint && !blueprint.startsWith('generator-jhipster')) {
-            return `generator-jhipster-${blueprint}`;
-        }
-        return blueprint;
-    }
-
-    /**
      * Compose external blueprint module
      * @param {string} blueprint - name of the blueprint
      * @param {string} subGen - sub generator
@@ -736,7 +722,7 @@ module.exports = class extends Generator {
      */
     composeBlueprint(blueprint, subGen, options = {}) {
         if (blueprint) {
-            blueprint = this.normalizeBlueprintName(blueprint);
+            blueprint = jhipsterUtils.normalizeBlueprintName(blueprint);
             if (options.skipChecks === undefined || !options.skipChecks) {
                 this.checkBlueprint(blueprint, subGen);
             }

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -46,7 +46,8 @@ module.exports = {
     getDBTypeFromDBValue,
     getBase64Secret,
     getRandomHex,
-    checkStringInFile
+    checkStringInFile,
+    normalizeBlueprintName
 };
 
 /**
@@ -467,4 +468,18 @@ function getBase64Secret(value, len = 50) {
 function checkStringInFile(path, search, generator) {
     const fileContent = generator.fs.read(path);
     return fileContent.includes(search);
+}
+
+/**
+ * Normalize blueprint name: prepend 'generator-jhipster-' if needed
+ * @param {string} blueprint - name of the blueprint
+ */
+function normalizeBlueprintName(blueprint) {
+    if (blueprint && blueprint.startsWith('@')) {
+        return blueprint;
+    }
+    if (blueprint && !blueprint.startsWith('generator-jhipster')) {
+        return `generator-jhipster-${blueprint}`;
+    }
+    return blueprint;
 }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -74,4 +74,18 @@ describe('JHipster Utils', () => {
             });
         });
     });
+    describe('::normalizeBlueprintName', () => {
+        it('adds generator-jhipster prefix if it is absent', () => {
+            const generatorName = utils.normalizeBlueprintName('foo');
+            assert.textEqual(generatorName, 'generator-jhipster-foo');
+        });
+        it('keeps generator-jhipster prefix if it is present', () => {
+            const generatorName = utils.normalizeBlueprintName('generator-jhipster-foo');
+            assert.textEqual(generatorName, 'generator-jhipster-foo');
+        });
+        it("doesn't  do anything for scoped package", () => {
+            const generatorName = utils.normalizeBlueprintName('@corp/foo');
+            assert.textEqual(generatorName, '@corp/foo');
+        });
+    });
 });


### PR DESCRIPTION
…m commands

A blueprint can be referenced with cli option --blueprint as both generator-jhipster-foo or just foo.
Moved utility function normalizeBlueprintName() from generator-base-private to utils, and added unit tests.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
