### PR TITLE
Add message when traefik is use with oauth2 and a link to documentation

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -99,8 +99,7 @@ export class LoginService {
         this.authServerProvider.logout().subscribe(response => {
             const data = response.body;
             let logoutUrl = data.logoutUrl;
-            // Add here, the custom path if traefik is used
-            const redirectUri = window.location.origin;
+            const redirectUri = `${location.origin}${this.location.prepareExternalUrl('/')}`;
 
             // if Keycloak, uri has protocol/openid-connect/token
             if (logoutUrl.indexOf('/protocol') > -1) {

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -99,13 +99,16 @@ export class LoginService {
         this.authServerProvider.logout().subscribe(response => {
             const data = response.body;
             let logoutUrl = data.logoutUrl;
+            // Add here, the custom path if traefik is used
+            const redirectUri = window.location.origin;
+
             // if Keycloak, uri has protocol/openid-connect/token
             if (logoutUrl.indexOf('/protocol') > -1) {
-                logoutUrl = logoutUrl + '?redirect_uri=' + window.location.origin;
+                logoutUrl = logoutUrl + '?redirect_uri=' + redirectUri;
             } else {
                 // Okta
                 logoutUrl = logoutUrl + '?id_token_hint=' +
-                    data.idToken + '&post_logout_redirect_uri=' + window.location.origin;
+                    data.idToken + '&post_logout_redirect_uri=' + redirectUri;
             }
             window.location.href = logoutUrl;
         });

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -208,6 +208,9 @@ module.exports = class extends BaseDockerGenerator {
             },
 
             saveConfig() {
+                if (this.monitoring === 'no') {
+                    this.consoleOptions = [];
+                }
                 this.config.set({
                     appsFolders: this.appsFolders,
                     directoryPath: this.directoryPath,

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -94,6 +94,7 @@ module.exports = class extends BaseDockerGenerator {
                     const yamlConfig = yaml.services[`${lowercaseBaseName}-app`];
                     if (this.gatewayType === 'traefik' && appConfig.applicationType === 'gateway') {
                         delete yamlConfig.ports; // Do not export the ports as Traefik is the gateway
+                        this.keycloakRedirectUris += '"http://localhost/*", "https://localhost/*", ';
                     } else if (appConfig.applicationType === 'gateway' || appConfig.applicationType === 'monolith') {
                         this.keycloakRedirectUris += `"http://localhost:${portIndex}/*", "https://localhost:${portIndex}/*", `;
                         const ports = yamlConfig.ports[0].split(':');
@@ -218,6 +219,7 @@ module.exports = class extends BaseDockerGenerator {
             }
         };
     }
+
     get writing() {
         return writeFiles();
     }

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -218,7 +218,6 @@ module.exports = class extends BaseDockerGenerator {
             }
         };
     }
-
     get writing() {
         return writeFiles();
     }
@@ -231,7 +230,13 @@ module.exports = class extends BaseDockerGenerator {
         } else {
             this.log(`\n${chalk.bold.green('Docker Compose configuration successfully generated!')}`);
         }
-        this.log(`You can launch all your infrastructure by running : ${chalk.cyan('docker-compose up -d')}`);
+        if (this.gatewayType === 'traefik' && this.authenticationType === 'oauth2') {
+            this.log(`\n${chalk.yellow.bold('WARNING!')} The complete generation of the stack with traefik and oauth2 is not possible.`)
+            this.log(`Please refer to the documentation to finish the configuration of your stack.`)
+            this.log('Visit https://www.jhipster.tech/traefik/#configure-for-oauth2')
+        } else{
+            this.log(`You can launch all your infrastructure by running : ${chalk.cyan('docker-compose up -d')}`);
+        }
         if (this.gatewayNb + this.monolithicNb > 1) {
             this.log('\nYour applications will be accessible on these URLs:');
             let portIndex = 8080;

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -231,10 +231,10 @@ module.exports = class extends BaseDockerGenerator {
             this.log(`\n${chalk.bold.green('Docker Compose configuration successfully generated!')}`);
         }
         if (this.gatewayType === 'traefik' && this.authenticationType === 'oauth2') {
-            this.log(`\n${chalk.yellow.bold('WARNING!')} The complete generation of the stack with traefik and oauth2 is not possible.`)
-            this.log(`Please refer to the documentation to finish the configuration of your stack.`)
-            this.log('Visit https://www.jhipster.tech/traefik/#configure-for-oauth2')
-        } else{
+            this.log(`\n${chalk.yellow.bold('WARNING!')} The complete generation of the stack with Traefik and OAuth 2.0 is not complete.`);
+            this.log('Please refer to the documentation to finish the configuration of your stack.');
+            this.log('Visit https://www.jhipster.tech/traefik/#configure-for-oauth2');
+        } else {
             this.log(`You can launch all your infrastructure by running : ${chalk.cyan('docker-compose up -d')}`);
         }
         if (this.gatewayNb + this.monolithicNb > 1) {

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -202,6 +202,8 @@ module.exports = class extends BaseDockerGenerator {
                     }
                     yamlString = yamlArray.join('\n');
                     this.appsYaml.push(yamlString);
+
+                    this.skipClient = appConfig.skipClient;
                 });
             },
 
@@ -233,9 +235,16 @@ module.exports = class extends BaseDockerGenerator {
             this.log(`\n${chalk.bold.green('Docker Compose configuration successfully generated!')}`);
         }
         if (this.gatewayType === 'traefik' && this.authenticationType === 'oauth2') {
-            this.log(`\n${chalk.yellow.bold('WARNING!')} The complete generation of the stack with Traefik and OAuth 2.0 is not complete.`);
-            this.log('Please refer to the documentation to finish the configuration of your stack.');
-            this.log('Visit https://www.jhipster.tech/traefik/#configure-for-oauth2');
+            if (!this.skipClient) {
+                this.log(
+                    `\n${chalk.yellow.bold('WARNING!')} The complete generation of the stack with Traefik and OAuth 2.0 is not complete.`
+                );
+                this.log('Please refer to the documentation to finish the configuration of your stack.');
+                this.log('Visit https://www.jhipster.tech/traefik/#configure-for-oauth2');
+            } else {
+                this.log('Please refer to the documentation to help you for the configuration of your stack.');
+                this.log('Visit https://www.jhipster.tech/traefik/#configuration-with-oauth-2.0-and-traefik');
+            }
         } else {
             this.log(`You can launch all your infrastructure by running : ${chalk.cyan('docker-compose up -d')}`);
         }

--- a/generators/docker-compose/templates/central-server-config/application.yml.ejs
+++ b/generators/docker-compose/templates/central-server-config/application.yml.ejs
@@ -36,9 +36,10 @@ jhipster:
             enabled: true
             report-frequency: 60 # in seconds
 <%_ } _%>
-<%_ if (consoleOptions.includes('zipkin') || !skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
+
+<%_ if (consoleOptions && consoleOptions.includes('zipkin') || skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
 spring:
-    <%_ if (consoleOptions.includes('zipkin')) {_%>
+    <%_ if (consoleOptions && consoleOptions.includes('zipkin')) {_%>
     zipkin:
         base-url: http://jhipster-zipkin:9411
         enabled: true
@@ -46,7 +47,7 @@ spring:
         sampler:
             probability: 1 # report 100% of traces to Zipkin
     <%_ } _%>
-    <%_ if (!skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
+    <%_ if (skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
     cloud:
         consul:
             discovery:

--- a/generators/docker-compose/templates/central-server-config/application.yml.ejs
+++ b/generators/docker-compose/templates/central-server-config/application.yml.ejs
@@ -36,7 +36,7 @@ jhipster:
             enabled: true
             report-frequency: 60 # in seconds
 <%_ } _%>
-<%_ if (consoleOptions.includes('zipkin') || gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
+<%_ if (consoleOptions.includes('zipkin') || !skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
 spring:
     <%_ if (consoleOptions.includes('zipkin')) {_%>
     zipkin:
@@ -46,7 +46,7 @@ spring:
         sampler:
             probability: 1 # report 100% of traces to Zipkin
     <%_ } _%>
-    <%_ if ((gatewayType === 'traefik') && authenticationType === 'oauth2') { _%>
+    <%_ if (!skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
     cloud:
         consul:
             discovery:

--- a/generators/docker-compose/templates/central-server-config/application.yml.ejs
+++ b/generators/docker-compose/templates/central-server-config/application.yml.ejs
@@ -35,20 +35,34 @@ jhipster:
         logs: # report metrics in the logs
             enabled: true
             report-frequency: 60 # in seconds
-  <%_ if (consoleOptions.includes('zipkin')) { _%>
+<%_ } _%>
+<%_ if (consoleOptions.includes('zipkin') || gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
 spring:
+    <%_ if (consoleOptions.includes('zipkin')) {_%>
     zipkin:
         base-url: http://jhipster-zipkin:9411
         enabled: true
     sleuth:
         sampler:
             probability: 1 # report 100% of traces to Zipkin
-  <%_ } _%>
+    <%_ } _%>
+    <%_ if ((gatewayType === 'traefik') && authenticationType === 'oauth2') { _%>
+    cloud:
+        consul:
+            discovery:
+                tags:
+                    - traefik.enable=true
+                    - traefik.frontend.login.rule=PathPrefix:/login
+                    - traefik.frontend.login.priority=1001
+                    - traefik.frontend.oauth.rule=PathPrefix:/oauth2
+                    - traefik.frontend.oauth.priority=1001
+    <%_ } _%>
 <%_ } _%>
-
 <%_ if (serviceDiscoveryType === 'eureka') { _%>
 eureka:
     client:
         service-url:
             defaultZone: http://admin:${jhipster.registry.password}@jhipster-registry:8761/eureka/
 <%_ } _%>
+
+

--- a/generators/docker-compose/templates/central-server-config/application.yml.ejs
+++ b/generators/docker-compose/templates/central-server-config/application.yml.ejs
@@ -37,7 +37,7 @@ jhipster:
             report-frequency: 60 # in seconds
 <%_ } _%>
 
-<%_ if (consoleOptions && consoleOptions.includes('zipkin') || skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
+<%_ if (consoleOptions && consoleOptions.includes('zipkin') || !skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
 spring:
     <%_ if (consoleOptions && consoleOptions.includes('zipkin')) {_%>
     zipkin:
@@ -47,7 +47,7 @@ spring:
         sampler:
             probability: 1 # report 100% of traces to Zipkin
     <%_ } _%>
-    <%_ if (skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
+    <%_ if (!skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
     cloud:
         consul:
             discovery:

--- a/generators/docker-compose/templates/traefik/traefik.toml.ejs
+++ b/generators/docker-compose/templates/traefik/traefik.toml.ejs
@@ -21,3 +21,20 @@ endpoint = "consul:8500"
 exposedByDefault = true
 prefix = "traefik"
 frontEndRule = "PathPrefixStrip: /services/{{.ServiceName}}"
+
+
+<%_ if (skipClient && authenticationType === 'oauth2') { _%>
+
+[file]
+
+[backends]
+  [backends.gateway]
+    [backends.gateway.server.server1]
+    url= "http://localhost:9000"
+[frontends]
+  [frontends.frontend1]
+    backend= "gateway"
+    [frontends.frontend1.routes.domain]
+    rule = "Host:localhost:9000"
+
+<%_ } _%>


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/9769
Fix https://github.com/jhipster/generator-jhipster/issues/9770

Add a message when traefik is use with oauth2, and a link to the documentation for complete the configuration.
Add a variable to simplify the configuration with traefik

Documentation update in https://github.com/jhipster/jhipster.github.io/pull/754

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
