### PR TITLE
Increase timeout to 30s to fix intermittent failures

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,7 +45,7 @@
         "ejslint": "ejslint",
         "pretest": "npm run lint",
         "test": "npm run test:unit -- test/**/*.spec.js test/*.spec.js --no-insight",
-        "test:unit": "mocha --timeout 20000 --slow 0 --reporter spec",
+        "test:unit": "mocha --timeout 30000 --slow 0 --reporter spec",
         "jsdoc": "jsdoc --configure jsdoc-conf.json"
     },
     "dependencies": {


### PR DESCRIPTION
Few builds/tests are intermittently failing due to timeouts like:
https://travis-ci.org/jhipster/generator-jhipster/jobs/566793051

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
