### PR TITLE
Add support to blueprint with peer dependency on generator-jhispter

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -865,19 +865,32 @@ module.exports = class extends Generator {
      */
     checkJHipsterBlueprintVersion(blueprintPkgName) {
         const blueprintPackageJson = this.findBlueprintPackageJson(blueprintPkgName);
-        if (!blueprintPackageJson || !blueprintPackageJson.dependencies || !blueprintPackageJson.dependencies['generator-jhipster']) {
+        if (!blueprintPackageJson) {
             this.warning(`Could not retrieve version of JHipster declared by blueprint '${blueprintPkgName}'`);
             return;
         }
         const mainGeneratorJhipsterVersion = packagejs.version;
-        const blueprintJhipsterVersion = blueprintPackageJson.dependencies['generator-jhipster'];
-        if (mainGeneratorJhipsterVersion !== blueprintJhipsterVersion) {
+        const blueprintJhipsterVersion = blueprintPackageJson.dependencies && blueprintPackageJson.dependencies['generator-jhipster'];
+        if (blueprintJhipsterVersion && mainGeneratorJhipsterVersion !== blueprintJhipsterVersion) {
             this.error(
                 `The installed ${chalk.yellow(
                     blueprintPkgName
                 )} blueprint targets JHipster v${blueprintJhipsterVersion} and is not compatible with this JHipster version. Either update the blueprint or JHipster. You can also disable this check using --skip-checks at your own risk`
             );
         }
+        const blueprintPeerJhipsterVersion =
+            blueprintPackageJson.peerDependencies && blueprintPackageJson.peerDependencies['generator-jhipster'];
+        if (blueprintPeerJhipsterVersion) {
+            if (semver.satisfies(mainGeneratorJhipsterVersion, blueprintPeerJhipsterVersion)) {
+                return;
+            }
+            this.error(
+                `The installed ${chalk.yellow(
+                    blueprintPkgName
+                )} blueprint targets JHipster ${blueprintPeerJhipsterVersion} and is not compatible with this JHipster version. Either update the blueprint or JHipster. You can also disable this check using --skip-checks at your own risk`
+            );
+        }
+        this.warning(`Could not retrieve version of JHipster declared by blueprint '${blueprintPkgName}'`);
     }
 
     /**

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -866,7 +866,6 @@ module.exports = class extends Generator {
     checkJHipsterBlueprintVersion(blueprintPkgName) {
         const blueprintPackageJson = this.findBlueprintPackageJson(blueprintPkgName);
         if (!blueprintPackageJson) {
-            this.warning(`Could not retrieve version of JHipster declared by blueprint '${blueprintPkgName}'`);
             return;
         }
         const mainGeneratorJhipsterVersion = packagejs.version;

--- a/test/blueprint/app-blueprint.spec.js
+++ b/test/blueprint/app-blueprint.spec.js
@@ -124,4 +124,119 @@ describe('JHipster application generator with blueprint', () => {
                 });
         });
     });
+
+    describe('generate application with a peer version-compatible blueprint', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/app'))
+                .inTmpDir(dir => {
+                    // Fake the presence of the blueprint in node_modules
+                    const packagejs = {
+                        name: 'generator-jhipster-myblueprint',
+                        version: '9.9.9',
+                        peerDependencies: {
+                            'generator-jhipster': '^6.0.0'
+                        }
+                    };
+                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
+                    fse.ensureDirSync(fakeBlueprintModuleDir);
+                    fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
+                })
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    skipChecks: false,
+                    blueprint: 'myblueprint'
+                })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    cacheProvider: 'ehcache',
+                    enableHibernateCache: true,
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Memory',
+                    prodDatabaseType: 'mysql',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr']
+                })
+                .on('end', done);
+        });
+
+        it('creates expected default files for server and angularX', () => {
+            assert.file(expectedFiles.common);
+            assert.file(expectedFiles.server);
+            assert.file(
+                getFilesForOptions(angularFiles, {
+                    enableTranslation: true,
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    testFrameworks: []
+                })
+            );
+        });
+
+        it('blueprint version is saved in .yo-rc.json', () => {
+            assert.JSONFileContent('.yo-rc.json', {
+                'generator-jhipster': { blueprints: [{ name: 'generator-jhipster-myblueprint', version: '9.9.9' }] }
+            });
+        });
+        it('blueprint module and version are in package.json', () => {
+            assert.fileContent('package.json', /"generator-jhipster-myblueprint": "9.9.9"/);
+        });
+    });
+
+    describe('generate application with a peer conflicting version blueprint', () => {
+        it('throws an error', done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/app'))
+                .inTmpDir(dir => {
+                    // Fake the presence of the blueprint in node_modules
+                    const packagejs = {
+                        name: 'generator-jhipster-myblueprint',
+                        version: '9.9.9',
+                        peerDependencies: {
+                            'generator-jhipster': '1.1.1'
+                        }
+                    };
+                    const fakeBlueprintModuleDir = path.join(dir, 'node_modules/generator-jhipster-myblueprint');
+                    fse.ensureDirSync(fakeBlueprintModuleDir);
+                    fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
+                })
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    skipChecks: false,
+                    blueprint: 'myblueprint'
+                })
+                .withPrompts({
+                    baseName: 'jhipster',
+                    clientFramework: 'angularX',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    cacheProvider: 'ehcache',
+                    enableHibernateCache: true,
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Memory',
+                    prodDatabaseType: 'mysql',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr']
+                })
+                .on('error', error => {
+                    expect(error.message.includes('targets JHipster 1.1.1 and is not compatible with this JHipster version')).to.be.true;
+                    done();
+                })
+                .on('end', () => {
+                    expect(true).to.be.false;
+                    done();
+                });
+        });
+    });
 });


### PR DESCRIPTION
This PR adapts checkJHipsterBlueprintVersion to accept peerDependency on generator-jhipster.
https://github.com/jhipster/generator-jhipster/issues/10611

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
