### PR TITLE
Faker: don't generate unnecessary column declaration for loading data

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -217,7 +217,11 @@
             <%_ } _%>
             <%_ for (idx in relationships) {
                     let loadColumnType = 'numeric';
-                    if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
+                    if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired
+                        && (relationships[idx].relationshipType === "many-to-one"
+                            || (relationships[idx].relationshipType === "one-to-one" && relationships[idx].ownerSide === true
+                                && (relationships[idx].useJPADerivedIdentifier == null || relationships[idx].useJPADerivedIdentifier === false))
+                    )) {
                         let baseColumnName = getColumnName(relationships[idx].relationshipName) + '_id';
                         if (relationships[idx].otherEntityNameCapitalized === 'User' && authenticationType === 'oauth2') {
                             loadColumnType = 'varchar(100)';


### PR DESCRIPTION
Columns are declared in liquibase changeset, but not generated in csv file, in the following cases:
 - one-to-many relationship
 - one-to-one with ownerSide = false or with useJPADerivedIdentifier = true

Fixes https://github.com/jhipster/generator-jhipster/issues/10577

-   Please make sure the below checklist is followed for Pull Requests.
-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
