### PR TITLE
upgrade to gradle 5.6 and using plugin management

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -26,8 +26,6 @@ buildscript {
         maven { url "http://repo.spring.io/plugins-release" }
     }
     dependencies {
-        classpath "org.springframework.boot:spring-boot-gradle-plugin:${spring_boot_version}"
-        classpath "io.spring.gradle:propdeps-plugin:0.0.10.RELEASE"
         //jhipster-needle-gradle-buildscript-dependency - JHipster will add additional gradle build script plugins here
     }
 }
@@ -37,21 +35,22 @@ plugins {
     id "maven"
     id "idea"
     id "jacoco"
-    id "com.google.cloud.tools.jib" version "<%= JIB_VERSION %>"
-    id "com.gorylenko.gradle-git-properties" version "2.0.0"
+    id "org.springframework.boot"
+    id "com.google.cloud.tools.jib"
+    id "com.gorylenko.gradle-git-properties"
     <%_ if (enableSwaggerCodegen) { _%>
-    id "org.openapi.generator" version "4.1.0"
+    id "org.openapi.generator"
     <%_ } _%>
     <%_ if (!skipClient) { _%>
-    id "com.github.node-gradle.node" version "2.0.0"
+    id "com.github.node-gradle.node"
     <%_ } _%>
-    id "net.ltgt.apt-eclipse" version "0.21"
-    id "net.ltgt.apt-idea" version "0.21"
-    id "net.ltgt.apt" version "0.21"
+    id "net.ltgt.apt-eclipse"
+    id "net.ltgt.apt-idea"
+    id "net.ltgt.apt"
     <%_ if (databaseType === 'sql') { _%>
-    id "org.liquibase.gradle" version "2.0.1"
+    id "org.liquibase.gradle"
     <%_ } _%>
-    id "org.sonarqube" version "2.7.1"
+    id "org.sonarqube"
     //jhipster-needle-gradle-plugins - JHipster will add additional gradle plugins here
 }
 
@@ -63,9 +62,6 @@ description = ""
 sourceCompatibility=<%= JAVA_VERSION %>
 targetCompatibility=<%= JAVA_VERSION %>
 assert System.properties["java.specification.version"] == "1.8" || "11" || "12"
-
-apply plugin: "org.springframework.boot"
-apply plugin: "propdeps"
 
 apply from: "gradle/docker.gradle"
 apply from: "gradle/sonar.gradle"
@@ -526,7 +522,7 @@ task cleanResources(type: Delete) {
 }
 
 wrapper {
-    gradleVersion = "5.5.1"
+    gradleVersion = "5.6"
 }
 <%_ if (!skipClient) { _%>
 

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -53,7 +53,7 @@ liquibase_plugin_version=2.0.1
 <%_ } _%>
 sonarqube_plugin_version=2.7.1
 <%_ if (enableSwaggerCodegen) { _%>
-openapi_plugin_version=4.0.1
+openapi_plugin_version=4.1.0
 <%_ } _%>
 
 # jhipster-needle-gradle-property - JHipster will add additional properties here

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -41,6 +41,21 @@ liquibaseTaskPrefix=liquibase
 jaxb_runtime_version=2.3.2
 <%_ } _%>
 
+# gradle plugin version
+jib_plugin_version=<%= JIB_VERSION %>
+git_properties_plugin_version=2.0.0
+<%_ if (!skipClient) { _%>
+gradle_node_plugin_version=2.0.0
+<%_ } _%>
+apt_plugin_version=0.21
+<%_ if (databaseType === 'sql') { _%>
+liquibase_plugin_version=2.0.1
+<%_ } _%>
+sonarqube_plugin_version=2.7.1
+<%_ if (enableSwaggerCodegen) { _%>
+openapi_plugin_version=4.0.1
+<%_ } _%>
+
 # jhipster-needle-gradle-property - JHipster will add additional properties here
 
 ## below are some of the gradle performance improvement settings that can be used as required, these are not enabled by default

--- a/generators/server/templates/gradle/wrapper/gradle-wrapper.properties
+++ b/generators/server/templates/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/generators/server/templates/settings.gradle.ejs
+++ b/generators/server/templates/settings.gradle.ejs
@@ -16,4 +16,26 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+
+pluginManagement {
+     plugins {
+          id 'org.springframework.boot' version "${spring_boot_version}"
+          id 'com.google.cloud.tools.jib' version "${jib_plugin_version}"
+          id 'com.gorylenko.gradle-git-properties' version "${git_properties_plugin_version}"
+          <%_ if (enableSwaggerCodegen) { _%>
+          id "org.openapi.generator" version "${openapi_plugin_version}"
+          <%_ } _%>
+          <%_ if (!skipClient) { _%>
+          id 'com.github.node-gradle.node' version "${gradle_node_plugin_version}"
+          <%_ } _%>
+          <%_ if (databaseType === 'sql') { _%>
+          id 'org.liquibase.gradle' version "${liquibase_plugin_version}"
+          <%_ } _%>
+          id 'org.sonarqube' version "${sonarqube_plugin_version}"
+          id 'net.ltgt.apt-eclipse' version "${apt_plugin_version}"
+          id 'net.ltgt.apt-idea' version "${apt_plugin_version}"
+          id 'net.ltgt.apt' version "${apt_plugin_version}"
+     }
+}
+
 rootProject.name = "<%= dasherizedBaseName %>"


### PR DESCRIPTION
* regular upgrade to latest and final gradle 5.x version
* using the new [plugin management](https://docs.gradle.org/5.6/userguide/plugins.html#sec:plugin_version_management) to define plugin versions via properties
* removed the [propdeps plugin](https://github.com/spring-gradle-plugins/propdeps-plugin) as (at least) we don't use it directly and it seems quite outdated

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
