### PR TITLE
enable UAA microservices w/o eureka

### DIFF
--- a/generators/docker-compose/files.js
+++ b/generators/docker-compose/files.js
@@ -74,7 +74,7 @@ function writeFiles() {
             // Generate a list of target apps to monitor for the prometheus config
             const appsToMonitor = [];
             for (let i = 0; i < this.appConfigs.length; i++) {
-                appsToMonitor.push(`        - ${this.appConfigs[i].baseName}-app:${this.appConfigs[i].serverPort}`);
+                appsToMonitor.push(`        - ${this.appConfigs[i].baseName}:${this.appConfigs[i].serverPort}`);
             }
 
             // Format the application target list as a YAML array

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -92,7 +92,7 @@ module.exports = class extends BaseDockerGenerator {
                     const path = this.destinationPath(this.directoryPath + appsFolder);
                     // Add application configuration
                     const yaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/app.yml`));
-                    const yamlConfig = yaml.services[`${lowercaseBaseName}`];
+                    const yamlConfig = yaml.services[`${lowercaseBaseName}-app`];
                     if (this.gatewayType === 'traefik' && appConfig.applicationType === 'gateway') {
                         delete yamlConfig.ports; // Do not export the ports as Traefik is the gateway
                         this.keycloakRedirectUris += '"http://localhost/*", "https://localhost/*", ';
@@ -115,6 +115,10 @@ module.exports = class extends BaseDockerGenerator {
                     if (this.serviceDiscoveryType === 'eureka') {
                         // Set the JHipster Registry password
                         yamlConfig.environment.push(`JHIPSTER_REGISTRY_PASSWORD=${this.adminPassword}`);
+                    }
+
+                    if (!this.serviceDiscoveryType && appConfig.applicationType !== 'gateway') {
+                        yamlConfig.environment.push('SERVER_PORT=80'); // to simplify service resolution in docker/k8s
                     }
 
                     parentConfiguration[`${lowercaseBaseName}`] = yamlConfig;

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -92,7 +92,7 @@ module.exports = class extends BaseDockerGenerator {
                     const path = this.destinationPath(this.directoryPath + appsFolder);
                     // Add application configuration
                     const yaml = jsyaml.load(this.fs.read(`${path}/src/main/docker/app.yml`));
-                    const yamlConfig = yaml.services[`${lowercaseBaseName}-app`];
+                    const yamlConfig = yaml.services[`${lowercaseBaseName}`];
                     if (this.gatewayType === 'traefik' && appConfig.applicationType === 'gateway') {
                         delete yamlConfig.ports; // Do not export the ports as Traefik is the gateway
                         this.keycloakRedirectUris += '"http://localhost/*", "https://localhost/*", ';
@@ -117,7 +117,7 @@ module.exports = class extends BaseDockerGenerator {
                         yamlConfig.environment.push(`JHIPSTER_REGISTRY_PASSWORD=${this.adminPassword}`);
                     }
 
-                    parentConfiguration[`${lowercaseBaseName}-app`] = yamlConfig;
+                    parentConfiguration[`${lowercaseBaseName}`] = yamlConfig;
 
                     // Add database configuration
                     const database = appConfig.prodDatabaseType;

--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -206,13 +206,13 @@ spec:
           containerPort: <%= app.serverPort %>
         readinessProbe:
           httpGet:
-            path: <%= app.applicationType === 'microservice' && !app.serviceDiscoveryType ? `/services/${app.baseName.toLowerCase()}` : '' %>/management/health
+            path: /management/health
             port: http
           initialDelaySeconds: 20
           periodSeconds: 15
           failureThreshold: 6
         livenessProbe:
           httpGet:
-            path: <%= app.applicationType === 'microservice' && !app.serviceDiscoveryType ? `/services/${app.baseName.toLowerCase()}` : '' %>/management/info
+            path: /management/health
             port: http
           initialDelaySeconds: 120

--- a/generators/kubernetes/templates/service.yml.ejs
+++ b/generators/kubernetes/templates/service.yml.ejs
@@ -35,4 +35,9 @@ spec:
   <%_ } _%>
   ports:
   - name: http
+  <%_ if (app.applicationType === 'microservice' || app.applicationType === 'uaa') { _%>
+    port: 80
+    targetPort: <%= app.serverPort %>
+  <%_ } else { _%>
     port: <%= app.serverPort %>
+  <%_ } _%>

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -566,6 +566,10 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}web/filter/RefreshTokenFilterConfigurer.java`
                 },
                 {
+                    file: 'package/web/filter/RouteDetectorFilter.java',
+                    renameTo: generator => `${generator.javaDir}web/filter/RouteDetectorFilter.java`
+                },
+                {
                     file: 'package/config/oauth2/OAuth2AuthenticationConfiguration.java',
                     renameTo: generator => `${generator.javaDir}config/oauth2/OAuth2AuthenticationConfiguration.java`
                 },

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -694,7 +694,7 @@
         </dependency>
 <%_ } _%>
         <!-- Spring Cloud -->
-<%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
+<%_ if (applicationType === 'gateway') { _%>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter-netflix-zuul</artifactId>

--- a/generators/server/templates/src/main/java/package/Application.java.ejs
+++ b/generators/server/templates/src/main/java/package/Application.java.ejs
@@ -44,7 +44,7 @@ import org.springframework.boot.context.properties.EnableConfigurationProperties
 <%_ if (serviceDiscoveryType) { _%>
 import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
 <%_ } _%>
-<%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
+<%_ if (applicationType === 'gateway') { _%>
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 <%_ } _%>
 <%_ if (applicationType === 'microservice' && authenticationType === 'uaa') { _%>
@@ -68,7 +68,7 @@ import java.util.Collection;
 <%_ if (serviceDiscoveryType) { _%>
 @EnableDiscoveryClient
 <%_ } _%>
-<%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
+<%_ if (applicationType === 'gateway') { _%>
 @EnableZuulProxy
 <%_ } _%>
 public class <%= mainClass %> implements InitializingBean {

--- a/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
@@ -43,7 +43,7 @@ public class UaaSignatureVerifierClient implements OAuth2SignatureVerifierClient
     private final RestTemplate restTemplate;
     protected final OAuth2Properties oAuth2Properties;
 
-    public UaaSignatureVerifierClient(DiscoveryClient discoveryClient, @Qualifier("loadBalancedRestTemplate") RestTemplate restTemplate,
+    public UaaSignatureVerifierClient(DiscoveryClient discoveryClient, @Qualifier("<%=!serviceDiscoveryType ? 'vanillaRestTemplate' : 'loadBalancedRestTemplate' %>") RestTemplate restTemplate,
                                   OAuth2Properties oAuth2Properties) {
         this.restTemplate = restTemplate;
         this.oAuth2Properties = oAuth2Properties;

--- a/generators/server/templates/src/main/java/package/security/oauth2/UaaTokenEndpointClient.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/UaaTokenEndpointClient.java.ejs
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 @Component
 public class UaaTokenEndpointClient extends OAuth2TokenEndpointClientAdapter implements OAuth2TokenEndpointClient {
 
-    public UaaTokenEndpointClient(@Qualifier("loadBalancedRestTemplate") RestTemplate restTemplate,
+    public UaaTokenEndpointClient(@Qualifier("<%=!serviceDiscoveryType ? 'vanillaRestTemplate' : 'loadBalancedRestTemplate' %>") RestTemplate restTemplate,
                                   JHipsterProperties jHipsterProperties, OAuth2Properties oAuth2Properties) {
         super(restTemplate, jHipsterProperties, oAuth2Properties);
     }

--- a/generators/server/templates/src/main/java/package/web/filter/RouteDetectorFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/filter/RouteDetectorFilter.java.ejs
@@ -1,0 +1,111 @@
+<%#
+ Copyright 2013-2019 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://jhipster.github.io/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.web.filter;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.cloud.netflix.zuul.filters.ZuulProperties;
+import org.springframework.cloud.netflix.zuul.web.ZuulHandlerMapping;
+import org.springframework.core.annotation.Order;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.HashSet;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/**
+ * Detects if a call is to be forwarded to a microservice and adds it to zuul routes
+ */
+@Component
+@Order(1)
+public class RouteDetectorFilter implements Filter {
+    private static Logger log = LoggerFactory.getLogger(RouteDetectorFilter.class);
+    private final RestTemplate restTemplate;
+    private final ZuulProperties zuulProperties;
+    private final ZuulHandlerMapping zuulHandlerMapping;
+
+    public RouteDetectorFilter(@Qualifier("vanillaRestTemplate") RestTemplate restTemplate, ZuulProperties zuulProperties, ZuulHandlerMapping zuulHandlerMapping) {
+        this.restTemplate = restTemplate;
+        this.zuulProperties = zuulProperties;
+        this.zuulHandlerMapping = zuulHandlerMapping;
+    }
+
+    @Override
+    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+
+        String requestURL = ((HttpServletRequest) request).getRequestURI();
+
+        Pattern pattern = Pattern.compile("/services/(.*?)/.*");
+        Matcher matcher = pattern.matcher(requestURL);
+
+        // match a service-call by a rule like /services/{serviceName}/**
+        if (matcher.find()) {
+            String serviceName = matcher.group(1);
+
+            // test, if the service is missing in zuul routes
+            if (!zuulProperties.getRoutes().containsKey(serviceName)) {
+                try {
+                    URI uri = new URI(
+                        "http",
+                        null,
+                        serviceName,
+                        80,
+                        "/management/health",
+                        null,
+                        null
+                    );
+
+                    // try to reach the health endpoint
+                    ResponseEntity<String> responseEntity = restTemplate.getForEntity(uri, String.class);
+                    if (!responseEntity.getStatusCode().isError()) {
+                        ZuulProperties.ZuulRoute route = new ZuulProperties.ZuulRoute(
+                            serviceName,
+                            "/" + serviceName + "/**",
+                            null,
+                            "http://" + serviceName + "/",
+                            true,
+                            false,
+                            new HashSet<>()
+                        );
+
+                        // update routes
+                        zuulProperties.getRoutes().put(serviceName, route);
+                        zuulHandlerMapping.setDirty(true);
+                        log.info("added route {} dynamically", route);
+                    } else {
+                        log.warn("could not reach health endpoint of service {}", serviceName);
+                    }
+                } catch (URISyntaxException e) {
+                    log.error("could not parse URI", e);
+                }
+            }
+
+        }
+
+        chain.doFilter(request, response);
+    }
+}

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -60,7 +60,7 @@ ribbon:
     eureka:
         enabled: true
 <%_ } _%>
-<%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
+<%_ if (applicationType === 'gateway') { _%>
 # See http://cloud.spring.io/spring-cloud-netflix/spring-cloud-netflix.html
 zuul: # those values must be configured depending on the application specific needs
     sensitive-headers: Cookie,Set-Cookie #see https://github.com/spring-cloud/spring-cloud-netflix/issues/3126
@@ -257,9 +257,6 @@ security:
 
 server:
     servlet:
-        <%_ if ((applicationType === 'microservice' || applicationType === 'uaa') && !serviceDiscoveryType) { _%>
-        context-path: /services/${spring.application.name}
-        <%_ } _%>
         session:
             cookie:
                 http-only: true


### PR DESCRIPTION


this PR enhances the experience when using microservices (in particular
UAA) without eureka in docker-compose and kubernetes

closes #8967 and #9027

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
