### PR TITLE
import mappings for zalando problem

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -40,7 +40,7 @@ plugins {
     id "com.google.cloud.tools.jib" version "<%= JIB_VERSION %>"
     id "com.gorylenko.gradle-git-properties" version "2.0.0"
     <%_ if (enableSwaggerCodegen) { _%>
-    id "org.openapi.generator" version "4.0.1"
+    id "org.openapi.generator" version "4.0.2"
     <%_ } _%>
     <%_ if (!skipClient) { _%>
     id "com.github.node-gradle.node" version "1.3.0"

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -28,9 +28,6 @@ buildscript {
     dependencies {
         classpath "org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}"
         classpath "io.spring.gradle:propdeps-plugin:0.0.10.RELEASE"
-        <%_ if (enableSwaggerCodegen) { _%>
-        classpath "org.openapitools:openapi-generator-gradle-plugin:3.3.4"
-        <%_ } _%>
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }
@@ -42,6 +39,9 @@ plugins {
     id "jacoco"
     id "com.google.cloud.tools.jib" version "<%= JIB_VERSION %>"
     id "com.gorylenko.gradle-git-properties" version "2.0.0"
+    <%_ if (enableSwaggerCodegen) { _%>
+    id "org.openapi.generator" version "4.0.1"
+    <%_ } _%>
     <%_ if (!skipClient) { _%>
     id "com.github.node-gradle.node" version "1.3.0"
     <%_ } _%>
@@ -316,6 +316,9 @@ dependencies {
     <%_ } _%>
     <%_ if (databaseType === 'cassandra' || applicationType === 'gateway') { _%>
     implementation "commons-codec:commons-codec"
+    <%_ } _%>
+    <%_ if (enableSwaggerCodegen) { _%>
+    implementation "org.openapitools:jackson-databind-nullable:0.1.0"
     <%_ } _%>
     implementation "org.apache.commons:commons-lang3"
     implementation "commons-io:commons-io"

--- a/generators/server/templates/gradle/swagger.gradle.ejs
+++ b/generators/server/templates/gradle/swagger.gradle.ejs
@@ -33,6 +33,7 @@ openApiGenerate {
     supportingFilesConstrainedTo = ["ApiUtil.java"]
     configOptions = [delegatePattern: "true", title: "<%= dasherizedBaseName %>"]
     validateSpec = true
+    importMappings = [Problem:"org.zalando.problem.Problem"]
 }
 
 sourceSets {

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -112,7 +112,9 @@
         <log4j2-mock.version>0.0.1</log4j2-mock.version>
 <%_ } _%>
         <mapstruct.version>1.3.0.Final</mapstruct.version>
-
+<%_ if (enableSwaggerCodegen) { _%>
+        <jackson-databind-nullable.version>0.1.0</jackson-databind-nullable.version>
+<%_ } _%>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
         <maven-compiler-plugin.version>3.8.1</maven-compiler-plugin.version>
@@ -133,7 +135,7 @@
         <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 <%_ if (enableSwaggerCodegen) { _%>
-        <openapi-generator-maven-plugin.version>4.0.1</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>4.0.2</openapi-generator-maven-plugin.version>
 <%_ } _%>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.6.0.1398</sonar-maven-plugin.version>
@@ -298,7 +300,7 @@
         <dependency>
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
-            <version>0.1.0</version>
+            <version>${jackson-databind-nullable.version}</version>
         </dependency>
 <%_ } _%>
         <dependency>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -133,7 +133,7 @@
         <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 <%_ if (enableSwaggerCodegen) { _%>
-        <openapi-generator-maven-plugin.version>3.3.4</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>4.0.1</openapi-generator-maven-plugin.version>
 <%_ } _%>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.6.0.1398</sonar-maven-plugin.version>
@@ -294,6 +294,13 @@
             <groupId>commons-io</groupId>
             <artifactId>commons-io</artifactId>
         </dependency>
+<%_ if (enableSwaggerCodegen) { _%>
+        <dependency>
+            <groupId>org.openapitools</groupId>
+            <artifactId>jackson-databind-nullable</artifactId>
+            <version>0.1.0</version>
+        </dependency>
+<%_ } _%>
         <dependency>
             <groupId>org.apache.commons</groupId>
             <artifactId>commons-lang3</artifactId>
@@ -1243,6 +1250,7 @@
                                 <apiPackage><%= packageName %>.web.api</apiPackage>
                                 <modelPackage><%= packageName %>.web.api.model</modelPackage>
                                 <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
+                                <importMappings>Problem=org.zalando.problem.Problem</importMappings>
                                 <validateSpec>true</validateSpec>
                                 <configOptions>
     <%_ if (reactive) { _%>

--- a/generators/server/templates/src/main/resources/swagger/api.yml.ejs
+++ b/generators/server/templates/src/main/resources/swagger/api.yml.ejs
@@ -24,9 +24,9 @@ info:
     version: 0.0.1
 servers:
     - url: http://localhost:<%= serverPort %>
-      description: Developpement server
+      description: Development server
     - url: https://localhost:<%= serverPort %>
-      description: Developpement server with TLS Profile
+      description: Development server with TLS Profile
 paths: {}
 <% if(authenticationType === 'jwt') { %>
 components:


### PR DESCRIPTION
* Updating open api plugin to 4.0.1
* Add new required dependency for `json-nullable` (because of updated templates in swagger templates)
* Add import mapping for zalando problem, such these classes are not generated

closes #9911 
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
