### PR TITLE
entity faker csv string regex improvements

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
@@ -153,7 +153,9 @@ for (lineNb = 1; lineNb <= numberOfRows; lineNb++) {
         // Validation rules
         if (fields[idx].fieldValidate === true) {
             if (fields[idx].fieldValidateRules.includes('pattern')) {
-                data = `"${new this.randexp(fields[idx].fieldValidateRulesPattern).gen()}"`;
+                const randExp = new this.randexp(fields[idx].fieldValidateRulesPattern)
+                randExp.max = 5;
+                data = `"${randExp.gen().replace(/"/g, '""')}"`;
             }
 
             // manage String max length


### PR DESCRIPTION
Fix #10513

Related to https://github.com/jhipster/generator-jhipster/pull/10332 which fixed the semicolon issue, because we are quoting the string in the CSV, we need to escape any quotes within the string

- escape quotes in regex-generated random string, needed for proper csv format (CSV uses `""` to indicate an escaped quote, [source](https://stackoverflow.com/a/17808731/3737815))
- set max repetitional tokens (such as * or +) to 5 instead of default 100 (similar to [here](https://github.com/jhipster/generator-jhipster/blob/master/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs#L253-L254))

    
-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
