### PR TITLE
Add Support for Generating String Patterns for Regex in JDL

### DIFF
--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 const _ = require('lodash');
+const Randexp = require('randexp');
 const utils = require('../utils');
 const constants = require('../generator-constants');
 
@@ -266,11 +267,19 @@ function addEnumerationFiles(generator, templateDir, clientFolder) {
     });
 }
 
+function addSampleRegexTestingStrings(generator) {
+    generator.fields.forEach(field => {
+        if (field.fieldValidateRulesPattern !== undefined) {
+            field.fieldValidateSampleString = new Randexp(field.fieldValidateRulesPattern).gen();
+        }
+    });
+}
+
 function writeFiles() {
     return {
         writeClientFiles() {
             if (this.skipClient) return;
-
+            addSampleRegexTestingStrings(this);
             if (this.clientFramework === 'angularX') {
                 // write client side files for angular 2.x +
                 this.writeFilesToDisk(

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -110,6 +110,7 @@ describe('<%= entityClass %> e2e test', () => {
             const fieldType = field.fieldType;
             const fieldTypeBlobContent = field.fieldTypeBlobContent;
             const fieldIsEnum = field.fieldIsEnum;
+            const fieldValidateSampleString = field.fieldValidateSampleString;
             if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5'),
             <%_ } else if (fieldType === 'LocalDate') { _%>
@@ -126,6 +127,8 @@ describe('<%= entityClass %> e2e test', () => {
             <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption(),
             <%_ } else if (fieldType === 'UUID'){ _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974'),
+            <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
+            <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldValidateSampleString %>'),
             <%_ } else if (fieldType !== 'Boolean') { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>'),
             <%_ } _%>
@@ -148,6 +151,7 @@ describe('<%= entityClass %> e2e test', () => {
             const fieldType = field.fieldType;
             const fieldTypeBlobContent = field.fieldTypeBlobContent;
             const fieldIsEnum = field.fieldIsEnum;
+            const fieldValidateSampleString = field.fieldValidateSampleString;
             if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('5', 'Expected <%=fieldName%> value to be equals to 5');
             <%_ } else if (fieldType === 'LocalDate') { _%>
@@ -156,6 +160,8 @@ describe('<%= entityClass %> e2e test', () => {
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('2001-01-01T02:30', 'Expected <%=fieldName%> value to be equals to 2000-12-31');
             <%_ } else if (fieldType === 'Duration') { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('12', 'Expected <%=fieldName%> value to be equals to 12');
+            <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldValidateSampleString %>', 'Expected <%=fieldNameCapitalized%> value to be equals to <%= fieldValidateSampleString %>');
             <%_ } else if (fieldType === 'Boolean') { _%>
         const selected<%= fieldNameCapitalized %> = <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input();
         if (await selected<%= fieldNameCapitalized %>.isSelected()) {

--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -106,6 +106,7 @@ describe('<%= entityClass %> e2e test', () => {
                 const fieldType = field.fieldType;
                 const fieldTypeBlobContent = field.fieldTypeBlobContent;
                 const fieldIsEnum = field.fieldIsEnum;
+                const fieldValidateSampleString = field.fieldValidateSampleString;
             _%>
             <%_ if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
             await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5');
@@ -138,6 +139,9 @@ describe('<%= entityClass %> e2e test', () => {
             <%_ } else if (fieldType === 'UUID'){ _%>
             await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
             expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match(/64c99148-3908-465d-8c4a-e510e3ade974/);
+            <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
+            await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldValidateSampleString %>');
+            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match(/<%= fieldValidateSampleString %>/);
             <%_ } else { _%>
             await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>');
             expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match(/<%= fieldName %>/);


### PR DESCRIPTION
This adds support to automatically test regex patterns in JDL in our e2e tests. 

Fixes #10704

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
