### PR TITLE
Fixing elastic search template

### DIFF
--- a/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
@@ -44,6 +44,10 @@ metadata:
 spec:
   serviceName: jhipster-elasticsearch-master
   replicas: 1
+  selector:
+    matchLabels:
+      component: jhipster-elasticsearch
+      role: master
   template:
     metadata:
       labels:
@@ -194,6 +198,10 @@ metadata:
 spec:
   serviceName: jhipster-elasticsearch-data
   replicas: 1
+  selector:
+    matchLabels:
+      component: jhipster-elasticsearch
+      role: data
   template:
     metadata:
       labels:


### PR DESCRIPTION
This PR fixes the `kubernetes` generator when selecting to use the JHipster console for monitoring. 

The fix relies on the Kubernetes documentation around `StatefulSet` https://kubernetes.io/docs/concepts/workloads/controllers/statefulset/#pod-selector 

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->

