### PR TITLE
JAXB runtime must always be present in maven-compiler-plugin config when using JPA

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -791,13 +791,11 @@
                             <artifactId>hibernate-jpamodelgen</artifactId>
                             <version>${hibernate.version}</version>
                         </path>
-    <%_ if (authenticationType !== 'uaa') { _%>
                         <path>
                             <groupId>org.glassfish.jaxb</groupId>
                             <artifactId>jaxb-runtime</artifactId>
                             <version>${jaxb-runtime.version}</version>
                         </path>
-    <%_ } _%>
 <%_ } _%>
                     </annotationProcessorPaths>
                 </configuration>


### PR DESCRIPTION
JAXB runtime must always be present in maven-compiler-plugin config when using JPA

Fix #9788

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed