### PR TITLE
Revert upgrade openapitools

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -147,7 +147,7 @@
     <%_ if (protractorTests) { _%>
     "webdriver-manager": "12.1.6",
     <%_ } _%>
-    "@openapitools/openapi-generator-cli": "0.0.19-4.1.2",
+    "@openapitools/openapi-generator-cli": "0.0.14-4.0.2",
     "webpack": "4.39.3",
     "webpack-cli": "3.3.7",
     "webpack-dev-server": "3.8.0",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -166,7 +166,7 @@ limitations under the License.
     <%_ if (protractorTests) { _%>
     "webdriver-manager": "12.1.6",
     <%_ } _%>
-    "@openapitools/openapi-generator-cli": "0.0.19-4.1.2",
+    "@openapitools/openapi-generator-cli": "0.0.14-4.0.2",
     "webpack": "4.28.4",
     "webpack-cli": "3.3.0",
     "webpack-dev-server": "3.2.1",

--- a/generators/server/templates/package.json.ejs
+++ b/generators/server/templates/package.json.ejs
@@ -30,7 +30,7 @@
     "<%= module.name %>": "<%= module.version %>",
     <%_ }); _%>
     "generator-jhipster": "<%= jhipsterVersion %>",
-    "@openapitools/openapi-generator-cli": "0.0.19-4.1.2"
+    "@openapitools/openapi-generator-cli": "0.0.14-4.0.2"
   },
   "engines": {
     "node": ">=8.9.0"

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,9 +45,9 @@
             "integrity": "sha512-shAmDyaQC4H92APFoIaVDHCx5bStIocgvbwQyxPRrbUY20V1EYTbSDchWbuwlMG3V17cprZhA6+78JfB+3DTPw=="
         },
         "@openapitools/openapi-generator-cli": {
-            "version": "0.0.19-4.1.2",
-            "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-0.0.19-4.1.2.tgz",
-            "integrity": "sha512-Os5Xv/qKw/accUGadjcPIgbk63LKDJi9ts2gQJIWC1y0BuJxYVnoBLuEAujjIgB/zdDZODNrqllf+zlmmNg20w==",
+            "version": "0.0.14-4.0.2",
+            "resolved": "https://registry.npmjs.org/@openapitools/openapi-generator-cli/-/openapi-generator-cli-0.0.14-4.0.2.tgz",
+            "integrity": "sha512-x4gKaGNgG5Eqt43B4V814Bp0zUBT5h9/K0Tz4oTi5wGy+5sqU5/gElKys0jmM6wvEio2OXJm728BIFuKPuFi5w==",
             "dev": true
         },
         "@sindresorhus/is": {

--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
         "sinon": "7.2.5",
         "yeoman-assert": "3.1.1",
         "yeoman-test": "1.9.1",
-        "@openapitools/openapi-generator-cli": "0.0.19-4.1.2"
+        "@openapitools/openapi-generator-cli": "0.0.14-4.0.2"
     },
     "resolutions": {
         "inquirer": "6.3.1"


### PR DESCRIPTION
If we upgrade to `0.0.19-4.1.2`, there are some problems:
- `npm test` failed
- after using openapi-client, the project won't compile
- it is related to missing `ApiKeyRequestInterceptor.java` and `ClientConfiguration.java`

The easiest way for now is to revert the upgrade for now.

cc @DanielFran 

_____


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
