### PR TITLE
Revert to old lint-staged version to fix issue on windows

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -50,7 +50,7 @@ const files = {
         },
         {
             condition: generator => !generator.skipCommitHook,
-            templates: ['.huskyrc']
+            templates: ['.huskyrc', '.lintstagedrc.js']
         }
     ],
     sass: [

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -51,7 +51,7 @@ const files = {
         },
         {
             condition: generator => !generator.skipCommitHook,
-            templates: ['.huskyrc']
+            templates: ['.huskyrc', '.lintstagedrc.js']
         }
     ],
     sass: [

--- a/generators/client/templates/angular/.lintstagedrc.js.ejs
+++ b/generators/client/templates/angular/.lintstagedrc.js.ejs
@@ -1,0 +1,3 @@
+module.exports = {
+  '{,src/**/}*.{md,json,ts,css,scss,yml}': ['prettier --write', 'git add']
+};

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -109,7 +109,7 @@
     "jest-preset-angular": "7.1.1",
     "jest-sonar-reporter": "2.0.0",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "9.2.5",
+    "lint-staged": "8.2.1",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.19",
@@ -157,16 +157,8 @@
   },
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
-    "yarn": ">=1.16.0"<% } %>
+    "yarn": ">=1.17.3"<% } %>
   },
-  <%_ if (!skipCommitHook) { _%>
-  "lint-staged": {
-    "{,src/**/}*.{md,json,ts,css,scss,yml}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  <%_ } _%>
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,css,scss,yml}\"",
     "lint": "eslint . --ext .js,.ts",

--- a/generators/client/templates/react/.lintstagedrc.js.ejs
+++ b/generators/client/templates/react/.lintstagedrc.js.ejs
@@ -1,0 +1,3 @@
+module.exports = {
+  '{,src/**/}*.{md,json,ts,css,scss,yml}': ['prettier --write', 'git add']
+};

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -113,7 +113,7 @@ limitations under the License.
     "generator-jhipster": "<%= packagejs.version %>",
     "html-webpack-plugin": "3.2.0",
     <%_ if (!skipCommitHook) { _%>
-    "husky": "1.3.1",
+    "husky": "3.0.4",
     <%_ } _%>
     "identity-obj-proxy": "3.0.0",
     "jest": "24.5.0",
@@ -121,7 +121,7 @@ limitations under the License.
     "jest-sonar-reporter": "2.0.0",
     "json-loader": "0.5.7",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "8.1.5",
+    "lint-staged": "8.2.1",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.18",
@@ -133,7 +133,7 @@ limitations under the License.
     "moment-locales-webpack-plugin": "1.0.7",
     "optimize-css-assets-webpack-plugin": "5.0.1",
     "postcss-loader": "3.0.0",
-    "prettier": "1.16.4",
+    "prettier": "1.18.2",
     <%_ if (protractorTests) { _%>
     "protractor": "5.4.2",
     <%_ } _%>
@@ -179,16 +179,8 @@ limitations under the License.
 <%_ } _%>
   "engines": {
     "node": ">=8.9.0"<% if (clientPackageManager === 'yarn') { %>,
-    "yarn": ">=1.3.2"<% } %>
+    "yarn": ">=1.17.3"<% } %>
   },
-  <%_ if (!skipCommitHook) { _%>
-  "lint-staged": {
-    "{,src/**/}*.{md,json,ts,tsx,css,scss,yml}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  <%_ } _%>
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,tsx,css,scss,yml}\"",
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -359,6 +359,7 @@ const expectedFiles = {
         '.eslintrc.json',
         '.eslintignore',
         '.huskyrc',
+        '.lintstagedrc.js',
         'package.json',
         'postcss.config.js',
         'proxy.conf.json',


### PR DESCRIPTION
- Closes #10312  
- Revert to old `lint-staged` dependency version that works on windows and doesn't degrade initial commit performance.
- Move lint-stage configurations to separate file, so, that future upgrade can be easy.
- Upgrade husky, lint-staged and prettier dependencies on react codebase to keep them in sync with angular.
---
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
