### PR TITLE
Fix Protractor tests in Travis

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -57,7 +57,7 @@ exports.config = {
     },
 
     onPrepare: function() {
-        browser.driver.manage().window().setSize(1280, 1024);
+        browser.driver.manage().window().setSize(1280, 10240);
         // Disable animations
         // @ts-ignore
         browser.executeScript('document.body.className += " notransition";');


### PR DESCRIPTION
Fixes #10806

Seems that something changed in the latest `webdriver-manager` version `12.1.7` to what our clients were updated by #10676. Seems that if UI element is not inside visible area then `Protractor` is not able to get reference to that element any more.

In this PR I changed Chrome window 10 times higher and now Protractor tests are passing.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
