### PR TITLE
fix gradlew wrapper script

### DIFF
--- a/generators/server/templates/gradlew
+++ b/generators/server/templates/gradlew
@@ -97,7 +97,7 @@ Please set the JAVA_HOME variable in your environment to match the
 location of your Java installation."
     fi
 else
-    JAVACMD="/usr/lib/jvm/java-11-openjdk/bin/java"
+    JAVACMD="java"
     which java >/dev/null 2>&1 || die "ERROR: JAVA_HOME is not set and no 'java' command could be found in your PATH.
 
 Please set the JAVA_HOME variable in your environment to match the


### PR DESCRIPTION
For some reason when I generated the wrapper for 5.6.3 the unix script was generated with ` JAVACMD="/usr/lib/jvm/java-11-openjdk/bin/java"` which does not work in all environments (e.g. gitlab ci). While I prepared my demo for my upcoming talk I generated the wrapper again and it was created with a different command (as in older versions).

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
