### PR TITLE
angular: fix toast alert

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -104,7 +104,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
 
     setClasses(alert) {
         return {
-            toast: !!alert.toast,
+            'jhi-toast': alert.toast,
             [alert.position]: true
         };
     }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
@@ -41,7 +41,7 @@ export class <%=jhiPrefixCapitalized%>AlertComponent implements OnInit, OnDestro
 
     setClasses(alert) {
         return {
-            toast: !!alert.toast,
+            'jhi-toast': alert.toast,
             [alert.position]: true
         };
     }

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -135,7 +135,7 @@ Custom alerts for notification
             font-size: 10px;
         }
     }
-    .toast {
+    .jhi-toast {
         position: fixed;
         width: 100%;
         &.left {
@@ -154,7 +154,7 @@ Custom alerts for notification
 }
 
 @media screen and (min-width: 480px) {
-    .alerts .toast {
+    .alerts .jhi-toast {
         width: 50%;
     }
 }


### PR DESCRIPTION
Fix #9447 

It was due to a conflict with Bootstrap v4 which add a `toast` class. So I renamed our `toast` class into `jhi-toast` to avoid conflicts with Bootstrap class.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
