### PR TITLE
Fix "Unable to find MailServiceIT.java" in translations

### DIFF
--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -121,10 +121,7 @@ module.exports = class extends BaseBlueprintGenerator {
                     configuration.get('serviceDiscoveryType') === 'no' ? false : configuration.get('serviceDiscoveryType');
                 // Make dist dir available in templates
                 this.BUILD_DIR = this.getBuildDirectoryForBuildTool(configuration.get('buildTool'));
-                this.skipUserManagement =
-                    this.authenticationType === 'oauth2' ||
-                    (this.databaseType === 'no' && this.authenticationType !== 'uaa') ||
-                    (this.applicationType === 'gateway' && this.authenticationType === 'uaa');
+                this.skipUserManagement = configuration.get('skipUserManagement');
             }
         };
     }
@@ -238,7 +235,7 @@ module.exports = class extends BaseBlueprintGenerator {
                         this.updateLanguagesInMomentWebpackReact(this.languages);
                     }
                 }
-                if (!this.skipServer && !this.skipUserManagement) {
+                if (!this.skipUserManagement) {
                     this.updateLanguagesInLanguageMailServiceIT(this.languages, this.packageFolder);
                 }
             }

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -121,6 +121,10 @@ module.exports = class extends BaseBlueprintGenerator {
                     configuration.get('serviceDiscoveryType') === 'no' ? false : configuration.get('serviceDiscoveryType');
                 // Make dist dir available in templates
                 this.BUILD_DIR = this.getBuildDirectoryForBuildTool(configuration.get('buildTool'));
+                this.skipUserManagement =
+                    this.authenticationType === 'oauth2' ||
+                    (this.databaseType === 'no' && this.authenticationType !== 'uaa') ||
+                    (this.applicationType === 'gateway' && this.authenticationType === 'uaa');
             }
         };
     }
@@ -234,7 +238,7 @@ module.exports = class extends BaseBlueprintGenerator {
                         this.updateLanguagesInMomentWebpackReact(this.languages);
                     }
                 }
-                if (!this.skipServer) {
+                if (!this.skipServer && !this.skipUserManagement) {
                     this.updateLanguagesInLanguageMailServiceIT(this.languages, this.packageFolder);
                 }
             }


### PR DESCRIPTION
Add a skipUserManagement variable in the language generator to reflect the behaviour of the server generator. I'm not sure if it's the correct place to initialize the variable.

Fix #10136 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
