### PR TITLE
make service layer not depend on web layer

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1026,6 +1026,26 @@ const serverFiles = {
             ]
         }
     ],
+    serverJavaServiceError: [
+        {
+            condition: generator => !generator.skipUserManagement,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/service/EmailAlreadyUsedException.java',
+                    renameTo: generator => `${generator.javaDir}service/EmailAlreadyUsedException.java`
+                },
+                {
+                    file: 'package/service/InvalidPasswordException.java',
+                    renameTo: generator => `${generator.javaDir}service/InvalidPasswordException.java`
+                },
+                {
+                    file: 'package/service/LoginAlreadyUsedException.java',
+                    renameTo: generator => `${generator.javaDir}service/LoginAlreadyUsedException.java`
+                }
+            ]
+        }
+    ],
     serverJavaService: [
         {
             path: SERVER_MAIN_SRC_DIR,

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1040,8 +1040,8 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}service/InvalidPasswordException.java`
                 },
                 {
-                    file: 'package/service/LoginAlreadyUsedException.java',
-                    renameTo: generator => `${generator.javaDir}service/LoginAlreadyUsedException.java`
+                    file: 'package/service/UsernameAlreadyUsedException.java',
+                    renameTo: generator => `${generator.javaDir}service/UsernameAlreadyUsedException.java`
                 }
             ]
         }

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -771,6 +771,15 @@ const serverFiles = {
             condition: generator => !generator.reactive,
             path: SERVER_MAIN_SRC_DIR,
             templates: [{ file: 'package/ApplicationWebXml.java', renameTo: generator => `${generator.javaDir}ApplicationWebXml.java` }]
+        },
+        {
+            path: SERVER_TEST_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/ArchTest.java',
+                    renameTo: generator => `${generator.testDir}ArchTest.java`
+                }
+            ]
         }
     ],
     serverJavaConfig: [

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -491,6 +491,8 @@ dependencies {
     <%_ if (cucumberTests) { _%>
     testImplementation "org.junit.vintage:junit-vintage-engine"
     <%_ } _%>
+    testImplementation 'com.tngtech.archunit:archunit-junit5-api:0.11.0'
+    testRuntime 'com.tngtech.archunit:archunit-junit5-engine:0.11.0'
     testImplementation "org.assertj:assertj-core"
     testImplementation "junit:junit"
     testImplementation "org.mockito:mockito-core"

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -588,7 +588,7 @@
             <artifactId>archunit-junit5-api</artifactId>
             <version>0.11.0</version>
             <scope>test</scope>
-        </dependency
+        </dependency>
         <!-- Adding the engine dependency to the surefire-plugin unfortunately does not work in the current version. -->
         <!-- https://www.archunit.org/userguide/html/000_Index.html#_junit_5 -->
         <dependency>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -583,6 +583,20 @@
             <artifactId>spring-security-test</artifactId>
             <scope>test</scope>
         </dependency>
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5-api</artifactId>
+            <version>0.11.0</version>
+            <scope>test</scope>
+        </dependency
+        <!-- Adding the engine dependency to the surefire-plugin unfortunately does not work in the current version. -->
+        <!-- https://www.archunit.org/userguide/html/000_Index.html#_junit_5 -->
+        <dependency>
+            <groupId>com.tngtech.archunit</groupId>
+            <artifactId>archunit-junit5-engine</artifactId>
+            <version>0.11.0</version>
+            <scope>test</scope>
+        </dependency>
 <%_ if (messageBroker === 'kafka') { _%>
         <!-- Kafka support -->
         <dependency>

--- a/generators/server/templates/src/main/java/package/service/EmailAlreadyUsedException.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/EmailAlreadyUsedException.java.ejs
@@ -1,0 +1,27 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.service;
+
+public class EmailAlreadyUsedException extends RuntimeException {
+
+    public EmailAlreadyUsedException() {
+        super("Email is already in use!");
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/service/InvalidPasswordException.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/InvalidPasswordException.java.ejs
@@ -1,0 +1,27 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.service;
+
+public class InvalidPasswordException extends RuntimeException {
+
+    public InvalidPasswordException() {
+        super("Incorrect password");
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/service/LoginAlreadyUsedException.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/LoginAlreadyUsedException.java.ejs
@@ -1,0 +1,27 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.service;
+
+public class LoginAlreadyUsedException extends RuntimeException {
+
+    public LoginAlreadyUsedException() {
+        super("Login name already used!");
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -42,7 +42,6 @@ import <%=packageName%>.security.SecurityUtils;
 import <%=packageName%>.service.dto.<%= asDto('User') %>;
 <%_ if (authenticationType !== 'oauth2') { _%>
 import <%=packageName%>.service.util.RandomUtil;
-import <%=packageName%>.web.rest.errors.*;
 <%_ } _%>
 
 <%_ if (databaseType !== 'no') { _%>

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -225,7 +225,7 @@ public class UserService {
         userRepository.findOneByLogin(userDTO.getLogin().toLowerCase()).ifPresent(existingUser -> {
             boolean removed = removeNonActivatedUser(existingUser);
             if (!removed) {
-                throw new LoginAlreadyUsedException();
+                throw new UsernameAlreadyUsedException();
             }
         });
         userRepository.findOneByEmailIgnoreCase(userDTO.getEmail()).ifPresent(existingUser -> {
@@ -277,7 +277,7 @@ public class UserService {
                     <%_ } _%>
                     return userRepository.delete(existingUser);
                 } else {
-                    throw new LoginAlreadyUsedException();
+                    throw new UsernameAlreadyUsedException();
                 }
             })
             .then(userRepository.findOneByEmailIgnoreCase(userDTO.getEmail()))

--- a/generators/server/templates/src/main/java/package/service/UsernameAlreadyUsedException.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UsernameAlreadyUsedException.java.ejs
@@ -18,9 +18,9 @@
 -%>
 package <%=packageName%>.service;
 
-public class LoginAlreadyUsedException extends RuntimeException {
+public class UsernameAlreadyUsedException extends RuntimeException {
 
-    public LoginAlreadyUsedException() {
+    public UsernameAlreadyUsedException() {
         super("Login name already used!");
     }
 

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -162,19 +162,19 @@ _%>
     <%_ } _%>
     <%_ if (!skipUserManagement) { _%>
     @ExceptionHandler
-    public ResponseEntity<Problem> handleEmailAreadyUsedException(<%=packageName%>.service.EmailAlreadyUsedException ex, NativeWebRequest request) {
+    public <%- returnType %> handleEmailAreadyUsedException(<%=packageName%>.service.EmailAlreadyUsedException ex, <%= requestClass %> request) {
         EmailAlreadyUsedException problem = new EmailAlreadyUsedException();
         return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
     }
 
     @ExceptionHandler
-    public ResponseEntity<Problem> handleLoginAreadyUsedException(<%=packageName%>.service.LoginAlreadyUsedException ex, NativeWebRequest request) {
+    public <%- returnType %> handleLoginAreadyUsedException(<%=packageName%>.service.LoginAlreadyUsedException ex, <%= requestClass %> request) {
         LoginAlreadyUsedException problem = new LoginAlreadyUsedException();
         return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
     }
 
     @ExceptionHandler
-    public ResponseEntity<Problem> handleInvalidPasswordException(<%=packageName%>.service.InvalidPasswordException ex, NativeWebRequest request) {
+    public <%- returnType %> handleInvalidPasswordException(<%=packageName%>.service.InvalidPasswordException ex, <%= requestClass %> request) {
         return create(new InvalidPasswordException(), request);
     }
     <%_ } _%>

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -168,7 +168,7 @@ _%>
     }
 
     @ExceptionHandler
-    public <%- returnType %> handleLoginAreadyUsedException(<%=packageName%>.service.LoginAlreadyUsedException ex, <%= requestClass %> request) {
+    public <%- returnType %> handleUsernameAreadyUsedException(<%=packageName%>.service.UsernameAlreadyUsedException ex, <%= requestClass %> request) {
         LoginAlreadyUsedException problem = new LoginAlreadyUsedException();
         return create(problem, request, HeaderUtil.createFailureAlert(applicationName,  <%= enableTranslation %>, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
     }

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -160,7 +160,25 @@ _%>
         return create(ex, problem, request);
     }
     <%_ } _%>
+    <%_ if (!skipUserManagement) { _%>
+    @ExceptionHandler
+    public ResponseEntity<Problem> handleEmailAreadyUsedException(<%=packageName%>.service.EmailAlreadyUsedException ex, NativeWebRequest request) {
+        EmailAlreadyUsedException problem = new EmailAlreadyUsedException();
+        return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
+    }
 
+    @ExceptionHandler
+    public ResponseEntity<Problem> handleLoginAreadyUsedException(<%=packageName%>.service.LoginAlreadyUsedException ex, NativeWebRequest request) {
+        LoginAlreadyUsedException problem = new LoginAlreadyUsedException();
+        return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
+    }
+
+    @ExceptionHandler
+    public ResponseEntity<Problem> handleInvalidPasswordException(<%=packageName%>.service.InvalidPasswordException ex, NativeWebRequest request) {
+        InvalidPasswordException problem = new InvalidPasswordException();
+        return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, null, null, problem.getMessage()));
+    }
+    <%_ } _%>
     @ExceptionHandler
     public <%- returnType %> handleBadRequestAlertException(BadRequestAlertException ex, <%= requestClass %> request) {
         return create(ex, request, HeaderUtil.createFailureAlert(applicationName, <%= enableTranslation %>, ex.getEntityName(), ex.getErrorKey(), ex.getMessage()));

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -175,8 +175,7 @@ _%>
 
     @ExceptionHandler
     public ResponseEntity<Problem> handleInvalidPasswordException(<%=packageName%>.service.InvalidPasswordException ex, NativeWebRequest request) {
-        InvalidPasswordException problem = new InvalidPasswordException();
-        return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, null, null, problem.getMessage()));
+        return create(new InvalidPasswordException(), request);
     }
     <%_ } _%>
     @ExceptionHandler

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -164,13 +164,13 @@ _%>
     @ExceptionHandler
     public <%- returnType %> handleEmailAreadyUsedException(<%=packageName%>.service.EmailAlreadyUsedException ex, <%= requestClass %> request) {
         EmailAlreadyUsedException problem = new EmailAlreadyUsedException();
-        return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
+        return create(problem, request, HeaderUtil.createFailureAlert(applicationName,  <%= enableTranslation %>, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
     }
 
     @ExceptionHandler
     public <%- returnType %> handleLoginAreadyUsedException(<%=packageName%>.service.LoginAlreadyUsedException ex, <%= requestClass %> request) {
         LoginAlreadyUsedException problem = new LoginAlreadyUsedException();
-        return create(problem, request, HeaderUtil.createFailureAlert(applicationName, true, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
+        return create(problem, request, HeaderUtil.createFailureAlert(applicationName,  <%= enableTranslation %>, problem.getEntityName(), problem.getErrorKey(), problem.getMessage()));
     }
 
     @ExceptionHandler

--- a/generators/server/templates/src/test/java/package/ArchTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/ArchTest.java.ejs
@@ -20,7 +20,7 @@ package <%=packageName%>;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
-import org.junit.jupiter.api.DisplayName;
+import com.tngtech.archunit.core.importer.ImportOption;;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
@@ -30,7 +30,9 @@ class ArchTest {
     @Test
     void servicesAndRepositoriesShouldNotDependOnWebLayer() {
 
-        JavaClasses importedClasses = new ClassFileImporter().importPackages("<%=packageName%>");
+        JavaClasses importedClasses = new ClassFileImporter()
+            .withImportOption(ImportOption.Predefined.DO_NOT_INCLUDE_TESTS)
+            .importPackages("<%=packageName%>");
 
         noClasses()
             .that()

--- a/generators/server/templates/src/test/java/package/ArchTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/ArchTest.java.ejs
@@ -1,0 +1,45 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>;
+
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+class ArchTest {
+
+    @Test
+    void servicesAndRepositoriesShouldNotDependOnWebLayer() {
+
+        JavaClasses importedClasses = new ClassFileImporter().importPackages("<%=packageName%>");
+
+        noClasses()
+            .that()
+                .resideInAnyPackage("..service..")
+            .or()
+                .resideInAnyPackage("..repository..")
+            .should().dependOnClassesThat()
+                .resideInAnyPackage("..<%=packageName%>.web..")
+        .because("Services and repositories should not depend on web layer")
+        .check(importedClasses);
+    }
+}


### PR DESCRIPTION
As already proposed in [this sample](https://github.com/atomfrede/jh-9876) this PR does the following:

* Adding [archunit](https://www.archunit.org/) to check that the service layer does not depend on the web layer
* Add new exceptions in service layer package which are used by the userservice instead of the web excetions/problems
* Instead of renaming the web exceptions to something like `...WebException` or `...Problem` I just kept the name and use in the translator a fully qualified classname. Otherwise we would have had to rename/remove the all exceptions, change all imports elsewhere. With the current approach updating e.g. is easy and the diff will be pretty small.

I will take care of adding a paragraph about arch unit to our documentation after it is merged.


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
