### PR TITLE
Modify Readme Page with Sponsor Logos Horizontally Aligned

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,47 +14,126 @@ Support this project by becoming a sponsor! [Become a sponsor](https://opencolle
 
 **Thank you to our sponsors!**
 
-**Gold sponsors**
+### Gold Sponsors
 
-[![Okta][okta-image]][okta-url]
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://developer.okta.com/signup?utm_source=JHipster&utm_medium=logo&utm_campaign=Gold-Sponsor" target="_blank">
+          <img width="200em" src="https://www.jhipster.tech/images/open-collective/okta.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="http://www.octoconsulting.com/" target="_blank">
+          <img width="200em" src="https://www.jhipster.tech/images/open-collective/octoconsulting.png">
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-[![Octo Consulting Group][octoconsulting-image]][octoconsulting-url]
+### Silver sponsors
 
-**Silver sponsors**
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.bizequity.com/" target="_blank">
+          <img width="200em" src="https://www.jhipster.tech/images/open-collective/bizequity.png">
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
-[![BizEquity][bizequity-image]][bizequity-url]
+### Bronze sponsors
 
-**Bronze sponsors**
-
-[![ForsysLab][forsyslab-image]][forsyslab-url]
-
-[![CUBA Platform][cubaplatform-image]][cubaplatform-url]
-
-[![Intesys][intesys-image]][intesys-url]
-
-[![CodeFirst][codefirst-image]][codefirst-url]
-
-[![Blokt][blokt-image]][blokt-url]
-
-[![Clay][clay-image]][clay-url]
-
-[![UX Planet][uxplanet-image]][uxplanet-url]
-
-[![Top Web Design Agencies][top-web-design-agencies-image]][top-web-design-agencies-url]
-
-[![The Pirate Bay][the-pirate-bay-image]][the-pirate-bay-url]
-
-[![Edusson][edusson-image]][edusson-url]
-
-[![Crosswordsolver][crosswordsolver-image]][crosswordsolver-url]
-
-[![FairLaan][fair-laan-image]][fair-laan-url]
-
-[![SuperKredit][superkredit-image]][superkredit-url]
-
-[![MatchBankerPl][matchbanker-pl-image]][matchbanker-pl-url]
-
-[![matchbankerNo][matchbanker-no-image]][matchbanker-no-url]
+<table>
+  <tbody>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://forsyslab.com/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/forsyslab.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://www.cuba-platform.com/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/cubaplatform.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://www.intesys.it/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/intesys.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://www.codefirst.co.uk" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/codefirst.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://blokt.com/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/blokt.png">
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://clay.global/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/clay.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://uxplanet.org/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/uxplanet.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://opencollective.com/top-web-design-agencies" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/top-web-design-agencies.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://piratebay.ink/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/the-pirate-bay.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://edusson.com/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/edusson.png">
+        </a>
+      </td>
+    </tr>
+    <tr>
+      <td align="center" valign="middle">
+        <a href="https://www.crosswordsolver.com/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/crosswordsolver.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://fair-laan.se/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/fair-laan.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://superkredit.net" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/superkredit.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://matchbanker.pl/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/matchbanker.png">
+        </a>
+      </td>
+      <td align="center" valign="middle">
+        <a href="https://matchbanker.no/" target="_blank">
+          <img width="50em" src="https://www.jhipster.tech/images/open-collective/matchbanker.png">
+        </a>
+      </td>
+    </tr>
+  </tbody>
+</table>
 
 **Thank you to all our backers!**
 
@@ -125,42 +204,6 @@ Additional builds at [hipster-labs/jhipster-daily-builds](https://github.com/hip
 [daviddm-url]: https://david-dm.org/jhipster/generator-jhipster
 [backers-image]: https://opencollective.com/generator-jhipster/tiers/backer.svg?avatarHeight=40&width=890
 [backers-url]: https://opencollective.com/generator-jhipster
-[okta-image]: https://www.jhipster.tech/images/open-collective/okta.png
-[okta-url]: https://developer.okta.com/signup?utm_source=JHipster&utm_medium=logo&utm_campaign=Gold-Sponsor
-[octoconsulting-image]: https://www.jhipster.tech/images/open-collective/octoconsulting.png
-[octoconsulting-url]: http://www.octoconsulting.com/
-[bizequity-image]: https://www.jhipster.tech/images/open-collective/bizequity.png
-[bizequity-url]: https://www.bizequity.com/
-[forsyslab-image]: https://www.jhipster.tech/images/open-collective/forsyslab.png
-[forsyslab-url]: https://forsyslab.com/
-[cubaplatform-image]: https://www.jhipster.tech/images/open-collective/cubaplatform.png
-[cubaplatform-url]: https://www.cuba-platform.com/
-[intesys-image]: https://www.jhipster.tech/images/open-collective/intesys.png
-[intesys-url]: https://www.intesys.it/
-[codefirst-image]: https://www.jhipster.tech/images/open-collective/codefirst.png
-[codefirst-url]: https://www.codefirst.co.uk
-[blokt-image]: https://www.jhipster.tech/images/open-collective/blokt.png
-[blokt-url]: https://blokt.com/
-[clay-image]: https://www.jhipster.tech/images/open-collective/clay.png
-[clay-url]: https://clay.global/
-[uxplanet-image]: https://www.jhipster.tech/images/open-collective/uxplanet.png
-[uxplanet-url]: https://uxplanet.org/
-[top-web-design-agencies-image]: https://www.jhipster.tech/images/open-collective/top-web-design-agencies.png
-[top-web-design-agencies-url]: https://opencollective.com/top-web-design-agencies
-[the-pirate-bay-image]: https://www.jhipster.tech/images/open-collective/the-pirate-bay.png
-[the-pirate-bay-url]: https://piratebay.ink/
-[edusson-image]: https://www.jhipster.tech/images/open-collective/edusson.png
-[edusson-url]: https://edusson.com/
-[crosswordsolver-image]: https://www.jhipster.tech/images/open-collective/crosswordsolver.png
-[crosswordsolver-url]: https://www.crosswordsolver.com/
-[fair-laan-image]: https://www.jhipster.tech/images/open-collective/fair-laan.png
-[fair-laan-url]: https://fair-laan.se/
-[superkredit-image]: https://www.jhipster.tech/images/open-collective/superkredit.png
-[superkredit-url]: https://superkredit.net
-[matchbanker-pl-image]: https://www.jhipster.tech/images/open-collective/matchbanker.png
-[matchbanker-pl-url]: https://matchbanker.pl/
-[matchbanker-no-image]: https://www.jhipster.tech/images/open-collective/matchbanker.png
-[matchbanker-no-url]: https://matchbanker.no/
 [issue-template]: https://github.com/jhipster/generator-jhipster/issues/new?template=BUG_REPORT.md
 [feature-template]: https://github.com/jhipster/generator-jhipster/issues/new?template=FEATURE_REQUEST.md
 [npmcharts-image]: https://img.shields.io/npm/dm/generator-jhipster.svg?label=Downloads&style=flat


### PR DESCRIPTION
The logos in our README.md file seems a bit space consuming with their vertical stacking. I re-formatted it to contain in a html table. 

To see how it looks --> https://github.com/SudharakaP/generator-jhipster/tree/modify-readme-page-with-sponsor-logo-alignment

I hope this looks better. :smile: 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
