### PR TITLE
introduce dynamic storage provisioning in k8s sub-gen

### DIFF
--- a/generators/kubernetes-base.js
+++ b/generators/kubernetes-base.js
@@ -69,6 +69,8 @@ function loadConfig() {
     this.ingressDomain = this.config.get('ingressDomain');
     this.istio = this.config.get('istio');
     this.dbRandomPassword = crypto.randomBytes(30).toString('hex');
+    this.kubernetesUseDynamicStorage = this.config.get('kubernetesUseDynamicStorage');
+    this.kubernetesStorageClassName = this.config.get('kubernetesStorageClassName');
 }
 
 function saveConfig() {
@@ -82,6 +84,8 @@ function saveConfig() {
         dockerPushCommand: this.dockerPushCommand,
         kubernetesNamespace: this.kubernetesNamespace,
         kubernetesServiceType: this.kubernetesServiceType,
+        kubernetesUseDynamicStorage: this.kubernetesUseDynamicStorage,
+        kubernetesStorageClassName: this.kubernetesStorageClassName,
         ingressType: this.ingressType,
         ingressDomain: this.ingressDomain,
         monitoring: this.monitoring,

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -54,7 +54,9 @@ module.exports = class extends BaseDockerGenerator {
             askForIstioSupport: prompts.askForIstioSupport,
             askForKubernetesServiceType: prompts.askForKubernetesServiceType,
             askForIngressType: prompts.askForIngressType,
-            askForIngressDomain: prompts.askForIngressDomain
+            askForIngressDomain: prompts.askForIngressDomain,
+            askForPersistentStorage: prompts.askForPersistentStorage,
+            askForStorageClassName: prompts.askForStorageClassName
         };
     }
 

--- a/generators/kubernetes/prompts.js
+++ b/generators/kubernetes/prompts.js
@@ -274,7 +274,7 @@ function askForStorageClassName() {
     ];
 
     this.prompt(prompts).then(props => {
-        this.kubernetesStorageClassName = props.kubernetesStorageClassName;
+        this.kubernetesStorageClassName = props.kubernetesStorageClassName.trim();
         done();
     });
 }

--- a/generators/kubernetes/prompts.js
+++ b/generators/kubernetes/prompts.js
@@ -25,6 +25,8 @@ module.exports = {
     askForIngressType,
     askForIngressDomain,
     askForIstioSupport,
+    askForPersistentStorage,
+    askForStorageClassName,
     ...dockerPrompts
 };
 
@@ -216,6 +218,63 @@ function askForIstioSupport() {
 
     this.prompt(prompts).then(props => {
         this.istio = props.istio;
+        done();
+    });
+}
+
+function askForPersistentStorage() {
+    if (this.regenerate) return;
+    const done = this.async();
+    let usingDataBase = false;
+    this.appConfigs.forEach((appConfig, index) => {
+        if (appConfig.prodDatabaseType !== 'no') {
+            usingDataBase = true;
+        }
+    });
+
+    const prompts = [
+        {
+            when: () => usingDataBase,
+            type: 'list',
+            name: 'kubernetesUseDynamicStorage',
+            message: 'Do you want to use dynamic storage provisioning for your stateful services?',
+            choices: [
+                {
+                    value: false,
+                    name: 'No'
+                },
+                {
+                    value: true,
+                    name: 'Yes'
+                }
+            ],
+            default: this.kubernetesUseDynamicStorage
+        }
+    ];
+
+    this.prompt(prompts).then(props => {
+        this.kubernetesUseDynamicStorage = props.kubernetesUseDynamicStorage;
+        done();
+    });
+}
+
+function askForStorageClassName() {
+    if (this.regenerate) return;
+    const done = this.async();
+    const kubernetesUseDynamicStorage = this.kubernetesUseDynamicStorage;
+
+    const prompts = [
+        {
+            when: () => kubernetesUseDynamicStorage,
+            type: 'input',
+            name: 'kubernetesStorageClassName',
+            message: 'Do you want to use a specific storage class? (leave empty for using the clusters default storage class)',
+            default: this.kubernetesStorageClassName ? this.kubernetesStorageClassName : ''
+        }
+    ];
+
+    this.prompt(prompts).then(props => {
+        this.kubernetesStorageClassName = props.kubernetesStorageClassName;
         done();
     });
 }

--- a/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
@@ -178,6 +178,10 @@ spec:
       - name: config
         configMap:
           name: es-config
+<%_ if (!kubernetesUseDynamicStorage) { _%>
+      - name: storage
+        emptyDir: {}
+<%_ } else { _%>
   volumeClaimTemplates:
   - metadata:
       name: storage
@@ -186,6 +190,10 @@ spec:
       resources:
         requests:
           storage: 1Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+      storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+<%_ } _%>
 ---
 apiVersion: <%= KUBERNETES_STATEFULSET_API_VERSION %>
 kind: StatefulSet

--- a/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/console/jhipster-elasticsearch.yml.ejs
@@ -190,7 +190,7 @@ spec:
       resources:
         requests:
           storage: 1Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
       storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 <%_ } _%>

--- a/generators/kubernetes/templates/db/couchbase.yml.ejs
+++ b/generators/kubernetes/templates/db/couchbase.yml.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
 kind: PersistentVolumeClaim
 metadata:
   name: <%= app.baseName.toLowerCase() %>-mongodb-pvc

--- a/generators/kubernetes/templates/db/couchbase.yml.ejs
+++ b/generators/kubernetes/templates/db/couchbase.yml.ejs
@@ -16,7 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-mongodb-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
 ---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
 kind: Secret
 metadata:
@@ -161,6 +177,11 @@ spec:
         imagePullPolicy: IfNotPresent
       restartPolicy: Always
       terminationGracePeriodSeconds: 30
+<%_ if (!kubernetesUseDynamicStorage) { _%>
+      volumes:
+      - name: <%= app.baseName.toLowerCase() %>-couchbase-data
+        emptyDir: {}
+<%_ } else { _%>
   volumeClaimTemplates:
   - metadata:
       name: <%= app.baseName.toLowerCase() %>-couchbase-data
@@ -169,6 +190,10 @@ spec:
       resources:
         requests:
           storage: 1Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+      storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+<%_ } _%>
 ---
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
 kind: Service

--- a/generators/kubernetes/templates/db/couchbase.yml.ejs
+++ b/generators/kubernetes/templates/db/couchbase.yml.ejs
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
   storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 ---

--- a/generators/kubernetes/templates/db/elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/db/elasticsearch.yml.ejs
@@ -16,6 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-elasticsearch-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_DEPLOYMENT_API_VERSION %>
 kind: Deployment
 metadata:
@@ -37,7 +54,12 @@ spec:
     spec:
       volumes:
       - name: data
+        <%_ if (kubernetesUseDynamicStorage) { _%>
+        persistentVolumeClaim:
+          claimName: <%= app.baseName.toLowerCase() %>-mariadb-pvc
+        <%_ } else { _%>
         emptyDir: {}
+        <%_ } _%>
       initContainers:
       - name: init-sysctl
         image: busybox

--- a/generators/kubernetes/templates/db/elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/db/elasticsearch.yml.ejs
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
   storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 ---

--- a/generators/kubernetes/templates/db/elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/db/elasticsearch.yml.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
 kind: PersistentVolumeClaim
 metadata:
   name: <%= app.baseName.toLowerCase() %>-elasticsearch-pvc

--- a/generators/kubernetes/templates/db/mariadb.yml.ejs
+++ b/generators/kubernetes/templates/db/mariadb.yml.ejs
@@ -16,6 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-mariadb-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
 kind: Secret
 metadata:
@@ -48,7 +65,12 @@ spec:
     spec:
       volumes:
       - name: data
+        <%_ if (kubernetesUseDynamicStorage) { _%>
+        persistentVolumeClaim:
+          claimName: <%= app.baseName.toLowerCase() %>-mariadb-pvc
+        <%_ } else { _%>
         emptyDir: {}
+        <%_ } _%>
       containers:
       - name: mariadb
         image: <%= DOCKER_MARIADB %>

--- a/generators/kubernetes/templates/db/mariadb.yml.ejs
+++ b/generators/kubernetes/templates/db/mariadb.yml.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
 kind: PersistentVolumeClaim
 metadata:
   name: <%= app.baseName.toLowerCase() %>-mariadb-pvc

--- a/generators/kubernetes/templates/db/mariadb.yml.ejs
+++ b/generators/kubernetes/templates/db/mariadb.yml.ejs
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
   storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 ---

--- a/generators/kubernetes/templates/db/mongodb.yml.ejs
+++ b/generators/kubernetes/templates/db/mongodb.yml.ejs
@@ -16,6 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-mongodb-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
 kind: ConfigMap
 metadata:
@@ -311,6 +328,10 @@ spec:
             name: <%= app.baseName.toLowerCase() %>-mongodb-init
         - name: configdir
           emptyDir: {}
+<%_ if (!kubernetesUseDynamicStorage) { _%>
+        - name: datadir
+          emptyDir: {}
+<%_ } else { _%>
   volumeClaimTemplates:
     - metadata:
         name: datadir
@@ -319,6 +340,10 @@ spec:
         resources:
           requests:
             storage: "1Gi"
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+        storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+<%_ } _%>
 ---
 # Headless service for DNS record
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>

--- a/generators/kubernetes/templates/db/mongodb.yml.ejs
+++ b/generators/kubernetes/templates/db/mongodb.yml.ejs
@@ -16,23 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
-kind: PersistentVolumeClaim
-metadata:
-  name: <%= app.baseName.toLowerCase() %>-mongodb-pvc
-  namespace: <%= kubernetesNamespace %>
-spec:
-  accessModes:
-  - ReadWriteOnce
-  resources:
-    requests:
-      storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
-  storageClassName: <%= kubernetesStorageClassName %>
-  <%_ } _%>
----
-<%_ } _%>
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
 kind: ConfigMap
 metadata:
@@ -340,7 +323,7 @@ spec:
         resources:
           requests:
             storage: "1Gi"
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
         storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 <%_ } _%>

--- a/generators/kubernetes/templates/db/mssql.yml.ejs
+++ b/generators/kubernetes/templates/db/mssql.yml.ejs
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
   storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 ---

--- a/generators/kubernetes/templates/db/mssql.yml.ejs
+++ b/generators/kubernetes/templates/db/mssql.yml.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
 kind: PersistentVolumeClaim
 metadata:
   name: <%= app.baseName.toLowerCase() %>-mssql-pvc

--- a/generators/kubernetes/templates/db/mssql.yml.ejs
+++ b/generators/kubernetes/templates/db/mssql.yml.ejs
@@ -16,6 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-mssql-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_DEPLOYMENT_API_VERSION %>
 kind: Deployment
 metadata:
@@ -40,7 +57,12 @@ spec:
         persistentVolumeClaim:
           claimName: mssql-data
       - name: data
+        <%_ if (kubernetesUseDynamicStorage) { _%>
+        persistentVolumeClaim:
+          claimName: <%= app.baseName.toLowerCase() %>-mssql-pvc
+        <%_ } else { _%>
         emptyDir: {}
+        <%_ } _%>
       containers:
       - name: mysql
         image: <%= DOCKER_MSSQL %>

--- a/generators/kubernetes/templates/db/mysql.yml.ejs
+++ b/generators/kubernetes/templates/db/mysql.yml.ejs
@@ -16,6 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-mysql-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_DEPLOYMENT_API_VERSION %>
 kind: Deployment
 metadata:
@@ -37,7 +54,12 @@ spec:
     spec:
       volumes:
       - name: data
+        <%_ if (kubernetesUseDynamicStorage) { _%>
+        persistentVolumeClaim:
+          claimName: <%= app.baseName.toLowerCase() %>-mysql-pvc
+        <%_ } else { _%>
         emptyDir: {}
+        <%_ } _%>
       containers:
       - name: mysql
         image: <%= DOCKER_MYSQL %>

--- a/generators/kubernetes/templates/db/mysql.yml.ejs
+++ b/generators/kubernetes/templates/db/mysql.yml.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
 kind: PersistentVolumeClaim
 metadata:
   name: <%= app.baseName.toLowerCase() %>-mysql-pvc

--- a/generators/kubernetes/templates/db/mysql.yml.ejs
+++ b/generators/kubernetes/templates/db/mysql.yml.ejs
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
   storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 ---

--- a/generators/kubernetes/templates/db/postgresql.yml.ejs
+++ b/generators/kubernetes/templates/db/postgresql.yml.ejs
@@ -16,6 +16,23 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-postgresql-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName !== '') { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+---
+<%_ } _%>
 apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
 kind: Secret
 metadata:
@@ -48,7 +65,12 @@ spec:
     spec:
       volumes:
       - name: data
+        <%_ if (kubernetesUseDynamicStorage) { _%>
+        persistentVolumeClaim:
+          claimName: <%= app.baseName.toLowerCase() %>-postgresql-pvc
+        <%_ } else { _%>
         emptyDir: {}
+        <%_ } _%>
       containers:
       - name: postgres
         image: <%= DOCKER_POSTGRESQL %>

--- a/generators/kubernetes/templates/db/postgresql.yml.ejs
+++ b/generators/kubernetes/templates/db/postgresql.yml.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_ if (kubernetesUseDynamicStorage) { _%>
-apiVersion: v1
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
 kind: PersistentVolumeClaim
 metadata:
   name: <%= app.baseName.toLowerCase() %>-postgresql-pvc

--- a/generators/kubernetes/templates/db/postgresql.yml.ejs
+++ b/generators/kubernetes/templates/db/postgresql.yml.ejs
@@ -28,7 +28,7 @@ spec:
   resources:
     requests:
       storage: 2Gi
-  <%_ if (kubernetesStorageClassName !== '') { _%>
+  <%_ if (kubernetesStorageClassName) { _%>
   storageClassName: <%= kubernetesStorageClassName %>
   <%_ } _%>
 ---

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -463,28 +463,28 @@ describe('JHipster Kubernetes Sub Generator', () => {
         });
         it('creates expected mysql files', () => {
             assert.file(expectedFiles.msmysql);
-            assert.fileContent(expectedFiles.msmysql, /PersistentVolumeClaim/);
-            assert.fileContent(expectedFiles.msmysql, /claimName:/);
+            assert.fileContent(expectedFiles.msmysql[1], /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.msmysql[1], /claimName:/);
         });
 
         it('creates expected psql files', () => {
             assert.file(expectedFiles.mspsql);
-            assert.fileContent(expectedFiles.mspsql, /PersistentVolumeClaim/);
-            assert.fileContent(expectedFiles.mspsql, /claimName:/);
+            assert.fileContent(expectedFiles.mspsql[1], /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.mspsql[1], /claimName:/);
         });
         it('creates expected mongodb files', () => {
             assert.file(expectedFiles.msmongodb);
-            assert.fileContent(expectedFiles.msmongodb, /volumeClaimTemplates:/);
+            assert.fileContent(expectedFiles.msmongodb[1], /volumeClaimTemplates:/);
         });
         it('creates expected mariadb files', () => {
             assert.file(expectedFiles.msmariadb);
-            assert.fileContent(expectedFiles.msmariadb, /PersistentVolumeClaim/);
-            assert.fileContent(expectedFiles.msmariadb, /claimName:/);
+            assert.fileContent(expectedFiles.msmariadb[1], /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.msmariadb[1], /claimName:/);
         });
         it('creates expected mssql files', () => {
             assert.file(expectedFiles.msmssqldb);
-            assert.fileContent(expectedFiles.msmssqldb, /PersistentVolumeClaim/);
-            assert.fileContent(expectedFiles.msmssqldb, /claimName:/);
+            assert.fileContent(expectedFiles.msmssqldb[1], /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.msmssqldb[1], /claimName:/);
         });
 
         it('create the apply script', () => {

--- a/test/kubernetes.spec.js
+++ b/test/kubernetes.spec.js
@@ -67,7 +67,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'jhipsternamespace',
                     jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -102,7 +104,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -138,7 +142,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     monitoring: 'elk',
                     jhipsterConsole: true,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -176,7 +182,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     kubernetesServiceType: 'Ingress',
                     ingressDomain: 'example.com',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -208,7 +216,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -246,7 +256,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -293,7 +305,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -325,7 +339,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     jhipsterConsole: false,
                     kubernetesServiceType: 'LoadBalancer',
-                    clusteredDbApps: []
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -356,7 +372,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     dockerPushCommand: 'docker push',
                     kubernetesNamespace: 'mynamespace',
                     monitoring: 'prometheus',
-                    kubernetesServiceType: 'LoadBalancer'
+                    kubernetesServiceType: 'LoadBalancer',
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -394,7 +412,9 @@ describe('JHipster Kubernetes Sub Generator', () => {
                     kubernetesNamespace: 'default',
                     ingressDomain: 'example.com',
                     clusteredDbApps: [],
-                    istio: true
+                    istio: true,
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
                 })
                 .on('end', done);
         });
@@ -407,6 +427,66 @@ describe('JHipster Kubernetes Sub Generator', () => {
         it('creates expected routing gateway and istio files', () => {
             assert.file(expectedFiles.jhgategateway);
         });
+        it('create the apply script', () => {
+            assert.file(expectedFiles.applyScript);
+        });
+    });
+
+    describe('mysql, psql, mongodb, mariadb, mssql microservices with dynamic storage provisioning', () => {
+        before(done => {
+            helpers
+                .run(require.resolve('../generators/kubernetes'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/compose/'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    deploymentApplicationType: 'microservice',
+                    directoryPath: './',
+                    chosenApps: ['01-gateway', '02-mysql', '03-psql', '04-mongo', '07-mariadb', '11-mssql'],
+                    dockerRepositoryName: 'jhipster',
+                    dockerPushCommand: 'docker push',
+                    kubernetesNamespace: 'default',
+                    jhipsterConsole: false,
+                    kubernetesServiceType: 'LoadBalancer',
+                    clusteredDbApps: [],
+                    kubernetesUseDynamicStorage: true,
+                    kubernetesStorageClassName: ''
+                })
+                .on('end', done);
+        });
+        it('creates expected registry files', () => {
+            assert.file(expectedFiles.eurekaregistry);
+        });
+        it('creates expected gateway files', () => {
+            assert.file(expectedFiles.jhgate);
+        });
+        it('creates expected mysql files', () => {
+            assert.file(expectedFiles.msmysql);
+            assert.fileContent(expectedFiles.msmysql, /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.msmysql, /claimName:/);
+        });
+
+        it('creates expected psql files', () => {
+            assert.file(expectedFiles.mspsql);
+            assert.fileContent(expectedFiles.mspsql, /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.mspsql, /claimName:/);
+        });
+        it('creates expected mongodb files', () => {
+            assert.file(expectedFiles.msmongodb);
+            assert.fileContent(expectedFiles.msmongodb, /volumeClaimTemplates:/);
+        });
+        it('creates expected mariadb files', () => {
+            assert.file(expectedFiles.msmariadb);
+            assert.fileContent(expectedFiles.msmariadb, /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.msmariadb, /claimName:/);
+        });
+        it('creates expected mssql files', () => {
+            assert.file(expectedFiles.msmssqldb);
+            assert.fileContent(expectedFiles.msmssqldb, /PersistentVolumeClaim/);
+            assert.fileContent(expectedFiles.msmssqldb, /claimName:/);
+        });
+
         it('create the apply script', () => {
             assert.file(expectedFiles.applyScript);
         });


### PR DESCRIPTION
with this feature, all stateful services (such as `Deployment`, `StatefulSet` for databases) will use persistent volume claims instead of `emptyDir`. There are two new options for the user, so it is possible to enable dynamic storage provisioning and specify a custom storage class.

Another update in context with this PR, is that `StatefulSet`s are no longer generated with `volumeClaimTemplate` by default, as it was before. Instead, the data dirs are either `emptyDir`, if dynamic storage provisioning is disabled, or we use volume claim templates with the same configuration as for the deployments.

close #10804

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
