### PR TITLE
Remove bold from menu and restore browser height 1024 in Protractor t…

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/content/scss/_bootstrap-variables.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/_bootstrap-variables.scss.ejs
@@ -41,4 +41,7 @@ $body-bg: #e4e5e6;
 // Font, line-height, and color for body text, headings, and more.
 
 $font-size-base: 1rem;
+
+$dropdown-link-hover-color: white;
+$dropdown-link-hover-bg: #343a40;
 <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -33,9 +33,23 @@ h4 {
 
 <%_ if (clientTheme === 'none') { _%>
 /* Increase contrast of links to get 100% on Lighthouse Accessability Audit. Override this color if you want to change the link color, or use a Bootswatch theme */
-a, a:hover {
+a {
     color: #533f03;
     font-weight: bold;
+}
+
+a:hover {
+    color: #533f03;
+}
+
+/* override hover color for dropdown-item forced by bootstrap to all a:not([href]):not([tabindex]) elements in _reboot.scss */
+a:not([href]):not([tabindex]):hover.dropdown-item {
+  color: $dropdown-link-hover-color;
+}
+
+/* override .dropdown-item.active background-color on hover */
+.dropdown-item:hover {
+  background-color: $dropdown-link-hover-bg;
 }
 <%_ } _%>
 

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -44,12 +44,12 @@ a:hover {
 
 /* override hover color for dropdown-item forced by bootstrap to all a:not([href]):not([tabindex]) elements in _reboot.scss */
 a:not([href]):not([tabindex]):hover.dropdown-item {
-  color: $dropdown-link-hover-color;
+    color: $dropdown-link-hover-color;
 }
 
 /* override .dropdown-item.active background-color on hover */
-.dropdown-item:hover {
-  background-color: $dropdown-link-hover-bg;
+.dropdown-item.active:hover {
+    background-color: mix($dropdown-link-hover-bg, $dropdown-link-active-bg, 50%);
 }
 <%_ } _%>
 

--- a/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/protractor.conf.js.ejs
@@ -57,7 +57,7 @@ exports.config = {
     },
 
     onPrepare: function() {
-        browser.driver.manage().window().setSize(1280, 10240);
+        browser.driver.manage().window().setSize(1280, 1024);
         // Disable animations
         // @ts-ignore
         browser.executeScript('document.body.className += " notransition";');


### PR DESCRIPTION
…ests

This is alternative fix for #10806, this reverts current fix #10815 as #10815 can be called a hack. This is mentioned also by this comment: https://github.com/jhipster/generator-jhipster/pull/10815#issuecomment-557417432

Idea for this PR is coming from https://github.com/jhipster/generator-jhipster/pull/10815#issuecomment-557600257

I changed default theme:
* removed bold from a:hover
* changed dropdown-item colors
* fixed bootstrap problems after previous changes

As I'm not familiar with colors then if someone can find better way or better colors to remove `bold` from `a:hover` then I'm more than happy if this PR will be closed and alternative solution will be accepted.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
