### PR TITLE
Use official adoptopenjdk docker image now that it is available from docker hub

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -19,7 +19,7 @@
 
 // version of docker images
 const DOCKER_JHIPSTER_REGISTRY = 'jhipster/jhipster-registry:v5.0.2';
-const DOCKER_JAVA_JRE = 'adoptopenjdk/openjdk11:alpine-jre';
+const DOCKER_JAVA_JRE = 'adoptopenjdk:11-jre-hotspot';
 const DOCKER_MYSQL = 'mysql:8.0.16';
 const DOCKER_MARIADB = 'mariadb:10.4.5';
 const DOCKER_POSTGRESQL = 'postgres:11.3';


### PR DESCRIPTION
Adoptopenjdk have been approved by the docker hub as official images now, see https://github.com/docker-library/official-images/pull/5710

However alpine is not offered as it is not recommended for now (see the PR). IMO if the people from the adoptopenjdk project don't recommend using those images, then we refrain from using them for now.