### PR TITLE
Strict option in blocks folder in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -26,45 +26,29 @@ import { LoginService } from 'app/core/login/login.service';
 <%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
 import { LoginModalService } from 'app/core/login/login-modal.service';
 <%_ } _%>
-<%_ if (['session', 'oauth2', 'jwt'].includes(authenticationType)) { _%>
 import { StateStorageService } from 'app/core/auth/state-storage.service';
-<%_ } _%>
 
 @Injectable()
 export class AuthExpiredInterceptor implements HttpInterceptor {
-
     constructor(
         private loginService: LoginService,
         <%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
         private loginModalService: LoginModalService,
         <%_ } _%>
-        <%_ if (['session', 'oauth2', 'jwt'].includes(authenticationType)) { _%>
         private stateStorageService: StateStorageService,
-        <%_ } _%>
         private router: Router
     ) {}
 
-<%_ if (authenticationType === 'uaa') { _%>
-    intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
-            if (err.status === 401) {
-                if (this.loginService.isAuthenticated()) {
-                    this.loginService.logoutDirectly();
-                    this.loginModalService.open();
-                } else {
-                    this.loginService.logout();
-                    this.router.navigate(['/']);
-                }
-            }
-        }));
-    }
-<%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2' || authenticationType === 'jwt') { _%>
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
             if (err.status === 401 && err.url && !err.url.includes('api/account')) {
                 this.stateStorageService.storeUrl(this.router.routerState.snapshot.url);
-<%_ if (authenticationType === 'jwt' || authenticationType === 'session') { _%>
+<%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
+                <%_ if (authenticationType === 'uaa') { _%>
+                this.loginService.logoutDirectly();
+                <%_ } else { _%>
                 this.loginService.logout();
+                <%_ } _%>
                 this.router.navigate(['']);
                 this.loginModalService.open();
 <%_ } else { _%>
@@ -73,5 +57,4 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
             }
         }));
     }
-<%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -46,34 +46,30 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
 
 <%_ if (authenticationType === 'uaa') { _%>
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap(null, (err: any) => {
-            if (err instanceof HttpErrorResponse) {
-                if (err.status === 401) {
-                    if (this.loginService.isAuthenticated()) {
-                        this.loginService.logoutDirectly();
-                        this.loginModalService.open();
-                    } else {
-                        this.loginService.logout();
-                        this.router.navigate(['/']);
-                    }
+        return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
+            if (err.status === 401) {
+                if (this.loginService.isAuthenticated()) {
+                    this.loginService.logoutDirectly();
+                    this.loginModalService.open();
+                } else {
+                    this.loginService.logout();
+                    this.router.navigate(['/']);
                 }
             }
         }));
     }
 <%_ } else if (authenticationType === 'session' || authenticationType === 'oauth2' || authenticationType === 'jwt') { _%>
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap(null, (err: any) => {
-            if (err instanceof HttpErrorResponse) {
-                if (err.status === 401 && err.url && !err.url.includes('api/account')) {
-                    this.stateStorageService.storeUrl(this.router.routerState.snapshot.url);
+        return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
+            if (err.status === 401 && err.url && !err.url.includes('api/account')) {
+                this.stateStorageService.storeUrl(this.router.routerState.snapshot.url);
 <%_ if (authenticationType === 'jwt' || authenticationType === 'session') { _%>
-                    this.loginService.logout();
-                    this.router.navigate(['']);
-                    this.loginModalService.open();
+                this.loginService.logout();
+                this.router.navigate(['']);
+                this.loginModalService.open();
 <%_ } else { _%>
-                    this.loginService.login();
+                this.loginService.login();
 <%_ } _%>
-                }
             }
         }));
     }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/errorhandler.interceptor.ts.ejs
@@ -17,23 +17,19 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-import { JhiEventManager } from 'ng-jhipster';
+import { JhiEventManager, JhiEventWithContent } from 'ng-jhipster';
 import { HttpInterceptor, HttpRequest, HttpErrorResponse, HttpHandler, HttpEvent } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { tap } from 'rxjs/operators';
 
 @Injectable()
 export class ErrorHandlerInterceptor implements HttpInterceptor {
-
-    constructor(private eventManager: JhiEventManager) {
-    }
+    constructor(private eventManager: JhiEventManager) {}
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap(() => {}, (err: any) => {
-            if (err instanceof HttpErrorResponse) {
-                if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('api/account'))))) {
-                    this.eventManager.broadcast({name: '<%=angularAppName%>.httpError', content: err});
-                }
+        return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
+            if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('api/account'))))) {
+                this.eventManager.broadcast(new JhiEventWithContent('<%=angularAppName%>.httpError', err));
             }
         }));
     }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/notification.interceptor.ts.ejs
@@ -43,13 +43,7 @@ export class NotificationInterceptor implements HttpInterceptor {
                     }<% } %>
                 });
                 if (alert) {
-                    if (typeof alert === 'string') {
-                        <%_ if (enableTranslation) { _%>
-                        this.alertService.success(alert, { param : alertParams }, null);
-                        <%_ } else { _%>
-                        this.alertService.success(alert, null, null);
-                        <%_ } _%>
-                    }
+                    this.alertService.success(alert<% if (enableTranslation) { %>, { param : alertParams }<% } %>);
                 }
             }
         }));

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -64,23 +64,13 @@ export class LoginService {
 
     <%_ if (authenticationType === 'uaa') { _%>
 
-    isAuthenticated(): boolean {
-        return this.accountService.isAuthenticated();
-    }
-
     logoutDirectly(): void {
         this.accountService.authenticate(null);
     }
     <%_ } _%>
 
     logout(): void {
-        <%_ if (authenticationType === 'uaa') { _%>
-        if (this.accountService.isAuthenticated()) {
-            this.authServerProvider.logout().subscribe(() => this.accountService.authenticate(null));
-        } else {
-            this.accountService.authenticate(null);
-        }
-        <%_ } else if (authenticationType === 'oauth2') { _%>
+        <%_ if (authenticationType === 'oauth2') { _%>
         this.authServerProvider.logout().subscribe((logout: Logout) => {
             let logoutUrl = logout.logoutUrl;
             const redirectUri = `${location.origin}${this.location.prepareExternalUrl('/')}`;


### PR DESCRIPTION
This is the next piece for the #10631 - blocks folder.

Some comments below.

https://angular.io/guide/http#getting-error-details says: _The HttpClient captures both kinds of errors in its HttpErrorResponse and you can inspect that response to figure out what really happened._  
So `HttpClient` error is always `HttpErrorResponse` and no need to check is this indeed `HttpErrorResponse`.  
`HttpErrorResponse` can contain HTTP error response or `ErrorEvent` in `HttpErrorResponse.error` (then `HttpErrorResponse.status` is `0`).

NotificationInterceptor: `HttpHeaders.get` is returning `string | null` - so no need to check `if (typeof alert === 'string')`, checking `if (alert)` is enough.

This PR has 2 commits:
* first one https://github.com/jhipster/generator-jhipster/commit/476b5e16314c0869f68791b4d0010553f2e9fc1d resolves strict option problems
* second one https://github.com/jhipster/generator-jhipster/commit/2fe069384e9a241e6589560b27083b72e470f174 improves UAA auth expired and not logged in users behavior to match how it's working with other authentication types, this also simplifies templates and if #10733 will be resolved then the same solution will be work also for UAA after these changes

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
