### PR TITLE
upgrade typescript-eslint packages

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -72,9 +72,9 @@
     "@types/mocha": "5.2.7",
     <%_ } _%>
     "@types/node": "10.12.27",
-    "@typescript-eslint/eslint-plugin": "2.0.0",
-    "@typescript-eslint/eslint-plugin-tslint": "2.0.0",
-    "@typescript-eslint/parser": "2.0.0",
+    "@typescript-eslint/eslint-plugin": "2.7.0",
+    "@typescript-eslint/eslint-plugin-tslint": "2.7.0",
+    "@typescript-eslint/parser": "2.7.0",
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.2",
     <%_ } _%>

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -85,8 +85,8 @@ limitations under the License.
     "@types/selenium-webdriver": "4.0.2",
     <%_ } _%>
     "@types/webpack-env": "1.13.9",
-    "@typescript-eslint/eslint-plugin": "2.0.0",
-    "@typescript-eslint/parser": "2.0.0",
+    "@typescript-eslint/eslint-plugin": "2.7.0",
+    "@typescript-eslint/parser": "2.7.0",
     "autoprefixer": "9.5.0",
     "base-href-webpack-plugin": "2.0.0",
     "browser-sync": "2.26.5",


### PR DESCRIPTION
When working in dev, `npm start` occasionally crashes because of eslint (requires restarting `npm start`).  I couldn't find an exact way to reproduce the issue, but I experienced it several times myself and several Gitter users have reported it.

`Parsing error: Cannot read property 'parent' of null`

Related to https://github.com/typescript-eslint/typescript-eslint/issues/1114

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
