### PR TITLE
remove extra semicolon causing 'mvn verify' failure

### DIFF
--- a/generators/server/templates/src/test/java/package/ArchTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/ArchTest.java.ejs
@@ -20,7 +20,7 @@ package <%=packageName%>;
 
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ClassFileImporter;
-import com.tngtech.archunit.core.importer.ImportOption;;
+import com.tngtech.archunit.core.importer.ImportOption;
 import org.junit.jupiter.api.Test;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;


### PR DESCRIPTION
`./mvnw verify` fails on my Mac with the following error:
```
[INFO] Running com.mycompany.myapp.ArchTest
[ERROR] Tests run: 1, Failures: 0, Errors: 1, Skipped: 0, Time elapsed: 0.016 s <<< FAILURE! - in com.mycompany.myapp.ArchTest
[ERROR] servicesAndRepositoriesShouldNotDependOnWebLayer  Time elapsed: 0.011 s  <<< ERROR!
java.lang.Error: 
Unresolved compilation problem: 
	Syntax error on token ";", delete this token

	at com.mycompany.myapp.ArchTest.<init>(ArchTest.java:5)
```
```
##### **Environment and Tools**
java version "1.8.0_181"
Java(TM) SE Runtime Environment (build 1.8.0_181-b13)
Java HotSpot(TM) 64-Bit Server VM (build 25.181-b13, mixed mode)
git version 2.20.1
node: v10.16.0
npm: 6.10.1
```
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
