### PR TITLE
Update JHipster dependencies to 3.0.2-SNAPSHOT

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -255,6 +255,8 @@ repositories {
         }
     }
     <%_ } _%>
+    // TODO To remove after final JHipster release
+    maven { url "http://oss.sonatype.org/content/repositories/snapshots" }
     //jhipster-needle-gradle-repositories - JHipster will add additional repositories
 }
 

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -25,7 +25,7 @@ npm_version=<%= NPM_VERSION %>
 yarn_version=<%= YARN_VERSION %>
 
 # Dependency versions
-jhipster_dependencies_version=3.0.1
+jhipster_dependencies_version=3.0.2-SNAPSHOT
 # The spring-boot version should match the one managed by
 # https://mvnrepository.com/artifact/io.github.jhipster/jhipster-dependencies/${jhipster_dependencies_version}
 spring_boot_version=2.1.5.RELEASE

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -41,6 +41,17 @@
             </releases>
         </repository>
 <%_ } _%>
+        <!-- TODO To remove after final JHipster release -->
+        <repository>
+            <id>oss.sonatype.org-snapshot</id>
+            <url>http://oss.sonatype.org/content/repositories/snapshots</url>
+            <releases>
+                <enabled>false</enabled>
+            </releases>
+            <snapshots>
+                <enabled>true</enabled>
+            </snapshots>
+        </repository>
         <!-- jhipster-needle-maven-repository -->
     </repositories>
 
@@ -80,7 +91,7 @@
         <profile.tls />
 
         <!-- Dependency versions -->
-        <jhipster-dependencies.version>3.0.1</jhipster-dependencies.version>
+        <jhipster-dependencies.version>3.0.2-SNAPSHOT</jhipster-dependencies.version>
         <!-- The spring-boot version should match the one managed by
         https://mvnrepository.com/artifact/io.github.jhipster/jhipster-dependencies/${jhipster-dependencies.version} -->
         <spring-boot.version>2.1.5.RELEASE</spring-boot.version>


### PR DESCRIPTION
Update JHipster dependencies
According to : https://github.com/jhipster/generator-jhipster/commit/96f524baa230b18762e4fec37120fb75cb26f085

We need a new snapshot release for JHipster dependencies. @jdubois could you please do that?

Thanks

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
