### PR TITLE
Add basic plugin support.

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1123,6 +1123,14 @@ module.exports = class extends PrivateBase {
                 // Use as plugin
                 if (this._.isFunction(generator)) {
                     generator = generator(require(`./${subGen}`)); // eslint-disable-line import/no-dynamic-require, global-require
+                } else if (this._.isFunction(generator.plugin)) {
+                    if (generator.subGen) {
+                        // eslint-disable-next-line import/no-dynamic-require, global-require
+                        generator = generator.plugin(require(`./${generator.subGen}`));
+                    } else {
+                        // eslint-disable-next-line import/no-dynamic-require, global-require
+                        generator = generator.plugin(require(`./${subGen}`));
+                    }
                 } else {
                     // Add additional plugin structure here.
                     throw new Error('blueprint is not a generator nor a plugin');

--- a/test/plugin/client-plugin-multiple.spec.js
+++ b/test/plugin/client-plugin-multiple.spec.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const fse = require('fs-extra');
+
+const expectedFiles = require('../utils/expected-files');
+
+describe('JHipster client generator with plugin', () => {
+    describe('generate client with blueprint (plugin) option', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/client'))
+                .inTmpDir(dir => {
+                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
+                    fse.ensureDirSync(fakeBlueprintModuleDir);
+                    fse.copySync(path.join(__dirname, '../templates/plugins/client-multiple'), fakeBlueprintModuleDir);
+                })
+                .withOptions({
+                    'from-cli': true,
+                    build: 'maven',
+                    auth: 'jwt',
+                    db: 'mysql',
+                    skipInstall: true,
+                    blueprints: [{ name: 'myblueprint' }],
+                    skipChecks: true
+                })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr']
+                })
+                .on('end', done);
+        });
+
+        it('creates expected files from jhipster client generator', () => {
+            assert.file(expectedFiles.client);
+            assert.file(expectedFiles.i18nJson);
+        });
+
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', /dummy-blueprint-property/);
+        });
+    });
+});

--- a/test/plugin/client-plugin-override.spec.js
+++ b/test/plugin/client-plugin-override.spec.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const fse = require('fs-extra');
+
+const expectedFiles = require('../utils/expected-files');
+
+describe('JHipster client generator with plugin that overrides another', () => {
+    describe('generate client with blueprint (plugin) option', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/common'))
+                .inTmpDir(dir => {
+                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
+                    fse.ensureDirSync(fakeBlueprintModuleDir);
+                    fse.copySync(path.join(__dirname, '../templates/plugins/client-override'), fakeBlueprintModuleDir);
+                })
+                .withOptions({
+                    'from-cli': true,
+                    build: 'maven',
+                    auth: 'jwt',
+                    db: 'mysql',
+                    skipInstall: true,
+                    blueprints: [{ name: 'myblueprint' }],
+                    skipChecks: true
+                })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr']
+                })
+                .on('end', done);
+        });
+
+        it('creates expected files from jhipster client generator', () => {
+            assert.file(expectedFiles.client);
+            assert.file(expectedFiles.i18nJson);
+        });
+
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', /dummy-blueprint-property/);
+        });
+    });
+});

--- a/test/plugin/client-plugin.spec.js
+++ b/test/plugin/client-plugin.spec.js
@@ -1,0 +1,46 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const fse = require('fs-extra');
+
+const expectedFiles = require('../utils/expected-files');
+
+describe('JHipster client generator with plugin', () => {
+    describe('generate client with blueprint (plugin) option', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/client'))
+                .inTmpDir(dir => {
+                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
+                    fse.ensureDirSync(fakeBlueprintModuleDir);
+                    fse.copySync(path.join(__dirname, '../templates/plugins/client'), fakeBlueprintModuleDir);
+                })
+                .withOptions({
+                    'from-cli': true,
+                    build: 'maven',
+                    auth: 'jwt',
+                    db: 'mysql',
+                    skipInstall: true,
+                    blueprints: [{ name: 'myblueprint' }],
+                    skipChecks: true
+                })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr']
+                })
+                .on('end', done);
+        });
+
+        it('creates expected files from jhipster client generator', () => {
+            assert.file(expectedFiles.client);
+            assert.file(expectedFiles.i18nJson);
+        });
+
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('package.json', /dummy-blueprint-property/);
+        });
+    });
+});

--- a/test/templates/plugins/client-multiple/generators/client/index.js
+++ b/test/templates/plugins/client-multiple/generators/client/index.js
@@ -1,0 +1,22 @@
+module.exports = function(Generator) {
+    return class NewGenerator extends Generator {
+        constructor(args, opts) {
+            super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+            const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+            if (!jhContext) {
+                this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint myblueprint')}");
+            }
+            this.configOptions = jhContext.configOptions || {};
+            // This sets up options for this sub generator and is being reused from JHipster
+            jhContext.setupClientOptions(this, jhContext);
+        }
+
+        get writing() {
+            return {
+                addDummyProperty() {
+                    this.composeBlueprint('generator-jhipster-myblueprint', 'custom-client', this.options);
+                }
+            };
+        }
+    };
+};

--- a/test/templates/plugins/client-multiple/generators/custom-client/index.js
+++ b/test/templates/plugins/client-multiple/generators/custom-client/index.js
@@ -1,0 +1,53 @@
+module.exports = {
+    plugin,
+    subGen: 'client'
+};
+
+function plugin(Generator) {
+    return class NewGenerator extends Generator {
+        constructor(args, opts) {
+            super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+            const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+            if (!jhContext) {
+                this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint myblueprint')}");
+            }
+            this.configOptions = jhContext.configOptions || {};
+            // This sets up options for this sub generator and is being reused from JHipster
+            jhContext.setupClientOptions(this, jhContext);
+        }
+
+        get initializing() {
+            return super._initializing();
+        }
+
+        get prompting() {
+            return super._prompting();
+        }
+
+        get configuring() {
+            return super._configuring();
+        }
+
+        get default() {
+            return super._default();
+        }
+
+        get writing() {
+            const phaseFromJHipster = super._writing();
+            const customPhaseSteps = {
+                addDummyProperty() {
+                    this.addNpmDependency('dummy-blueprint-property', '2.0');
+                }
+            };
+            return { ...phaseFromJHipster, ...customPhaseSteps };
+        }
+
+        get install() {
+            return super._install();
+        }
+
+        get end() {
+            return super._end();
+        }
+    };
+};

--- a/test/templates/plugins/client-multiple/package.json
+++ b/test/templates/plugins/client-multiple/package.json
@@ -1,0 +1,1 @@
+{"name":"generator-jhipster-myblueprint","version":"9.9.9"}

--- a/test/templates/plugins/client-override/generators/common/index.js
+++ b/test/templates/plugins/client-override/generators/common/index.js
@@ -1,0 +1,53 @@
+module.exports = {
+    plugin,
+    subGen: 'client'
+};
+
+function plugin(Generator) {
+    return class NewGenerator extends Generator {
+        constructor(args, opts) {
+            super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+            const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+            if (!jhContext) {
+                this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint myblueprint')}");
+            }
+            this.configOptions = jhContext.configOptions || {};
+            // This sets up options for this sub generator and is being reused from JHipster
+            jhContext.setupClientOptions(this, jhContext);
+        }
+
+        get initializing() {
+            return super._initializing();
+        }
+
+        get prompting() {
+            return super._prompting();
+        }
+
+        get configuring() {
+            return super._configuring();
+        }
+
+        get default() {
+            return super._default();
+        }
+
+        get writing() {
+            const phaseFromJHipster = super._writing();
+            const customPhaseSteps = {
+                addDummyProperty() {
+                    this.addNpmDependency('dummy-blueprint-property', '2.0');
+                }
+            };
+            return { ...phaseFromJHipster, ...customPhaseSteps };
+        }
+
+        get install() {
+            return super._install();
+        }
+
+        get end() {
+            return super._end();
+        }
+    };
+};

--- a/test/templates/plugins/client-override/package.json
+++ b/test/templates/plugins/client-override/package.json
@@ -1,0 +1,1 @@
+{"name":"generator-jhipster-myblueprint","version":"9.9.9"}

--- a/test/templates/plugins/client/generators/client/index.js
+++ b/test/templates/plugins/client/generators/client/index.js
@@ -1,0 +1,48 @@
+module.exports = function(Generator) {
+    return class NewGenerator extends Generator {
+        constructor(args, opts) {
+            super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+            const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+            if (!jhContext) {
+                this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint myblueprint')}");
+            }
+            this.configOptions = jhContext.configOptions || {};
+            // This sets up options for this sub generator and is being reused from JHipster
+            jhContext.setupClientOptions(this, jhContext);
+        }
+
+        get initializing() {
+            return super._initializing();
+        }
+
+        get prompting() {
+            return super._prompting();
+        }
+
+        get configuring() {
+            return super._configuring();
+        }
+
+        get default() {
+            return super._default();
+        }
+
+        get writing() {
+            const phaseFromJHipster = super._writing();
+            const customPhaseSteps = {
+                addDummyProperty() {
+                    this.addNpmDependency('dummy-blueprint-property', '2.0');
+                }
+            };
+            return { ...phaseFromJHipster, ...customPhaseSteps };
+        }
+
+        get install() {
+            return super._install();
+        }
+
+        get end() {
+            return super._end();
+        }
+    };
+};

--- a/test/templates/plugins/client/package.json
+++ b/test/templates/plugins/client/package.json
@@ -1,0 +1,1 @@
+{"name":"generator-jhipster-myblueprint","version":"9.9.9"}


### PR DESCRIPTION
JHipster can be installed as a peer dependency.
So, fixes the problem of blueprints installing a different version.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
