### PR TITLE
GAE: Trim gcpCloudSqlInstanceName Variable to Remove White-Spaces

### DIFF
--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -495,7 +495,7 @@ module.exports = class extends BaseGenerator {
                 const done = this.async();
 
                 const cloudSqlDatabases = [{ value: '', name: 'New Database' }];
-                const name = this.gcpCloudSqlInstanceName.split(':')[2];
+                const name = this.gcpCloudSqlInstanceName.split(':')[2].trim();
                 exec(
                     `gcloud sql databases list -i ${name} --format='value(name)' --project="${this.gcpProjectId}"`,
                     (err, stdout, stderr) => {
@@ -623,7 +623,7 @@ module.exports = class extends BaseGenerator {
 
                 this.log(chalk.bold('\nConfiguring Cloud SQL Login'));
 
-                const name = this.gcpCloudSqlInstanceName.split(':')[2];
+                const name = this.gcpCloudSqlInstanceName.split(':')[2].trim();
                 exec(`gcloud sql users list -i jhipster --format='value(name)' --project="${this.gcpProjectId}"`, (err, stdout) => {
                     if (_.includes(stdout, this.gcpCloudSqlUserName)) {
                         this.log(chalk.bold(`... User "${chalk.cyan(this.gcpCloudSqlUserName)}" already exists`));
@@ -654,7 +654,7 @@ module.exports = class extends BaseGenerator {
                 if (this.gcpCloudSqlDatabaseNameExists) return;
                 const done = this.async();
 
-                const name = this.gcpCloudSqlInstanceName.split(':')[2];
+                const name = this.gcpCloudSqlInstanceName.split(':')[2].trim();
                 this.log(chalk.bold(`\nCreating Database ${chalk.cyan(this.gcpCloudSqlDatabaseName)}`));
                 const cmd = `gcloud sql databases create "${this.gcpCloudSqlDatabaseName}" --charset=utf8 -i "${name}" --project="${
                     this.gcpProjectId

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -407,7 +407,7 @@ module.exports = class extends BaseGenerator {
                         } else {
                             _.forEach(stdout.toString().split(os.EOL), instance => {
                                 if (!instance) return;
-                                cloudSqlInstances.push({ value: instance, name: instance });
+                                cloudSqlInstances.push({ value: instance.trim(), name: instance });
                             });
                         }
 
@@ -495,7 +495,7 @@ module.exports = class extends BaseGenerator {
                 const done = this.async();
 
                 const cloudSqlDatabases = [{ value: '', name: 'New Database' }];
-                const name = this.gcpCloudSqlInstanceName.split(':')[2].trim();
+                const name = this.gcpCloudSqlInstanceName.split(':')[2];
                 exec(
                     `gcloud sql databases list -i ${name} --format='value(name)' --project="${this.gcpProjectId}"`,
                     (err, stdout, stderr) => {
@@ -623,7 +623,7 @@ module.exports = class extends BaseGenerator {
 
                 this.log(chalk.bold('\nConfiguring Cloud SQL Login'));
 
-                const name = this.gcpCloudSqlInstanceName.split(':')[2].trim();
+                const name = this.gcpCloudSqlInstanceName.split(':')[2];
                 exec(`gcloud sql users list -i jhipster --format='value(name)' --project="${this.gcpProjectId}"`, (err, stdout) => {
                     if (_.includes(stdout, this.gcpCloudSqlUserName)) {
                         this.log(chalk.bold(`... User "${chalk.cyan(this.gcpCloudSqlUserName)}" already exists`));
@@ -654,7 +654,7 @@ module.exports = class extends BaseGenerator {
                 if (this.gcpCloudSqlDatabaseNameExists) return;
                 const done = this.async();
 
-                const name = this.gcpCloudSqlInstanceName.split(':')[2].trim();
+                const name = this.gcpCloudSqlInstanceName.split(':')[2];
                 this.log(chalk.bold(`\nCreating Database ${chalk.cyan(this.gcpCloudSqlDatabaseName)}`));
                 const cmd = `gcloud sql databases create "${this.gcpCloudSqlDatabaseName}" --charset=utf8 -i "${name}" --project="${
                     this.gcpProjectId


### PR DESCRIPTION
While testing, #10533, I've noticed that the gae generator has the tendency to fail sometimes when the cloud sql instances are created due to `this.gcpCloudSqlInstanceName.split(':')[2]` having a extra new line character at the end. So I've went ahead and added a trim method to get rid of any extra white-space characters. 

Related to: https://github.com/jhipster/generator-jhipster/issues/10533

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
