### PR TITLE
fixed issue about not retrieving url param issue

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -94,7 +94,7 @@
     }
 
     transition() {
-        this.router.navigate(['/<%= entityUrl %>'], {queryParams:
+        this.router.navigate(['/<%= entityUrl %>',
             {
                 page: this.page,
                 size: this.itemsPerPage,
@@ -103,8 +103,7 @@
                 <%_ } _%>
                 sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc')
             }
-        });
-        this.loadAll();
+        ]);
     }
 
     clear() {


### PR DESCRIPTION
In angular pagination template, `transition()` in the previous version add params in ' ? a = 1 & b = 2' way, but the way retrieve params in activatedRoute goes angular way: '; a=1; b=2', which causes some issue when you retrieve params from the url in constructor function.
In angular, the best practice is to deal with url params in angular way, which is what I updated in transition().
The issue is easily reproduced when you go to page 2(if you choose pagination when generate your entity), and jump to another page, and then click go back button, the page would go to 0 again, the current search is just the same, when you redirect to this page, the current search just clears.
