### PR TITLE
Strict option in user management in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<form name="deleteForm" (ngSubmit)="confirmDelete(user.login)">
+<form *ngIf="user" name="deleteForm" (ngSubmit)="confirmDelete(user.login)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true"

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
@@ -28,25 +28,22 @@ import { UserService } from 'app/core/user/user.service';
     templateUrl: './user-management-delete-dialog.component.html'
 })
 export class UserManagementDeleteDialogComponent {
-
-    user: User;
+    user?: User;
 
     constructor(
         private userService: UserService,
         public activeModal: NgbActiveModal,
         private eventManager: JhiEventManager
-    ) {
+    ) {}
+
+    clear(): void {
+        this.activeModal.dismiss();
     }
 
-    clear() {
-        this.activeModal.dismiss('cancel');
-    }
-
-    confirmDelete(login) {
+    confirmDelete(login: string): void {
         this.userService.delete(login).subscribe(() => {
-            this.eventManager.broadcast({ name: 'userListModification',
-                content: 'Deleted a user'});
-            this.activeModal.close(true);
+            this.eventManager.broadcast('userListModification');
+            this.activeModal.close();
         });
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.ts.ejs
@@ -26,16 +26,15 @@ import { User } from 'app/core/user/user.model';
     templateUrl: './user-management-detail.component.html'
 })
 export class UserManagementDetailComponent implements OnInit {
-
-    user: User;
+    user: User | null = null;
 
     constructor(
         private route: ActivatedRoute
     ) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.route.data.subscribe(({user}) => {
-            this.user = user.body ? user.body : user;
+            this.user = user;
         });
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
@@ -22,7 +22,7 @@
             <h2 id="myUserLabel" jhiTranslate="userManagement.home.createOrEditLabel">
                 Create or edit a User
             </h2>
-            <div>
+            <div *ngIf="user">
                 <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
                 <div class="form-group" [hidden]="!user.id">
                     <label jhiTranslate="global.field.id">ID</label>
@@ -108,7 +108,8 @@
                 </div>
                 <div class="form-check">
                     <label class="form-check-label" for="activated">
-                        <input class="form-check-input" [disabled]="user.id === null" type="checkbox" id="activated" name="activated"  formControlName="activated">
+                        <input class="form-check-input" [attr.disabled]="user.id === undefined ? 'disabled' : null"
+                        type="checkbox" id="activated" name="activated" formControlName="activated">
                         <span jhiTranslate="userManagement.activated">Activated</span>
                     </label>
                 </div>
@@ -128,7 +129,7 @@
                     </select>
                 </div>
             </div>
-            <div>
+            <div *ngIf="user">
                 <button type="button" class="btn btn-secondary" (click)="previousState()">
                     <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span
                     jhiTranslate="entity.action.cancel">Cancel</span>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -32,20 +32,20 @@ import { UserService } from 'app/core/user/user.service';
 })
 export class UserManagementUpdateComponent implements OnInit {
 
-    user: User;
+    user!: User;
     <%_ if (enableTranslation) { _%>
-    languages: any[];
+    languages: string[];
     <%_ } _%>
-    authorities: any[];
-    isSaving: boolean;
+    authorities: string[] = [];
+    isSaving = false;
 
     editForm = this.fb.group({
-        id: [null],
+        id: [],
         login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('^[_.@A-Za-z0-9-]*')]],
         firstName: ['', [Validators.maxLength(50)]],
         lastName: ['', [Validators.maxLength(50)]],
         email: ['', [Validators.minLength(5), Validators.maxLength(254), Validators.email]],
-        activated: [true],
+        activated: [],
         langKey: [],
         authorities: []
     });
@@ -57,21 +57,25 @@ export class UserManagementUpdateComponent implements OnInit {
         private userService: UserService,
         private route: ActivatedRoute,
         private fb: FormBuilder
-    ) {}
-
-    ngOnInit() {
-        this.isSaving = false;
-        this.route.data.subscribe(({user}) => {
-            this.user = user.body ? user.body : user;
-            this.updateForm(this.user);
-        });
-        this.authorities = [];
-        this.userService.authorities().subscribe((authorities) => {
-            this.authorities = authorities;
-        });
+    ) {
         <%_ if (enableTranslation) { _%>
         this.languages = this.languageHelper.getAll();
         <%_ } _%>
+    }
+
+    ngOnInit(): void {
+        this.route.data.subscribe(({user}) => {
+            if (user) {
+                this.user = user;
+                if (this.user.id === undefined) {
+                    this.user.activated = true;
+                }
+                this.updateForm(user);
+            }
+        });
+        this.userService.authorities().subscribe((authorities) => {
+            this.authorities = authorities;
+        });
     }
 
     private updateForm(user: User): void {
@@ -87,14 +91,14 @@ export class UserManagementUpdateComponent implements OnInit {
         });
     }
 
-    previousState() {
+    previousState(): void {
         window.history.back();
     }
 
-    save() {
+    save(): void {
         this.isSaving = true;
         this.updateUser(this.user);
-        if (this.user.id !== null) {
+        if (this.user.id !== undefined) {
             this.userService.update(this.user).subscribe(() => this.onSaveSuccess(), () => this.onSaveError());
         } else {<% if (!enableTranslation) { %>
             this.user.langKey = 'en';<% } %>
@@ -103,21 +107,21 @@ export class UserManagementUpdateComponent implements OnInit {
     }
 
     private updateUser(user: User): void {
-        user.login = this.editForm.get(['login']).value;
-        user.firstName = this.editForm.get(['firstName']).value;
-        user.lastName = this.editForm.get(['lastName']).value;
-        user.email = this.editForm.get(['email']).value;
-        user.activated = this.editForm.get(['activated']).value;
-        user.langKey = this.editForm.get(['langKey']).value;
-        user.authorities = this.editForm.get(['authorities']).value;
+        user.login = this.editForm.get(['login'])!.value;
+        user.firstName = this.editForm.get(['firstName'])!.value;
+        user.lastName = this.editForm.get(['lastName'])!.value;
+        user.email = this.editForm.get(['email'])!.value;
+        user.activated = this.editForm.get(['activated'])!.value;
+        user.langKey = this.editForm.get(['langKey'])!.value;
+        user.authorities = this.editForm.get(['authorities'])!.value;
     }
 
-    private onSaveSuccess() {
+    private onSaveSuccess(): void {
         this.isSaving = false;
         this.previousState();
     }
 
-    private onSaveError() {
+    private onSaveError(): void {
         this.isSaving = false;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
@@ -23,11 +23,12 @@
             <fa-icon [icon]="'plus'"></fa-icon> <span jhiTranslate="userManagement.home.createLabel">Create a new User</span>
         </button>
     </h2>
+    <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
     <<%= jhiPrefixDashed %>-alert></<%= jhiPrefixDashed %>-alert>
     <div class="table-responsive" *ngIf="users">
         <table class="table table-striped" aria-describedby="user-management-page-heading">
             <thead>
-            <tr<% if (databaseType !== 'cassandra') { %> jhiSort [(predicate)]="predicate" [(ascending)]="reverse" [callback]="transition.bind(this)"<% } %>>
+            <tr<% if (databaseType !== 'cassandra') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"<% } %>>
                 <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
                 <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="login"<% } %>><span jhiTranslate="userManagement.login">Login</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
                 <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="email"<% } %>><span jhiTranslate="userManagement.email">Email</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -17,19 +17,21 @@
  limitations under the License.
 -%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
-import { HttpResponse } from '@angular/common/http';
-import { Subscription } from 'rxjs';
+import { HttpResponse, HttpHeaders } from '@angular/common/http';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
-
+import { Subscription } from 'rxjs';
 <%_ if (prodDatabaseType !== 'cassandra') { _%>
+import { flatMap } from 'rxjs/operators';
 import { ActivatedRoute, Router } from '@angular/router';
-import { JhiEventManager, JhiParseLinks, JhiAlertService } from 'ng-jhipster';
+import { JhiEventManager } from 'ng-jhipster';
 
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
 <%_ } else { _%>
-import { JhiEventManager, JhiAlertService } from 'ng-jhipster';
+import { JhiEventManager } from 'ng-jhipster';
+
 <%_ } _%>
 import { AccountService } from 'app/core/auth/account.service';
+import { Account } from 'app/core/user/account.model';
 import { UserService } from 'app/core/user/user.service';
 import { User } from 'app/core/user/user.model';
 import { UserManagementDeleteDialogComponent } from './user-management-delete-dialog.component';
@@ -39,138 +41,117 @@ import { UserManagementDeleteDialogComponent } from './user-management-delete-di
     templateUrl: './user-management.component.html'
 })
 export class UserManagementComponent implements OnInit, OnDestroy {
-
-    currentAccount: any;
-    users: User[];
-    error: any;
-    success: any;
-    userListSubscription: Subscription;
+    currentAccount: Account | null = null;
+    users: User[] | null = null;
+    userListSubscription?: Subscription;
     <%_ if (databaseType !== 'cassandra') { _%>
-    routeData: Subscription;
-    links: any;
-    totalItems: any;
-    itemsPerPage: any;
-    page: any;
-    predicate: any;
-    previousPage: any;
-    reverse: any;
+    totalItems = 0;
+    itemsPerPage = ITEMS_PER_PAGE;
+    page!: number;
+    predicate!: string;
+    previousPage!: number;
+    ascending!: boolean;
     <%_ } _%>
 
     constructor(
         private userService: UserService,
-        private alertService: JhiAlertService,
         private accountService: AccountService,
         <%_ if (prodDatabaseType !== 'cassandra') { _%>
-        private parseLinks: JhiParseLinks,
         private activatedRoute: ActivatedRoute,
         private router: Router,
         <%_ } _%>
         private eventManager: JhiEventManager,
         private modalService: NgbModal,
-    ) {
-        <%_ if (databaseType !== 'cassandra') { _%>
-        this.itemsPerPage = ITEMS_PER_PAGE;
-        this.routeData = this.activatedRoute.data.subscribe((data) => {
-            this.page = data.pagingParams.page;
-            this.previousPage = data.pagingParams.page;
-            this.reverse = data.pagingParams.ascending;
-            this.predicate = data.pagingParams.predicate;
-        });
-        <%_ } _%>
-    }
+    ) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
+        <%_ if (databaseType === 'cassandra') { _%>
         this.accountService.identity().subscribe((account) => {
             this.currentAccount = account;
             this.loadAll();
-            this.registerChangeInUsers();
+            this.userListSubscription = this.eventManager.subscribe('userListModification', () => this.loadAll());
         });
+        <%_ } else { _%>
+        this.activatedRoute.data
+            .pipe(
+                flatMap(
+                    () => this.accountService.identity(),
+                    (data, account) => {
+                        this.page = data.pagingParams.page;
+                        this.previousPage = data.pagingParams.page;
+                        this.ascending = data.pagingParams.ascending;
+                        this.predicate = data.pagingParams.predicate;
+                        this.currentAccount = account;
+                        this.loadAll();
+                        this.userListSubscription = this.eventManager.subscribe('userListModification', () => this.loadAll());
+                    }
+                )
+            )
+            .subscribe();
+        <%_ } _%>
     }
 
-    ngOnDestroy() {
-        <%_ if (databaseType !== 'cassandra') { _%>
-        this.routeData.unsubscribe();
-        <%_ } _%>
-        if(this.userListSubscription) {
+    ngOnDestroy(): void {
+        if (this.userListSubscription) {
             this.eventManager.destroy(this.userListSubscription);
         }
     }
 
-    registerChangeInUsers() {
-        this.userListSubscription = this.eventManager.subscribe('userListModification', () => this.loadAll());
-    }
-
-    setActive(user, isActivated) {
+    setActive(user: User, isActivated: boolean): void {
         user.activated = isActivated;
-
-        this.userService.update(user).subscribe(
-            () => {
-                this.error = null;
-                this.success = 'OK';
-                this.loadAll();
-            }, () => {
-                this.success = null;
-                this.error = 'ERROR';
-            });
+        this.userService.update(user).subscribe(() => this.loadAll(), () => (user.activated = !isActivated));
     }
 
-    loadAll() {
+    private loadAll(): void {
         this.userService.query(<% if (databaseType !== 'cassandra') { %>{
             page: this.page - 1,
             size: this.itemsPerPage,
             sort: this.sort()}<% } %>).subscribe(
-                (res: HttpResponse<User[]>) => this.onSuccess(res.body<% if (databaseType !== 'cassandra') { %>, res.headers<% } %>),
-                (res: HttpResponse<any>) => this.onError(res.body)
+                (res: HttpResponse<User[]>) => this.onSuccess(res.body<% if (databaseType !== 'cassandra') { %>, res.headers<% } %>)
         );
     }
 
-    trackIdentity(index, item: User) {
+    trackIdentity(index: number, item: User): any {
         return item.id;
     }
-
     <%_ if (databaseType !== 'cassandra') { _%>
-    sort() {
-        const result = [this.predicate + ',' + (this.reverse ? 'asc' : 'desc')];
+
+    private sort(): string[] {
+        const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
             result.push('id');
         }
         return result;
     }
 
-    loadPage(page: number) {
+    loadPage(page: number): void {
         if (page !== this.previousPage) {
             this.previousPage = page;
             this.transition();
         }
     }
 
-    transition() {
+    transition(): void {
         this.router.navigate(['./'], {
             relativeTo: this.activatedRoute.parent,
             queryParams: {
                 page: this.page,
-                sort: this.predicate + ',' + (this.reverse ? 'asc' : 'desc')
+                sort: this.predicate + ',' + (this.ascending ? 'asc' : 'desc')
             }
         });
         this.loadAll();
     }
-
     <%_ } _%>
 
-    deleteUser(user: User) {
+    deleteUser(user: User): void {
         const modalRef = this.modalService.open(UserManagementDeleteDialogComponent, { size: 'lg', backdrop: 'static' });
         modalRef.componentInstance.user = user;
     }
 
-    private onSuccess(data<% if (databaseType !== 'cassandra') { %>, headers<% } %>) {
+    private onSuccess(users: User[] | null<% if (databaseType !== 'cassandra') { %>, headers: HttpHeaders<% } %>): void {
         <%_ if (databaseType !== 'cassandra') { _%>
-        this.links = this.parseLinks.parse(headers.get('link'));
-        this.totalItems = headers.get('X-Total-Count');
+        this.totalItems = Number(headers.get('X-Total-Count'));
         <%_ } _%>
-        this.users = data;
-    }
-
-    private onError(error) {
-        this.alertService.error(error.error, error.message, null);
+        this.users = users;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -98,8 +98,7 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     }
 
     setActive(user: User, isActivated: boolean): void {
-        user.activated = isActivated;
-        this.userService.update(user).subscribe(() => this.loadAll(), () => (user.activated = !isActivated));
+        this.userService.update({ ...user, activated: isActivated }).subscribe(() => this.loadAll());
     }
 
     private loadAll(): void {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
@@ -18,26 +18,25 @@
 -%>
 import { Injectable } from '@angular/core';
 import { Resolve, ActivatedRouteSnapshot, Routes } from '@angular/router';
+import { Observable, of } from 'rxjs';
 import { JhiResolvePagingParams } from 'ng-jhipster';
 
-import { User } from 'app/core/user/user.model';
+import { User, IUser } from 'app/core/user/user.model';
 import { UserService } from 'app/core/user/user.service';
 import { UserManagementComponent } from './user-management.component';
 import { UserManagementDetailComponent } from './user-management-detail.component';
 import { UserManagementUpdateComponent } from './user-management-update.component';
 
 @Injectable({providedIn: 'root'})
-export class UserManagementResolve implements Resolve<any> {
+export class UserManagementResolve implements Resolve<IUser> {
+    constructor(private service: UserService) {}
 
-    constructor(private service: UserService) {
-    }
-
-    resolve(route: ActivatedRouteSnapshot) {
+    resolve(route: ActivatedRouteSnapshot): Observable<IUser> {
         const id = route.params['login'] ? route.params['login'] : null;
         if (id) {
             return this.service.find(id);
         }
-        return new User();
+        return of(new User());
     }
 }
 
@@ -68,6 +67,9 @@ export const userManagementRoute: Routes = [
         component: UserManagementUpdateComponent,
         resolve: {
             user: UserManagementResolve
+        },
+        data: {
+            pageTitle: 'userManagement.home.title'
         }
     },
     {
@@ -75,6 +77,9 @@ export const userManagementRoute: Routes = [
         component: UserManagementUpdateComponent,
         resolve: {
             user: UserManagementResolve
+        },
+        data: {
+            pageTitle: 'userManagement.home.title'
         }
     }
 ];

--- a/generators/client/templates/angular/src/main/webapp/app/core/user/user.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/user/user.model.ts.ejs
@@ -48,19 +48,5 @@ export class User implements IUser {
         public lastModifiedBy?: string,
         public lastModifiedDate?: Date,
         public password?: string
-    ) {
-        this.id = id ? id : null;
-        this.login = login ? login : null;
-        this.firstName = firstName ? firstName : null;
-        this.lastName = lastName ? lastName : null;
-        this.email = email ? email : null;
-        this.activated = activated ? activated : false;
-        this.langKey = langKey ? langKey : null;
-        this.authorities = authorities ? authorities : null;
-        this.createdBy = createdBy ? createdBy : null;
-        this.createdDate = createdDate ? createdDate : null;
-        this.lastModifiedBy = lastModifiedBy ? lastModifiedBy : null;
-        this.lastModifiedDate = lastModifiedDate ? lastModifiedDate : null;
-        this.password = password ? password : null;
-    }
+    ) {}
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
@@ -22,6 +22,8 @@ import { of } from 'rxjs';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
+import { MockEventManager } from '../../../helpers/mock-event-manager.service';
+import { MockActiveModal } from '../../../helpers/mock-active-modal.service';
 import { UserManagementDeleteDialogComponent } from 'app/admin/user-management/user-management-delete-dialog.component';
 import { UserService } from 'app/core/user/user.service';
 
@@ -31,8 +33,8 @@ describe('Component Tests', () => {
         let comp: UserManagementDeleteDialogComponent;
         let fixture: ComponentFixture<UserManagementDeleteDialogComponent>;
         let service: UserService;
-        let mockEventManager: any;
-        let mockActiveModal: any;
+        let mockEventManager: MockEventManager;
+        let mockActiveModal: MockActiveModal;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
@@ -47,8 +49,8 @@ describe('Component Tests', () => {
             fixture = TestBed.createComponent(UserManagementDeleteDialogComponent);
             comp = fixture.componentInstance;
             service = fixture.debugElement.injector.get(UserService);
-            mockEventManager = fixture.debugElement.injector.get(JhiEventManager);
-            mockActiveModal = fixture.debugElement.injector.get(NgbActiveModal);
+            mockEventManager = TestBed.get(JhiEventManager);
+            mockActiveModal = TestBed.get(NgbActiveModal);
         });
 
         describe('confirmDelete', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
@@ -11,7 +11,7 @@ describe('Component Tests', () => {
     describe('User Management Detail Component', () => {
         let comp: UserManagementDetailComponent;
         let fixture: ComponentFixture<UserManagementDetailComponent>;
-        const route = ({data: of({user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin', null, null, null)})} as any) as ActivatedRoute;
+        const route: ActivatedRoute = ({data: of({user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin')})} as any) as ActivatedRoute;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
@@ -50,11 +50,7 @@ describe('Component Tests', () => {
                     activated: true,
                     langKey: 'en',
                     authorities: ['ROLE_USER'],
-                    createdBy: 'admin',
-                    createdDate: null,
-                    lastModifiedBy: null,
-                    lastModifiedDate: null,
-                    password: null
+                    createdBy: 'admin'
                 }));
             });
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
@@ -26,6 +26,9 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
+<%_ if (enableTranslation) { _%>
+import { MockLanguageHelper } from '../../../helpers/mock-language.service';
+<%_ } _%>
 import { UserManagementUpdateComponent } from 'app/admin/user-management/user-management-update.component';
 import { UserService } from 'app/core/user/user.service';
 import { User } from 'app/core/user/user.model';
@@ -40,9 +43,9 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<UserManagementUpdateComponent>;
         let service: UserService;
         <%_ if (enableTranslation) { _%>
-        let mockLanguageHelper: any;
+        let mockLanguageHelper: MockLanguageHelper;
         <%_ } _%>
-        const route = ({data: of({user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin', null, null, null)})} as any) as ActivatedRoute;
+        const route: ActivatedRoute = ({data: of({user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin')})} as any) as ActivatedRoute;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
@@ -65,7 +68,7 @@ describe('Component Tests', () => {
             comp = fixture.componentInstance;
             service = fixture.debugElement.injector.get(UserService);
             <%_ if (enableTranslation) { _%>
-            mockLanguageHelper = fixture.debugElement.injector.get(JhiLanguageHelper);
+            mockLanguageHelper = TestBed.get(JhiLanguageHelper);
             <%_ } _%>
         });
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -91,7 +91,7 @@ describe('Component Tests', () => {
                         tick(); // simulate async
 
                         // THEN
-                        expect(service.update).toHaveBeenCalledWith(user);
+                        expect(service.update).toHaveBeenCalledWith({ ...user, activated: true });
                         expect(service.query).toHaveBeenCalled();
                         expect(comp.users && comp.users[0]).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
                     })

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -67,7 +67,7 @@ describe('Component Tests', () => {
 
                         // THEN
                         expect(service.query).toHaveBeenCalled();
-                        expect(comp.users[0]).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
+                        expect(comp.users && comp.users[0]).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
                     })
                 )
             );
@@ -93,7 +93,7 @@ describe('Component Tests', () => {
                         // THEN
                         expect(service.update).toHaveBeenCalledWith(user);
                         expect(service.query).toHaveBeenCalled();
-                        expect(comp.users[0]).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
+                        expect(comp.users && comp.users[0]).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
                     })
                 )
             );


### PR DESCRIPTION
User management module for #10631 

Some comments about changes:

* https://github.com/jhipster/generator-jhipster/pull/10383/files#diff-fbe805378490e83898dff42879a82b67L42-R43 changed `userService.find` return type from `Observable<HttpResponse<IUser>>` to `Observable<IUser>` so in detail and update component `ngOnInit` no need to check for `user.body` any more

* `activated` in update form: if reading code then can see that goal is to set `activated=true` in adding new user and disable changing that in update form (because back end forces `activated=true` if adding a new user) but in my testing either didn't work, so I adjusted code to make it work as intended

* http errors were not shown in user list component, added `<<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>` and http errors are shown now

* `ActivatedRoute.data` observable doesn't need unsubscribe (https://angular.io/guide/router#observable-parammap-and-component-reuse). As this unsubscribe is not done in entities and was removed also from audits module then removed also from user management module, to follow the same style and to make code shorter

* in the `setActive` method in user list component I changed logic: if error occurs in saving (`activated` is not changed in the database) then restoring initial activated value (currently, if error occurs then UI shows as data was changed, shows wrong value)

* removed redundant `onError` method:
    * errors are shown by `AlertErrorComponent` now
    * in current master parameter to `onError` is `HttpErrorResponse.body` but as `HttpErrorResponse` misses property `body` then this throws constantly error: cant't read property error of undefined
    * in `onError` function is runned `this.alertService.error` - but this doesn't show error, this just constructs `JhiAlert` and that's all, so this wouldn't work if fixing parameter to `onError` and no need to duplicate `AlertErrorComponent`

* if adding or changing the user then the page title was `translation-not-found...` - this is fixed now

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
