### PR TITLE
Remove SpringBootTest from ClientForwardController test

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -212,4 +212,7 @@ function cleanupOldServerFiles(generator, javaDir, testDir, mainResourceDir, tes
         generator.config.delete('blueprint');
         generator.config.delete('blueprintVersion');
     }
+    if (generator.isJhipsterVersionLessThan('6.5.2')) {
+        generator.removeFile(`${testDir}web/rest/ClientForwardControllerIT.java`);
+    }
 }

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1247,8 +1247,8 @@ const serverFiles = {
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
-                    file: 'package/web/rest/ClientForwardControllerIT.java',
-                    renameTo: generator => `${generator.testDir}web/rest/ClientForwardControllerIT.java`
+                    file: 'package/web/rest/ClientForwardControllerTest.java',
+                    renameTo: generator => `${generator.testDir}web/rest/ClientForwardControllerTest.java`
                 }
             ]
         },

--- a/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerTest.java.ejs
@@ -18,22 +18,8 @@
 -%>
 package <%=packageName%>.web.rest;
 
-<%_ if (databaseType === 'cassandra') { _%>
-import <%= packageName %>.AbstractCassandraTest;
-<%_ } _%>
-<%_ if (cacheProvider === 'redis') { _%>
-import <%=packageName%>.RedisTestContainerExtension;
-<%_ } _%>
-import <%=packageName%>.<%= mainClass %>;
-<%_ if (authenticationType === 'oauth2') { _%>
-import <%=packageName%>.config.TestSecurityConfiguration;
-<%_ } _%>
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (cacheProvider === 'redis') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
-<%_ } _%>
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.ResultActions;
@@ -47,17 +33,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Integration tests for the {@link ClientForwardController} REST controller.
+ * Unit tests for the {@link ClientForwardController} REST controller.
  */
-<%_ if (authenticationType === 'oauth2') { _%>
-@SpringBootTest(classes = {<%= mainClass %>.class, TestSecurityConfiguration.class})
-<%_ } else { _%>
-@SpringBootTest(classes = <%= mainClass %>.class)
-<%_ } _%>
-<%_ if (cacheProvider === 'redis') { _%>
-@ExtendWith(RedisTestContainerExtension.class)
-<%_ } _%>
-public class ClientForwardControllerIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class ClientForwardControllerTest {
 
     private MockMvc restMockMvc;
 


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
Remove SpringBootTest from ClientForwardController test making it a fast unit test