### PR TITLE
Add Ionic 4 redirect URIs to Keycloak web_app client

### DIFF
--- a/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
+++ b/generators/docker-compose/templates/realm-config/jhipster-realm.json.ejs
@@ -823,7 +823,8 @@
         <%- keycloakRedirectUris %>
         "http://localhost:8100/*",
         "http://127.0.0.1:8761/*",
-        "http://localhost:9000/*"
+        "http://localhost:9000/*",
+        "dev.localhost.ionic:*"
       ],
       "webOrigins": [
         <%- keycloakRedirectUris %>

--- a/generators/server/templates/src/main/docker/config/realm-config/jhipster-realm.json.ejs
+++ b/generators/server/templates/src/main/docker/config/realm-config/jhipster-realm.json.ejs
@@ -823,7 +823,8 @@
         "http://localhost:*",
         "https://localhost:*",
         "http://127.0.0.1:*",
-        "https://127.0.0.1:*"
+        "https://127.0.0.1:*",
+        "dev.localhost.ionic:*"
       ],
       "webOrigins": ["*"],
       "notBefore": 0,


### PR DESCRIPTION
These are necessary to run Ionic for JHipster on iOS and Android with Keycloak.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
