### PR TITLE
Fix jhipsterContext for entity client, server and i18n blueprints and

### DIFF
--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -27,8 +27,9 @@ let useBlueprint;
 module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
-        utils.copyObjectProps(this, this.options.context);
-        this.configOptions = this.options.configOptions || {};
+        utils.copyObjectProps(this, opts.context);
+        this.jhipsterContext = opts.jhipsterContext || opts.context;
+        this.configOptions = opts.configOptions || {};
         const blueprint = this.options.blueprint || this.configOptions.blueprint || this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -27,8 +27,9 @@ let useBlueprint;
 module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
-        utils.copyObjectProps(this, this.options.context);
-        this.configOptions = this.options.configOptions || {};
+        utils.copyObjectProps(this, opts.context);
+        this.jhipsterContext = opts.jhipsterContext || opts.context;
+        this.configOptions = opts.configOptions || {};
         const blueprint = this.options.blueprint || this.configOptions.blueprint || this.config.get('blueprint');
         if (!opts.fromBlueprint) {
             // use global variable since getters dont have access to instance property

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -28,7 +28,8 @@ module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         utils.copyObjectProps(this, opts.context);
-        this.configOptions = this.options.configOptions || {};
+        this.jhipsterContext = opts.jhipsterContext || opts.context;
+        this.configOptions = opts.configOptions || {};
         if (this.databaseType === 'cassandra') {
             this.pkType = 'UUID';
         }

--- a/test/blueprint/entity-client-blueprint.spec.js
+++ b/test/blueprint/entity-client-blueprint.spec.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const fse = require('fs-extra');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const expectedFiles = require('../utils/expected-files').entity;
+const EntityClientGenerator = require('../../generators/entity-client');
+const constants = require('../../generators/generator-constants');
+
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+const ANGULAR_DIR = constants.ANGULAR_DIR;
+
+const mockBlueprintSubGen = class extends EntityClientGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        if (!this.jhipsterContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+    }
+
+    get writing() {
+        return {
+            customPhase() {
+                this.name = 'JHipster';
+                this.template(path.join(process.cwd(), 'HelloVue.html.ejs'), `${ANGULAR_DIR}HelloVue.html`);
+            }
+        };
+    }
+};
+
+describe('JHipster entity client generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate client entity with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../../test/templates/ngx-blueprint'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:entity-client']])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected server + i18n entity files from jhipster entity generator', () => {
+                assert.file(expectedFiles.server);
+                assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`);
+            });
+
+            it('does not create default entity client files from jhipster entity generator', () => {
+                assert.noFile(expectedFiles.clientNg2);
+            });
+
+            it('contains the specific change added by the blueprint', () => {
+                assert.fileContent(`${ANGULAR_DIR}HelloVue.html`, /Hello JHipster/);
+            });
+        });
+    });
+});

--- a/test/blueprint/entity-i18n-blueprint.spec.js
+++ b/test/blueprint/entity-i18n-blueprint.spec.js
@@ -1,0 +1,75 @@
+const path = require('path');
+const fse = require('fs-extra');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const expectedFiles = require('../utils/expected-files').entity;
+const EntityI18NGenerator = require('../../generators/entity-i18n');
+const constants = require('../../generators/generator-constants');
+
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+
+const mockBlueprintSubGen = class extends EntityI18NGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        if (!this.jhipsterContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+    }
+
+    get writing() {
+        return {
+            customPhase() {
+                this.name = 'JHipster';
+                this.template(path.join(process.cwd(), 'custom-i18n.json.ejs'), `${CLIENT_MAIN_SRC_DIR}i18n/custom-i18n.json`);
+            }
+        };
+    }
+};
+
+describe('JHipster entity server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server entity with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../../test/templates/ngx-blueprint'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:entity-i18n']])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected entity server + client files from jhipster entity generator', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.clientNg2);
+            });
+
+            it('does not create default entity i18n files from jhipster entity generator', () => {
+                assert.noFile(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`);
+            });
+
+            it('contains the specific change added by the blueprint', () => {
+                assert.JSONFileContent(`${CLIENT_MAIN_SRC_DIR}i18n/custom-i18n.json`, {
+                    myblueprintApp: { name: 'JHipster' }
+                });
+            });
+        });
+    });
+});

--- a/test/blueprint/entity-server-blueprint.spec.js
+++ b/test/blueprint/entity-server-blueprint.spec.js
@@ -1,0 +1,74 @@
+const path = require('path');
+const fse = require('fs-extra');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const expectedFiles = require('../utils/expected-files').entity;
+const EntityServerGenerator = require('../../generators/entity-server');
+const constants = require('../../generators/generator-constants');
+
+const SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
+const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
+
+const mockBlueprintSubGen = class extends EntityServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        if (!this.jhipsterContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+    }
+
+    get writing() {
+        return {
+            customPhase() {
+                this.name = 'JHipster';
+                this.template(path.join(process.cwd(), 'HelloKotlin.kt.ejs'), `${SERVER_MAIN_SRC_DIR}${this.packageFolder}/HelloKotlin.kt`);
+            }
+        };
+    }
+};
+
+describe('JHipster entity server generator with blueprint', () => {
+    const blueprintNames = ['generator-jhipster-myblueprint', 'myblueprint'];
+
+    blueprintNames.forEach(blueprintName => {
+        describe(`generate server entity with blueprint option '${blueprintName}'`, () => {
+            before(done => {
+                helpers
+                    .run(path.join(__dirname, '../../generators/entity'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../../test/templates/ngx-blueprint'), dir);
+                    })
+                    .withArguments(['foo'])
+                    .withOptions({
+                        'from-cli': true,
+                        skipInstall: true,
+                        blueprint: blueprintName,
+                        skipChecks: true
+                    })
+                    .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:entity-server']])
+                    .withPrompts({
+                        fieldAdd: false,
+                        relationshipAdd: false,
+                        dto: 'no',
+                        service: 'no',
+                        pagination: 'no'
+                    })
+                    .on('end', done);
+            });
+
+            it('creates expected entity client files from jhipster entity generator', () => {
+                assert.file(expectedFiles.clientNg2);
+                assert.file(`${CLIENT_MAIN_SRC_DIR}i18n/en/foo.json`);
+            });
+
+            it('does not create default entity server files from jhipster entity generator', () => {
+                assert.noFile(expectedFiles.server.filter(f => f.endsWith('.java')));
+            });
+
+            it('contains the specific change added by the blueprint', () => {
+                assert.fileContent(`${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/HelloKotlin.kt`, /Hello JHipster/);
+            });
+        });
+    });
+});

--- a/test/needle-api/needle-client-react.spec.js
+++ b/test/needle-api/needle-client-react.spec.js
@@ -101,7 +101,7 @@ describe('needle API React: JHipster client generator with blueprint', () => {
         const indexReducerPath = `${CLIENT_MAIN_SRC_DIR}app/shared/reducers/index.ts`;
 
         assert.fileContent(indexModulePath, "import entityName from './entityFolderName';");
-                assert.fileContent(indexModulePath, '<ErrorBoundaryRoute path={`${match.url}/entityFileName`} component={entityName} />'); // eslint-disable-line
+        assert.fileContent(indexModulePath, '<ErrorBoundaryRoute path={`${match.url}/entityFileName`} component={entityName} />'); // eslint-disable-line
 
         assert.fileContent(
             indexReducerPath,

--- a/test/needle-api/needle-server-liquibase.spec.js
+++ b/test/needle-api/needle-server-liquibase.spec.js
@@ -159,7 +159,7 @@ describe('needle API server liquibase: JHipster server generator with blueprint'
             `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/dummy_changelog.xml`,
             '    <changeSet id="20180328000000-2" author="jhipster">\n' +
             '        <createTable tableName="test">\n' +
-                    '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
+            '            <column name="id" type="bigint" autoIncrement="${autoIncrement}">\n' + // eslint-disable-line
                 '                <constraints primaryKey="true" nullable="false"/>\n' +
                 '            </column>\n' +
                 '        </createTable>\n' +

--- a/test/templates/ngx-blueprint/.yo-rc.json
+++ b/test/templates/ngx-blueprint/.yo-rc.json
@@ -22,7 +22,7 @@
         "enableSwaggerCodegen": false,
         "jwtSecretKey": "147e04cf224f52908a60d7a2902e19e0648d0a8c52503b4624f1708478dd29ba2885a9bb823c85873a76b27964a90e22f1e8",
         "clientFramework": "angularX",
-                "clientPackageManager": "npm"
+        "clientPackageManager": "npm"
     },
     "generator-jhipster": {
         "promptValues": {

--- a/test/templates/ngx-blueprint/HelloKotlin.kt.ejs
+++ b/test/templates/ngx-blueprint/HelloKotlin.kt.ejs
@@ -1,0 +1,17 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+  This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+  Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.test
+
+fun main() = println("Hello <%= name %>!!!")

--- a/test/templates/ngx-blueprint/HelloVue.html.ejs
+++ b/test/templates/ngx-blueprint/HelloVue.html.ejs
@@ -1,0 +1,44 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+  This file is part of the JHipster project, see http://www.jhipster.tech/
+ for more information.
+  Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+       http://www.apache.org/licenses/LICENSE-2.0
+  Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<!DOCTYPE html>
+<html lang="en">
+  <meta>
+    <meta charset="UTF-8">
+    <title>Hello World in Vue.js</title>
+  </meta>
+
+  <body>
+
+    <div id="hello-world-app">
+      <h1>{{ msg }}</h1>
+    </div>
+
+    <script
+      src="//cdnjs.cloudflare.com/ajax/libs/vue/2.1.6/vue.min.js">
+    </script>
+
+    <script>
+      new Vue({
+        el: "#hello-world-app",
+        data() {
+          return {
+            msg: "Hello <%= name %>!"
+          }
+        }
+      });
+    </script>
+
+  </body>
+</html>

--- a/test/templates/ngx-blueprint/custom-i18n.json.ejs
+++ b/test/templates/ngx-blueprint/custom-i18n.json.ejs
@@ -1,0 +1,23 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+{
+    "<%= angularAppName %>": {
+        "name" : "<%= name %>"
+    }
+}


### PR DESCRIPTION
Fix `jhipsterContext` for entity client, server and i18n sub-gens and allow creating blueprints without having to override the parent entity sub-gen.

The problem is actually described by @yelhouti at https://github.com/jhipster/generator-jhipster-blueprint/issues/38 and I used the same workaround for https://github.com/jhipster/jhipster-kotlin/pull/146.

This fixes the problem and will make the workaround obsolete and further simplify the code for the blueprints, for  example:

**Before:**
```
module.exports = class extends EntityServerGenerator {
    constructor(args, opts) {
        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important

        const jhContext = (this.jhipsterContext = this.options.jhipsterContext || opts.jhipsterContext);

        if (!jhContext) {
            this.error(`This is a JHipster blueprint and should be used only like ${chalk.yellow('jhipster --blueprint kotlin')}`);
        }

        this.configOptions = jhContext.configOptions || {};
    }

    get writing() {
        return writeFiles();
    }
};
``` 
**After:**
```
module.exports = class extends EntityServerGenerator {
    constructor(args, opts) {
        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
        if (!this.jhipsterContext) {
            this.error(`This is a JHipster blueprint and should be used only like ${chalk.yellow('jhipster --blueprint kotlin')}`);
        }
    }

    get writing() {
        return writeFiles();
    }
};
``` 
#### Related issues:
- https://github.com/jhipster/generator-jhipster-blueprint/issues/38
- https://github.com/jhipster/generator-jhipster-blueprint/issues/10
- https://github.com/jhipster/jhipster-kotlin/pull/146

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
