### PR TITLE
fix gradle compile on Heroku

### DIFF
--- a/generators/heroku/templates/heroku.gradle.ejs
+++ b/generators/heroku/templates/heroku.gradle.ejs
@@ -22,6 +22,13 @@ heroku {
   appName = "<%= herokuAppName %>"
   buildpacks = ["heroku/jvm"]
 }
+<%_ if (herokuDeployType === 'git') { _%>
+
+// Task stage is used by Heroku, see also
+// https://devcenter.heroku.com/articles/deploying-gradle-apps-on-heroku
+// and GRADLE_TASK configuration variable.
+task stage(dependsOn: "bootJar") {
+}
 
 gradle.taskGraph.whenReady {taskGraph ->
     taskGraph.afterTask() {task ->
@@ -31,3 +38,4 @@ gradle.taskGraph.whenReady {taskGraph ->
         }
     }
 }
+<%_ } _%>


### PR DESCRIPTION
fix #9814

Currently jhipster master version fails in Heroku when choosing `compile on Heroku` with error
```
Could not find io.github.jhipster:jhipster-dependencies:3.0.2-SNAPSHOT
```
Seems that same issue as #9753

If applying this fix to app which is generated with released JHipster 6.0.1 then `compile on Heroku` works.

`compile locally` option works fine after doing `./mvnw clean install -Dgpg.skip` in project github.com/jhipster/jhipster as suggested in #9753 (without that the same io.github.jhipster:jhipster-dependencies:3.0.2-SNAPSHOT not found error occurs)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
