### PR TITLE
use default link colors of Bootstrap/Bootswatch theme

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -31,14 +31,15 @@ h4 {
     font-weight: 300;
 }
 
-a {
+<%_ if (clientTheme === 'none') { _%>
+/* Increase contrast of links to get 100% on Lighthouse Accessability Audit. Override this color if you want to change the link color, or use a Bootswatch theme */
+a, a:hover {
     color: #533f03;
     font-weight: bold;
 }
+<%_ } _%>
 
 a:hover {
-    color: #533f03;
-    font-weight: bold;
     /* make sure browsers use the pointer cursor for anchors, even with no href */
     cursor: pointer;
 }


### PR DESCRIPTION
With c55634ed99317aedebf5efad441a3a3e87f3f23b, it was decided to override the link color and font-weight of Bootstrap/the Bootswatch theme for passing the Lighthouse accessibility audit.

I think this is a bad idea since 1. the picked color might not match the color scheme of the Bootswatch theme and 2. it should be the responsibility of the theme to consider accessibility concerns and not JHipster building on top of this. This also again reduces the JHipster provided CSS (which I think is in general a good idea).

I thus suggest to remove this custom overriding of the link colors again.