### PR TITLE
[Feature Request] Enable autoprefixer for component specific styles

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -113,7 +113,7 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         },
         {
             test: /\.scss$/,
-            use: ['to-string-loader', 'css-loader', {
+            use: ['to-string-loader', 'css-loader', 'postcss-loader', {
                 loader: 'sass-loader',
                 options: { implementation: sass }
             }],

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -54,7 +54,7 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
         },
         {
             test: /\.scss$/,
-            use: ['to-string-loader', 'css-loader', {
+            use: ['to-string-loader', 'css-loader', 'postcss-loader', {
                 loader: 'sass-loader',
                 options: { implementation: sass }
             }],


### PR DESCRIPTION
Treat component specific SASS styles the same way as vendor and global styles using the autoprefixer.
