### PR TITLE
Prevents duplicated imports of enums in DTO

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -62,9 +62,9 @@ import java.util.UUID;
 <%_ if (fieldsContainBlob && databaseType === 'sql') { _%>
 import javax.persistence.Lob;
 <%_ } _%>
-<%_ for (idx in fields) { if (fields[idx].fieldIsEnum) { _%>
-import <%=packageName%>.domain.enumeration.<%= fields[idx].fieldType %>;
-<%_ } } _%>
+<%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
+import <%=packageName%>.domain.enumeration.<%= element %>;
+<%_ }); _%>
 
 /**
  * A DTO for the {@link <%=packageName%>.domain.<%= asEntity(entityClass) %>} entity.


### PR DESCRIPTION
This happens e.g. with the following JDL:
```
enum MyEnum { A, B }
entity MyEntity {
    value1 MyEnum
    value2 MyEnum
}
dto * with mapstruct
```
MyEntityDTO will contain the import of MyEnum twice.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
