### PR TITLE
Use simple modal in entity delete in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.html.ejs
@@ -23,7 +23,6 @@
 <div class="container-fluid">
     <div class="card jh-card">
         <router-outlet></router-outlet>
-        <router-outlet name="popup"></router-outlet>
     </div>
     <<%= jhiPrefixDashed %>-footer></<%= jhiPrefixDashed %>-footer>
 </div>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
@@ -19,17 +19,15 @@
 <%_
 const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 _%>
-import { Component, OnInit, OnDestroy } from '@angular/core';
-import { ActivatedRoute, Router } from '@angular/router';
+import { Component } from '@angular/core';
 
-import { NgbActiveModal, NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
+import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
 
 @Component({
-    selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>-delete-dialog',
     templateUrl: './<%= entityFileName %>-delete-dialog.component.html'
 })
 export class <%= entityAngularName %>DeleteDialogComponent {
@@ -55,40 +53,5 @@ export class <%= entityAngularName %>DeleteDialogComponent {
             });
             this.activeModal.dismiss(true);
         });
-    }
-}
-
-@Component({
-    selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>-delete-popup',
-    template: ''
-})
-export class <%= entityAngularName %>DeletePopupComponent implements OnInit, OnDestroy {
-
-    protected ngbModalRef: NgbModalRef;
-
-    constructor(
-        protected activatedRoute: ActivatedRoute,
-        protected router: Router,
-        protected modalService: NgbModal
-    ) {}
-
-    ngOnInit() {
-        this.activatedRoute.data.subscribe(({<%= entityInstance %>}) => {
-            setTimeout(() => {
-                this.ngbModalRef = this.modalService.open(<%= entityAngularName %>DeleteDialogComponent as Component, { size: 'lg', backdrop: 'static'});
-                this.ngbModalRef.componentInstance.<%= entityInstance %> = <%= entityInstance %>;
-                this.ngbModalRef.result.then(() => {
-                    this.router.navigate(['/<%= entityUrl %>', { outlets: { popup: null }}]);
-                    this.ngbModalRef = null;
-                }, () => {
-                    this.router.navigate(['/<%= entityUrl %>', { outlets: { popup: null }}]);
-                    this.ngbModalRef = null;
-                });
-            }, 0);
-        });
-    }
-
-    ngOnDestroy() {
-        this.ngbModalRef = null;
     }
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
@@ -160,10 +160,7 @@
                             <fa-icon [icon]="'pencil-alt'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
                         </button>
-                        <button type="submit"
-                                [routerLink]="['/<%= entityUrl %>', { outlets: { popup: <%= entityInstance %>.id + '/delete'} }]"
-                                replaceUrl="true"
-                                queryParamsHandling="merge"
+                        <button type="submit" (click)="delete(<%= entityInstance %>)"
                                 class="btn btn-danger btn-sm">
                             <fa-icon [icon]="'times'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -25,12 +25,16 @@ import { ActivatedRoute } from '@angular/router';
 <%_ } _%>
 import { Subscription } from 'rxjs';
 import { JhiEventManager <% if (pagination !== 'no') { %>, JhiParseLinks <% } %><% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
+import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 <%_ if (pagination !== 'no') { %>
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 <%_ } _%>
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
+<%_ if (!readOnly) { _%>
+import { <%= entityAngularName %>DeleteDialogComponent } from './<%= entityFileName %>-delete-dialog.component';
+<%_ } _%>
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-<%= entityFileName %>',
@@ -76,6 +80,13 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
     registerChangeIn<%= entityClassPlural %>() {
         this.eventSubscriber = this.eventManager.subscribe('<%= entityInstance %>ListModification', () => <%= eventCallBack %>);
     }
+    <%_ if (!readOnly) { _%>
+
+    delete(<%= entityInstance %>: I<%= entityAngularName %>) {
+        const modalRef = this.modalService.open(<%= entityAngularName %>DeleteDialogComponent, { size: 'lg', backdrop: 'static' });
+        modalRef.componentInstance.<%= entityInstance %> = <%= entityInstance %>;
+    }
+    <%_ } _%>
     <%_ if (pagination !== 'no') { _%>
         <%_ if (databaseType !== 'cassandra') { _%>
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -25,7 +25,9 @@ import { ActivatedRoute } from '@angular/router';
 <%_ } _%>
 import { Subscription } from 'rxjs';
 import { JhiEventManager <% if (pagination !== 'no') { %>, JhiParseLinks <% } %><% if (fieldsContainBlob) { %>, JhiDataUtils<% } %> } from 'ng-jhipster';
+<%_ if (!readOnly) { _%>
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
+<%_ } _%>
 
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 <%_ if (pagination !== 'no') { %>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -24,19 +24,14 @@ import { <%= entityAngularName %>Component } from './<%= entityFileName %>.compo
 import { <%= entityAngularName %>DetailComponent } from './<%= entityFileName %>-detail.component';
 <%_ if (!readOnly) { _%>
 import { <%= entityAngularName %>UpdateComponent } from './<%= entityFileName %>-update.component';
-import { <%= entityAngularName %>DeletePopupComponent, <%= entityAngularName %>DeleteDialogComponent } from './<%= entityFileName %>-delete-dialog.component';
+import { <%= entityAngularName %>DeleteDialogComponent } from './<%= entityFileName %>-delete-dialog.component';
 <%_ } _%>
-import { <%= entityInstance %>Route, <%= entityInstance %>PopupRoute } from './<%= entityFileName %>.route';
-
-const ENTITY_STATES = [
-    ...<%= entityInstance %>Route,
-    ...<%= entityInstance %>PopupRoute,
-];
+import { <%= entityInstance %>Route } from './<%= entityFileName %>.route';
 
 @NgModule({
     imports: [
         <%= angularXAppName %>SharedModule,
-        RouterModule.forChild(ENTITY_STATES)
+        RouterModule.forChild(<%= entityInstance %>Route)
     ],
     declarations: [
         <%= entityAngularName %>Component,
@@ -44,7 +39,6 @@ const ENTITY_STATES = [
         <%_ if (!readOnly) { _%>
         <%= entityAngularName %>UpdateComponent,
         <%= entityAngularName %>DeleteDialogComponent,
-        <%= entityAngularName %>DeletePopupComponent,
         <%_ } %>
     ],
     entryComponents: [

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
@@ -31,13 +31,6 @@ import { <%= entityAngularName %>Component } from './<%= entityFileName %>.compo
 import { <%= entityAngularName %>DetailComponent } from './<%= entityFileName %>-detail.component';
 <%_ if (!readOnly) { _%>
 import { <%= entityAngularName %>UpdateComponent } from './<%= entityFileName %>-update.component';
-<%_ if (entityFileName.length <= 30) { _%>
-import { <%= entityAngularName %>DeletePopupComponent } from './<%= entityFileName %>-delete-dialog.component';
-<%_ } else { _%>
-import {
-    <%= entityAngularName %>DeletePopupComponent
-} from './<%= entityFileName %>-delete-dialog.component';
-<%_ } _%>
 <%_ } _%>
 import { I<%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 
@@ -113,23 +106,5 @@ export const <%= entityInstance %>Route: Routes = [
         },
         canActivate: [UserRouteAccessService]
     },
-    <%_ } _%>
-];
-
-export const <%= entityInstance %>PopupRoute: Routes = [
-    <%_ if (!readOnly) { _%>
-    {
-        path: ':id/delete',
-        component: <%= entityAngularName %>DeletePopupComponent,
-        resolve: {
-            <%= entityInstance %>: <%= entityAngularName %>Resolve
-        },
-        data: {
-            authorities: ['ROLE_USER'],
-            pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
-        },
-        canActivate: [UserRouteAccessService],
-        outlet: 'popup'
-    }
     <%_ } _%>
 ];

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -34,6 +34,7 @@
         protected dataUtils: JhiDataUtils,
         <%_ } _%>
         protected eventManager: JhiEventManager,
+        protected modalService: NgbModal,
         protected parseLinks: JhiParseLinks,
         <%_ if (searchEngine === 'elasticsearch') { _%>
         protected activatedRoute: ActivatedRoute,

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -34,7 +34,9 @@
         protected dataUtils: JhiDataUtils,
         <%_ } _%>
         protected eventManager: JhiEventManager,
+        <%_ if (!readOnly) { _%>
         protected modalService: NgbModal,
+        <%_ } _%>
         protected parseLinks: JhiParseLinks,
         <%_ if (searchEngine === 'elasticsearch') { _%>
         protected activatedRoute: ActivatedRoute,

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -28,6 +28,7 @@
         protected dataUtils: JhiDataUtils,
         <%_ } _%>
         protected eventManager: JhiEventManager,
+        protected modalService: NgbModal,
         <%_ if (searchEngine === 'elasticsearch') { _%>
         protected activatedRoute: ActivatedRoute,
         <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -28,7 +28,9 @@
         protected dataUtils: JhiDataUtils,
         <%_ } _%>
         protected eventManager: JhiEventManager,
+        <%_ if (!readOnly) { _%>
         protected modalService: NgbModal,
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         protected activatedRoute: ActivatedRoute,
         <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -42,7 +42,8 @@
         protected dataUtils: JhiDataUtils,
         <%_ } _%>
         protected router: Router,
-        protected eventManager: JhiEventManager
+        protected eventManager: JhiEventManager,
+        protected modalService: NgbModal
     ) {
         <%_ if (databaseType !== 'cassandra') { _%>
         this.itemsPerPage = ITEMS_PER_PAGE;

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -43,7 +43,9 @@
         <%_ } _%>
         protected router: Router,
         protected eventManager: JhiEventManager,
+        <%_ if (!readOnly) { _%>
         protected modalService: NgbModal
+        <%_ } _%>
     ) {
         <%_ if (databaseType !== 'cassandra') { _%>
         this.itemsPerPage = ITEMS_PER_PAGE;


### PR DESCRIPTION
I looked at entity delete component while dealing with #10631 and found heavy code for delete.

In user management module it's light and simple. I looked at Git history and found out that in user management this was simplified by https://github.com/jhipster/generator-jhipster/commit/3d180131fd6e0d47af6888f25695b1ee85f47a2e as part of #7406

I made the same simplification in entities and removed popup router outlet as this is not needed any more now.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
