### PR TITLE
Use client side package version if build tool is undefined

### DIFF
--- a/generators/client/templates/angular/webpack/utils.js.ejs
+++ b/generators/client/templates/angular/webpack/utils.js.ejs
@@ -19,8 +19,7 @@
 const path = require('path');
 
 module.exports = {
-    root,
-    isExternalLib
+    root
 };
 
 const _root = path.resolve(__dirname, '..');
@@ -28,12 +27,4 @@ const _root = path.resolve(__dirname, '..');
 function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [_root].concat(args));
-}
-
-function isExternalLib(module, check = /node_modules/) {
-    const req = module.userRequest;
-    if (typeof req !== 'string') {
-        return false;
-    }
-    return req.search(check) >= 0;
 }

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -23,8 +23,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const rxPaths = require('rxjs/_esm5/path-mapping');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
-<%_ } _%>
+<%_ } if (buildTool === undefined) { _%>
 
+const packageJson = require('./../package.json');
+<%_ } _%>
 const utils = require('./utils.js');
 
 module.exports = (options) => ({
@@ -78,12 +80,11 @@ module.exports = (options) => ({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
                 BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
-<%_ if (buildTool === 'gradle' || buildTool === 'maven') { _%>
-                // If webpack is run through Gradle 'webpack'/'webpackBuildDev' NpmTasks / Maven 'frontend-maven-plugin', then APP_VERSION is set.
-                VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
+<%_ if (buildTool === undefined) { _%>
+                VERSION: `'${packageJson.version}'`,
 <%_ } else { _%>
-                // Server generation is skipped, so there is no way to determine the application version from server.
-                VERSION: `'0.0.1-SNAPSHOT'`,
+                // APP_VERSION is passed as an environment variable from the Gradle / Maven build tasks.
+                VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
 <%_ } _%>
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.

--- a/generators/client/templates/react/webpack/utils.js.ejs
+++ b/generators/client/templates/react/webpack/utils.js.ejs
@@ -19,8 +19,7 @@
 const path = require('path');
 
 module.exports = {
-  root,
-  isExternalLib
+  root
 };
 
 const _root = path.resolve(__dirname, '..');
@@ -28,12 +27,4 @@ const _root = path.resolve(__dirname, '..');
 function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [_root].concat(args));
-}
-
-function isExternalLib(module, check = /node_modules/) {
-  const req = module.userRequest;
-  if (typeof req !== 'string') {
-    return false;
-  }
-  return req.search(check) >= 0;
 }

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+const path = require('path');
 const webpack = require('webpack');
 const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
@@ -23,9 +24,10 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require('merge-jsons-webpack-plugin');
-<%_ } _%>
-const path = require('path');
+<%_ } if (buildTool === undefined) { _%>
 
+const packageJson = require('./../package.json');
+<%_ } _%>
 const utils = require('./utils.js');
 
 const getTsLoaderRule = env => {
@@ -123,12 +125,11 @@ module.exports = options => ({
         <%_ if (enableTranslation) { _%>
         BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
         <%_ } _%>
-<%_ if (buildTool === 'gradle' || buildTool === 'maven') { _%>
-        // If webpack is run through Gradle 'webpack'/'webpackBuildDev' NpmTasks / Maven 'frontend-maven-plugin', then APP_VERSION is set.
-        VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
+<%_ if (buildTool === undefined) { _%>
+        VERSION: `'${packageJson.version}'`,
 <%_ } else { _%>
-        // Server generation is skipped, so there is no way to determine the application version from server.
-        VERSION: `'0.0.1-SNAPSHOT'`,
+        // APP_VERSION is passed as an environment variable from the Gradle / Maven build tasks.
+        VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
 <%_ } _%>
         DEBUG_INFO_ENABLED: options.env === 'development',
         // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.


### PR DESCRIPTION
1. Follow up on #9986
If `skip server` option is used, then, consider `package.json` version to be displayed on the UI. Current default was hard coded to '0.0.1-SNAPSHOT'
2. Remove non used function from utils

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
