### PR TITLE
Define Typescript aliases in a single place

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -1,3 +1,5 @@
+const tsconfig = require('../../../tsconfig.json');
+
 module.exports = {
     preset: 'jest-preset-angular',
     setupFilesAfterEnv: ['<rootDir>/src/test/javascript/jest.ts'],
@@ -12,9 +14,7 @@ module.exports = {
     coveragePathIgnorePatterns: [
         '<rootDir>/src/test/javascript'
     ],
-    moduleNameMapper: {
-        'app/(.*)': '<rootDir>/<%= CLIENT_MAIN_SRC_DIR %>app/$1'
-    },
+    moduleNameMapper: addAliasesFromTypescriptConfig({}),
     reporters: [
         'default',
         [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/TESTS-results-jest.xml' } ]
@@ -25,3 +25,12 @@ module.exports = {
     rootDir: '../../../',
     testURL: 'http://localhost/'
 };
+
+function addAliasesFromTypescriptConfig(initialAliases) {
+  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
+    const finalAliasName = aliasName.replace(/(.*)(\/\*)$/, '$1/(.*)');
+    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/(.*)(\/\*)$/, '$1/\$ 1').replace(/\/\$ 1$/, '/$1');
+    aliases[finalAliasName] = `<rootDir>/${finalPath}`;
+    return aliases;
+  }, initialAliases);
+}

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -14,7 +14,7 @@ module.exports = {
     coveragePathIgnorePatterns: [
         '<rootDir>/src/test/javascript'
     ],
-    moduleNameMapper: addAliasesFromTypescriptConfig({}),
+    moduleNameMapper: mapTypescriptAliasToJestAlias(),
     reporters: [
         'default',
         [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/TESTS-results-jest.xml' } ]
@@ -26,11 +26,28 @@ module.exports = {
     testURL: 'http://localhost/'
 };
 
-function addAliasesFromTypescriptConfig(initialAliases) {
-  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
-    const finalAliasName = aliasName.replace(/(.*)(\/\*)$/, '$1/(.*)');
-    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/(.*)(\/\*)$/, '$1/\$ 1').replace(/\/\$ 1$/, '/$1');
-    aliases[finalAliasName] = `<rootDir>/${finalPath}`;
-    return aliases;
-  }, initialAliases);
-}
+function mapTypescriptAliasToJestAlias(alias = {}) {
+    const jestAliases = { ...alias };
+    Object.entries(tsconfig.compilerOptions.paths)
+      .filter(([key, value]) => {
+        // use Typescript alias in Jest only if this has value
+        if (value.length) {
+          return true;
+        }
+        return false;
+      })
+      .map(([key, value]) => {
+        // if Typescript alias ends with /* then in Jest:
+        // - alias key must end with /(.*)
+        // - alias value must end with /$1
+        const regexToReplace = /(.*)\/\*$/;
+        const aliasKey = key.replace(regexToReplace, '$1/(.*)');
+        const aliasValue = value[0].replace(regexToReplace, '$1/$$1');
+        return [aliasKey, `<rootDir>/${aliasValue}`];
+      })
+      .reduce((aliases, [key, value]) => {
+        aliases[key] = value;
+        return aliases;
+      }, jestAliases);
+    return jestAliases;
+  }

--- a/generators/client/templates/angular/webpack/utils.js.ejs
+++ b/generators/client/templates/angular/webpack/utils.js.ejs
@@ -18,8 +18,11 @@
 -%>
 const path = require('path');
 
+const tsconfig = require('../tsconfig.json');
+
 module.exports = {
-    root
+    root,
+    addAliasesFromTypescriptConfig
 };
 
 const _root = path.resolve(__dirname, '..');
@@ -27,4 +30,13 @@ const _root = path.resolve(__dirname, '..');
 function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [_root].concat(args));
+}
+
+function addAliasesFromTypescriptConfig(initialAliases) {
+  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
+    const finalAliasName = aliasName.replace(/\/\*$/, '');
+    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
+    aliases[finalAliasName] = root(finalPath);
+    return aliases;
+  }, initialAliases);
 }

--- a/generators/client/templates/angular/webpack/utils.js.ejs
+++ b/generators/client/templates/angular/webpack/utils.js.ejs
@@ -22,7 +22,7 @@ const tsconfig = require('../tsconfig.json');
 
 module.exports = {
     root,
-    addAliasesFromTypescriptConfig
+    mapTypescriptAliasToWebpackAlias
 };
 
 const _root = path.resolve(__dirname, '..');
@@ -32,11 +32,26 @@ function root(args) {
   return path.join.apply(path, [_root].concat(args));
 }
 
-function addAliasesFromTypescriptConfig(initialAliases) {
-  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
-    const finalAliasName = aliasName.replace(/\/\*$/, '');
-    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
-    aliases[finalAliasName] = root(finalPath);
-    return aliases;
-  }, initialAliases);
+function mapTypescriptAliasToWebpackAlias(alias = {}) {
+  const webpackAliases = { ...alias };
+  Object.entries(tsconfig.compilerOptions.paths)
+    .filter(([key, value]) => {
+      // use Typescript alias in Webpack only if this has value
+      if (value.length) {
+        return true;
+      }
+      return false;
+    })
+    .map(([key, value]) => {
+      // if Typescript alias ends with /* then remove this for Webpack
+      const regexToReplace = /\/\*$/;
+      const aliasKey = key.replace(regexToReplace, '');
+      const aliasValue = value[0].replace(regexToReplace, '');
+      return [aliasKey, root(aliasValue)];
+    })
+    .reduce((aliases, [key, value]) => {
+      aliases[key] = value;
+      return aliases;
+    }, webpackAliases);
+  return webpackAliases;
 }

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -26,7 +26,6 @@ const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
 
 const packageJson = require('./../package.json');
 <%_ } _%>
-const tsconfig = require('../tsconfig.json');
 const utils = require('./utils.js');
 
 module.exports = (options) => ({
@@ -34,12 +33,7 @@ module.exports = (options) => ({
         extensions: ['.ts', '.js'],
         modules: ['node_modules'],
         mainFields: [ 'es2015', 'browser', 'module', 'main'],
-        alias: Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
-          const finalAliasName = aliasName.replace(/\/\*$/, '');
-          const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
-          aliases[finalAliasName] = utils.root(finalPath);
-          return aliases;
-        }, {})
+        alias: utils.addAliasesFromTypescriptConfig({})
     },
     stats: {
         children: false

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -33,7 +33,7 @@ module.exports = (options) => ({
         extensions: ['.ts', '.js'],
         modules: ['node_modules'],
         mainFields: [ 'es2015', 'browser', 'module', 'main'],
-        alias: utils.addAliasesFromTypescriptConfig({})
+        alias: utils.mapTypescriptAliasToWebpackAlias()
     },
     stats: {
         children: false

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -26,6 +26,7 @@ const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
 
 const packageJson = require('./../package.json');
 <%_ } _%>
+const tsconfig = require('../tsconfig.json');
 const utils = require('./utils.js');
 
 module.exports = (options) => ({
@@ -33,9 +34,12 @@ module.exports = (options) => ({
         extensions: ['.ts', '.js'],
         modules: ['node_modules'],
         mainFields: [ 'es2015', 'browser', 'module', 'main'],
-        alias: {
-            app: utils.root('<%= MAIN_SRC_DIR %>app/')
-        }
+        alias: Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
+          const finalAliasName = aliasName.replace(/\/\*$/, '');
+          const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
+          aliases[finalAliasName] = utils.root(finalPath);
+          return aliases;
+        }, {})
     },
     stats: {
         children: false

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -1,3 +1,5 @@
+const tsconfig = require('../../../tsconfig.json');
+
 module.exports = {
   transform: {
     '^.+\\.tsx?$': 'ts-jest'
@@ -10,10 +12,9 @@ module.exports = {
   coveragePathIgnorePatterns: [
     '<rootDir>/src/test/javascript'
   ],
-  moduleNameMapper: {
-    'app/(.*)': '<rootDir>/<%= CLIENT_MAIN_SRC_DIR %>app/$1',
+  moduleNameMapper: addAliasesFromTypescriptConfig({
     '\\.(css|scss)$': 'identity-obj-proxy'
-  },
+  }),
   reporters: [
     'default',
     [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/TESTS-results-jest.xml' } ]
@@ -34,3 +35,12 @@ module.exports = {
     }
   }
 };
+
+function addAliasesFromTypescriptConfig(initialAliases) {
+  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
+    const finalAliasName = aliasName.replace(/(.*)(\/\*)$/, '$1/(.*)');
+    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/(.*)(\/\*)$/, '$1/\$ 1').replace(/\/\$ 1$/, '/$1');
+    aliases[finalAliasName] = `<rootDir>/${finalPath}`;
+    return aliases;
+  }, initialAliases);
+}

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -12,7 +12,7 @@ module.exports = {
   coveragePathIgnorePatterns: [
     '<rootDir>/src/test/javascript'
   ],
-  moduleNameMapper: addAliasesFromTypescriptConfig({
+  moduleNameMapper: mapTypescriptAliasToJestAlias({
     '\\.(css|scss)$': 'identity-obj-proxy'
   }),
   reporters: [
@@ -36,11 +36,28 @@ module.exports = {
   }
 };
 
-function addAliasesFromTypescriptConfig(initialAliases) {
-  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
-    const finalAliasName = aliasName.replace(/(.*)(\/\*)$/, '$1/(.*)');
-    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/(.*)(\/\*)$/, '$1/\$ 1').replace(/\/\$ 1$/, '/$1');
-    aliases[finalAliasName] = `<rootDir>/${finalPath}`;
-    return aliases;
-  }, initialAliases);
-}
+function mapTypescriptAliasToJestAlias(alias = {}) {
+    const jestAliases = { ...alias };
+    Object.entries(tsconfig.compilerOptions.paths)
+      .filter(([key, value]) => {
+        // use Typescript alias in Jest only if this has value
+        if (value.length) {
+          return true;
+        }
+        return false;
+      })
+      .map(([key, value]) => {
+        // if Typescript alias ends with /* then in Jest:
+        // - alias key must end with /(.*)
+        // - alias value must end with /$1
+        const regexToReplace = /(.*)\/\*$/;
+        const aliasKey = key.replace(regexToReplace, '$1/(.*)');
+        const aliasValue = value[0].replace(regexToReplace, '$1/$$1');
+        return [aliasKey, `<rootDir>/${aliasValue}`];
+      })
+      .reduce((aliases, [key, value]) => {
+        aliases[key] = value;
+        return aliases;
+      }, jestAliases);
+    return jestAliases;
+  }

--- a/generators/client/templates/react/webpack/utils.js.ejs
+++ b/generators/client/templates/react/webpack/utils.js.ejs
@@ -22,7 +22,7 @@ const tsconfig = require('../tsconfig.json');
 
 module.exports = {
   root,
-  addAliasesFromTypescriptConfig
+  mapTypescriptAliasToWebpackAlias
 };
 
 const _root = path.resolve(__dirname, '..');
@@ -32,11 +32,26 @@ function root(args) {
   return path.join.apply(path, [_root].concat(args));
 }
 
-function addAliasesFromTypescriptConfig(initialAliases) {
-  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
-    const finalAliasName = aliasName.replace(/\/\*$/, '');
-    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
-    aliases[finalAliasName] = root(finalPath);
-    return aliases;
-  }, initialAliases);
+function mapTypescriptAliasToWebpackAlias(alias = {}) {
+  const webpackAliases = { ...alias };
+  Object.entries(tsconfig.compilerOptions.paths)
+    .filter(([key, value]) => {
+      // use Typescript alias in Webpack only if this has value
+      if (value.length) {
+        return true;
+      }
+      return false;
+    })
+    .map(([key, value]) => {
+      // if Typescript alias ends with /* then remove this for Webpack
+      const regexToReplace = /\/\*$/;
+      const aliasKey = key.replace(regexToReplace, '');
+      const aliasValue = value[0].replace(regexToReplace, '');
+      return [aliasKey, root(aliasValue)];
+    })
+    .reduce((aliases, [key, value]) => {
+      aliases[key] = value;
+      return aliases;
+    }, webpackAliases);
+  return webpackAliases;
 }

--- a/generators/client/templates/react/webpack/utils.js.ejs
+++ b/generators/client/templates/react/webpack/utils.js.ejs
@@ -18,8 +18,11 @@
 -%>
 const path = require('path');
 
+const tsconfig = require('../tsconfig.json');
+
 module.exports = {
-  root
+  root,
+  addAliasesFromTypescriptConfig
 };
 
 const _root = path.resolve(__dirname, '..');
@@ -27,4 +30,13 @@ const _root = path.resolve(__dirname, '..');
 function root(args) {
   args = Array.prototype.slice.call(arguments, 0);
   return path.join.apply(path, [_root].concat(args));
+}
+
+function addAliasesFromTypescriptConfig(initialAliases) {
+  return Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
+    const finalAliasName = aliasName.replace(/\/\*$/, '');
+    const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
+    aliases[finalAliasName] = root(finalPath);
+    return aliases;
+  }, initialAliases);
 }

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -28,6 +28,7 @@ const MergeJsonWebpackPlugin = require('merge-jsons-webpack-plugin');
 
 const packageJson = require('./../package.json');
 <%_ } _%>
+const tsconfig = require('../tsconfig.json');
 const utils = require('./utils.js');
 
 const getTsLoaderRule = env => {
@@ -70,9 +71,12 @@ module.exports = options => ({
       '.js', '.jsx', '.ts', '.tsx', '.json'
     ],
     modules: ['node_modules'],
-    alias: {
-      app: utils.root('<%= MAIN_SRC_DIR %>app/')
-    }
+    alias: Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
+      const finalAliasName = aliasName.replace(/\/\*$/, '');
+      const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
+      aliases[finalAliasName] = utils.root(finalPath);
+      return aliases;
+    }, {})
   },
   module: {
     rules: [

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -70,7 +70,7 @@ module.exports = options => ({
       '.js', '.jsx', '.ts', '.tsx', '.json'
     ],
     modules: ['node_modules'],
-    alias: utils.addAliasesFromTypescriptConfig({})
+    alias: utils.mapTypescriptAliasToWebpackAlias()
   },
   module: {
     rules: [

--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -28,7 +28,6 @@ const MergeJsonWebpackPlugin = require('merge-jsons-webpack-plugin');
 
 const packageJson = require('./../package.json');
 <%_ } _%>
-const tsconfig = require('../tsconfig.json');
 const utils = require('./utils.js');
 
 const getTsLoaderRule = env => {
@@ -71,12 +70,7 @@ module.exports = options => ({
       '.js', '.jsx', '.ts', '.tsx', '.json'
     ],
     modules: ['node_modules'],
-    alias: Object.keys(tsconfig.compilerOptions.paths).reduce((aliases, aliasName) => {
-      const finalAliasName = aliasName.replace(/\/\*$/, '');
-      const finalPath = tsconfig.compilerOptions.paths[aliasName][0].replace(/\/\*$/, '');
-      aliases[finalAliasName] = utils.root(finalPath);
-      return aliases;
-    }, {})
+    alias: utils.addAliasesFromTypescriptConfig({})
   },
   module: {
     rules: [


### PR DESCRIPTION
If adding new alias to Typescript then currently must add this alias both to Typescript and Webpack config. After this change it's enough to add alias to Typescript config. Webpack reads aliases directly from Typescript config.

If in current version adding new path only to `tsconfig.json` into section `compilerOptions.paths` then on building app the following error occur: `Module not found: Error: Can't resolve '...'`.

This improves developer experience:
* for these who doesn't know Webpack and Typescript in depth this can save time which it takes to understand and resolve errors if changing only `tsconfig.json`
* for these who know Webpack and Typescript well this avoids annoying double change, for example developers and testers of the ng-jhipster can route generated application to use locally built ng-jhipster with single change

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
