### PR TITLE
change swagger client auth key to match api.yml

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/swagger-ui/index.html.ejs
@@ -106,7 +106,7 @@
                 <%_ } else if (authenticationType === 'jwt') { _%>
                     var authToken = JSON.parse(localStorage.getItem("<%=jhiPrefixDashed %>-authenticationtoken") || sessionStorage.getItem("<%=jhiPrefixDashed %>-authenticationtoken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
-                    window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
+                    window.swaggerUi.api.clientAuthorizations.add("jwt", apiKeyAuth);
                 <%_ } _%>
                 }
 

--- a/generators/client/templates/react/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/swagger-ui/index.html.ejs
@@ -111,7 +111,7 @@
                 <%_ } else if (authenticationType === 'jwt') { _%>
                     var authToken = JSON.parse(localStorage.getItem("jhi-authenticationToken") || sessionStorage.getItem("jhi-authenticationToken"));
                     var apiKeyAuth = new SwaggerClient.ApiKeyAuthorization("Authorization", "Bearer " + authToken, "header");
-                    window.swaggerUi.api.clientAuthorizations.add("bearer", apiKeyAuth);
+                    window.swaggerUi.api.clientAuthorizations.add("jwt", apiKeyAuth);
                 <%_ } _%>
                 }
 


### PR DESCRIPTION
previously this was "bearer" whereas api.yml uses "jwt" as the security
key name causing authorization headers to not be sent

Fix #10330

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
