### PR TITLE
Add More Appropriate Title for Test Checkbox in Pull Requests

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,6 +1,6 @@
 -   Please make sure the below checklist is followed for Pull Requests.
 
--   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
+-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
 -   [ ] Tests are added where necessary
 -   [ ] Documentation is added/updated where necessary
 -   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed


### PR DESCRIPTION
Currently it says "Travis Tests" which doesn't make sense as we use Azure and Github CI; so I've changed it. :smile: 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
