### PR TITLE
Fix fake data with UUID for MySQL and MariaDB

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -209,7 +209,7 @@
                     loadColumnType = 'blob';
                 } else if (columnType === '${clobType}') {
                     loadColumnType = 'clob';
-                } else if (columnType === '${uuidType}') {
+                } else if (columnType === '${uuidType}' && prodDatabaseType !== 'mysql' && prodDatabaseType !== 'mariadb') {
                     loadColumnType = '${uuidType}';
                 }
                 _%>


### PR DESCRIPTION
For MySQL and MariaDB, it should be string.
For PostgreSQL, it should be uuid.

Following https://github.com/jhipster/generator-jhipster/pull/10767#issuecomment-553826284

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
