### PR TITLE
[Angular] Fix strict in account and audits module

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.ts.ejs
@@ -32,7 +32,7 @@ export class PasswordComponent implements OnInit {
     doNotMatch = false;
     error = false;
     success = false;
-    account$?: Observable<Account>;
+    account$?: Observable<Account | null>;
     passwordForm = this.fb.group({
         currentPassword: ['', [Validators.required]],
         newPassword: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]],

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -75,22 +75,11 @@ export class RegisterComponent implements AfterViewInit {
         if (password !== this.registerForm.get(['confirmPassword'])!.value) {
             this.doNotMatch = true;
         } else {
-<%_ if (enableTranslation) { _%>
-            this.languageService.getCurrent().then((langKey) => {
-                const login = this.registerForm.get(['login'])!.value;
-                const email = this.registerForm.get(['email'])!.value;
-                this.registerService.save({ login, email, password, langKey }).subscribe(() => {
-                    this.success = true;
-                }, (response) => this.processError(response));
-            });
-<%_ } else { _%>
             const login = this.registerForm.get(['login'])!.value;
             const email = this.registerForm.get(['email'])!.value;
-            const langKey = 'en';
-            this.registerService.save({ login, email, password, langKey }).subscribe(() => {
-                this.success = true;
-            }, (response) => this.processError(response));
-<%_ } _%>
+            this.registerService
+                .save({ login, email, password, langKey: <% if (enableTranslation) { %>this.languageService.getCurrentLanguage()<% } else { %>'en'<% } %> })
+                .subscribe(() => (this.success = true), response => this.processError(response));
         }
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.ts.ejs
@@ -28,7 +28,7 @@ import { Account } from 'app/core/user/account.model';
     templateUrl: './sessions.component.html'
 })
 export class SessionsComponent implements OnInit {
-    account?: Account;
+    account: Account | null = null;
     error = false;
     success = false;
     sessions: Session[] = [];

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -58,7 +58,16 @@ export class SettingsComponent implements OnInit {
 
     ngOnInit(): void {
         this.accountService.identity().subscribe((account) => {
-            this.updateForm(account);
+            if (account) {
+                this.settingsForm.patchValue({
+                    firstName: account.firstName,
+                    lastName: account.lastName,
+                    email: account.email<% if (enableTranslation) { %>,
+                    langKey: account.langKey<% } %>
+                });
+        
+                this.account = account;
+            }
         });
     }
 
@@ -75,29 +84,13 @@ export class SettingsComponent implements OnInit {
         this.accountService.save(this.account).subscribe(() => {
             this.success = true;
 
-            this.accountService.identity(true).subscribe((account) => {
-                this.updateForm(account);
-            });
+            this.accountService.authenticate(this.account);
             <%_ if (enableTranslation) { _%>
 
-            this.languageService.getCurrent().then((current) => {
-                if (this.account.langKey !== current) {
-                    this.languageService.changeLanguage(this.account.langKey);
-                }
-            });
+            if (this.account.langKey !== this.languageService.getCurrentLanguage()) {
+                this.languageService.changeLanguage(this.account.langKey);
+            }
             <%_ } _%>
         });
     }
-
-    private updateForm(account: Account): void {
-        this.settingsForm.patchValue({
-            firstName: account.firstName,
-            lastName: account.lastName,
-            email: account.email<% if (enableTranslation) { %>,
-            langKey: account.langKey<% } %>
-        });
-
-        this.account = account;
-    }
-
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
@@ -24,10 +24,6 @@ import { of, throwError } from 'rxjs';
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { PasswordComponent } from 'app/account/password/password.component';
 import { PasswordService } from 'app/account/password/password.service';
-<%_ if (websocket === 'spring-websocket') { _%>
-import { TrackerService } from 'app/core/tracker/tracker.service';
-import { MockTrackerService } from '../../../helpers/mock-tracker.service';
-<%_ } _%>
 
 describe('Component Tests', () => {
 
@@ -41,15 +37,7 @@ describe('Component Tests', () => {
             TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
                 declarations: [PasswordComponent],
-                providers: [
-                    FormBuilder,
-                    <%_ if (websocket === 'spring-websocket') { _%>
-                    {
-                        provide: TrackerService,
-                        useClass: MockTrackerService
-                    }
-                    <%_ } _%>
-                ]
+                providers: [FormBuilder]
             })
             .overrideTemplate(PasswordComponent, '')
             .compileComponents();

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
@@ -81,7 +81,7 @@ describe('Component Tests', () => {
                     });
                     expect(comp.success).toBe(true);
                     <%_ if (enableTranslation) { _%>
-                    expect(mockTranslate.getCurrentSpy).toHaveBeenCalled();
+                    expect(mockTranslate.getCurrentLanguageSpy).toHaveBeenCalled();
                     <%_ } _%>
                     expect(comp.errorUserExists).toBe(false);
                     expect(comp.errorEmailExists).toBe(false);

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
@@ -24,10 +24,7 @@ import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/user/account.model';
 import { SettingsComponent } from 'app/account/settings/settings.component';
-<%_ if (websocket === 'spring-websocket') { _%>
-import { TrackerService } from 'app/core/tracker/tracker.service';
-import { MockTrackerService } from '../../../helpers/mock-tracker.service';
-<%_ } _%>
+import { MockAccountService } from '../../../helpers/mock-account.service';
 
 describe('Component Tests', () => {
 
@@ -35,21 +32,13 @@ describe('Component Tests', () => {
 
         let comp: SettingsComponent;
         let fixture: ComponentFixture<SettingsComponent>;
-        let mockAuth: any;
+        let mockAuth: MockAccountService;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
                 declarations: [SettingsComponent],
-                providers: [
-                    FormBuilder,
-                    <%_ if (websocket === 'spring-websocket') { _%>
-                    {
-                        provide: TrackerService,
-                        useClass: MockTrackerService
-                    },
-                    <%_ } _%>
-                ]
+                providers: [FormBuilder]
             })
             .overrideTemplate(SettingsComponent, '')
             .compileComponents();
@@ -58,7 +47,7 @@ describe('Component Tests', () => {
         beforeEach(() => {
             fixture = TestBed.createComponent(SettingsComponent);
             comp = fixture.componentInstance;
-            mockAuth = fixture.debugElement.injector.get(AccountService);
+            mockAuth = TestBed.get(AccountService);
         });
 
         it('should send the current identity upon save', () => {
@@ -88,6 +77,7 @@ describe('Component Tests', () => {
             // THEN
             expect(mockAuth.identitySpy).toHaveBeenCalled();
             expect(mockAuth.saveSpy).toHaveBeenCalledWith(accountValues);
+            expect(mockAuth.authenticateSpy).toHaveBeenCalledWith(accountValues);
             expect(comp.settingsForm.value).toEqual(settingsFormValues);
         });
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
@@ -140,7 +140,7 @@ describe('Component Tests', () => {
 
                 // THEN
                 expect(service.query).toHaveBeenCalled();
-                expect(comp.audits[0]).toEqual(jasmine.objectContaining(audit));
+                expect(comp.audits && comp.audits[0]).toEqual(jasmine.objectContaining(audit));
                 expect(comp.totalItems).toBe(1);
             });
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-account.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-account.service.ts.ejs
@@ -26,6 +26,7 @@ export class MockAccountService extends SpyObject {
 
     getSpy: Spy;
     saveSpy: Spy;
+    authenticateSpy: Spy;
     fakeResponse: any;
     identitySpy: Spy;
     getAuthenticationStateSpy: Spy;
@@ -36,6 +37,7 @@ export class MockAccountService extends SpyObject {
         this.fakeResponse = null;
         this.getSpy = this.spy('get').andReturn(this);
         this.saveSpy = this.spy('save').andReturn(this);
+        this.authenticateSpy = this.spy('authenticate').andReturn(this);
         this.setIdentitySpy({});
     }
 

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-language.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-language.service.ts.ejs
@@ -22,20 +22,18 @@ import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import Spy = jasmine.Spy;
 
 export class MockLanguageService extends SpyObject {
-
-    getCurrentSpy: Spy;
-    fakeResponse: any;
+    getCurrentLanguageSpy: Spy;
+    fakeResponse: string;
 
     constructor() {
         super(JhiLanguageService);
 
         this.fakeResponse = '<%= nativeLanguage %>';
-        this.getCurrentSpy = this.spy('getCurrent').andReturn(Promise.resolve(this.fakeResponse));
+        this.getCurrentLanguageSpy = this.spy('getCurrentLanguage').andReturn(this.fakeResponse);
     }
 }
 
 export class MockLanguageHelper extends SpyObject {
-
     getAllSpy: Spy;
 
     constructor() {

--- a/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
@@ -31,9 +31,6 @@ import { AccountService } from 'app/core/auth/account.service';
 <%_ if (authenticationType !== 'oauth2') { _%>
 import { LoginModalService } from 'app/core/login/login-modal.service';
 <%_ } _%>
-<%_ if (websocket === 'spring-websocket') { _%>
-import { TrackerService } from 'app/core/tracker/tracker.service';
-<%_ } _%>
 import { MockAccountService } from './helpers/mock-account.service';
 import { MockActivatedRoute, MockRouter } from './helpers/mock-route.service';
 import { MockActiveModal } from './helpers/mock-active-modal.service';
@@ -56,12 +53,6 @@ _%>
         {
             provide: JhiLanguageHelper,
             useClass: MockLanguageHelper
-        },
-        <%_ } _%>
-        <%_ if (websocket === 'spring-websocket') { _%>
-        {
-            provide: TrackerService,
-            useValue: null
         },
         <%_ } _%>
         {


### PR DESCRIPTION
* after merging 3 PR (account, audits, core+tracker), strict option reported some problems, which this PR fixes
* also using new `getCurrentLanguage()` from the new `ng-jhipster`
* and also cleans code

Related to #10631 #10639 #10683 #10786

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
