### PR TITLE
fix `google` meta tag attribute

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/index.html.ejs
@@ -24,7 +24,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>
     <meta name="description" content="Description for <%= baseName %>"><% if (enableTranslation) { %>
-    <meta name="google" value="notranslate"><% } %>
+    <meta name="google" content="notranslate"><% } %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <link rel="shortcut icon" href="favicon.ico" />

--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -24,7 +24,7 @@
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <title><%= baseName %></title>
     <meta name="description" content="Description for <%= baseName %>"><% if (enableTranslation) { %>
-    <meta name="google" value="notranslate"><% } %>
+    <meta name="google" content="notranslate"><% } %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
     <link rel="shortcut icon" href="favicon.ico" />


### PR DESCRIPTION
For some reason, `google` meta tag had attribute `value` instead of `content`. According to the [documentation](https://support.google.com/webmasters/answer/79812?hl=en) this is wrong. Therefore, this commit introduces `content` attribute instead of `value`.