### PR TITLE
allow using Gradle project version in jib configuration

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -55,6 +55,11 @@ plugins {
     //jhipster-needle-gradle-plugins - JHipster will add additional gradle plugins here
 }
 
+group = "<%= packageName %>"
+version = "0.0.1-SNAPSHOT"
+
+description = ""
+
 sourceCompatibility=<%= JAVA_VERSION %>
 targetCompatibility=<%= JAVA_VERSION %>
 assert System.properties["java.specification.version"] == "1.8" || "11" || "12"
@@ -122,11 +127,6 @@ if (OperatingSystem.current().isWindows()) {
 }
 
 defaultTasks "bootRun"
-
-group = "<%= packageName %>"
-version = "0.0.1-SNAPSHOT"
-
-description = ""
 
 springBoot {
     mainClassName = "<%= packageName %>.<%= mainClass %>"


### PR DESCRIPTION
We decided to not use `latest` as the tag for the Docker image built by jib, but the Gradle project version. While I think changing the default Docker image tag is not a good change for JHipster in general, moving the project version up allows it to be referenced by Jib. Not knowing too much about Gradle project configuration before, we stumbled over this and I want to save others this learning.