### PR TITLE
pass app version to NPM as env var instead of parsing it from build file

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -150,9 +150,7 @@
     "webpack-notifier": "1.7.0",
     "webpack-visualizer-plugin": "0.1.11",
     "workbox-webpack-plugin": "4.3.1",
-    "write-file-webpack-plugin": "4.5.0"<% if (buildTool === 'maven') { %>,
-    "xml2js": "0.4.19"
-    <%_ } _%>
+    "write-file-webpack-plugin": "4.5.0"
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,

--- a/generators/client/templates/angular/webpack/utils.js.ejs
+++ b/generators/client/templates/angular/webpack/utils.js.ejs
@@ -16,49 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-    parseVersion,
     root,
     isExternalLib
 };
-
-<%_ if (buildTool === 'maven') { _%>
-const parseString = require('xml2js').parseString;
-// return the version number from `pom.xml` file
-function parseVersion() {
-    let version = null;
-    const pomXml = fs.readFileSync('pom.xml', 'utf8');
-    parseString(pomXml, (err, result) => {
-        if (err) {
-            throw new Error('Failed to parse pom.xml: ' + err);
-        }
-        if (result.project.version && result.project.version[0]) {
-            version = result.project.version[0];
-        } else if (result.project.parent && result.project.parent[0] && result.project.parent[0].version && result.project.parent[0].version[0]) {
-            version = result.project.parent[0].version[0];
-        }
-    });
-    if (version === null) {
-        throw new Error('pom.xml is malformed. No version is defined');
-    }
-    return version;
-}
-<%_ } else if (buildTool === 'gradle') { _%>
-// Returns the second occurrence of the version number from `build.gradle` file
-function parseVersion() {
-    const versionRegex = /^version\s*=\s*[',"]([^',"]*)[',"]/gm; // Match and group the version number
-    const buildGradle = fs.readFileSync('build.gradle', 'utf8');
-    return versionRegex.exec(buildGradle)[1];
-}
-<%_ } else { _%>
-// Returns a static version number when server is skipped
-function parseVersion() {
-    return '0.0.1-SNAPSHOT';
-};
-<%_ } _%>
 
 const _root = path.resolve(__dirname, '..');
 

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -78,7 +78,13 @@ module.exports = (options) => ({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
                 BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
-                VERSION: `'${utils.parseVersion()}'`,
+<%_ if (buildTool === 'gradle' || buildTool === 'maven') { _%>
+                // If webpack is run through Gradle 'webpack'/'webpackBuildDev' NpmTasks / Maven 'frontend-maven-plugin', then APP_VERSION is set.
+                VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
+<%_ } else { _%>
+                // Server generation is skipped, so there is no way to determine the application version from server.
+                VERSION: `'0.0.1-SNAPSHOT'`,
+<%_ } _%>
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
                 // If this URL is left empty (""), then it will be relative to the current context.

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -172,8 +172,7 @@ limitations under the License.
     "webpack-merge": "4.2.1",
     "webpack-notifier": "1.7.0",
     "workbox-webpack-plugin": "4.1.1",
-    "write-file-webpack-plugin": "4.5.0"<% if (buildTool === 'maven') { %>,
-    "xml2js": "0.4.19"<% } %>
+    "write-file-webpack-plugin": "4.5.0"
   },
 <%_ if (clientPackageManager === 'yarn') { _%>
   "resolutions": {

--- a/generators/client/templates/react/webpack/utils.js.ejs
+++ b/generators/client/templates/react/webpack/utils.js.ejs
@@ -16,46 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-const fs = require('fs');
 const path = require('path');
 
 module.exports = {
-  parseVersion,
   root,
   isExternalLib
 };
-
-<%_ if (buildTool === 'maven') { _%>
-const parseString = require('xml2js').parseString;
-// return the version number from `pom.xml` file
-function parseVersion() {
-  let version = null;
-  const pomXml = fs.readFileSync('pom.xml', 'utf8');
-  parseString(pomXml, (err, result) => {
-    if (result.project.version && result.project.version[0]) {
-      version = result.project.version[0];
-    } else if (result.project.parent && result.project.parent[0] && result.project.parent[0].version && result.project.parent[0].version[0]) {
-      version = result.project.parent[0].version[0];
-    }
-  });
-  if (version === null) {
-    throw new Error('pom.xml is malformed. No version is defined');
-  }
-  return version;
-}
-<%_ } else if (buildTool === 'gradle') { _%>
-// Returns the second occurrence of the version number from `build.gradle` file
-function parseVersion() {
-  const versionRegex = /^version\s*=\s*[',"]([^',"]*)[',"]/gm; // Match and group the version number
-  const buildGradle = fs.readFileSync('build.gradle', 'utf8');
-  return versionRegex.exec(buildGradle)[1];
-}
-<%_ } else { _%>
-// Returns a static version number when server is skipped
-function parseVersion() {
-  return '0.0.1-SNAPSHOT';
-}
-<%_ } _%>
 
 const _root = path.resolve(__dirname, '..');
 

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -123,7 +123,13 @@ module.exports = options => ({
         <%_ if (enableTranslation) { _%>
         BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
         <%_ } _%>
-        VERSION: `'${utils.parseVersion()}'`,
+<%_ if (buildTool === 'gradle' || buildTool === 'maven') { _%>
+        // If webpack is run through Gradle 'webpack'/'webpackBuildDev' NpmTasks / Maven 'frontend-maven-plugin', then APP_VERSION is set.
+        VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
+<%_ } else { _%>
+        // Server generation is skipped, so there is no way to determine the application version from server.
+        VERSION: `'0.0.1-SNAPSHOT'`,
+<%_ } _%>
         DEBUG_INFO_ENABLED: options.env === 'development',
         // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
         // If this URL is left empty (""), then it will be relative to the current context.

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -71,6 +71,7 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
     dependsOn <%= clientPackageManager %><%_ if (clientPackageManager === 'npm') { _%>Install<%_ } _%>
 
     args = ["run", "webpack:build"]
+    environment = [APP_VERSION: project.version]
 }
 <%_ } _%>
 

--- a/generators/server/templates/gradle/profile_prod.gradle.ejs
+++ b/generators/server/templates/gradle/profile_prod.gradle.ejs
@@ -49,6 +49,7 @@ task webpack_test(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn
 
 task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task, dependsOn: "<%= clientPackageManager %><%_ if (clientPackageManager === 'npm') { _%>Install<%_ } _%>") {
     args = ["run", "webpack:prod"]
+    environment = [APP_VERSION: project.version]
 }
 <%_ } _%>
 

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1393,6 +1393,9 @@
                                 <phase>generate-resources</phase>
                                 <configuration>
                                     <arguments>run webpack:build</arguments>
+                                    <environmentVariables>
+                                        <APP_VERSION>${project.version}</APP_VERSION>
+                                    </environmentVariables>
     <%_ if (clientPackageManager === 'yarn') { _%>
                                     <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
     <%_ } else if (clientPackageManager === 'npm') { _%>
@@ -1545,6 +1548,9 @@
                                 <phase>generate-resources</phase>
                                 <configuration>
                                     <arguments>run webpack:prod</arguments>
+                                    <environmentVariables>
+                                        <APP_VERSION>${project.version}</APP_VERSION>
+                                    </environmentVariables>
     <%_ if (clientPackageManager === 'yarn') { _%>
                                     <yarnInheritsProxyConfigFromMaven>false</yarnInheritsProxyConfigFromMaven>
     <%_ } else if (clientPackageManager === 'npm') { _%>


### PR DESCRIPTION
Currently, the webpack `DefinePlugin` sets the `VERSION` by parsing it from either `build.gradle`
(in case of a Gradle build) or from `pom.xml` (in case of a Maven build). The problem with this is
that if the version is not statically set, but rather dynamically calcualted (e.g. using
https://github.com/palantir/gradle-git-version to determine it from the Git repo), the parsing
breaks.

Thus, this PR changes this by passing the version to show in the frontend from the server build
tool (Gradle/Maven) as an environment variable to the NPM webpack task. This is more robust and
does not rely on parsing the Gradle/maven file. The downside is that if only `npm start` is run,
instead of the version, `UNKNOWN` is shown.

I think the advantages (allowing dynamic version in Gradle, removing parsing code) outweigh this
downside.

I tested this by
1. generating Maven and Gradle projects
2. generating Angular and React clients
3. running it using `dev` vs. `prod` profiles
4. running the server build tool vs. `npm start`

(but not all combinations of the above :-).

This PR depends on https://github.com/jhipster/generator-jhipster/pull/9985, so that Gradle
project version can be accessed in the `gradle/profile_prod/dev.gradle` files.