### PR TITLE
Fix #10166 ESM5 version of libraries are bundled

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -20,7 +20,6 @@ const webpack = require('webpack');
 const { BaseHrefWebpackPlugin } = require('base-href-webpack-plugin');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const rxPaths = require('rxjs/_esm5/path-mapping');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
 <%_ } if (buildTool === undefined) { _%>
@@ -33,9 +32,9 @@ module.exports = (options) => ({
     resolve: {
         extensions: ['.ts', '.js'],
         modules: ['node_modules'],
+        mainFields: [ 'es2015', 'browser', 'module', 'main'],
         alias: {
-            app: utils.root('<%= MAIN_SRC_DIR %>app/'),
-            ...rxPaths()
+            app: utils.root('<%= MAIN_SRC_DIR %>app/')
         }
     },
     stats: {


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Fixes #10166.

Note: the RxJS path mappings are not needed anymore as they are correctly resolved via the `mainFields` property and the corresponding entry in the `package.json` of RxJS.
