### PR TITLE
Increase Sleep Timeout for MariaDB a Bit Further

### DIFF
--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -80,7 +80,7 @@ services:
             - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
                 <%_ } _%>
             <%_ } else if (prodDatabaseType === 'mariadb') { _%>
-            - JHIPSTER_SLEEP=90 # gives time for mariadb server to start
+            - JHIPSTER_SLEEP=120 # gives time for mariadb server to start
             <%_ } else { _%>
             - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
             <%_ } _%>


### PR DESCRIPTION
It seems that MariaDB builds overall is working fine as per #10604, but [once in a while](https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build/results?buildId=7468) I see some failures MariaDB builds timing out. I would like to increase the sleep timeout a bit further to see if we could get the builds not timeout at all; just to make it perfect. :smile: 

Related to https://github.com/jhipster/generator-jhipster/issues/10604

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
