### PR TITLE
Add support for scheduled audit event deletion

### DIFF
--- a/generators/server/templates/src/main/java/package/config/ApplicationProperties.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ApplicationProperties.java.ejs
@@ -28,5 +28,4 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
  */
 @ConfigurationProperties(prefix = "application", ignoreUnknownFields = false)
 public class ApplicationProperties {
-
 }

--- a/generators/server/templates/src/main/java/package/repository/PersistenceAuditEventRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/PersistenceAuditEventRepository.java.ejs
@@ -20,9 +20,14 @@ package <%=packageName%>.repository;
 
 import <%=packageName%>.domain.PersistentAuditEvent;
 import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;<% if (databaseType === 'sql') { %>
-import org.springframework.data.jpa.repository.JpaRepository;<% } %><% if (databaseType === 'mongodb') { %>
-import org.springframework.data.mongodb.repository.MongoRepository;<% } %>
+import org.springframework.data.domain.Pageable;
+
+<% if (databaseType === 'sql') { %>
+import org.springframework.data.jpa.repository.JpaRepository;
+<% } %>
+<% if (databaseType === 'mongodb') { %>
+import org.springframework.data.mongodb.repository.MongoRepository;
+<% } %>
 
 import java.time.Instant;
 import java.util.List;
@@ -46,4 +51,6 @@ public interface PersistenceAuditEventRepository extends <% if (databaseType ===
     List<PersistentAuditEvent> findByPrincipalAndAuditEventDateAfterAndAuditEventType(String principal, Instant after, String type);
 
     Page<PersistentAuditEvent> findAllByAuditEventDateBetween(Instant fromDate, Instant toDate, Pageable pageable);
+
+    List<PersistentAuditEvent> findByAuditEventDateBefore(Instant before);
 }

--- a/generators/server/templates/src/main/java/package/service/AuditEventService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/AuditEventService.java.ejs
@@ -18,15 +18,22 @@
 -%>
 package <%=packageName%>.service;
 
+import io.github.jhipster.config.JHipsterProperties;
 import <%=packageName%>.config.audit.AuditEventConverter;
 import <%=packageName%>.repository.PersistenceAuditEventRepository;
 import org.springframework.boot.actuate.audit.AuditEvent;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
-import org.springframework.stereotype.Service;<% if (databaseType === 'sql') { %>
-import org.springframework.transaction.annotation.Transactional;<% } %>
+import org.springframework.stereotype.Service;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+<% if (databaseType === 'sql') { %>
+import org.springframework.transaction.annotation.Transactional;
+<% } %>
 
 import java.time.Instant;
+import java.time.temporal.ChronoUnit;
 import java.util.Optional;
 
 /**
@@ -38,16 +45,36 @@ import java.util.Optional;
 @Transactional<% } %>
 public class AuditEventService {
 
+    private final Logger log = LoggerFactory.getLogger(AuditEventService.class);
+
+    private final JHipsterProperties jHipsterProperties;
+
     private final PersistenceAuditEventRepository persistenceAuditEventRepository;
 
     private final AuditEventConverter auditEventConverter;
 
     public AuditEventService(
         PersistenceAuditEventRepository persistenceAuditEventRepository,
-        AuditEventConverter auditEventConverter) {
+        AuditEventConverter auditEventConverter, JHipsterProperties jhipsterProperties) {
 
         this.persistenceAuditEventRepository = persistenceAuditEventRepository;
         this.auditEventConverter = auditEventConverter;
+        this.jHipsterProperties = jhipsterProperties;
+    }
+
+    /**
+    * Old audit events should be automatically deleted after 30 days.
+    *
+    * This is scheduled to get fired at 12:00 (am).
+    */
+    @Scheduled(cron = "0 0 12 * * ?")
+    public void removeOldAuditEvents() {
+        persistenceAuditEventRepository
+            .findByAuditEventDateBefore(Instant.now().minus(jHipsterProperties.getAuditEvents().getRetentionPeriod(), ChronoUnit.DAYS))
+            .forEach(auditEvent -> {
+                log.debug("Deleting audit data {}", auditEvent.toString());
+                persistenceAuditEventRepository.delete(auditEvent);
+        });
     }
 
     public Page<AuditEvent> findAll(Pageable pageable) {

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -367,6 +367,8 @@ jhipster:
             host: localhost
             port: 5000
             queue-size: 512
+    audit-events:
+        retention-period: 30 # Number of days before audit events are deleted.
 <%_ if (applicationType === 'uaa') { _%>
 uaa:
     key-store:

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -351,6 +351,8 @@ jhipster:
             host: localhost
             port: 5000
             queue-size: 512
+    audit-events:
+        retention-period: 30 # Number of days before audit events are deleted.
 <%_ if (applicationType === 'uaa') { _%>
 uaa:
     #be sure to to change to a different keystore in production!

--- a/generators/server/templates/src/test/java/package/web/rest/AuditResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AuditResourceIT.java.ejs
@@ -22,6 +22,7 @@ import <%=packageName%>.<%= mainClass %>;
 <%_ if (authenticationType === 'oauth2') { _%>
 import <%=packageName%>.config.TestSecurityConfiguration;
 <%_ } _%>
+import io.github.jhipster.config.JHipsterProperties;
 import <%=packageName%>.config.audit.AuditEventConverter;
 import <%=packageName%>.domain.PersistentAuditEvent;
 import <%=packageName%>.repository.PersistenceAuditEventRepository;
@@ -82,6 +83,9 @@ public class AuditResourceIT {
     private AuditEventConverter auditEventConverter;
 
     @Autowired
+    private JHipsterProperties jhipsterProperties;
+
+    @Autowired
     private MappingJackson2HttpMessageConverter jacksonMessageConverter;
 
     @Autowired
@@ -99,7 +103,7 @@ public class AuditResourceIT {
     public void setup() {
         MockitoAnnotations.initMocks(this);
         AuditEventService auditEventService =
-            new AuditEventService(auditEventRepository, auditEventConverter);
+            new AuditEventService(auditEventRepository, auditEventConverter, jhipsterProperties);
         AuditResource auditResource = new AuditResource(auditEventService);
         this.restAuditMockMvc = MockMvcBuilders.standaloneSetup(auditResource)
             .setCustomArgumentResolvers(pageableArgumentResolver)


### PR DESCRIPTION
This adds support for automatically deleting audit logs after the duration specified in the properties file. 

Fix  #10253

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
