### PR TITLE
removed rate limiting feature for gateways when not using hazelcast

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -519,7 +519,8 @@ const serverFiles = {
             ]
         },
         {
-            condition: generator => generator.applicationType === 'gateway' && generator.serviceDiscoveryType && generator.cacheProvider === 'hazelcast',
+            condition: generator =>
+                generator.applicationType === 'gateway' && generator.serviceDiscoveryType && generator.cacheProvider === 'hazelcast',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -504,10 +504,6 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}config/apidoc/GatewaySwaggerResourcesProvider.java`
                 },
                 {
-                    file: 'package/gateway/ratelimiting/RateLimitingFilter.java',
-                    renameTo: generator => `${generator.javaDir}gateway/ratelimiting/RateLimitingFilter.java`
-                },
-                {
                     file: 'package/gateway/accesscontrol/AccessControlFilter.java',
                     renameTo: generator => `${generator.javaDir}gateway/accesscontrol/AccessControlFilter.java`
                 },
@@ -519,6 +515,16 @@ const serverFiles = {
                 {
                     file: 'package/web/rest/GatewayResource.java',
                     renameTo: generator => `${generator.javaDir}web/rest/GatewayResource.java`
+                }
+            ]
+        },
+        {
+            condition: generator => generator.applicationType === 'gateway' && generator.serviceDiscoveryType && generator.cacheProvider === 'hazelcast',
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/gateway/ratelimiting/RateLimitingFilter.java',
+                    renameTo: generator => `${generator.javaDir}gateway/ratelimiting/RateLimitingFilter.java`
                 }
             ]
         },

--- a/generators/server/templates/src/main/java/package/config/GatewayConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/GatewayConfiguration.java.ejs
@@ -20,7 +20,9 @@ package <%=packageName%>.config;
 
 import io.github.jhipster.config.JHipsterProperties;
 
+<%_ if (cacheProvider === 'hazelcast') { _%>
 import <%=packageName%>.gateway.ratelimiting.RateLimitingFilter;
+<%_ } _%>
 import <%=packageName%>.gateway.accesscontrol.AccessControlFilter;
 import <%=packageName%>.gateway.responserewriting.SwaggerBasePathRewritingFilter;
 
@@ -64,10 +66,11 @@ public class GatewayConfiguration {
         public RateLimitingConfiguration(JHipsterProperties jHipsterProperties) {
             this.jHipsterProperties = jHipsterProperties;
         }
-
+        <%_ if (cacheProvider === 'hazelcast') { _%>
         @Bean
         public RateLimitingFilter rateLimitingFilter() {
             return new RateLimitingFilter(jHipsterProperties);
         }
+        <%_ } _%>
     }
 }

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -1549,6 +1549,45 @@ describe('JHipster generator', () => {
             it('creates expected files with the gateway application type', () => {
                 assert.file(expectedFiles.jwtServer);
                 assert.file(expectedFiles.gateway);
+                assert.noFile(expectedFiles.rateLimitingFilesForGateways);
+                assert.file(expectedFiles.feignConfig);
+                assert.file(expectedFiles.eureka);
+                assert.noFile(expectedFiles.consul);
+            });
+        });
+
+        describe('gateway with eureka and rate limiting', () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../generators/app'))
+                    .withOptions({ 'from-cli': true, skipInstall: true, skipChecks: true })
+                    .withPrompts({
+                        applicationType: 'gateway',
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        clientFramework: 'angularX',
+                        serviceDiscoveryType: 'eureka',
+                        authenticationType: 'jwt',
+                        cacheProvider: 'hazelcast',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected files with the gateway application type', () => {
+                assert.file(expectedFiles.jwtServer);
+                assert.file(expectedFiles.gateway);
+                assert.file(expectedFiles.rateLimitingFilesForGateways);
                 assert.file(expectedFiles.feignConfig);
                 assert.file(expectedFiles.eureka);
                 assert.noFile(expectedFiles.consul);
@@ -1740,6 +1779,7 @@ describe('JHipster generator', () => {
 
             it('creates expected files for UAA auth with the Gateway application type', () => {
                 assert.file(expectedFiles.gateway);
+                assert.file(expectedFiles.rateLimitingFilesForGateways);
                 assert.file(expectedFiles.gatewayWithUaa);
                 assert.file(expectedFiles.dockerServices);
                 assert.file(expectedFiles.eureka);
@@ -1780,6 +1820,44 @@ describe('JHipster generator', () => {
             it('creates expected files with the gateway application type', () => {
                 assert.file(expectedFiles.jwtServer);
                 assert.file(expectedFiles.gateway);
+                assert.noFile(expectedFiles.rateLimitingFilesForGateways);
+                assert.noFile(expectedFiles.eureka);
+                assert.file(expectedFiles.consul);
+            });
+        });
+
+        describe('gateway with consul and rate limiting', () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../generators/app'))
+                    .withOptions({ 'from-cli': true, skipInstall: true, skipChecks: true })
+                    .withPrompts({
+                        applicationType: 'gateway',
+                        baseName: 'jhipster',
+                        packageName: 'com.mycompany.myapp',
+                        packageFolder: 'com/mycompany/myapp',
+                        clientFramework: 'angularX',
+                        serviceDiscoveryType: 'consul',
+                        authenticationType: 'jwt',
+                        cacheProvider: 'hazelcast',
+                        enableHibernateCache: true,
+                        databaseType: 'sql',
+                        devDatabaseType: 'h2Memory',
+                        prodDatabaseType: 'mysql',
+                        enableTranslation: true,
+                        nativeLanguage: 'en',
+                        languages: ['fr'],
+                        buildTool: 'maven',
+                        rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                        serverSideOptions: []
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected files with the gateway application type', () => {
+                assert.file(expectedFiles.jwtServer);
+                assert.file(expectedFiles.gateway);
+                assert.file(expectedFiles.rateLimitingFilesForGateways);
                 assert.noFile(expectedFiles.eureka);
                 assert.file(expectedFiles.consul);
             });
@@ -1854,6 +1932,7 @@ describe('JHipster generator', () => {
             it('creates expected files with the gateway application type', () => {
                 assert.file(expectedFiles.jwtServer);
                 assert.noFile(expectedFiles.gateway);
+                assert.noFile(expectedFiles.rateLimitingFilesForGateways);
                 assert.noFile(expectedFiles.eureka);
                 assert.noFile(expectedFiles.consul);
             });
@@ -1891,6 +1970,7 @@ describe('JHipster generator', () => {
             it('creates expected files with the gateway application type', () => {
                 assert.file(expectedFiles.gatewayWithUaa);
                 assert.noFile(expectedFiles.gateway);
+                assert.noFile(expectedFiles.rateLimitingFilesForGateways);
                 assert.noFile(expectedFiles.eureka);
                 assert.noFile(expectedFiles.consul);
             });

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -601,7 +601,6 @@ const expectedFiles = {
         `${SERVER_TEST_RES_DIR}config/bootstrap.yml`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/GatewayConfiguration.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/apidoc/GatewaySwaggerResourcesProvider.java`,
-        `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/gateway/ratelimiting/RateLimitingFilter.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/gateway/accesscontrol/AccessControlFilter.java`,
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/gateway/responserewriting/SwaggerBasePathRewritingFilter.java`,
         `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/gateway/responserewriting/SwaggerBasePathRewritingFilterTest.java`,
@@ -612,6 +611,8 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}app/admin/gateway/gateway.component.html`,
         `${CLIENT_MAIN_SRC_DIR}app/admin/gateway/gateway-routes.service.ts`
     ],
+
+    rateLimitingFilesForGateways: [`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/gateway/ratelimiting/RateLimitingFilter.java`],
 
     gatewayWithUaa: [
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/10055

Right now, having gateway cache enforced to hazelcast removed, the generation for server-side files using ratelimiting feature makes some of (soon-to-be) daily builds crash. This is a PR to fix them


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
