### PR TITLE
separate loading data from definition of data structure

### DIFF
--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -59,6 +59,17 @@ const serverFiles = {
                         }
                     },
                     renameTo: generator => `config/liquibase/data/${generator.entityTableName}.csv`
+                },
+                {
+                    file: 'config/liquibase/changelog/added_entity_data.xml',
+                    options: {
+                        interpolate: INTERPOLATE_REGEX,
+                        context: {
+                            faker,
+                            randexp
+                        }
+                    },
+                    renameTo: generator => `config/liquibase/changelog/${generator.changelogDate}_import_data_${generator.entityClass}.xml`
                 }
             ]
         },
@@ -267,6 +278,7 @@ function writeFiles() {
                     this.addConstraintsChangelogToLiquibase(`${this.changelogDate}_added_entity_constraints_${this.entityClass}`);
                 }
                 this.addChangelogToLiquibase(`${this.changelogDate}_added_entity_${this.entityClass}`);
+                this.addDataImportChangelogToLiquibase(`${this.changelogDate}_import_data_${this.entityClass}`);
 
                 if (['ehcache', 'infinispan'].includes(this.cacheProvider) && this.enableHibernateCache) {
                     this.addEntityToCache(

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -150,56 +150,6 @@
         } _%>
     </changeSet>
 
-    <!--
-        Load sample data generated with Faker.js
-        - This data can be easily edited using a CSV editor (or even MS Excel) and
-          is located in the 'src/main/resources/config/liquibase/data' directory
-        - By default this data is applied when running with the JHipster 'dev' profile.
-          This can be customized by adding or removing 'faker' in the 'spring.liquibase.contexts'
-          Spring Boot configuration key.
-    -->
-    <changeSet id="<%= changelogDate %>-1-data" author="jhipster" context="faker">
-        <loadData
-                  file="config/liquibase/data/<%= entityTableName %>.csv"
-                  separator=";"
-                  tableName="<%= entityTableName %>"
-                  context="dev">
-            <column name="id" type="numeric"/>
-            <%_ for (idx in fields) {
-                let loadColumnType = 'string';
-                let columnType = fields[idx].columnType;
-                if (columnType === 'integer' || columnType === 'bigint' || columnType === 'double' || columnType === 'decimal(21,2)' || columnType === '${floatType}') {
-                    loadColumnType = 'numeric';
-                } else if (columnType === 'date' || columnType === 'datetime') {
-                    loadColumnType = 'date';
-                } else if (columnType === 'boolean') {
-                    loadColumnType = 'boolean';
-                } else if (fields[idx].fieldIsEnum) {
-                    loadColumnType = 'string';
-                } else if (columnType === 'blob' || columnType === 'longblob') {
-                    loadColumnType = 'blob';
-                } else if (columnType === '${clobType}') {
-                    loadColumnType = 'clob';
-                }
-                _%>
-            <column name="<%=fields[idx].fieldNameAsDatabaseColumn%>" type="<%=loadColumnType%>"/>
-                <%_ if (fields[idx].fieldType === 'byte[]' && fields[idx].fieldTypeBlobContent !== 'text') { _%>
-            <column name="<%=fields[idx].fieldNameAsDatabaseColumn%>_content_type" type="string"/>
-                <%_ } _%>
-            <%_ } _%>
-            <%_ for (idx in relationships) {
-                    let loadColumnType = 'numeric';
-                    if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
-                        let baseColumnName = getColumnName(relationships[idx].relationshipName) + '_id';
-                        if (relationships[idx].otherEntityNameCapitalized === 'User' && authenticationType === 'oauth2') {
-                            loadColumnType = 'varchar(100)';
-                        } _%>
-            <column name="<%=baseColumnName%>" type="<%=loadColumnType%>"/>
-                <%_ } _%>
-            <%_  } _%>
-        </loadData>
-    </changeSet>
-
     <changeSet id="<%= changelogDate %>-1-relations" author="jhipster">
         <%_ for (idx in relationships) {
             const relationshipType = relationships[idx].relationshipType,

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity_data.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity_data.xml.ejs
@@ -1,0 +1,75 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:ext="http://www.liquibase.org/xml/ns/dbchangelog-ext"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd
+                        http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
+    <!--
+        Load sample data generated with Faker.js
+        - This data can be easily edited using a CSV editor (or even MS Excel) and
+          is located in the 'src/main/resources/config/liquibase/data' directory
+        - By default this data is applied when running with the JHipster 'dev' profile.
+          This can be customized by adding or removing 'faker' in the 'spring.liquibase.contexts'
+          Spring Boot configuration key.
+    -->
+    <changeSet id="<%= changelogDate %>-1-data" author="jhipster" context="faker">
+        <loadData
+            file="config/liquibase/data/<%= entityTableName %>.csv"
+            separator=";"
+            tableName="<%= entityTableName %>"
+            context="dev">
+            <column name="id" type="numeric"/>
+            <%_ for (idx in fields) {
+                let loadColumnType = 'string';
+                let columnType = fields[idx].columnType;
+                if (columnType === 'integer' || columnType === 'bigint' || columnType === 'double' || columnType === 'decimal(21,2)' || columnType === '${floatType}') {
+                    loadColumnType = 'numeric';
+                } else if (columnType === 'date' || columnType === 'datetime') {
+                    loadColumnType = 'date';
+                } else if (columnType === 'boolean') {
+                    loadColumnType = 'boolean';
+                } else if (fields[idx].fieldIsEnum) {
+                    loadColumnType = 'string';
+                } else if (columnType === 'blob' || columnType === 'longblob') {
+                    loadColumnType = 'blob';
+                } else if (columnType === '${clobType}') {
+                    loadColumnType = 'clob';
+                }
+            _%>
+            <column name="<%=fields[idx].fieldNameAsDatabaseColumn%>" type="<%=loadColumnType%>"/>
+            <%_ if (fields[idx].fieldType === 'byte[]' && fields[idx].fieldTypeBlobContent !== 'text') { _%>
+            <column name="<%=fields[idx].fieldNameAsDatabaseColumn%>_content_type" type="string"/>
+            <%_ } _%>
+            <%_ } _%>
+            <%_ for (idx in relationships) {
+                let loadColumnType = 'numeric';
+            if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
+                let baseColumnName = getColumnName(relationships[idx].relationshipName) + '_id';
+                if (relationships[idx].otherEntityNameCapitalized === 'User' && authenticationType === 'oauth2') {
+                    loadColumnType = 'varchar(100)';
+                } _%>
+            <column name="<%=baseColumnName%>" type="<%=loadColumnType%>"/>
+            <%_ } _%>
+            <%_  } _%>
+        </loadData>
+    </changeSet>
+</databaseChangeLog>

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -482,6 +482,15 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add a new changelog to the Liquibase import_data.xml file.
+     *
+     * @param {string} changelogName - The name of the changelog (name of the file without .xml at the end).
+     */
+    addDataImportChangelogToLiquibase(changelogName) {
+        this.needleApi.serverLiquibase.addDataImportChangelog(changelogName);
+    }
+
+    /**
      * Add a new changelog to the Liquibase master.xml file.
      *
      * @param {string} changelogName - The name of the changelog (name of the file without .xml at the end).

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -246,7 +246,8 @@ const serverFiles = {
                     renameTo: () => 'config/liquibase/changelog/00000000000000_initial_schema.xml',
                     options: { interpolate: INTERPOLATE_REGEX }
                 },
-                'config/liquibase/master.xml'
+                'config/liquibase/master.xml',
+                'config/liquibase/changelog/import_data.xml'
             ]
         },
         {

--- a/generators/server/needle-api/needle-server-liquibase.js
+++ b/generators/server/needle-api/needle-server-liquibase.js
@@ -54,4 +54,18 @@ module.exports = class extends needleServer {
 
         this.addBlockContentToFile(rewriteFileModel, errorMessage);
     }
+
+    addDataImportChangelog(changelogName) {
+        this.addChangelogToImportData(changelogName, 'jhipster-needle-liquibase-add-import-data-changelog');
+    }
+
+    addChangelogToImportData(changelogName, needle) {
+        const errorMessage = `${chalk.yellow('Reference to ') + changelogName}.xml ${chalk.yellow('not added.\n')}`;
+        const fullPath = `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/import_data.xml`;
+        const content = `<include file="config/liquibase/changelog/${changelogName}.xml" relativeToChangelogFile="false"/>`;
+
+        const rewriteFileModel = this.generateFileModel(fullPath, needle, content);
+
+        this.addBlockContentToFile(rewriteFileModel, errorMessage);
+    }
 };

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/import_data.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/import_data.xml.ejs
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<databaseChangeLog
+    xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+    xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-3.6.xsd">
+
+    <!-- jhipster-needle-liquibase-add-import-data-changelog - JHipster will add liquibase changelogs relative to data manipulation here -->
+</databaseChangeLog>

--- a/generators/server/templates/src/main/resources/config/liquibase/master.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/master.xml.ejs
@@ -25,10 +25,11 @@
     <%_ } else { _%>
     <property name="clobType" value="clob" dbms="h2"/>
     <%_ } _%>
-    
+
     <property name="clobType" value="clob" dbms="mysql, oracle, mssql, mariadb, postgresql"/>
 
     <include file="config/liquibase/changelog/00000000000000_initial_schema.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->
+    <include file="config/liquibase/changelog/import_data.xml" relativeToChangelogFile="false"/>
 </databaseChangeLog>

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -669,6 +669,7 @@ const expectedFiles = {
 
     liquibase: [
         `${SERVER_MAIN_RES_DIR}config/liquibase/master.xml`,
+        `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/import_data.xml`,
         `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/00000000000000_initial_schema.xml`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/LiquibaseConfiguration.java`
     ],


### PR DESCRIPTION
Separate loading of fake data from definition of data structure. I'm not sure on the file structure, however. In this PR, it lead to this kind of file structure:

- liquibase
    - changelog
        - initial_schema.xml
        - added_entity_changelog.xml
        - import_data_added_entity_changelog.xml
        - import_data.xml
    - data
        - users.csv
        - entity_data.csv
    - master.xml

However, it might be better to have everything related to data loading in the data subfolder...

Fix #9804 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
