### PR TITLE
Fix TranslateModule usage

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -46,7 +46,7 @@
     <%_ } _%>
     "core-js": "3.2.1",
     "moment": "2.24.0",
-    "ng-jhipster": "0.11.0",
+    "ng-jhipster": "0.11.1",
     "ngx-cookie": "4.0.2",
     "ngx-infinite-scroll": "8.0.0",
     "ngx-webstorage": "4.0.1",

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
@@ -18,10 +18,6 @@
 -%>
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-<%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from 'ng-jhipster';
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
-<%_ } _%>
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
 /* jhipster-needle-add-admin-module-import - JHipster will add admin modules imports here */
 
@@ -77,9 +73,6 @@ import { <%=jhiPrefixCapitalized%>TrackerComponent } from './tracker/tracker.com
         <%_ } _%>
         <%=jhiPrefixCapitalized%>MetricsMonitoringComponent
     ],
-    <%_ if (enableTranslation) { _%>
-    providers: [ { provide: JhiLanguageService, useClass: JhiLanguageService } ],
-    <%_ } _%>
     entryComponents: [
         <%_ if (!skipUserManagement) { _%>
         UserMgmtDeleteDialogComponent,
@@ -88,13 +81,4 @@ import { <%=jhiPrefixCapitalized%>TrackerComponent } from './tracker/tracker.com
     ]
 })
 export class <%=angularXAppName%>AdminModule {
-    <%_ if (enableTranslation) { _%>
-    constructor(private languageService: JhiLanguageService, private languageHelper: JhiLanguageHelper) {
-        this.languageHelper.language.subscribe((languageKey: string) => {
-            if (languageKey) {
-                this.languageService.changeLanguage(languageKey);
-            }
-        });
-    }
-    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -16,12 +16,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HTTP_INTERCEPTORS, <% if (enableTranslation) { %>HttpClient<% } %> } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
-import { NgJhipsterModule } from 'ng-jhipster';
+<%_ if (enableTranslation) { _%>
+import { TranslateModule, TranslateLoader, MissingTranslationHandler } from '@ngx-translate/core';
+<%_ } _%>
 import { NgxWebstorageModule } from 'ngx-webstorage';
+import { NgJhipsterModule, <% if (enableTranslation) { %>translatePartialLoader, missingTranslationHandler, JhiConfigService<% } %> } from 'ng-jhipster';
 
 import './vendor';
 <%_ if (authenticationType === 'jwt') { _%>
@@ -62,6 +65,20 @@ import { ErrorComponent } from './layouts/error/error.component';
             defaultI18nLang: '<%= nativeLanguage %>'
             <%_ } _%>
         }),
+        <%_ if (enableTranslation) { _%>
+        TranslateModule.forRoot({
+            loader: {
+                provide: TranslateLoader,
+                useFactory: translatePartialLoader,
+                deps: [HttpClient]
+            },
+            missingTranslationHandler: {
+                provide: MissingTranslationHandler,
+                useFactory: missingTranslationHandler,
+                deps: [JhiConfigService]
+            }
+        }),
+        <%_ } _%>
         <%=angularXAppName%>SharedModule,
         <%=angularXAppName%>CoreModule,
         <%=angularXAppName%>HomeModule,

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -20,7 +20,6 @@ import { Injectable, RendererFactory2, Renderer2 } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router, ActivatedRouteSnapshot } from '@angular/router';
 import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
-import { BehaviorSubject, Observable } from 'rxjs';
 
 import { LANGUAGES } from 'app/core/language/language.constants';
 <%_ if (enableI18nRTL) { _%>
@@ -30,7 +29,6 @@ import { FindLanguageFromKeyPipe } from 'app/shared/language/find-language-from-
 @Injectable({providedIn: 'root'})
 export class JhiLanguageHelper {
     private renderer: Renderer2 = null;
-    private _language: BehaviorSubject<string>;
 
     constructor(
         private translateService: TranslateService,
@@ -41,17 +39,12 @@ export class JhiLanguageHelper {
         private router: Router,
         rootRenderer: RendererFactory2
     ) {
-        this._language = new BehaviorSubject<string>(this.translateService.currentLang);
         this.renderer = rootRenderer.createRenderer(document.querySelector('html'), null);
         this.init();
     }
 
     getAll(): Promise<any> {
         return Promise.resolve(LANGUAGES);
-    }
-
-    get language(): Observable<string> {
-        return this._language.asObservable();
     }
 
     /**
@@ -73,7 +66,6 @@ export class JhiLanguageHelper {
 
     private init() {
         this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-            this._language.next(this.translateService.currentLang);
             this.renderer.setAttribute(document.querySelector('html'), 'lang', this.translateService.currentLang);
             this.updateTitle();
             <%_ if (enableI18nRTL) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
@@ -24,6 +24,9 @@ import { NgJhipsterModule } from 'ng-jhipster';
 import { InfiniteScrollModule } from 'ngx-infinite-scroll';
 import { CookieModule } from 'ngx-cookie';
 import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
+<%_ if (enableTranslation) { _%>
+import { TranslateModule } from '@ngx-translate/core';
+<%_ } _%>
 
 @NgModule({
     imports: [
@@ -40,7 +43,10 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
         NgJhipsterModule,
         InfiniteScrollModule,
         FontAwesomeModule,
-        ReactiveFormsModule
+        ReactiveFormsModule,
+        <%_ if (enableTranslation) { _%>
+        TranslateModule
+        <%_ } _%>
     ]
 })
 export class <%=angularXAppName%>SharedLibsModule {}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -18,10 +18,6 @@
 -%>
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-<%_ if (enableTranslation) { _%>
-import { JhiLanguageService } from 'ng-jhipster';
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
-<%_ } _%>
 
 import { <%= angularXAppName %>SharedModule } from 'app/shared/shared.module';
 import { <%= entityAngularName %>Component } from './<%= entityFileName %>.component';
@@ -52,19 +48,7 @@ const ENTITY_STATES = [
         <%= entityAngularName %>UpdateComponent,
         <%= entityAngularName %>DeleteDialogComponent,
         <%= entityAngularName %>DeletePopupComponent,
-    ],
-    <%_ if (enableTranslation) { _%>
-    providers: [ { provide: JhiLanguageService, useClass: JhiLanguageService } ],
-    <%_ } _%>
+    ]
 })
 export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {
-    <%_ if (enableTranslation) { _%>
-    constructor(private languageService: JhiLanguageService, private languageHelper: JhiLanguageHelper) {
-        this.languageHelper.language.subscribe((languageKey: string) => {
-            if (languageKey) {
-                this.languageService.changeLanguage(languageKey);
-            }
-        });
-    }
-    <%_ } _%>
 }


### PR DESCRIPTION
Because of ng-jhipster packaging, we had one instance of TranslateModule per lazy loaded modules. This caused some issues when we introduced lazy-loading and we had to do some strange hacks. 
You can see the removed code in this PR to check the hacks.

We should do one `forRoot` call in our `AppModule` instead of doing it multiple times, so I think we should remove the `forRoot` in the ng-jhipster lib and do that in the generated app instead.

We need https://github.com/jhipster/ng-jhipster/pull/99 to be closed and a `ng-jhipster` release before merging this.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
