### PR TITLE
Better exception/log for MailService

### DIFF
--- a/generators/server/templates/src/main/java/package/service/MailService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/MailService.java.ejs
@@ -30,6 +30,7 @@ import javax.mail.internet.MimeMessage;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.context.MessageSource;
+import org.springframework.mail.MailException;
 import org.springframework.mail.javamail.JavaMailSender;
 import org.springframework.mail.javamail.MimeMessageHelper;
 import org.springframework.scheduling.annotation.Async;
@@ -83,7 +84,7 @@ public class MailService {
             message.setText(content, isHtml);
             javaMailSender.send(mimeMessage);
             log.debug("Sent email to User '{}'", to);
-        }  catch (MessagingException e) {
+        }  catch (MailException | MessagingException e) {
             log.warn("Email could not be sent to user '{}'", to, e);
         }
     }

--- a/generators/server/templates/src/main/java/package/service/MailService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/MailService.java.ejs
@@ -24,6 +24,7 @@ import io.github.jhipster.config.JHipsterProperties;
 
 import java.nio.charset.StandardCharsets;
 import java.util.Locale;
+import javax.mail.MessagingException;
 import javax.mail.internet.MimeMessage;
 
 import org.slf4j.Logger;
@@ -82,12 +83,8 @@ public class MailService {
             message.setText(content, isHtml);
             javaMailSender.send(mimeMessage);
             log.debug("Sent email to User '{}'", to);
-        } catch (Exception e) {
-            if (log.isDebugEnabled()) {
-                log.warn("Email could not be sent to user '{}'", to, e);
-            } else {
-                log.warn("Email could not be sent to user '{}': {}", to, e.getMessage());
-            }
+        }  catch (MessagingException e) {
+            log.warn("Email could not be sent to user '{}'", to, e);
         }
     }
 

--- a/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
@@ -43,6 +43,7 @@ import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
+import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
@@ -228,7 +229,7 @@ public class MailServiceIT <% if (databaseType === 'cassandra') { %>extends Abst
 
     @Test
     public void testSendEmailWithException() throws Exception {
-        doThrow(MailSendException.class).when(javaMailSender).send(any(MimeMessage.class));
+        doThrow(MessagingException.class).when(javaMailSender).send(any(MimeMessage.class));
         mailService.sendEmail("john.doe@example.com", "testSubject", "testContent", false, false);
     }
 

--- a/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
@@ -54,8 +54,6 @@ import java.io.InputStreamReader;
 import java.net.URI;
 import java.net.URL;
 import java.nio.charset.Charset;
-import java.util.Arrays;
-import java.util.List;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;

--- a/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
@@ -43,7 +43,6 @@ import org.springframework.mail.MailSendException;
 import org.springframework.mail.javamail.JavaMailSenderImpl;
 import org.thymeleaf.spring5.SpringTemplateEngine;
 
-import javax.mail.MessagingException;
 import javax.mail.Multipart;
 import javax.mail.internet.MimeBodyPart;
 import javax.mail.internet.MimeMessage;
@@ -229,7 +228,7 @@ public class MailServiceIT <% if (databaseType === 'cassandra') { %>extends Abst
 
     @Test
     public void testSendEmailWithException() throws Exception {
-        doThrow(MessagingException.class).when(javaMailSender).send(any(MimeMessage.class));
+        doThrow(MailSendException.class).when(javaMailSender).send(any(MimeMessage.class));
         mailService.sendEmail("john.doe@example.com", "testSubject", "testContent", false, false);
     }
 


### PR DESCRIPTION
Only `MessagingException` should be thrown by the code, so we should only catch them instead of `Exception`

Testing `isDebugEnabled` while the message is logged at warn level is very strange. If level is configured at DEBUG, no message will be logged because of the `warn` level of the logs. So the `else` branch is useless, and only the `if` branch is useful. Also, logging only the message of the exception is bad practice.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
