### PR TITLE
generate jacoco report for all test tasks

### DIFF
--- a/generators/server/templates/gradle/sonar.gradle.ejs
+++ b/generators/server/templates/gradle/sonar.gradle.ejs
@@ -21,6 +21,9 @@ jacoco {
 }
 
 jacocoTestReport {
+    executionData tasks.withType(Test)
+    classDirectories = files(sourceSets.main.output.classesDirs)
+    sourceDirectories = files(sourceSets.main.java.srcDirs)
     reports {
         xml.enabled true
     }


### PR DESCRIPTION
When looking into https://github.com/jhipster/generator-jhipster/issues/9631 I found that the jacoco report (html/xml) is not generated for all test tasks. With this change the report is generated for e.g. test and integration test.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
