### PR TITLE
Remove unused currentAccount variable from entity component in Angular

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -29,7 +29,6 @@ import { filter, map } from 'rxjs/operators';
 import { JhiEventManager <% if (pagination !== 'no') { %>, JhiParseLinks <% } %><% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
 
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
-import { AccountService } from 'app/core/auth/account.service';
 <%_ if (pagination !== 'no') { %>
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 <%_ } _%>
@@ -50,9 +49,6 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
 
     ngOnInit() {
         this.loadAll();
-        this.accountService.identity().subscribe((account) => {
-            this.currentAccount = account;
-        });
         this.registerChangeIn<%= entityClassPlural %>();
     }
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
     <%= entityInstancePlural %>: I<%= entityAngularName %>[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     itemsPerPage: number;
     links: any;
@@ -39,7 +38,6 @@
         <%_ if (searchEngine === 'elasticsearch') { _%>
         protected activatedRoute: ActivatedRoute,
         <%_ } _%>
-        protected accountService: AccountService
     ) {
         this.<%= entityInstancePlural %> = [];
         this.itemsPerPage = ITEMS_PER_PAGE;

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
     <%= entityInstancePlural %>: I<%= entityAngularName %>[];
-    currentAccount: any;
     eventSubscriber: Subscription;
     <%_ if (searchEngine === 'elasticsearch') { _%>
     currentSearch: string;
@@ -32,7 +31,6 @@
         <%_ if (searchEngine === 'elasticsearch') { _%>
         protected activatedRoute: ActivatedRoute,
         <%_ } _%>
-        protected accountService: AccountService
     ) {
         <%_ if (searchEngine === 'elasticsearch') { _%>
         this.currentSearch = this.activatedRoute.snapshot && this.activatedRoute.snapshot.queryParams['search'] ?

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -16,7 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-    currentAccount: any;
     <%= entityInstancePlural %>: I<%= entityAngularName %>[];
     error: any;
     success: any;
@@ -38,7 +37,6 @@
     constructor(
         protected <%= entityInstance %>Service: <%= entityAngularName %>Service,
         protected parseLinks: JhiParseLinks,
-        protected accountService: AccountService,
         protected activatedRoute: ActivatedRoute,
         <%_ if (fieldsContainBlob) { _%>
         protected dataUtils: JhiDataUtils,


### PR DESCRIPTION
Seems that initial entity code is copied from user management code. In user management account is used to disable inactivation and deletion of currently logged in user. In entities variable `currentAccount` is unused and can be removed.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
