### PR TITLE
Fix typo in kubernetes readme

### DIFF
--- a/generators/kubernetes/templates/README-KUBERNETES.md.ejs
+++ b/generators/kubernetes/templates/README-KUBERNETES.md.ejs
@@ -126,7 +126,7 @@ Check the docker registry your Kubernetes cluster is accessing. If you are using
 
 > my applications get killed, before they can boot up
 
-This can occur if your cluster has low resource (e.g. Minikube). Increase the `initialDelySeconds` value of livenessProbe of your deployments
+This can occur if your cluster has low resource (e.g. Minikube). Increase the `initialDelaySeconds` value of livenessProbe of your deployments
 
 > my applications are starting very slow, despite I have a cluster with many resources
 


### PR DESCRIPTION
The kubernetes field is called `initialDelaySeconds`
Fixed typo error in the readme template

source: https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
