### PR TITLE
Re-enable unit tests for upgrade subgenerator

### DIFF
--- a/test/upgrade.spec.js
+++ b/test/upgrade.spec.js
@@ -5,6 +5,7 @@ const shelljs = require('shelljs');
 const fse = require('fs-extra');
 const expect = require('chai').expect;
 const expectedFiles = require('./utils/expected-files');
+const packageJson = require('../package.json');
 
 describe('JHipster upgrade generator', function() {
     this.timeout(200000);
@@ -44,7 +45,12 @@ describe('JHipster upgrade generator', function() {
                 .on('end', () => {
                     helpers
                         .run(path.join(__dirname, '../generators/upgrade'))
-                        .withOptions({ 'from-cli': true, force: true, silent: false })
+                        .withOptions({
+                            'from-cli': true,
+                            force: true,
+                            silent: false,
+                            'target-version': packageJson.version
+                        })
                         .inTmpDir(() => {
                             /* eslint-disable-next-line no-console */
                             console.log('Upgrading the JHipster application');
@@ -118,7 +124,12 @@ describe('JHipster upgrade generator', function() {
                 .on('end', () => {
                     helpers
                         .run(path.join(__dirname, '../generators/upgrade'))
-                        .withOptions({ 'from-cli': true, force: true, silent: false })
+                        .withOptions({
+                            'from-cli': true,
+                            force: true,
+                            silent: false,
+                            'target-version': packageJson.version
+                        })
                         .inTmpDir(() => {
                             /* eslint-disable-next-line no-console */
                             console.log('Upgrading the JHipster application');


### PR DESCRIPTION
The target version is now forced, it should prevent issue when beta releases are done

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
