### PR TITLE
disable logstash appender during tests

### DIFF
--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -162,9 +162,8 @@ jhipster:
     logging:
         # To test json console appender
         use-json-format: true # By default, logs are in Json format
-        # To test logstash appender
         logstash:
-            enabled: true
+            enabled: false
             host: localhost
             port: 5000
             queue-size: 512


### PR DESCRIPTION
cc @pascalgrimaud 

fix https://github.com/jhipster/generator-jhipster/issues/10065

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
