### PR TITLE
Remove sudo key value

### DIFF
--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -25,7 +25,6 @@ node_js:
   - "<%= NODE_VERSION %>"
 jdk:
   - oraclejdk8
-sudo: false
 cache:
   directories:
     - node


### PR DESCRIPTION
Container based infrastructure has been deprecated and thus sudo: false no longer holds; https://docs.travis-ci.com/user/reference/trusty/#container-based-infrastructure

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
