### PR TITLE
Fix 404 error on clicking bug template url

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ Greetings, Java Hipster!
 
 Full documentation and information is available on our website at [https://www.jhipster.tech/][jhipster-url]
 
-Please read our [guidelines](/CONTRIBUTING.md#submitting-an-issue) before submitting an issue. If your issue is a bug, please use the bug template pre-populated [here](issue-template). For feature requests and queries you can use [this template][feature-template].
+Please read our [guidelines](/CONTRIBUTING.md#submitting-an-issue) before submitting an issue. If your issue is a bug, please use the bug template pre-populated [here][issue-template]. For feature requests and queries you can use [this template][feature-template].
 
 ## Sponsors
 


### PR DESCRIPTION
This corrects the 404 error when clicking the bug template url link. 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] Documentation is added/updated where necessary

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
