### PR TITLE
Fix javadoc issue that prevents JDK 11 from building the javadoc when using Couchbase

### DIFF
--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -333,7 +333,7 @@ public class DatabaseConfiguration {
     }
 
     /**
-     * Simple singleton to convert from {@link String} {@link byte[]} representation.
+     * Simple singleton to convert from {@link String} {@code byte[]} representation.
      */
     @ReadingConverter
     public enum StringToByteConverter implements Converter<String, byte[]> {


### PR DESCRIPTION
Fix #9803

This fixes the javadoc issue that causes the javadoc tool to crash and fail the build when using Couchbase and JDK 11. See logs of `ngx-couchbase` at https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=3139

While the javadoc was invalid the javadoc tool should also not crash and emit a warning instead. This has been reported at https://bugs.openjdk.java.net/browse/JDK-8200432 and fixed at JDK 12.

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed