### PR TITLE
Use embeddableLaunchScript=true for apps generated by older JHipster versions

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -307,6 +307,12 @@ module.exports = class extends BaseGenerator {
                         this.clientPackageManager = 'yarn';
                     }
                 }
+                // Set embeddableLaunchScript to true if not defined, for backward compatibility
+                // See https://github.com/jhipster/generator-jhipster/issues/10255
+                this.embeddableLaunchScript = this.config.get('embeddableLaunchScript');
+                if (!this.embeddableLaunchScript) {
+                    this.embeddableLaunchScript = true;
+                }
             }
         };
     }

--- a/test-integration/samples/app-sample-dev/.yo-rc.json
+++ b/test-integration/samples/app-sample-dev/.yo-rc.json
@@ -12,7 +12,6 @@
         "devDatabaseType": "h2Disk",
         "prodDatabaseType": "mysql",
         "searchEngine": false,
-
         "buildTool": "maven",
         "enableTranslation": true,
         "nativeLanguage": "en",
@@ -24,6 +23,7 @@
         "messageBroker": false,
         "serviceDiscoveryType": false,
         "clientPackageManager": "npm",
-        "clientFramework": "angularX"
+        "clientFramework": "angularX",
+        "embeddableLaunchScript": false
     }
 }


### PR DESCRIPTION
Linked to #10282 
Set embeddableLaunchScript to true for apps generated with old JHipster versions
We don't want to surprise users that were relying on this feature to be enable by default.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
