### PR TITLE
Remove redundant entryComponents in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/entities/entity.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/entities/entity.module.ts.ejs
@@ -24,9 +24,6 @@ import { RouterModule } from '@angular/router';
         RouterModule.forChild([
             /* jhipster-needle-add-entity-route - JHipster will add entity modules routes here */
         ])
-    ],
-    declarations: [],
-    entryComponents: [],
-    providers: []
+    ]
 })
 export class <%=angularXAppName%>EntityModule {}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -44,10 +44,7 @@ const ENTITY_STATES = [
         <%= entityAngularName %>DeletePopupComponent,
     ],
     entryComponents: [
-        <%= entityAngularName %>Component,
-        <%= entityAngularName %>UpdateComponent,
-        <%= entityAngularName %>DeleteDialogComponent,
-        <%= entityAngularName %>DeletePopupComponent,
+        <%= entityAngularName %>DeleteDialogComponent
     ]
 })
 export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {


### PR DESCRIPTION
As explained in https://angular.io/guide/entry-components, only dynamically loaded components must be in entryComponents array, so leaving only dynamically loaded components there to follow best practice.

This redundancy was found while reviewing #10408 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
