### PR TITLE
Update open api plugin to remove gradle workaround

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -534,15 +534,9 @@ task cleanResources(type: Delete) {
     delete "build/resources"
 }
 
-<%_ if (enableSwaggerCodegen) { _%>
-wrapper {
-    gradleVersion = "5.6.4"
-}
-<%_ } else { _%>
 wrapper {
     gradleVersion = "<%= GRADLE_VERSION %>"
 }
-<%_ } _%>
 
 <%_ if (!skipClient) { _%>
 

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -64,7 +64,7 @@ liquibase_plugin_version=2.0.1
 <%_ } _%>
 sonarqube_plugin_version=2.8
 <%_ if (enableSwaggerCodegen) { _%>
-openapi_plugin_version=4.2.0
+openapi_plugin_version=4.2.1
 <%_ } _%>
 spring_no_http_plugin_version=0.0.3.RELEASE
 checkstyle_version=8.24

--- a/generators/server/templates/gradle/wrapper/gradle-wrapper.properties.ejs
+++ b/generators/server/templates/gradle/wrapper/gradle-wrapper.properties.ejs
@@ -1,9 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-<%_ if (enableSwaggerCodegen) { _%>
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.6.4-bin.zip
-<%_ } else { _%>
 distributionUrl=https\://services.gradle.org/distributions/gradle-<%= GRADLE_VERSION %>-bin.zip
-<%_ } _%>
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -129,7 +129,7 @@
         <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 <%_ if (enableSwaggerCodegen) { _%>
-        <openapi-generator-maven-plugin.version>4.2.0</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>4.2.1</openapi-generator-maven-plugin.version>
 <%_ } _%>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.7.0.1746</sonar-maven-plugin.version>


### PR DESCRIPTION
This updates the [openapi plugin to 4.2.1
](https://github.com/OpenAPITools/openapi-generator/releases) which has removed the usage of some [deprecated gradle api](https://github.com/OpenAPITools/openapi-generator/pull/4352) such that we can remove the workaround of using gradle 5.6.4 instead of 6.x when using api first option


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
