### PR TITLE
Remove project name condition (underscore) in microservice generation

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1685,9 +1685,6 @@ module.exports = class extends PrivateBase {
                     if (!/^([a-zA-Z0-9_]*)$/.test(input)) {
                         return 'Your base name cannot contain special characters or a blank space';
                     }
-                    if ((generator.applicationType === 'microservice' || generator.applicationType === 'uaa') && /_/.test(input)) {
-                        return 'Your base name cannot contain underscores as this does not meet the URI spec';
-                    }
                     if (generator.applicationType === 'uaa' && input === 'auth') {
                         return "Your UAA base name cannot be named 'auth' as it conflicts with the gateway login routes";
                     }

--- a/generators/server/templates/src/main/docker/prometheus/prometheus.yml.ejs
+++ b/generators/server/templates/src/main/docker/prometheus/prometheus.yml.ejs
@@ -37,7 +37,7 @@ scrape_configs:
     scrape_interval: 5s
 
     # scheme defaults to 'http'.
-    metrics_path: <% if ((applicationType === 'microservice' || applicationType === 'uaa') && !serviceDiscoveryType) { %>/services/<%= baseName %><% } %>/management/prometheus
+    metrics_path: <% if ((applicationType === 'microservice' || applicationType === 'uaa') && !serviceDiscoveryType) { %>/services/<%= dasherizedBaseName %><% } %>/management/prometheus
     static_configs:
       - targets:
           # On MacOS, replace localhost by host.docker.internal


### PR DESCRIPTION
When we creating a microservice application we don't allow an application name that contain an underscore even if it's authorized when we creating a monolith.

I understand it's for url definition but as we already do for kafka we can use c for urls definition and authorized underscore in applications name for every case.

We need to know where dasherizedBaseName is mandatory, so I start with a draft PR and feel free to tell me where I should replace baseName by dasherizedBaseName.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
