### PR TITLE
Disable H2 MULTI_THREADED feature to avoid possible deadlock when running ITs

### DIFF
--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -57,7 +57,7 @@ spring:
     <%_ if (databaseType === 'sql') { _%>
     datasource:
         type: com.zaxxer.hikari.HikariDataSource
-        url: jdbc:h2:mem:<%= baseName %>;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE
+        url: jdbc:h2:mem:<%= baseName %>;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE;MULTI_THREADED=FALSE
         name:
         username:
         password:


### PR DESCRIPTION
In some cases the daily builds terminate due to timeout(see `gradle-ms-ngx-gateway-eureka-uaa` and `gradle-ms-ngx-gateway-consul-uaa` at https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=3172.

The problem is called by a deadlock issue due to the use of the H2 in-memory DB. This bug has already been reported at https://github.com/h2database/h2database/issues/1841 and https://github.com/h2database/h2database/issues/1870. It has been fixed at https://github.com/h2database/h2database/pull/1842 and will be available with the next release of H2.

Added `MULTI_THREADED=FALSE`(enabled by default in 1.4.198) to the URL in order to workaround this problem. Once the next version is out we can then try again removing this option.

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed