### PR TITLE
Use strict typescript option in audits module in Angular

### DIFF
--- a/generators/client/templates/angular/.eslintrc.json.ejs
+++ b/generators/client/templates/angular/.eslintrc.json.ejs
@@ -36,6 +36,7 @@
         "args": "after-used",
         "ignoreRestSiblings": false
       }
-    ]
+    ],
+    "@typescript-eslint/no-non-null-assertion": "off"
   }
 }

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -106,6 +106,7 @@
     "husky": "3.0.4",
     <%_ } _%>
     "jest": "24.9.0",
+    "jest-date-mock": "1.0.7",
     "jest-junit": "8.0.0",
     "jest-preset-angular": "7.1.1",
     "jest-sonar-reporter": "2.0.0",

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
@@ -21,7 +21,7 @@
 
     <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
 
-    <div class="row" *ngIf="initialized">
+    <div class="row">
         <div class="col-md-5">
             <h4 jhiTranslate="audits.filter.title">Filter by date</h4>
             <div class="input-group mb-3">
@@ -38,13 +38,13 @@
         </div>
     </div>
 
-    <div class="alert alert-warning" *ngIf="dataHaveBeenLoaded && audits.length === 0">
+    <div class="alert alert-warning" *ngIf="audits?.length === 0">
         <span jhiTranslate="audits.notFound">No audit found</span>
     </div>
 
-    <div class="table-responsive" *ngIf="audits.length > 0">
+    <div class="table-responsive" *ngIf="audits?.length > 0">
         <table class="table table-sm table-striped"  aria-describedby="audits-page-heading">
-            <thead [ngSwitch]="canLoad">
+            <thead [ngSwitch]="canLoad()">
             <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)" *ngSwitchCase="true">
                 <th scope="col" jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
                 <th scope="col" jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span> <fa-icon [icon]="'sort'"></fa-icon></th>
@@ -72,12 +72,12 @@
         </table>
     </div>
 
-    <div *ngIf="audits.length > 0">
+    <div *ngIf="audits?.length > 0">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
         <div class="row justify-content-center">
-            <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)" [disabled]="!canLoad"></ngb-pagination>
+            <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)" [disabled]="!canLoad()"></ngb-pagination>
         </div>
     </div>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
@@ -16,10 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<div *ngIf="audits">
+<div>
     <h2 id="audits-page-heading" jhiTranslate="audits.title">Audits</h2>
 
-    <div class="row">
+    <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
+
+    <div class="row" *ngIf="initialized">
         <div class="col-md-5">
             <h4 jhiTranslate="audits.filter.title">Filter by date</h4>
             <div class="input-group mb-3">
@@ -36,17 +38,24 @@
         </div>
     </div>
 
-    <div class="alert alert-warning" *ngIf="audits?.length === 0">
+    <div class="alert alert-warning" *ngIf="dataHaveBeenLoaded && audits.length === 0">
         <span jhiTranslate="audits.notFound">No audit found</span>
     </div>
-    <div class="table-responsive" *ngIf="audits?.length > 0">
+
+    <div class="table-responsive" *ngIf="audits.length > 0">
         <table class="table table-sm table-striped"  aria-describedby="audits-page-heading">
-            <thead>
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)">
-                <th scope="col" jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span><fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span><fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" jhiSortBy="auditEventType"><span jhiTranslate="audits.table.header.status">State</span><fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" ><span jhiTranslate="audits.table.header.data">Extra data</span></th>
+            <thead [ngSwitch]="canLoad">
+            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)" *ngSwitchCase="true">
+                <th scope="col" jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                <th scope="col" jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                <th scope="col" jhiSortBy="auditEventType"><span jhiTranslate="audits.table.header.status">State</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                <th scope="col"><span jhiTranslate="audits.table.header.data">Extra data</span></th>
+            </tr>
+            <tr *ngSwitchCase="false">
+                <th scope="col"><span jhiTranslate="audits.table.header.date">Date</span></th>
+                <th scope="col"><span jhiTranslate="audits.table.header.principal">User</span></th>
+                <th scope="col"><span jhiTranslate="audits.table.header.status">State</span></th>
+                <th scope="col"><span jhiTranslate="audits.table.header.data">Extra data</span></th>
             </tr>
             </thead>
             <tbody>
@@ -62,12 +71,13 @@
             </tbody>
         </table>
     </div>
-    <div [hidden]="audits?.length === 0">
+
+    <div *ngIf="audits.length > 0">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
         <div class="row justify-content-center">
-            <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)"></ngb-pagination>
+            <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)" [disabled]="!canLoad"></ngb-pagination>
         </div>
     </div>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.ts.ejs
@@ -16,11 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { HttpResponse } from '@angular/common/http';
+import { Component, OnInit } from '@angular/core';
+import { HttpResponse, HttpHeaders } from '@angular/common/http';
 import { DatePipe } from '@angular/common';
 import { ActivatedRoute, Router } from '@angular/router';
-import { JhiParseLinks, JhiAlertService } from 'ng-jhipster';
 
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 import { Audit } from './audit.model';
@@ -30,113 +29,109 @@ import { AuditsService } from './audits.service';
   selector: '<%= jhiPrefixDashed %>-audit',
   templateUrl: './audits.component.html'
 })
-export class AuditsComponent implements OnInit, OnDestroy {
-    audits: Audit[];
-    fromDate: string;
-    itemsPerPage: any;
-    links: any;
-    page: number;
-    routeData: any;
-    predicate: any;
-    previousPage: any;
-    reverse: boolean;
-    toDate: string;
-    totalItems: number;
+export class AuditsComponent implements OnInit {
+    private dateFormat = 'yyyy-MM-dd';
+    audits: Audit[] = [];
+    fromDate = '';
+    itemsPerPage = ITEMS_PER_PAGE;
+    page!: number;
+    predicate!: string;
+    previousPage!: number;
+    ascending!: boolean;
+    toDate = '';
+    totalItems = 0;
+    canLoad = false;
+    initialized = false;
+    dataHaveBeenLoaded = false;
 
     constructor(
         private auditsService: AuditsService,
-        private alertService: JhiAlertService,
-        private parseLinks: JhiParseLinks,
         private activatedRoute: ActivatedRoute,
         private datePipe: DatePipe,
         private router: Router
-    ) {
-        this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
+    ) {}
+
+    ngOnInit(): void {
+        this.today();
+        this.previousMonth();
+        this.activatedRoute.data.subscribe(data => {
             this.page = data['pagingParams'].page;
             this.previousPage = data['pagingParams'].page;
-            this.reverse = data['pagingParams'].ascending;
+            this.ascending = data['pagingParams'].ascending;
             this.predicate = data['pagingParams'].predicate;
+            this.canLoad = true;
+            this.loadData();
         });
     }
 
-    ngOnInit() {
-        this.today();
-        this.previousMonth();
-        this.loadAll();
-    }
-
-    ngOnDestroy() {
-        this.routeData.unsubscribe();
-    }
-
-    previousMonth() {
-        const dateFormat = 'yyyy-MM-dd';
-        let fromDate: Date = new Date();
-
-        if (fromDate.getMonth() === 0) {
-            fromDate = new Date(fromDate.getFullYear() - 1, 11, fromDate.getDate());
+    private previousMonth(): void {
+        let date = new Date();
+        if (date.getMonth() === 0) {
+            date = new Date(date.getFullYear() - 1, 11, date.getDate());
         } else {
-            fromDate = new Date(fromDate.getFullYear(), fromDate.getMonth() - 1, fromDate.getDate());
+            date = new Date(date.getFullYear(), date.getMonth() - 1, date.getDate());
         }
-
-        this.fromDate = this.datePipe.transform(fromDate, dateFormat);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.fromDate = this.datePipe.transform(date, this.dateFormat)!;
     }
 
-    today() {
-        const dateFormat = 'yyyy-MM-dd';
+    private today(): void {
         // Today + 1 day - needed if the current day must be included
-        const today: Date = new Date();
-        today.setDate(today.getDate() + 1);
-        const date = new Date(today.getFullYear(), today.getMonth(), today.getDate());
-        this.toDate = this.datePipe.transform(date, dateFormat);
+        const date = new Date();
+        date.setDate(date.getDate() + 1);
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        this.toDate = this.datePipe.transform(date, this.dateFormat)!;
     }
 
-    loadAll() {
-        this.auditsService.query({
-            page: this.page - 1,
-            size: this.itemsPerPage,
-            sort: this.sort(),
-            fromDate: this.fromDate,
-            toDate: this.toDate}).subscribe(
-            (res: HttpResponse<Audit[]>) => this.onSuccess(res.body, res.headers),
-            (res: HttpResponse<any>) => this.onError(res.body)
-        );
+    private loadData(): void {
+        this.auditsService
+            .query({
+                page: this.page - 1,
+                size: this.itemsPerPage,
+                sort: this.sort(),
+                fromDate: this.fromDate,
+                toDate: this.toDate
+            })
+            .subscribe((res: HttpResponse<Audit[]>) => this.onSuccess(res.body, res.headers), () => (this.initialized = true));
     }
 
-    sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+    private sort(): string[] {
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
         return result;
     }
 
-    loadPage(page: number) {
+    loadPage(page: number): void {
         if (page !== this.previousPage) {
             this.previousPage = page;
             this.transition();
         }
     }
 
-    transition() {
+    transition(): void {
+        this.canLoad = this.fromDate !== '' && this.toDate !== '';
+        if (!this.canLoad) {
+            return;
+        }
         this.router.navigate(['/admin/audits'], {
             queryParams: {
                 page: this.page,
-                sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc')
+                sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc')
             }
         });
-        this.loadAll();
+        this.loadData();
     }
 
-    private onSuccess(data, headers) {
-        this.links = this.parseLinks.parse(headers.get('link'));
-        this.totalItems = headers.get('X-Total-Count');
-        this.audits = data;
+    private onSuccess(audits: Audit[] | null, headers: HttpHeaders): void {
+        this.totalItems = Number(headers.get('X-Total-Count'));
+        if (audits === null) {
+            this.audits = [];
+        } else {
+            this.audits = audits;
+        }
+        this.dataHaveBeenLoaded = true;
+        this.initialized = true;
     }
-
-    private onError(error) {
-        this.alertService.error(error.error, error.message, null);
-    }
-
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.ts.ejs
@@ -30,8 +30,7 @@ import { AuditsService } from './audits.service';
   templateUrl: './audits.component.html'
 })
 export class AuditsComponent implements OnInit {
-    private dateFormat = 'yyyy-MM-dd';
-    audits: Audit[] = [];
+    audits?: Audit[];
     fromDate = '';
     itemsPerPage = ITEMS_PER_PAGE;
     page!: number;
@@ -40,9 +39,8 @@ export class AuditsComponent implements OnInit {
     ascending!: boolean;
     toDate = '';
     totalItems = 0;
-    canLoad = false;
-    initialized = false;
-    dataHaveBeenLoaded = false;
+
+    private dateFormat = 'yyyy-MM-dd';
 
     constructor(
         private auditsService: AuditsService,
@@ -52,35 +50,32 @@ export class AuditsComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        this.today();
-        this.previousMonth();
+        this.toDate = this.today();
+        this.fromDate = this.previousMonth();
         this.activatedRoute.data.subscribe(data => {
             this.page = data['pagingParams'].page;
             this.previousPage = data['pagingParams'].page;
             this.ascending = data['pagingParams'].ascending;
             this.predicate = data['pagingParams'].predicate;
-            this.canLoad = true;
             this.loadData();
         });
     }
 
-    private previousMonth(): void {
+    private previousMonth(): string {
         let date = new Date();
         if (date.getMonth() === 0) {
             date = new Date(date.getFullYear() - 1, 11, date.getDate());
         } else {
             date = new Date(date.getFullYear(), date.getMonth() - 1, date.getDate());
         }
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.fromDate = this.datePipe.transform(date, this.dateFormat)!;
+        return this.datePipe.transform(date, this.dateFormat)!;
     }
 
-    private today(): void {
+    private today(): string {
         // Today + 1 day - needed if the current day must be included
         const date = new Date();
         date.setDate(date.getDate() + 1);
-        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-        this.toDate = this.datePipe.transform(date, this.dateFormat)!;
+        return this.datePipe.transform(date, this.dateFormat)!;
     }
 
     private loadData(): void {
@@ -92,7 +87,7 @@ export class AuditsComponent implements OnInit {
                 fromDate: this.fromDate,
                 toDate: this.toDate
             })
-            .subscribe((res: HttpResponse<Audit[]>) => this.onSuccess(res.body, res.headers), () => (this.initialized = true));
+            .subscribe((res: HttpResponse<Audit[]>) => this.onSuccess(res.body, res.headers));
     }
 
     private sort(): string[] {
@@ -110,18 +105,20 @@ export class AuditsComponent implements OnInit {
         }
     }
 
+    canLoad(): boolean {
+        return this.fromDate !== '' && this.toDate !== '';
+    }
+
     transition(): void {
-        this.canLoad = this.fromDate !== '' && this.toDate !== '';
-        if (!this.canLoad) {
-            return;
+        if (this.canLoad()) {
+            this.router.navigate(['/admin/audits'], {
+                queryParams: {
+                    page: this.page,
+                    sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc')
+                }
+            });
+            this.loadData();
         }
-        this.router.navigate(['/admin/audits'], {
-            queryParams: {
-                page: this.page,
-                sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc')
-            }
-        });
-        this.loadData();
     }
 
     private onSuccess(audits: Audit[] | null, headers: HttpHeaders): void {
@@ -131,7 +128,5 @@ export class AuditsComponent implements OnInit {
         } else {
             this.audits = audits;
         }
-        this.dataHaveBeenLoaded = true;
-        this.initialized = true;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.service.ts.ejs
@@ -28,10 +28,8 @@ import { Audit } from './audit.model';
 export class AuditsService  {
     constructor(private http: HttpClient) { }
 
-    query(req: any): Observable<HttpResponse<Audit[]>> {
+    query(req: { page?: number; size?: number; sort?: string[]; fromDate: string; toDate: string }): Observable<HttpResponse<Audit[]>> {
         const params: HttpParams = createRequestOption(req);
-        params.set('fromDate', req.fromDate);
-        params.set('toDate', req.toDate);
 
         const requestURL = SERVER_API_URL + '<%- apiUaaPath %>management/audits';
 

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -2,6 +2,7 @@ const tsconfig = require('../../../tsconfig.json');
 
 module.exports = {
     preset: 'jest-preset-angular',
+    setupFiles: ['jest-date-mock'],
     setupFilesAfterEnv: ['<rootDir>/src/test/javascript/jest.ts'],
     cacheDirectory: '<rootDir>/<%= BUILD_DIR %>jest-cache',
     coverageDirectory: '<rootDir>/<%= BUILD_DIR %>test-results/',

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
@@ -17,8 +17,9 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { of } from 'rxjs';
+import { of, throwError } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
+import { advanceTo } from 'jest-date-mock';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { AuditsComponent } from 'app/admin/audits/audits.component';
@@ -26,11 +27,11 @@ import { AuditsService } from 'app/admin/audits/audits.service';
 import { Audit } from 'app/admin/audits/audit.model';
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 
-function build2DigitsDatePart(datePart: number) {
+function build2DigitsDatePart(datePart: number): string {
     return `0${datePart}`.slice(-2);
 }
 
-function getDate(isToday = true) {
+function getDate(isToday = true): string {
     let date: Date = new Date();
     if (isToday) {
         // Today + 1 day - needed if the current day must be included
@@ -74,36 +75,60 @@ describe('Component Tests', () => {
             service = fixture.debugElement.injector.get(AuditsService);
         });
 
-        describe('today function ', () => {
+        describe('today function', () => {
             it('should set toDate to current date', () => {
-               comp.today();
-               expect(comp.toDate).toBe(getDate());
+                comp.ngOnInit();
+                expect(comp.toDate).toBe(getDate());
+            });
+
+            it('if current day is last day of month then should set toDate to first day of next month', () => {
+                advanceTo(new Date(2019, 0, 31, 0, 0, 0));
+                comp.ngOnInit();
+                expect(comp.toDate).toBe('2019-02-01');
+            });
+
+            it('if current day is not last day of month then should set toDate to next day of current month', () => {
+                advanceTo(new Date(2019, 0, 27, 0, 0, 0));
+                comp.ngOnInit();
+                expect(comp.toDate).toBe('2019-01-28');
             });
         });
 
-        describe('previousMonth function ', () => {
-            it('should set fromDate to current date', () => {
-               comp.previousMonth();
-               expect(comp.fromDate).toBe(getDate(false));
+        describe('previousMonth function', () => {
+            it('should set fromDate to previous month', () => {
+                comp.ngOnInit();
+                expect(comp.fromDate).toBe(getDate(false));
+            });
+
+            it('if current month is January then should set fromDate to previous year last month', () => {
+                advanceTo(new Date(2019, 0, 20, 0, 0, 0));
+                comp.ngOnInit();
+                expect(comp.fromDate).toBe('2018-12-20');
+            });
+
+            it('if current month is not January then should set fromDate to current year previous month', () => {
+                advanceTo(new Date(2019, 1, 20, 0, 0, 0));
+                comp.ngOnInit();
+                expect(comp.fromDate).toBe('2019-01-20');
             });
         });
 
         describe('By default, on init', () => {
             it('should set all default values correctly', () => {
-               fixture.detectChanges();
-               expect(comp.toDate).toBe(getDate());
-               expect(comp.fromDate).toBe(getDate(false));
-               expect(comp.itemsPerPage).toBe(ITEMS_PER_PAGE);
-               expect(comp.page).toBe(10);
-               expect(comp.reverse).toBeFalsy();
-               expect(comp.predicate).toBe('id');
+                fixture.detectChanges();
+                expect(comp.toDate).toBe(getDate());
+                expect(comp.fromDate).toBe(getDate(false));
+                expect(comp.itemsPerPage).toBe(ITEMS_PER_PAGE);
+                expect(comp.page).toBe(10);
+                expect(comp.ascending).toBe(false);
+                expect(comp.predicate).toBe('id');
             });
         });
 
         describe('OnInit', () => {
             it('Should call load all on init', () => {
                 // GIVEN
-                const headers = new HttpHeaders().append('link', 'link;link');
+                const headers = new HttpHeaders().append('X-Total-Count', '1');
                 const audit = new Audit({ remoteAddress: '127.0.0.1', sessionId: '123' }, 'user', '20140101', 'AUTHENTICATION_SUCCESS');
                 spyOn(service, 'query').and.returnValue(of(new HttpResponse({
                     body: [audit],
@@ -116,35 +141,116 @@ describe('Component Tests', () => {
                 // THEN
                 expect(service.query).toHaveBeenCalled();
                 expect(comp.audits[0]).toEqual(jasmine.objectContaining(audit));
+                expect(comp.totalItems).toBe(1);
+                expect(comp.dataHaveBeenLoaded).toBe(true);
+                expect(comp.initialized).toBe(true);
+            });
+
+            it('Should set initialized to true even if error occurred on loading', () => {
+                // GIVEN
+                spyOn(service, 'query').and.returnValue(throwError({}));
+
+                // WHEN
+                comp.ngOnInit();
+
+                // THEN
+                expect(service.query).toHaveBeenCalled();
+                expect(comp.dataHaveBeenLoaded).toBe(false);
+                expect(comp.initialized).toBe(true);
             });
         });
 
         describe('Create sort object', () => {
+            beforeEach(() => {
+                comp.toDate = getDate();
+                comp.fromDate = getDate(false);
+                spyOn(service, 'query').and.returnValue(of(new HttpResponse({ body: null })));
+            });
+
             it('Should sort only by id asc', () => {
                 // GIVEN
                 comp.predicate = 'id';
-                comp.reverse = false;
+                comp.ascending = false;
 
                 // WHEN
-                const sort = comp.sort();
+                comp.transition();
 
                 // THEN
-                expect(sort.length).toEqual(1);
-                expect(sort[0]).toEqual('id,desc');
+                expect(service.query).toBeCalledWith(
+                    expect.objectContaining({
+                        sort: ['id,desc']
+                    })
+                );
             });
 
             it('Should sort by timestamp asc then by id', () => {
                 // GIVEN
                 comp.predicate = 'timestamp';
-                comp.reverse = true;
+                comp.ascending = true;
 
                 // WHEN
-                const sort = comp.sort();
+                comp.transition();
 
                 // THEN
-                expect(sort.length).toEqual(2);
-                expect(sort[0]).toEqual('timestamp,asc');
-                expect(sort[1]).toEqual('id');
+                expect(service.query).toBeCalledWith(
+                    expect.objectContaining({
+                        sort: ['timestamp,asc', 'id']
+                    })
+                );
+            });
+        });
+
+        describe('loadPage', () => {
+            beforeEach(() => {
+                comp.toDate = getDate();
+                comp.fromDate = getDate(false);
+                comp.previousPage = 1;
+                spyOn(comp, 'transition');
+            });
+
+            it('Should not reload page already shown', () => {
+                // WHEN
+                comp.loadPage(1);
+
+                // THEN
+                expect(comp.transition).not.toBeCalled();
+            });
+
+            it('Should load new page', () => {
+                // WHEN
+                comp.loadPage(2);
+
+                // THEN
+                expect(comp.previousPage).toBe(2);
+                expect(comp.transition).toBeCalled();
+            });
+        });
+
+        describe('transition', () => {
+            beforeEach(() => {
+                spyOn(service, 'query').and.returnValue(of(new HttpResponse({ body: null })));
+            });
+
+            it('Should not query data if fromDate and toDate are empty', () => {
+                // WHEN
+                comp.transition();
+
+                // THEN
+                expect(comp.canLoad).toBe(false);
+                expect(service.query).not.toBeCalled();
+            });
+
+            it('Should query data if fromDate and toDate are not empty', () => {
+                // GIVEN
+                comp.toDate = getDate();
+                comp.fromDate = getDate(false);
+
+                // WHEN
+                comp.transition();
+
+                // THEN
+                expect(comp.canLoad).toBe(true);
+                expect(service.query).toBeCalled();
             });
         });
     });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { of, throwError } from 'rxjs';
+import { of } from 'rxjs';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { advanceTo } from 'jest-date-mock';
 
@@ -142,21 +142,6 @@ describe('Component Tests', () => {
                 expect(service.query).toHaveBeenCalled();
                 expect(comp.audits[0]).toEqual(jasmine.objectContaining(audit));
                 expect(comp.totalItems).toBe(1);
-                expect(comp.dataHaveBeenLoaded).toBe(true);
-                expect(comp.initialized).toBe(true);
-            });
-
-            it('Should set initialized to true even if error occurred on loading', () => {
-                // GIVEN
-                spyOn(service, 'query').and.returnValue(throwError({}));
-
-                // WHEN
-                comp.ngOnInit();
-
-                // THEN
-                expect(service.query).toHaveBeenCalled();
-                expect(comp.dataHaveBeenLoaded).toBe(false);
-                expect(comp.initialized).toBe(true);
             });
         });
 
@@ -236,7 +221,7 @@ describe('Component Tests', () => {
                 comp.transition();
 
                 // THEN
-                expect(comp.canLoad).toBe(false);
+                expect(comp.canLoad()).toBe(false);
                 expect(service.query).not.toBeCalled();
             });
 
@@ -249,7 +234,7 @@ describe('Component Tests', () => {
                 comp.transition();
 
                 // THEN
-                expect(comp.canLoad).toBe(true);
+                expect(comp.canLoad()).toBe(true);
                 expect(service.query).toBeCalled();
             });
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.service.spec.ts.ejs
@@ -22,13 +22,15 @@ import { AuditsService } from 'app/admin/audits/audits.service';
 import { Audit } from 'app/admin/audits/audit.model';
 import { SERVER_API_URL } from 'app/app.constants';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+import { HttpResponse } from '@angular/common/http';
 
 describe('Service Tests', () => {
 
     describe('Audits Service', () => {
         let service: AuditsService;
-        let httpMock;
-        let expectedResult;
+        let httpMock: HttpTestingController;
+        let expectedResult: HttpResponse<Audit[]>;
+        const fakeRequest = { fromDate: '', toDate: '' };
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -37,7 +39,6 @@ describe('Service Tests', () => {
                 ]
             });
 
-            expectedResult = {};
             service = TestBed.get(AuditsService);
             httpMock = TestBed.get(HttpTestingController);
         });
@@ -48,7 +49,7 @@ describe('Service Tests', () => {
 
         describe('Service methods', () => {
             it('should call correct URL', () => {
-                service.query({}).subscribe(() => { });
+                service.query(fakeRequest).subscribe();
 
                 const req = httpMock.expectOne({ method: 'GET' });
                 const resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>management/audits';
@@ -59,18 +60,23 @@ describe('Service Tests', () => {
 
                 const audit = new Audit({ remoteAddress: '127.0.0.1', sessionId: '123' }, 'user', '20140101', 'AUTHENTICATION_SUCCESS');
 
-                service.query({}).subscribe((received) => {
+                service.query(fakeRequest).subscribe((received) => {
                     expectedResult = received;
                 });
 
                 const req = httpMock.expectOne({ method: 'GET' });
                 req.flush([audit]);
-                expect(expectedResult.body[0]).toEqual(audit);
+                let audits: Audit[] = [];
+                if (expectedResult.body !== null) {
+                    audits = expectedResult.body;
+                }
+                expect(audits.length).toBe(1);
+                expect(audits[0]).toEqual(audit);
             });
 
             it('should propagate not found response', () => {
 
-                service.query({}).subscribe(null, (_error: any) => {
+                service.query(fakeRequest).subscribe(null, (_error: any) => {
                     expectedResult = _error.status;
                 });
 


### PR DESCRIPTION
This is next peace for #10631

Some comments about changes.

* Switching on typescript `strict` option forces to look at all kind of corner cases. So I made some changes in logic. I tested all these cases manually, but added also full unit tests.

* For date testing added `jest-date-mock` library.

* All internal methods are now private.

* Error messages were not shown before these changes.

* If start or end date was empty then NPE in server side before these changes.

* I removed `routeData.unsubscribe()`, because this in not necessary according to https://angular.io/guide/router#!#route-parameters (but it states: _Feel free to unsubscribe anyway. It is harmless and never a bad practice._) - currently in `audits` and `user-management` this `unsubscribe` is used, but in `entities` is not used. I believe it's better to not write unnecessary code as this is currently in entities.

* `link` header is not used, so removed variable for that

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
