### PR TITLE
Exclude swagger-ui for service-worker so PWAs work out-of-the-box

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -167,6 +167,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         new WorkboxPlugin.GenerateSW({
           clientsClaim: true,
           skipWaiting: true,
+          exclude: [/swagger-ui/]
         })
     ],
     mode: 'production'

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -121,6 +121,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
     new WorkboxPlugin.GenerateSW({
       clientsClaim: true,
       skipWaiting: true,
+      exclude: [/swagger-ui/]
     })
   ]
 });


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

See https://stackoverflow.com/questions/57979835/how-to-fix-uncaught-in-promise-bad-precaching-response-error-with-service-wo/57982417#57982417 to see why this is a solution.

Related: https://groups.google.com/forum/#!topic/jhipster-dev/BO4ywuY4S8I