### PR TITLE
Loading of fake data

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -152,6 +152,30 @@
         } _%>
     </changeSet>
 
+    <changeSet id="<%= changelogDate %>-1-relations" author="jhipster">
+        <%_ for (idx in relationships) {
+            const relationshipType = relationships[idx].relationshipType,
+            relationshipName = relationships[idx].relationshipName,
+            ownerSide = relationships[idx].ownerSide,
+            otherEntityName = relationships[idx].otherEntityName;
+            if (relationshipType === 'many-to-many' && ownerSide) {
+                const joinTableName = getJoinTableName(entityTableName, relationshipName, prodDatabaseType);
+          _%>
+
+        <createTable tableName="<%= joinTableName %>">
+            <column name="<%= getColumnName(relationshipName) %>_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+            <column name="<%= getColumnName(name) %>_id" type="bigint">
+                <constraints nullable="false"/>
+            </column>
+        </createTable>
+
+        <addPrimaryKey columnNames="<%= getColumnName(name) %>_id, <%= getColumnName(relationshipName) %>_id" tableName="<%= joinTableName %>"/>
+        <% } %><% } %>
+    </changeSet>
+    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
+
     <!--
         Load sample data generated with Faker.js
         - This data can be easily edited using a CSV editor (or even MS Excel) and
@@ -200,30 +224,8 @@
             <column name="<%=baseColumnName%>" type="<%=loadColumnType%>"/>
                 <%_ } _%>
             <%_  } _%>
+            <!-- jhipster-needle-liquibase-add-loadcolumn - JHipster (and/or extensions) can add load columns here, do not remove-->
         </loadData>
     </changeSet>
 
-    <changeSet id="<%= changelogDate %>-1-relations" author="jhipster">
-        <%_ for (idx in relationships) {
-            const relationshipType = relationships[idx].relationshipType,
-            relationshipName = relationships[idx].relationshipName,
-            ownerSide = relationships[idx].ownerSide,
-            otherEntityName = relationships[idx].otherEntityName;
-            if (relationshipType === 'many-to-many' && ownerSide) {
-                const joinTableName = getJoinTableName(entityTableName, relationshipName, prodDatabaseType);
-          _%>
-
-        <createTable tableName="<%= joinTableName %>">
-            <column name="<%= getColumnName(relationshipName) %>_id" type="bigint">
-                <constraints nullable="false"/>
-            </column>
-            <column name="<%= getColumnName(name) %>_id" type="bigint">
-                <constraints nullable="false"/>
-            </column>
-        </createTable>
-
-        <addPrimaryKey columnNames="<%= getColumnName(name) %>_id, <%= getColumnName(relationshipName) %>_id" tableName="<%= joinTableName %>"/>
-        <% } %><% } %>
-    </changeSet>
-    <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
 </databaseChangeLog>

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -503,7 +503,7 @@ module.exports = class extends PrivateBase {
 
     /**
      * Add a new load column to a Liquibase changelog file for entity.
-     * 
+     *
      * @param {string} filePath - The full path of the changelog file.
      * @param {string} content - The content to be added as column, can have multiple columns as well
      */

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -502,6 +502,16 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add a new load column to a Liquibase changelog file for entity.
+     * 
+     * @param {string} filePath - The full path of the changelog file.
+     * @param {string} content - The content to be added as column, can have multiple columns as well
+     */
+    addLoadColumnToLiquibaseEntityChangeSet(filePath, content) {
+        this.needleApi.serverLiquibase.addLoadColumnToEntityChangeSet(filePath, content);
+    }
+
+    /**
      * Add a new changeset to a Liquibase changelog file for entity.
      *
      * @param {string} filePath - The full path of the changelog file.

--- a/generators/server/needle-api/needle-server-liquibase.js
+++ b/generators/server/needle-api/needle-server-liquibase.js
@@ -48,6 +48,13 @@ module.exports = class extends needleServer {
         this.addBlockContentToFile(rewriteFileModel, errorMessage);
     }
 
+    addLoadColumnToEntityChangeSet(filePath, content) {
+        const errorMessage = 'LoadColumn not added.';
+        const rewriteFileModel = this.generateFileModel(filePath, 'jhipster-needle-liquibase-add-loadcolumn', content);
+        
+        this.addBlockContentToFile(rewriteFileModel, errorMessage);
+    }
+
     addChangesetToEntityChangelog(filePath, content) {
         const errorMessage = 'Changeset not added.';
         const rewriteFileModel = this.generateFileModel(filePath, 'jhipster-needle-liquibase-add-changeset', content);

--- a/generators/server/needle-api/needle-server-liquibase.js
+++ b/generators/server/needle-api/needle-server-liquibase.js
@@ -51,7 +51,7 @@ module.exports = class extends needleServer {
     addLoadColumnToEntityChangeSet(filePath, content) {
         const errorMessage = 'LoadColumn not added.';
         const rewriteFileModel = this.generateFileModel(filePath, 'jhipster-needle-liquibase-add-loadcolumn', content);
-        
+
         this.addBlockContentToFile(rewriteFileModel, errorMessage);
     }
 

--- a/test/needle-api/needle-server-liquibase.spec.js
+++ b/test/needle-api/needle-server-liquibase.spec.js
@@ -84,7 +84,7 @@ const mockBlueprintSubGen = class extends ServerGenerator {
             addLoadColumnStep() {
                 this.addLoadColumnToLiquibaseEntityChangeSet(
                     `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
-                    '            <column name="test" type="string" />'
+                    '            <column name="loadColumn" type="string" />'
                 );
             }
         };
@@ -160,16 +160,23 @@ describe('needle API server liquibase: JHipster server generator with blueprint'
         );
     });
 
+    it('Assert that load column is added to an existing changelog', () => {
+        assert.fileContent(
+            `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
+            '            <column name="loadColumn" type="string" />'
+        );
+    });
+
     it('Assert that changeSet is added to an existing changelog', () => {
         assert.fileContent(
             `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
             '    <changeSet id="20180328000000-2" author="jhipster">\n' +
             '        <createTable tableName="test">\n' +
-                    '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
-                '                <constraints primaryKey="true" nullable="false"/>\n' +
-                '            </column>\n' +
-                '        </createTable>\n' +
-                '    </changeSet>'
+            '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
+        '                <constraints primaryKey="true" nullable="false"/>\n' +
+        '            </column>\n' +
+        '        </createTable>\n' +
+        '    </changeSet>'
         );
     });
 });

--- a/test/needle-api/needle-server-liquibase.spec.js
+++ b/test/needle-api/needle-server-liquibase.spec.js
@@ -173,10 +173,10 @@ describe('needle API server liquibase: JHipster server generator with blueprint'
             '    <changeSet id="20180328000000-2" author="jhipster">\n' +
             '        <createTable tableName="test">\n' +
             '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
-        '                <constraints primaryKey="true" nullable="false"/>\n' +
-        '            </column>\n' +
-        '        </createTable>\n' +
-        '    </changeSet>'
+                '                <constraints primaryKey="true" nullable="false"/>\n' +
+                '            </column>\n' +
+                '        </createTable>\n' +
+                '    </changeSet>'
         );
     });
 });

--- a/test/needle-api/needle-server-liquibase.spec.js
+++ b/test/needle-api/needle-server-liquibase.spec.js
@@ -80,6 +80,12 @@ const mockBlueprintSubGen = class extends ServerGenerator {
                         '        </createTable>\n' +
                         '    </changeSet>'
                 );
+            },
+            addLoadColumnStep() {
+                this.addLoadColumnToLiquibaseEntityChangeSet(
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
+                    '            <column name="test" type="string" />'
+                );
             }
         };
         return { ...phaseFromJHipster, ...customPhaseSteps };

--- a/test/needle-api/templates/src/main/resources/config/liquibase/changelog/dummy_changelog.xml.ejs
+++ b/test/needle-api/templates/src/main/resources/config/liquibase/changelog/dummy_changelog.xml.ejs
@@ -49,4 +49,16 @@
         </createTable>
     </changeSet>
     <!-- jhipster-needle-liquibase-add-changeset - JHipster will add changesets here, do not remove-->
+
+    <changeSet id="20180328000000-1-data" author="jhipster" context="faker">
+        <loadData
+                  file="config/liquibase/data/test.csv"
+                  separator=";"
+                  tableName="test"
+                  context="dev">
+            <column name="id" type="numeric"/>
+            <!-- jhipster-needle-liquibase-add-loadcolumn - JHipster (and/or extensions) can add load columns here, do not remove-->
+        </loadData>
+    </changeSet>
+
 </databaseChangeLog>


### PR DESCRIPTION
With regards to the discussion in #9862 (which addresses approach 2 of #9804) a less invasive change:

* moved 'load data' section to end of file
* added new needle to allow 3rd party extensions to add additional 'load columns' (```jhipster-needle-liquibase-add-loadcolumn```)

Open issue/topic: 
* Do we need a special treatment to disable foreign key constraint checks during load process (e.g.
```<sql dbms="h2">SET REFERENTIAL_INTEGRITY FALSE</sql>``` or 
```<sql dbms="mysql">SET FOREIGN_KEY_CHECKS = 0</sql>```
 (of course re-enable at end of load changeset))?

Fix: #9804 (utilizing slightly modified Approach 1)

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
