### PR TITLE
OpenAPI Client Bug Fix: Set proper default value for `cliName` variable

### DIFF
--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -191,7 +191,7 @@ function askExistingAvailableDocs() {
     this.prompt(prompts).then(props => {
         if (props.availableDoc !== undefined) {
             this.props.inputSpec = props.availableDoc.url;
-            this.props.cliName = props.availableDoc.name;
+            this.props.cliName = props.availableDoc.name === 'default' ? 'apidocs' : props.availableDoc.name;
         }
         done();
     });

--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -218,7 +218,7 @@ function askGenerationInfos() {
             when: response => this.props.action === 'new' && !response.useServiceDiscovery,
             type: 'input',
             name: 'cliName',
-            message: 'What is the unique name for your API client ?',
+            message: 'What is the unique name for your API client (please avoid using Java keywords) ?',
             default: this.props.cliName || 'petstore',
             validate: input => {
                 if (!/^([a-zA-Z0-9_]*)$/.test(input)) {

--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -191,7 +191,7 @@ function askExistingAvailableDocs() {
     this.prompt(prompts).then(props => {
         if (props.availableDoc !== undefined) {
             this.props.inputSpec = props.availableDoc.url;
-            this.props.cliName = props.availableDoc.name === 'default' ? 'apidocs' : props.availableDoc.name;
+            this.props.cliName = props.availableDoc.name === 'default' ? 'apidocs' : props.availableDoc.name; // "default" cannot be used as it's a keyword in java
         }
         done();
     });


### PR DESCRIPTION
While working on #10491, I realized that the word `default` is used as the default value of the variable `cliName`. Since `default` is a keyword in Java this creates problems in the generated classes. This creates a minor fix for that. 

Related to  #10491

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
