### PR TITLE
Default Caching Option for Microservices Should be Hazelcast

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -250,7 +250,7 @@ function askForServerSideOpts(meta) {
                     name: 'No - Warning, when using an SQL database, this will disable the Hibernate 2nd level cache!'
                 }
             ],
-            default: applicationType === 'microservice' || applicationType === 'uaa' ? 1 : 0
+            default: applicationType === 'microservice' || applicationType === 'uaa' ? 2 : 0
         },
         {
             when: response =>


### PR DESCRIPTION
Going through some micro-service workflows, I discovered our recent addition of Caffeine cache has made Caffeine the default option for Micro-services, instead of Hazelcast. This pull fixes that. :smile: 

Related to  #9351

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
