### PR TITLE
Increase Sleep Time for MariaDB to Start

### DIFF
--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -76,9 +76,14 @@ services:
             - SPRING_DATA_CASSANDRA_CONTACTPOINTS=<%= baseName.toLowerCase() %>-cassandra
                 <%_ if (authenticationType === 'uaa') { _%>
             - JHIPSTER_SLEEP=80 # gives time for uaa and the Cassandra cluster to start and execute the migration scripts
-                <%_ } _%>
-            <%_ } _%>
+                <%_ } else { _%>
             - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
+                <%_ } _%>
+            <%_ } else if (prodDatabaseType === 'mariadb') { _%>
+            - JHIPSTER_SLEEP=90 # gives time for mariadb server to start
+            <%_ } else { _%>
+            - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
+            <%_ } _%>
             <%_ if (searchEngine === 'elasticsearch') { _%>
             - SPRING_DATA_JEST_URI=http://<%= baseName.toLowerCase() %>-elasticsearch:9200
             - SPRING_ELASTICSEARCH_REST_URIS=http://<%= baseName.toLowerCase() %>-elasticsearch:9200


### PR DESCRIPTION
This adds a missing part to https://github.com/jhipster/generator-jhipster/pull/10673. Apart from opening port 3306 we need to give a decent sleep time for the `store` app since MariaDB seems to take some time to configure itself especially in CI environments. 

Fixes part of https://github.com/jhipster/generator-jhipster/issues/10604

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
