### PR TITLE
Fix UserServiceIT.testUserDetailsWithLangKey

### DIFF
--- a/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
@@ -477,13 +477,13 @@ public class UserServiceIT <% if (databaseType === 'cassandra') { %>extends Abst
     @Transactional
     <%_ } _%>
     public void testUserDetailsWithLangKey() {
-        userDetails.put("langKey", "DEFAULT_LANGKEY");
+        userDetails.put("langKey", DEFAULT_LANGKEY);
         userDetails.put("locale", "en-US");
 
         OAuth2AuthenticationToken authentication = createMockOAuth2AuthenticationToken(userDetails);
         <%= asDto('User') %> userDTO = userService.getUserFromAuthentication(authentication);
 
-        assertThat(userDTO.getLangKey()).isEqualTo("DEFAULT_LANGKEY");
+        assertThat(userDTO.getLangKey()).isEqualTo(DEFAULT_LANGKEY);
     }
 
     @Test


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

`UserServiceIT.testUserDetailsWithLangKey` is failing with oauth2/mongodb.
