### PR TITLE
Retiring the use of Azul JDK and go fo OpenJDK

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -101,7 +101,12 @@ jobs:
                     sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
                     java -version
                 else
-                    echo '*** Using OpenJDK 8 by default'
+                    echo '*** Using OpenJDK 8'
+                    sudo add-apt-repository ppa:openjdk-r/ppa
+                    sudo apt-get update
+                    sudo apt-get install -y openjdk-8-jdk
+                    sudo update-java-alternatives -s java-1.8.0-openjdk-amd64
+                    java -version
                 fi
             displayName: 'TOOLS: configuring OpenJDK'
           - script: |

--- a/test-integration/scripts/00-init-env.sh
+++ b/test-integration/scripts/00-init-env.sh
@@ -44,6 +44,6 @@ if [[ "$JHI_FOLDER_UAA" == "" ]]; then
 fi
 
 # set correct OpenJDK version
-if [[ "$JHI_JDK" == "11" && "$JHI_GITHUB_CI" != "true" ]]; then
+if [[ "$JHI_GITHUB_CI" != "true" ]]; then
     JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:bin/java::")
 fi


### PR DESCRIPTION
This is related to jhipster/generator-jhipster#10594

I think we should run OpenJDK 8 to be consistent everywhere. The default Azul OpenJDK provided by Azure cannot be trusted I think given that we saw some inconsistencies in the above issue with Couchbase. smile

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
