### PR TITLE
use older gradle version when using openapi plugin

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -25,6 +25,8 @@ const NODE_VERSION = '12.13.0';
 const YARN_VERSION = '1.19.0';
 const NPM_VERSION = '6.13.0';
 
+const GRADLE_VERSION = '6.0';
+
 // Libraries version
 const JIB_VERSION = '1.7.0';
 
@@ -305,6 +307,7 @@ const constants = {
     YARN_VERSION,
     NPM_VERSION,
     KAFKA_VERSION,
+    GRADLE_VERSION,
 
     // Libraries
     JIB_VERSION,

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -180,7 +180,7 @@ const serverFiles = {
                 { file: 'gradlew', method: 'copy', noEjs: true },
                 { file: 'gradlew.bat', method: 'copy', noEjs: true },
                 { file: 'gradle/wrapper/gradle-wrapper.jar', method: 'copy', noEjs: true },
-                { file: 'gradle/wrapper/gradle-wrapper.properties', method: 'copy', noEjs: true }
+                'gradle/wrapper/gradle-wrapper.properties'
             ]
         },
         {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -123,6 +123,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.NODE_VERSION = constants.NODE_VERSION;
                 this.YARN_VERSION = constants.YARN_VERSION;
                 this.NPM_VERSION = constants.NPM_VERSION;
+                this.GRADLE_VERSION = constants.GRADLE_VERSION;
 
                 this.JIB_VERSION = constants.JIB_VERSION;
                 this.JACOCO_VERSION = constants.JACOCO_VERSION;

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -534,9 +534,16 @@ task cleanResources(type: Delete) {
     delete "build/resources"
 }
 
+<%_ if (enableSwaggerCodegen) { _%>
 wrapper {
-    gradleVersion = "6.0"
+    gradleVersion = "5.6.4"
 }
+<%_ } else { _%>
+wrapper {
+    gradleVersion = "<%= GRADLE_VERSION %>"
+}
+<%_ } _%>
+
 <%_ if (!skipClient) { _%>
 
 if (project.hasProperty("nodeInstall")) {

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -64,7 +64,7 @@ liquibase_plugin_version=2.0.1
 <%_ } _%>
 sonarqube_plugin_version=2.8
 <%_ if (enableSwaggerCodegen) { _%>
-openapi_plugin_version=4.1.3
+openapi_plugin_version=4.2.0
 <%_ } _%>
 spring_no_http_plugin_version=0.0.3.RELEASE
 checkstyle_version=8.24

--- a/generators/server/templates/gradle/wrapper/gradle-wrapper.properties
+++ b/generators/server/templates/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,0 @@
-distributionBase=GRADLE_USER_HOME
-distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.0-bin.zip
-zipStoreBase=GRADLE_USER_HOME
-zipStorePath=wrapper/dists

--- a/generators/server/templates/gradle/wrapper/gradle-wrapper.properties.ejs
+++ b/generators/server/templates/gradle/wrapper/gradle-wrapper.properties.ejs
@@ -1,0 +1,9 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+<%_ if (enableSwaggerCodegen) { _%>
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
+<%_ } else { _%>
+distributionUrl=https\://services.gradle.org/distributions/gradle-<%= GRADLE_VERSION %>-bin.zip
+<%_ } _%>
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -129,7 +129,7 @@
         <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 <%_ if (enableSwaggerCodegen) { _%>
-        <openapi-generator-maven-plugin.version>4.1.3</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>4.2.0</openapi-generator-maven-plugin.version>
 <%_ } _%>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>


### PR DESCRIPTION
THis PR does two things:

1. It extrnalizes the gradle version into a constant such that updating should be easier
2. Until the open api plguin has been released in a new version (compatible with gradle 6) when using open api the latest 5.6.4 version is used. This involves minimal branching in two files so the effort to maintain and remove it is quite small

So with this change most of our users will get the latest and greatest gradle version without breaking the open api support.

For details see https://github.com/jhipster/generator-jhipster/pull/10750#issuecomment-552209980

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
