### PR TITLE
In ManyToMany relations the id's are in join table

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -217,7 +217,8 @@
             <%_ } _%>
             <%_ for (idx in relationships) {
                     let loadColumnType = 'numeric';
-                    if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
+                    if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired
+                        && relationships[idx].relationshipType !== 'many-to-many') {
                         let baseColumnName = getColumnName(relationships[idx].relationshipName) + '_id';
                         if (relationships[idx].otherEntityNameCapitalized === 'User' && authenticationType === 'oauth2') {
                             loadColumnType = 'varchar(100)';


### PR DESCRIPTION
When an entity is marked as required in a ManyToMayn relation then the liquibase script for faker is specifying the foreign key which is actually part of the join table. That's why it needs to be removed.

Fixes #10577

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
