### PR TITLE
Add aws-sdk and Related Dependencies to package.json

### DIFF
--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const shelljs = require('shelljs');
 const S3 = require('./s3.js');
 const Rds = require('./rds.js');
 const Eb = require('./eb.js');
@@ -27,21 +26,8 @@ let generator;
 
 const AwsFactory = (module.exports = function AwsFactory(generatorRef, cb) {
     generator = generatorRef;
-    try {
-        Aws = require('aws-sdk'); // eslint-disable-line
-        cb();
-    } catch (e) {
-        generator.log('Installing AWS dependencies');
-        let installCommand = 'yarn add aws-sdk progress uuid';
-        if (generator.config.get('clientPackageManager') === 'npm') {
-            installCommand = 'npm install aws-sdk progress uuid --save';
-        }
-        shelljs.exec(installCommand, { silent: false }, code => {
-            if (code !== 0) generator.error('Something went wrong while installing the aws-sdk\n');
-            Aws = require('aws-sdk'); // eslint-disable-line
-            cb();
-        });
-    }
+    Aws = require('aws-sdk'); // eslint-disable-line
+    cb();
 });
 
 AwsFactory.prototype.init = function initAws(options) {

--- a/generators/aws/lib/aws.js
+++ b/generators/aws/lib/aws.js
@@ -26,8 +26,12 @@ let generator;
 
 const AwsFactory = (module.exports = function AwsFactory(generatorRef, cb) {
     generator = generatorRef;
-    Aws = require('aws-sdk'); // eslint-disable-line
-    cb();
+    try {
+        Aws = require('aws-sdk'); // eslint-disable-line
+        cb();
+    } catch (e) {
+        generator.error(`Something went wrong while running jhipster:aws:\n${e}`);
+    }
 });
 
 AwsFactory.prototype.init = function initAws(options) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -373,6 +373,29 @@
             "resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
             "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
         },
+        "aws-sdk": {
+            "version": "2.533.0",
+            "resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.533.0.tgz",
+            "integrity": "sha512-OSe7C0jnBdgfzedOtK+TgBEwtJaaZovm+Q2fbqIlfhUWg3rhhkt3oLyQ9bRD30/CFaunLhLr/8HAAN+/x+DWAA==",
+            "requires": {
+                "buffer": "4.9.1",
+                "events": "1.1.1",
+                "ieee754": "1.1.13",
+                "jmespath": "0.15.0",
+                "querystring": "0.2.0",
+                "sax": "1.2.1",
+                "url": "0.10.3",
+                "uuid": "3.3.2",
+                "xml2js": "0.4.19"
+            },
+            "dependencies": {
+                "uuid": {
+                    "version": "3.3.2",
+                    "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+                    "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+                }
+            }
+        },
         "aws-sign2": {
             "version": "0.7.0",
             "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
@@ -458,6 +481,11 @@
                     "integrity": "sha512-s5kLOcnH0XqDO+FvuaLX8DDjZ18CGFk7VygH40QoKPUQhW4e2rvM0rwUq0t8IQDOwYSeLK01U90OjzBTme2QqA=="
                 }
             }
+        },
+        "base64-js": {
+            "version": "1.3.1",
+            "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
+            "integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
         },
         "bcrypt-pbkdf": {
             "version": "1.0.2",
@@ -569,6 +597,16 @@
             "resolved": "https://registry.npmjs.org/browser-stdout/-/browser-stdout-1.3.1.tgz",
             "integrity": "sha512-qhAVI1+Av2X7qelOfAIYwXONood6XlZE/fXaBSmW/T5SzLAmCgzi+eiWE7fUvbHaeNBQH13UftjpXxsfLkMpgw==",
             "dev": true
+        },
+        "buffer": {
+            "version": "4.9.1",
+            "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+            "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+            "requires": {
+                "base64-js": "^1.0.2",
+                "ieee754": "^1.1.4",
+                "isarray": "^1.0.0"
+            }
         },
         "buffer-alloc": {
             "version": "1.2.0",
@@ -1956,6 +1994,11 @@
             "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
             "dev": true
         },
+        "events": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+            "integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+        },
         "execa": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/execa/-/execa-1.0.0.tgz",
@@ -2825,6 +2868,11 @@
                 "safer-buffer": ">= 2.1.2 < 3"
             }
         },
+        "ieee754": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
+            "integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+        },
         "ignore": {
             "version": "3.3.10",
             "resolved": "https://registry.npmjs.org/ignore/-/ignore-3.3.10.tgz",
@@ -3340,6 +3388,11 @@
                     "integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
                 }
             }
+        },
+        "jmespath": {
+            "version": "0.15.0",
+            "resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+            "integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
         },
         "js-object-pretty-print": {
             "version": "0.3.0",
@@ -4900,8 +4953,7 @@
         "progress": {
             "version": "2.0.3",
             "resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-            "dev": true
+            "integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
         },
         "promise": {
             "version": "8.0.3",
@@ -4954,6 +5006,11 @@
                 "object-assign": "^4.1.0",
                 "strict-uri-encode": "^1.0.0"
             }
+        },
+        "querystring": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
+            "integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
         },
         "quick-lru": {
             "version": "1.1.0",
@@ -5350,6 +5407,11 @@
             "resolved": "https://registry.npmjs.org/samsam/-/samsam-1.3.0.tgz",
             "integrity": "sha512-1HwIYD/8UlOtFS3QO3w7ey+SdSDFE4HRNLZoZRYVQefrOY3l17epswImeB1ijgJFQJodIaHcwkp3r/myBjFVbg==",
             "dev": true
+        },
+        "sax": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+            "integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
         },
         "scoped-regex": {
             "version": "1.0.0",
@@ -6546,6 +6608,22 @@
             "resolved": "https://registry.npmjs.org/urix/-/urix-0.1.0.tgz",
             "integrity": "sha1-2pN/emLiH+wf0Y1Js1wpNQZ6bHI="
         },
+        "url": {
+            "version": "0.10.3",
+            "resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+            "integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+            "requires": {
+                "punycode": "1.3.2",
+                "querystring": "0.2.0"
+            },
+            "dependencies": {
+                "punycode": {
+                    "version": "1.3.2",
+                    "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+                    "integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+                }
+            }
+        },
         "url-parse-lax": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
@@ -6578,9 +6656,9 @@
             "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
         },
         "uuid": {
-            "version": "3.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-            "integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+            "version": "3.3.3",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.3.tgz",
+            "integrity": "sha512-pW0No1RGHgzlpHJO1nsVrHKpOEIxkGg1xB+v0ZmdNH5OAeAwzAVrCnI2/6Mtx+Uys6iaylxa+D3g4j63IKKjSQ=="
         },
         "v8-compile-cache": {
             "version": "2.1.0",
@@ -6830,6 +6908,20 @@
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/xdg-basedir/-/xdg-basedir-3.0.0.tgz",
             "integrity": "sha1-SWsswQnsqNus/i3HK2A8F8WHCtQ="
+        },
+        "xml2js": {
+            "version": "0.4.19",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+            "integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+            "requires": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~9.0.1"
+            }
+        },
+        "xmlbuilder": {
+            "version": "9.0.7",
+            "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
+            "integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
         },
         "xmlcreate": {
             "version": "2.0.1",

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "jsdoc": "jsdoc --configure jsdoc-conf.json"
     },
     "dependencies": {
+        "aws-sdk": "2.533.0",
         "axios": "0.19.0",
         "chalk": "2.4.2",
         "commander": "2.19.0",
@@ -69,12 +70,13 @@
         "parse-gitignore": "1.0.1",
         "pluralize": "7.0.0",
         "prettier": "1.16.4",
+        "progress": "2.0.3",
         "randexp": "0.5.3",
         "semver": "5.6.0",
         "shelljs": "0.8.3",
         "tabtab": "2.2.2",
         "through2": "3.0.1",
-        "uuid": "3.3.2",
+        "uuid": "3.3.3",
         "sync-request": "6.0.0",
         "yeoman-environment": "2.3.4",
         "yeoman-generator": "3.2.0",


### PR DESCRIPTION
Previously we try to install aws-sdk in the aws subgenerator if it isn't installed. This is not very consistent and creates different kinds of problems. This commit simplifies the code by adding the aws-sdk and related dependencies to package.json

Fixes #10472

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
