### PR TITLE
Revert "Couchbase Container Increase Memory Quota"

### DIFF
--- a/generators/server/templates/src/test/java/package/config/DatabaseConfigurationIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/DatabaseConfigurationIT.java.ejs
@@ -81,7 +81,6 @@ public class DatabaseConfigurationIT extends AbstractCouchbaseConfiguration {
         }
         couchbaseContainer = new CouchbaseContainer("<%= DOCKER_COUCHBASE %>");
         couchbaseContainer
-            .withMemoryQuota("8000")
             .withNewBucket(DefaultBucketSettings.builder()
                 .name(getBucketName())
                 .password(getBucketPassword())


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/10594

Reverting this as although it improves Java 8 Daily build problem it seems to reintroduce failing builds for Java 11; also jhipster/generator-jhipster#10594 seems to reduce the java 8 build failures so I think we are okay to remove this change. 

cc: @pascalgrimaud  

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
