### PR TITLE
Entity: fix check of reserved word for field 

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -766,7 +766,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     if (_.isUndefined(field.fieldNameAsDatabaseColumn)) {
                         const fieldNameUnderscored = _.snakeCase(field.fieldName);
                         const jhiFieldNamePrefix = this.getColumnName(context.jhiPrefix);
-                        if (jhiCore.isReservedTableName(fieldNameUnderscored, context.databaseType)) {
+                        if (jhiCore.isReservedTableName(fieldNameUnderscored, context.prodDatabaseType)) {
                             if (!jhiFieldNamePrefix) {
                                 this.warning(
                                     chalk.red(


### PR DESCRIPTION
The check was using databaseType rather than prodDatabaseType, and thus was returning false positive.
Eg: 'label' is only a reserved word for Oracle, but was considered as a reserved word for MySQL or PostgreSQL

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
