### PR TITLE
Add option to suppress the transfer progress for maven download

### DIFF
--- a/test-integration/scripts/21-tests-backend.sh
+++ b/test-integration/scripts/21-tests-backend.sh
@@ -8,7 +8,7 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 cd "$JHI_FOLDER_APP"
 if [ -f "mvnw" ]; then
-    ./mvnw enforcer:display-info
+    ./mvnw -ntp enforcer:display-info
 elif [ -f "gradlew" ]; then
     ./gradlew -v
 fi
@@ -17,7 +17,7 @@ fi
 # Check Javadoc generation
 #-------------------------------------------------------------------------------
 if [ -f "mvnw" ]; then
-    ./mvnw javadoc:javadoc
+    ./mvnw -ntp javadoc:javadoc
 elif [ -f "gradlew" ]; then
     ./gradlew javadoc
 fi
@@ -27,7 +27,7 @@ fi
 #-------------------------------------------------------------------------------
 if [[ "$JHI_APP" == *"uaa"* ]]; then
     cd "$JHI_FOLDER_UAA"
-    ./mvnw verify
+    ./mvnw -ntp verify
 fi
 
 #-------------------------------------------------------------------------------
@@ -35,7 +35,7 @@ fi
 #-------------------------------------------------------------------------------
 cd "$JHI_FOLDER_APP"
 if [ -f "mvnw" ]; then
-    ./mvnw verify \
+    ./mvnw -ntp verify \
         -Dlogging.level.ROOT=OFF \
         -Dlogging.level.org.zalando=OFF \
         -Dlogging.level.io.github.jhipster=OFF \

--- a/test-integration/scripts/23-package.sh
+++ b/test-integration/scripts/23-package.sh
@@ -8,7 +8,7 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 if [[ "$JHI_APP" == *"uaa"* ]]; then
     cd "$JHI_FOLDER_UAA"
-    ./mvnw verify -DskipTests -Pdev
+    ./mvnw -ntp verify -DskipTests -Pdev
     mv target/*.jar app.jar
 fi
 
@@ -26,7 +26,7 @@ fi
 # Package the application
 #-------------------------------------------------------------------------------
 if [ -f "mvnw" ]; then
-    ./mvnw verify -DskipTests -P"$JHI_PROFILE"
+    ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE"
     mv target/*.jar app.jar
 elif [ -f "gradlew" ]; then
     ./gradlew bootJar -P"$JHI_PROFILE" -x test
@@ -45,7 +45,7 @@ fi
 #-------------------------------------------------------------------------------
 if [ "$JHI_WAR" == 1 ]; then
     if [ -f "mvnw" ]; then
-        ./mvnw verify -DskipTests -P"$JHI_PROFILE",war
+        ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE",war
         mv target/*.war app.war
     elif [ -f "gradlew" ]; then
         ./gradlew bootWar -P"$JHI_PROFILE" -Pwar -x test

--- a/test-integration/scripts/25-sonar-analyze.sh
+++ b/test-integration/scripts/25-sonar-analyze.sh
@@ -9,14 +9,14 @@ cd "$JHI_FOLDER_APP"
 
 if [[ "$JHI_APP" = "ngx-default" && "$TRAVIS_REPO_SLUG" = "jhipster/generator-jhipster" && "$TRAVIS_BRANCH" = "master" && "$TRAVIS_PULL_REQUEST" = "false" ]]; then
     echo "*** Sonar analyze for master branch"
-    ./mvnw initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+    ./mvnw -ntp initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.projectKey=io.github.jhipster.sample:jhipster-sample-application \
         -Dsonar.login=$SONAR_TOKEN
 
 elif [[ $JHI_SONAR = 1 ]]; then
     echo "*** Sonar analyze locally"
-    ./mvnw initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+    ./mvnw -ntp initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=http://localhost:9001 \
         -Dsonar.projectKey=JHipsterSonar
         


### PR DESCRIPTION
Related to #7785.

Maven has now an option to suppress the transfer progress when downloading/uploading in interactive mode.
This is only for automated tests for main generator. Not for generated project.

See more at https://maven.apache.org/docs/3.6.1/release-notes.html

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
