### PR TITLE
Refactor command suggestion logic

### DIFF
--- a/cli/utils.js
+++ b/cli/utils.js
@@ -46,7 +46,7 @@ const error = function(msg, trace) {
     if (trace) {
         console.log(trace);
     }
-    process.exit(1);
+    return; // eslint-disable-line
 };
 
 const init = function(program) {
@@ -88,7 +88,7 @@ const initHelp = (program, cliName) => {
     });
 
     program.on('command:*', name => {
-        logger.info(`${chalk.yellow(name)} is not a known command. See '${chalk.white(`${cliName} --help`)}'.`);
+        logger.error(`${chalk.yellow(name)} is not a known command. See '${chalk.white(`${cliName} --help`)}'.`);
 
         const cmd = Object.values(name).join('');
         const availableCommands = program.commands.map(cmd => {
@@ -97,8 +97,10 @@ const initHelp = (program, cliName) => {
 
         const suggestion = didYouMean(cmd, availableCommands);
         if (suggestion) {
-            logger.log(`  ${chalk.red(`Did you mean ${chalk.yellow(suggestion)}?`)}`);
+            logger.info(`Did you mean ${chalk.yellow(suggestion)}?`);
         }
+
+        process.exit(1);
     });
 };
 

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -88,15 +88,17 @@ const initHelp = (program, cliName) => {
     });
 
     program.on('command:*', name => {
-        logger.error(`${chalk.yellow(name)} is not a known command. See '${chalk.white(`${cliName} --help`)}'.`);
+        logger.info(`${chalk.yellow(name)} is not a known command. See '${chalk.white(`${cliName} --help`)}'.`);
 
-        const d = didYouMean(name.toString(), program.commands, '_name');
+        const cmd = Object.values(name).join('');
+        const availableCommands = program.commands.map(cmd => {
+            return cmd._name;
+        });
 
-        if (d) {
-            logger.info(`Did you mean: ${chalk.yellow(d)}?`);
+        const suggestion = didYouMean(cmd, availableCommands);
+        if (suggestion) {
+            logger.log(`  ${chalk.red(`Did you mean ${chalk.yellow(suggestion)}?`)}`);
         }
-
-        process.exit(1);
     });
 };
 


### PR DESCRIPTION
Closes #9782 

Refactored the command suggestion logic such that it suggests matching commands as intended. 

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
