### PR TITLE
Remove redundant filter in entity in Angular

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -30,7 +30,7 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
 <%_ if (queries && queries.length > 0) { _%>
-import { filter, map } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 <%_ } _%>
 <%_ if ( fieldsContainDate ) { _%>
 import * as moment from 'moment';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -29,9 +29,6 @@ import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
 import { FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { Observable } from 'rxjs';
-<%_ if (queries && queries.length > 0) { _%>
-import { map } from 'rxjs/operators';
-<%_ } _%>
 <%_ if ( fieldsContainDate ) { _%>
 import * as moment from 'moment';
     <%_ if ( fieldsContainInstant || fieldsContainZonedDateTime ) { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -24,8 +24,6 @@ import { ActivatedRoute, Router } from '@angular/router';
 import { ActivatedRoute } from '@angular/router';
 <%_ } _%>
 import { Subscription } from 'rxjs';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { filter, map } from 'rxjs/operators';
 import { JhiEventManager <% if (pagination !== 'no') { %>, JhiParseLinks <% } %><% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
 
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
@@ -24,7 +24,7 @@ import { JhiResolvePagingParams } from 'ng-jhipster';
 <%_ } _%>
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { Observable, of } from 'rxjs';
-import { filter, map } from 'rxjs/operators';
+import { map } from 'rxjs/operators';
 import { <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
 import { <%= entityAngularName %>Component } from './<%= entityFileName %>.component';
@@ -51,7 +51,6 @@ export class <%= entityAngularName %>Resolve implements Resolve<I<%= entityAngul
         const id = route.params['id'];
         if (id) {
             return this.service.find(id).pipe(
-                filter((response: HttpResponse<<%= entityAngularName %>>) => response.ok),
                 map((<%= entityInstance %>: HttpResponse<<%= entityAngularName %>>) => <%= entityInstance %>.body)
             );
         }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -45,21 +45,15 @@
         if (this.currentSearch) {
             this.<%= entityInstance %>Service.search({
                 query: this.currentSearch,
-                }).pipe(
-                    filter((res: HttpResponse<I<%= entityAngularName %>[]>) => res.ok),
-                    map((res: HttpResponse<I<%= entityAngularName %>[]>) => res.body),
-                ).subscribe(
-                    (res: I<%= entityAngularName %>[]) => this.<%= entityInstancePlural %> = res
+                }).subscribe(
+                    (res: HttpResponse<I<%= entityAngularName %>[]>) => this.<%= entityInstancePlural %> = res.body
                 );
             return;
        }
        <%_ } _%>
-        this.<%= entityInstance %>Service.query().pipe(
-            filter((res: HttpResponse<I<%= entityAngularName %>[]>) => res.ok),
-            map((res: HttpResponse<I<%= entityAngularName %>[]>) => res.body),
-        ).subscribe(
-            (res: I<%= entityAngularName %>[]) => {
-                this.<%= entityInstancePlural %> = res;
+        this.<%= entityInstance %>Service.query().subscribe(
+            (res: HttpResponse<I<%= entityAngularName %>[]>) => {
+                this.<%= entityInstancePlural %> = res.body;
             <%_ if (searchEngine === 'elasticsearch') { _%>
                 this.currentSearch = '';
             <%_ } _%>

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -964,21 +964,15 @@ module.exports = class extends Generator {
                 }
 
                 query = `this.${relationship.otherEntityName}Service
-            .query({${filter}}).pipe(
-                map((response: HttpResponse<I${relationship.otherEntityAngularName}[]>) => response.body),
-            )
-            .subscribe((res: I${relationship.otherEntityAngularName}[]) => {
+            .query({${filter}}).subscribe((res: HttpResponse<I${relationship.otherEntityAngularName}[]>) => {
                 if (${relationshipFieldNameIdCheck}) {
-                    this.${variableName} = res;
+                    this.${variableName} = res.body;
                 } else {
                     this.${relationship.otherEntityName}Service
                         .find(this.editForm.get('${relationshipFieldName}${dto !== 'no' ? 'Id' : ''}').value${
                     dto === 'no' ? '.id' : ''
-                }).pipe(
-                            map((subResponse: HttpResponse<I${relationship.otherEntityAngularName}>) => subResponse.body),
-                        )
-                        .subscribe((subRes: I${relationship.otherEntityAngularName}) =>
-                            this.${variableName} = [subRes].concat(res)
+                }).subscribe((subRes: HttpResponse<I${relationship.otherEntityAngularName}>) =>
+                            this.${variableName} = [subRes.body].concat(res.body)
                         , (subRes: HttpErrorResponse) => this.onError(subRes.message));
                 }
             }, (res: HttpErrorResponse) => this.onError(res.message));`;
@@ -987,11 +981,8 @@ module.exports = class extends Generator {
                 if (variableName === entityInstance) {
                     variableName += 'Collection';
                 }
-                query = `this.${relationship.otherEntityName}Service.query().pipe(
-                            map((response: HttpResponse<I${relationship.otherEntityAngularName}[]>) => response.body),
-                        )
-            .subscribe(
-                (res: I${relationship.otherEntityAngularName}[]) => this.${variableName} = res,
+                query = `this.${relationship.otherEntityName}Service.query().subscribe(
+                (res: HttpResponse<I${relationship.otherEntityAngularName}[]>) => this.${variableName} = res.body,
                 (res: HttpErrorResponse) => this.onError(res.message));`;
             }
             if (variableName && !this.contains(queries, query)) {

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -965,7 +965,6 @@ module.exports = class extends Generator {
 
                 query = `this.${relationship.otherEntityName}Service
             .query({${filter}}).pipe(
-                filter((mayBeOk: HttpResponse<I${relationship.otherEntityAngularName}[]>) => mayBeOk.ok),
                 map((response: HttpResponse<I${relationship.otherEntityAngularName}[]>) => response.body),
             )
             .subscribe((res: I${relationship.otherEntityAngularName}[]) => {
@@ -976,7 +975,6 @@ module.exports = class extends Generator {
                         .find(this.editForm.get('${relationshipFieldName}${dto !== 'no' ? 'Id' : ''}').value${
                     dto === 'no' ? '.id' : ''
                 }).pipe(
-                            filter((subResMayBeOk: HttpResponse<I${relationship.otherEntityAngularName}>) => subResMayBeOk.ok),
                             map((subResponse: HttpResponse<I${relationship.otherEntityAngularName}>) => subResponse.body),
                         )
                         .subscribe((subRes: I${relationship.otherEntityAngularName}) =>
@@ -990,7 +988,6 @@ module.exports = class extends Generator {
                     variableName += 'Collection';
                 }
                 query = `this.${relationship.otherEntityName}Service.query().pipe(
-                            filter((mayBeOk: HttpResponse<I${relationship.otherEntityAngularName}[]>) => mayBeOk.ok),
                             map((response: HttpResponse<I${relationship.otherEntityAngularName}[]>) => response.body),
                         )
             .subscribe(


### PR DESCRIPTION
Angular http component routes response to Observable error chain if HTTP error occurs: https://angular.io/guide/http#getting-error-details  
So no need to filter `HttpClient` response with `res.ok`, #10383 removed such code from client sub-generator, this PR removes this from entity client sub-generator to avoid confusion and make code cleaner.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
