### PR TITLE
Remove old test about yeoman

### DIFF
--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -1466,7 +1466,6 @@ describe('JHipster generator', () => {
                         ['package.json']
                     )
                 );
-                assert.noFile(['gradle/yeoman.gradle']);
             });
             it('generates README with instructions for Gradle', () => {
                 assert.fileContent('README.md', './gradlew');


### PR DESCRIPTION
The file `gradle/yeoman.gradle` is no longer generated since we moved from bower to webpack. So the test about this file can be removed.

@jdubois I noticed a strange thing about the automatic project update process. The `yeoman.gradle` file is still present in the [jhipster-sample-app-gradle repo](https://github.com/jhipster/jhipster-sample-app-gradle/tree/master/gradle).  
Why does this file have not been removed. I don't know properly the process for the update of all github repos.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
