### PR TITLE
Remove exception mapping of NoSuchElementException

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/errors/ErrorConstants.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ErrorConstants.java.ejs
@@ -29,9 +29,6 @@ public final class ErrorConstants {
     public static final String PROBLEM_BASE_URL = "https://www.jhipster.tech/problem";
     public static final URI DEFAULT_TYPE = URI.create(PROBLEM_BASE_URL + "/problem-with-message");
     public static final URI CONSTRAINT_VIOLATION_TYPE = URI.create(PROBLEM_BASE_URL + "/constraint-violation");
-    <%_ if (!reactive) { _%>
-    public static final URI ENTITY_NOT_FOUND_TYPE = URI.create(PROBLEM_BASE_URL + "/entity-not-found");
-    <%_ } _%>
     <%_ if (!skipUserManagement) { _%>
     public static final URI INVALID_PASSWORD_TYPE = URI.create(PROBLEM_BASE_URL + "/invalid-password");
     public static final URI EMAIL_ALREADY_USED_TYPE = URI.create(PROBLEM_BASE_URL + "/email-already-used");

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -149,17 +149,6 @@ _%>
             .build();
         return create(ex, problem, request);
     }
-    <%_ if (!reactive) { _%>
-
-    @ExceptionHandler
-    public ResponseEntity<Problem> handleNoSuchElementException(NoSuchElementException ex, NativeWebRequest request) {
-        Problem problem = Problem.builder()
-            .withStatus(Status.NOT_FOUND)
-            .with(MESSAGE_KEY, ErrorConstants.ENTITY_NOT_FOUND_TYPE)
-            .build();
-        return create(ex, problem, request);
-    }
-    <%_ } _%>
     <%_ if (!skipUserManagement) { _%>
     @ExceptionHandler
     public <%- returnType %> handleEmailAlreadyUsedException(<%=packageName%>.service.EmailAlreadyUsedException ex, <%= requestClass %> request) {


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
NoSuchElementException is thrown when calling get() on an empty Optional. That's something that shouldn't happen on the server and should result in a HTTP error 500.
If we want to use an exception for 404, it should be a dedicated one. Although I haven't found a place in the code where this is needed.