### PR TITLE
Fix markdown link in leaflet installation instructions for importing the css file

### DIFF
--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -194,7 +194,7 @@ Edit [<%= CLIENT_MAIN_SRC_DIR %>app/vendor.ts](<%= CLIENT_MAIN_SRC_DIR %>app/ven
 import 'leaflet/dist/leaflet.js';
 ~~~
 
-Edit [<%= CLIENT_MAIN_SRC_DIR %>content/css/vendor.css](<%= CLIENT_MAIN_SRC_DIR %>content/css/vendor.css) file:
+Edit [<%= CLIENT_MAIN_SRC_DIR %>content/scss/vendor.scss](<%= CLIENT_MAIN_SRC_DIR %>content/scss/vendor.scss) file:
 ~~~
 @import '~leaflet/dist/leaflet.css';
 ~~~


### PR DESCRIPTION
Since the change to Sass happened leaflet.css should be imported in `<%= CLIENT_MAIN_SRC_DIR %>content/scss/vendor.scss` rather than the old `<%= CLIENT_MAIN_SRC_DIR %>content/css/vendor.css`

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [X] Tests are added where necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
