### PR TITLE
Entity: getEntityParentPathAddition don't considers paths with '..'

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1442,10 +1442,26 @@ module.exports = class extends Generator {
      * @param {string} clientRootFolder
      */
     getEntityParentPathAddition(clientRootFolder) {
-        if (clientRootFolder) {
-            return '../';
+        if (!clientRootFolder) {
+            return '';
         }
-        return '';
+        const relative = path.relative(`/app/entities/${clientRootFolder}/`, '/app/entities/');
+        if (relative.includes('app')) {
+            // Relative path outside angular base dir.
+            const message = `
+                "clientRootFolder outside app base dir '${clientRootFolder}'"
+            `;
+            // Test case doesn't have a environment instance so return 'error'
+            if (this.env === undefined) {
+                throw new Error(message);
+            }
+            this.error(message);
+        }
+        const entityFolderPathAddition = relative.replace(/[/]?..\/entities/, '').replace('entities', '..');
+        if (!entityFolderPathAddition) {
+            return '';
+        }
+        return `${entityFolderPathAddition}/`;
     }
 
     /**

--- a/test/generator-base-private.spec.js
+++ b/test/generator-base-private.spec.js
@@ -283,4 +283,56 @@ export * from './entityFolderName/entityFileName.state';`;
             });
         });
     });
+    describe('getEntityParentPathAddition', () => {
+        describe('when passing /', () => {
+            it('returns an empty string', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('/')).to.equal('');
+            });
+        });
+        describe('when passing /foo/', () => {
+            it('returns ../', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('/foo/')).to.equal('../');
+            });
+        });
+        describe('when passing undefined', () => {
+            it('returns an empty string', () => {
+                expect(BaseGenerator.getEntityParentPathAddition()).to.equal('');
+            });
+        });
+        describe('when passing empty', () => {
+            it('returns an empty string', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('')).to.equal('');
+            });
+        });
+        describe('when passing foo', () => {
+            it('returns ../', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('foo')).to.equal('../');
+            });
+        });
+        describe('when passing foo/bar', () => {
+            it('returns ../../', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('foo/bar')).to.equal('../../');
+            });
+        });
+        describe('when passing ../foo', () => {
+            it('returns an empty string', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('../foo')).to.equal('');
+            });
+        });
+        describe('when passing ../foo/bar', () => {
+            it('returns ../', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('../foo/bar')).to.equal('../');
+            });
+        });
+        describe('when passing ../foo/bar/foo2', () => {
+            it('returns ../../', () => {
+                expect(BaseGenerator.getEntityParentPathAddition('../foo/bar/foo2')).to.equal('../../');
+            });
+        });
+        describe('when passing ../../foo', () => {
+            it('throw an error', () => {
+                expect(() => BaseGenerator.getEntityParentPathAddition('../../foo')).to.throw();
+            });
+        });
+    });
 });


### PR DESCRIPTION
Improve getEntityParentPathAddition logic to count directories, ignoring
parent path '../' and ignoring self path './'

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
