### PR TITLE
Add /api to default servers URL to expose them to UI

### DIFF
--- a/generators/server/templates/src/main/resources/swagger/api.yml.ejs
+++ b/generators/server/templates/src/main/resources/swagger/api.yml.ejs
@@ -23,9 +23,9 @@ info:
     title: "<%= baseName %>"
     version: 0.0.1
 servers:
-    - url: http://localhost:<%= serverPort %>
+    - url: http://localhost:<%= serverPort %>/api
       description: Development server
-    - url: https://localhost:<%= serverPort %>
+    - url: https://localhost:<%= serverPort %>/api
       description: Development server with TLS Profile
 paths: {}
 <% if(authenticationType === 'jwt') { %>


### PR DESCRIPTION
fix a part of #9752 by adding `/api` to default servers configuration in openapi api.yml
The generated api will be available under `/api` JHipster default path and available in the springfox ui.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` to your commit message to skip Travis tests
-->
