### PR TITLE
fix travis multiline jdk script

### DIFF
--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -45,14 +45,14 @@ env:
 before_install:
   -
     if [[ $JHI_JDK = '8' ]]; then
-      echo '*** Using OpenJDK 8'
+      echo '*** Using OpenJDK 8';
     else
-      echo '*** Using OpenJDK 11 by default'
-      sudo add-apt-repository ppa:openjdk-r/ppa
-      sudo apt-get update
-      sudo apt-get install -y openjdk-11-jdk
-      sudo update-java-alternatives -s java-1.11.0-openjdk-amd64
-      java -version
+      echo '*** Using OpenJDK 11 by default';
+      sudo add-apt-repository ppa:openjdk-r/ppa;
+      sudo apt-get update;
+      sudo apt-get install -y openjdk-11-jdk;
+      sudo update-java-alternatives -s java-1.11.0-openjdk-amd64;
+      java -version;
     fi
   - java -version
   - sudo /etc/init.d/mysql stop


### PR DESCRIPTION
it seems that travis is incorrectly collapsing this multiline to execute
as a single line without the trailing semicolon

this explicitly adds it so concatenation will work

Closes #10655

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
