### PR TITLE
Only show health details for admin user

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -116,6 +116,7 @@ management:
     endpoint:
         health:
             show-details: when-authorized
+            roles: "ROLE_ADMIN"
         jhimetrics:
             enabled: true
     info:


### PR DESCRIPTION
Health details might contain some sensitive information so it should be showed to admin user only.

Example of health details response:

```
{
    "status": "UP",
    "details": {
        "diskSpace": {
            "status": "UP",
            "details": {
                "total": 254930841600,
                "free": 29542526976,
                "threshold": 10485760
            }
        },
        "mongo": {
            "status": "UP",
            "details": {
                "version": "4.0.6"
            }
        }
    }
}
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
