### PR TITLE
Strict option in home module in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -22,7 +22,7 @@ import { HttpClient } from '@angular/common/http';
 import { JhiLanguageService } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
-import { Observable, Subject, of } from 'rxjs';
+import { Observable, ReplaySubject, of } from 'rxjs';
 import { shareReplay, tap, catchError } from 'rxjs/operators';
 
 import { SERVER_API_URL } from 'app/app.constants';
@@ -34,7 +34,7 @@ import { TrackerService } from '../tracker/tracker.service';
 @Injectable({providedIn: 'root'})
 export class AccountService  {
     private userIdentity: Account | null = null;
-    private authenticationState = new Subject<Account | null>();
+    private authenticationState = new ReplaySubject<Account | null>(1);
     private accountCache$?: Observable<Account | null>;
 
     constructor(
@@ -78,11 +78,9 @@ export class AccountService  {
     identity(force?: boolean): Observable<Account | null> {
         if (!this.accountCache$ || force || !this.isAuthenticated()) {
             this.accountCache$ = this.fetch().pipe(
-              catchError(
-                () => {
-                    return of(null);
-                }
-              ),
+              catchError(() => {
+                return of(null);
+              }),
               tap((account: Account | null) => {
                 this.authenticate(account);
                 <%_ if (enableTranslation) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.ts.ejs
@@ -19,8 +19,6 @@
 import { Component, OnInit<%_ if (authenticationType !== 'oauth2') { _%>, OnDestroy <%_ } _%> } from '@angular/core';
 <%_ if (authenticationType !== 'oauth2') { _%>
 import { Subscription } from 'rxjs';
-import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-import { JhiEventManager } from 'ng-jhipster';
 <%_ } _%>
 
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -40,56 +38,44 @@ import { Account } from 'app/core/user/account.model';
 
 })
 export class HomeComponent implements OnInit <%_ if (authenticationType !== 'oauth2') { _%>, OnDestroy <%_ } _%> {
-    account: Account;
+    account: Account | null = null;
     <%_ if (authenticationType !== 'oauth2') { _%>
-    authSubscription: Subscription;
-    modalRef: NgbModalRef;
+    authSubscription?: Subscription;
     <%_ } _%>
 
     constructor(
         private accountService: AccountService,
         <%_ if (authenticationType !== 'oauth2') { _%>
-        private loginModalService: LoginModalService,
-        private eventManager: JhiEventManager
+        private loginModalService: LoginModalService
         <%_ } else { _%>
         private loginService: LoginService
         <%_ } _%>
-    ) {
-    }
+    ) {}
 
-    ngOnInit() {
-        this.accountService.identity().subscribe((account: Account) => {
-            this.account = account;
-        });
-        <%_ if (authenticationType !== 'oauth2') { _%>
-        this.registerAuthenticationSuccess();
-    }
-
-    registerAuthenticationSuccess() {
-        this.authSubscription = this.eventManager.subscribe('authenticationSuccess', () => {
-            this.accountService.identity().subscribe((account) => {
-                this.account = account;
-            });
-        });
+    ngOnInit(): void {
+        <%_ if (authenticationType === 'oauth2') { _%>
+        this.accountService.identity().subscribe(account => (this.account = account));
+        <%_ } else { _%>
+        this.authSubscription = this.accountService.getAuthenticationState().subscribe(account => (this.account = account));
         <%_ } _%>
     }
 
-    isAuthenticated() {
+    isAuthenticated(): boolean {
         return this.accountService.isAuthenticated();
     }
 
-    login() {
+    login(): void {
         <%_ if (authenticationType !== 'oauth2') { _%>
-        this.modalRef = this.loginModalService.open();
+        this.loginModalService.open();
         <%_ } else { _%>
         this.loginService.login();
         <%_ }_%>
     }
 
     <%_ if (authenticationType !== 'oauth2') { _%>
-    ngOnDestroy() {
+    ngOnDestroy(): void {
         if(this.authSubscription) {
-            this.eventManager.destroy(this.authSubscription);
+            this.authSubscription.unsubscribe();
         }
     }
     <%_ }_%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -20,7 +20,6 @@ import { Component, AfterViewInit, Renderer, ElementRef } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Router } from '@angular/router';
-import { JhiEventManager } from 'ng-jhipster';
 
 import { LoginService } from 'app/core/login/login.service';
 import { StateStorageService } from 'app/core/auth/state-storage.service';
@@ -39,7 +38,6 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
     });
 
     constructor(
-        private eventManager: JhiEventManager,
         private loginService: LoginService,
         private stateStorageService: StateStorageService,
         private elementRef: ElementRef,
@@ -75,11 +73,6 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
 this.router.url.startsWith('/account/reset/')) {
                 this.router.navigate(['']);
             }
-
-            this.eventManager.broadcast({
-                name: 'authenticationSuccess',
-                content: 'Sending Authentication Success'
-            });
 
             // previousState was set in the authExpiredInterceptor before being redirected to login modal.
             // since login is successful, go to stored previousState and clear previousState

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
@@ -20,7 +20,6 @@ import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angu
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
-import { JhiEventManager } from 'ng-jhipster';
 
 import { LoginService } from 'app/core/login/login.service';
 import { <%=jhiPrefixCapitalized%>LoginModalComponent } from 'app/shared/login/login.component';
@@ -38,7 +37,6 @@ describe('Component Tests', () => {
         let mockLoginService: any;
         let mockStateStorageService: any;
         let mockRouter: any;
-        let mockEventManager: any;
         let mockActiveModal: any;
 
         beforeEach(async(() => {
@@ -67,7 +65,6 @@ describe('Component Tests', () => {
             mockLoginService = fixture.debugElement.injector.get(LoginService);
             mockStateStorageService = fixture.debugElement.injector.get(StateStorageService);
             mockRouter = fixture.debugElement.injector.get(Router);
-            mockEventManager = fixture.debugElement.injector.get(JhiEventManager);
             mockActiveModal = fixture.debugElement.injector.get(NgbActiveModal);
         });
 
@@ -97,7 +94,6 @@ describe('Component Tests', () => {
                     // THEN
                     expect(comp.authenticationError).toEqual(false);
                     expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('login success');
-                    expect(mockEventManager.broadcastSpy).toHaveBeenCalledTimes(1);
                     expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
                     expect(mockStateStorageService.getUrlSpy).toHaveBeenCalledTimes(1);
                     expect(mockStateStorageService.storeUrlSpy).toHaveBeenCalledWith(null);
@@ -131,7 +127,6 @@ describe('Component Tests', () => {
                     // THEN
                     expect(comp.authenticationError).toEqual(false);
                     expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('login success');
-                    expect(mockEventManager.broadcastSpy).toHaveBeenCalledTimes(1);
                     expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
                     expect(mockStateStorageService.getUrlSpy).toHaveBeenCalledTimes(1);
                     expect(mockStateStorageService.storeUrlSpy).not.toHaveBeenCalled();


### PR DESCRIPTION
This is the next piece for the #10631 - home module.

One note about changes: `AccountService.identity()` must be called in `HomeComponent` only if authentication type is oauth2, for other authentication types this is already called in `LoginService.login()`: 
https://github.com/jhipster/generator-jhipster/blob/master/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs#L60-L62

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
