### PR TITLE
change to supported  jest-junit api from removed api

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -18,7 +18,7 @@ module.exports = {
     moduleNameMapper: mapTypescriptAliasToJestAlias(),
     reporters: [
         'default',
-        [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/TESTS-results-jest.xml' } ]
+        [ 'jest-junit', { outputDirectory: './<%= BUILD_DIR %>test-results/', outputName: 'TESTS-results-jest.xml' } ]
     ],
     testResultsProcessor: 'jest-sonar-reporter',
     transformIgnorePatterns: ['node_modules/'],

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -119,7 +119,7 @@ limitations under the License.
     <%_ } _%>
     "identity-obj-proxy": "3.0.0",
     "jest": "24.5.0",
-    "jest-junit": "6.3.0",
+    "jest-junit": "8.0.0",
     "jest-sonar-reporter": "2.0.0",
     "json-loader": "0.5.7",
     <%_ if (!skipCommitHook) { _%>

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -18,7 +18,7 @@ module.exports = {
   }),
   reporters: [
     'default',
-    [ 'jest-junit', { output: './<%= BUILD_DIR %>test-results/TESTS-results-jest.xml' } ]
+    [ 'jest-junit', { outputDirectory: './<%= BUILD_DIR %>test-results/', outputName: 'TESTS-results-jest.xml' } ]
   ],
   testResultsProcessor: 'jest-sonar-reporter',
   testPathIgnorePatterns: [


### PR DESCRIPTION
since jest-unit 8.0.0 there is no longer an output parameter; Use OutputDirectory and OutputName instead

Fix #10445

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
