### PR TITLE
Use strict option in the majority of the core module and in the tracker module in Angular

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -280,6 +280,7 @@ const files = {
                 { file: 'admin/tracker/tracker.module.ts', method: 'processJs' },
                 { file: 'admin/tracker/tracker.component.ts', method: 'processJs' },
                 { file: 'admin/tracker/tracker.component.html', method: 'processHtml' },
+                'core/tracker/tracker-activity.model.ts',
                 'core/tracker/tracker.service.ts'
             ]
         },
@@ -330,8 +331,14 @@ const files = {
             condition: generator => generator.authenticationType !== 'oauth2',
             templates: [
                 // login
+                'core/login/login.model.ts',
                 'core/login/login-modal.service.ts'
             ]
+        },
+        {
+            path: ANGULAR_DIR,
+            condition: generator => generator.authenticationType === 'oauth2',
+            templates: ['core/login/logout.model.ts']
         },
         {
             condition: generator => !generator.skipUserManagement || generator.authenticationType === 'oauth2',

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -72,6 +72,9 @@
     "@types/mocha": "5.2.7",
     <%_ } _%>
     "@types/node": "10.12.27",
+    <%_ if (websocket === 'spring-websocket') { _%>
+    "@types/sockjs-client": "1.1.1",
+    <%_ } _%>
     "@typescript-eslint/eslint-plugin": "2.7.0",
     "@typescript-eslint/eslint-plugin-tslint": "2.7.0",
     "@typescript-eslint/parser": "2.7.0",

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
@@ -17,23 +17,25 @@
  limitations under the License.
 -%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
 
-import { <%=jhiPrefixCapitalized%>TrackerService } from 'app/core/tracker/tracker.service';
+import { TrackerService } from 'app/core/tracker/tracker.service';
+import { TrackerActivity } from 'app/core/tracker/tracker-activity.model';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-tracker',
     templateUrl: './tracker.component.html'
 })
-export class <%=jhiPrefixCapitalized%>TrackerComponent implements OnInit, OnDestroy {
-
-    activities: any[] = [];
+export class TrackerComponent implements OnInit, OnDestroy {
+    activities: TrackerActivity[] = [];
+    subscription: Subscription | null = null;
 
     constructor(
-        private trackerService: <%=jhiPrefixCapitalized%>TrackerService
+        private trackerService: TrackerService
     ) {
     }
 
-    showActivity(activity: any) {
+    showActivity(activity: TrackerActivity): void {
         let existingActivity = false;
         for (let index = 0; index < this.activities.length; index++) {
             if (this.activities[index].sessionId === activity.sessionId) {
@@ -50,14 +52,17 @@ export class <%=jhiPrefixCapitalized%>TrackerComponent implements OnInit, OnDest
         }
     }
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.trackerService.subscribe();
-        this.trackerService.receive().subscribe((activity) => {
+        this.subscription = this.trackerService.receive().subscribe((activity: TrackerActivity) => {
             this.showActivity(activity);
         });
     }
 
-    ngOnDestroy() {
+    ngOnDestroy(): void {
         this.trackerService.unsubscribe();
+        if (this.subscription !== null) {
+            this.subscription.unsubscribe();
+        }
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
@@ -61,7 +61,7 @@ export class TrackerComponent implements OnInit, OnDestroy {
 
     ngOnDestroy(): void {
         this.trackerService.unsubscribe();
-        if (this.subscription !== null) {
+        if (this.subscription) {
             this.subscription.unsubscribe();
         }
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.ts.ejs
@@ -28,7 +28,7 @@ import { TrackerActivity } from 'app/core/tracker/tracker-activity.model';
 })
 export class TrackerComponent implements OnInit, OnDestroy {
     activities: TrackerActivity[] = [];
-    subscription: Subscription | null = null;
+    subscription?: Subscription;
 
     constructor(
         private trackerService: TrackerService

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.module.ts.ejs
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
 
-import { <%=jhiPrefixCapitalized%>TrackerComponent } from './tracker.component';
+import { TrackerComponent } from './tracker.component';
 
 import { trackerRoute } from './tracker.route';
 
@@ -11,6 +11,6 @@ import { trackerRoute } from './tracker.route';
     <%=angularXAppName%>SharedModule,
     RouterModule.forChild([trackerRoute])
   ],
-  declarations: [<%=jhiPrefixCapitalized%>TrackerComponent]
+  declarations: [TrackerComponent]
 })
 export class TrackerModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.route.ts.ejs
@@ -18,11 +18,11 @@
 -%>
 import { Route } from '@angular/router';
 
-import { <%=jhiPrefixCapitalized%>TrackerComponent } from './tracker.component';
+import { TrackerComponent } from './tracker.component';
 
 export const trackerRoute: Route = {
     path: '',
-    component: <%=jhiPrefixCapitalized%>TrackerComponent,
+    component: TrackerComponent,
     data: {
         pageTitle: 'tracker.title'
     }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -72,8 +72,7 @@ export class AccountService  {
         if (!Array.isArray(authorities)) {
             authorities = [authorities];
         }
-        const account = this.userIdentity;
-        return authorities.some((authority: string) => account.authorities.includes(authority));
+        return this.userIdentity.authorities.some((authority: string) => authorities.includes(authority));
     }
 
     identity(force?: boolean): Observable<Account | null> {

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -17,26 +17,25 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
+import { HttpClient } from '@angular/common/http';
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
-import { HttpClient } from '@angular/common/http';
 import { Observable, Subject, of } from 'rxjs';
 import { shareReplay, tap, catchError } from 'rxjs/operators';
 
 import { SERVER_API_URL } from 'app/app.constants';
 import { Account } from 'app/core/user/account.model';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from '../tracker/tracker.service';
+import { TrackerService } from '../tracker/tracker.service';
 <%_ } _%>
 
 @Injectable({providedIn: 'root'})
 export class AccountService  {
-    private userIdentity: Account;
-    private authenticated = false;
-    private authenticationState = new Subject<any>();
-    private accountCache$: Observable<Account>;
+    private userIdentity: Account | null = null;
+    private authenticationState = new Subject<Account | null>();
+    private accountCache$: Observable<Account | null> | null = null;
 
     constructor(
         <%_ if (enableTranslation) { _%>
@@ -44,74 +43,58 @@ export class AccountService  {
         private sessionStorage: SessionStorageService,
         <%_ } _%>
         private http: HttpClient<% if (websocket === 'spring-websocket') { %>,
-        private trackerService: <%=jhiPrefixCapitalized%>TrackerService<% } %>) { }
+        private trackerService: TrackerService<% } %>) { }
 
-    fetch(): Observable<Account> {
+    private fetch(): Observable<Account> {
         return this.http.get<Account>(SERVER_API_URL + '<%- apiUaaPath %>api/account');
     }
 
-    save(account: Account): Observable<Account> {
-        return this.http.post<Account>(SERVER_API_URL + '<%- apiUaaPath %>api/account', account);
+    save(account: Account): Observable<{}> {
+        return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account', account);
     }
 
-    authenticate(identity) {
+    authenticate(identity: Account | null): void {
         this.userIdentity = identity;
-        this.authenticated = identity !== null;
         this.authenticationState.next(this.userIdentity);
+        <%_ if (websocket === 'spring-websocket') { _%>
+        if (identity) {
+            this.trackerService.connect();
+        } else {
+            this.trackerService.disconnect();
+        }
+        <%_ } _%>
     }
 
     hasAnyAuthority(authorities: string[] | string): boolean {
-        if (!this.authenticated || !this.userIdentity || !this.userIdentity.authorities) {
+        if (!this.userIdentity || !this.userIdentity.authorities) {
             return false;
         }
-
         if (!Array.isArray(authorities)) {
             authorities = [authorities];
         }
-
-        return authorities.some((authority: string) => this.userIdentity.authorities.includes(authority));
+        const account = this.userIdentity;
+        return authorities.some((authority: string) => account.authorities.includes(authority));
     }
 
-    identity(force?: boolean): Observable<Account> {
-        if (force || !this.authenticated) {
-            this.accountCache$ = null;
-        }
-
-        if (!this.accountCache$) {
+    identity(force?: boolean): Observable<Account | null> {
+        if (this.accountCache$ == null || force || !this.isAuthenticated()) {
             this.accountCache$ = this.fetch().pipe(
               catchError(
                 () => {
-                    <%_ if (websocket === 'spring-websocket') { _%>
-                    if (this.trackerService.stompClient && this.trackerService.stompClient.connected) {
-                        this.trackerService.disconnect();
-                    }
-                    <%_ } _%>
                     return of(null);
                 }
               ),
-              tap(
-                account => {
-                  if (account) {
-                    this.userIdentity = account;
-                    this.authenticated = true;
-                    <%_ if (websocket === 'spring-websocket') { _%>
-                    this.trackerService.connect();
-                    <%_ } _%>
-                    <%_ if (enableTranslation) { _%>
-                    // After retrieve the account info, the language will be changed to
-                    // the user's preferred language configured in the account setting
-                    if (this.userIdentity.langKey) {
-                        const langKey = this.sessionStorage.retrieve('locale') || this.userIdentity.langKey;
-                        this.languageService.changeLanguage(langKey);
-                    }
-                    <%_ } _%>
-                  } else {
-                    this.userIdentity = null;
-                    this.authenticated = false;
-                  }
-                  this.authenticationState.next(this.userIdentity);
+              tap((account: Account | null) => {
+                this.authenticate(account);
+                <%_ if (enableTranslation) { _%>
+                // After retrieve the account info, the language will be changed to
+                // the user's preferred language configured in the account setting
+                if (account && account.langKey) {
+                  const langKey = this.sessionStorage.retrieve('locale') || account.langKey;
+                  this.languageService.changeLanguage(langKey);
                 }
-              ),
+                <%_ } _%>
+              }),
               shareReplay()
             );
         }
@@ -119,18 +102,14 @@ export class AccountService  {
     }
 
     isAuthenticated(): boolean {
-        return this.authenticated;
+        return this.userIdentity !== null;
     }
 
-    isIdentityResolved(): boolean {
-        return this.userIdentity !== undefined;
-    }
-
-    getAuthenticationState(): Observable<any> {
+    getAuthenticationState(): Observable<Account | null> {
         return this.authenticationState.asObservable();
     }
 
     getImageUrl(): string {
-        return this.isIdentityResolved() ? this.userIdentity.imageUrl : null;
+        return this.userIdentity ? this.userIdentity.imageUrl : '';
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -35,7 +35,7 @@ import { TrackerService } from '../tracker/tracker.service';
 export class AccountService  {
     private userIdentity: Account | null = null;
     private authenticationState = new Subject<Account | null>();
-    private accountCache$: Observable<Account | null> | null = null;
+    private accountCache$?: Observable<Account | null>;
 
     constructor(
         <%_ if (enableTranslation) { _%>
@@ -76,7 +76,7 @@ export class AccountService  {
     }
 
     identity(force?: boolean): Observable<Account | null> {
-        if (this.accountCache$ == null || force || !this.isAuthenticated()) {
+        if (!this.accountCache$ || force || !this.isAuthenticated()) {
             this.accountCache$ = this.fetch().pipe(
               catchError(
                 () => {

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -25,7 +25,14 @@ import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
 
 import { SERVER_API_URL } from 'app/app.constants';
+import { Login } from 'app/core/login/login.model';
 
+<%_ if (authenticationType !== 'uaa') { _%>
+type JwtToken = {
+  id_token: string;
+};
+
+<%_ } _%>
 @Injectable({providedIn: 'root'})
 export class AuthServerProvider {
     constructor(
@@ -35,61 +42,40 @@ export class AuthServerProvider {
 <%_ } _%>
     ) {}
 
-    getToken() {
 <%_ if (authenticationType === 'uaa') { _%>
-        return null;
-<% } else { %>
-        return this.$localStorage.retrieve('authenticationToken') || this.$sessionStorage.retrieve('authenticationToken');
-<%_ } _%>
+    login(credentials: Login): Observable<any> {
+        return this.http.post(SERVER_API_URL + 'auth/login', credentials);
     }
 
-    login(credentials): Observable<any> {
-<%_ if (authenticationType === 'uaa') { _%>
-        const data = {
-            username: credentials.username,
-            password: credentials.password,
-            rememberMe: credentials.rememberMe
-        };
-        return this.http.post(SERVER_API_URL + 'auth/login', data, {});
-<% } else { %>
-        const data = {
-            username: credentials.username,
-            password: credentials.password,
-            rememberMe: credentials.rememberMe
-        };
-
-        function authenticateSuccess(resp) {
-            const bearerToken = resp.headers.get('Authorization');
-            if (bearerToken && bearerToken.slice(0, 7) === 'Bearer ') {
-                const jwt = bearerToken.slice(7, bearerToken.length);
-                this.storeAuthenticationToken(jwt, credentials.rememberMe);
-                return jwt;
-            }
-        }
-
-        return this.http.post(SERVER_API_URL + 'api/authenticate', data, {observe : 'response'}).pipe(map(authenticateSuccess.bind(this)));
-<%_ } _%>
+    logout(): Observable<{}> {
+        return this.http.post(SERVER_API_URL + 'auth/logout', null);
     }
-<%_ if (authenticationType !== 'uaa') { _%>
+<% } else { %>
+    getToken(): string {
+        return this.$localStorage.retrieve('authenticationToken') || this.$sessionStorage.retrieve('authenticationToken') || '';
+    }
 
-    storeAuthenticationToken(jwt, rememberMe) {
+    login(credentials: Login): Observable<void> {
+        return this.http
+            .post<JwtToken>(SERVER_API_URL + 'api/authenticate', credentials)
+            .pipe(map(response => this.authenticateSuccess(response, credentials.rememberMe)));
+    }
+
+    private authenticateSuccess(response: JwtToken, rememberMe: boolean): void {
+        const jwt = response.id_token;
         if (rememberMe) {
             this.$localStorage.store('authenticationToken', jwt);
         } else {
             this.$sessionStorage.store('authenticationToken', jwt);
         }
     }
-<%_ } _%>
 
-    logout(): Observable<any> {
-<%_ if (authenticationType === 'uaa') { _%>
-        return this.http.post(SERVER_API_URL + 'auth/logout', null);
-<% } else { %>
+    logout(): Observable<void> {
         return new Observable((observer) => {
             this.$localStorage.clear('authenticationToken');
             this.$sessionStorage.clear('authenticationToken');
             observer.complete();
         });
-<%_ } _%>
     }
+<%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
@@ -17,11 +17,18 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpResponse<% if (authenticationType !== 'oauth2') { %>, HttpHeaders<% } %> } from '@angular/common/http';
+import { HttpClient<% if (authenticationType !== 'oauth2') { %>, HttpHeaders<% } %> } from '@angular/common/http';
 import { Observable } from 'rxjs';
+<%_ if (authenticationType !== 'oauth2') { _%>
 import { map } from 'rxjs/operators';
+<%_ } _%>
 
 import { SERVER_API_URL } from 'app/app.constants';
+<%_ if (authenticationType === 'oauth2') { _%>
+import { Logout } from 'app/core/login/logout.model';
+<%_ } else { _%>
+import { Login } from 'app/core/login/login.model';
+<%_ } _%>
 
 @Injectable({providedIn: 'root'})
 export class AuthServerProvider {
@@ -31,28 +38,31 @@ export class AuthServerProvider {
     ) {}
 <%_ if (authenticationType !== 'oauth2') { _%>
 
-    login(credentials): Observable<any> {
+    login(credentials: Login): Observable<{}> {
         const data =
             `username=${encodeURIComponent(credentials.username)}` +
             `&password=${encodeURIComponent(credentials.password)}` +
             `&remember-me=${credentials.rememberMe}` +
             '&submit=Login';
+
         const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
 
         return this.http.post(SERVER_API_URL + 'api/authentication', data, { headers });
     }
-<%_ } _%>
 
-    logout(): Observable<any> {
+    logout(): Observable<void> {
         // logout from the server
-        return this.http.post(SERVER_API_URL + 'api/logout', {}, { observe: 'response' }).pipe(
-            map((response: HttpResponse<any>) => {
-            <%_ if (applicationType !== 'gateway') { _%>
-            // to get a new csrf token call the api
-            this.http.get(SERVER_API_URL + 'api/account').subscribe(() => {}, () => {});
-            <%_ } _%>
-            return response;
+        return this.http.post(SERVER_API_URL + 'api/logout', {}).pipe(
+            map(() => {
+                // to get a new csrf token call the api
+                this.http.get(SERVER_API_URL + 'api/account').subscribe();
             })
         );
     }
+<%_ } else { _%>
+
+    logout(): Observable<Logout> {
+        return this.http.post<Logout>(SERVER_API_URL + 'api/logout', {});
+    }
+<%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/csrf.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/csrf.service.ts.ejs
@@ -24,7 +24,7 @@ export class CSRFService {
 
     constructor(private cookieService: CookieService) {}
 
-    getCSRF(name = 'XSRF-TOKEN') {
+    getCSRF(name = 'XSRF-TOKEN'): string {
         return this.cookieService.get(name);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/state-storage.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/state-storage.service.ts.ejs
@@ -25,11 +25,11 @@ export class StateStorageService {
         private $sessionStorage: SessionStorageService
     ) {}
 
-    storeUrl(url: string) {
+    storeUrl(url: string): void {
         this.$sessionStorage.store('previousUrl', url);
     }
 
-    getUrl() {
+    getUrl(): string {
         return this.$sessionStorage.retrieve('previousUrl');
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -28,7 +28,7 @@ import { FindLanguageFromKeyPipe } from 'app/shared/language/find-language-from-
 
 @Injectable({providedIn: 'root'})
 export class JhiLanguageHelper {
-    private renderer: Renderer2 = null;
+    private renderer: Renderer2;
 
     constructor(
         private translateService: TranslateService,
@@ -54,7 +54,7 @@ export class JhiLanguageHelper {
      * 2. $state.$current.data.pageTitle (current state page title)
      * 3. 'global.title'
      */
-    updateTitle(titleKey?: string) {
+    updateTitle(titleKey?: string): void {
         if (!titleKey) {
              titleKey = this.getPageTitle(this.router.routerState.snapshot.root);
         }
@@ -64,7 +64,7 @@ export class JhiLanguageHelper {
         });
     }
 
-    private init() {
+    private init(): void {
         this.translateService.onLangChange.subscribe(() => {
             this.renderer.setAttribute(document.querySelector('html'), 'lang', this.translateService.currentLang);
             this.updateTitle();
@@ -74,7 +74,7 @@ export class JhiLanguageHelper {
         });
     }
 
-    private getPageTitle(routeSnapshot: ActivatedRouteSnapshot) {
+    private getPageTitle(routeSnapshot: ActivatedRouteSnapshot): string {
         let title: string = (routeSnapshot.data && routeSnapshot.data['pageTitle']) ? routeSnapshot.data['pageTitle'] : '<%= angularAppName %>';
         if (routeSnapshot.firstChild) {
             title = this.getPageTitle(routeSnapshot.firstChild) || title;
@@ -83,7 +83,7 @@ export class JhiLanguageHelper {
     }
     <%_ if (enableI18nRTL) { _%>
 
-    private updatePageDirection() {
+    private updatePageDirection(): void {
         this.renderer.setAttribute(document.querySelector('html'), 'dir', this.findLanguageFromKeyPipe.isRTL(this.translateService.currentLang) ? 'rtl' : 'ltr');
     }
     <%_ }_%>

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.model.ts.ejs
@@ -16,14 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { SpyObject } from './spyobject';
-import { TrackerService } from 'app/core/tracker/tracker.service';
-
-export class MockTrackerService extends SpyObject {
-
-    constructor() {
-        super(TrackerService);
-    }
-
-    connect() {}
+export class Login {
+    constructor(public username: string, public password: string, public rememberMe: boolean) {}
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -19,14 +19,23 @@
 import { Injectable } from '@angular/core';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { Location } from '@angular/common';
+
 <%_ } else { _%>
+import { Observable } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
+
+import { Account } from 'app/core/user/account.model';
 import { AccountService } from 'app/core/auth/account.service';
 <%_ } _%>
 <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
 import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
 <%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2') { _%>
 import { AuthServerProvider } from 'app/core/auth/auth-session.service';
+<%_ } _%>
+<%_ if (authenticationType === 'oauth2') { _%>
+import { Logout } from './logout.model';
+<%_ } else { _%>
+import { Login } from './login.model';
 <%_ } _%>
 
 @Injectable({providedIn: 'root'})
@@ -42,29 +51,29 @@ export class LoginService {
     ) {}
 
     <%_ if (authenticationType === 'oauth2') { _%>
-    login() {
+    login(): void {
         // If you have configured multiple OIDC providers, then, you can update this URL to /login.
         // It will show a Spring Security generated login page with links to configured OIDC providers.
         location.href = `${location.origin}${this.location.prepareExternalUrl('oauth2/authorization/oidc')}`;
     }
     <%_ } else { _%>
-    login(credentials) {
+    login(credentials: Login): Observable<Account | null> {
         return this.authServerProvider.login(credentials).pipe(flatMap(() => this.accountService.identity(true)));
     }
     <%_ } _%>
 
     <%_ if (authenticationType === 'uaa') { _%>
 
-    isAuthenticated() {
+    isAuthenticated(): boolean {
         return this.accountService.isAuthenticated();
     }
 
-    logoutDirectly() {
+    logoutDirectly(): void {
         this.accountService.authenticate(null);
     }
     <%_ } _%>
 
-    logout() {
+    logout(): void {
         <%_ if (authenticationType === 'uaa') { _%>
         if (this.accountService.isAuthenticated()) {
             this.authServerProvider.logout().subscribe(() => this.accountService.authenticate(null));
@@ -72,18 +81,17 @@ export class LoginService {
             this.accountService.authenticate(null);
         }
         <%_ } else if (authenticationType === 'oauth2') { _%>
-        this.authServerProvider.logout().subscribe(response => {
-            const data = response.body;
-            let logoutUrl = data.logoutUrl;
+        this.authServerProvider.logout().subscribe((logout: Logout) => {
+            let logoutUrl = logout.logoutUrl;
             const redirectUri = `${location.origin}${this.location.prepareExternalUrl('/')}`;
 
             // if Keycloak, uri has protocol/openid-connect/token
-            if (logoutUrl.indexOf('/protocol') > -1) {
+            if (logoutUrl.includes('/protocol')) {
                 logoutUrl = logoutUrl + '?redirect_uri=' + redirectUri;
             } else {
                 // Okta
                 logoutUrl = logoutUrl + '?id_token_hint=' +
-                    data.idToken + '&post_logout_redirect_uri=' + redirectUri;
+                    logout.idToken + '&post_logout_redirect_uri=' + redirectUri;
             }
             window.location.href = logoutUrl;
         });

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/logout.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/logout.model.ts.ejs
@@ -16,14 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { SpyObject } from './spyobject';
-import { TrackerService } from 'app/core/tracker/tracker.service';
-
-export class MockTrackerService extends SpyObject {
-
-    constructor() {
-        super(TrackerService);
-    }
-
-    connect() {}
+export class Logout {
+    constructor(public idToken: string, public logoutUrl: string) {}
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker-activity.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker-activity.model.ts.ejs
@@ -1,0 +1,4 @@
+export class TrackerActivity {
+    constructor(public sessionId: string, public userLogin: string, public ipAddress: string, public page: string, public time: string) {}
+  }
+  

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -54,7 +54,7 @@ export class TrackerService {
     ) {}
 
     connect(): void {
-        if (this.stompClient !== null && this.stompClient.connected) {
+        if (this.stompClient && this.stompClient.connected) {
             return;
         }
 
@@ -85,7 +85,7 @@ export class TrackerService {
     }
 
     disconnect(): void {
-        if (this.stompClient !== null) {
+        if (this.stompClient) {
             if (this.stompClient.connected) {
                 this.stompClient.disconnect();
             }
@@ -94,7 +94,7 @@ export class TrackerService {
 
         this.connectionSubject = new ReplaySubject(1);
 
-        if (this.routerSubscription !== null) {
+        if (this.routerSubscription) {
             this.routerSubscription.unsubscribe();
             this.routerSubscription = null;
         }
@@ -105,7 +105,7 @@ export class TrackerService {
     }
 
     private sendActivity(): void {
-        if (this.stompClient !== null && this.stompClient.connected) {
+        if (this.stompClient && this.stompClient.connected) {
             this.stompClient.send(
                 '/topic/activity', // destination
                 JSON.stringify({'page': this.router.routerState.snapshot.url}), // body
@@ -115,12 +115,12 @@ export class TrackerService {
     }
 
     subscribe(): void {
-        if (this.connectionSubscription !== null) {
+        if (this.connectionSubscription) {
             return;
         }
       
         this.connectionSubscription = this.connectionSubject.subscribe(() => {
-            if (this.stompClient !== null) {
+            if (this.stompClient) {
                 this.stompSubscription = this.stompClient.subscribe('/topic/tracker', (data: Stomp.Message) => {
                     this.listenerSubject.next(JSON.parse(data.body));
                 });
@@ -129,12 +129,12 @@ export class TrackerService {
     }
 
     unsubscribe(): void {
-        if (this.connectionSubscription !== null) {
+        if (this.connectionSubscription) {
             this.connectionSubscription.unsubscribe();
             this.connectionSubscription = null;
         }
 
-        if (this.stompSubscription !== null) {
+        if (this.stompSubscription) {
             this.stompSubscription.unsubscribe();
             this.stompSubscription = null;
         }

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -35,10 +35,9 @@ import { TrackerActivity } from './tracker-activity.model';
 @Injectable({providedIn: 'root'})
 export class TrackerService {
     stompClient: Stomp.Client | null = null;
-    subscriber: Stomp.Subscription | null = null;
-    connectionSubject: ReplaySubject<void>;
-    listenerSubject: Subject<TrackerActivity>;
-    alreadyConnectedOnce = false;
+    stompSubscription: Stomp.Subscription | null = null;
+    connectionSubject: ReplaySubject<void> = new ReplaySubject(1);
+    listenerSubject: Subject<TrackerActivity> = new Subject();
 
     private connectionSubscription: Subscription | null = null;
     private routerSubscription: Subscription | null = null;
@@ -52,12 +51,13 @@ export class TrackerService {
         private authServerProvider: AuthServerProvider,
         <%_ } _%>
         private location: Location
-    ) {
-        this.connectionSubject = new ReplaySubject(1);
-        this.listenerSubject = new Subject();
-    }
+    ) {}
 
     connect(): void {
+        if (this.stompClient !== null && this.stompClient.connected) {
+            return;
+        }
+
         // building absolute path so that websocket doesn't fail when deploying with a context path
         let url = '/websocket/tracker';
         url = this.location.prepareExternalUrl(url);
@@ -74,14 +74,13 @@ export class TrackerService {
         headers['X-XSRF-TOKEN'] = this.csrfService.getCSRF('XSRF-TOKEN');
         <%_ } _%>
         this.stompClient.connect(headers, () => {
+            this.connectionSubject.next();
+
             this.sendActivity();
-            if (!this.alreadyConnectedOnce) {
-                this.connectionSubject.next();
-                this.routerSubscription = this.router.events
-                    .pipe(filter((event: Event) => event instanceof NavigationEnd))
-                    .subscribe(() => this.sendActivity());
-                this.alreadyConnectedOnce = true;
-            }
+
+            this.routerSubscription = this.router.events
+                .pipe(filter((event: Event) => event instanceof NavigationEnd))
+                .subscribe(() => this.sendActivity());
         });
     }
 
@@ -92,11 +91,13 @@ export class TrackerService {
             }
             this.stompClient = null;
         }
-        if (this.routerSubscription) {
+
+        this.connectionSubject = new ReplaySubject(1);
+
+        if (this.routerSubscription !== null) {
             this.routerSubscription.unsubscribe();
             this.routerSubscription = null;
         }
-        this.alreadyConnectedOnce = false;
     }
 
     receive(): Subject<TrackerActivity> {
@@ -114,9 +115,13 @@ export class TrackerService {
     }
 
     subscribe(): void {
+        if (this.connectionSubscription !== null) {
+            return;
+        }
+      
         this.connectionSubscription = this.connectionSubject.subscribe(() => {
             if (this.stompClient !== null) {
-                this.subscriber = this.stompClient.subscribe('/topic/tracker', (data: Stomp.Message) => {
+                this.stompSubscription = this.stompClient.subscribe('/topic/tracker', (data: Stomp.Message) => {
                     this.listenerSubject.next(JSON.parse(data.body));
                 });
             }
@@ -126,9 +131,12 @@ export class TrackerService {
     unsubscribe(): void {
         if (this.connectionSubscription !== null) {
             this.connectionSubscription.unsubscribe();
+            this.connectionSubscription = null;
         }
-        if (this.subscriber !== null) {
-            this.subscriber.unsubscribe();
+
+        if (this.stompSubscription !== null) {
+            this.stompSubscription.unsubscribe();
+            this.stompSubscription = null;
         }
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -34,13 +34,12 @@ import { TrackerActivity } from './tracker-activity.model';
 
 @Injectable({providedIn: 'root'})
 export class TrackerService {
-    stompClient: Stomp.Client | null = null;
-    stompSubscription: Stomp.Subscription | null = null;
-    connectionSubject: ReplaySubject<void> = new ReplaySubject(1);
-    listenerSubject: Subject<TrackerActivity> = new Subject();
-
-    private connectionSubscription: Subscription | null = null;
+    private stompClient: Stomp.Client | null = null;
     private routerSubscription: Subscription | null = null;
+    private connectionSubject: ReplaySubject<void> = new ReplaySubject(1);
+    private connectionSubscription: Subscription | null = null;
+    private stompSubscription: Stomp.Subscription | null = null;
+    private listenerSubject: Subject<TrackerActivity> = new Subject();
   
     constructor(
         private router: Router,
@@ -85,18 +84,20 @@ export class TrackerService {
     }
 
     disconnect(): void {
-        if (this.stompClient) {
-            if (this.stompClient.connected) {
-                this.stompClient.disconnect();
-            }
-            this.stompClient = null;
-        }
+        this.unsubscribe();
 
         this.connectionSubject = new ReplaySubject(1);
 
         if (this.routerSubscription) {
             this.routerSubscription.unsubscribe();
             this.routerSubscription = null;
+        }
+
+        if (this.stompClient) {
+            if (this.stompClient.connected) {
+                this.stompClient.disconnect();
+            }
+            this.stompClient = null;
         }
     }
 
@@ -129,14 +130,14 @@ export class TrackerService {
     }
 
     unsubscribe(): void {
-        if (this.connectionSubscription) {
-            this.connectionSubscription.unsubscribe();
-            this.connectionSubscription = null;
-        }
-
         if (this.stompSubscription) {
             this.stompSubscription.unsubscribe();
             this.stompSubscription = null;
+        }
+
+        if (this.connectionSubscription) {
+            this.connectionSubscription.unsubscribe();
+            this.connectionSubscription = null;
         }
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -17,92 +17,93 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-import { Router, NavigationEnd } from '@angular/router';
-import { Observable, Observer, Subscription } from 'rxjs';
 import { Location } from '@angular/common';
-
-import { CSRFService } from '../auth/csrf.service';
-<%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
-import { AuthServerProvider } from '../auth/auth-jwt.service';
-<%_ } _%>
-
+import { Router, NavigationEnd, Event } from '@angular/router';
+import { Subscription, ReplaySubject, Subject } from 'rxjs';
+import { filter } from 'rxjs/operators';
 import * as SockJS from 'sockjs-client';
 import * as Stomp from 'webstomp-client';
 
-@Injectable({providedIn: 'root'})
-export class <%=jhiPrefixCapitalized%>TrackerService {
-    stompClient = null;
-    subscriber = null;
-    connection: Promise<any>;
-    connectedPromise: any;
-    listener: Observable<any>;
-    listenerObserver: Observer<any>;
-    alreadyConnectedOnce = false;
-    private subscription: Subscription;
+<%_ if (authenticationType === 'session') { _%>
+import { CSRFService } from 'app/core/auth/csrf.service';
+<%_ } _%>
+<%_ if (authenticationType === 'jwt') { _%>
+import { AuthServerProvider } from 'app/core/auth/auth-jwt.service';
+<%_ } _%>
+import { TrackerActivity } from './tracker-activity.model';
 
+@Injectable({providedIn: 'root'})
+export class TrackerService {
+    stompClient: Stomp.Client | null = null;
+    subscriber: Stomp.Subscription | null = null;
+    connectionSubject: ReplaySubject<void>;
+    listenerSubject: Subject<TrackerActivity>;
+    alreadyConnectedOnce = false;
+
+    private connectionSubscription: Subscription | null = null;
+    private routerSubscription: Subscription | null = null;
+  
     constructor(
         private router: Router,
-        <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+        <%_ if (authenticationType === 'session') { _%>
+        private csrfService: CSRFService,
+        <%_ } _%>
+        <%_ if (authenticationType === 'jwt') { _%>
         private authServerProvider: AuthServerProvider,
         <%_ } _%>
-        private location: Location,
-        private csrfService: CSRFService
+        private location: Location
     ) {
-        this.connection = this.createConnection();
-        this.listener = this.createListener();
+        this.connectionSubject = new ReplaySubject(1);
+        this.listenerSubject = new Subject();
     }
 
-    connect() {
-        if (this.connectedPromise === null) {
-          this.connection = this.createConnection();
-        }
+    connect(): void {
         // building absolute path so that websocket doesn't fail when deploying with a context path
         let url = '/websocket/tracker';
         url = this.location.prepareExternalUrl(url);
-        <%_ if (authenticationType === 'jwt' || authenticationType === 'uaa') { _%>
+        <%_ if (authenticationType === 'jwt') { _%>
         const authToken = this.authServerProvider.getToken();
         if (authToken) {
             url += '?access_token=' + authToken;
         }
         <%_ } _%>
-        const socket = new SockJS(url);
+        const socket: WebSocket = new SockJS(url);
         this.stompClient = Stomp.over(socket);
-        const headers = {};
+        const headers: Stomp.ConnectionHeaders = {};
         <%_ if (authenticationType === 'session') { _%>
         headers['X-XSRF-TOKEN'] = this.csrfService.getCSRF('XSRF-TOKEN');
         <%_ } _%>
         this.stompClient.connect(headers, () => {
-            this.connectedPromise('success');
-            this.connectedPromise = null;
             this.sendActivity();
             if (!this.alreadyConnectedOnce) {
-                this.subscription = this.router.events.subscribe((event) => {
-                  if (event instanceof NavigationEnd) {
-                    this.sendActivity();
-                  }
-                });
+                this.connectionSubject.next();
+                this.routerSubscription = this.router.events
+                    .pipe(filter((event: Event) => event instanceof NavigationEnd))
+                    .subscribe(() => this.sendActivity());
                 this.alreadyConnectedOnce = true;
             }
         });
     }
 
-    disconnect() {
+    disconnect(): void {
         if (this.stompClient !== null) {
-            this.stompClient.disconnect();
+            if (this.stompClient.connected) {
+                this.stompClient.disconnect();
+            }
             this.stompClient = null;
         }
-        if (this.subscription) {
-            this.subscription.unsubscribe();
-            this.subscription = null;
+        if (this.routerSubscription) {
+            this.routerSubscription.unsubscribe();
+            this.routerSubscription = null;
         }
         this.alreadyConnectedOnce = false;
     }
 
-    receive() {
-        return this.listener;
+    receive(): Subject<TrackerActivity> {
+        return this.listenerSubject;
     }
 
-    sendActivity() {
+    private sendActivity(): void {
         if (this.stompClient !== null && this.stompClient.connected) {
             this.stompClient.send(
                 '/topic/activity', // destination
@@ -112,28 +113,22 @@ export class <%=jhiPrefixCapitalized%>TrackerService {
         }
     }
 
-    subscribe() {
-        this.connection.then(() => {
-            this.subscriber = this.stompClient.subscribe('/topic/tracker', (data) => {
-                this.listenerObserver.next(JSON.parse(data.body));
-            });
+    subscribe(): void {
+        this.connectionSubscription = this.connectionSubject.subscribe(() => {
+            if (this.stompClient !== null) {
+                this.subscriber = this.stompClient.subscribe('/topic/tracker', (data: Stomp.Message) => {
+                    this.listenerSubject.next(JSON.parse(data.body));
+                });
+            }
         });
     }
 
-    unsubscribe() {
+    unsubscribe(): void {
+        if (this.connectionSubscription !== null) {
+            this.connectionSubscription.unsubscribe();
+        }
         if (this.subscriber !== null) {
             this.subscriber.unsubscribe();
         }
-        this.listener = this.createListener();
-    }
-
-    private createListener(): Observable<any> {
-        return new Observable((observer) => {
-            this.listenerObserver = observer;
-        });
-    }
-
-    private createConnection(): Promise<any> {
-        return new Promise(resolve => this.connectedPromise = resolve);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.ts.ejs
@@ -49,7 +49,7 @@ export class UserService {
     }
 <%_ if (authenticationType !== 'oauth2') { _%>
 
-    delete(login: string): Observable<any> {
+    delete(login: string): Observable<{}> {
         return this.http.delete(`${this.resourceUrl}/${login}`);
     }
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
@@ -25,7 +25,7 @@ import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { PasswordComponent } from 'app/account/password/password.component';
 import { PasswordService } from 'app/account/password/password.service';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from 'app/core/tracker/tracker.service';
+import { TrackerService } from 'app/core/tracker/tracker.service';
 import { MockTrackerService } from '../../../helpers/mock-tracker.service';
 <%_ } _%>
 
@@ -45,7 +45,7 @@ describe('Component Tests', () => {
                     FormBuilder,
                     <%_ if (websocket === 'spring-websocket') { _%>
                     {
-                        provide: <%=jhiPrefixCapitalized%>TrackerService,
+                        provide: TrackerService,
                         useClass: MockTrackerService
                     }
                     <%_ } _%>

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
@@ -25,7 +25,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/user/account.model';
 import { SettingsComponent } from 'app/account/settings/settings.component';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from 'app/core/tracker/tracker.service';
+import { TrackerService } from 'app/core/tracker/tracker.service';
 import { MockTrackerService } from '../../../helpers/mock-tracker.service';
 <%_ } _%>
 
@@ -45,7 +45,7 @@ describe('Component Tests', () => {
                     FormBuilder,
                     <%_ if (websocket === 'spring-websocket') { _%>
                     {
-                        provide: <%=jhiPrefixCapitalized%>TrackerService,
+                        provide: TrackerService,
                         useClass: MockTrackerService
                     },
                     <%_ } _%>

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -1,9 +1,7 @@
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
-import { SERVER_API_URL } from 'app/app.constants';
-import { AccountService } from 'app/core/auth/account.service';
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%= jhiPrefixCapitalized %>TrackerService } from 'app/core/tracker/tracker.service';
+import { TrackerService } from 'app/core/tracker/tracker.service';
 <%_ } _%>
 import { JhiDateUtils
 <%_ if (enableTranslation) { _%>
@@ -11,6 +9,10 @@ import { JhiDateUtils
 <%_ } _%>
 } from 'ng-jhipster';
 import { NgxWebstorageModule } from 'ngx-webstorage';
+
+import { SERVER_API_URL } from 'app/app.constants';
+import { AccountService } from 'app/core/auth/account.service';
+import { Account } from 'app/core/user/account.model';
 <%_ if (enableTranslation) { _%>
 import { MockLanguageService } from '../../../helpers/mock-language.service';
 <%_ } _%>
@@ -18,10 +20,23 @@ import { MockLanguageService } from '../../../helpers/mock-language.service';
 import { MockTrackerService } from '../../../helpers/mock-tracker.service';
 <%_ } _%>
 
+function accountWithAuthorities(authorities: string[]): Account {
+  return {
+    activated: true,
+    authorities,
+    email: '',
+    firstName: '',
+    langKey: '',
+    lastName: '',
+    login: '',
+    imageUrl: ''
+  };
+}
+
 describe('Service Tests', () => {
     describe('Account Service', () => {
         let service: AccountService;
-        let httpMock;
+        let httpMock: HttpTestingController;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -39,7 +54,7 @@ describe('Service Tests', () => {
                     <%_ } _%>
                     <%_ if (websocket === 'spring-websocket') { _%>
                     {
-                        provide: <%= jhiPrefixCapitalized %>TrackerService,
+                        provide: TrackerService,
                         useClass: MockTrackerService
                     }
                     <%_ } _%>
@@ -56,34 +71,23 @@ describe('Service Tests', () => {
 
         describe('Service methods', () => {
             it('should call /account if user is undefined', () => {
-                service.identity().subscribe(() => {});
+                service.identity().subscribe();
                 const req = httpMock.expectOne({ method: 'GET' });
                 const resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/account';
 
                 expect(req.request.url).toEqual(`${resourceUrl}`);
             });
 
-            it('should call /account only once', () => {
-                service.identity().subscribe(() => service.identity().subscribe(() => {}));
-                const req = httpMock.expectOne({ method: 'GET' });
-                const resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/account';
-
-                expect(req.request.url).toEqual(`${resourceUrl}`);
-                req.flush({
-                    firstName: 'John'
-                });
-            });
-
-            it('should call /account again if user has logged out', () => {
+            it('should call /account only once if not logged out after first authentication and should call /account again if user has logged out', () => {
                 // Given the user is authenticated
-                service.identity().subscribe(() => {});
+                service.identity().subscribe();
                 const req = httpMock.expectOne({ method: 'GET' });
                 req.flush({
                     firstName: 'Unimportant'
                 });
 
                 // When I call
-                service.identity().subscribe(() => {});
+                service.identity().subscribe();
 
                 // Then there is no second request
                 httpMock.expectNone({ method: 'GET' });
@@ -91,7 +95,7 @@ describe('Service Tests', () => {
                 // When I log out
                 service.authenticate(null);
                 // and then call
-                service.identity().subscribe(() => {});
+                service.identity().subscribe();
 
                 // Then there is a new request
                 httpMock.expectOne({ method: 'GET' });
@@ -100,27 +104,23 @@ describe('Service Tests', () => {
             describe('hasAnyAuthority string parameter', () => {
                 it('should return false if user is not logged', () => {
                     const hasAuthority = service.hasAnyAuthority('ROLE_USER');
-                    expect(hasAuthority).toBeFalsy();
+                    expect(hasAuthority).toBe(false);
                 });
 
                 it('should return false if user is logged and has not authority',  () => {
-                    service.authenticate({
-                        authorities: ['ROLE_USER']
-                    });
+                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
 
                     const hasAuthority = service.hasAnyAuthority('ROLE_ADMIN');
 
-                    expect(hasAuthority).toBeFalsy();
+                    expect(hasAuthority).toBe(false);
                 });
 
                 it('should return true if user is logged and has authority', () => {
-                    service.authenticate({
-                        authorities: ['ROLE_USER']
-                    });
+                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
 
                     const hasAuthority = service.hasAnyAuthority('ROLE_USER');
 
-                    expect(hasAuthority).toBeTruthy();
+                    expect(hasAuthority).toBe(true);
                 });
             });
 
@@ -131,23 +131,19 @@ describe('Service Tests', () => {
                 });
 
                 it('should return false if user is logged and has not authority', () => {
-                    service.authenticate({
-                        authorities: ['ROLE_USER']
-                    });
+                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
 
                     const hasAuthority = service.hasAnyAuthority(['ROLE_ADMIN']);
 
-                    expect(hasAuthority).toBeFalsy();
+                    expect(hasAuthority).toBe(false);
                 });
 
                 it('should return true if user is logged and has authority', () => {
-                    service.authenticate({
-                        authorities: ['ROLE_USER']
-                    });
+                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
 
                     const hasAuthority = service.hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN']);
 
-                    expect(hasAuthority).toBeTruthy();
+                    expect(hasAuthority).toBe(true);
                 });
             });
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
@@ -17,19 +17,19 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
+import { HttpErrorResponse } from '@angular/common/http';
+import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { JhiDateUtils } from 'ng-jhipster';
 
 import { UserService } from 'app/core/user/user.service';
 import { User } from 'app/core/user/user.model';
 import { SERVER_API_URL } from 'app/app.constants';
-import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('Service Tests', () => {
 
     describe('User Service', () => {
         let service: UserService;
-        let httpMock;
-        let expectedResult;
+        let httpMock: HttpTestingController;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -41,7 +41,6 @@ describe('Service Tests', () => {
                 ]
             });
 
-            expectedResult = {};
             service = TestBed.get(UserService);
             httpMock = TestBed.get(HttpTestingController);
         });
@@ -52,13 +51,14 @@ describe('Service Tests', () => {
 
         describe('Service methods', () => {
             it('should call correct URL', () => {
-                service.find('user').subscribe(() => {});
+                service.find('user').subscribe();
 
                 const req  = httpMock.expectOne({ method: 'GET' });
                 const resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/users';
                 expect(req.request.url).toEqual(`${resourceUrl}/user`);
             });
             it('should return User', () => {
+                let expectedResult: string | undefined;
 
                 service.find('user').subscribe(received => {
                     expectedResult = received.login;
@@ -71,9 +71,10 @@ describe('Service Tests', () => {
 
             <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
             it('should return Authorities', () => {
+                let expectedResult: string[] = [];
 
-                service.authorities().subscribe(_authorities => {
-                    expectedResult = _authorities;
+                service.authorities().subscribe(authorities => {
+                    expectedResult = authorities;
                 });
                 const req = httpMock.expectOne({ method: 'GET' });
 
@@ -83,9 +84,10 @@ describe('Service Tests', () => {
 
             <%_ } _%>
             it('should propagate not found response', () => {
+                let expectedResult = 0;
 
-                service.find('user').subscribe(null, (_error: any) => {
-                    expectedResult = _error.status;
+                service.find('user').subscribe(null, (error: HttpErrorResponse) => {
+                    expectedResult = error.status;
                 });
 
                 const req  = httpMock.expectOne({ method: 'GET' });

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-tracker.service.ts.ejs
@@ -26,4 +26,6 @@ export class MockTrackerService extends SpyObject {
     }
 
     connect() {}
+
+    disconnect() {}
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
@@ -32,7 +32,7 @@ import { AccountService } from 'app/core/auth/account.service';
 import { LoginModalService } from 'app/core/login/login-modal.service';
 <%_ } _%>
 <%_ if (websocket === 'spring-websocket') { _%>
-import { <%=jhiPrefixCapitalized%>TrackerService } from 'app/core/tracker/tracker.service';
+import { TrackerService } from 'app/core/tracker/tracker.service';
 <%_ } _%>
 import { MockAccountService } from './helpers/mock-account.service';
 import { MockActivatedRoute, MockRouter } from './helpers/mock-route.service';
@@ -60,7 +60,7 @@ _%>
         <%_ } _%>
         <%_ if (websocket === 'spring-websocket') { _%>
         {
-            provide: <%=jhiPrefixCapitalized%>TrackerService,
+            provide: TrackerService,
             useValue: null
         },
         <%_ } _%>

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -596,6 +596,7 @@ describe('JHipster generator', () => {
 
             it('creates expected files with authenticationType "oauth2"', () => {
                 assert.file(expectedFiles.oauth2);
+                assert.file(expectedFiles.oauth2Client);
                 assert.file(expectedFiles.mysql);
                 assert.file(expectedFiles.hibernateTimeZoneConfig);
             });
@@ -633,6 +634,7 @@ describe('JHipster generator', () => {
 
             it('creates expected files with authenticationType "oauth2" and elasticsearch', () => {
                 assert.file(expectedFiles.oauth2);
+                assert.file(expectedFiles.oauth2Client);
                 assert.file(expectedFiles.elasticsearch);
                 assert.file(expectedFiles.hibernateTimeZoneConfig);
                 assert.file(expectedFiles.mysql);
@@ -668,6 +670,7 @@ describe('JHipster generator', () => {
 
             it('creates expected files with authenticationType "oauth2" and mongodb', () => {
                 assert.file(expectedFiles.oauth2);
+                assert.file(expectedFiles.oauth2Client);
                 assert.file(expectedFiles.mongodb);
             });
         });

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -455,6 +455,7 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}app/shared/language/find-language-from-key.pipe.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/language/language.constants.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/language/language.helper.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/core/login/login.model.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/login/login-modal.service.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/login/login.component.html`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/login/login.component.ts`,
@@ -588,6 +589,8 @@ const expectedFiles = {
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/AccountResource.java`,
         `${DOCKER_DIR}keycloak.yml`
     ],
+
+    oauth2Client: [`${CLIENT_MAIN_SRC_DIR}app/core/login/logout.model.ts`],
 
     messageBroker: [
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/web/rest/JhipsterKafkaResource.java`,


### PR DESCRIPTION
This PR is next peace for the #10631

This PR resolves problems in the most places of **core module** and entirely in the **tracker module**.

I started only with `core/auth` folder, but as tracker module is related then I included also tracker module.

Unresolved stay after this PR:
* `core/login/login-modal.service.ts` - this can be done after in all places is `open()` used as `void`, account module PR #10639 is doing that already for account module
* `core/user/user.model.ts` - this can be done in conjunction with user-management module

Some notes about changes:

* there where memory leaks in tracker component and service (missing unsubscribes from observables), in my testing these are removed now

* following direction taken in #10220 I removed prefixes from tracker component and service

* UAA login returns from server object with tokens and other information, but as this object is not used then I didn't declare model object for that information and left return type to `any`

* user logout was not reflected in tracker component, because `trackerService.disconnect` was not called on user logout (`accountService.authenticate(null)` is used for logout), now this is fixed

* simplified `account.service` and removed repeated code from `account.service`

* `hasAnyAuthority` in `account.service` uses callback to check if user has authority and typescript compiler thinks that `this.userIdentity` can be changed before this callback function is called and gives null check error, currently I resolved this by defining local variable `account` and using this in callback function, so typescript compiler can be sure that no one changes this to `null` before callback function is called

* in `auth-jwt.service getToken()` for UAA was constantly returning `null` and the only usage was in tracker service where actions were performed on `if (getToken()) { .....` - so dead code and I removed that from both places (tracker is working fine with UUA in my testing, so this was really unnecessary code)

* in `auth-jwt.service` for JWT authentication the function `authenticateSuccess` was:
    * in old AngularJs style, this is now replaced with correct Typescript code
    * token was read from http header, now this is read from service response body

* in `auth-session.service` is comment "**to get a new csrf token call the api**" and under that was condition `<%_ if (applicationType !== 'gateway') { _%>`, this resulted the following behavior in 3 possible cases:
    * session authentication (only monolith is possible) is calling this and necessary work is done
    * oauth2 gateway doesn't call this and all is working fine
    * oauth2 monolith made this call but this is not necessary because in oauth authentication flow is user redirected to other page for authentication and after authentication redirected back to JHipster application, so I removed this redundant call also from oauth2 monolith and tested with both Keycloak and Okta and all is working fine

* FYI some links about this `gateway` condition in `auth-session.service`:
    * SO question: https://stackoverflow.com/questions/48660523/jhipster-with-oauth2-oidc-option-csrf-disabled-in-generated-java-config-but-ca?noredirect=1#comment84470664_48660523
    * Issue: #7090
    * PR adding gateway condition: #7129

* simplified tracker service and replaced promises with rxjs objects (mostly promises was removed by #10383, but this file was untouched by #10383)

* test "**should call /account only once**" in `accout.service.spec` was not testing what it claimed it tests, but as test "**should call /account again if user has logged out**" tested also the first one then I removed redundant test and changed correct test name to reflect all cases that it tests


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [Travis tests](https://travis-ci.org/jhipster/generator-jhipster/pull_requests) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
