### PR TITLE
Fix languages module workflow

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -133,7 +133,7 @@ module.exports = class extends BaseBlueprintGenerator {
                     if (this.nativeLanguage === undefined) {
                         this.nativeLanguage = 'en';
                     }
-                    if (this.languages === undefined) {
+                    if (this.enableTranslation && this.languages === undefined) {
                         this.languages = ['en', 'fr'];
                     }
 
@@ -272,6 +272,12 @@ module.exports = class extends BaseBlueprintGenerator {
     // Public API method used by the getter and also by Blueprints
     _default() {
         return {
+            composeLanguages() {
+                if (this.configOptions.skipI18nQuestion) return;
+
+                this.composeLanguagesSub(this, this.configOptions, 'client');
+            },
+
             getSharedConfigOptions() {
                 if (this.configOptions.cacheProvider) {
                     this.cacheProvider = this.configOptions.cacheProvider;
@@ -338,12 +344,6 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.DIST_DIR = this.getResourceBuildDirectoryForBuildTool(this.configOptions.buildTool) + constants.CLIENT_DIST_DIR;
                 this.AOT_DIR = `${this.getResourceBuildDirectoryForBuildTool(this.configOptions.buildTool)}aot`;
                 this.CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
-            },
-
-            composeLanguages() {
-                if (this.configOptions.skipI18nQuestion) return;
-
-                this.composeLanguagesSub(this, this.configOptions, 'client');
             }
         };
     }

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -148,9 +148,12 @@ module.exports = class extends BaseBlueprintGenerator {
         return {
             saveConfig() {
                 if (this.enableTranslation) {
-                    this.languages = _.union(this.currentLanguages, this.languagesToApply);
+                    this.languages = _.union(this.currentLanguages, this.languagesToApply, this.configOptions.languages);
+                    // Update configOptions with additional languages.
+                    this.configOptions.languages = this.languages;
                     this.config.set('languages', this.languages);
                 }
+                this.languages = this.languages || [];
             }
         };
     }
@@ -213,7 +216,7 @@ module.exports = class extends BaseBlueprintGenerator {
     _writing() {
         return {
             translateFile() {
-                this.languagesToApply.forEach(language => {
+                this.languages.forEach(language => {
                     if (!this.skipClient) {
                         this.installI18nClientFilesByLanguage(this, constants.CLIENT_MAIN_SRC_DIR, language);
                     }

--- a/generators/languages/prompts.js
+++ b/generators/languages/prompts.js
@@ -24,7 +24,6 @@ module.exports = {
 
 function askForLanguages() {
     if (this.languages) return;
-    const done = this.async();
     const languageOptions = this.getAllSupportedLanguageOptions();
     const prompts = [
         {
@@ -35,6 +34,7 @@ function askForLanguages() {
         }
     ];
     if (this.enableTranslation || this.configOptions.enableTranslation) {
+        const done = this.async();
         this.prompt(prompts).then(props => {
             this.languagesToApply = props.languages || [];
             done();

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -279,7 +279,7 @@ module.exports = class extends BaseBlueprintGenerator {
                     if (this.nativeLanguage === undefined) {
                         this.nativeLanguage = 'en';
                     }
-                    if (this.languages === undefined) {
+                    if (this.enableTranslation && this.languages === undefined) {
                         this.languages = ['en', 'fr'];
                     }
                     // user-management will be handled by UAA app, oauth expects users to be managed in IpP
@@ -430,6 +430,12 @@ module.exports = class extends BaseBlueprintGenerator {
     // Public API method used by the getter and also by Blueprints
     _default() {
         return {
+            composeLanguages() {
+                if (this.configOptions.skipI18nQuestion) return;
+
+                this.composeLanguagesSub(this, this.configOptions, 'server');
+            },
+
             getSharedConfigOptions() {
                 if (this.configOptions.enableTranslation !== undefined) {
                     this.enableTranslation = this.configOptions.enableTranslation;
@@ -455,12 +461,6 @@ module.exports = class extends BaseBlueprintGenerator {
                 }
                 this.gatlingTests = this.testFrameworks.includes('gatling');
                 this.cucumberTests = this.testFrameworks.includes('cucumber');
-            },
-
-            composeLanguages() {
-                if (this.configOptions.skipI18nQuestion) return;
-
-                this.composeLanguagesSub(this, this.configOptions, 'server');
             }
         };
     }


### PR DESCRIPTION
- this.languagesToApply is only new selected languages, use
this.languages instead (union of old and new languages).
- Ignore writing steps when enableTranslation is not true.
- Languages prompt: call generator.async only if the prompt will be
displayed.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
