### PR TITLE
fix clientTheme assignation

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -214,6 +214,9 @@ module.exports = class extends BaseBlueprintGenerator {
                 }
                 this.clientFramework = configuration.get('clientFramework');
                 this.clientTheme = configuration.get('clientTheme');
+                if (!this.clientTheme) {
+                    this.clientTheme = 'none';
+                }
                 const testFrameworks = configuration.get('testFrameworks');
                 if (testFrameworks) {
                     this.testFrameworks = testFrameworks;


### PR DESCRIPTION
For SecurityConfiguration class on a brand new JHipster generation:
The clientTheme variable is not defined to `'none'` so `clientTheme !== 'none'` is `true` so we don't have (I think) the good code for this class.

When we run again `jhipster` on this generated project, this time, clientTheme is set to 'none', so SecurityConfiguration is modified and it is the one we want (to be confirmed @atomfrede @SudharakaP ) . 

Everything was fine about clientTheme assignation on client side (client/index.js) code but not on the server side (server/index.js, fixed by this PR).