### PR TITLE
exclude static folder from Devtools restart

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -68,9 +68,7 @@ spring:
     devtools:
         restart:
             enabled: true
-            <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
-            additional-exclude: .h2.server.properties
-            <%_ } _%>
+            additional-exclude: static/**<% if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %>,.h2.server.properties<% } %>
         livereload:
             enabled: false # we use Webpack dev server + BrowserSync for livereload
     jackson:


### PR DESCRIPTION
Fixes an issue where Webpack emits file changes causing Devtools to restart.  Devtools will now ignore frontend changes.

I couldn't think of a simple condition that would work together with the checks for `!skipClient` and `h2` so I always excluded `static/**` instead of adding several `if` statements.

Fix #10792

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
