### PR TITLE
Survive paths removal from tsconfig.json

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -29,6 +29,9 @@ module.exports = {
 
 function mapTypescriptAliasToJestAlias(alias = {}) {
     const jestAliases = { ...alias };
+    if (!tsconfig.compilerOptions.paths) {
+      return jestAliases;
+    }
     Object.entries(tsconfig.compilerOptions.paths)
       .filter(([key, value]) => {
         // use Typescript alias in Jest only if this has value

--- a/generators/client/templates/angular/webpack/utils.js.ejs
+++ b/generators/client/templates/angular/webpack/utils.js.ejs
@@ -34,6 +34,9 @@ function root(args) {
 
 function mapTypescriptAliasToWebpackAlias(alias = {}) {
   const webpackAliases = { ...alias };
+  if (!tsconfig.compilerOptions.paths) {
+    return webpackAliases;
+  }
   Object.entries(tsconfig.compilerOptions.paths)
     .filter(([key, value]) => {
       // use Typescript alias in Webpack only if this has value

--- a/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/jest.conf.js.ejs
@@ -39,6 +39,9 @@ module.exports = {
 
 function mapTypescriptAliasToJestAlias(alias = {}) {
     const jestAliases = { ...alias };
+    if (!tsconfig.compilerOptions.paths) {
+      return jestAliases;
+    }
     Object.entries(tsconfig.compilerOptions.paths)
       .filter(([key, value]) => {
         // use Typescript alias in Jest only if this has value

--- a/generators/client/templates/react/webpack/utils.js.ejs
+++ b/generators/client/templates/react/webpack/utils.js.ejs
@@ -34,6 +34,9 @@ function root(args) {
 
 function mapTypescriptAliasToWebpackAlias(alias = {}) {
   const webpackAliases = { ...alias };
+  if (!tsconfig.compilerOptions.paths) {
+    return webpackAliases;
+  }
   Object.entries(tsconfig.compilerOptions.paths)
     .filter(([key, value]) => {
       // use Typescript alias in Webpack only if this has value


### PR DESCRIPTION
This PR is follow-up to #10252 and is motivated by #10502 - if `paths` is removed from `tsconfig.json` then current implementation gives errors.  
Now checking that `tsconfig.compilerOptions.paths` is defined.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
