### PR TITLE
improve security headers

### DIFF
--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -88,6 +88,7 @@ import org.springframework.security.web.csrf.CsrfFilter;
 <%_ if (authenticationType === 'jwt' && applicationType !== 'microservice') { _%>
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 <%_ } _%>
+import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWriter;
 <%_ if (applicationType !== 'microservice') { _%>
 import org.springframework.web.filter.CorsFilter;
 <%_ } _%>
@@ -223,8 +224,14 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             <%_ } _%>
         .and()
             .headers()
+            .contentSecurityPolicy("default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; style-src 'self' 'unsafe-inline'")
+        .and()
+            .referrerPolicy(ReferrerPolicyHeaderWriter.ReferrerPolicy.STRICT_ORIGIN_WHEN_CROSS_ORIGIN)
+        .and()
+            .featurePolicy("geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; fullscreen 'self'; payment 'none'")
+        .and()
             .frameOptions()
-            .disable()
+            .deny()
         .and()
         <%_ if (authenticationType === 'jwt' || (authenticationType === 'oauth2' && applicationType === 'microservice')) { _%>
             .sessionManagement()


### PR DESCRIPTION
by setting `content-security`, `feature-policy`, `referrer-policy` header and deny embedding in an iframe.

Due to angular or an ng plugin we need to allow unsafe inline and eval (same for inline styles). Did not check if that is required for react or vue. Before the `X-Frame-Options` where disabled at all, now it is set to `deny` so embedding is not allowed by default.

See #9549 for the open question (thats why it is currently in draft mode). I tested also with local development via npm and gradle it works fine and I couldn't see any problems.

These are the current results for security headers https://securityheaders.com/?q=https%3A%2F%2Fgradleheroku.herokuapp.com%2F&followRedirects=on

And this is the deployed application https://gradleheroku.herokuapp.com/

closes #9549

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
