### PR TITLE
merge duplicate volume sections in mssql.yml kubernetes

### DIFF
--- a/generators/kubernetes/templates/db/mssql.yml.ejs
+++ b/generators/kubernetes/templates/db/mssql.yml.ejs
@@ -36,6 +36,9 @@ spec:
      <%_ } _%>
     spec:
       volumes:
+      - name: mssqldb
+        persistentVolumeClaim:
+          claimName: mssql-data
       - name: data
         emptyDir: {}
       containers:
@@ -50,16 +53,12 @@ spec:
           valueFrom:
             secretKeyRef:
               name: mssql
-              key: SA_PASSWORD 
+              key: SA_PASSWORD
         ports:
         - containerPort: 1433
         volumeMounts:
         - name: mssqldb
           mountPath: /var/opt/mssql
-      volumes:
-      - name: mssqldb
-        persistentVolumeClaim:
-          claimName: mssql-data
 
 ---
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -30,6 +30,7 @@ const expectedFiles = {
     ],
     msmongodb: ['./msmongodb/msmongodb-deployment.yml', './msmongodb/msmongodb-mongodb.yml', './msmongodb/msmongodb-service.yml'],
     msmariadb: ['./msmariadb/msmariadb-deployment.yml', './msmariadb/msmariadb-mariadb.yml', './msmariadb/msmariadb-service.yml'],
+    msmssqldb: ['./msmssqldb/msmssqldb-deployment.yml', './msmssqldb/msmssqldb-mssql.yml', './msmssqldb/msmssqldb-service.yml'],
     monolith: [
         './samplemysql/samplemysql-deployment.yml',
         './samplemysql/samplemysql-mysql.yml',
@@ -236,7 +237,7 @@ describe('JHipster Kubernetes Sub Generator', () => {
         });
     });
 
-    describe('gateway, mysql, psql, mongodb, mariadb microservices', () => {
+    describe('gateway, mysql, psql, mongodb, mariadb, mssql microservices', () => {
         before(done => {
             helpers
                 .run(require.resolve('../generators/kubernetes'))
@@ -247,7 +248,7 @@ describe('JHipster Kubernetes Sub Generator', () => {
                 .withPrompts({
                     deploymentApplicationType: 'microservice',
                     directoryPath: './',
-                    chosenApps: ['01-gateway', '02-mysql', '03-psql', '04-mongo', '07-mariadb'],
+                    chosenApps: ['01-gateway', '02-mysql', '03-psql', '04-mongo', '07-mariadb', '11-mssql'],
                     dockerRepositoryName: 'jhipster',
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'default',
@@ -274,6 +275,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
         });
         it('creates expected mariadb files', () => {
             assert.file(expectedFiles.msmariadb);
+        });
+        it('creates expected mssql files', () => {
+            assert.file(expectedFiles.msmssqldb);
         });
         it('create the apply script', () => {
             assert.file(expectedFiles.applyScript);

--- a/test/templates/compose/11-mssql/.yo-rc.json
+++ b/test/templates/compose/11-mssql/.yo-rc.json
@@ -1,0 +1,30 @@
+{
+  "generator-jhipster": {
+    "jhipsterVersion": "3.0.0",
+    "baseName": "msmssqldb",
+    "packageName": "com.mycompany.myapp",
+    "packageFolder": "com/mycompany/myapp",
+    "serverPort": "8081",
+    "authenticationType": "jwt",
+    "cacheProvider": "hazelcast",
+    "enableHibernateCache": true,
+    "databaseType": "sql",
+    "devDatabaseType": "h2Disk",
+    "prodDatabaseType": "mssql",
+    "searchEngine": "no",
+    "buildTool": "maven",
+    "jwtSecretKey": "fd54a45s65fds737b9aafcb3412e07ed99b267f33413274720ddbb7f6c5e64e9f14075f2d7ed041592f0b7657baf8",
+    "enableTranslation": true,
+    "applicationType": "microservice",
+    "testFrameworks": [
+      "gatling"
+    ],
+    "jhiPrefix": "jhi",
+    "skipClient": true,
+    "skipUserManagement": true,
+    "nativeLanguage": "en",
+    "languages": [
+      "en"
+    ]
+  }
+}

--- a/test/templates/compose/11-mssql/src/main/docker/app.yml
+++ b/test/templates/compose/11-mssql/src/main/docker/app.yml
@@ -1,0 +1,23 @@
+version: '2'
+services:
+    msmssql-app:
+        image: msmssql
+        environment:
+            - _JAVA_OPTIONS=-Xmx512m -Xms256m
+            - SPRING_PROFILES_ACTIVE=prod,swagger
+            - MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true
+            - EUREKA_CLIENT_SERVICE_URL_DEFAULTZONE=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/eureka
+            - SPRING_CLOUD_CONFIG_URI=http://admin:$${jhipster.registry.password}@jhipster-registry:8761/config
+            - SPRING_DATASOURCE_URL=jdbc:sqlserver://msmssql-mssql:1433;database=msmssql
+            - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
+    msmssql-mssql:
+        extends:
+            file: mssql.yml
+            service: msmssql-mssql
+    jhipster-registry:
+        extends:
+            file: jhipster-registry.yml
+            service: jhipster-registry
+        environment:
+            - SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_TYPE=native
+            - SPRING_CLOUD_CONFIG_SERVER_COMPOSITE_0_SEARCH_LOCATIONS=file:./central-config/docker-config/

--- a/test/templates/compose/11-mssql/src/main/docker/mssql.yml
+++ b/test/templates/compose/11-mssql/src/main/docker/mssql.yml
@@ -1,0 +1,15 @@
+version: '2'
+services:
+    msmssql-mssql:
+        image: microsoft/mssql-server-linux:latest
+        # volumes are not supported on macOS
+        # volumes:
+        #     - ~/volumes/jhipster/tempdb/mssql/:/var/opt/mssql/data/
+        environment:
+            - ACCEPT_EULA=Y
+            - SA_PASSWORD=yourStrong(!)Password
+            - MSSQL_DATABASE=msmssql
+            - MSSQL_SLEEP=7
+        ports:
+            - 1433:1433
+        command: /bin/bash -c '/opt/mssql/bin/sqlservr & echo "wait $$MSSQL_SLEEP sec for DB to start "; sleep $$MSSQL_SLEEP; /opt/mssql-tools/bin/sqlcmd -U sa -P $$SA_PASSWORD -d tempdb -q "EXIT(CREATE DATABASE $$MSSQL_DATABASE)"; wait;'


### PR DESCRIPTION
Reported in the Gitter, `jhipster kubernetes` fails for apps using MSSQL because there are two `volume` keys in the yml.  Also added it to the tests.



<details>
<summary>Stacktrace</summary>
<pre>
```
(node:19906) UnhandledPromiseRejectionWarning: SyntaxError: Map keys must be unique; "volumes" is repeated (16:7)
  14 |         app: msmssqldb-mssql
  15 |     spec:
> 16 |       volumes:
     |       ^^^^^^^^^^^^^^^^^
> 17 |       - name: data
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 18 |         emptyDir: {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 19 |       containers:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 20 |       - name: mysql
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 21 |         image: microsoft/mssql-server-linux:latest
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 22 |         env:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 23 |         - name: MSSQL_PID
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 24 |           value: "Developer"
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 25 |         - name: ACCEPT_EULA
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 26 |           value: "Y"
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 27 |         - name: MSSQL_SA_PASSWORD
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 28 |           valueFrom:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 29 |             secretKeyRef:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 30 |               name: mssql
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 31 |               key: SA_PASSWORD 
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 32 |         ports:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 33 |         - containerPort: 1433
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 34 |         volumeMounts:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 35 |         - name: mssqldb
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 36 |           mountPath: /var/opt/mssql
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 37 |       volumes:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 38 |       - name: mssqldb
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 39 |         persistentVolumeClaim:
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 40 |           claimName: mssql-data
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 41 | 
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
> 42 | ---
     | ^
  43 | apiVersion: v1
  44 | kind: Service
  45 | metadata:
    at e (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/parser-yaml.js:1:323)
    at Object.parse (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/parser-yaml.js:1:135315)
    at Object.parse$2 [as parse] (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/index.js:10639:19)
    at coreFormat (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/index.js:13856:23)
    at format (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/index.js:14115:73)
    at formatWithCursor (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/index.js:14131:12)
    at /Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/index.js:42399:15
    at Object.format (/Users/ruddell/Contrib/generator-jhipster/node_modules/prettier/index.js:42418:12)
    at prettier.resolveConfig.then.options (/Users/ruddell/Contrib/generator-jhipster/generators/generator-transforms.js:44:39)
    at <anonymous>
```
</pre>
</details>

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
