### PR TITLE
Update yo version to 3.1.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -472,6 +472,11 @@
             "integrity": "sha512-5am6HnnfN+urzt4yfg7IgTbotDjIT/u8AJpEt0sIU9FtXfVeezXAPKswrG+xKUCOYAINpSdgZVDU6QFh+cuH3w==",
             "dev": true
         },
+        "boolean": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/boolean/-/boolean-1.0.0.tgz",
+            "integrity": "sha512-IB1lgIywn37N9Aff8CciCblVpMUflgL42vyxPUH0IvaDdIi/QwBHKv1lq/HOkATHCfa7c4MbMYJ7Bo7hGuoI+w=="
+        },
         "boxen": {
             "version": "1.3.0",
             "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
@@ -1008,6 +1013,11 @@
             "resolved": "https://registry.npmjs.org/copy-descriptor/-/copy-descriptor-0.1.1.tgz",
             "integrity": "sha1-Z29us8OZl8LuGsOpJP1hJHSPV40="
         },
+        "core-js": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.2.1.tgz",
+            "integrity": "sha512-Qa5XSVefSVPRxy2XfUC13WbvqkxhkwB3ve+pgCQveNgYzbM/UxZeu1dcOX/xr4UmfUd+muuvsaxilQzCyUurMw=="
+        },
         "core-util-is": {
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
@@ -1144,7 +1154,6 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.3.tgz",
             "integrity": "sha512-3MqfYKj2lLzdMSf8ZIZE/V+Zuy+BgD6f164e8K2w7dgnpKArBDerGYpM46IYYcjnkdPNMjPk9A6VFB8+3SKlXQ==",
-            "dev": true,
             "requires": {
                 "object-keys": "^1.0.12"
             }
@@ -1205,6 +1214,11 @@
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/detect-conflict/-/detect-conflict-1.0.1.tgz",
             "integrity": "sha1-CIZXpmqWHAUBnbfEIwiDsca0F24="
+        },
+        "detect-node": {
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/detect-node/-/detect-node-2.0.4.tgz",
+            "integrity": "sha512-ZIzRpLJrOj7jjP2miAtgqIfmzbxa4ZOr5jJc601zklsfEx9oTzmmj2nVpIPRpNlRTIh8lc1kyViIY7BWSGNmKw=="
         },
         "diagnostics": {
             "version": "1.1.1",
@@ -1270,22 +1284,6 @@
             "version": "0.1.4",
             "resolved": "https://registry.npmjs.org/duplexer3/-/duplexer3-0.1.4.tgz",
             "integrity": "sha1-7gHdHKwO08vH/b6jfcCo8c4ALOI="
-        },
-        "each-async": {
-            "version": "1.1.1",
-            "resolved": "https://registry.npmjs.org/each-async/-/each-async-1.1.1.tgz",
-            "integrity": "sha1-3uUim98KtrogEqOV4bhpq/iBNHM=",
-            "requires": {
-                "onetime": "^1.0.0",
-                "set-immediate-shim": "^1.0.0"
-            },
-            "dependencies": {
-                "onetime": {
-                    "version": "1.1.0",
-                    "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
-                    "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
-                }
-            }
         },
         "ecc-jsbn": {
             "version": "0.1.2",
@@ -1457,6 +1455,11 @@
                 "is-date-object": "^1.0.1",
                 "is-symbol": "^1.0.2"
             }
+        },
+        "es6-error": {
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/es6-error/-/es6-error-4.1.1.tgz",
+            "integrity": "sha512-Um/+FxMr9CISWh0bi5Zv0iOD+4cFh5qLeks1qhAopKVAJw3drgKbKySikp7wGhDL0HPeaja0P5ULZrxLkniUVg=="
         },
         "es6-promise": {
             "version": "4.2.8",
@@ -2383,8 +2386,7 @@
         "function-bind": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
-            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
-            "dev": true
+            "integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
         },
         "functional-red-black-tree": {
             "version": "1.0.1",
@@ -2497,6 +2499,27 @@
             "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.3.0.tgz",
             "integrity": "sha1-jFoUlNIGbFcMw7/kSWF1rMTVAqs="
         },
+        "global-agent": {
+            "version": "2.0.2",
+            "resolved": "https://registry.npmjs.org/global-agent/-/global-agent-2.0.2.tgz",
+            "integrity": "sha512-mQLICTW+QGJPuEI8WvEjdyPCcEnx5OqmJH2ADGtv9NknBfUsTnUsV9NeKfrjkwauT2zrSGQqDrS49f86kvnXoA==",
+            "requires": {
+                "boolean": "^1.0.0",
+                "core-js": "^3.2.1",
+                "es6-error": "^4.1.1",
+                "matcher": "^2.0.0",
+                "roarr": "^2.14.1",
+                "semver": "^6.3.0",
+                "serialize-error": "^4.1.0"
+            },
+            "dependencies": {
+                "semver": {
+                    "version": "6.3.0",
+                    "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+                    "integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+                }
+            }
+        },
         "global-dirs": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
@@ -2521,6 +2544,16 @@
             "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
             "integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
             "dev": true
+        },
+        "globalthis": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.0.tgz",
+            "integrity": "sha512-vcCAZTJ3r5Qcu5l8/2oyVdoFwxKgfYnMTR2vwWeux/NAVZK3PwcMaWkdUIn4GJbmKuRK7xcvDsLuK+CKcXyodg==",
+            "requires": {
+                "define-properties": "^1.1.2",
+                "function-bind": "^1.1.1",
+                "object-keys": "^1.0.12"
+            }
         },
         "globby": {
             "version": "8.0.2",
@@ -2898,6 +2931,11 @@
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/invert-kv/-/invert-kv-2.0.0.tgz",
             "integrity": "sha512-wPVv/y/QQ/Uiirj/vh3oP+1Ww+AWehmi1g5fFWGPF6IpCBCDVrhgHRMvrLfdYcwDh3QJbGXDW4JAuzxElLSqKA=="
+        },
+        "ip-regex": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/ip-regex/-/ip-regex-2.1.0.tgz",
+            "integrity": "sha1-+ni/XS5pE8kRzp+BnuUUa7bYROk="
         },
         "is-accessor-descriptor": {
             "version": "0.1.6",
@@ -3651,6 +3689,21 @@
             "integrity": "sha512-c+yYdCZJQrsRjTPhUx7VKkApw9bwDkNbHUKo1ovgcfDjb2kc8rLuRbIFyXL5WOEUwzSSKo3IXpph2K6DqB/KZg==",
             "dev": true
         },
+        "matcher": {
+            "version": "2.0.0",
+            "resolved": "https://registry.npmjs.org/matcher/-/matcher-2.0.0.tgz",
+            "integrity": "sha512-nlmfSlgHBFx36j/Pl/KQPbIaqE8Zf0TqmSMjsuddHDg6PMSVgmyW9HpkLs0o0M1n2GIZ/S2BZBLIww/xjhiGng==",
+            "requires": {
+                "escape-string-regexp": "^2.0.0"
+            },
+            "dependencies": {
+                "escape-string-regexp": {
+                    "version": "2.0.0",
+                    "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-2.0.0.tgz",
+                    "integrity": "sha512-UpzcLCXolUWcNu5HtVMHYdXJjArjsF9C0aNnquZYY4uW/Vu0miy5YoWvbV345HauVvcAUnpRuhMMcqTcGOY2+w=="
+                }
+            }
+        },
         "mdurl": {
             "version": "1.0.1",
             "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-1.0.1.tgz",
@@ -4263,13 +4316,7 @@
         "object-keys": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/object-keys/-/object-keys-1.1.0.tgz",
-            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg==",
-            "dev": true
-        },
-        "object-values": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/object-values/-/object-values-1.0.0.tgz",
-            "integrity": "sha1-cq+DljARnluYw7AruMJ+MjcVgQU="
+            "integrity": "sha512-6OO5X1+2tYkNyNEx6TsCxEqFfRWaqx6EtMiSbGrw8Ob8v9Ne+Hl8rBAgLBZn5wjEz3s/s6U1WXFUFOcxxAwUpg=="
         },
         "object-visit": {
             "version": "1.0.1",
@@ -4354,10 +4401,10 @@
                 "mimic-fn": "^1.0.0"
             }
         },
-        "opn": {
-            "version": "5.5.0",
-            "resolved": "https://registry.npmjs.org/opn/-/opn-5.5.0.tgz",
-            "integrity": "sha512-PqHpggC9bLV0VeWcdKhkpxY+3JTzetLSqTCWL/z/tFIbI6G8JCjondXklT1JinczLz2Xib62sSp0T/gKT4KksA==",
+        "open": {
+            "version": "6.4.0",
+            "resolved": "https://registry.npmjs.org/open/-/open-6.4.0.tgz",
+            "integrity": "sha512-IFenVPgF70fSm1keSd2iDBIDIBZkroLeuffXq+wKTzTJlBpesFWojV9lb8mzOfaAzM1sr7HQHuO0vtV0zYekGg==",
             "requires": {
                 "is-wsl": "^1.1.0"
             }
@@ -5022,6 +5069,49 @@
             "resolved": "https://registry.npmjs.org/replace-ext/-/replace-ext-0.0.1.tgz",
             "integrity": "sha1-KbvZIHinOfC8zitO5B6DeVNSKSQ="
         },
+        "request": {
+            "version": "2.88.0",
+            "resolved": "https://registry.npmjs.org/request/-/request-2.88.0.tgz",
+            "integrity": "sha512-NAqBSrijGLZdM0WZNsInLJpkJokL72XYjUpnB0iwsRgxh7dB6COrHnTBNwN0E+lHDAJzu7kLAkDeY08z2/A0hg==",
+            "requires": {
+                "aws-sign2": "~0.7.0",
+                "aws4": "^1.8.0",
+                "caseless": "~0.12.0",
+                "combined-stream": "~1.0.6",
+                "extend": "~3.0.2",
+                "forever-agent": "~0.6.1",
+                "form-data": "~2.3.2",
+                "har-validator": "~5.1.0",
+                "http-signature": "~1.2.0",
+                "is-typedarray": "~1.0.0",
+                "isstream": "~0.1.2",
+                "json-stringify-safe": "~5.0.1",
+                "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
+                "performance-now": "^2.1.0",
+                "qs": "~6.5.2",
+                "safe-buffer": "^5.1.2",
+                "tough-cookie": "~2.4.3",
+                "tunnel-agent": "^0.6.0",
+                "uuid": "^3.3.2"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.4.1",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
+                    "integrity": "sha1-wNWmOycYgArY4esPpSachN1BhF4="
+                },
+                "tough-cookie": {
+                    "version": "2.4.3",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.4.3.tgz",
+                    "integrity": "sha512-Q5srk/4vDM54WJsJio3XNn6K2sCG+CQ8G5Wz6bZhRZoAe/+TxjWB/GlFAnYEbkYVlON9FMk/fE3h2RLpPXo4lQ==",
+                    "requires": {
+                        "psl": "^1.1.24",
+                        "punycode": "^1.4.1"
+                    }
+                }
+            }
+        },
         "require-directory": {
             "version": "2.1.1",
             "resolved": "https://registry.npmjs.org/require-directory/-/require-directory-2.1.1.tgz",
@@ -5106,6 +5196,26 @@
                 "glob": "^7.1.3"
             }
         },
+        "roarr": {
+            "version": "2.14.1",
+            "resolved": "https://registry.npmjs.org/roarr/-/roarr-2.14.1.tgz",
+            "integrity": "sha512-Fhm9shQ8JhpjFnOT7bgxKR7Xcg1Tq+0/Tdy+bloB4sUxxAib4MZDMJ6AjUBRE+798l2MnhhF2JTqbqx1+/kRyQ==",
+            "requires": {
+                "boolean": "^1.0.0",
+                "detect-node": "^2.0.4",
+                "globalthis": "^1.0.0",
+                "json-stringify-safe": "^5.0.1",
+                "semver-compare": "^1.0.0",
+                "sprintf-js": "^1.1.2"
+            },
+            "dependencies": {
+                "sprintf-js": {
+                    "version": "1.1.2",
+                    "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.1.2.tgz",
+                    "integrity": "sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug=="
+                }
+            }
+        },
         "root-check": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/root-check/-/root-check-1.0.0.tgz",
@@ -5177,6 +5287,11 @@
             "resolved": "https://registry.npmjs.org/semver/-/semver-5.6.0.tgz",
             "integrity": "sha512-RS9R6R35NYgQn++fkDWaOmqGoj4Ek9gGs+DPxNUZKuwE183xjJroKvyo1IzVFeXvUrvmALy6FWD5xrdJT25gMg=="
         },
+        "semver-compare": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/semver-compare/-/semver-compare-1.0.0.tgz",
+            "integrity": "sha1-De4hahyUGrN+nvsXiPavxf9VN/w="
+        },
         "semver-diff": {
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
@@ -5198,16 +5313,19 @@
                 "semver": "^5.3.0"
             }
         },
+        "serialize-error": {
+            "version": "4.1.0",
+            "resolved": "https://registry.npmjs.org/serialize-error/-/serialize-error-4.1.0.tgz",
+            "integrity": "sha512-5j9GgyGsP9vV9Uj1S0lDCvlsd+gc2LEPVK7HHHte7IyPwOD4lVQFeaX143gx3U5AnoCi+wbcb3mvaxVysjpxEw==",
+            "requires": {
+                "type-fest": "^0.3.0"
+            }
+        },
         "set-blocking": {
             "version": "2.0.0",
             "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
             "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
             "dev": true
-        },
-        "set-immediate-shim": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/set-immediate-shim/-/set-immediate-shim-1.0.1.tgz",
-            "integrity": "sha1-SysbJ+uAip+NzEgaWOXlb1mfP2E="
         },
         "set-value": {
             "version": "2.0.1",
@@ -6182,6 +6300,11 @@
             "integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
             "dev": true
         },
+        "type-fest": {
+            "version": "0.3.1",
+            "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.3.1.tgz",
+            "integrity": "sha512-cUGJnCdr4STbePCgqNFbpVNCepa+kAVohJs1sLhxzdH+gnEoOd8VhbYa7pD3zZYGiURWM2xzEII3fQcRizDkYQ=="
+        },
         "typedarray": {
             "version": "0.0.6",
             "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
@@ -6450,6 +6573,14 @@
             "integrity": "sha1-X6VeAr58qTTt/BJmVjLoSbcuUgk=",
             "requires": {
                 "semver": "^5.0.1"
+            }
+        },
+        "windows-release": {
+            "version": "3.2.0",
+            "resolved": "https://registry.npmjs.org/windows-release/-/windows-release-3.2.0.tgz",
+            "integrity": "sha512-QTlz2hKLrdqukrsapKsINzqMgOUpQW268eJ0OaOpJN32h272waxR9fkB9VoWRtK7uKHG5EHJcTXQBD8XZVJkFA==",
+            "requires": {
+                "execa": "^1.0.0"
             }
         },
         "winston": {
@@ -6937,18 +7068,17 @@
             }
         },
         "yeoman-doctor": {
-            "version": "3.0.3",
-            "resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-3.0.3.tgz",
-            "integrity": "sha512-L/1PUIReI8cOzAWgmBY64VBCLeH2IEpgtnF3X97BUU6SraQFczeXXIzh6n5idG4jfzMfWRF1lS4zf6wdg7hAbw==",
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/yeoman-doctor/-/yeoman-doctor-4.0.0.tgz",
+            "integrity": "sha512-CP0fwGk5Y+jel+A0AQbyqnIFZRRpkKOeYUibiTSmlgV9PcgNFFVwn86VcUIpDLOqVjF+9v+O9FWQMo+IUcV2mA==",
             "requires": {
                 "ansi-styles": "^3.2.0",
                 "bin-version-check": "^3.0.0",
                 "chalk": "^2.3.0",
-                "each-async": "^1.1.1",
+                "global-agent": "^2.0.0",
                 "global-tunnel-ng": "^2.5.3",
                 "latest-version": "^3.1.0",
                 "log-symbols": "^2.1.0",
-                "object-values": "^1.0.0",
                 "semver": "^5.0.3",
                 "twig": "^1.10.5",
                 "user-home": "^2.0.0"
@@ -7372,9 +7502,9 @@
             }
         },
         "yo": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/yo/-/yo-2.0.6.tgz",
-            "integrity": "sha512-1OleNumZXtE/Lo/ZDPsMXqOX8oXr8tpBXYgUGEDAONYqLX3/n3PV3BWkXI7Iwq6vhuAAYPRLinncUe30izlcSg==",
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/yo/-/yo-3.1.0.tgz",
+            "integrity": "sha512-boSESRRyvfyns3DfzxF2F0LVV97wSEFbKUi1oC7RwnZTA66KZ7Bo3JjOLe7mM6IjjeI0vEZcr4BbFjrSHh8d0Q==",
             "requires": {
                 "async": "^2.6.1",
                 "chalk": "^2.4.1",
@@ -7383,15 +7513,16 @@
                 "cross-spawn": "^6.0.5",
                 "figures": "^2.0.0",
                 "fullname": "^3.2.0",
-                "global-tunnel-ng": "^2.5.3",
+                "global-agent": "^2.0.0",
+                "global-tunnel-ng": "^2.7.1",
                 "got": "^8.3.2",
                 "humanize-string": "^1.0.2",
                 "inquirer": "^6.0.0",
-                "insight": "0.10.1",
-                "lodash": "^4.17.10",
+                "insight": "^0.10.3",
+                "lodash": "^4.17.11",
                 "meow": "^3.0.0",
                 "npm-keyword": "^5.0.0",
-                "opn": "^5.3.0",
+                "open": "^6.3.0",
                 "package-json": "^5.0.0",
                 "parse-help": "^1.0.0",
                 "read-pkg-up": "^4.0.0",
@@ -7403,8 +7534,8 @@
                 "update-notifier": "^2.5.0",
                 "user-home": "^2.0.0",
                 "yeoman-character": "^1.0.0",
-                "yeoman-doctor": "^3.0.1",
-                "yeoman-environment": "^2.3.0",
+                "yeoman-doctor": "^4.0.0",
+                "yeoman-environment": "^2.4.0",
                 "yosay": "^2.0.2"
             },
             "dependencies": {
@@ -7437,6 +7568,18 @@
                     "resolved": "https://registry.npmjs.org/chardet/-/chardet-0.7.0.tgz",
                     "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA=="
                 },
+                "conf": {
+                    "version": "1.4.0",
+                    "resolved": "https://registry.npmjs.org/conf/-/conf-1.4.0.tgz",
+                    "integrity": "sha512-bzlVWS2THbMetHqXKB8ypsXN4DQ/1qopGwNJi1eYbpwesJcd86FBjFciCQX/YwAhp9bM7NVnPFqZ5LpV7gP0Dg==",
+                    "requires": {
+                        "dot-prop": "^4.1.0",
+                        "env-paths": "^1.0.0",
+                        "make-dir": "^1.0.0",
+                        "pkg-up": "^2.0.0",
+                        "write-file-atomic": "^2.3.0"
+                    }
+                },
                 "debug": {
                     "version": "2.6.9",
                     "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
@@ -7446,9 +7589,9 @@
                     }
                 },
                 "external-editor": {
-                    "version": "3.0.3",
-                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.0.3.tgz",
-                    "integrity": "sha512-bn71H9+qWoOQKyZDo25mOMVpSmXROAsTJVVVYzrrtol3d4y+AsKjf4Iwl2Q+IuT0kFSQ1qo166UuIwqYq7mGnA==",
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-3.1.0.tgz",
+                    "integrity": "sha512-hMQ4CX1p1izmuLYyZqLMO/qGNw10wSv9QDCPfzXfyFrOaCSSoRfqE1Kf1s5an66J5JZC62NewG+mK49jOCtQew==",
                     "requires": {
                         "chardet": "^0.7.0",
                         "iconv-lite": "^0.4.24",
@@ -7507,9 +7650,9 @@
                     }
                 },
                 "inquirer": {
-                    "version": "6.4.1",
-                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.4.1.tgz",
-                    "integrity": "sha512-/Jw+qPZx4EDYsaT6uz7F4GJRNFMRdKNeUZw3ZnKV8lyuUgz/YWRCSUAJMZSVhSq4Ec0R2oYnyi6b3d4JXcL5Nw==",
+                    "version": "6.5.2",
+                    "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-6.5.2.tgz",
+                    "integrity": "sha512-cntlB5ghuB0iuO65Ovoi8ogLHiWGs/5yNrtUcKjFhSSiVeAIVpD7koaSU9RM8mpXw5YDi9RdYXGQMaOURB7ycQ==",
                     "requires": {
                         "ansi-escapes": "^3.2.0",
                         "chalk": "^2.4.2",
@@ -7517,13 +7660,29 @@
                         "cli-width": "^2.0.0",
                         "external-editor": "^3.0.3",
                         "figures": "^2.0.0",
-                        "lodash": "^4.17.11",
+                        "lodash": "^4.17.12",
                         "mute-stream": "0.0.7",
                         "run-async": "^2.2.0",
                         "rxjs": "^6.4.0",
                         "string-width": "^2.1.0",
                         "strip-ansi": "^5.1.0",
                         "through": "^2.3.6"
+                    }
+                },
+                "insight": {
+                    "version": "0.10.3",
+                    "resolved": "https://registry.npmjs.org/insight/-/insight-0.10.3.tgz",
+                    "integrity": "sha512-YOncxSN6Omh+1Oqxt+OJAvJVMDKw7l6IEG0wT2cTMGxjsTcroOGW4IR926QDzxg/uZHcFZ2cZbckDWdZhc2pZw==",
+                    "requires": {
+                        "async": "^2.6.2",
+                        "chalk": "^2.4.2",
+                        "conf": "^1.4.0",
+                        "inquirer": "^6.3.1",
+                        "lodash.debounce": "^4.0.8",
+                        "os-name": "^3.1.0",
+                        "request": "^2.88.0",
+                        "tough-cookie": "^3.0.1",
+                        "uuid": "^3.3.2"
                     }
                 },
                 "is-fullwidth-code-point": {
@@ -7568,6 +7727,11 @@
                             "integrity": "sha1-zg6+ql94yxiSXqfYENe1mwEP1RU="
                         }
                     }
+                },
+                "macos-release": {
+                    "version": "2.3.0",
+                    "resolved": "https://registry.npmjs.org/macos-release/-/macos-release-2.3.0.tgz",
+                    "integrity": "sha512-OHhSbtcviqMPt7yfw5ef5aghS2jzFVKEFyCJndQt2YpSQ9qRVSEv2axSJI1paVThEu+FFGs584h/1YhxjVqajA=="
                 },
                 "map-obj": {
                     "version": "1.0.1",
@@ -7617,15 +7781,24 @@
                     "resolved": "https://registry.npmjs.org/onetime/-/onetime-1.1.0.tgz",
                     "integrity": "sha1-ofeDj4MUxRbwXs78vEzP4EtO14k="
                 },
+                "os-name": {
+                    "version": "3.1.0",
+                    "resolved": "https://registry.npmjs.org/os-name/-/os-name-3.1.0.tgz",
+                    "integrity": "sha512-h8L+8aNjNcMpo/mAIBPn5PXCM16iyPGjHNWo6U1YO8sJTMHtEtyczI6QJnLoplswm6goopQkqc7OAnjhWcugVg==",
+                    "requires": {
+                        "macos-release": "^2.2.0",
+                        "windows-release": "^3.1.0"
+                    }
+                },
                 "p-cancelable": {
                     "version": "0.4.1",
                     "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-0.4.1.tgz",
                     "integrity": "sha512-HNa1A8LvB1kie7cERyy21VNeHb2CWJJYqyyC2o3klWFfMGlFmWv2Z7sFgZH8ZiaYL95ydToKTFVXgMV/Os0bBQ=="
                 },
                 "p-limit": {
-                    "version": "2.2.0",
-                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
-                    "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
+                    "version": "2.2.1",
+                    "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.1.tgz",
+                    "integrity": "sha512-85Tk+90UCVWvbDavCLKPOLC9vvY8OwEX/RtKF+/1OADJMVlFfEHOiMTPVyxg7mk/dKa+ipdHm0OUkTvCpMTuwg==",
                     "requires": {
                         "p-try": "^2.0.0"
                     }
@@ -7932,6 +8105,16 @@
                         }
                     }
                 },
+                "tough-cookie": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-3.0.1.tgz",
+                    "integrity": "sha512-yQyJ0u4pZsv9D4clxO69OEjLWYw+jbgspjTue4lTQZLfV0c5l1VmK2y1JK8E9ahdpltPOaAThPcp5nKPUgSnsg==",
+                    "requires": {
+                        "ip-regex": "^2.1.0",
+                        "psl": "^1.1.28",
+                        "punycode": "^2.1.1"
+                    }
+                },
                 "trim-newlines": {
                     "version": "1.0.0",
                     "resolved": "https://registry.npmjs.org/trim-newlines/-/trim-newlines-1.0.0.tgz",
@@ -7943,6 +8126,56 @@
                     "integrity": "sha1-FrXK/Afb42dsGxmZF3gj1lA6yww=",
                     "requires": {
                         "prepend-http": "^2.0.0"
+                    }
+                },
+                "yeoman-environment": {
+                    "version": "2.4.0",
+                    "resolved": "https://registry.npmjs.org/yeoman-environment/-/yeoman-environment-2.4.0.tgz",
+                    "integrity": "sha512-SsvoL0RNAFIX69eFxkUhwKUN2hG1UwUjxrcP+T2ytwdhqC/kHdnFOH2SXdtSN1Ju4aO4xuimmzfRoheYY88RuA==",
+                    "requires": {
+                        "chalk": "^2.4.1",
+                        "cross-spawn": "^6.0.5",
+                        "debug": "^3.1.0",
+                        "diff": "^3.5.0",
+                        "escape-string-regexp": "^1.0.2",
+                        "globby": "^8.0.1",
+                        "grouped-queue": "^0.3.3",
+                        "inquirer": "^6.0.0",
+                        "is-scoped": "^1.0.0",
+                        "lodash": "^4.17.10",
+                        "log-symbols": "^2.2.0",
+                        "mem-fs": "^1.1.0",
+                        "strip-ansi": "^4.0.0",
+                        "text-table": "^0.2.0",
+                        "untildify": "^3.0.3"
+                    },
+                    "dependencies": {
+                        "ansi-regex": {
+                            "version": "3.0.0",
+                            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-3.0.0.tgz",
+                            "integrity": "sha1-7QMXwyIGT3lGbAKWa922Bas32Zg="
+                        },
+                        "debug": {
+                            "version": "3.2.6",
+                            "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
+                            "integrity": "sha512-mel+jf7nrtEl5Pn1Qx46zARXKDpBbvzezse7p7LqINmdoIk8PYP5SySaxEmYv6TZ0JyEKA1hsCId6DIhgITtWQ==",
+                            "requires": {
+                                "ms": "^2.1.1"
+                            }
+                        },
+                        "ms": {
+                            "version": "2.1.2",
+                            "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+                            "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+                        },
+                        "strip-ansi": {
+                            "version": "4.0.0",
+                            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
+                            "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
+                            "requires": {
+                                "ansi-regex": "^3.0.0"
+                            }
+                        }
                     }
                 }
             }

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "uuid": "3.3.2",
         "yeoman-environment": "2.3.4",
         "yeoman-generator": "3.2.0",
-        "yo": "2.0.6"
+        "yo": "3.1.0"
     },
     "devDependencies": {
         "chai": "4.2.0",


### PR DESCRIPTION
Fix warning available in CI:

````sh
> yo@2.0.6 postinstall /home/travis/build/jhipster/generator-jhipster/node_modules/yo
> yodoctor
Yeoman Doctor

Running sanity checks on your system
✔ Global configuration file is valid
✔ NODE_PATH matches the npm root
✔ Node.js version
✔ No .bowerrc file in home directory
✔ No .yo-rc.json file in home directory
✔ npm version
✖ yo version

Your yo version is outdated.

Upgrade to the latest version by running:
npm install -g yo@latest
````
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
