### PR TITLE
invalidate Account cache, if user has logged out

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -73,7 +73,7 @@ export class AccountService  {
     }
 
     identity(force?: boolean): Observable<Account> {
-        if (force) {
+        if (force || !this.authenticated) {
             this.accountCache$ = null;
         }
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -74,6 +74,29 @@ describe('Service Tests', () => {
                 });
             });
 
+            it('should call /account again if user has logged out', () => {
+                // Given the user is authenticated
+                service.identity().subscribe(() => {});
+                const req = httpMock.expectOne({ method: 'GET' });
+                req.flush({
+                    firstName: 'Unimportant'
+                });
+
+                // When I call
+                service.identity().subscribe(() => {});
+
+                // Then there is no second request
+                httpMock.expectNone({ method: 'GET' });
+
+                // When I log out
+                service.authenticate(null);
+                // and then call
+                service.identity().subscribe(() => {});
+
+                // Then there is a new request
+                httpMock.expectOne({ method: 'GET' });
+            });
+
             describe('hasAnyAuthority string parameter', () => {
                 it('should return false if user is not logged', () => {
                     const hasAuthority = service.hasAnyAuthority('ROLE_USER');


### PR DESCRIPTION
With the upgrade to JHipster 6.4.0 we noticed some behavior surprising to us. I think it is related to https://github.com/jhipster/generator-jhipster/pull/10383/files#.

In particular, we noticed that if we explicitly log out, we will still receive the old `Account` after calling `AccountService.identity().subscribe(..)`. As far as I could see, this is due to the `accountCache` that does not get invalidated, even if the user logs out. In my opinion, it does not make sense to ever return the last cached `Account`, if `AccountService.authenticated` has been switched to `false` meanwhile, i.e. the user has been logged out. This PR changes the behavior to invalidate the cache within `identity()`, if `authenticated == false`. It would also possible to adjust `AccountService.authenticate(null)` to invalidate the cache, but since the cache is only used for `identity()` and the behavior is somewhat similar to `force`, I added it there.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed