### PR TITLE
Fix MariaDB Accessibility Issues on E2E Tests in Daily Builds

### DIFF
--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -126,7 +126,7 @@ module.exports = class extends BaseDockerGenerator {
                         const databaseYaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/${database}.yml`));
                         const databaseServiceName = `${lowercaseBaseName}-${database}`;
                         let databaseYamlConfig = databaseYaml.services[databaseServiceName];
-                        delete databaseYamlConfig.ports;
+                        if (database !== 'mariadb') delete databaseYamlConfig.ports;
 
                         if (database === 'cassandra') {
                             // node config


### PR DESCRIPTION
This fixes the [error seen in `docker-compose` logs](https://github.com/openzipkin/docker-zipkin/issues/181) due to MariaDB not being accessible. Although I did this as part of my investigations on #10604, I think this will make all MariaDB builds (running under docker) more stable; as you see currently all MariaDB builds in our Daily Builds are flaky. 

Fixes part of #10604 

Reference: https://github.com/openzipkin/docker-zipkin/issues/181

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
