### PR TITLE
fix webpack proxy when client/server are separated

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -38,7 +38,15 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         contentBase: './<%= DIST_DIR %>',
         proxy: [{
             context: [
-                '/'
+                '/api',
+                '/services',
+                '/management',
+                '/swagger-resources',
+                '/v2/api-docs',
+                '/h2-console',<% if (authenticationType === 'oauth2') { %>
+                '/oauth2',
+                '/login',<% } %>
+                '/auth'
             ],
             target: `http${options.tls ? 's' : ''}://localhost:<%= serverPort %>`,
             secure: false,
@@ -54,7 +62,8 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         watchOptions: {
             ignored: /node_modules/
         },
-        https: options.tls
+        https: options.tls,
+        historyApiFallback: true
     },
     entry: {
         polyfills: './<%= MAIN_SRC_DIR %>app/polyfills',

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -60,7 +60,15 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     contentBase: './<%= DIST_DIR %>',
     proxy: [{
       context: [
-        '/'
+        '/api',
+        '/services',
+        '/management',
+        '/swagger-resources',
+        '/v2/api-docs',
+        '/h2-console',<% if (authenticationType === 'oauth2') { %>
+        '/oauth2',
+        '/login',<% } %>
+        '/auth'
       ],
       target: `http${options.tls ? 's' : ''}://localhost:<%= serverPort %>`,
       secure: false,
@@ -75,7 +83,8 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     watchOptions: {
       ignored: /node_modules/
     },
-    https: options.tls
+    https: options.tls,
+    historyApiFallback: true
   },
   stats: process.env.JHI_DISABLE_WEBPACK_LOGS ? 'none' : options.stats,
   plugins: [


### PR DESCRIPTION
When using separate client/server, ClientForwardController and index.html do not exist on the backend.  Refreshing http://localhost:9000/account/settings when using the webpack-dev-server (port 9000) gives a server-side 404.  

To fix that we need to add the paths back to the webpack proxy so it will know to load the frontend for non-server routes (currently all requests go to backend based on `/`).

Then webpack gives a 404 of its own, which is fixed by adding [`historyApiFallback`](https://webpack.js.org/configuration/dev-server/#devserverhistoryapifallback)

Very simple to reproduce with the JDL in the linked issue, just try going directly to http://localhost:9000/account/settings after running `npm start`

Fix #9839

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
