### PR TITLE
make variable overrides in _bootstrap-variables.scss change components

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
@@ -22,10 +22,12 @@
 put Sass variables here:
 eg $input-color: red;
 ****************************/
-// Override Boostrap variables
 <%_ if (clientTheme !== 'none') {_%>
 @import "~bootswatch/dist/<%= clientTheme %>/variables";
-<%_ } _%>// Import Bootstrap source files from node_modules
+<%_ } _%>
+// Override Bootstrap variables
+@import "bootstrap-variables";
+// Import Bootstrap source files from node_modules
 @import '~bootstrap/scss/bootstrap';
 <%_ if (clientTheme !== 'none') { _%>
 @import "~bootswatch/dist/<%= clientTheme %>/bootswatch";


### PR DESCRIPTION
Currently, the `_bootstrap_variables.scss` file is not included into `vendor.scss`. Thus, the overriden variables in there are not affecting the bootstrap components. This commit fixes that. Now, the variables defined in this file influence the bootstrap component colors and other styles.

Since `_bootstrap-variables.scss` is also present (but being empty) when generating without a Bootswatch client theme, I think it still makes sense to also include it in this case. But in order to allow overriding variables already set in the `variables.scss` file of the Bootswatch theme, `_bootstrap-variables.scss` needs to be imported after this file.


The downside of this change is that now, the default layout has a white box on gray background:

![image](https://user-images.githubusercontent.com/1331981/61519331-f1d2d880-aa0b-11e9-9d33-4a568960bd04.png)

I suggest to thus also change the value of `$body-bg` in `_bootstrap-variables.scss` to `white`. What do you think?