### PR TITLE
[react] remove useless second /api/account call 

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/home/home.tsx.ejs
@@ -25,18 +25,13 @@ import { connect } from 'react-redux';
 import { Row, Col, Alert } from 'reactstrap';
 
 import { IRootState } from 'app/shared/reducers';
-import { getSession } from 'app/shared/reducers/authentication';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { getLoginUrl } from 'app/shared/util/url-utils';
 <%_ } _%>
 
-export interface IHomeProp extends StateProps, DispatchProps {}
+export type IHomeProp = StateProps;
 
 export class Home extends React.Component<IHomeProp> {
-  componentDidMount() {
-    this.props.getSession();
-  }
-
   render() {
     const { account } = this.props;
     return (
@@ -128,9 +123,6 @@ const mapStateToProps = storeState => ({
   isAuthenticated: storeState.authentication.isAuthenticated
 });
 
-const mapDispatchToProps = { getSession };
-
 type StateProps = ReturnType<typeof mapStateToProps>;
-type DispatchProps = typeof mapDispatchToProps;
 
-export default connect(mapStateToProps, mapDispatchToProps)(Home);
+export default connect(mapStateToProps)(Home);


### PR DESCRIPTION
This extra call is not necessary since it is already done in the main app component
-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
