### PR TITLE
chore: always use the latest JDK 11 release in generator tests

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -47,7 +47,7 @@ jobs:
                   node-version: ${{ matrix.node_version }}
             - uses: actions/setup-java@v1
               with:
-                  java-version: '11.0.3'
+                  java-version: '11.x'
             - name: Config git variables
               run: $JHI_SCRIPTS/04-git-config.sh
             - name: Install Jhipster


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
