### PR TITLE
update Node version to v12.13.0, npm to v6.12.1

### DIFF
--- a/.github/workflows/applications.yml
+++ b/.github/workflows/applications.yml
@@ -23,7 +23,7 @@ jobs:
         strategy:
             fail-fast: false
             matrix:
-                node_version: [10.x]
+                node_version: [12.x]
                 os: [ubuntu-latest]
                 app-type: [ngx-session-cassandra-fr, ngx-mongodb-kafka-cucumber, ngx-couchbase]
                 include:

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,7 @@ services:
     - xvfb
 language: node_js
 node_js:
-    - '10.16.3'
+    - '12.13.0'
 cache:
     directories:
         - $HOME/.m2

--- a/Dockerfile
+++ b/Dockerfile
@@ -28,7 +28,7 @@ RUN \
   apt-get install -y openjdk-11-jdk && \
   update-java-alternatives -s java-1.11.0-openjdk-amd64 && \
   # install node.js
-  wget https://nodejs.org/dist/v10.16.3/node-v10.16.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \
+  wget https://nodejs.org/dist/v12.13.0/node-v12.13.0-linux-x64.tar.gz -O /tmp/node.tar.gz && \
   tar -C /usr/local --strip-components 1 -xzf /tmp/node.tar.gz && \
   # upgrade npm
   npm install -g npm && \

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -90,7 +90,7 @@ jobs:
           #----------------------------------------------------------------------
           - task: NodeTool@0
             inputs:
-                versionSpec: '10.16.3'
+                versionSpec: '12.13.0'
             displayName: 'TOOLS: install Node.js'
           - script: |
                 if [[ $JHI_JDK = '11' ]]; then

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -21,9 +21,9 @@
 const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
 
 // Version of Node, Yarn, NPM
-const NODE_VERSION = '10.16.3';
+const NODE_VERSION = '12.13.0';
 const YARN_VERSION = '1.19.0';
-const NPM_VERSION = '6.12.0';
+const NPM_VERSION = '6.12.1';
 
 // Libraries version
 const JIB_VERSION = '1.7.0';


### PR DESCRIPTION
Fix #10677

I left the `10.x` test in `.github/workflows/generator.yml`, not sure if that should be removed.  https://github.com/jhipster/generator-jhipster/blob/3a24eace8422107f8d2257f5f5f4114768e51df9/.github/workflows/generator.yml#L11 

I used a script for this that clones all of the repos and replaces the version number, manually validated that it matches the last Node Upgrade PR

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
