### PR TITLE
Remove redundant import from Angular admin routing

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin-routing.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin-routing.module.ts.ejs
@@ -18,12 +18,10 @@
 -%>
 import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
-import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
 /* jhipster-needle-add-admin-module-import - JHipster will add admin modules imports here */
 
 @NgModule({
   imports: [
-    <%=angularXAppName%>SharedModule,
     /* jhipster-needle-add-admin-module - JHipster will add admin modules here */
     RouterModule.forChild(
       [
@@ -64,7 +62,6 @@ import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
         <%_ if (websocket === 'spring-websocket') { _%>
         {
           path: 'tracker',
-            
           loadChildren: () => import('./tracker/tracker.module').then(m => m.TrackerModule)
         },
         <%_ } _%>


### PR DESCRIPTION
This is follow-up to #10443, removes redundant import.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
