### PR TITLE
Fix entity test lint in Angular if relationshipRequired or useJPADeri…

### DIFF
--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -16,15 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor, <% } %>promise } from 'protractor';
-import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
-
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { <%= entityClass %>ComponentsPage, <%= entityClass %>DeleteDialog, <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
-<%_ if (fieldsContainBlobOrImage) { _%>
-import * as path from 'path';
-<%_ } _%>
 <%_
 let elementGetter = `getText()`;
 let openBlockComment = ``;
@@ -39,6 +30,15 @@ for (let relationship of relationships) {
         break;
     }
 } _%>
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor, <% } %>promise } from 'protractor';
+import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
+
+// eslint-disable-next-line @typescript-eslint/no-unused-vars
+import { <%= entityClass %>ComponentsPage,<%= openBlockComment %><%= entityClass %>DeleteDialog,<%= closeBlockComment %> <%= entityClass %>UpdatePage } from './<%= entityFileName %>.page-object';
+<%_ if (fieldsContainBlobOrImage) { _%>
+import * as path from 'path';
+<%_ } _%>
 
 const expect = chai.expect;
 


### PR DESCRIPTION
…vedIdentifier

This PR removes lint warnings `@typescript-eslint/no-unused-vars` from those entity tests which has relationship with `relationship.relationshipRequired = true` or `relationship.useJPADerivedIdentifier = true`.  
See current warnings in the latest daily build: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=5652&view=logs&jobId=156bdf7b-70dc-51a2-f964-752e46e62347&taskId=a5e5751f-49b1-5b43-b771-5a00c195aeaf&lineStart=23&lineEnd=41&colStart=1&colEnd=36

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
