### PR TITLE
Remove duplicated code.

### DIFF
--- a/generators/server/templates/src/main/java/package/domain/AbstractAuditingEntity.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/AbstractAuditingEntity.java.ejs
@@ -22,9 +22,6 @@ package <%=packageName%>.domain;
 import com.couchbase.client.java.repository.annotation.Field;
 <%_ } _%>
 import com.fasterxml.jackson.annotation.JsonIgnore;
-<%_ if (databaseType === 'sql') { _%>
-import org.hibernate.envers.Audited;
-<%_ } _%>
 <%_ if (!reactive) { _%>
 import org.springframework.data.annotation.CreatedBy;
 <%_ } _%>
@@ -54,7 +51,6 @@ import javax.persistence.MappedSuperclass;
  */
 <%_ if (databaseType === 'sql') { _%>
 @MappedSuperclass
-@Audited
 @EntityListeners(AuditingEntityListener.class)
 <%_ } _%>
 public abstract class AbstractAuditingEntity implements Serializable {


### PR DESCRIPTION
You use `@EntityListeners(AuditingEntityListener.class)` to audit some entity like User entity, but this is spring data auditing based on jpa auditing, which use lifecycle call backs like `@Prepersist`, `@Preupdate`  to make auditing works.
But you also added `@Audited` in hibernate enver, which actually do nothing here. What hibernate do behind the `@Audited` is way different than custom jpa auditing, it creates a new auditing table and records every changes, deletion included, which enables entity versioning.
I guess `@Audited` is somewhat duplicate code, since all you need is `@EntityListeners(AuditingEntityListener.class)` here.
