### PR TITLE
Fix for the default CSS not loading on index.html

### DIFF
--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -29,7 +29,7 @@
     <meta name="theme-color" content="#000000">
     <link rel="shortcut icon" href="favicon.ico" />
     <link rel="manifest" href="manifest.webapp" />
-    <link rel="stylesheet" href="static/css/loading.css">
+    <link rel="stylesheet" href="content/css/loading.css">
     <!-- jhipster-needle-add-resources-to-root - JHipster will add new resources here -->
 </head>
 <body>


### PR DESCRIPTION
Hi Guys,

I apologize if I get the below wrong as I am a bit new to contributing. I encountered a small issue when generating a jhipster react app in that the css file is not loaded because the folder is incorrect. "content" rather than "static".

For your review and perhaps approval.
