### PR TITLE
Fix React+Yarn build, using resolution for redux lib

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -177,7 +177,8 @@ limitations under the License.
   },
 <%_ if (clientPackageManager === 'yarn') { _%>
   "resolutions": {
-    "@types/react": "16.8.10"
+    "@types/react": "16.8.10",
+    "redux": "4.0.1"
   },
 <%_ } _%>
   "engines": {


### PR DESCRIPTION
It will fix the daily builds for React+Yarn:
https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=5298&view=logs&j=1325b5b4-61f4-5784-74f4-9f398d404aa2

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
