### PR TITLE
Get rid of netflix URLConfigurationSource warning

### DIFF
--- a/generators/server/templates/src/main/resources/logback-spring.xml.ejs
+++ b/generators/server/templates/src/main/resources/logback-spring.xml.ejs
@@ -70,6 +70,7 @@
     <%_ } _%>
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway' || serviceDiscoveryType === 'eureka') { _%>
     <logger name="com.netflix" level="WARN"/>
+    <logger name="com.netflix.config.sources.URLConfigurationSource" level="ERROR"/>
     <logger name="com.netflix.discovery" level="INFO"/>
     <%_ } _%>
     <logger name="com.ryantenney" level="WARN"/>

--- a/generators/server/templates/src/test/resources/logback.xml.ejs
+++ b/generators/server/templates/src/test/resources/logback.xml.ejs
@@ -42,6 +42,7 @@
     <%_ } _%>
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway') { _%>
     <logger name="com.netflix" level="WARN"/>
+    <logger name="com.netflix.config.sources.URLConfigurationSource" level="ERROR"/>
     <logger name="com.netflix.discovery" level="INFO"/>
     <%_ } _%>
     <logger name="com.ryantenney" level="WARN"/>


### PR DESCRIPTION
Get rid of  warning of netflix URLConfigurationSource
````sh
WARN  [main] c.n.c.s.URLConfigurationSource - No URLs will be polled as dynamic configuration sources.
````
that comes from https://github.com/Netflix/archaius/blob/master/archaius-core/src/main/java/com/netflix/config/sources/URLConfigurationSource.java#L126, defining a new entry in logback.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
