### PR TITLE
Reintroduce Couchbase Docker Start

### DIFF
--- a/test-integration/scripts/20-docker-compose.sh
+++ b/test-integration/scripts/20-docker-compose.sh
@@ -26,9 +26,7 @@ if [ -a src/main/docker/mongodb.yml ]; then
     docker-compose -f src/main/docker/mongodb.yml up -d
 fi
 if [ -a src/main/docker/couchbase.yml ]; then
-    # this container can't be started otherwise, it will be conflict with tests
-    # so here, only prepare the image
-    docker-compose -f src/main/docker/couchbase.yml build
+    docker-compose -f src/main/docker/couchbase.yml up -d
 fi
 if [ -a src/main/docker/mysql.yml ]; then
     docker-compose -f src/main/docker/mysql.yml up -d

--- a/test-integration/scripts/24-tests-e2e.sh
+++ b/test-integration/scripts/24-tests-e2e.sh
@@ -3,16 +3,6 @@
 source $(dirname $0)/00-init-env.sh
 
 #-------------------------------------------------------------------------------
-# Specific for couchbase
-#-------------------------------------------------------------------------------
-cd "$JHI_FOLDER_APP"
-if [ -a src/main/docker/couchbase.yml ]; then
-    docker-compose -f src/main/docker/couchbase.yml up -d
-    sleep 20
-    docker ps -a
-fi
-
-#-------------------------------------------------------------------------------
 # Functions
 #-------------------------------------------------------------------------------
 launchCurlOrProtractor() {


### PR DESCRIPTION
This reintroduces the Couchbase docker start as discussed in; https://github.com/jhipster/generator-jhipster/issues/10594#issuecomment-541296271

Although this works in [my own fork's Github CI pipeline](https://github.com/SudharakaP/generator-jhipster/runs/257408009) I am unsure if it will have problems here. So we will see how it goes and if there are any problems we will revert this back so that [my other fix](https://github.com/jhipster/generator-jhipster/pull/10596) will take effect.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
