### PR TITLE
Add ability to skip database changelog generation

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -99,6 +99,7 @@ const defaultCommands = {
     --ignore-application  # Ignores application generation                                         Default: false
     --ignore-deployments  # Ignores deployments generation                                         Default: false
     --skip-ui-grouping    # Disable the UI grouping behavior for entity client side code           Default: false
+    --skip-db-changelog   # Disable the generator of database changelogs                           Default: false
     --inline              # Pass JDL content inline. Argument can be skipped when passing this
 
 Arguments:

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -99,7 +99,7 @@ const defaultCommands = {
     --ignore-application  # Ignores application generation                                         Default: false
     --ignore-deployments  # Ignores deployments generation                                         Default: false
     --skip-ui-grouping    # Disable the UI grouping behavior for entity client side code           Default: false
-    --skip-db-changelog   # Disable the generator of database changelogs                           Default: false
+    --skip-db-changelog   # Disable generation of database changelogs                              Default: false
     --inline              # Pass JDL content inline. Argument can be skipped when passing this
 
 Arguments:

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -190,6 +190,7 @@ const generateEntityFiles = (generator, entity, inFolder, env, shouldTriggerInst
         'skip-server': entity.skipServer,
         'no-fluent-methods': entity.noFluentMethod,
         'skip-user-management': entity.skipUserManagement,
+        'skip-db-changelog': generator.options['skip-db-changelog'],
         'skip-ui-grouping': generator.options['skip-ui-grouping']
     };
     const command = `${CLI_NAME}:entity ${entity.name}`;

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -41,7 +41,7 @@ faker.seed(42);
 const serverFiles = {
     db: [
         {
-            condition: generator => generator.databaseType === 'sql',
+            condition: generator => generator.databaseType === 'sql' && !generator.skipDbChangelog,
             path: SERVER_MAIN_RES_DIR,
             templates: [
                 {
@@ -65,6 +65,7 @@ const serverFiles = {
         {
             condition: generator =>
                 generator.databaseType === 'sql' &&
+                !generator.skipDbChangelog &&
                 (generator.fieldsContainOwnerManyToMany || generator.fieldsContainOwnerOneToOne || generator.fieldsContainManyToOne),
             path: SERVER_MAIN_RES_DIR,
             templates: [
@@ -78,17 +79,20 @@ const serverFiles = {
         },
         {
             condition: generator =>
-                generator.databaseType === 'sql' && (generator.fieldsContainImageBlob === true || generator.fieldsContainBlob === true),
+                generator.databaseType === 'sql' &&
+                !generator.skipDbChangelog &&
+                (generator.fieldsContainImageBlob === true || generator.fieldsContainBlob === true),
             path: SERVER_MAIN_RES_DIR,
             templates: [{ file: 'config/liquibase/fake-data/blob/hipster.png', method: 'copy', noEjs: true }]
         },
         {
-            condition: generator => generator.databaseType === 'sql' && generator.fieldsContainTextBlob === true,
+            condition: generator =>
+                generator.databaseType === 'sql' && !generator.skipDbChangelog && generator.fieldsContainTextBlob === true,
             path: SERVER_MAIN_RES_DIR,
             templates: [{ file: 'config/liquibase/fake-data/blob/hipster.txt', method: 'copy' }]
         },
         {
-            condition: generator => generator.databaseType === 'cassandra',
+            condition: generator => generator.databaseType === 'cassandra' && !generator.skipDbChangelog,
             path: SERVER_MAIN_RES_DIR,
             templates: [
                 {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -106,6 +106,13 @@ class EntityGenerator extends BaseBlueprintGenerator {
             defaults: false
         });
 
+        // This adds support for a `--skip-db-changelog` flag
+        this.option('skip-db-changelog', {
+            desc: 'Skip the generation of database changelog (liquibase for sql databases)',
+            type: Boolean,
+            defaults: false
+        });
+
         // This adds support for a `--db` flag
         this.option('db', {
             desc: 'Provide DB option for the application when using skip-server flag',
@@ -192,6 +199,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 context.skipClient =
                     context.applicationType === 'microservice' || this.options['skip-client'] || configuration.get('skipClient');
                 context.skipServer = this.options['skip-server'] || configuration.get('skipServer');
+                context.skipDbChangelog = this.options['skip-db-changelog'] || configuration.get('skipDbChangelog');
 
                 context.angularAppName = this.getAngularAppName(context.baseName);
                 context.angularXAppName = this.getAngularXAppName(context.baseName);

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -65,6 +65,7 @@ function testDocumentsRelationships() {
             'skip-install': true,
             'skip-server': undefined,
             'skip-ui-grouping': undefined,
+            'skip-db-changelog': undefined,
             'skip-user-management': undefined
         });
     });
@@ -138,6 +139,56 @@ describe('JHipster generator import jdl', () => {
         });
     });
 
+    describe('imports a JDL entity model from single file with --skip-db-changelog', () => {
+        beforeEach(done => {
+            testInTempDir(dir => {
+                fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
+                importJdl(['jdl.jdl'], { 'skip-db-changelog': true, skipInstall: true }, env);
+                done();
+            });
+        });
+
+        it('creates entity json files', () => {
+            assert.file([
+                '.jhipster/Department.json',
+                '.jhipster/JobHistory.json',
+                '.jhipster/Job.json',
+                '.jhipster/Employee.json',
+                '.jhipster/Location.json',
+                '.jhipster/Task.json',
+                '.jhipster/Country.json',
+                '.jhipster/Region.json'
+            ]);
+        });
+        it('calls entity subgenerator', () => {
+            expect(subGenCallParams.count).to.equal(8);
+            expect(subGenCallParams.commands).to.eql([
+                'jhipster:entity Region',
+                'jhipster:entity Country',
+                'jhipster:entity Location',
+                'jhipster:entity Department',
+                'jhipster:entity Task',
+                'jhipster:entity Employee',
+                'jhipster:entity Job',
+                'jhipster:entity JobHistory'
+            ]);
+            expect(subGenCallParams.options[0]).to.eql({
+                regenerate: true,
+                force: false,
+                skipInstall: true,
+                'from-cli': true,
+                interactive: true,
+                'no-fluent-methods': undefined,
+                'skip-client': undefined,
+                'skip-install': true,
+                'skip-server': undefined,
+                'skip-ui-grouping': undefined,
+                'skip-db-changelog': true,
+                'skip-user-management': undefined
+            });
+        });
+    });
+
     describe('imports a JDL entity model from single file in interactive mode by default', () => {
         beforeEach(done => {
             testInTempDir(dir => {
@@ -181,6 +232,7 @@ describe('JHipster generator import jdl', () => {
                 'skip-install': true,
                 'skip-server': undefined,
                 'skip-ui-grouping': undefined,
+                'skip-db-changelog': undefined,
                 'skip-user-management': undefined
             });
         });
@@ -240,6 +292,7 @@ describe('JHipster generator import jdl', () => {
                 'skip-install': true,
                 'skip-server': undefined,
                 'skip-ui-grouping': undefined,
+                'skip-db-changelog': undefined,
                 'skip-user-management': undefined
             });
         });
@@ -272,6 +325,7 @@ describe('JHipster generator import jdl', () => {
                 'skip-install': true,
                 'skip-server': undefined,
                 'skip-ui-grouping': undefined,
+                'skip-db-changelog': undefined,
                 'skip-user-management': undefined
             });
         });

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -621,6 +621,62 @@ describe('JHipster generator for entity', () => {
             });
         });
 
+        describe('with --skip-db-changelog', () => {
+            describe('SQL database', () => {
+                before(done => {
+                    helpers
+                        .run(require.resolve('../generators/entity'))
+                        .inTmpDir(dir => {
+                            fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                            fse.copySync(
+                                path.join(__dirname, '../test/templates/export-jdl/.jhipster/Country.json'),
+                                path.join(dir, '.jhipster/Foo.json')
+                            );
+                        })
+                        .withArguments(['Foo'])
+                        .withOptions({ regenerate: true, force: true, skipDbChangelog: true })
+                        .on('end', done);
+                });
+
+                it('creates expected default files', () => {
+                    assert.file(expectedFiles.server);
+                    assert.file(expectedFiles.clientNg2);
+                    assert.file(expectedFiles.gatling);
+                });
+                it("doesn't creates database changelogs", () => {
+                    assert.noFile([
+                        `${constants.SERVER_MAIN_RES_DIR}config/liquibase/changelog/20160926101210_added_entity_Foo.xml`,
+                        `${constants.SERVER_MAIN_RES_DIR}config/liquibase/changelog/20160926101210_added_entity_constraints_Foo.xml`
+                    ]);
+                });
+            });
+
+            describe('Cassandra database', () => {
+                before(done => {
+                    helpers
+                        .run(require.resolve('../generators/entity'))
+                        .inTmpDir(dir => {
+                            fse.copySync(path.join(__dirname, '../test/templates/compose/05-cassandra'), dir);
+                            fse.copySync(
+                                path.join(__dirname, '../test/templates/export-jdl/.jhipster/Country.json'),
+                                path.join(dir, '.jhipster/Foo.json')
+                            );
+                        })
+                        .withArguments(['Foo'])
+                        .withOptions({ regenerate: true, force: true, skipDbChangelog: true })
+                        .on('end', done);
+                });
+
+                it('creates expected default files', () => {
+                    assert.file(expectedFiles.server);
+                    assert.file(expectedFiles.gatling);
+                });
+                it("doesn't creates database changelogs", () => {
+                    assert.noFile([`${constants.SERVER_MAIN_RES_DIR}config/cql/changelog/20160926101210_added_entity_Foo.cql`]);
+                });
+            });
+        });
+
         context('microservice', () => {
             describe('with dto, service, pagination', () => {
                 before(done => {


### PR DESCRIPTION
Both from `jhipster import-jdl` or from `jhipster entity`

I used `--skip-db-changelog` since it's a bit more generic than `--skip-liquibase` and we also support database changelog for Cassandra without using Liquibase

Fixes #10059

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
