### PR TITLE
Added a noopcachemanager verification for user resources tests

### DIFF
--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -522,7 +522,7 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
-        <%_ if (cacheManagerIsAvailable === true) {  _%>
+        <%_ if (cacheManagerIsAvailable === true) { _%>
 
         assertThat(cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).get(user.getLogin())).isNull();
         <%_ } _%>
@@ -556,9 +556,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
             .jsonPath("$.langKey").isEqualTo(DEFAULT_LANGKEY);
         <%_ } _%>
 
-        <%_ if (cacheProvider === 'memcached') {  _%>
-        if(!(cacheManager instanceof NoOpCacheManager))
+        <%_ if (cacheProvider === 'memcached') { _%>
+        if (!(cacheManager instanceof NoOpCacheManager)) {
             assertThat(cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).get(user.getLogin())).isNotNull();
+        }
         <%_ } else if (cacheManagerIsAvailable === true) { _%>
         assertThat(cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).get(user.getLogin())).isNotNull();
         <%_ } _%>

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -54,6 +54,9 @@ import org.springframework.boot.test.context.SpringBootTest;
 <%_ if (cacheManagerIsAvailable === true) { _%>
 import org.springframework.cache.CacheManager;
 <%_ } _%>
+<%_ if (cacheProvider === 'memcached' ) { _%>
+import org.springframework.cache.support.NoOpCacheManager;
+<%_ } _%>
 <%_ if (!reactive) { _%>
 import org.springframework.data.web.PageableHandlerMethodArgumentResolver;
 <%_ } _%>
@@ -519,7 +522,7 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
-        <%_ if (cacheManagerIsAvailable === true) { _%>
+        <%_ if (cacheManagerIsAvailable === true) {  _%>
 
         assertThat(cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).get(user.getLogin())).isNull();
         <%_ } _%>
@@ -552,8 +555,11 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
             <%_ } _%>
             .jsonPath("$.langKey").isEqualTo(DEFAULT_LANGKEY);
         <%_ } _%>
-        <%_ if (cacheManagerIsAvailable === true) { _%>
 
+        <%_ if (cacheProvider === 'memcached') {  _%>
+        if(!(cacheManager instanceof NoOpCacheManager))
+            assertThat(cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).get(user.getLogin())).isNotNull();
+        <%_ } else if (cacheManagerIsAvailable === true) { _%>
         assertThat(cacheManager.getCache(UserRepository.USERS_BY_LOGIN_CACHE).get(user.getLogin())).isNotNull();
         <%_ } _%>
     }


### PR DESCRIPTION
This PR is to make sure when the memcached is disabled, the tests are taking note of it.

Fixes #9901 

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
