### PR TITLE
Support inline content for JDL

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -156,6 +156,7 @@
             "program": "${workspaceFolder}/cli/jhipster.js",
             "args": [
                 "import-jdl",
+                "--inline",
                 "application { config { baseName jhapp }}"
             ],
             "cwd": "${workspaceFolder}/test-integration/samples/app-sample-dev/",

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -155,7 +155,8 @@
             "name": "jhipster import-jdl",
             "program": "${workspaceFolder}/cli/jhipster.js",
             "args": [
-                "import-jdl"
+                "import-jdl",
+                "application { config { baseName jhapp }}"
             ],
             "cwd": "${workspaceFolder}/test-integration/samples/app-sample-dev/",
             "console": "integratedTerminal"

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -87,7 +87,7 @@ const defaultCommands = {
         desc: 'Deploy the current application to Heroku'
     },
     'import-jdl': {
-        argument: ['jdlFiles...', 'jdlContent'],
+        argument: ['jdlFiles...'],
         cliOnly: true,
         desc: `Create entities from the JDL file/content passed in argument.
   By default everything is run in parallel. If you like to interact with the console use '--interactive' flag.`,
@@ -99,21 +99,22 @@ const defaultCommands = {
     --ignore-application  # Ignores application generation                                         Default: false
     --ignore-deployments  # Ignores deployments generation                                         Default: false
     --skip-ui-grouping    # Disable the UI grouping behavior for entity client side code           Default: false
+    --inline              # Pass JDL content inline. Argument can be skipped when passing this
 
 Arguments:
-    jdlFiles | jdlContent  # The JDL file names Type: String[] or JDL content Type: String  Required: true
+    jdlFiles # The JDL file names Type: String[] Required: true if --inline is not set
 
 Example:
     jhipster import-jdl myfile.jdl
     jhipster import-jdl myfile.jdl --interactive
     jhipster import-jdl myfile1.jdl myfile2.jdl
-    jhipster import-jdl "application { config { baseName jhapp, testFrameworks [protractor] }}"
-    jhipster import-jdl \\
-        "application { \\
-            config { \\
-                baseName jhapp, \\
-                testFrameworks [protractor] \\
-            } \\
+    jhipster import-jdl --inline "application { config { baseName jhapp, testFrameworks [protractor] }}"
+    jhipster import-jdl --inline \\
+        "application {
+            config {
+                baseName jhapp,
+                testFrameworks [protractor]
+            }
         }"
         `
     },

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -87,9 +87,9 @@ const defaultCommands = {
         desc: 'Deploy the current application to Heroku'
     },
     'import-jdl': {
-        argument: ['jdlFiles...'],
+        argument: ['jdlFiles...', 'jdlContent'],
         cliOnly: true,
-        desc: `Create entities from the JDL file passed in argument.
+        desc: `Create entities from the JDL file/content passed in argument.
   By default everything is run in parallel. If you like to interact with the console use '--interactive' flag.`,
         help: `
     --skip-install        # Do not automatically install dependencies                              Default: false
@@ -101,12 +101,20 @@ const defaultCommands = {
     --skip-ui-grouping    # Disable the UI grouping behavior for entity client side code           Default: false
 
 Arguments:
-    jdlFiles  # The JDL file names  Type: String[]  Required: true
+    jdlFiles | jdlContent  # The JDL file names Type: String[] or JDL content Type: String  Required: true
 
 Example:
     jhipster import-jdl myfile.jdl
     jhipster import-jdl myfile.jdl --interactive
     jhipster import-jdl myfile1.jdl myfile2.jdl
+    jhipster import-jdl "application { config { baseName jhapp, testFrameworks [protractor] }}"
+    jhipster import-jdl \\
+        "application { \\
+            config { \\
+                baseName jhapp, \\
+                testFrameworks [protractor] \\
+            } \\
+        }"
         `
     },
     info: {

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -253,7 +253,9 @@ const isAllCompleted = items => Object.values(items).every(it => it);
 
 class JDLProcessor {
     constructor(jdlFiles, jdlContent, options) {
-        logger.debug(`JDLProcessor started with content: ${jdlFiles} and options: ${toString(options)}`);
+        logger.debug(
+            `JDLProcessor started with ${jdlContent ? `content: ${jdlContent}` : `files: ${jdlFiles}`} and options: ${toString(options)}`
+        );
         this.jdlFiles = jdlFiles;
         this.jdlContent = jdlContent;
         this.options = options;

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -107,7 +107,7 @@ const initHelp = (program, cliName) => {
  */
 const getArgs = opts => {
     if (opts.argument) {
-        return `[${opts.argument.join(' ')}]`;
+        return `[${opts.argument.join('|')}]`;
     }
     return '';
 };

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -107,7 +107,7 @@ const initHelp = (program, cliName) => {
  */
 const getArgs = opts => {
     if (opts.argument) {
-        return `[${opts.argument.join('|')}]`;
+        return `[${opts.argument.join(' ')}]`;
     }
     return '';
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -725,9 +725,9 @@
             "dev": true
         },
         "chevrotain": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-4.4.0.tgz",
-            "integrity": "sha512-CS0auzIhlLxo9RCVarVZJIsKj339jJrLIdCbX3rwk/kTu7+VkYdiXiAD8aJOXJEcRc1GGcbOQ587e/85+xLxaA==",
+            "version": "6.2.0",
+            "resolved": "https://registry.npmjs.org/chevrotain/-/chevrotain-6.2.0.tgz",
+            "integrity": "sha512-wA/7Py7CrNWe4vgAkvA2S+mQcW7jIERkB/FWAexqsdIRPVvEXdu4T8f3XWI8EMMQtkb3sJo3DHmafy+gbCPzTQ==",
             "requires": {
                 "regexp-to-ast": "0.4.0"
             }
@@ -947,9 +947,9 @@
             "integrity": "sha1-+IiQMGhcfE/54qVZ9Qd+t2qBb5Y="
         },
         "colors": {
-            "version": "1.3.3",
-            "resolved": "https://registry.npmjs.org/colors/-/colors-1.3.3.tgz",
-            "integrity": "sha512-mmGt/1pZqYRjMxB1axhTo16/snVZ5krrKkcmMeVKxzECMMXoCgnvTPp10QgHfcbQZw8Dq2jMNG6je4JlWU0gWg=="
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/colors/-/colors-1.4.0.tgz",
+            "integrity": "sha512-a+UqTh4kgZg/SlGvfbzDHpgRu7AAQOmmqRHJnxhRZICKFUT91brVhNNt58CMWU9PsBbv3PDCZUHbVxuDiH2mtA=="
         },
         "colorspace": {
             "version": "1.1.2",
@@ -2175,9 +2175,9 @@
             "dev": true
         },
         "fast-safe-stringify": {
-            "version": "2.0.6",
-            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.6.tgz",
-            "integrity": "sha512-q8BZ89jjc+mz08rSxROs8VsrBBcn1SIw1kq9NjolL509tkABRk9io01RAjSaEv1Xb2uFLt8VtRiZbGp5H8iDtg=="
+            "version": "2.0.7",
+            "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+            "integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
         },
         "fecha": {
             "version": "2.3.3",
@@ -3309,11 +3309,11 @@
             }
         },
         "jhipster-core": {
-            "version": "4.3.0",
-            "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-4.3.0.tgz",
-            "integrity": "sha512-6EY28JQ84FswajMon3n6D9SwbDFYEiU4Yw4Unj2C14XUkB33FMBBs5tXO0uDky8GCCGuFp/fMrDWhYeAMf6vAg==",
+            "version": "4.4.0",
+            "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-4.4.0.tgz",
+            "integrity": "sha512-Vb5oiDA86/CQtM+UM83ppunITHkYUMnReGRDoVHu4qKJfUI3kND80bF8mGhXfBvQ1SLdBID/M0JPEYeQ8iz1jg==",
             "requires": {
-                "chevrotain": "4.4.0",
+                "chevrotain": "6.2.0",
                 "fs-extra": "8.1.0",
                 "lodash": "4.17.15",
                 "winston": "3.2.1"

--- a/package-lock.json
+++ b/package-lock.json
@@ -3309,9 +3309,9 @@
             }
         },
         "jhipster-core": {
-            "version": "4.4.0",
-            "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-4.4.0.tgz",
-            "integrity": "sha512-Vb5oiDA86/CQtM+UM83ppunITHkYUMnReGRDoVHu4qKJfUI3kND80bF8mGhXfBvQ1SLdBID/M0JPEYeQ8iz1jg==",
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/jhipster-core/-/jhipster-core-5.0.0.tgz",
+            "integrity": "sha512-pAkFqICz0IU5jpWDUGN3KHiXWE/HFpp7vVz53M5w5XmjeBOCEln2kMigYBH9j6PLkr7txAzcfSIf57Tzx2QUWw==",
             "requires": {
                 "chevrotain": "6.2.0",
                 "fs-extra": "8.1.0",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "glob": "7.1.3",
         "gulp-filter": "5.1.0",
         "insight": "0.10.1",
-        "jhipster-core": "4.3.0",
+        "jhipster-core": "4.4.0",
         "js-object-pretty-print": "0.3.0",
         "js-yaml": "3.13.1",
         "lodash": "4.17.13",

--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
         "glob": "7.1.3",
         "gulp-filter": "5.1.0",
         "insight": "0.10.1",
-        "jhipster-core": "4.4.0",
+        "jhipster-core": "5.0.0",
         "js-object-pretty-print": "0.3.0",
         "js-yaml": "3.13.1",
         "lodash": "4.17.13",

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -311,6 +311,44 @@ describe('JHipster generator import jdl', () => {
         });
     });
 
+    describe('imports single app and entities passed with --inline', () => {
+        beforeEach(done => {
+            testInTempDir(dir => {
+                shelljs.rm(`${dir}/.yo-rc.json`);
+                importJdl(
+                    [],
+                    {
+                        skipInstall: true,
+                        noInsight: true,
+                        'skip-git': false,
+                        inline: 'application { config { baseName jhapp }} entity Customer'
+                    },
+                    env,
+                    mockFork(done, 1)
+                );
+            });
+        });
+
+        it('creates the application', () => {
+            assert.file(['.yo-rc.json']);
+        });
+        it('creates the entities', () => {
+            assert.file([path.join('.jhipster', 'Customer.json')]);
+        });
+        it('calls application generator', () => {
+            expect(subGenCallParams.count).to.equal(1);
+            expect(subGenCallParams.commands).to.eql(['jhipster:app']);
+            expect(subGenCallParams.options[0]).to.eql([
+                '--skip-install',
+                '--no-insight',
+                '--no-skip-git',
+                '--with-entities',
+                '--force',
+                '--from-cli'
+            ]);
+        });
+    });
+
     describe('imports single app only', () => {
         beforeEach(done => {
             testInTempDir(dir => {

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -314,14 +314,13 @@ describe('JHipster generator import jdl', () => {
     describe('imports single app and entities passed with --inline', () => {
         beforeEach(done => {
             testInTempDir(dir => {
-                shelljs.rm(`${dir}/.yo-rc.json`);
                 importJdl(
                     [],
                     {
                         skipInstall: true,
                         noInsight: true,
                         'skip-git': false,
-                        inline: 'application { config { baseName jhapp }} entity Customer'
+                        inline: 'application { config { baseName jhapp } entities * } entity Customer'
                     },
                     env,
                     mockFork(done, 1)
@@ -342,6 +341,17 @@ describe('JHipster generator import jdl', () => {
                 '--skip-install',
                 '--no-insight',
                 '--no-skip-git',
+                '--inline',
+                'application',
+                '{',
+                'config',
+                'baseName',
+                'jhapp',
+                '}',
+                'entities',
+                '*',
+                'entity',
+                'Customer',
                 '--with-entities',
                 '--force',
                 '--from-cli'


### PR DESCRIPTION
Makes it possible to invoke import-jdl with inline content

```
jhipster import-jdl --inline \
        "application {
            config {
                baseName jhapp,
                testFrameworks [protractor]
            }
        }"
```

or 

```
jhipster import-jdl --inline "application { config { baseName jhapp, testFrameworks [protractor] }}"
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
