### PR TITLE
Remove duplicated import in CacheConfiguration.java

### DIFF
--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -24,12 +24,6 @@ import java.time.Duration;
 import org.ehcache.config.builders.*;
 import org.ehcache.jsr107.Eh107Configuration;
 
-    <%_ if (enableHibernateCache) { _%>
-import org.hibernate.cache.jcache.ConfigSettings;
-    <%_ } _%>
-import io.github.jhipster.config.JHipsterProperties;
-
-<%_ } _%>
 <%_ if (cacheProvider === 'caffeine') { _%>
 import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
 import java.util.OptionalLong;


### PR DESCRIPTION
From:
```
<%_ if (enableHibernateCache) { _%>
import org.hibernate.cache.jcache.ConfigSettings;
<%_ } _%>
import io.github.jhipster.config.JHipsterProperties;

<%_ } _%>
<%_ if (cacheProvider === 'caffeine') { _%>
import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
import java.util.OptionalLong;
import java.util.concurrent.TimeUnit;

<%_ if (enableHibernateCache) { _%>
import org.hibernate.cache.jcache.ConfigSettings;
<%_ } _%>
import io.github.jhipster.config.JHipsterProperties;

<%_ } _%>
```
to:

```
<%_ if (cacheProvider === 'caffeine') { _%>
import com.github.benmanes.caffeine.jcache.configuration.CaffeineConfiguration;
import java.util.OptionalLong;
import java.util.concurrent.TimeUnit;

<%_ if (enableHibernateCache) { _%>
import org.hibernate.cache.jcache.ConfigSettings;
<%_ } _%>
import io.github.jhipster.config.JHipsterProperties;

<%_ } _%>
```

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
