### PR TITLE
Fix entities with mongo and elastic mapping, avoinding no associated …

### DIFF
--- a/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
@@ -64,16 +64,22 @@ public class ElasticsearchConfiguration {
     @Primary
     public ElasticsearchOperations elasticsearchTemplate(final JestClient jestClient,
                                                          final ElasticsearchConverter elasticsearchConverter,
+        <%_ if (databaseType !== 'mongodb') { _%>
                                                          final SimpleElasticsearchMappingContext simpleElasticsearchMappingContext,
+        <%_ } _%>
                                                          EntityMapper mapper) {
+        <%_ if (databaseType === 'mongodb') { _%>
+        CustomElasticsearchMappingContext mappingContext = new CustomElasticsearchMappingContext();
+        <%_ } _%>
         return new JestElasticsearchTemplate(
             jestClient,
             <%_ if (databaseType === 'mongodb') { _%>
-            new MappingElasticsearchConverter(new CustomElasticsearchMappingContext()),
+            new MappingElasticsearchConverter(mappingContext),
+            new DefaultJestResultsMapper(mappingContext, mapper));
             <%_ } else { _%>
             elasticsearchConverter,
-            <%_ } _%>
             new DefaultJestResultsMapper(simpleElasticsearchMappingContext, mapper));
+            <%_ } _%>
     }
 
     public class CustomEntityMapper implements EntityMapper {


### PR DESCRIPTION
When using mongodb/elasticsearch together sometimes an error about "IllegalStateException: No association found!" occurs, as described in https://github.com/jhipster/generator-jhipster/issues/8666 when I am using JestElasticsearchTemplate to search elastic.

Searching about this problem it is related about DBRef mongo references, and CustomElasticsearchMappingContext that was incorporated in that issue solves the problem

Unfortunately this custom mapping context is not being passed to jest query engine (DefaultJestResultsMapper) . With this PR CustomElasticsearchMappingContext  is used by DefaultJestResultsMapper and solves this problem.

…errors in jest queries

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
