### PR TITLE
Use require.resolve to find yeoman library when checking blueprint version.

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -832,7 +832,7 @@ module.exports = class extends Generator {
         }
 
         // Path to the yo cli script in generator-jhipster's node_modules
-        const yoInternalCliPath = path.join(__dirname, '../node_modules/yo/lib/cli.js');
+        const yoInternalCliPath = require.resolve('yo/lib/cli.js');
 
         shelljs.exec(`node ${yoInternalCliPath} --generators`, { silent: true }, (err, stdout, stderr) => {
             if (!stdout.includes(` ${blueprint}\n`) && !stdout.includes(` ${generatorName}\n`)) {


### PR DESCRIPTION
Fix #10257 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
