### PR TITLE
Remove extra column in fake data generation

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/data/table.csv.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/data/table.csv.ejs
@@ -29,8 +29,14 @@ for (idx in fields) {
     }
 }
 for (idx in relationships) {
-    if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
-        header.push(getColumnName(relationships[idx].relationshipName) + '_id');
+    const relationshipType = relationships[idx].relationshipType
+    if (
+        (relationshipType === "many-to-one"
+            || (relationshipType === "one-to-one" && relationships[idx].ownerSide === true
+               && (relationships[idx].useJPADerivedIdentifier == null || relationships[idx].useJPADerivedIdentifier === false))
+        ) && (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired)
+    ) {
+        header.push(getColumnName(relationships[idx].relationshipName) + "_id");
     }
 }
 table.push(header);
@@ -189,7 +195,13 @@ for (lineNb = 1; lineNb <= numberOfRows; lineNb++) {
     }
 
     for (idx in relationships) {
-        if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
+        const relationshipType = relationships[idx].relationshipType;
+        if (
+            (relationshipType === "many-to-one"
+                || (relationshipType === "one-to-one" && relationships[idx].ownerSide === true
+                   && (relationships[idx].useJPADerivedIdentifier == null || relationships[idx].useJPADerivedIdentifier === false))
+            ) && (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired)
+        ) {
             if (relationships[idx].otherEntityNameCapitalized === 'User') {
                 line.push(this.faker.random.number({min: 1, max: 2}));
             } else {


### PR DESCRIPTION
- [x] Remove extra column in fake data generation to reflect what is in the changelogs (see https://github.com/jhipster/generator-jhipster/blob/11ce9a49130000dd0ecaed82987eaf5710cfeb3b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs#L131-L142)

The other issue raised in 9721 (uniqueness in relationships) is already mentionned in #9579.

Fix #9721 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
