### PR TITLE
use correct Spring profiles when building app with different Gradle profile

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -75,6 +75,8 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
 <%_ } _%>
 
 processResources {
+    inputs.property('version', version)
+    inputs.property('springProfiles', profiles)
     filesMatching("**/application.yml") {
         filter {
             it.replace("#project.version#", version)

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -53,6 +53,8 @@ task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%
 <%_ } _%>
 
 processResources {
+    inputs.property('version', version)
+    inputs.property('springProfiles', profiles)
     filesMatching("**/application.yml") {
         filter {
             it.replace("#project.version#", version)


### PR DESCRIPTION
Before, when first compiling the project with Gradle `dev` profile and then, without cleaning the
project, with Gradle `prod` profile, the list of active Spring profiles was not updated. Now it is.