### PR TITLE
use version from package.json when not provided via environment

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -19,7 +19,7 @@
 <%_ var optionsForwarder = clientPackageManager == 'yarn' ? '' : '-- ' _%>
 {
   "name": "<%= dasherizedBaseName %>",
-  "version": "0.0.0",
+  "version": "0.0.1-SNAPSHOT",
   "description": "Description for <%= baseName %>",
   "private": true,
   "license": "UNLICENSED",

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -83,7 +83,7 @@ module.exports = (options) => ({
                 VERSION: `'${packageJson.version}'`,
 <%_ } else { _%>
                 // APP_VERSION is passed as an environment variable from the Gradle / Maven build tasks.
-                VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
+                VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'DEV'}'`,
 <%_ } _%>
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -19,7 +19,7 @@ limitations under the License.
 <%_ var optionsForwarder = clientPackageManager == 'yarn' ? '' : '-- ' _%>
 {
   "name": "<%= dasherizedBaseName %>",
-  "version": "0.0.0",
+  "version": "0.0.1-SNAPSHOT",
   "description": "Description for <%= baseName %>",
   "private": true,
   "license": "UNLICENSED",

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -129,7 +129,7 @@ module.exports = options => ({
         VERSION: `'${packageJson.version}'`,
 <%_ } else { _%>
         // APP_VERSION is passed as an environment variable from the Gradle / Maven build tasks.
-        VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'UNKNOWN'}'`,
+        VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'DEV'}'`,
 <%_ } _%>
         DEBUG_INFO_ENABLED: options.env === 'development',
         // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.


### PR DESCRIPTION
This uses the version from package.json in case it is not provided via environment from maven/gradle task. To make it rock solid we could try to update the version in `package.json` from [maven](https://github.com/ASzc/jsonpath-maven-plugin)/gradle, but in that case both frontend and backend always have the same version (which is ok, but maybe there are usecases where they must be different).

closes #10192

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
