### PR TITLE
angular: Bumped library versions, remove acorn dependency

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -46,7 +46,7 @@
     <%_ } _%>
     "core-js": "3.2.1",
     "moment": "2.24.0",
-    "ng-jhipster": "0.10.1",
+    "ng-jhipster": "0.11.0",
     "ngx-cookie": "4.0.2",
     "ngx-infinite-scroll": "8.0.0",
     "ngx-webstorage": "4.0.1",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -27,28 +27,28 @@
     "node_modules"
   ],
   "dependencies": {
-    "@angular/common": "8.0.0",
-    "@angular/compiler": "8.0.0",
-    "@angular/core": "8.0.0",
-    "@angular/forms": "8.0.0",
-    "@angular/platform-browser": "8.0.0",
-    "@angular/platform-browser-dynamic": "8.0.0",
-    "@angular/router": "8.0.0",
-    "@fortawesome/angular-fontawesome": "0.4.0",
-    "@fortawesome/fontawesome-svg-core": "1.2.19",
-    "@fortawesome/free-solid-svg-icons": "5.9.0",
-    "@ng-bootstrap/ng-bootstrap": "4.2.1",
+    "@angular/common": "8.2.2",
+    "@angular/compiler": "8.2.2",
+    "@angular/core": "8.2.2",
+    "@angular/forms": "8.2.2",
+    "@angular/platform-browser": "8.2.2",
+    "@angular/platform-browser-dynamic": "8.2.2",
+    "@angular/router": "8.2.2",
+    "@fortawesome/angular-fontawesome": "0.5.0",
+    "@fortawesome/fontawesome-svg-core": "1.2.21",
+    "@fortawesome/free-solid-svg-icons": "5.10.1",
+    "@ng-bootstrap/ng-bootstrap": "5.1.0",
     "@ngx-translate/core": "11.0.1",
     "@ngx-translate/http-loader": "4.0.0",
     "bootstrap": "4.3.1",
     <%_ if (clientTheme !== 'none') { _%>
     "bootswatch": "4.3.1",
     <%_ } _%>
-    "core-js": "3.1.3",
+    "core-js": "3.2.1",
     "moment": "2.24.0",
     "ng-jhipster": "0.10.1",
     "ngx-cookie": "4.0.2",
-    "ngx-infinite-scroll": "7.2.0",
+    "ngx-infinite-scroll": "8.0.0",
     "ngx-webstorage": "4.0.1",
     "rxjs": "6.5.2",
     "swagger-ui": "2.2.10",
@@ -57,17 +57,17 @@
     "webstomp-client": "1.2.6",
     <%_ } _%>
     "tslib": "1.10.0",
-    "zone.js": "0.9.1"
+    "zone.js": "0.10.2"
   },
   "devDependencies": {
-    "@angular/cli": "8.0.2",
-    "@angular/compiler-cli": "8.0.0",
-    "@ngtools/webpack": "8.0.2",
+    "@angular/cli": "8.2.2",
+    "@angular/compiler-cli": "8.2.2",
+    "@ngtools/webpack": "8.2.2",
     <%_ if (protractorTests) { _%>
-    "@types/chai": "4.1.7",
-    "@types/chai-string": "1.4.1",
+    "@types/chai": "4.2.0",
+    "@types/chai-string": "1.4.2",
     <%_ } _%>
-    "@types/jest": "24.0.14",
+    "@types/jest": "24.0.18",
     <%_ if (protractorTests) { _%>
     "@types/mocha": "5.2.7",
     <%_ } _%>
@@ -76,74 +76,68 @@
     "@typescript-eslint/eslint-plugin-tslint": "2.0.0",
     "@typescript-eslint/parser": "2.0.0",
     <%_ if (protractorTests) { _%>
-    "@types/selenium-webdriver": "4.0.0",
+    "@types/selenium-webdriver": "4.0.2",
     <%_ } _%>
-<%#
-The acorn dependency is added in order to fix a webpack/NPM issue:
-Please see: https://github.com/webpack/webpack/issues/8656
-Remove it once the issue is closed
--%>
-    "acorn": "6.1.1",
     "angular-router-loader": "0.8.5",
     "angular2-template-loader": "0.6.2",
-    "autoprefixer": "9.6.0",
+    "autoprefixer": "9.6.1",
     "base-href-webpack-plugin": "2.0.0",
     "browser-sync": "2.26.7",
     "browser-sync-webpack-plugin": "2.2.2",
-    "cache-loader": "4.0.0",
+    "cache-loader": "4.1.0",
     <%_ if (protractorTests) { _%>
     "chai": "4.2.0",
     "chai-as-promised": "7.1.1",
     "chai-string": "1.5.0",
     <%_ } _%>
     "codelyzer": "5.1.0",
-    "copy-webpack-plugin": "5.0.3",
-    "css-loader": "3.0.0",
+    "copy-webpack-plugin": "5.0.4",
+    "css-loader": "3.2.0",
     "eslint": "6.1.0",
     "eslint-config-prettier": "6.0.0",
     "eslint-loader": "2.2.1",
-    "file-loader": "4.0.0",
-    "fork-ts-checker-webpack-plugin": "1.3.6",
+    "file-loader": "4.2.0",
+    "fork-ts-checker-webpack-plugin": "1.5.0",
     "friendly-errors-webpack-plugin": "1.7.0",
     "generator-jhipster": "<%= packagejs.version %>",
     "html-loader": "0.5.5",
     "html-webpack-plugin": "3.2.0",
     <%_ if (!skipCommitHook) { _%>
-    "husky": "2.4.1",
+    "husky": "3.0.4",
     <%_ } _%>
-    "jest": "24.8.0",
-    "jest-junit": "6.4.0",
+    "jest": "24.9.0",
+    "jest-junit": "7.0.0",
     "jest-preset-angular": "7.1.1",
     "jest-sonar-reporter": "2.0.0",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "8.2.0",
+    "lint-staged": "9.2.3",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.19",
     <%_ } _%>
-    "mini-css-extract-plugin": "0.7.0",
+    "mini-css-extract-plugin": "0.8.0",
     <%_ if (protractorTests) { _%>
-    "mocha": "6.1.4",
+    "mocha": "6.2.0",
     <%_ } _%>
-    "moment-locales-webpack-plugin": "1.0.7",
-    "optimize-css-assets-webpack-plugin": "5.0.1",
+    "moment-locales-webpack-plugin": "1.1.0",
+    "optimize-css-assets-webpack-plugin": "5.0.3",
     "postcss-loader": "3.0.0",
     "prettier": "1.18.2",
     <%_ if (protractorTests) { _%>
     "protractor": "5.4.2",
     <%_ } _%>
     "reflect-metadata": "0.1.13",
-    "rimraf": "2.6.3",
-    "sass": "1.21.0",
-    "sass-loader": "7.1.0",
+    "rimraf": "3.0.0",
+    "sass": "1.22.10",
+    "sass-loader": "7.2.0",
     "simple-progress-webpack-plugin": "1.1.2",
-    "style-loader": "0.23.1",
-    "terser-webpack-plugin": "1.3.0",
-    "thread-loader": "2.1.2",
+    "style-loader": "1.0.0",
+    "terser-webpack-plugin": "1.4.1",
+    "thread-loader": "2.1.3",
     "to-string-loader": "1.1.5",
-    "ts-loader": "6.0.2",
+    "ts-loader": "6.0.4",
     <%_ if (protractorTests) { _%>
-    "ts-node": "8.2.0",
+    "ts-node": "8.3.0",
     <%_ } _%>
     "tslint": "5.18.0",
     "typescript": "3.4.5",
@@ -151,16 +145,16 @@ Remove it once the issue is closed
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
     <%_ if (protractorTests) { _%>
-    "webdriver-manager": "12.1.5",
+    "webdriver-manager": "12.1.6",
     <%_ } _%>
-    "webpack": "4.34.0",
-    "webpack-cli": "3.3.4",
-    "webpack-dev-server": "3.7.1",
+    "webpack": "4.39.2",
+    "webpack-cli": "3.3.7",
+    "webpack-dev-server": "3.8.0",
     "webpack-merge": "4.2.1",
-    "webpack-notifier": "1.7.0",
+    "webpack-notifier": "1.8.0",
     "webpack-visualizer-plugin": "0.1.11",
     "workbox-webpack-plugin": "4.3.1",
-    "write-file-webpack-plugin": "4.5.0"
+    "write-file-webpack-plugin": "4.5.1"
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,

--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -16,15 +16,16 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import './vendor.ts';
-
+import { HTTP_INTERCEPTORS } from '@angular/common/http';
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HTTP_INTERCEPTORS } from '@angular/common/http';
+import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+import { fas } from '@fortawesome/free-solid-svg-icons';
 import { NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
-import { NgxWebstorageModule } from 'ngx-webstorage';
 import { NgJhipsterModule } from 'ng-jhipster';
+import { NgxWebstorageModule } from 'ngx-webstorage';
 
+import { icons } from './vendor';
 <%_ if (authenticationType === 'jwt') { _%>
 import { AuthInterceptor } from './blocks/interceptor/auth.interceptor';
 <%_ } _%>
@@ -110,7 +111,9 @@ import { ErrorComponent } from './layouts/error/error.component';
     bootstrap: [ <%=jhiPrefixCapitalized%>MainComponent ]
 })
 export class <%=angularXAppName%>AppModule {
-    constructor(private dpConfig: NgbDatepickerConfig) {
+    constructor(private dpConfig: NgbDatepickerConfig, iconLibrary: FaIconLibrary) {
         this.dpConfig.minDate = {year: moment().year() - 100, month: 1, day: 1};
+        iconLibrary.addIconPacks(fas);
+        iconLibrary.addIcons(...icons);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/vendor.ts.ejs
@@ -21,7 +21,6 @@ import '../content/scss/vendor.scss';
 
 // Imports all fontawesome core and solid icons
 
-import { library } from '@fortawesome/fontawesome-svg-core';
 import {
     faUser,
     faSort,
@@ -60,40 +59,40 @@ import {
 } from '@fortawesome/free-solid-svg-icons';
 
 // Adds the SVG icon to the library so you can use it in your page
-library.add(faUser);
-library.add(faSort);
-library.add(faSortUp);
-library.add(faSortDown);
-library.add(faSync);
-library.add(faEye);
-library.add(faBan);
-library.add(faTimes);
-library.add(faArrowLeft);
-library.add(faSave);
-library.add(faPlus);
-library.add(faPencilAlt);
-library.add(faBars);
-library.add(faHome);
-library.add(faThList);
-library.add(faUserPlus);
-library.add(faRoad);
-library.add(faTachometerAlt);
-library.add(faHeart);
-library.add(faList);
-library.add(faBell);
-library.add(faTasks);
-library.add(faBook);
-library.add(faHdd);
-library.add(faFlag);
-library.add(faWrench);
-library.add(faLock);
-library.add(faCloud);
-library.add(faSignOutAlt);
-library.add(faSignInAlt);
-library.add(faCalendarAlt);
-library.add(faSearch);
-library.add(faTrashAlt);
-library.add(faAsterisk);
-
-// jhipster-needle-add-element-to-vendor - JHipster will add new menu items here
+export const icons = [
+  faUser,
+  faSort,
+  faSortUp,
+  faSortDown,
+  faSync,
+  faEye,
+  faBan,
+  faTimes,
+  faArrowLeft,
+  faSave,
+  faPlus,
+  faPencilAlt,
+  faBars,
+  faHome,
+  faThList,
+  faUserPlus,
+  faRoad,
+  faTachometerAlt,
+  faHeart,
+  faList,
+  faBell,
+  faTasks,
+  faBook,
+  faHdd,
+  faFlag,
+  faWrench,
+  faLock,
+  faCloud,
+  faSignOutAlt,
+  faSignInAlt,
+  faCalendarAlt,
+  faSearch,
+  faTrashAlt,
+  faAsterisk
+];
 


### PR DESCRIPTION
- Closes #10209 
- Bumped `angular` and associated library versions.
- Removed direct dependency on `acorn` that was added to fix dynamic import issue. Related to https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/upgrading/0.4.0-0.5.0.md
- Updated usage of font awesome library to fix warnings. Related to https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/upgrading/0.4.0-0.5.0.md


---


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
