### PR TITLE
Remove unused arguments in Angular

### DIFF
--- a/generators/client/templates/angular/.eslintrc.json.ejs
+++ b/generators/client/templates/angular/.eslintrc.json.ejs
@@ -30,7 +30,7 @@
       }
     ],
     "@typescript-eslint/no-unused-vars": [
-      "error",
+      "warn",
       {
         "vars": "all",
         "args": "after-used",

--- a/generators/client/templates/angular/.eslintrc.json.ejs
+++ b/generators/client/templates/angular/.eslintrc.json.ejs
@@ -28,6 +28,14 @@
       {
         "lintFile": "./tslint.json"
       }
+    ],
+    "@typescript-eslint/no-unused-vars": [
+      "error",
+      {
+        "vars": "all",
+        "args": "after-used",
+        "ignoreRestSiblings": false
+      }
     ]
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.ts.ejs
@@ -49,7 +49,7 @@ export class SessionsComponent implements OnInit {
 
     invalidate(series) {
         this.sessionsService.delete(encodeURIComponent(series)).subscribe(
-            (response) => {
+            () => {
                 this.error = null;
                 this.success = 'OK';
                 this.sessionsService.findAll().subscribe((sessions) => this.sessions = sessions);

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
@@ -43,7 +43,7 @@ export class UserManagementDeleteDialogComponent {
     }
 
     confirmDelete(login) {
-        this.userService.delete(login).subscribe((response) => {
+        this.userService.delete(login).subscribe(() => {
             this.eventManager.broadcast({ name: 'userListModification',
                 content: 'Deleted a user'});
             this.activeModal.close(true);

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -95,10 +95,10 @@ export class UserManagementUpdateComponent implements OnInit {
         this.isSaving = true;
         this.updateUser(this.user);
         if (this.user.id !== null) {
-            this.userService.update(this.user).subscribe((response) => this.onSaveSuccess(response), () => this.onSaveError());
+            this.userService.update(this.user).subscribe(() => this.onSaveSuccess(), () => this.onSaveError());
         } else {<% if (!enableTranslation) { %>
             this.user.langKey = 'en';<% } %>
-            this.userService.create(this.user).subscribe((response) => this.onSaveSuccess(response), () => this.onSaveError());
+            this.userService.create(this.user).subscribe(() => this.onSaveSuccess(), () => this.onSaveError());
         }
     }
 
@@ -112,7 +112,7 @@ export class UserManagementUpdateComponent implements OnInit {
         user.authorities = this.editForm.get(['authorities']).value;
     }
 
-    private onSaveSuccess(result) {
+    private onSaveSuccess() {
         this.isSaving = false;
         this.previousState();
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -97,14 +97,14 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     }
 
     registerChangeInUsers() {
-        this.userListSubscription = this.eventManager.subscribe('userListModification', (response) => this.loadAll());
+        this.userListSubscription = this.eventManager.subscribe('userListModification', () => this.loadAll());
     }
 
     setActive(user, isActivated) {
         user.activated = isActivated;
 
         this.userService.update(user).subscribe(
-            (response) => {
+            () => {
                 this.error = null;
                 this.success = 'OK';
                 this.loadAll();
@@ -119,7 +119,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
             page: this.page - 1,
             size: this.itemsPerPage,
             sort: this.sort()}<% } %>).subscribe(
-                (res: HttpResponse<User[]>) => this.onSuccess(res.body, res.headers),
+                (res: HttpResponse<User[]>) => this.onSuccess(res.body<% if (databaseType !== 'cassandra') { %>, res.headers<% } %>),
                 (res: HttpResponse<any>) => this.onError(res.body)
         );
     }
@@ -162,7 +162,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
         modalRef.componentInstance.user = user;
     }
 
-    private onSuccess(data, headers) {
+    private onSuccess(data<% if (databaseType !== 'cassandra') { %>, headers<% } %>) {
         <%_ if (databaseType !== 'cassandra') { _%>
         this.links = this.parseLinks.parse(headers.get('link'));
         this.totalItems = headers.get('X-Total-Count');

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Routes } from '@angular/router';
+import { Resolve, ActivatedRouteSnapshot, Routes } from '@angular/router';
 import { JhiResolvePagingParams } from 'ng-jhipster';
 
 import { User } from 'app/core/user/user.model';
@@ -32,7 +32,7 @@ export class UserManagementResolve implements Resolve<any> {
     constructor(private service: UserService) {
     }
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot) {
+    resolve(route: ActivatedRouteSnapshot) {
         const id = route.params['login'] ? route.params['login'] : null;
         if (id) {
             return this.service.find(id);

--- a/generators/client/templates/angular/src/main/webapp/app/app.main.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.main.ts.ejs
@@ -28,5 +28,5 @@ if (module['hot']) {
 
 platformBrowserDynamic().bootstrapModule(<%=angularXAppName%>AppModule, { preserveWhitespaces: true })
     // eslint-disable-next-line no-console
-    .then((success) => console.log('Application started'))
+    .then(() => console.log('Application started'))
     .catch((err) => console.error(err));

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -59,7 +59,7 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
 
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap((event: HttpEvent<any>) => {}, (err: any) => {
+        return next.handle(request).pipe(tap(() => {}, (err: any) => {
             if (err instanceof HttpErrorResponse) {
                 if (err.status === 401) {
 <%_ if (authenticationType === 'jwt') { _%>
@@ -79,7 +79,7 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
     }
 <%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap((event: HttpEvent<any>) => {}, (err: any) => {
+        return next.handle(request).pipe(tap(() => {}, (err: any) => {
             if (err instanceof HttpErrorResponse) {
                 if (err.status === 401 && err.url && !err.url.includes('api/account')) {
                     const destination = this.stateStorageService.getDestinationState();

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
@@ -29,7 +29,7 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     }
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap((event: HttpEvent<any>) => {}, (err: any) => {
+        return next.handle(request).pipe(tap(() => {}, (err: any) => {
             if (err instanceof HttpErrorResponse) {
                 if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('api/account'))))) {
                     this.eventManager.broadcast({name: '<%=angularAppName%>.httpError', content: err});

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
@@ -52,6 +52,6 @@ export class NotificationInterceptor implements HttpInterceptor {
                     }
                 }
             }
-        }, (err: any) => {}));
+        }));
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -19,9 +19,8 @@
 import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import {map} from 'rxjs/operators';
 <%_ if (authenticationType !== 'uaa') { _%>
+import {map} from 'rxjs/operators';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
 
@@ -71,16 +70,16 @@ export class AuthServerProvider {
         return this.http.post(SERVER_API_URL + 'api/authenticate', data, {observe : 'response'}).pipe(map(authenticateSuccess.bind(this)));
 <%_ } _%>
     }
+<%_ if (authenticationType !== 'uaa') { _%>
 
     storeAuthenticationToken(jwt, rememberMe) {
-<%_ if (authenticationType !== 'uaa') { _%>
         if (rememberMe) {
             this.$localStorage.store('authenticationToken', jwt);
         } else {
             this.$sessionStorage.store('authenticationToken', jwt);
         }
-<%_ } _%>
     }
+<%_ } _%>
 
     logout(): Observable<any> {
 <%_ if (authenticationType === 'uaa') { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -19,7 +19,7 @@
 import { Injectable, RendererFactory2, Renderer2 } from '@angular/core';
 import { Title } from '@angular/platform-browser';
 import { Router, ActivatedRouteSnapshot } from '@angular/router';
-import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
+import { TranslateService } from '@ngx-translate/core';
 
 import { LANGUAGES } from 'app/core/language/language.constants';
 <%_ if (enableI18nRTL) { _%>
@@ -65,7 +65,7 @@ export class JhiLanguageHelper {
     }
 
     private init() {
-        this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
+        this.translateService.onLangChange.subscribe(() => {
             this.renderer.setAttribute(document.querySelector('html'), 'lang', this.translateService.currentLang);
             this.updateTitle();
             <%_ if (enableI18nRTL) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -19,9 +19,10 @@
 import { Injectable } from '@angular/core';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { Location } from '@angular/common';
-<%_ } _%>
+<%_ } else { _%>
 import { flatMap } from 'rxjs/operators';
 import { AccountService } from 'app/core/auth/account.service';
+<%_ } _%>
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
 import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
 <%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
@@ -32,9 +33,10 @@ import { AuthServerProvider } from 'app/core/auth/auth-session.service';
 export class LoginService {
 
     constructor(
-        private accountService: AccountService,
         <%_ if (authenticationType === 'oauth2') { _%>
         private location: Location,
+        <%_ } else { _%>
+        private accountService: AccountService,
         <%_ } _%>
         private authServerProvider: AuthServerProvider
     ) {}

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -134,6 +134,6 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
     }
 
     private createConnection(): Promise<any> {
-        return new Promise((resolve, reject) => this.connectedPromise = resolve);
+        return new Promise(resolve => this.connectedPromise = resolve);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.ts.ejs
@@ -66,7 +66,7 @@ export class HomeComponent implements OnInit <%_ if (authenticationType !== 'oau
     }
 
     registerAuthenticationSuccess() {
-        this.authSubscription = this.eventManager.subscribe('authenticationSuccess', (message) => {
+        this.authSubscription = this.eventManager.subscribe('authenticationSuccess', () => {
             this.accountService.identity().subscribe((account) => {
                 this.account = account;
             });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -47,23 +47,29 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
             switch (httpErrorResponse.status) {
                 // connection refused, server not reachable
                 case 0:
-                    this.addErrorAlert('Server not reachable', 'error.server.not.reachable');
+                    this.addErrorAlert('Server not reachable'<% if (enableTranslation) { %>, 'error.server.not.reachable'<% } %>);
                     break;
 
                 case 400: {
                     const arr = httpErrorResponse.headers.keys();
                     let errorHeader = null;
+                    <%_ if (enableTranslation) { _%>
                     let entityKey = null;
+                    <%_ } _%>
                     arr.forEach((entry) => {
                         if (entry.toLowerCase().endsWith('app-error')) {
                             errorHeader = httpErrorResponse.headers.get(entry);
+                        <%_ if (enableTranslation) { _%>
                         } else if (entry.toLowerCase().endsWith('app-params')) {
                             entityKey = httpErrorResponse.headers.get(entry);
+                        <%_ } _%>
                         }
                     });
                     if (errorHeader) {
-                        const entityName = <% if (enableTranslation) { %>translateService.instant('global.menu.entities.' + entityKey)<% }else{ %>entityKey<% } %>;
-                        this.addErrorAlert(errorHeader, errorHeader, { entityName });
+                        <%_ if (enableTranslation) { _%>
+                        const entityName = translateService.instant('global.menu.entities.' + entityKey);
+                        <%_ } _%>
+                        this.addErrorAlert(errorHeader<% if (enableTranslation) { %>, errorHeader, { entityName }<% } %>);
                     } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.fieldErrors) {
                         const fieldErrors = httpErrorResponse.error.fieldErrors;
                         for (i = 0; i < fieldErrors.length; i++) {
@@ -77,17 +83,17 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
                                 fieldError.objectName + '.' + convertedField)<% } else { %>convertedField.charAt(0).toUpperCase() +
                                 convertedField.slice(1)<% } %>;
                             this.addErrorAlert(
-                                'Error on field "' + fieldName + '"', 'error.' + fieldError.message, { fieldName });
+                                'Error on field "' + fieldName + '"'<% if (enableTranslation) { %>, 'error.' + fieldError.message, { fieldName }<% } %>);
                         }
                     } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-                        this.addErrorAlert(httpErrorResponse.error.message, httpErrorResponse.error.message, httpErrorResponse.error.params);
+                        this.addErrorAlert(httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
                     } else {
                         this.addErrorAlert(httpErrorResponse.error);
                     }
                     break;
                 }
                 case 404:
-                    this.addErrorAlert('Not found', 'error.url.not.found');
+                    this.addErrorAlert('Not found'<% if (enableTranslation) { %>, 'error.url.not.found'<% } %>);
                     break;
 
                 default:
@@ -114,11 +120,11 @@ export class <%=jhiPrefixCapitalized%>AlertErrorComponent implements OnDestroy {
         }
     }
 
-    addErrorAlert(message, key?, data?) {
+    addErrorAlert(message<% if (enableTranslation) { %>, key?, data?<% } %>) {
         <%_ if (enableTranslation) { _%>
         message = (key && key !== null) ? key : message;
-        <%_ } _%>
 
+        <%_ } _%>
         const newAlert: JhiAlert = {
             type: 'danger',
             msg: message,

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/has-any-authority.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/has-any-authority.directive.ts.ejs
@@ -45,7 +45,7 @@ export class HasAnyAuthorityDirective {
         this.authorities = typeof value === 'string' ? [ value ] : value;
         this.updateView();
         // Get notified each time authentication state changes.
-        this.accountService.getAuthenticationState().subscribe((identity) => this.updateView());
+        this.accountService.getAuthenticationState().subscribe(() => this.updateView());
     }
 
     private updateView(): void {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
@@ -47,7 +47,7 @@ describe('Component Tests', () => {
                     {
                         provide: Renderer,
                         useValue: {
-                            invokeElementMethod(renderElement: any, methodName: string, args?: any[]) {}
+                            invokeElementMethod() {}
                         }
                     },
                     {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/finish/password-reset-finish.component.spec.ts.ejs
@@ -19,7 +19,6 @@
 import { ComponentFixture, TestBed, inject, tick, fakeAsync } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
-import { Renderer, ElementRef } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
 
 import { <%=angularXAppName%>TestModule } from '../../../../test.module';
@@ -43,16 +42,6 @@ describe('Component Tests', () => {
                     {
                         provide: ActivatedRoute,
                         useValue: new MockActivatedRoute({'key': 'XYZPDQ'})
-                    },
-                    {
-                        provide: Renderer,
-                        useValue: {
-                            invokeElementMethod() {}
-                        }
-                    },
-                    {
-                        provide: ElementRef,
-                        useValue: new ElementRef(null)
                     }
                 ]
             })
@@ -74,13 +63,12 @@ describe('Component Tests', () => {
         });
 
         it('sets focus after the view has been initialized',
-            inject([ElementRef], (elementRef: ElementRef) => {
+            () => {
                 const element = fixture.nativeElement;
                 const node = {
                     focus() {}
                 };
 
-                elementRef.nativeElement = element;
                 spyOn(element, 'querySelector').and.returnValue(node);
                 spyOn(node, 'focus');
 
@@ -88,7 +76,7 @@ describe('Component Tests', () => {
 
                 expect(element.querySelector).toHaveBeenCalledWith('#password');
                 expect(node.focus).toHaveBeenCalled();
-            })
+            }
         );
 
         it('should ensure the two passwords entered match', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
@@ -41,7 +41,7 @@ describe('Component Tests', () => {
                     {
                         provide: Renderer,
                         useValue: {
-                            invokeElementMethod(renderElement: any, methodName: string, args?: any[]) {}
+                            invokeElementMethod() {}
                         }
                     },
                     {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password-reset/init/password-reset-init.component.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, inject } from '@angular/core/testing';
-import { Renderer, ElementRef } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
 
@@ -36,19 +35,7 @@ describe('Component Tests', () => {
             fixture = TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
                 declarations: [PasswordResetInitComponent],
-                providers: [
-                    FormBuilder,
-                    {
-                        provide: Renderer,
-                        useValue: {
-                            invokeElementMethod() {}
-                        }
-                    },
-                    {
-                        provide: ElementRef,
-                        useValue: new ElementRef(null)
-                    }
-                ]
+                providers: [FormBuilder]
             })
             .overrideTemplate(PasswordResetInitComponent, '')
             .createComponent(PasswordResetInitComponent);
@@ -62,13 +49,12 @@ describe('Component Tests', () => {
         });
 
         it('sets focus after the view has been initialized',
-            inject([ElementRef], (elementRef: ElementRef) => {
+            () => {
                 const element = fixture.nativeElement;
                 const node = {
                     focus() {}
                 };
 
-                elementRef.nativeElement = element;
                 spyOn(element, 'querySelector').and.returnValue(node);
                 spyOn(node, 'focus');
 
@@ -76,7 +62,7 @@ describe('Component Tests', () => {
 
                 expect(element.querySelector).toHaveBeenCalledWith('#email');
                 expect(node.focus).toHaveBeenCalled();
-            })
+            }
         );
 
         it('notifies of success upon successful requestReset',

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-language.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-language.service.ts.ejs
@@ -32,16 +32,6 @@ export class MockLanguageService extends SpyObject {
         this.fakeResponse = '<%= nativeLanguage %>';
         this.getCurrentSpy = this.spy('getCurrent').andReturn(Promise.resolve(this.fakeResponse));
     }
-
-    init() {}
-
-    changeLanguage(languageKey: string) {}
-
-    setLocations(locations: string[]) {}
-
-    addLocation(location: string) {}
-
-    reload() {}
 }
 
 export class MockLanguageHelper extends SpyObject {

--- a/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { DatePipe } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { NgModule, ElementRef, Renderer } from '@angular/core';
+import { NgModule } from '@angular/core';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { <% if (enableTranslation) { %>JhiLanguageService, <% } %>JhiDataUtils, JhiDateUtils, JhiEventManager, JhiAlertService, JhiParseLinks } from 'ng-jhipster';
@@ -90,14 +90,6 @@ _%>
             useValue: null
         },
         <%_ } _%>
-        {
-            provide: ElementRef,
-            useValue: null
-        },
-        {
-            provide: Renderer,
-            useValue: null
-        },
         {
             provide: JhiAlertService,
             useValue: null

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
@@ -48,7 +48,7 @@ export class <%= entityAngularName %>DeleteDialogComponent {
     }
 
     confirmDelete(id: <% if (primaryKeyType === 'String' || pkType === 'UUID') { %>string<% } else { %>number<% } %>) {
-        this.<%= entityInstance %>Service.delete(id).subscribe((response) => {
+        this.<%= entityInstance %>Service.delete(id).subscribe(() => {
             this.eventManager.broadcast({
                 name: '<%= entityInstance %>ListModification',
                 content: 'Deleted an <%= entityInstance %>'
@@ -77,10 +77,10 @@ export class <%= entityAngularName %>DeletePopupComponent implements OnInit, OnD
             setTimeout(() => {
                 this.ngbModalRef = this.modalService.open(<%= entityAngularName %>DeleteDialogComponent as Component, { size: 'lg', backdrop: 'static'});
                 this.ngbModalRef.componentInstance.<%= entityInstance %> = <%= entityInstance %>;
-                this.ngbModalRef.result.then((result) => {
+                this.ngbModalRef.result.then(() => {
                     this.router.navigate(['/<%= entityUrl %>', { outlets: { popup: null }}]);
                     this.ngbModalRef = null;
-                }, (reason) => {
+                }, () => {
                     this.router.navigate(['/<%= entityUrl %>', { outlets: { popup: null }}]);
                     this.ngbModalRef = null;
                 });

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -80,7 +80,7 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
     } _%>
 
     registerChangeIn<%= entityClassPlural %>() {
-        this.eventSubscriber = this.eventManager.subscribe('<%= entityInstance %>ListModification', (response) => <%= eventCallBack %>);
+        this.eventSubscriber = this.eventManager.subscribe('<%= entityInstance %>ListModification', () => <%= eventCallBack %>);
     }
     <%_ if (pagination !== 'no') { _%>
         <%_ if (databaseType !== 'cassandra') { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Injectable } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
-import { Resolve, ActivatedRouteSnapshot, RouterStateSnapshot, Routes } from '@angular/router';
+import { Resolve, ActivatedRouteSnapshot, Routes } from '@angular/router';
 <%_ if (pagination === 'pagination' || pagination === 'pager') { _%>
 import { JhiResolvePagingParams } from 'ng-jhipster';
 <%_ } _%>
@@ -47,7 +47,7 @@ export class <%= entityAngularName %>Resolve implements Resolve<I<%= entityAngul
     constructor(private service: <%= entityAngularName %>Service) {
     }
 
-    resolve(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<I<%= entityAngularName %>> {
+    resolve(route: ActivatedRouteSnapshot): Observable<I<%= entityAngularName %>> {
         const id = route.params['id'];
         if (id) {
             return this.service.find(id).pipe(

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { element, by, ElementFinder } from 'protractor';
+import { element, by<% if (!readOnly) { %>, ElementFinder<% } %> } from 'protractor';
 
 <%_
 let elementGetter = `getText()`;
@@ -40,11 +40,11 @@ export class <%= entityClass %>ComponentsPage {
     title = element.all(by.css('<%= jhiPrefixDashed %>-<%= entityFileName %> div h2#page-heading span')).first();
 
 <%_ if (!readOnly) { _%>
-    async clickOnCreateButton(timeout?: number) {
+    async clickOnCreateButton() {
         await this.createButton.click();
     }
 
-    async clickOnLastDeleteButton(timeout?: number) {
+    async clickOnLastDeleteButton() {
         await this.deleteButtons.last().click();
     }
 
@@ -104,7 +104,7 @@ export class <%= entityClass %>UpdatePage {
             let ngModelOption = '';
     _%>
             <%_ if (fieldType === 'Boolean') { _%>
-    get<%= fieldNameCapitalized %>Input(timeout?: number) {
+    get<%= fieldNameCapitalized %>Input() {
         return this.<%= fieldName %>Input;
     }
             <%_ } else if (fieldIsEnum) { _%>
@@ -116,7 +116,7 @@ export class <%= entityClass %>UpdatePage {
         return await this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
     }
 
-    async <%=fieldName %>SelectLastOption(timeout?: number) {
+    async <%=fieldName %>SelectLastOption() {
         await this.<%=fieldName %>Select.all(by.tagName('option')).last().click();
     }
 
@@ -148,7 +148,7 @@ export class <%= entityClass %>UpdatePage {
         const relationshipNameCapitalized = relationship.relationshipNameCapitalized; _%>
 
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-    async <%=relationshipName %>SelectLastOption(timeout?: number) {
+    async <%=relationshipName %>SelectLastOption() {
         await this.<%=relationshipName %>Select.all(by.tagName('option')).last().click();
     }
 
@@ -166,11 +166,11 @@ export class <%= entityClass %>UpdatePage {
 
     <%_ } _%>
     <%_ }); _%>
-    async save(timeout?: number) {
+    async save() {
         await this.saveButton.click();
     }
 
-    async cancel(timeout?: number) {
+    async cancel() {
         await this.cancelButton.click();
     }
 
@@ -187,7 +187,7 @@ export class <%= entityClass %>DeleteDialog {
         return this.dialogTitle.<%- elementGetter %>;
     }
 
-    async clickOnConfirmButton(timeout?: number) {
+    async clickOnConfirmButton() {
         await this.confirmButton.click();
     }
 }

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -30,11 +30,9 @@ for (let relationship of relationships) {
         break;
     }
 } _%>
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
-import { browser, ExpectedConditions as ec, <% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>protractor, <% } %>promise } from 'protractor';
+import { browser, ExpectedConditions as ec <% if (!readOnly) { %><%= openBlockComment %><% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>, protractor<% } %>, promise<%= closeBlockComment %><% } %> } from 'protractor';
 import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
 
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
 import { <%= entityClass %>ComponentsPage,
     <%_ if (!readOnly) { _%>
     <%= openBlockComment %><%= entityClass %>DeleteDialog,

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -876,8 +876,7 @@ module.exports = class extends PrivateBase {
                         /(,[\s]*(resolve):[\s]*[{][\s]*(translatePartialLoader)['a-zA-Z0-9$,(){.<%=\->;\s:[\]]*(;[\s]*\}\][\s]*\}))/, // ng1 resolve block
                         /([\s]import\s\{\s?JhiLanguageService\s?\}\sfrom\s["|']ng-jhipster["|'];)/, // ng2 import jhiLanguageService
                         /(,?\s?JhiLanguageService,?\s?)/, // ng2 import jhiLanguageService
-                        /(private\s[a-zA-Z0-9]*(L|l)anguageService\s?:\s?JhiLanguageService\s?,*[\s]*)/, // ng2 jhiLanguageService constructor argument
-                        /(this\.[a-zA-Z0-9]*(L|l)anguageService\.setLocations\(\[['"a-zA-Z0-9\-_,\s]+\]\);[\s]*)/ // jhiLanguageService invocations
+                        /(private\s[a-zA-Z0-9]*(L|l)anguageService\s?:\s?JhiLanguageService\s?,*[\s]*)/ // ng2 jhiLanguageService constructor argument
                     ]
                         .map(r => r.source)
                         .join('|'),


### PR DESCRIPTION
This PR switches `@typescript-eslint/no-unused-vars` `args` parameter to default value: `"args": "after-used"`, currently this is turned off: https://github.com/jhipster/eslint-config-jhipster/blob/master/base/index.js#L43

Some of this rule violations were fixed by #10383. This PR fixes remaining problems.

Comment about change in `generator-base.js`: location and reload functions were removed from `JhiLanguageService` by this commit: https://github.com/jhipster/ng-jhipster/commit/39aec06b84dead9e74217dda309ed74d96621c3c and seems that this code was forgotten to be removed from the generator.

This PR is a draft ATM. After CI passes I switch `@typescript-eslint/no-unused-vars` from `error` to `warn`.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
