### PR TITLE
Increasing Protractor Browser Wait Timeout to 10 Seconds

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -18,6 +18,7 @@
 -%>
 exports.config = {
     allScriptsTimeout: 20000,
+    getPageTimeout: 20000,
 
     specs: [
         './e2e/account/**/*.spec.ts',

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -75,7 +75,7 @@ describe('<%= entityClass %> e2e test', () => {
     it('should load <%= entityClassPlural %>', async () => {
         await navBarPage.goToEntity('<%= entityStateName %>');
         <%= entityInstance %>ComponentsPage = new <%= entityClass %>ComponentsPage();
-        await browser.wait(ec.visibilityOf(<%= entityInstance %>ComponentsPage.title), 10000);
+        await browser.wait(ec.visibilityOf(<%= entityInstance %>ComponentsPage.title), 20000);
         <%_ if (enableTranslation) { _%>
         expect(await <%= entityInstance %>ComponentsPage.getTitle())
             .to.eq('<%= angularAppName %>.<%= entityTranslationKey %>.home.title');

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -75,7 +75,7 @@ describe('<%= entityClass %> e2e test', () => {
     it('should load <%= entityClassPlural %>', async () => {
         await navBarPage.goToEntity('<%= entityStateName %>');
         <%= entityInstance %>ComponentsPage = new <%= entityClass %>ComponentsPage();
-        await browser.wait(ec.visibilityOf(<%= entityInstance %>ComponentsPage.title), 5000);
+        await browser.wait(ec.visibilityOf(<%= entityInstance %>ComponentsPage.title), 10000);
         <%_ if (enableTranslation) { _%>
         expect(await <%= entityInstance %>ComponentsPage.getTitle())
             .to.eq('<%= angularAppName %>.<%= entityTranslationKey %>.home.title');


### PR DESCRIPTION
This increases the protractor browser wait timeout to 10 seconds. I believe this will fix our e2e issues with entity ServiceClass + Pagination + DTO.

Fixes #10806 

**UPDATE**: What I initally thought was wrong. There some underlying cause for the failure; trying to find it currently. 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
