### PR TITLE
angular: Migrate from TSLint to ESLint

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -37,6 +37,8 @@ const files = {
                 'tsconfig.json',
                 'tsconfig-aot.json',
                 'tslint.json',
+                '.eslintrc.json',
+                '.eslintignore',
                 'angular.json',
                 'webpack/utils.js',
                 'webpack/webpack.common.js',

--- a/generators/client/templates/angular/.eslintignore.ejs
+++ b/generators/client/templates/angular/.eslintignore.ejs
@@ -1,0 +1,9 @@
+node_modules/
+src/main/docker/
+src/test/javascript/protractor.conf.js
+src/test/javascript/jest.conf.js
+webpack/
+target/
+build/
+node/
+postcss.config.js

--- a/generators/client/templates/angular/.eslintrc.json.ejs
+++ b/generators/client/templates/angular/.eslintrc.json.ejs
@@ -1,0 +1,58 @@
+{
+  "parser": "@typescript-eslint/parser",
+  "plugins": [
+    "@typescript-eslint",
+    "@typescript-eslint/tslint"
+  ],
+  "extends": [
+    "eslint:recommended",
+    "plugin:@typescript-eslint/eslint-recommended",
+    "plugin:@typescript-eslint/recommended",
+    "prettier",
+    "prettier/@typescript-eslint",
+    "eslint-config-prettier"
+  ],
+  "env": {
+    "browser": true,
+    "es6": true,
+    "commonjs": true
+  },
+  "parserOptions": {
+    "project": "./tsconfig.json",
+    "ecmaVersion": 2018,
+    "sourceType": "module"
+  },
+  "rules": {
+    "@typescript-eslint/tslint/config": ["error", {
+      "lintFile": "./tslint.json"
+    }],
+    "@typescript-eslint/explicit-member-accessibility": "off",
+    "@typescript-eslint/explicit-function-return-type": "off",
+    "@typescript-eslint/no-parameter-properties": [
+      "warn", { "allows": ["public", "private", "protected"] }
+    ],
+    "@typescript-eslint/no-explicit-any": "off",
+    "@typescript-eslint/ban-types": "off",
+    "@typescript-eslint/no-unused-vars": ["warn", {
+      "vars": "all",
+      "args": "none",
+      "ignoreRestSiblings": false
+    }],
+    "@typescript-eslint/interface-name-prefix": "off",
+    "spaced-comment": ["warn", "always"],
+    "guard-for-in": "error",
+    "no-labels": "error",
+    "no-caller": "error",
+    "no-bitwise": "error",
+    "no-console": ["error", { "allow": ["warn", "error"] }],
+    "no-new-wrappers": "error",
+    "no-eval": "error",
+    "no-shadow": "error",
+    "no-new": "error",
+    "no-var": "error",
+    "radix": "error",
+    "eqeqeq": ["error", "always", {"null": "ignore"}],
+    "prefer-const": "error",
+    "object-shorthand": ["error", "always", { "avoidExplicitReturnArrows": true }]
+  }
+}

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -72,6 +72,9 @@
     "@types/mocha": "5.2.7",
     <%_ } _%>
     "@types/node": "10.12.27",
+    "@typescript-eslint/eslint-plugin": "1.13.0",
+    "@typescript-eslint/eslint-plugin-tslint": "1.13.0",
+    "@typescript-eslint/parser": "1.13.0",
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.0",
     <%_ } _%>
@@ -96,6 +99,9 @@ Remove it once the issue is closed
     "codelyzer": "5.1.0",
     "copy-webpack-plugin": "5.0.3",
     "css-loader": "3.0.0",
+    "eslint": "5.16.0",
+    "eslint-config-prettier": "5.1.0",
+    "eslint-loader": "2.2.1",
     "file-loader": "4.0.0",
     "fork-ts-checker-webpack-plugin": "1.3.6",
     "friendly-errors-webpack-plugin": "1.7.0",
@@ -139,9 +145,7 @@ Remove it once the issue is closed
     <%_ if (protractorTests) { _%>
     "ts-node": "8.2.0",
     <%_ } _%>
-    "tslint": "5.17.0",
-    "tslint-config-prettier": "1.18.0",
-    "tslint-loader": "3.5.4",
+    "tslint": "5.18.0",
     "typescript": "3.4.5",
     <%_ otherModules.forEach(module => { _%>
     "<%= module.name %>": "<%= module.version %>",
@@ -172,7 +176,7 @@ Remove it once the issue is closed
   <%_ } _%>
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,css,scss,yml}\"",
-    "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
+    "lint": "eslint . --ext .js,.ts",
     "lint:fix": "<%= clientPackageManager %> run lint <%= optionsForwarder %>--fix",
     "ngc": "ngc -p tsconfig-aot.json",
     "cleanup": "rimraf <%= DIST_DIR %> <%= AOT_DIR %>",

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, OnInit, AfterViewInit, Renderer, ElementRef } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, AfterViewInit, Renderer, ElementRef } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 
 import { EMAIL_NOT_FOUND_TYPE } from 'app/shared';
 import { PasswordResetInitService } from './password-reset-init.service';

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password-strength-bar.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password-strength-bar.component.ts.ejs
@@ -44,7 +44,7 @@ export class PasswordStrengthBarComponent {
     measureStrength(p: string): number {
 
         let force = 0;
-        const regex = /[$-/:-?{-~!"^_`\[\]]/g; // "
+        const regex = /[$-/:-?{-~!"^_`[\]]/g; // "
         const lowerLetters = /[a-z]+/.test(p);
         const upperLetters = /[A-Z]+/.test(p);
         const numbers = /[0-9]+/.test(p);

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 
 import { AccountService } from 'app/core';
 import { PasswordService } from './password.service';

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Component, OnInit, AfterViewInit, Renderer, ElementRef } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 import { JhiLanguageService } from 'ng-jhipster';
 

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -17,11 +17,10 @@
  limitations under the License.
 -%>
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { JhiLanguageService } from 'ng-jhipster';
 
 import { AccountService<% if (enableTranslation) { %>, JhiLanguageHelper<% } %> } from 'app/core';
-import { Account } from 'app/core/user/account.model';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-settings',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.route.ts.ejs
@@ -16,9 +16,8 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Route } from '@angular/router';
-import { JhiPaginationUtil, JhiResolvePagingParams } from 'ng-jhipster';
+import { Route } from '@angular/router';
+import { JhiResolvePagingParams } from 'ng-jhipster';
 
 import { AuditsComponent } from './audits.component';
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
@@ -41,7 +41,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationComponent implements OnInit {
         this.reverse = false;
     }
 
-    keys(dict): Array<string> {
+    keys(dict): string[] {
         return (dict === undefined) ? [] : Object.keys(dict);
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
@@ -35,7 +35,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationService {
                 const properties: any[] = [];
                 const propertiesObject = this.getConfigPropertiesObjects(res.body);
                 for (const key in propertiesObject) {
-                    if (propertiesObject.hasOwnProperty(key)) {
+                    if (Object.prototype.hasOwnProperty.call(propertiesObject, key)) {
                         properties.push(propertiesObject[key]);
                     }
                 }
@@ -47,7 +47,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationService {
         );
     }
 
-    getConfigPropertiesObjects(res: Object) {
+    getConfigPropertiesObjects(res: Record<string, any> ) {
         // This code is for Spring Boot 2
         if (res['contexts'] !== undefined) {
             for (const key in res['contexts']) {
@@ -74,7 +74,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationService {
                     const detailProperties = propertyObject['properties'];
                     const vals: any[] = [];
                     for (const keyDetail in detailProperties) {
-                        if (detailProperties.hasOwnProperty(keyDetail)) {
+                        if (Object.prototype.hasOwnProperty.call(detailProperties, keyDetail)) {
                             vals.push({key: keyDetail, val: detailProperties[keyDetail]['value']});
                         }
                     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
@@ -67,7 +67,7 @@ export class <%=jhiPrefixCapitalized%>HealthService {
         let hasDetails = false;
 
         for (const key in healthObject) {
-            if (healthObject.hasOwnProperty(key)) {
+            if (Object.prototype.hasOwnProperty.call(healthObject, key)) {
                 const value = healthObject[key];
                 if (key === 'status' || key === 'error') {
                     healthData[key] = value;
@@ -94,7 +94,7 @@ export class <%=jhiPrefixCapitalized%>HealthService {
 
     private flattenHealthData(result, path, data): any {
         for (const key in data) {
-            if (data.hasOwnProperty(key)) {
+            if (Object.prototype.hasOwnProperty.call(data, key)) {
                 const value = data[key];
                 if (this.isHealthObject(value)) {
                     if (this.hasSubSystem(value)) {
@@ -127,7 +127,7 @@ export class <%=jhiPrefixCapitalized%>HealthService {
         let result = false;
 
         for (const key in healthObject) {
-            if (healthObject.hasOwnProperty(key)) {
+            if (Object.prototype.hasOwnProperty.call(healthObject, key)) {
                 const value = healthObject[key];
                 if (value && value.status) {
                     result = true;
@@ -141,7 +141,7 @@ export class <%=jhiPrefixCapitalized%>HealthService {
         let result = false;
 
         for (const key in healthObject) {
-            if (healthObject.hasOwnProperty(key)) {
+            if (Object.prototype.hasOwnProperty.call(healthObject, key)) {
                 if (key === 'status') {
                     result = true;
                 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { User } from 'app/core';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, OnInit } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute, Router } from '@angular/router';
 
 import { <% if (enableTranslation) { %>JhiLanguageHelper,<% } %> User, UserService } from 'app/core';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Routes, CanActivate } from '@angular/router';
-import { JhiPaginationUtil, JhiResolvePagingParams } from 'ng-jhipster';
+import { JhiResolvePagingParams } from 'ng-jhipster';
 
 import { AccountService, User, UserService } from 'app/core';
 import { UserMgmtComponent } from './user-management.component';

--- a/generators/client/templates/angular/src/main/webapp/app/app.constants.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.constants.ts.ejs
@@ -21,6 +21,6 @@
 // If you change the values in the webpack config files, you need to re run webpack to update the application
 
 export const VERSION = process.env.VERSION;
-export const DEBUG_INFO_ENABLED: boolean = !!process.env.DEBUG_INFO_ENABLED;
+export const DEBUG_INFO_ENABLED = !!process.env.DEBUG_INFO_ENABLED;
 export const SERVER_API_URL = process.env.SERVER_API_URL;
 export const BUILD_TIMESTAMP = process.env.BUILD_TIMESTAMP;

--- a/generators/client/templates/angular/src/main/webapp/app/app.main.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.main.ts.ejs
@@ -27,5 +27,6 @@ if (module['hot']) {
 }
 
 platformBrowserDynamic().bootstrapModule(<%=angularXAppName%>AppModule, { preserveWhitespaces: true })
-    .then((success) => console.log(`Application started`))
+    // eslint-disable-next-line no-console
+    .then((success) => console.log('Application started'))
     .catch((err) => console.error(err));

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/uib-pagination.config.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/uib-pagination.config.ts.ejs
@@ -22,7 +22,6 @@ import { ITEMS_PER_PAGE } from 'app/shared';
 
 @Injectable({providedIn: 'root'})
 export class PaginationConfig {
-    // tslint:disable-next-line: no-unused-variable
     constructor(private config: NgbPaginationConfig) {
         config.boundaryLinks = true;
         config.maxSize = 5;

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth.interceptor.ts.ejs
@@ -38,7 +38,7 @@ export class AuthInterceptor implements HttpInterceptor {
         }
 
         const token = this.localStorage.retrieve('authenticationToken') || this.sessionStorage.retrieve('authenticationToken');
-        if (!!token) {
+        if (token) {
             request = request.clone({
                 setHeaders: {
                     Authorization: 'Bearer ' + token

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -19,6 +19,7 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import {map} from 'rxjs/operators';
 <%_ if (authenticationType !== 'uaa') { _%>
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
@@ -57,7 +58,6 @@ export class AuthServerProvider {
             password: credentials.password,
             rememberMe: credentials.rememberMe
         };
-        return this.http.post(SERVER_API_URL + 'api/authenticate', data, {observe : 'response'}).pipe(map(authenticateSuccess.bind(this)));
 
         function authenticateSuccess(resp) {
             const bearerToken = resp.headers.get('Authorization');
@@ -67,6 +67,8 @@ export class AuthServerProvider {
                 return jwt;
             }
         }
+
+        return this.http.post(SERVER_API_URL + 'api/authenticate', data, {observe : 'response'}).pipe(map(authenticateSuccess.bind(this)));
 <%_ } _%>
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
@@ -36,7 +36,7 @@ export class AuthServerProvider {
             `username=${encodeURIComponent(credentials.username)}` +
             `&password=${encodeURIComponent(credentials.password)}` +
             `&remember-me=${credentials.rememberMe}` +
-            `&submit=Login`;
+            '&submit=Login';
         const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
 
         return this.http.post(SERVER_API_URL + 'api/authentication', data, { headers });

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -46,7 +46,6 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
         private authServerProvider: AuthServerProvider,
         <%_ } _%>
         private location: Location,
-        // tslint:disable-next-line: no-unused-variable
         private csrfService: CSRFService
     ) {
         this.connection = this.createConnection();

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -38,9 +38,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
 
     alerts: any[];
     cleanHttpErrorListener: Subscription;
-    /* tslint:disable */
     constructor(private alertService: JhiAlertService, private eventManager: JhiEventManager<% if (enableTranslation) { %>, private translateService: TranslateService<% } %>) {
-    /* tslint:enable */
         this.alerts = [];
 
         this.cleanHttpErrorListener = eventManager.subscribe('<%=angularAppName%>.httpError', (response) => {
@@ -52,7 +50,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                     this.addErrorAlert('Server not reachable', 'error.server.not.reachable');
                     break;
 
-                case 400:
+                case 400: {
                     const arr = httpErrorResponse.headers.keys();
                     let errorHeader = null;
                     let entityKey = null;
@@ -87,7 +85,7 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                         this.addErrorAlert(httpErrorResponse.error);
                     }
                     break;
-
+                }
                 case 404:
                     this.addErrorAlert('Not found', 'error.url.not.found');
                     break;

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, AfterViewInit, Renderer, ElementRef } from '@angular/core';
-import { FormBuilder, FormGroup, Validators } from '@angular/forms';
+import { FormBuilder } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Router } from '@angular/router';
 import { JhiEventManager } from 'ng-jhipster';

--- a/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 /* after changing this file run '<%= clientPackageManager %> run webpack:build' */
-/* tslint:disable */
 import '../content/scss/vendor.scss';
 
 // Imports all fontawesome core and solid icons

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -5,6 +5,7 @@ let elementGetter = `getText()`;
 if (enableTranslation) {
     elementGetter = `getAttribute('jhiTranslate')`;
 } _%>
+/* eslint @typescript-eslint/no-use-before-define: 0 */
 export class NavBarPage {
     entityMenu = element(by.id('entity-menu'));
     accountMenu = element(by.id('account-menu'));

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -23,5 +23,5 @@ module.exports = {
     transformIgnorePatterns: ['node_modules/(?!@angular/common/locales)'],
     testMatch: ['<rootDir>/src/test/javascript/spec/**/@(*.)@(spec.ts)'],
     rootDir: '../../../',
-    testURL: "http://localhost/"
+    testURL: 'http://localhost/'
 };

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -16,7 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-
 exports.config = {
     allScriptsTimeout: 20000,
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { Observable, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { Renderer, ElementRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
 import { Renderer, ElementRef } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
-import { Observable, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../../test.module';
 import { PasswordResetInitComponent } from 'app/account/password-reset/init/password-reset-init.component';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
-import { Observable, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { PasswordComponent } from 'app/account/password/password.component';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { ComponentFixture, TestBed, async, inject, tick, fakeAsync } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { Observable, of, throwError } from 'rxjs';
+import { of, throwError } from 'rxjs';
 
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/sessions/sessions.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/sessions/sessions.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { Session } from 'app/account/sessions/session.model';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
@@ -18,10 +18,10 @@
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
-import { Observable, throwError } from 'rxjs';
+import { throwError } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
-import { AccountService, Account } from 'app/core';
+import { AccountService } from 'app/core';
 import { SettingsComponent } from 'app/account/settings/settings.component';
 <%_ if (websocket === 'spring-websocket') { _%>
 import { <%=jhiPrefixCapitalized%>TrackerService } from 'app/core/tracker/tracker.service';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -18,13 +18,10 @@ limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { of } from 'rxjs';
-import { HttpHeaders, HttpResponse } from '@angular/common/http';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { <%=jhiPrefixCapitalized%>ConfigurationComponent } from 'app/admin/configuration/configuration.component';
 import { <%=jhiPrefixCapitalized%>ConfigurationService } from 'app/admin/configuration/configuration.service';
-import { ITEMS_PER_PAGE } from 'app/shared';
-import { Log } from 'app/admin';
 
 describe('Component Tests', () => {
     describe('<%=jhiPrefixCapitalized%>ConfigurationComponent', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -21,7 +21,6 @@ import { TestBed } from '@angular/core/testing';
 import { <%=jhiPrefixCapitalized%>ConfigurationService } from 'app/admin/configuration/configuration.service';
 import { SERVER_API_URL } from 'app/app.constants';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpResponse } from '@angular/common/http';
 
 describe('Service Tests', () => {
     describe('Logs Service', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
@@ -23,7 +23,6 @@ import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { LogsComponent } from 'app/admin/logs/logs.component';
 import { LogsService } from 'app/admin/logs/logs.service';
-import { ITEMS_PER_PAGE } from 'app/shared';
 import { Log } from 'app/admin';
 
 describe('Component Tests', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.service.spec.ts.ejs
@@ -19,7 +19,6 @@ limitations under the License.
 import { TestBed } from '@angular/core/testing';
 
 import { LogsService } from 'app/admin/logs/logs.service';
-import { Log } from 'app/admin/logs/log.model';
 import { SERVER_API_URL } from 'app/app.constants';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
@@ -27,14 +26,12 @@ describe('Service Tests', () => {
     describe('Logs Service', () => {
         let service: LogsService;
         let httpMock;
-        let expectedResult;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule]
             });
 
-            expectedResult = {};
             service = TestBed.get(LogsService);
             httpMock = TestBed.get(HttpTestingController);
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.component.spec.ts.ejs
@@ -17,8 +17,7 @@ distributed under the License is distributed on an "AS IS" BASIS,
 limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { <%=jhiPrefixCapitalized%>MetricsMonitoringComponent } from 'app/admin/metrics/metrics.component';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
@@ -23,7 +23,7 @@ import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angu
 import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { UserMgmtUpdateComponent } from 'app/admin/user-management/user-management-update.component';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -20,7 +20,7 @@
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
@@ -1,4 +1,4 @@
-import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { JhiAlertService, JhiEventManager } from 'ng-jhipster';
 <%_ if (enableTranslation) { _%>

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/spyobject.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/spyobject.ts.ejs
@@ -76,10 +76,10 @@ export class SpyObject {
 
     /** @internal */
     _createGuinnessCompatibleSpy(name): GuinessCompatibleSpy {
-        const newSpy: GuinessCompatibleSpy = < any > jasmine.createSpy(name);
-        newSpy.andCallFake = < any > newSpy.and.callFake;
-        newSpy.andReturn = < any > newSpy.and.returnValue;
-        newSpy.reset = < any > newSpy.calls.reset;
+        const newSpy: GuinessCompatibleSpy = jasmine.createSpy(name) as any;
+        newSpy.andCallFake = newSpy.and.callFake as any;
+        newSpy.andReturn = newSpy.and.returnValue as any;
+        newSpy.reset = newSpy.calls.reset as any;
         // revisit return null here (previously needed for rtts_assert).
         newSpy.and.returnValue(null);
         return newSpy;

--- a/generators/client/templates/angular/tslint.json.ejs
+++ b/generators/client/templates/angular/tslint.json.ejs
@@ -20,107 +20,12 @@
     "rulesDirectory": [
         "node_modules/codelyzer"
     ],
-    "extends": [
-        "tslint-config-prettier"
-    ],
     "rules": {
-        "class-name": true,
-        "comment-format": [
-            true,
-            "check-space"
-        ],
-        "curly": true,
-        "eofline": true,
-        "forin": true,
-        "indent": [
-            true,
-            "spaces"
-        ],
-        "label-position": true,
-        "member-access": false,
         "member-ordering": [
             true,
             "static-before-instance",
             "variables-before-functions"
         ],
-        "no-arg": true,
-        "no-bitwise": true,
-        "no-console": [
-            true,
-            "debug",
-            "info",
-            "time",
-            "timeEnd",
-            "trace"
-        ],
-        "no-construct": true,
-        "no-debugger": true,
-        "no-duplicate-variable": true,
-        "no-empty": false,
-        "no-eval": true,
-        "no-inferrable-types": [true],
-        "no-shadowed-variable": true,
-        "no-string-literal": false,
-        "no-switch-case-fall-through": true,
-        "no-trailing-whitespace": true,
-        "no-unused-expression": true,
-        "no-var-keyword": true,
-        "object-literal-sort-keys": false,
-        "one-line": [
-            true,
-            "check-open-brace",
-            "check-catch",
-            "check-else",
-            "check-whitespace"
-        ],
-        "quotemark": [
-            true,
-            "single",
-            "avoid-escape"
-        ],
-        "radix": true,
-        "semicolon": [
-            true,
-            "always",
-            "ignore-bound-class-methods"
-        ],
-        "triple-equals": [
-            true,
-            "allow-null-check"
-        ],
-        "typedef-whitespace": [
-            true,
-            {
-                "call-signature": "nospace",
-                "index-signature": "nospace",
-                "parameter": "nospace",
-                "property-declaration": "nospace",
-                "variable-declaration": "nospace"
-            }
-        ],
-        "variable-name": false,
-        "whitespace": [
-            true,
-            "check-branch",
-            "check-decl",
-            "check-operator",
-            "check-separator",
-            "check-type"
-        ],
-        "prefer-const": true,
-        "arrow-parens": [true, "ban-single-arg-parens"],
-        "arrow-return-shorthand": [true],
-        "import-spacing": true,
-        "no-consecutive-blank-lines": [true],
-        "object-literal-shorthand": true,
-        "space-before-function-paren": [true, {
-            "asyncArrow": "always",
-            "anonymous": "never",
-            "constructor": "never",
-            "method": "never",
-            "named": "never"
-        }],
-
         "directive-selector": [true, "attribute", "<%=jhiPrefix%>", "camelCase"],
         "component-selector": [true, "element", "<%= jhiPrefixDashed %>", "kebab-case"],
         "no-inputs-metadata-property": true,

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -77,10 +77,10 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
     },
     module: {
         rules: [{
-            test: /\.ts$/,
+            test: /\.(j|t)s$/,
             enforce: 'pre',
-            loader: 'tslint-loader',
-            exclude: [/(node_modules)/, new RegExp('reflect-metadata\\' + path.sep + 'Reflect\\.ts')]
+            loader: 'eslint-loader',
+            exclude: /node_modules/
         },
         {
             test: /\.ts$/,

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -23,7 +23,9 @@ const variables = query.variables;
 let hasManyToMany = query.hasManyToMany;
 _%>
 import { Component, OnInit<% if (fieldsContainImageBlob) { %>, ElementRef<% } %> } from '@angular/core';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
@@ -228,8 +230,11 @@ _%>
             } else {
                 reject(`Base64 data was not set as file could not be extracted from passed parameter: ${event}`);
             }
-        }).then(() => console.log('blob added'),// sucess
-                this.onError);
+        }).then(
+            // eslint-disable-next-line no-console
+            () => console.log('blob added'),    // success
+            this.onError
+        );
     }
 
     <%_ if (fieldsContainImageBlob) { _%>
@@ -337,7 +342,7 @@ _%>
 <%_ entitiesSeen.push(otherEntityNameCapitalized); } } _%>
 <%_ if (hasManyToMany) { _%>
 
-    getSelected(selectedVals: Array<any>, option: any) {
+    getSelected(selectedVals: any[], option: any) {
         if (selectedVals) {
             for (let i = 0; i < selectedVals.length; i++) {
                 if (option.id === selectedVals[i].id) {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -24,6 +24,7 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 <%_ } _%>
 import { Subscription } from 'rxjs';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { filter, map } from 'rxjs/operators';
 import { JhiEventManager, <% if (pagination !== 'no') { %>JhiParseLinks, <% } %>JhiAlertService<% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
@@ -20,7 +20,7 @@ import { Injectable } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Routes } from '@angular/router';
 <%_ if (pagination === 'pagination' || pagination === 'pager') { _%>
-import { JhiPaginationUtil, JhiResolvePagingParams } from 'ng-jhipster';
+import { JhiResolvePagingParams } from 'ng-jhipster';
 <%_ } _%>
 import { UserRouteAccessService } from 'app/core';
 import { Observable, of } from 'rxjs';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
@@ -21,6 +21,7 @@ import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable } from 'rxjs';
 <%_ if (fieldsContainDate) { _%>
 import * as moment from 'moment';
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { DATE_FORMAT } from 'app/shared/constants/input.constants';
 import { map } from 'rxjs/operators';
 <%_ } _%>

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { browser, ExpectedConditions, element, by, ElementFinder } from 'protractor';
+import { element, by, ElementFinder } from 'protractor';
 
 <%_
 let elementGetter = `getText()`;

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -16,10 +16,11 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-/* tslint:disable no-unused-expression */
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor, <% } %>promise } from 'protractor';
 import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
 
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { <%= entityClass %>ComponentsPage, <%= entityClass %>DeleteDialog, <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
 <%_ if (fieldsContainBlobOrImage) { _%>
 import * as path from 'path';
@@ -33,8 +34,8 @@ if (enableTranslation) {
 }
 for (let relationship of relationships) {
     if (relationship.relationshipRequired || relationship.useJPADerivedIdentifier) {
-        openBlockComment = `/*`;
-        closeBlockComment = `*/`;
+        openBlockComment = `/* `;
+        closeBlockComment = ` */`;
         break;
     }
 } _%>

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
@@ -19,10 +19,9 @@
 <%_
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
-/* tslint:disable max-line-length */
 import { ComponentFixture, TestBed, inject, fakeAsync, tick } from '@angular/core/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
@@ -19,7 +19,6 @@
 <%_
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
-/* tslint:disable max-line-length */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
@@ -19,11 +19,10 @@
 <%_
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
-/* tslint:disable max-line-length */
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
 import { <%= entityAngularName %>UpdateComponent } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>-update.component';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
@@ -19,9 +19,8 @@
 <%_
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 _%>
-/* tslint:disable max-line-length */
 import { ComponentFixture, TestBed } from '@angular/core/testing';
-import { Observable, of } from 'rxjs';
+import { of } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 <%_ if (pagination !== 'no') { _%>
 import { ActivatedRoute, Data } from '@angular/router';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -20,11 +20,8 @@
 const tsKeyId = generateTestEntityId(pkType, prodDatabaseType);
 const variablesWithTypes = generateEntityClientFields(pkType, fields, relationships, dto);
 _%>
-/* tslint:disable max-line-length */
 import { TestBed, getTestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { HttpClient, HttpResponse } from '@angular/common/http';
-import { of } from 'rxjs';
 import { take, map } from 'rxjs/operators';
 <%_ if (fieldsContainDate) { _%>
 import * as moment from 'moment';
@@ -228,8 +225,7 @@ describe('Service Tests', () => {
             });
 
             it('should delete a <%= entityAngularName %>', async () => {
-                const rxPromise = service
-                    .delete(<%- tsKeyId %>).subscribe(resp => expectedResult = resp.ok);
+                service.delete(<%- tsKeyId %>).subscribe(resp => expectedResult = resp.ok);
 
                 const req  = httpMock.expectOne({ method: 'DELETE' });
                 req.flush({ status: 200 });

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -357,6 +357,8 @@ const expectedFiles = {
 
     client: [
         'angular.json',
+        '.eslintrc.json',
+        '.eslintignore',
         '.huskyrc',
         'package.json',
         'postcss.config.js',


### PR DESCRIPTION
- Migrate angular `TSLint` linting rules to their equivalent `ESLint` rules. Related to  #10105 
- Fix linting violations related to unused imports, unsafe methods. 
- To execute `codelyzer` rules that rely on the `TSLint`, fallback with `eslint-plugin-tslint`.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
