### PR TITLE
fix metrics for services in react

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/metrics/metrics.tsx.ejs
@@ -106,8 +106,8 @@ export const MetricsPage = (props: IMetricsPageProps) => {
       ) : (
         ''
       )}
-      {metrics && metrics.endpointsRequests ? (
-        <EndpointsRequestsMetrics endpointsRequestsMetrics={metrics.endpointsRequests} wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT} />
+      {metrics && metrics.services ? (
+        <EndpointsRequestsMetrics endpointsRequestsMetrics={metrics.services} wholeNumberFormat={APP_WHOLE_NUMBER_FORMAT} />
       ) : (
         ''
       )}


### PR DESCRIPTION
The following metric section isn't displayed for React:

![image](https://user-images.githubusercontent.com/766263/66581977-52902e00-eb81-11e9-9951-aeb074cb787d.png)
