### PR TITLE
Init test beans lazily

### DIFF
--- a/generators/server/templates/src/test/java/package/config/TestLazyBeanInitConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/TestLazyBeanInitConfiguration.java.ejs
@@ -1,0 +1,49 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://jhipster.github.io/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.config;
+
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanFactoryPostProcessor;
+import org.springframework.beans.factory.config.ConfigurableListableBeanFactory;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+/**
+ * This class allows you to run your tests without initializing unneeded beans.
+ * <br/>
+ * In order to override this for any specific test, add to it: {@code @ActiveProfiles(TestLazyBeanInitConfiguration.EAGER_BEAN_INIT)}
+ * <br/>
+ * When working with spring-boot 2.2.0 or later, should be replaced with property: <code>spring.main.lazy-initialization</code>.
+ * <br/>
+ * See <a href="https://spring.io/blog/2019/03/14/lazy-initialization-in-spring-boot-2-2">lazy-initialization-in-spring-boot-2-2</a>.
+ */
+@Component
+@Profile("!" + TestLazyBeanInitConfiguration.EAGER_BEAN_INIT)
+public class TestLazyBeanInitConfiguration {
+    public static final String EAGER_BEAN_INIT = "eagerBeanInit";
+
+    @Override
+    public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {
+        Arrays.stream(beanFactory.getBeanDefinitionNames())
+            .map(beanFactory::getBeanDefinition)
+            .forEach(beanDefinition -> beanDefinition.setLazyInit(true));
+    }
+}

--- a/generators/server/templates/src/test/java/package/config/TestLazyBeanInitConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/TestLazyBeanInitConfiguration.java.ejs
@@ -37,8 +37,8 @@ import java.util.Arrays;
  */
 @Component
 @Profile("!" + TestLazyBeanInitConfiguration.EAGER_BEAN_INIT)
-public class TestLazyBeanInitConfiguration {
-    public static final String EAGER_BEAN_INIT = "eagerBeanInit";
+public class TestLazyBeanInitConfiguration implements BeanFactoryPostProcessor {
+    public static final String EAGER_BEAN_INIT = "eager-bean-init";
 
     @Override
     public void postProcessBeanFactory(ConfigurableListableBeanFactory beanFactory) throws BeansException {


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
Something we did in our project, which cut down our test-time by ~1 min - I though it might be helpful to other devs.

I did not create an issue yet, I wanted to see if this seems like a welcome addition or not.