### PR TITLE
Position ngbDropdown dynamically

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -35,7 +35,7 @@
                 </a>
             </li>
             <!-- jhipster-needle-add-element-to-menu - JHipster will add new menu items here -->
-            <li *ngSwitchCase="true" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            <li *ngSwitchCase="true" ngbDropdown class="nav-item dropdown pointer" display="dynamic" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="entity-menu">
                     <span>
                         <fa-icon icon="th-list"></fa-icon>
@@ -48,7 +48,7 @@
                     <!-- jhipster-needle-add-entity-to-menu - JHipster will add entities to the menu here -->
                 </ul>
             </li>
-            <li *<%=jhiPrefix%>HasAnyAuthority="'ROLE_ADMIN'" ngbDropdown class="nav-item dropdown pointer" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            <li *<%=jhiPrefix%>HasAnyAuthority="'ROLE_ADMIN'" ngbDropdown class="nav-item dropdown pointer" display="dynamic" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="admin-menu">
                     <span>
                         <fa-icon icon="user-plus"></fa-icon>
@@ -130,7 +130,7 @@
                 </ul>
             </li>
             <%_ if (enableTranslation) { _%>
-            <li ngbDropdown class="nav-item dropdown pointer" *ngIf="languages && languages.length > 1">
+            <li ngbDropdown class="nav-item dropdown pointer" display="dynamic" *ngIf="languages && languages.length > 1">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="languagesnavBarDropdown">
                     <span>
                         <fa-icon icon="flag"></fa-icon>
@@ -144,7 +144,7 @@
                 </ul>
             </li>
             <%_ } _%>
-            <li ngbDropdown class="nav-item dropdown pointer" placement="bottom-right" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
+            <li ngbDropdown class="nav-item dropdown pointer" display="dynamic" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="account-menu">
                   <span *ngIf="!getImageUrl()">
                     <fa-icon icon="user"></fa-icon>


### PR DESCRIPTION
This PR is to position the dropdown menu dynamically to have this:
<img width="203" alt="Screenshot 2019-07-08 at 23 32 21" src="https://user-images.githubusercontent.com/766263/60844130-b6990400-a1d8-11e9-8004-4f4f684adcaf.png">

instead of

<img width="133" alt="Screenshot 2019-07-08 at 23 26 30" src="https://user-images.githubusercontent.com/766263/60843883-278bec00-a1d8-11e9-94c2-140f6fdfb982.png">

(previously fixed by placement="bottom-right")

The **display="dynamic"** attribute seems required using ng-bootstrap 4.2.1 (it was working well with 4.1.3) and only because the ngbDropdown is inside a navbar.

I found this out after having a look at:
- https://github.com/ng-bootstrap/ng-bootstrap/issues/3269
- https://ng-bootstrap.github.io/#/positioning#dropdown

This fix implies a rendering for mobile like this:
<img width="301" alt="Screenshot 2019-07-08 at 22 57 29" src="https://user-images.githubusercontent.com/766263/60844026-7df92a80-a1d8-11e9-9e7f-e9be92c01c30.png">

instead of

<img width="347" alt="Screenshot 2019-07-08 at 22 58 16" src="https://user-images.githubusercontent.com/766263/60844030-80f41b00-a1d8-11e9-8a7e-fa7993ce3546.png">


What do you think ?