### PR TITLE
Remove CUSTOM_ELEMENTS_SCHEMA and fix error found after that

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/account.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/account.module.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
@@ -49,7 +49,6 @@ import { accountState } from './account.route';
         SessionsComponent,
         <%_ } _%>
         SettingsComponent
-    ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    ]
 })
 export class <%=angularXAppName%>AccountModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin.module.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';
@@ -85,8 +85,7 @@ import { <%=jhiPrefixCapitalized%>TrackerComponent } from './tracker/tracker.com
         UserMgmtDeleteDialogComponent,
         <%_ } _%>
         <%=jhiPrefixCapitalized%>HealthModalComponent
-    ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    ]
 })
 export class <%=angularXAppName%>AdminModule {
     <%_ if (enableTranslation) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/entities/entity.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/entities/entity.module.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 @NgModule({
@@ -27,7 +27,6 @@ import { RouterModule } from '@angular/router';
     ],
     declarations: [],
     entryComponents: [],
-    providers: [],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    providers: []
 })
 export class <%=angularXAppName%>EntityModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.module.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
@@ -30,7 +30,6 @@ import { HomeComponent } from './home.component';
     ],
     declarations: [
         HomeComponent,
-    ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
+    ]
 })
 export class <%=angularXAppName%>HomeModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { <%=angularXAppName%>SharedCommonModule } from './shared-common.module';
 <%_ if (authenticationType !== 'oauth2') { _%>
 import { <%=jhiPrefixCapitalized%>LoginModalComponent } from './login/login.component';
@@ -42,9 +42,7 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         <%=jhiPrefixCapitalized%>LoginModalComponent,
         <%_ } _%>
         HasAnyAuthorityDirective
-    ],
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
-
+    ]
 })
 export class <%=angularXAppName%>SharedModule {
     static forRoot() {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
@@ -184,7 +184,7 @@
     <%_ } else if (pagination === 'pagination') { _%>
     <div [hidden]="<%=entityInstancePlural %>?.length === 0">
         <div class="row justify-content-center">
-            <jhi-item-count [page]="page" [total]="totalItems" [maxSize]="5" [itemsPerPage]="itemsPerPage"></jhi-item-count>
+            <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
         <div class="row justify-content-center">
             <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)"></ngb-pagination>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { NgModule, CUSTOM_ELEMENTS_SCHEMA } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';
@@ -56,7 +56,6 @@ const ENTITY_STATES = [
     <%_ if (enableTranslation) { _%>
     providers: [ { provide: JhiLanguageService, useClass: JhiLanguageService } ],
     <%_ } _%>
-    schemas: [CUSTOM_ELEMENTS_SCHEMA]
 })
 export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {
     <%_ if (enableTranslation) { _%>


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

This PR removes `CUSTOM_ELEMENTS_SCHEMA` from Angular modules. Apps generated by JHipster are not using custom elements schemas by default, so this is unnecessary to add this.  
Also _Angular CLI_ and Angular default tutorial app _Tour of Heroes_ doesn't have this.  

Angular is doing more checks after removing this and with help of Travis was caught error in `jhi-item-count` tag. In case in entity config is `"pagination": "pagination"` then redundant attribute `maxSize` was generated. This PR fixes also this problem.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
