### PR TITLE
Lazy Load Moment Locales

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -55,9 +55,7 @@ export class SettingsComponent implements OnInit {
             this.updateForm(account);
         });
         <%_ if (enableTranslation) { _%>
-        this.languageHelper.getAll().then((languages) => {
-            this.languages = languages;
-        });
+        this.languages = this.languageHelper.getAllNames();
         <%_ } _%>
 
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -65,9 +65,7 @@ export class UserMgmtUpdateComponent implements OnInit {
             this.authorities = authorities;
         });
         <%_ if (enableTranslation) { _%>
-        this.languageHelper.getAll().then((languages) => {
-            this.languages = languages;
-        });
+        this.languages = this.languageHelper.getAllNames();
         <%_ } _%>
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.constants.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.constants.ts.ejs
@@ -20,6 +20,6 @@
     Languages codes are ISO_639-1 codes, see http://en.wikipedia.org/wiki/List_of_ISO_639-1_codes
     They are written in English to avoid character encoding issues (not a perfect solution)
 */
-export const LANGUAGES: string[] = [
+export const LANGUAGES = [
     // jhipster-needle-i18n-language-constant - JHipster will add/remove languages in this array
 ];

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -55,6 +55,10 @@ export class JhiLanguageHelper {
         return this.getAll().map(lang => lang.value);
     }
 
+    get language(): Observable<string> {
+        return this._language.asObservable();
+    }
+
     /**
      * Update the window title using params in the following
      * order:

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -23,6 +23,7 @@ import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
 import { BehaviorSubject, Observable } from 'rxjs';
 
 import { LANGUAGES } from 'app/core/language/language.constants';
+import * as moment from 'moment';
 <%_ if (enableI18nRTL) { _%>
 import { FindLanguageFromKeyPipe } from 'app/shared/language/find-language-from-key.pipe';
 <%_ } _%>
@@ -46,12 +47,12 @@ export class JhiLanguageHelper {
         this.init();
     }
 
-    getAll(): Promise<any> {
-        return Promise.resolve(LANGUAGES);
+    getAll() {
+        return LANGUAGES;
     }
 
-    get language(): Observable<string> {
-        return this._language.asObservable();
+    getAllNames(): string[] {
+        return this.getAll().map(lang => lang.value);
     }
 
     /**
@@ -73,6 +74,14 @@ export class JhiLanguageHelper {
 
     private init() {
         this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
+            const language = this.getAll().find(lang => lang.value === event.lang);
+
+            // English is already bundled, no need to lazy-load
+            if (event.lang === 'en') {
+                moment.locale('en');
+            } else {
+                import(`moment/locale/${language.momentLocaleId}`).then(() => moment.locale(language.momentLocaleId));
+            }
             this._language.next(this.translateService.currentLang);
             this.renderer.setAttribute(document.querySelector('html'), 'lang', this.translateService.currentLang);
             this.updateTitle();

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
@@ -67,10 +67,7 @@ export class NavbarComponent implements OnInit {
 
     ngOnInit() {
         <%_ if (enableTranslation) { _%>
-        this.languageHelper.getAll().then((languages) => {
-            this.languages = languages;
-        });
-
+        this.languages = this.languageHelper.getAllNames();
         <%_ } _%>
         this.profileService.getProfileInfo().then((profileInfo) => {
             this.inProduction = profileInfo.inProduction;

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -21,6 +21,7 @@ const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const rxPaths = require('rxjs/_esm5/path-mapping');
+const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
 <%_ } if (buildTool === undefined) { _%>
@@ -120,6 +121,9 @@ module.exports = (options) => ({
             chunksSortMode: 'manual',
             inject: 'body'
         }),
-        new BaseHrefWebpackPlugin({ baseHref: '/' })
+        new BaseHrefWebpackPlugin({ baseHref: '/' }),
+        new MomentLocalesPlugin({
+            localesToKeep: []
+        })
     ]
 });

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -21,7 +21,6 @@ const webpackMerge = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const Visualizer = require('webpack-visualizer-plugin');
-const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const AngularCompilerPlugin = require('@ngtools/webpack').AngularCompilerPlugin;
@@ -146,11 +145,6 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
             // both options are optional
             filename: 'content/[name].[contenthash].css',
             chunkFilename: 'content/[id].css'
-        }),
-        new MomentLocalesPlugin({
-            localesToKeep: [
-                // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array
-            ]
         }),
         new Visualizer({
             // Webpack statistics in target folder

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -170,41 +170,6 @@ module.exports = class extends Generator {
     }
 
     /**
-     * Update Languages In Language Constant
-     *
-     * @param languages
-     */
-    updateLanguagesInLanguageConstant(languages) {
-        const fullPath = `${CLIENT_MAIN_SRC_DIR}app/components/language/language.constants.js`;
-        try {
-            let content = ".constant('LANGUAGES', [\n";
-            languages.forEach((language, i) => {
-                content += `            '${language}'${i !== languages.length - 1 ? ',' : ''}\n`;
-            });
-            content +=
-                '            // jhipster-needle-i18n-language-constant - JHipster will add/remove languages in this array\n        ]';
-
-            jhipsterUtils.replaceContent(
-                {
-                    file: fullPath,
-                    pattern: /\.constant.*LANGUAGES.*\[([^\]]*jhipster-needle-i18n-language-constant[^\]]*)\]/g,
-                    content
-                },
-                this
-            );
-        } catch (e) {
-            this.log(
-                chalk.yellow('\nUnable to find ') +
-                    fullPath +
-                    chalk.yellow(' or missing required jhipster-needle. LANGUAGE constant not updated with languages: ') +
-                    languages +
-                    chalk.yellow(' since block was not found. Check if you have enabled translation support.\n')
-            );
-            this.debug('Error:', e);
-        }
-    }
-
-    /**
      * Update Languages In Language Constant NG2
      *
      * @param languages
@@ -215,9 +180,10 @@ module.exports = class extends Generator {
         }
         const fullPath = `${CLIENT_MAIN_SRC_DIR}app/core/language/language.constants.ts`;
         try {
-            let content = 'export const LANGUAGES: string[] = [\n';
+            let content = 'export const LANGUAGES = [\n';
             languages.forEach((language, i) => {
-                content += `    '${language}'${i !== languages.length - 1 ? ',' : ''}\n`;
+                const momentLocaleId = this.getMomentLocaleId(language);
+                content += `    {value:'${language}', momentLocaleId:'${momentLocaleId}'}${i !== languages.length - 1 ? ',' : ''}\n`;
             });
             content += '    // jhipster-needle-i18n-language-constant - JHipster will add/remove languages in this array\n];';
 
@@ -334,42 +300,6 @@ module.exports = class extends Generator {
                 {
                     file: fullPath,
                     pattern: /groupBy:.*\[([^\]]*jhipster-needle-i18n-language-webpack[^\]]*)\]/g,
-                    content
-                },
-                this
-            );
-        } catch (e) {
-            this.log(
-                chalk.yellow('\nUnable to find ') +
-                    fullPath +
-                    chalk.yellow(' or missing required jhipster-needle. Webpack language task not updated with languages: ') +
-                    languages +
-                    chalk.yellow(' since block was not found. Check if you have enabled translation support.\n')
-            );
-            this.debug('Error:', e);
-        }
-    }
-
-    /**
-     * Update Moment Locales to keep in webpack prod build
-     *
-     * @param languages
-     */
-    updateLanguagesInMomentWebpackNgx(languages) {
-        const fullPath = 'webpack/webpack.prod.js';
-        try {
-            let content = 'localesToKeep: [\n';
-            languages.forEach((language, i) => {
-                content += `                    '${this.getMomentLocaleId(language)}'${i !== languages.length - 1 ? ',' : ''}\n`;
-            });
-            content +=
-                '                    // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array\n' +
-                '                ]';
-
-            jhipsterUtils.replaceContent(
-                {
-                    file: fullPath,
-                    pattern: /localesToKeep:.*\[([^\]]*jhipster-needle-i18n-language-moment-webpack[^\]]*)\]/g,
                     content
                 },
                 this

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -227,9 +227,6 @@ module.exports = class extends BaseBlueprintGenerator {
                     this.updateLanguagesInLanguagePipe(this.languages);
                     this.updateLanguagesInLanguageConstantNG2(this.languages);
                     this.updateLanguagesInWebpack(this.languages);
-                    if (this.clientFramework === 'angularX') {
-                        this.updateLanguagesInMomentWebpackNgx(this.languages);
-                    }
                     if (this.clientFramework === 'react') {
                         this.updateLanguagesInMomentWebpackReact(this.languages);
                     }


### PR DESCRIPTION
We weren't using moment locales when switching language.

Now we lazy load the requested language and then set the correct moment locale.
I also removed the usage of useless Promises in `LanguageHelper` class

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
