### PR TITLE
Rely on yeoman-environment to detect external modules (including blueprints)

### DIFF
--- a/cli/utils.js
+++ b/cli/utils.js
@@ -190,17 +190,8 @@ const done = errorMsg => {
 
 const createYeomanEnv = () => {
     const env = yeoman.createEnv();
-    /* Register yeoman generators */
-    Object.keys(SUB_GENERATORS)
-        .filter(command => !SUB_GENERATORS[command].cliOnly)
-        .forEach(generator => {
-            if (SUB_GENERATORS[generator].blueprint) {
-                /* eslint-disable prettier/prettier */
-                env.register(require.resolve(`${SUB_GENERATORS[generator].blueprint}/generators/${generator}`), `${CLI_NAME}:${generator}`);
-            } else {
-                env.register(require.resolve(`../generators/${generator}`), `${CLI_NAME}:${generator}`);
-            }
-        });
+    // Lookup for all available generators (blueprints, modules, ...)
+    env.lookup();
     return env;
 };
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1108,22 +1108,9 @@ module.exports = class extends PrivateBase {
      * @param {any} options - options to pass
      */
     composeExternalModule(npmPackageName, subGen, options) {
-        let generatorTocall = path.join(process.cwd(), 'node_modules', npmPackageName, 'generators', subGen);
-        try {
-            if (!fs.existsSync(generatorTocall)) {
-                this.debug('using global module as local version could not be found in node_modules');
-                generatorTocall = path.join(npmPackageName, 'generators', subGen);
-            }
-            this.debug('Running yeoman compose with options: ', generatorTocall, options);
-            this.composeWith(require.resolve(generatorTocall), options);
-        } catch (err) {
-            this.debug('ERROR:', err);
-            const generatorName = npmPackageName.replace('generator-', '');
-            const generatorCallback = `${generatorName}:${subGen}`;
-            // Fallback for legacy modules
-            this.debug('Running yeoman legacy compose with options: ', generatorCallback, options);
-            this.composeWith(generatorCallback, options);
-        }
+        const generatorName = npmPackageName.replace('generator-', '');
+        const generatorCallback = `${generatorName}:${subGen}`;
+        this.composeWith(generatorCallback, options);
     }
 
     /**

--- a/test/blueprint/app-blueprint.spec.js
+++ b/test/blueprint/app-blueprint.spec.js
@@ -9,6 +9,7 @@ const angularFiles = require('../../generators/client/files-angular').files;
 describe('JHipster application generator with blueprint', () => {
     describe('generate monolith application with blueprint', () => {
         before(done => {
+            let fakeBlueprintModuleDir;
             helpers
                 .run(path.join(__dirname, '../../generators/app'))
                 .inTmpDir(dir => {
@@ -17,10 +18,17 @@ describe('JHipster application generator with blueprint', () => {
                         name: 'generator-jhipster-myblueprint',
                         version: '9.9.9'
                     };
-                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
+                    fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
                     fse.ensureDirSync(fakeBlueprintModuleDir);
                     fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
                 })
+                .withGenerators([
+                    [
+                        helpers.createDummyGenerator(), // eslint-disable-line global-require
+                        'jhipster-myblueprint:server',
+                        path.join(fakeBlueprintModuleDir, 'generators/server/index.js')
+                    ]
+                ])
                 .withOptions({
                     'from-cli': true,
                     skipInstall: true,

--- a/test/blueprint/app-blueprint.spec.js
+++ b/test/blueprint/app-blueprint.spec.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
-const fse = require('fs-extra');
 const expectedFiles = require('../utils/expected-files');
 const getFilesForOptions = require('../utils/utils').getFilesForOptions;
 const angularFiles = require('../../generators/client/files-angular').files;
@@ -9,24 +8,14 @@ const angularFiles = require('../../generators/client/files-angular').files;
 describe('JHipster application generator with blueprint', () => {
     describe('generate monolith application with blueprint', () => {
         before(done => {
-            let fakeBlueprintModuleDir;
             helpers
                 .run(path.join(__dirname, '../../generators/app'))
-                .inTmpDir(dir => {
-                    // Fake the presence of the blueprint in node_modules
-                    const packagejs = {
-                        name: 'generator-jhipster-myblueprint',
-                        version: '9.9.9'
-                    };
-                    fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
-                    fse.ensureDirSync(fakeBlueprintModuleDir);
-                    fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
-                })
                 .withGenerators([
                     [
-                        helpers.createDummyGenerator(), // eslint-disable-line global-require
+                        // eslint-disable-next-line import/no-dynamic-require,global-require
+                        require(path.join(__dirname, '../templates/fake-blueprint/generators/server')),
                         'jhipster-myblueprint:server',
-                        path.join(fakeBlueprintModuleDir, 'generators/server/index.js')
+                        path.join(__dirname, '../templates/fake-blueprint/generators/server/index.js')
                     ]
                 ])
                 .withOptions({

--- a/test/blueprint/scoped-blueprint.spec.js
+++ b/test/blueprint/scoped-blueprint.spec.js
@@ -1,7 +1,6 @@
 const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
-const fse = require('fs-extra');
 const expectedFiles = require('../utils/expected-files');
 const getFilesForOptions = require('../utils/utils').getFilesForOptions;
 const angularFiles = require('../../generators/client/files-angular').files;
@@ -11,16 +10,14 @@ describe('JHipster application generator with scoped blueprint', () => {
         before(done => {
             helpers
                 .run(path.join(__dirname, '../../generators/app'))
-                .inTmpDir(dir => {
-                    // Fake the presence of the blueprint in node_modules
-                    const packagejs = {
-                        name: '@jhipster/generator-jhipster-scoped-blueprint',
-                        version: '9.9.9'
-                    };
-                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/@jhipster/generator-jhipster-scoped-blueprint');
-                    fse.ensureDirSync(fakeBlueprintModuleDir);
-                    fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
-                })
+                .withGenerators([
+                    [
+                        // eslint-disable-next-line import/no-dynamic-require,global-require
+                        require(path.join(__dirname, '../templates/fake-blueprint/generators/server')),
+                        '@jhipster/jhipster-scoped-blueprint:server',
+                        path.join(__dirname, '../templates/fake-blueprint/generators/server/index.js')
+                    ]
+                ])
                 .withOptions({
                     'from-cli': true,
                     skipInstall: true,

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -2,6 +2,7 @@
 
 const expect = require('chai').expect;
 const exec = require('child_process').exec;
+const stripAnsi = require('strip-ansi');
 
 const { getJHipsterCli } = require('../utils/utils');
 
@@ -46,7 +47,7 @@ describe('jhipster cli test', () => {
             expect(error.code).to.equal(1);
             /* eslint-disable prettier/prettier */
             expect(stdout.includes('No custom commands found within blueprint: generator-jhipster-bar')).to.be.true;
-            expect(stderr.includes('foo is not a known command')).to.be.true;
+            expect(stripAnsi(stderr).includes('foo is not a known command')).to.be.true;
             done();
         });
     });
@@ -61,7 +62,7 @@ describe('jhipster cli test', () => {
             /* eslint-disable prettier/prettier */
             expect(stdout.includes('No custom commands found within blueprint: generator-jhipster-bar')).to.be.true;
             expect(stdout.includes('No custom commands found within blueprint: generator-jhipster-baz')).to.be.true;
-            expect(stderr.includes('foo is not a known command')).to.be.true;
+            expect(stripAnsi(stderr).includes('foo is not a known command')).to.be.true;
             done();
         });
     });

--- a/test/templates/fake-blueprint/generators/server/index.js
+++ b/test/templates/fake-blueprint/generators/server/index.js
@@ -1,0 +1,43 @@
+const ServerGenerator = require('../../../../../generators/server');
+
+module.exports = class extends ServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+        if (!jhContext) {
+            this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint myblueprint')}");
+        }
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupServerOptions(this, jhContext);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        return super._writing();
+    }
+
+    get install() {
+        return super._install();
+    }
+
+    get end() {
+        return super._end();
+    }
+};
+

--- a/test/templates/fake-blueprint/package.json
+++ b/test/templates/fake-blueprint/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "generator-jhipster-myblueprint",
+  "version": "9.9.9",
+  "dependencies": {
+    "generator-jhipster": "1.1.1"
+  }
+}


### PR DESCRIPTION
This is an attempt to solve issues with detecting/loading external Yeoman generators: https://github.com/jhipster/jhipster-kotlin/issues/179, https://github.com/jhipster/generator-jhipster/issues/10223, https://github.com/jhipster/generator-jhipster/issues/10223, ...

The idea is to rely on yeoman-environment `lookup()` feature that will detect available generators on your computer for us.
This also simplifies JHipster code and logic, since we don't need to make multiple attempts to find generator (lookup in local `node_modules`, try to do a `require()`, and in last resort use the `yo` command that internally uses yeoman-environment lookup())



-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
