### PR TITLE
reduces db-password size to prevent fail in k8s

### DIFF
--- a/generators/kubernetes-base.js
+++ b/generators/kubernetes-base.js
@@ -68,7 +68,7 @@ function loadConfig() {
     this.ingressType = this.config.get('ingressType');
     this.ingressDomain = this.config.get('ingressDomain');
     this.istio = this.config.get('istio');
-    this.dbRandomPassword = crypto.randomBytes(128).toString('hex');
+    this.dbRandomPassword = crypto.randomBytes(30).toString('hex');
 }
 
 function saveConfig() {


### PR DESCRIPTION
sets the size of db generated passwords in a way, so the resulting password is 60 bytes long and not causing failures for PostgreSQL apps

fix #10803

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
