### PR TITLE
Allow all redirect URIs and CORS origin for keycloak

### DIFF
--- a/generators/server/templates/src/main/docker/config/realm-config/jhipster-realm.json.ejs
+++ b/generators/server/templates/src/main/docker/config/realm-config/jhipster-realm.json.ejs
@@ -820,18 +820,12 @@
       "clientAuthenticatorType": "client-secret",
       "secret": "web_app",
       "redirectUris": [
-        "http://localhost:<%= serverPort %>/*",
-        "https://localhost:<%= serverPort %>/*",
-        "http://localhost:8100/*",
-        "http://127.0.0.1:8761/*",
-        "http://localhost:9000/*"
+        "http://localhost:*",
+        "https://localhost:*",
+        "http://127.0.0.1:*",
+        "https://127.0.0.1:*"
       ],
-      "webOrigins": [
-        "http://localhost:<%= serverPort %>/*",
-        "http://localhost:8100/*",
-        "http://127.0.0.1:8761/*",
-        "http://localhost:9000/*"
-      ],
+      "webOrigins": ["*"],
       "notBefore": 0,
       "bearerOnly": false,
       "consentRequired": false,


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->

For instance, I use swagger-ui watcher to do hot reload of swagger-ui and which is served on localhost:8000.
This shouldn't be a security issue since the docker config shall only be used in dev (you would have other security issues in prod such as the secret being known)
