### PR TITLE
fix audits and user management with uaa and no database

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -257,7 +257,8 @@ const files = {
             ]
         },
         {
-            condition: generator => generator.databaseType !== 'no' && generator.databaseType !== 'cassandra',
+            condition: generator =>
+                (generator.databaseType !== 'no' ? true : generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra',
             path: ANGULAR_DIR,
             templates: [
                 { file: 'admin/audits/audits.route.ts', method: 'processJs' },
@@ -437,7 +438,8 @@ const files = {
             templates: ['spec/app/shared/login/login.component.spec.ts', 'spec/app/shared/alert/alert-error.component.spec.ts']
         },
         {
-            condition: generator => generator.databaseType !== 'no' && generator.databaseType !== 'cassandra',
+            condition: generator =>
+                (generator.databaseType !== 'no' ? true : generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra',
             path: TEST_SRC_DIR,
             templates: ['spec/app/admin/audits/audits.component.spec.ts', 'spec/app/admin/audits/audits.service.spec.ts']
         },

--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -258,7 +258,7 @@ const files = {
         },
         {
             condition: generator =>
-                (generator.databaseType !== 'no' ? true : generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra',
+                (generator.databaseType !== 'no' || generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra',
             path: ANGULAR_DIR,
             templates: [
                 { file: 'admin/audits/audits.route.ts', method: 'processJs' },
@@ -439,7 +439,7 @@ const files = {
         },
         {
             condition: generator =>
-                (generator.databaseType !== 'no' ? true : generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra',
+                (generator.databaseType !== 'no' || generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra',
             path: TEST_SRC_DIR,
             templates: ['spec/app/admin/audits/audits.component.spec.ts', 'spec/app/admin/audits/audits.service.spec.ts']
         },

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
@@ -27,7 +27,7 @@ import { <%=angularXAppName%>SharedModule } from 'app/shared';
 
 import {
     adminState,
-    <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     AuditsComponent,
     <%_ } _%>
     <%_ if (!skipUserManagement) { _%>
@@ -57,7 +57,7 @@ import {
         RouterModule.forChild(adminState)
     ],
     declarations: [
-        <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+        <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
         AuditsComponent,
         <%_ } _%>
         <%_ if (!skipUserManagement) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
@@ -27,7 +27,7 @@ import { <%=angularXAppName%>SharedModule } from 'app/shared';
 
 import {
     adminState,
-    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     AuditsComponent,
     <%_ } _%>
     <%_ if (!skipUserManagement) { _%>
@@ -57,7 +57,7 @@ import {
         RouterModule.forChild(adminState)
     ],
     declarations: [
-        <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+        <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
         AuditsComponent,
         <%_ } _%>
         <%_ if (!skipUserManagement) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin.route.ts.ejs
@@ -19,7 +19,7 @@
 import { Routes } from '@angular/router';
 
 import {
-    <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     auditsRoute,
     <%_ } _%>
     configurationRoute,
@@ -41,7 +41,7 @@ import {
 import { UserRouteAccessService } from 'app/core';
 
 const ADMIN_ROUTES = [
-    <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     auditsRoute,
     <%_ } _%>
     configurationRoute,

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin.route.ts.ejs
@@ -19,7 +19,7 @@
 import { Routes } from '@angular/router';
 
 import {
-    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     auditsRoute,
     <%_ } _%>
     configurationRoute,
@@ -41,7 +41,7 @@ import {
 import { UserRouteAccessService } from 'app/core';
 
 const ADMIN_ROUTES = [
-    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     auditsRoute,
     <%_ } _%>
     configurationRoute,

--- a/generators/client/templates/angular/src/main/webapp/app/admin/index.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/index.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 export * from './audits/audits.component';
 export * from './audits/audits.service';
 export * from './audits/audits.route';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/index.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/index.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 export * from './audits/audits.component';
 export * from './audits/audits.service';
 export * from './audits/audits.route';

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -98,7 +98,7 @@
                             <span jhiTranslate="global.menu.admin.configuration">Configuration</span>
                         </a>
                     </li>
-                    <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/audits" routerLinkActive="active" (click)="collapseNavbar()">
                             <fa-icon icon="bell" fixedWidth="true"></fa-icon>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -98,7 +98,7 @@
                             <span jhiTranslate="global.menu.admin.configuration">Configuration</span>
                         </a>
                     </li>
-                    <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                    <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                     <li>
                         <a class="dropdown-item" routerLink="admin/audits" routerLinkActive="active" (click)="collapseNavbar()">
                             <fa-icon icon="bell" fixedWidth="true"></fa-icon>

--- a/generators/client/templates/angular/src/main/webapp/robots.txt.ejs
+++ b/generators/client/templates/angular/src/main/webapp/robots.txt.ejs
@@ -24,7 +24,7 @@ Disallow: /api/account
 Disallow: /api/account/change-password
 Disallow: /api/account/sessions
 <%_ } _%>
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 Disallow: /api/audits/
 <%_ } _%>
 Disallow: /api/logs/

--- a/generators/client/templates/angular/src/main/webapp/robots.txt.ejs
+++ b/generators/client/templates/angular/src/main/webapp/robots.txt.ejs
@@ -24,7 +24,7 @@ Disallow: /api/account
 Disallow: /api/account/change-password
 Disallow: /api/account/sessions
 <%_ } _%>
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 Disallow: /api/audits/
 <%_ } _%>
 Disallow: /api/logs/

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -95,7 +95,7 @@ describe('administration', () => {
         expect(value1).to.eq(expect1);
     });
 
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     it('should load audits', async () => {
         await navBarPage.clickOnAdmin('audits');
         await browser.sleep(500);

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -95,7 +95,7 @@ describe('administration', () => {
         expect(value1).to.eq(expect1);
     });
 
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     it('should load audits', async () => {
         await navBarPage.clickOnAdmin('audits');
         await browser.sleep(500);

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/index.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/index.tsx.ejs
@@ -26,7 +26,7 @@ import Logs from './logs/logs';
 import Health from './health/health';
 import Metrics from './metrics/metrics';
 import Configuration from './configuration/configuration';
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 import Audits from './audits/audits';
 <%_ } _%>
 import Docs from './docs/docs';
@@ -52,7 +52,7 @@ const Routes = ({ match }) => (
     <ErrorBoundaryRoute exact path={`${match.url}/metrics`} component={Metrics} />
     <ErrorBoundaryRoute exact path={`${match.url}/docs`} component={Docs} />
     <ErrorBoundaryRoute exact path={`${match.url}/configuration`} component={Configuration} />
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     <ErrorBoundaryRoute exact path={`${match.url}/audits`} component={Audits} />
 <%_ } _%>
     <ErrorBoundaryRoute exact path={`${match.url}/logs`} component={Logs} />

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/index.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/index.tsx.ejs
@@ -26,7 +26,7 @@ import Logs from './logs/logs';
 import Health from './health/health';
 import Metrics from './metrics/metrics';
 import Configuration from './configuration/configuration';
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 import Audits from './audits/audits';
 <%_ } _%>
 import Docs from './docs/docs';
@@ -52,7 +52,7 @@ const Routes = ({ match }) => (
     <ErrorBoundaryRoute exact path={`${match.url}/metrics`} component={Metrics} />
     <ErrorBoundaryRoute exact path={`${match.url}/docs`} component={Docs} />
     <ErrorBoundaryRoute exact path={`${match.url}/configuration`} component={Configuration} />
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     <ErrorBoundaryRoute exact path={`${match.url}/audits`} component={Audits} />
 <%_ } _%>
     <ErrorBoundaryRoute exact path={`${match.url}/logs`} component={Logs} />

--- a/generators/client/templates/react/src/main/webapp/robots.txt.ejs
+++ b/generators/client/templates/react/src/main/webapp/robots.txt.ejs
@@ -24,7 +24,7 @@ Disallow: /api/account
 Disallow: /api/account/change-password
 Disallow: /api/account/sessions
 <%_ } _%>
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 Disallow: /api/audits/
 <%_ } _%>
 Disallow: /api/logs/

--- a/generators/client/templates/react/src/main/webapp/robots.txt.ejs
+++ b/generators/client/templates/react/src/main/webapp/robots.txt.ejs
@@ -24,7 +24,7 @@ Disallow: /api/account
 Disallow: /api/account/change-password
 Disallow: /api/account/sessions
 <%_ } _%>
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
 Disallow: /api/audits/
 <%_ } _%>
 Disallow: /api/logs/

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -72,7 +72,7 @@ describe('Administration', () => {
     expect(await element(by.id('configuration-page-heading')).getText()).to.eq('Configuration');
   });
 
-<%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
   it('should load audits', async () => {
     await navBarPage.clickOnAdminMenuItem('audits');
     expect(await element(by.id('audits-page-heading')).getText()).to.eq('Audits');

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -72,7 +72,7 @@ describe('Administration', () => {
     expect(await element(by.id('configuration-page-heading')).getText()).to.eq('Configuration');
   });
 
-<%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
   it('should load audits', async () => {
     await navBarPage.clickOnAdminMenuItem('audits');
     expect(await element(by.id('audits-page-heading')).getText()).to.eq('Audits');

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -67,7 +67,7 @@ module.exports = class extends Generator {
     installI18nClientFilesByLanguage(_this, webappDir, lang) {
         const generator = _this || this;
         const prefix = this.fetchFromInstalledJHipster('languages/templates');
-        if ((generator.databaseType !== 'no' ? true : generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra') {
+        if ((generator.databaseType !== 'no' || generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra') {
             generator.copyI18nFilesByName(generator, webappDir, 'audits.json', lang);
         }
         if (generator.applicationType === 'gateway' && generator.serviceDiscoveryType) {

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -67,7 +67,7 @@ module.exports = class extends Generator {
     installI18nClientFilesByLanguage(_this, webappDir, lang) {
         const generator = _this || this;
         const prefix = this.fetchFromInstalledJHipster('languages/templates');
-        if (generator.databaseType !== 'no' && generator.databaseType !== 'cassandra') {
+        if ((generator.databaseType !== 'no' ? true : generator.authenticationType === 'uaa') && generator.databaseType !== 'cassandra') {
             generator.copyI18nFilesByName(generator, webappDir, 'audits.json', lang);
         }
         if (generator.applicationType === 'gateway' && generator.serviceDiscoveryType) {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1917,7 +1917,7 @@ module.exports = class extends PrivateBase {
             generator.getDBTypeFromDBValue(dest.prodDatabaseType) ||
             context.configOptions.databaseType ||
             context.config.get('databaseType');
-        if (dest.authenticationType === 'oauth2' || dest.databaseType === 'no') {
+        if (dest.authenticationType === 'oauth2' || (dest.databaseType === 'no' && dest.authenticationType !== 'uaa')) {
             dest.skipUserManagement = true;
         }
         dest.searchEngine = context.config.get('searchEngine');

--- a/generators/languages/templates/src/main/webapp/i18n/al/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/al/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Shëndeti",
                 "configuration": "Konfigurimi",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditet",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/al/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/al/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Shëndeti",
                 "configuration": "Konfigurimi",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditet",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "الصحة",
                 "configuration": "الإعدادات",
                 "logs": "السجلات",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "عمليات التدقيق",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ar-ly/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ar-ly/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "الصحة",
                 "configuration": "الإعدادات",
                 "logs": "السجلات",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "عمليات التدقيق",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/bn/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Health",
                 "configuration": "Configuration",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/bn/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/bn/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Health",
                 "configuration": "Configuration",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/by/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/by/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Стан",
                 "configuration": "Налады",
                 "logs": "Логі",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аўдыт",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/by/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/by/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Стан",
                 "configuration": "Налады",
                 "logs": "Логі",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аўдыт",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ca/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Salud",
                 "configuration": "Configuració",
                 "logs": "Registres",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditories",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ca/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ca/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Salud",
                 "configuration": "Configuració",
                 "logs": "Registres",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditories",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/cs/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Stav systému",
                 "configuration": "Konfigurace",
                 "logs": "Logy",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audity",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/cs/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/cs/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Stav systému",
                 "configuration": "Konfigurace",
                 "logs": "Logy",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audity",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/da/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/da/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Sundheds",
                 "configuration": "Konfiguration",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/da/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/da/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Sundheds",
                 "configuration": "Konfiguration",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/de/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/de/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Konfiguration",
                 "logs": "Protokoll",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/de/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/de/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Konfiguration",
                 "logs": "Protokoll",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/el/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/el/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Υγεία",
                 "configuration": "Διαμόρφωση",
                 "logs": "Καταγραφές",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "'Ελεγχει",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/el/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/el/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Υγεία",
                 "configuration": "Διαμόρφωση",
                 "logs": "Καταγραφές",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "'Ελεγχει",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/en/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/en/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Health",
                 "configuration": "Configuration",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/en/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/en/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Health",
                 "configuration": "Configuration",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/es/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/es/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Salud",
                 "configuration": "Configuración",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorías",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/es/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/es/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Salud",
                 "configuration": "Configuración",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorías",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/et/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/et/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Tervis",
                 "configuration": "Konfiguratsioon",
                 "logs": "Logid",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/et/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/et/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Tervis",
                 "configuration": "Konfiguratsioon",
                 "logs": "Logid",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/fa/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "سلامتی",
                 "configuration": "پیکربندی",
                 "logs": "وقایع ثبت شده",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "وقایع بازرسی",
                 <%_ } _%>
                 "apidocs": "ای‌پی‌آی",

--- a/generators/languages/templates/src/main/webapp/i18n/fa/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fa/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "سلامتی",
                 "configuration": "پیکربندی",
                 "logs": "وقایع ثبت شده",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "وقایع بازرسی",
                 <%_ } _%>
                 "apidocs": "ای‌پی‌آی",

--- a/generators/languages/templates/src/main/webapp/i18n/fi/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fi/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Terveys",
                 "configuration": "Konfiguraatio",
                 "logs": "Logit",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit logit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/fi/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fi/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Terveys",
                 "configuration": "Konfiguraatio",
                 "logs": "Logit",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit logit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/fr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Diagnostics",
                 "configuration": "Configuration",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/fr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/fr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Diagnostics",
                 "configuration": "Configuration",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/gl/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Saúde",
                 "configuration": "Configuración",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorías",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/gl/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/gl/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Saúde",
                 "configuration": "Configuración",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorías",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/hi/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "स्वास्थ्य",
                 "configuration": "कॉन्फ़िगरेशन",
                 "logs": "लॉग",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "आडिट",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/hi/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hi/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "स्वास्थ्य",
                 "configuration": "कॉन्फ़िगरेशन",
                 "logs": "लॉग",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "आडिट",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/hu/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Akalmazás állapota",
                 "configuration": "Konfiguráció",
                 "logs": "Naplók",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Nyomkövetés",
                 <%_ } _%>
                 "apidocs": "API dokumentáció",

--- a/generators/languages/templates/src/main/webapp/i18n/hu/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hu/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Akalmazás állapota",
                 "configuration": "Konfiguráció",
                 "logs": "Naplók",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Nyomkövetés",
                 <%_ } _%>
                 "apidocs": "API dokumentáció",

--- a/generators/languages/templates/src/main/webapp/i18n/hy/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Health",
                 "configuration": "Կարգավորումներ",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Աուդիտ",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/hy/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/hy/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Health",
                 "configuration": "Կարգավորումներ",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Աուդիտ",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/in/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/in/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Kesehatan Aplikasi",
                 "configuration": "Konfigurasi",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/in/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/in/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Kesehatan Aplikasi",
                 "configuration": "Konfigurasi",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ko/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/global.json.ejs
@@ -46,7 +46,7 @@
                 "health": "상태 확인",
                 "configuration": "설정",
                 "logs": "로그",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ko/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ko/global.json.ejs
@@ -46,7 +46,7 @@
                 "health": "상태 확인",
                 "configuration": "설정",
                 "logs": "로그",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/mr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "आरोग्य",
                 "configuration": "संरचना",
                 "logs": "नोंदी",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "ऑडिट",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/mr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/mr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "आरोग्य",
                 "configuration": "संरचना",
                 "logs": "नोंदी",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "ऑडिट",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/my/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/my/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "စနစ်အခြေအနေ",
                 "configuration": "Configuration များ",
                 "logs": "Log များ",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "စာရင်းစစ်ဆေးခြင်း",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/my/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/my/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "စနစ်အခြေအနေ",
                 "configuration": "Configuration များ",
                 "logs": "Log များ",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "စာရင်းစစ်ဆေးခြင်း",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/nl/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Configuration",
                 "logs": "Logboek",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/nl/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/nl/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Configuration",
                 "logs": "Logboek",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audits",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/pl/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Konfiguracja",
                 "logs": "Logi",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audyty",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/pl/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pl/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Konfiguracja",
                 "logs": "Logi",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audyty",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Estado do Sistema",
                 "configuration": "Configuração",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorias",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-br/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-br/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Estado do Sistema",
                 "configuration": "Configuração",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorias",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Estado do Sistema",
                 "configuration": "Configuração",
                 "logs": "Logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorias",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/pt-pt/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/pt-pt/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Estado do Sistema",
                 "configuration": "Configuração",
                 "logs": "Logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Auditorias",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ro/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/global.json.ejs
@@ -50,7 +50,7 @@
                 "health": "Stare",
                 "configuration": "Configurare",
                 "logs": "Jurnal",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ro/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ro/global.json.ejs
@@ -50,7 +50,7 @@
                 "health": "Stare",
                 "configuration": "Configurare",
                 "logs": "Jurnal",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ru/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Состояние",
                 "configuration": "Настройки",
                 "logs": "Логи",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аудит",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ru/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ru/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Состояние",
                 "configuration": "Настройки",
                 "logs": "Логи",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аудит",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/sk/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Stav systému",
                 "configuration": "Konfigurácia",
                 "logs": "Logy",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audity",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/sk/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sk/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Stav systému",
                 "configuration": "Konfigurácia",
                 "logs": "Logy",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audity",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/sr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Ispravnost sistema",
                 "configuration": "Konfiguracija",
                 "logs": "Logovi",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Revizije",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/sr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Ispravnost sistema",
                 "configuration": "Konfiguracija",
                 "logs": "Logovi",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Revizije",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/sv/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Konfigurering",
                 "logs": "Loggar",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Granskningar",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/sv/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/sv/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Status",
                 "configuration": "Konfigurering",
                 "logs": "Loggar",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Granskningar",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ta/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "ஆரோக்கியம்",
                 "configuration": "கட்டமைப்பு",
                 "logs": "பதிவுகள்",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "தணிக்கைகள்",
                 <%_ } _%>
                 "apidocs": "எபிஐ ",

--- a/generators/languages/templates/src/main/webapp/i18n/ta/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ta/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "ஆரோக்கியம்",
                 "configuration": "கட்டமைப்பு",
                 "logs": "பதிவுகள்",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "தணிக்கைகள்",
                 <%_ } _%>
                 "apidocs": "எபிஐ ",

--- a/generators/languages/templates/src/main/webapp/i18n/te/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/te/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "పరిస్థితి",
                 "configuration": "ఆకృతీకరణ",
                 "logs": "లాగ్స్",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "తనిఖీలు",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/te/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/te/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "పరిస్థితి",
                 "configuration": "ఆకృతీకరణ",
                 "logs": "లాగ్స్",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "తనిఖీలు",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/th/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/th/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "สถานะระบบ",
                 "configuration": "องค์ประกอบ",
                 "logs": "บันทึกการทำงาน",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "การตรวจสอบ",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/th/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/th/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "สถานะระบบ",
                 "configuration": "องค์ประกอบ",
                 "logs": "บันทึกการทำงาน",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "การตรวจสอบ",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/tr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Sağlık",
                 "configuration": "Yapılandırma",
                 "logs": "Kayıtlar",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Denetim",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/tr/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/tr/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Sağlık",
                 "configuration": "Yapılandırma",
                 "logs": "Kayıtlar",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Denetim",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ua/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Стан",
                 "configuration": "Налаштування",
                 "logs": "Логи",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аудит",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/ua/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/ua/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Стан",
                 "configuration": "Налаштування",
                 "logs": "Логи",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аудит",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/global.json.ejs
@@ -44,7 +44,7 @@
                 "health": "Ҳолат",
                 "configuration": "Созламалар",
                 "logs": "Логлар",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аудит",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/global.json.ejs
@@ -44,7 +44,7 @@
                 "health": "Ҳолат",
                 "configuration": "Созламалар",
                 "logs": "Логлар",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Аудит",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Holat",
                 "configuration": "Sozlamalar",
                 "logs": "Loglar",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Latn-uz/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Holat",
                 "configuration": "Sozlamalar",
                 "logs": "Loglar",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Audit",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/vi/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Tình trạng",
                 "configuration": "Cấu hình",
                 "logs": "Ghi logs",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Kiểm duyệt",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/vi/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/vi/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "Tình trạng",
                 "configuration": "Cấu hình",
                 "logs": "Ghi logs",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "Kiểm duyệt",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "服务状态",
                 "configuration": "配置",
                 "logs": "日志",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "审核",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "服务状态",
                 "configuration": "配置",
                 "logs": "日志",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "审核",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "服務狀態",
                 "configuration": "設定",
                 "logs": "紀錄",
-                <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "稽核",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/global.json.ejs
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/global.json.ejs
@@ -47,7 +47,7 @@
                 "health": "服務狀態",
                 "configuration": "設定",
                 "logs": "紀錄",
-                <%_ if ((databaseType !== 'no' ? true : authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+                <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
                 "audits": "稽核",
                 <%_ } _%>
                 "apidocs": "API",

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -192,7 +192,9 @@ module.exports = class extends BaseBlueprintGenerator {
                     this.devDatabaseType = 'no';
                     this.prodDatabaseType = 'no';
                     this.enableHibernateCache = false;
-                    this.skipUserManagement = true;
+                    if (this.authenticationType !== 'uaa') {
+                        this.skipUserManagement = true;
+                    }
                 } else {
                     // sql
                     this.devDatabaseType = configuration.get('devDatabaseType');

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -323,7 +323,9 @@ function askForServerSideOpts(meta) {
             this.devDatabaseType = 'no';
             this.prodDatabaseType = 'no';
             this.enableHibernateCache = false;
-            this.skipUserManagement = true;
+            if (this.authenticationType !== 'uaa') {
+                this.skipUserManagement = true;
+            }
         } else if (this.databaseType === 'mongodb') {
             this.devDatabaseType = 'mongodb';
             this.prodDatabaseType = 'mongodb';

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-jhipster",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {


### PR DESCRIPTION
Should fix #9992 

However, I am wondering: it seems that we both rely on the same skipUserManagement in front end and backend, when with uaa, we want to generate userManagement for the front end, but not for back end. Should I refactor this logic instead of this PR ? 

Should I add test to see if expected files are correctly generated with the no database option ?

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
