### PR TITLE
feat (ci): Support Github CI in the ci-cd sub generator

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -60,6 +60,14 @@ module.exports = class extends BaseGenerator {
             defaults: false,
             description: 'Automatically configure Azure'
         });
+
+        // Automatically configure GitHub CI
+        this.argument('autoconfigure-github', {
+            type: Boolean,
+            defaults: false,
+            description: 'Automatically configure Github CI'
+        });
+
         this.registerPrettierTransform();
     }
 
@@ -88,6 +96,7 @@ module.exports = class extends BaseGenerator {
                 this.autoconfigureJenkins = this.options['autoconfigure-jenkins'];
                 this.autoconfigureGitlab = this.options['autoconfigure-gitlab'];
                 this.autoconfigureAzure = this.options['autoconfigure-azure'];
+                this.autoconfigureGithub = this.options['autoconfigure-github'];
                 this.abort = false;
             },
             initConstants() {
@@ -150,6 +159,9 @@ module.exports = class extends BaseGenerator {
         }
         if (this.pipeline === 'azure') {
             this.template('azure-pipelines.yml.ejs', 'azure-pipelines.yml');
+        }
+        if (this.pipeline === 'github') {
+            this.template('github-ci.yml.ejs', '.github/workflows/github-ci.yml');
         }
 
         if (this.cicdIntegrations.includes('deploy')) {

--- a/generators/ci-cd/prompts.js
+++ b/generators/ci-cd/prompts.js
@@ -52,6 +52,12 @@ function askPipeline() {
         return;
     }
 
+    if (this.autoconfigureGithub) {
+        this.log('Auto-configuring GitHub CI');
+        this.pipeline = 'github';
+        return;
+    }
+
     const done = this.async();
     const prompts = [
         {
@@ -63,6 +69,7 @@ function askPipeline() {
                 { name: 'Jenkins pipeline', value: 'jenkins' },
                 { name: 'Azure Pipelines', value: 'azure' },
                 { name: 'GitLab CI', value: 'gitlab' },
+                { name: 'GitHub CI', value: 'github' },
                 { name: 'Travis CI', value: 'travis' }
             ]
         }
@@ -74,7 +81,7 @@ function askPipeline() {
 }
 
 function askIntegrations() {
-    if (this.abort || !this.pipeline || this.pipeline === 'azure') return;
+    if (this.abort || !this.pipeline || this.pipeline === 'azure' || this.pipeline === 'github') return;
     if (this.autoconfigureTravis) {
         this.cicdIntegrations = [];
         return;
@@ -96,6 +103,12 @@ function askIntegrations() {
     if (this.autoconfigureAzure) {
         this.log('Auto-configuring Azure');
         this.pipeline = 'azure';
+        return;
+    }
+
+    if (this.autoconfigureGithub) {
+        this.log('Auto-configuring GitHub CI');
+        this.pipeline = 'github';
         return;
     }
 

--- a/generators/ci-cd/templates/github-ci.yml.ejs
+++ b/generators/ci-cd/templates/github-ci.yml.ejs
@@ -1,0 +1,69 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+name: Application CI
+on: [push, pull_request]
+jobs:
+    applications:
+        name: <%= baseName %> test suite
+        runs-on: ${{ matrix.os }}
+        timeout-minutes: 40
+        strategy:
+            fail-fast: false
+            matrix:
+                node_version: [<%= NODE_VERSION %>]
+                os: [ubuntu-latest]
+                java_version: ['8.x', '11.x']
+        env:
+            NODE_VERSION: ${{ matrix.node_version }}
+            SPRING_OUTPUT_ANSI_ENABLED: NEVER
+            SPRING_JPA_SHOW_SQL: false
+            JHI_DISABLE_WEBPACK_LOGS: true
+            NG_CLI_ANALYTICS: false
+        steps:
+            - uses: actions/checkout@v1
+            - uses: actions/setup-node@v1
+              with:
+                  node-version: ${{ matrix.node_version }}
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: ${{ matrix.java_version }}
+            - name: Stop MySQL server
+              run: sudo /etc/init.d/mysql stop
+            - name: Install node.js packages
+              run: <%= clientPackageManager %> install
+            - name: Run backend test
+              <%_ if (buildTool === 'maven') { _%>
+              run: |
+                 chmod +x mvnw
+                 ./mvnw -ntp clean verify <% if (!skipClient) { %>-P-webpack<% } %>
+              <%_ } else if (buildTool === 'gradle') { _%>
+              run: |
+                 chmod +x gradlew
+                 ./gradlew clean test integrationTest <% if (!skipClient) { %>-x webpack<% } %>
+              <%_ } _%>
+            <%_ if (!skipClient) { _%>
+            - name: Run frontend test
+              run: <%= clientPackageManager %> run <%= frontTestCommand %>
+            <%_ } _%>
+            - name: Package application
+              <%_ if (buildTool === 'maven') { _%>
+              run: ./mvnw -ntp package -Pprod -DskipTests -DskipIT
+              <%_ } else if (buildTool === 'gradle') { _%>
+              run: ./gradlew bootJar -Pprod -x test -x integrationTest
+              <%_ } _%>

--- a/generators/ci-cd/templates/github-ci.yml.ejs
+++ b/generators/ci-cd/templates/github-ci.yml.ejs
@@ -21,28 +21,24 @@ on: [push, pull_request]
 jobs:
     applications:
         name: <%= baseName %> test suite
-        runs-on: ${{ matrix.os }}
+        runs-on: ubuntu-latest
         timeout-minutes: 40
-        strategy:
-            fail-fast: false
-            matrix:
-                node_version: [<%= NODE_VERSION %>]
-                os: [ubuntu-latest]
-                java_version: ['8.x', '11.x']
         env:
-            NODE_VERSION: ${{ matrix.node_version }}
-            SPRING_OUTPUT_ANSI_ENABLED: NEVER
+            NODE_VERSION: <%= NODE_VERSION %>
+            SPRING_OUTPUT_ANSI_ENABLED: DETECT
             SPRING_JPA_SHOW_SQL: false
             JHI_DISABLE_WEBPACK_LOGS: true
+            <%_ if (clientFramework === 'angularX') { _%>
             NG_CLI_ANALYTICS: false
+            <%_ } _%>
         steps:
             - uses: actions/checkout@v1
             - uses: actions/setup-node@v1
               with:
-                  node-version: ${{ matrix.node_version }}
+                  node-version: <%= NODE_VERSION %>
             - uses: actions/setup-java@v1
               with:
-                  java-version: ${{ matrix.java_version }}
+                  java-version: '11.x'
             - name: Stop MySQL server
               run: sudo /etc/init.d/mysql stop
             - name: Install node.js packages
@@ -63,7 +59,7 @@ jobs:
             <%_ } _%>
             - name: Package application
               <%_ if (buildTool === 'maven') { _%>
-              run: ./mvnw -ntp package -Pprod -DskipTests -DskipIT
+              run: ./mvnw -ntp package -Pprod -DskipTests
               <%_ } else if (buildTool === 'gradle') { _%>
               run: ./gradlew bootJar -Pprod -x test -x integrationTest
               <%_ } _%>

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -9,6 +9,7 @@ const expectedFiles = {
     gitlab: ['.gitlab-ci.yml'],
     circle: ['circle.yml'],
     azure: ['azure-pipelines.yml'],
+    github: ['.github/workflows/github-ci.yml'],
     dockerRegistry: ['src/main/docker/docker-registry.yml']
 };
 
@@ -593,6 +594,100 @@ describe('JHipster CI-CD Sub Generator', () => {
         });
         it('creates expected files', () => {
             assert.file(expectedFiles.azure);
+        });
+    });
+
+    //--------------------------------------------------
+    // GitHub CI tests
+    //--------------------------------------------------
+    describe('GitHub CI: maven AngularX Yarn', () => {
+        before(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-yarn'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    pipeline: 'github',
+                    cicdIntegrations: []
+                })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.github);
+        });
+    });
+
+    describe('GitHub CI: maven AngularX NPM', () => {
+        before(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    pipeline: 'github',
+                    cicdIntegrations: []
+                })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.github);
+        });
+    });
+
+    describe('GitHub CI: Gradle AngularX Yarn', () => {
+        before(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-yarn'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    pipeline: 'github',
+                    cicdIntegrations: []
+                })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.github);
+        });
+    });
+
+    describe('GitHub CI: Gradle AngularX NPM', () => {
+        before(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    pipeline: 'github',
+                    cicdIntegrations: []
+                })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.github);
+        });
+    });
+
+    describe('GitHub CI: Autoconfigure', () => {
+        before(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-yarn'), dir);
+                })
+                .withOptions({ autoconfigureGithub: true })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.github);
         });
     });
 });


### PR DESCRIPTION
* Closes #10599 
* Followed Azure CI template (without external integrations) with Java 8 and Java 11 build support.
* Tested with `yarn + gradle + angular` combination @ https://github.com/vishal423/sample-jhipster-ng-gradle-yarn-app/commit/64d1fd3759b33d53f255566421a44d1b31845603/checks?check_suite_id=262455522
* Tested with `npm + maven + react` combination @ https://github.com/vishal423/sample-jhipster-react-mvn-npm-app/commit/41dfd24c8ad079409008635594fd8dff6dd9f26e/checks?check_suite_id=262455872

---

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
