### PR TITLE
Fix lint-stage long path issue on windows

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -50,7 +50,7 @@ const files = {
         },
         {
             condition: generator => !generator.skipCommitHook,
-            templates: ['.huskyrc']
+            templates: ['.huskyrc', '.lintstagedrc.js']
         }
     ],
     sass: [

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -51,7 +51,7 @@ const files = {
         },
         {
             condition: generator => !generator.skipCommitHook,
-            templates: ['.huskyrc']
+            templates: ['.huskyrc', '.lintstagedrc.js']
         }
     ],
     sass: [

--- a/generators/client/templates/angular/.lintstagedrc.js.ejs
+++ b/generators/client/templates/angular/.lintstagedrc.js.ejs
@@ -1,0 +1,4 @@
+module.exports = {
+  '{,src/**/}*.{md,json,ts,css,scss,yml}': [filenames => filenames.map(filename => `prettier --write '${filename}'`), 'git add'],
+  '*.{js,ts}': 'eslint'
+};

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -157,16 +157,8 @@
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
-    "yarn": ">=1.16.0"<% } %>
+    "yarn": ">=1.17.3"<% } %>
   },
-  <%_ if (!skipCommitHook) { _%>
-  "lint-staged": {
-    "{,src/**/}*.{md,json,ts,css,scss,yml}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  <%_ } _%>
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,css,scss,yml}\"",
     "lint": "eslint . --ext .js,.ts",

--- a/generators/client/templates/react/.lintstagedrc.js.ejs
+++ b/generators/client/templates/react/.lintstagedrc.js.ejs
@@ -1,0 +1,4 @@
+module.exports = {
+  '{,src/**/}*.{md,json,ts,css,scss,yml}': [filenames => filenames.map(filename => `prettier --write '${filename}'`), 'git add'],
+  '*.{js,ts,jsx,tsx}': 'eslint'
+};

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -179,16 +179,8 @@ limitations under the License.
 <%_ } _%>
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
-    "yarn": ">=1.3.2"<% } %>
+    "yarn": ">=1.17.3"<% } %>
   },
-  <%_ if (!skipCommitHook) { _%>
-  "lint-staged": {
-    "{,src/**/}*.{md,json,ts,tsx,css,scss,yml}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  <%_ } _%>
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,tsx,css,scss,yml}\"",
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -113,7 +113,7 @@ limitations under the License.
     "generator-jhipster": "<%= packagejs.version %>",
     "html-webpack-plugin": "3.2.0",
     <%_ if (!skipCommitHook) { _%>
-    "husky": "1.3.1",
+    "husky": "3.0.4",
     <%_ } _%>
     "identity-obj-proxy": "3.0.0",
     "jest": "24.5.0",
@@ -121,7 +121,7 @@ limitations under the License.
     "jest-sonar-reporter": "2.0.0",
     "json-loader": "0.5.7",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "8.1.5",
+    "lint-staged": "9.2.5",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.18",
@@ -133,7 +133,7 @@ limitations under the License.
     "moment-locales-webpack-plugin": "1.0.7",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "postcss-loader": "3.0.0",
-    "prettier": "1.16.4",
+    "prettier": "1.18.2",
     <%_ if (protractorTests) { _%>
     "protractor": "5.4.2",
     <%_ } _%>

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -359,6 +359,7 @@ const expectedFiles = {
         '.eslintrc.json',
         '.eslintignore',
         '.huskyrc',
+        '.lintstagedrc.js',
         'package.json',
         'postcss.config.js',
         'proxy.conf.json',


### PR DESCRIPTION
- Closes #10312 
- Use JavaScript variant to leverage functions in the lint-staged configurations
- Upgrade react configurations to be in sync with angular
- Integrate `ESLint` execution on staged files to prevent code check-in with lint failures.

---
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
