### PR TITLE
enable colored output for gradle on linux/gnome environment

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -222,6 +222,9 @@ spring:
                 size: 2
     thymeleaf:
         mode: HTML
+    output:
+        ansi:
+          console-available: true
 <%_ if (authenticationType === 'oauth2') { _%>
     security:
         oauth2:


### PR DESCRIPTION
Using gnome or vte terminals gradle is not very good in detecting it is running in an interactive terminal (depending on some upcoming things in vte based terminals). With this change `./gradlew` outputs colored logs but keeps the auto detection enabled.

https://stackoverflow.com/questions/28783832/getting-spring-boot-color-console-logging-working-within-intellij

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
