### PR TITLE
Graceful shutdown of pods with Kubernetes (Set shell to bash)

### DIFF
--- a/generators/server/templates/gradle/docker.gradle.ejs
+++ b/generators/server/templates/gradle/docker.gradle.ejs
@@ -24,7 +24,7 @@ jib {
         image = "<%= baseName.toLowerCase() %>:latest"
     }
     container {
-        entrypoint = ["sh", "-c", "chmod +x /entrypoint.sh && sync && /entrypoint.sh"]
+        entrypoint = ["bash", "-c", "chmod +x /entrypoint.sh && sync && /entrypoint.sh"]
         ports = ["<%= serverPort %>"<% if (cacheProvider === 'hazelcast') { %>, "5701/udp" <% } %>]
         environment = [
             <%_ if (cacheProvider === 'infinispan') { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1040,7 +1040,7 @@
                         </to>
                         <container>
                             <entrypoint>
-                                <shell>sh</shell>
+                                <shell>bash</shell>
                                 <option>-c</option>
                                 <arg>chmod +x /entrypoint.sh &amp;&amp; sync &amp;&amp; /entrypoint.sh</arg>
                             </entrypoint>


### PR DESCRIPTION
This PR fix https://github.com/jhipster/generator-jhipster/issues/10186

You can find here more details: https://pracucci.com/graceful-shutdown-of-kubernetes-pods.html

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
