### PR TITLE
angular: use dynamic import syntax

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -479,6 +479,10 @@ const files = {
             ]
         },
         {
+            condition: generator => generator.protractorTests,
+            templates: ['tsconfig.e2e.json']
+        },
+        {
             condition: generator => generator.authenticationType === 'oauth2',
             path: TEST_SRC_DIR,
             templates: ['spec/app/layouts/main/main.component.spec.ts']

--- a/generators/client/needle-api/needle-client-angular.js
+++ b/generators/client/needle-api/needle-client-angular.js
@@ -198,11 +198,11 @@ module.exports = class extends needleClientBase {
                 const splicable = isAnyEntityAlreadyGenerated
                     ? `|,{
                             |                path: '${entityUrl}',
-                            |                loadChildren: '${modulePath}#${moduleName}'
+                            |                loadChildren: () => import('${modulePath}').then(m => m.${moduleName})
                             |            }`
                     : `|{
                                 |                path: '${entityUrl}',
-                                |                loadChildren: '${modulePath}#${moduleName}'
+                                |                loadChildren: () => import('${modulePath}').then(m => m.${moduleName})
                                 |            }`;
                 const rewriteFileModel = this.generateFileModel(
                     entityModulePath,

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -75,7 +75,7 @@
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.0",
     <%_ } _%>
-    "acorn": "^6.1.1",
+    "acorn": "6.1.1",
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",
     "autoprefixer": "9.6.0",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -75,6 +75,11 @@
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.0",
     <%_ } _%>
+<%#
+The acorn dependency is added in order to fix a webpack/NPM issue:
+Please see: https://github.com/webpack/webpack/issues/8656
+Remove it once the issue is closed
+-%>
     "acorn": "6.1.1",
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -75,6 +75,7 @@
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.0",
     <%_ } _%>
+    "acorn": "^6.1.1",
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",
     "autoprefixer": "9.6.0",

--- a/generators/client/templates/angular/src/main/webapp/app/app-routing.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app-routing.module.ts.ejs
@@ -32,7 +32,7 @@ const LAYOUT_ROUTES = [
             [
                 {
                     path: 'admin',
-                    loadChildren: './admin/admin.module#<%=angularXAppName%>AdminModule'
+                    loadChildren: () => import('./admin/admin.module').then(m => m.<%=angularXAppName%>AdminModule)
                 },
                 ...LAYOUT_ROUTES
             ],

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -53,7 +53,7 @@ exports.config = {
 
     beforeLaunch: function() {
         require('ts-node').register({
-            project: ''
+            project: 'tsconfig.e2e.json'
         });
     },
 

--- a/generators/client/templates/angular/tsconfig-aot.json.ejs
+++ b/generators/client/templates/angular/tsconfig-aot.json.ejs
@@ -19,7 +19,7 @@
 {
     "compilerOptions": {
         "target": "es6",
-        "module": "es2015",
+        "module": "esnext",
         "moduleResolution": "node",
         "sourceMap": false,
         "emitDecoratorMetadata": true,

--- a/generators/client/templates/angular/tsconfig.e2e.json.ejs
+++ b/generators/client/templates/angular/tsconfig.e2e.json.ejs
@@ -1,0 +1,6 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "module": "commonjs"
+  }
+}

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -19,7 +19,7 @@
 {
     "compilerOptions": {
         "target": "es6",
-        "module": "commonjs",
+        "module": "esnext",
         "moduleResolution": "node",
         "sourceMap": true,
         "emitDecoratorMetadata": true,

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "generator-jhipster",
-    "version": "6.1.1",
+    "version": "6.1.2",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/test/needle-api/needle-client-angular.spec.js
+++ b/test/needle-api/needle-client-angular.spec.js
@@ -169,7 +169,7 @@ describe('needle API Angular: JHipster client generator with blueprint', () => {
             `${CLIENT_MAIN_SRC_DIR}app/entities/entity.module.ts`,
             '            {\n' +
                 "                path: 'entityUrl',\n" +
-                "                loadChildren: './entityFolderName/entityFileName.module#MicroServiceNameentityNameModule'\n" +
+                "                loadChildren: () => import('./entityFolderName/entityFileName.module').then(m => m.MicroServiceNameentityNameModule)\n" +
                 '            }'
         );
     });


### PR DESCRIPTION
Fix #9926 

Had to add the `acorn` dependency to force webpack to use the correct versions, thanks npm...

See there for more info on the issue: https://github.com/webpack/webpack/issues/8656


-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
