### PR TITLE
Switch eclipse to use new generated sources directory

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -95,7 +95,7 @@ eclipse {
     sourceSets {
         main {
             java {
-                srcDirs += ["build/generated/source/apt/main"]
+                srcDirs += ["build/generated/sources/annotationProcessor/java/main"]
             }
         }
     }


### PR DESCRIPTION
After upgrading to JHipster 6, the Eclipse build path for generated classes has changed from:

`build/generated/source/apt/main` 

to 

`build/generated/sources/annotationProcessor/java/main`

This is related to https://github.com/jhipster/generator-jhipster/issues/9134 and https://github.com/jhipster/generator-jhipster/pull/9468

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [X ] Tests are added where necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
