### PR TITLE
fix encoding in .war file by addin web.xml to generated .war file

### DIFF
--- a/generators/server/templates/gradle/war.gradle.ejs
+++ b/generators/server/templates/gradle/war.gradle.ejs
@@ -21,13 +21,18 @@ apply plugin: "war"
 bootWar {
     mainClassName = "<%= packageName %>.<%= mainClass %>"
     includes = ["WEB-INF/**", "META-INF/**"]
+    <%_ if (!skipClient) { _%>
+    webXml = file("${project.rootDir}/<%= CLIENT_MAIN_SRC_DIR %>WEB-INF/web.xml")
+    <%_ } _%>
 }
 
 war {
     <%_ if (!skipClient) { _%>
     webAppDirName = "<%= CLIENT_DIST_DIR %>"
+    webXml = file("${project.rootDir}/<%= CLIENT_MAIN_SRC_DIR %>WEB-INF/web.xml")
     <%_ } _%>
     enabled = true
     archiveExtension = "war.original"
     includes = ["WEB-INF/**", "META-INF/**"]
+
 }


### PR DESCRIPTION
The includes statement do not include the web.xml for some reason, setting it explictly adds the file to the .war file which fixes the encoding. Used @ruddell description to verify the fix.

closes #10698

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
