### PR TITLE
Gradle: change webpackBuildDev to webpack and fix CI command

### DIFF
--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -54,7 +54,7 @@ bootRun {
 }
 
 <%_ if (!skipClient) { _%>
-task webpackBuildDev(type: <%= _.upperFirst(clientPackageManager) %>Task) {
+task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task) {
     <%_ if (clientPackageManager==='npm') { _%>
     inputs.files("package-lock.json")
     <%_ } else { _%>
@@ -99,6 +99,6 @@ processResources {
 }
 
 <%_ if (!skipClient) { _%>
-processResources.dependsOn webpackBuildDev
+processResources.dependsOn webpack
 bootJar.dependsOn processResources
 <%_ } _%>

--- a/test-integration/scripts/21-tests-backend.sh
+++ b/test-integration/scripts/21-tests-backend.sh
@@ -19,7 +19,7 @@ fi
 if [ -f "mvnw" ]; then
     ./mvnw -ntp javadoc:javadoc
 elif [ -f "gradlew" ]; then
-    ./gradlew javadoc
+    ./gradlew javadoc -x webpack
 fi
 
 #-------------------------------------------------------------------------------
@@ -46,7 +46,7 @@ if [ -f "mvnw" ]; then
         -Dlogging.level.org.springframework.security=OFF
 
 elif [ -f "gradlew" ]; then
-    ./gradlew test -P-webpack integrationTest \
+    ./gradlew test integrationTest -x webpack \
         -Dlogging.level.ROOT=OFF \
         -Dlogging.level.org.zalando=OFF \
         -Dlogging.level.io.github.jhipster=OFF \


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

This PR is follow up to #10392 to fix Gradle part in this line: https://github.com/jhipster/generator-jhipster/pull/10392/files#diff-4451b02339edda1561d29b286ed1d9f7R49

In Gradle exclude task syntax is `-x <taskName>`

Changing also webpack task name in Gradle `dev` profile from `webpackBuildDev` to `webpack` to avoid distributing this inappropriate name as I explained and proposed in https://github.com/jhipster/generator-jhipster/issues/10363#issuecomment-530761661

Gradle allow task name abbreviations as described here: https://docs.gradle.org/current/userguide/command_line_interface.html#task_name_abbreviation so `-x webpack` would work also with current task name `webpackBuildDev`, but I think using abbreviations makes code poorly readable and should be avoided.

In CI added `-x webpack` also to javadoc generation to really avoid webpack execution in backend tests.

Using `-x webpack` in Gradle workflow in CI reduced job time in Travis from 25 minutes to 21 minutes.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
