### PR TITLE
add noopener noreferrer to external link in React gateway

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/gateway/gateway.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/gateway/gateway.tsx.ejs
@@ -66,7 +66,7 @@ export class GatewayPage extends React.Component<IGatewayPageProps> {
           <tbody>
             {route.serviceInstances.map((instance, i) =>
               <tr key={instance.instanceInfo + '-info'}>
-                <td><a href={instance.uri} target="_blank">{instance.uri}</a></td>
+                <td><a href={instance.uri} target="_blank" rel="noopener noreferrer">{instance.uri}</a></td>
                 <td>{this.badgeInfo(instance.instanceInfo)}</td>
                 <td>{this.metadata(instance.metadata)}</td>
               </tr>


### PR DESCRIPTION
Fix #10412

This only commit fixes the bug when lauching again `./mvnw` on the React API gateway but there are other external links with target="_blank" that should maybe be fixed in : 

- gateway.component.html.ejs
- microservices_index.html.ejs

What do you think about that?

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed