### PR TITLE
Fix redirect on account activation in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -71,7 +71,7 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
         }).then(() => {
             this.authenticationError = false;
             this.activeModal.dismiss('login success');
-            if (this.router.url === '/account/register' || this.router.url.startsWith('/account/activate/') ||
+            if (this.router.url === '/account/register' || this.router.url.startsWith('/account/activate') ||
 this.router.url.startsWith('/account/reset/')) {
                 this.router.navigate(['']);
             }


### PR DESCRIPTION
Currently user is not redirected to home page after account activation.
Activation route is in the form `/account/activate?key=...` and this doesn't start with `/account/activate/`

This seems to be regression from #6191 - this PR describes redirect after password reset, but also activation redirect functionality is changed.  
I found this issue while testing #10383

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
