### PR TITLE
Implement config module.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -318,6 +318,8 @@ module.exports = class extends BaseGenerator {
                 }
             },
             composeConfig() {
+                if (!this.experimental) return;
+
                 const options = this.options;
                 const configOptions = this.configOptions;
                 let configPrompts;

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -316,6 +316,19 @@ module.exports = class extends BaseGenerator {
                 if (!this.embeddableLaunchScript) {
                     this.embeddableLaunchScript = true;
                 }
+            },
+            composeConfig() {
+                const options = this.options;
+                const configOptions = this.configOptions;
+                let configPrompts;
+
+                this.composeWith(require.resolve('../config'), {
+                    ...options,
+                    configOptions,
+                    configPrompts,
+                    generatorSource: this,
+                    debug: this.isDebugEnabled
+                });
             }
         };
     }

--- a/generators/app/prompts.js
+++ b/generators/app/prompts.js
@@ -29,6 +29,8 @@ module.exports = {
 };
 
 function askForInsightOptIn() {
+    if (this.skipInsightPrompt) return;
+
     const done = this.async();
 
     this.prompt({
@@ -46,7 +48,7 @@ function askForInsightOptIn() {
 }
 
 function askForApplicationType(meta) {
-    if (!meta && this.existingProject) return;
+    if (this.skipApplicationTypePrompt || (!meta && this.existingProject)) return;
 
     const DEFAULT_APPTYPE = 'monolith';
 
@@ -109,18 +111,18 @@ function askForApplicationType(meta) {
 }
 
 function askForModuleName() {
-    if (this.existingProject) return;
+    if (this.skipModuleNamePrompt || this.existingProject) return;
 
     this.askModuleName(this);
 }
 
 function askFori18n() {
-    if (this.skipI18n || this.existingProject) return;
+    if (this.skipI18n || this.skipI18nPrompt || this.existingProject) return;
     this.aski18n(this);
 }
 
 function askForTestOpts(meta) {
-    if (!meta && this.existingProject) return;
+    if (this.skipTestOptsPrompt || (!meta && this.existingProject)) return;
 
     const choices = [];
     const defaultChoice = [];
@@ -151,7 +153,7 @@ function askForTestOpts(meta) {
 }
 
 function askForMoreModules() {
-    if (this.existingProject) {
+    if (this.skipMoreModulesPrompt || this.existingProject) {
         return;
     }
 

--- a/generators/config/index.js
+++ b/generators/config/index.js
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2013-2019 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable consistent-return */
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
+const appPrompts = require('../app/prompts');
+
+// Migrate to local variables with yeoman-generator 4.1.1 | 4.2.0
+let useBlueprints;
+let prompts;
+
+module.exports = class extends BaseBlueprintGenerator {
+    constructor(args, opts) {
+        super(args, opts);
+
+        this.generatorSource = this.options.generatorSource;
+        if (!this.generatorSource) {
+            this.error('Config module must have a generator source.');
+        }
+
+        this.configOptions = this.options.configOptions || {};
+
+        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('config', { generatorSource: this.generatorSource });
+
+        prompts = this.options.configPrompts || { ...appPrompts.configModule };
+    }
+
+    _initializing() {
+        return prompts.initializingPrompts;
+    }
+
+    get initializing() {
+        if (useBlueprints) return;
+        return this._initializing();
+    }
+
+    _prompting() {
+        return prompts.promptingPrompts;
+    }
+
+    get prompting() {
+        if (useBlueprints) return;
+        return this._prompting();
+    }
+
+    _configuring() {
+        return prompts.configuringPrompts;
+    }
+
+    get configuring() {
+        if (useBlueprints) return;
+        return this._configuring();
+    }
+};

--- a/test/blueprint/config-blueprint.spec.js
+++ b/test/blueprint/config-blueprint.spec.js
@@ -1,0 +1,137 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+
+const expectedFiles = require('../utils/expected-files');
+const getFilesForOptions = require('../utils/utils').getFilesForOptions;
+const angularFiles = require('../../generators/client/files-angular').files;
+const ConfigGenerator = require('../../generators/config');
+
+const mockBlueprintSubGen = class extends ConfigGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+        if (!jhContext) {
+            this.error("This is a JHipster blueprint and should be used only like 'jhipster --blueprint myblueprint')}");
+        }
+        this.configOptions = jhContext.configOptions || {};
+
+        this.generatorSource.skipInsightPrompt = false;
+        this.generatorSource.skipApplicationTypePrompt = false;
+        this.generatorSource.skipModuleNamePrompt = false;
+        this.generatorSource.skipI18n = false;
+        this.generatorSource.skipTestOptsPrompt = true;
+        this.generatorSource.skipMoreModulesPrompt = false;
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        const phaseFromJHipster = super._prompting();
+        const customPhaseSteps = {
+            overrideBase() {
+                assert.equal(this.generatorSource.baseName, 'originalJhipster');
+                this.generatorSource.baseName = 'jhipster';
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+
+    get configuring() {
+        const phaseFromJHipster = super._configuring();
+        const customPhaseSteps = {
+            overrideTest() {
+                assert.equal(this.generatorSource.testFrameworks, undefined);
+                this.generatorSource.testFrameworks = ['protractor'];
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        return super._writing();
+    }
+
+    get install() {
+        return super._install();
+    }
+
+    get end() {
+        return super._end();
+    }
+};
+
+describe('JHipster config generator with blueprint', () => {
+    describe('generate common with blueprint', () => {
+        before(done => {
+            helpers
+                .run(path.join(__dirname, '../../generators/app'))
+                .withOptions({
+                    'from-cli': true,
+                    skipInstall: true,
+                    skipChecks: true,
+                    blueprint: 'myblueprint',
+                    experimental: true
+                })
+                .withPrompts({
+                    // Will be replace by jhipster.
+                    baseName: 'originalJhipster',
+                    // Will be ignored.
+                    testFrameworks: ['gatling', 'protractor'],
+
+                    clientFramework: 'angularX',
+                    packageName: 'com.mycompany.myapp',
+                    packageFolder: 'com/mycompany/myapp',
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    cacheProvider: 'ehcache',
+                    enableHibernateCache: true,
+                    databaseType: 'sql',
+                    devDatabaseType: 'h2Memory',
+                    prodDatabaseType: 'mysql',
+                    enableTranslation: true,
+                    nativeLanguage: 'en',
+                    languages: ['fr'],
+                    buildTool: 'maven',
+                    rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                    skipClient: false,
+                    skipUserManagement: false,
+                    serverSideOptions: []
+                })
+                .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:config']])
+                .on('end', done);
+        });
+
+        it('creates expected default files for angularX', () => {
+            assert.file(expectedFiles.common);
+            assert.file(expectedFiles.server);
+            assert.file(expectedFiles.userManagementServer);
+            assert.file(expectedFiles.jwtServer);
+            assert.file(expectedFiles.maven);
+            assert.file(expectedFiles.dockerServices);
+            assert.file(expectedFiles.mysql);
+            assert.file(expectedFiles.hibernateTimeZoneConfig);
+            assert.file(
+                getFilesForOptions(angularFiles, {
+                    enableTranslation: true,
+                    serviceDiscoveryType: false,
+                    authenticationType: 'jwt',
+                    testFrameworks: ['protractor']
+                })
+            );
+        });
+
+        it('contains the specific change added by the blueprint', () => {
+            assert.fileContent('.yo-rc.json', /jhipster/);
+            assert.JSONFileContent('.yo-rc.json', {
+                'generator-jhipster': { baseName: 'jhipster', testFrameworks: ['protractor'] }
+            });
+        });
+    });
+});


### PR DESCRIPTION
This is a simplified version of https://github.com/jhipster/generator-jhipster/pull/10586.

With this new module, blueprints can skip app prompts by setting
```
this.generatorSource.skip(?)Prompt = true;
```

Setting as experimental.

This generator will be queued at app initializing phase, so it's phases will run always after app corresponding phase and before the other generators phases.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
