### PR TITLE
consider build.gradle for up2date check

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -60,6 +60,7 @@ task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
     <%_ } else { _%>
     inputs.files("yarn.lock")
     <%_ } _%>
+    inputs.files("build.gradle")
     inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
 
     def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>/")


### PR DESCRIPTION
This is very minor, but to be consistent we should consider `build.gradle` when building the frontend in dev mode as the version comes from that file now. Without this change you would change the version and in case nothing else has changed the frontend won't be rebuild so the old version number is displayed in the navbar.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
