### PR TITLE
Allow loading .yo-rc.json from an alternate root path other than cwd

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1995,7 +1995,12 @@ module.exports = class extends PrivateBase {
      * @param {boolean} force force getting direct from file
      */
     getAllJhipsterConfig(generator = this, force) {
-        return jhipsterUtils.getAllJhipsterConfig(generator, force);
+        const configRootPath =
+            generator.configRootPath ||
+            (generator.options && generator.options.configRootPath) ||
+            (generator.configOptions && generator.configOptions.configRootPath) ||
+            '';
+        return jhipsterUtils.getAllJhipsterConfig(generator, force, configRootPath);
     }
 
     /**

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -414,11 +414,13 @@ function decodeBase64(string, encoding = 'utf-8') {
  * Get all the generator configuration from the .yo-rc.json file
  * @param {Generator} generator the generator instance to use
  * @param {boolean} force force getting direct from file
+ * @param {String} base path where the .yo-rc.json file is located. Default is cwd.
  */
-function getAllJhipsterConfig(generator, force) {
+function getAllJhipsterConfig(generator, force, basePath = '') {
     let configuration = generator && generator.config ? generator.config.getAll() || {} : {};
-    if ((force || !configuration.baseName) && jhiCore.FileUtils.doesFileExist('.yo-rc.json')) {
-        const yoRc = JSON.parse(fs.readFileSync('.yo-rc.json', { encoding: 'utf-8' }));
+    const filePath = path.join(basePath, '.yo-rc.json');
+    if ((force || !configuration.baseName) && jhiCore.FileUtils.doesFileExist(filePath)) {
+        const yoRc = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
         configuration = yoRc['generator-jhipster'];
         // merge the blueprint config if available
         if (configuration.blueprint) {

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -418,7 +418,7 @@ function decodeBase64(string, encoding = 'utf-8') {
  */
 function getAllJhipsterConfig(generator, force, basePath = '') {
     let configuration = generator && generator.config ? generator.config.getAll() || {} : {};
-    const filePath = path.join(basePath, '.yo-rc.json');
+    const filePath = path.join(basePath || '', '.yo-rc.json');
     if ((force || !configuration.baseName) && jhiCore.FileUtils.doesFileExist(filePath)) {
         const yoRc = JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
         configuration = yoRc['generator-jhipster'];

--- a/test/upgrade.spec.js
+++ b/test/upgrade.spec.js
@@ -10,6 +10,7 @@ const packageJson = require('../package.json');
 describe('JHipster upgrade generator', function() {
     this.timeout(200000);
     describe('default application', () => {
+        const cwd = process.cwd();
         before(done => {
             let workingDirectory;
             helpers
@@ -77,8 +78,13 @@ describe('JHipster upgrade generator', function() {
             //   - master: merge commit of jhipster_upgrade
             expect(commitsCount).to.equal('5');
         });
+
+        after(() => {
+            process.chdir(cwd);
+        });
     });
     describe('blueprint application', () => {
+        const cwd = process.cwd();
         const blueprintName = 'generator-jhipster-sample-blueprint';
         const blueprintVersion = '0.1.1';
         before(done => {
@@ -161,6 +167,10 @@ describe('JHipster upgrade generator', function() {
             assert.fileContent('.yo-rc.json', new RegExp(`"blueprint": "${blueprintName}"`));
             assert.fileContent('.yo-rc.json', new RegExp(`"blueprintVersion": "${blueprintVersion}"`));
             assert.fileContent('package.json', new RegExp(`"${blueprintName}": "${blueprintVersion}"`));
+        });
+
+        after(() => {
+            process.chdir(cwd);
         });
     });
 });

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,4 +1,5 @@
 const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
 const utils = require('../generators/utils');
 
 describe('JHipster Utils', () => {
@@ -86,6 +87,42 @@ describe('JHipster Utils', () => {
         it("doesn't  do anything for scoped package", () => {
             const generatorName = utils.normalizeBlueprintName('@corp/foo');
             assert.textEqual(generatorName, '@corp/foo');
+        });
+    });
+    describe('::getAllJhipsterConfig', () => {
+        const cwd = process.cwd();
+        const configRootDir = './test/templates/default';
+        const expectedConfig = {
+            applicationType: 'monolith',
+            baseName: 'sampleMysql',
+            packageName: 'com.mycompany.myapp',
+            packageFolder: 'com/mycompany/myapp',
+            authenticationType: 'session',
+            cacheProvider: 'ehcache',
+            websocket: 'no',
+            databaseType: 'sql',
+            devDatabaseType: 'h2Disk',
+            prodDatabaseType: 'mysql',
+            searchEngine: 'no',
+            buildTool: 'maven',
+            enableTranslation: true,
+            nativeLanguage: 'en',
+            languages: ['en', 'fr'],
+            rememberMeKey: '2bb60a80889aa6e6767e9ccd8714982681152aa5',
+            testFrameworks: ['gatling']
+        };
+
+        it('load config from alternate directory', () => {
+            const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
+            assert.objectContent(loadedConfig, expectedConfig);
+        });
+        it('load config from current working directory', () => {
+            process.chdir(configRootDir);
+            const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true);
+            assert.objectContent(loadedConfig, expectedConfig);
+        });
+        after(() => {
+            process.chdir(cwd);
         });
     });
 });


### PR DESCRIPTION
Allow changing the parent root directory of the `.yo-rc.json`. The default remains the` cwd`.

The use case is to allow jhipster modules to take advantage of existing code and e.g. re-use the existing entity sub-gen while loading the configuration from a directory other than the `cwd`. See https://github.com/oktadeveloper/generator-jhipster-ionic/pull/109

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
