### PR TITLE
mvnw command instead of mvn for verifying

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -107,13 +107,13 @@ Before you submit your pull request consider the following guidelines:
 -   Generate a new JHipster project, and ensure that all tests pass
 
     ```shell
-    mvn verify -Pprod
+    mvnw verify -Pprod
     ```
 
 -   Test that the new project runs correctly:
 
     ```shell
-    mvn spring-boot:run
+    mvnw spring-boot:run
     ```
 
 -   You can generate our Continuous Integration (with Travis CI and Azure Pipelines) by following [this](#local-build)


### PR DESCRIPTION
I believe it's more appropriate to put ```mvnw``` instead of ```mvn``` here as maven might not be globally installed and even if that's the case ```mvnw``` will still work (this is the case in my local setup for example). 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
