### PR TITLE
Remove redundant forRoot methods in Angular part

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -62,7 +62,7 @@ import { ErrorComponent } from './layouts/error/error.component';
             defaultI18nLang: '<%= nativeLanguage %>'
             <%_ } _%>
         }),
-        <%=angularXAppName%>SharedModule.forRoot(),
+        <%=angularXAppName%>SharedModule,
         <%=angularXAppName%>CoreModule,
         <%=angularXAppName%>HomeModule,
         <%_ if (!skipUserManagement) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared-libs.module.ts.ejs
@@ -43,10 +43,4 @@ import { FontAwesomeModule } from '@fortawesome/angular-fontawesome';
         ReactiveFormsModule
     ]
 })
-export class <%=angularXAppName%>SharedLibsModule {
-    static forRoot() {
-        return {
-            ngModule: <%=angularXAppName%>SharedLibsModule
-        };
-    }
-}
+export class <%=angularXAppName%>SharedLibsModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
@@ -44,10 +44,4 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         HasAnyAuthorityDirective
     ]
 })
-export class <%=angularXAppName%>SharedModule {
-    static forRoot() {
-        return {
-            ngModule: <%=angularXAppName%>SharedModule
-        };
-    }
-}
+export class <%=angularXAppName%>SharedModule {}


### PR DESCRIPTION
`SharedLibsModule` and `SharedModule` has no providers in `forRoot` method, so these methods are doing nothing and can be deleted.  
This PR is doing this cleaning.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
