### PR TITLE
Exit import-jdl with status from the forked process.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -21,7 +21,18 @@ const program = require('commander');
 const chalk = require('chalk');
 
 const packageJson = require('../package.json');
-const { CLI_NAME, initHelp, logger, createYeomanEnv, toString, getCommand, getCommandOptions, getArgs, done } = require('./utils');
+const {
+    CLI_NAME,
+    initHelp,
+    logger,
+    createYeomanEnv,
+    toString,
+    getCommand,
+    getCommandOptions,
+    getArgs,
+    done,
+    getExitCode
+} = require('./utils');
 const initAutoCompletion = require('./completion').init;
 const SUB_GENERATORS = require('./commands');
 
@@ -31,6 +42,10 @@ const env = createYeomanEnv();
 
 /* setup debugging */
 logger.init(program);
+
+process.on('exit', code => {
+    process.exit(code || getExitCode());
+});
 
 /**
  *  Run a yeoman command

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -26,7 +26,7 @@ const pluralize = require('pluralize');
 const { fork } = require('child_process');
 
 const waitUntil = require('./wait-until');
-const { CLI_NAME, GENERATOR_NAME, logger, toString, getOptionsFromArgs, done, getOptionAsArgs } = require('./utils');
+const { CLI_NAME, GENERATOR_NAME, logger, toString, getOptionsFromArgs, done, getOptionAsArgs, setExitCode } = require('./utils');
 const jhipsterUtils = require('../generators/utils');
 
 const packagejs = require('../package.json');
@@ -138,6 +138,7 @@ const generateDeploymentFiles = ({ generator, deployment, inFolder }, forkProces
         }
     );
     childProc.on('exit', code => {
+        setExitCode(code);
         logger.info(`Deployment: child process exited with code ${code}`);
         generationCompletionState.exportedDeployments[deploymentType] = true;
     });
@@ -166,6 +167,7 @@ const generateApplicationFiles = ({ generator, application, withEntities, inFold
         }
     );
     childProc.on('exit', code => {
+        setExitCode(code);
         logger.info(`App: child process exited with code ${code}`);
         generationCompletionState.exportedApplications[baseName] = true;
     });
@@ -204,6 +206,7 @@ const generateEntityFiles = (generator, entity, inFolder, env, shouldTriggerInst
 
             const childProc = forkProcess(runYeomanProcess, [command, ...getOptionAsArgs(options, false, !options.interactive)], { cwd });
             childProc.on('exit', code => {
+                setExitCode(code);
                 logger.info(`Entity: child process exited with code ${code}`);
                 generationCompletionState.exportedEntities[entity.name] = true;
             });

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -27,6 +27,9 @@ const SUB_GENERATORS = require('./commands');
 
 const CLI_NAME = 'jhipster';
 const GENERATOR_NAME = 'generator-jhipster';
+
+let exitCode = 0;
+
 const debug = function(msg) {
     if (this.debugEnabled) {
         console.log(`${chalk.blue('DEBUG!')}  ${msg}`);
@@ -47,6 +50,7 @@ const error = function(msg, trace) {
         console.log(trace);
     }
     process.exit(1);
+    exitCode = 1;
 };
 
 const init = function(program) {
@@ -216,5 +220,15 @@ module.exports = {
     getCommandOptions,
     done,
     createYeomanEnv,
-    getOptionAsArgs
+    getOptionAsArgs,
+
+    getExitCode() {
+        return exitCode;
+    },
+
+    setExitCode(code) {
+        if (code !== 0) {
+            exitCode = code;
+        }
+    }
 };


### PR DESCRIPTION
Currently every import-jdl command exits with status 0, this patch will make import-jdl and probably other commands exit with the last non 0 status.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
