### PR TITLE
Fix import angular service filename

### DIFF
--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -95,7 +95,7 @@ const angularFiles = {
                 },
                 {
                     file: 'entities/entity.service.ts',
-                    renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityServiceFileName}.service.ts`
+                    renameTo: generator => `entities/${generator.entityFolderName}/${generator.entityFileName}.service.ts`
                 }
             ]
         }


### PR DESCRIPTION
Entity's json service is created with name '${generator.entityServiceFileName}.service.ts' but is imported as '<%= entityFileName %>.service'.
Fix this bug.

https://github.com/jhipster/generator-jhipster/blob/a1023e100dce9689289383f57fbe7a064b1b84d8/generators/entity-client/files.js#L98

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->