### PR TITLE
Fix old JHipster version check in cleanup

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -275,6 +275,8 @@ module.exports = class extends BaseGenerator {
                 if (this.jhipsterVersion === undefined) {
                     this.jhipsterVersion = this.config.get('jhipsterVersion');
                 }
+                // preserve old jhipsterVersion value for cleanup which occurs after new config is written into disk
+                this.jhipsterOldVersion = this.config.get('jhipsterVersion');
                 this.otherModules = this.config.get('otherModules') || [];
                 if (this.blueprints && this.blueprints.length > 0) {
                     this.blueprints.forEach(blueprint => {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -166,6 +166,8 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 context.jhiPrefixDashed = _.kebabCase(context.jhiPrefix);
                 context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
                 context.testFrameworks = configuration.get('testFrameworks');
+                // preserve old jhipsterVersion value for cleanup which occurs after new config is written into disk
+                this.jhipsterOldVersion = configuration.get('jhipsterVersion');
                 // backward compatibility on testing frameworks
                 if (context.testFrameworks === undefined) {
                     context.testFrameworks = ['gatling'];

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1256,11 +1256,11 @@ module.exports = class extends PrivateBase {
      * @param {string} version - A valid semver version string
      */
     isJhipsterVersionLessThan(version) {
-        const jhipsterVersion = this.config.get('jhipsterVersion');
-        if (!jhipsterVersion) {
-            return true;
+        if (!this.jhipsterOldVersion) {
+            // if old version is unknown then can't compare and return false
+            return false;
         }
-        return semver.lt(jhipsterVersion, version);
+        return semver.lt(this.jhipsterOldVersion, version);
     }
 
     /**

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -195,6 +195,8 @@ module.exports = class extends BaseBlueprintGenerator {
                 if (this.jhipsterVersion === undefined) {
                     this.jhipsterVersion = configuration.get('jhipsterVersion');
                 }
+                // preserve old jhipsterVersion value for cleanup which occurs after new config is written into disk
+                this.jhipsterOldVersion = configuration.get('jhipsterVersion');
                 this.authenticationType = configuration.get('authenticationType');
                 if (this.authenticationType === 'session') {
                     this.rememberMeKey = configuration.get('rememberMeKey');


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Follow up to #10185

@vishal423 pointed out in the review of the #10185 that `isJhipsterVersionLessThan` function is not working correctly.  
I found same conclusions in issue #9204:
* in @clement26695 comment: https://github.com/jhipster/generator-jhipster/issues/9204#issuecomment-461030165
* in @pmverma comment: https://github.com/jhipster/generator-jhipster/issues/9204#issuecomment-461074682

After investigating I also confirm that.  
I found that if `--skip-server` **is not used** then config is written into disk in this line:
https://github.com/jhipster/generator-jhipster/blob/master/generators/server/index.js#L406  
And if `--skip-server` **is used** then config is written into disk in this line:
https://github.com/jhipster/generator-jhipster/blob/master/generators/client/index.js#L262  
Both occur before `cleanup` is executed.

This PR adds new property `jhipsterOldVersion` to generator which has correct old JHipster version and `isJhipsterVersionLessThan` is now using this new property.

To ensure that the new version of the JHipster generator with changes from #10185 correctly cleans up barrels, this PR needs to be merged.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
