### PR TITLE
Upgrade Travis pipeline to OpenJDK11

### DIFF
--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -18,13 +18,12 @@
 -%>
 os:
   - linux
+dist: bionic
 services:
   - docker
 language: node_js
 node_js:
   - "<%= NODE_VERSION %>"
-jdk:
-  - oraclejdk8
 cache:
   directories:
     - node
@@ -45,7 +44,6 @@ env:
     - JHI_DISABLE_WEBPACK_LOGS=true
     - NG_CLI_ANALYTICS="false"
 before_install:
-  - jdk_switcher use oraclejdk8
   - java -version
   - sudo /etc/init.d/mysql stop
   - sudo /etc/init.d/postgresql stop


### PR DESCRIPTION
I've removed the jdk option of travis; this I believe is useless since it's only used when used in conjunction with ```language: java```. 

Also I've changed the linux distro to bionic since the default distro used by travis seems to be trusty and that doesn't have openjdk11 preinstalled (bionic does). This I believe makes the travis pipeline cleaner so that we don't have to manually install stuff on it and also could get rid of the ```jdk_switcher use oraclejdk8``` part (which seems redundant anyways).

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
