### PR TITLE
Fix duplicated blueprints loaded from config

### DIFF
--- a/generators/utils.js
+++ b/generators/utils.js
@@ -428,7 +428,7 @@ function getAllJhipsterConfig(generator, force, basePath = '') {
         // merge the blueprint configs if available
         const oldBlueprintName = configuration.blueprint;
         const blueprints = configuration.blueprints || [];
-        if (oldBlueprintName && blueprints.indexOf(oldBlueprintName) === -1) {
+        if (oldBlueprintName && blueprints.findIndex(e => e.name === oldBlueprintName) === -1) {
             const oldBlueprintVersion = configuration.blueprintVersion || 'latest';
             blueprints.push({
                 name: oldBlueprintName,

--- a/test/templates/ngx-blueprint/.yo-rc.json
+++ b/test/templates/ngx-blueprint/.yo-rc.json
@@ -42,6 +42,13 @@
             "en",
             "fr"
         ],
-        "blueprint": "generator-jhipster-myblueprint"
+        "blueprint": "generator-jhipster-myblueprint",
+        "blueprintVersion": "0.1",
+        "blueprints": [
+            {
+                "name": "generator-jhipster-myblueprint",
+                "version": "0.2"
+            }
+        ]
     }
 }

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -121,39 +121,73 @@ describe('JHipster Utils', () => {
         });
     });
     describe('::getAllJhipsterConfig', () => {
-        const cwd = process.cwd();
-        const configRootDir = './test/templates/default';
-        const expectedConfig = {
-            applicationType: 'monolith',
-            baseName: 'sampleMysql',
-            packageName: 'com.mycompany.myapp',
-            packageFolder: 'com/mycompany/myapp',
-            authenticationType: 'session',
-            cacheProvider: 'ehcache',
-            websocket: 'no',
-            databaseType: 'sql',
-            devDatabaseType: 'h2Disk',
-            prodDatabaseType: 'mysql',
-            searchEngine: 'no',
-            buildTool: 'maven',
-            enableTranslation: true,
-            nativeLanguage: 'en',
-            languages: ['en', 'fr'],
-            rememberMeKey: '2bb60a80889aa6e6767e9ccd8714982681152aa5',
-            testFrameworks: ['gatling']
-        };
+        describe('without blueprint', () => {
+            const cwd = process.cwd();
+            const configRootDir = './test/templates/default';
+            const expectedConfig = {
+                applicationType: 'monolith',
+                baseName: 'sampleMysql',
+                packageName: 'com.mycompany.myapp',
+                packageFolder: 'com/mycompany/myapp',
+                authenticationType: 'session',
+                cacheProvider: 'ehcache',
+                websocket: 'no',
+                databaseType: 'sql',
+                devDatabaseType: 'h2Disk',
+                prodDatabaseType: 'mysql',
+                searchEngine: 'no',
+                buildTool: 'maven',
+                enableTranslation: true,
+                nativeLanguage: 'en',
+                languages: ['en', 'fr'],
+                rememberMeKey: '2bb60a80889aa6e6767e9ccd8714982681152aa5',
+                testFrameworks: ['gatling']
+            };
 
-        it('load config from alternate directory', () => {
-            const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
-            assert.objectContent(loadedConfig, expectedConfig);
+            it('load config from alternate directory', () => {
+                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
+                assert.objectContent(loadedConfig, expectedConfig);
+            });
+            it('load config from current working directory', () => {
+                process.chdir(configRootDir);
+                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true);
+                assert.objectContent(loadedConfig, expectedConfig);
+            });
+            after(() => {
+                process.chdir(cwd);
+            });
         });
-        it('load config from current working directory', () => {
-            process.chdir(configRootDir);
-            const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true);
-            assert.objectContent(loadedConfig, expectedConfig);
-        });
-        after(() => {
-            process.chdir(cwd);
+        describe('with blueprint', () => {
+            const configRootDir = './test/templates/ngx-blueprint';
+
+            it('merges config from main generator and blueprint', () => {
+                const expectedConfig = {
+                    applicationType: 'monolith',
+                    baseName: 'myblueprint',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    authenticationType: 'jwt',
+                    cacheProvider: 'ehcache',
+                    websocket: false,
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Disk',
+                    prodDatabaseType: 'mysql',
+                    searchEngine: false,
+                    buildTool: 'maven',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['en', 'fr'],
+                    testFrameworks: ['gatling', 'protractor'],
+                    jhiPrefix: 'jhi'
+                };
+                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
+                assert.objectContent(loadedConfig, expectedConfig);
+            });
+            it('correctly handles deprecated blueprint information', () => {
+                const expectedBlueprints = [{ name: 'generator-jhipster-myblueprint', version: '0.2' }];
+                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
+                assert.deepStrictEqual(loadedConfig.get('blueprints'), expectedBlueprints);
+            });
         });
     });
 });


### PR DESCRIPTION
I encountered this bug while upgrading one of my project using a blueprint.

The .yo-rc.json contains somethings like that: 
```
{
  "generator-jhipster": {
    ...
    "blueprint": "generator-jhipster-xxxx",
    "blueprintVersion": "0.2.5",
    "blueprints": [
      {
        "name": "generator-jhipster-xxxx",
        "version": "0.3.0"
      }
    ]
  }
}
```

During the automatic upgrade I noticed that it was detecting twice the blueprint, and then trying to install both version.

The bug comes from the code merging new `blueprints` info and old `blueprint` info in `getAllJhipsterConfig()`. I added a test to verify the issue, and another new test for verify configuration merge with multiple generators (jhipster and blueprints) are involved.

Also: the second commit is an attempt to factorize the code that merges old and new blueprints information, to avoid duplication and potential issues.  I'm open to suggestion on that point 😉

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
