### PR TITLE
set MAVEN_USER_HOME variable

### DIFF
--- a/generators/ci-cd/templates/travis.yml.ejs
+++ b/generators/ci-cd/templates/travis.yml.ejs
@@ -42,6 +42,9 @@ env:
     - SPRING_JPA_SHOW_SQL=false
     - JHI_DISABLE_WEBPACK_LOGS=true
     - NG_CLI_ANALYTICS="false"
+<%_ if (buildTool === 'maven') { _%>
+    - MAVEN_USER_HOME=$HOME/.m2/repository/
+<%_ } _%>
 before_install:
   -
     if [[ $JHI_JDK = '8' ]]; then


### PR DESCRIPTION
Closes #10654

I decided to set the variable instead of dropping the override because the other CI platforms use that variable (hopefully successfully ;-)

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
