### PR TITLE
Instead of static tsconfig, decide one based on chosen frameworks

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -83,6 +83,10 @@ function cleanupOldFiles(generator) {
         generator.removeFile(`${ANGULAR_DIR}layouts/index.ts`);
         generator.removeFile(`${ANGULAR_DIR}shared/index.ts`);
     }
+
+    if (generator.isJhipsterVersionLessThan('6.3.0') && generator.configOptions && generator.configOptions.clientFramework === 'react') {
+        generator.removeFile('tslint.json');
+    }
 }
 
 /**

--- a/generators/client/templates/react/.eslintrc.json.ejs
+++ b/generators/client/templates/react/.eslintrc.json.ejs
@@ -17,7 +17,7 @@
     "commonjs": true
   },
   "parserOptions": {
-    "project": "./tsconfig.e2e.json",
+    "project": "./<% if (protractorTests) { %>tsconfig.e2e.json<% } else { %>tsconfig.json<% } %>",
     "ecmaVersion": 2018,
     "sourceType": "module",
     "ecmaFeatures": {


### PR DESCRIPTION
- Closes #10304 
- Instead of static `tsconfig`, decide one based on chosen frameworks.
- Delete `tslint.json` on upgrade.
---

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
