### PR TITLE
Use child_process in upgrade to allow interaction with cli.

### DIFF
--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -22,6 +22,7 @@ const shelljs = require('shelljs');
 const semver = require('semver');
 const fs = require('fs');
 const gitignore = require('parse-gitignore');
+const childProcess = require('child_process');
 const BaseGenerator = require('../generator-base');
 const constants = require('../generator-constants');
 const statistics = require('../statistics');
@@ -127,12 +128,14 @@ module.exports = class extends BaseGenerator {
             generatorCommand = `"${generatorDir.replace('\n', '')}/jhipster"`;
         }
         const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --skip-git --no-insight`;
-        this.info(regenerateCmd);
-        shelljs.exec(regenerateCmd, { silent: this.silent }, (code, msg, err) => {
-            if (code === 0) this.success(`Successfully regenerated application with JHipster ${jhipsterVersion}${blueprintInfo}`);
-            else this.error(`Something went wrong while generating project! ${err}`);
+        this.info(`new regenerate: ${regenerateCmd}`);
+        try {
+            childProcess.execSync(regenerateCmd, { stdio: 'inherit' });
+            this.success(`Successfully regenerated application with JHipster ${jhipsterVersion}${blueprintInfo}`);
             callback();
-        });
+        } catch (err) {
+            this.error(`Something went wrong while generating project! ${err}`);
+        }
     }
 
     _gitCommitAll(commitMsg, callback) {

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -128,7 +128,7 @@ module.exports = class extends BaseGenerator {
             generatorCommand = `"${generatorDir.replace('\n', '')}/jhipster"`;
         }
         const regenerateCmd = `${generatorCommand} --with-entities --force --skip-install --skip-git --no-insight`;
-        this.info(`new regenerate: ${regenerateCmd}`);
+        this.info(regenerateCmd);
         try {
             childProcess.execSync(regenerateCmd, { stdio: 'inherit' });
             this.success(`Successfully regenerated application with JHipster ${jhipsterVersion}${blueprintInfo}`);


### PR DESCRIPTION
Signed-off-by: Arjun Nayak <arjunglobal09@gmail.com>

Problem: We found that when running the jhipster upgrade process, when there were new prompts added in the newer version of our blueprint, the re-run of the blueprint did not allow for interactivity to answer the new prompts. 

This was a result of using `shelljs` which does not allow for interactivity by default. We followed the workaround described [here](https://github.com/shelljs/shelljs/wiki/FAQ#running-interactive-programs-with-exec). With the fix, the blueprint re-ran as a child process and allowed for normal prompt interaction.

Question: We manually tested this with our blueprint and it works as expected, however we could not figure out how to properly test this in the upgrade unit tests. Do you have any suggestions on how to test interactivity in the upgrade process?

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
