### PR TITLE
Added dependency to pom.xml templates so liquibase can find jhipster'…

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1119,6 +1119,11 @@
                     </configuration>
                     <dependencies>
                         <dependency>
+                            <groupId>io.github.jhipster</groupId>
+                            <artifactId>jhipster-framework</artifactId>
+                            <version>${jhipster-dependencies.version}</version>
+                        </dependency>
+                        <dependency>
                             <groupId>org.hibernate</groupId>
                             <artifactId>hibernate-core</artifactId>
                             <version>${hibernate-core.version}</version>

--- a/test/templates/ci-cd/maven-ngx-yarn/pom.xml
+++ b/test/templates/ci-cd/maven-ngx-yarn/pom.xml
@@ -497,6 +497,11 @@
                 </configuration>
                 <dependencies>
                     <dependency>
+                        <groupId>io.github.jhipster</groupId>
+                        <artifactId>jhipster-framework</artifactId>
+                        <version>${jhipster-dependencies.version}</version>
+                    </dependency>
+                    <dependency>
                         <groupId>org.javassist</groupId>
                         <artifactId>javassist</artifactId>
                         <version>${javassist.version}</version>


### PR DESCRIPTION
As requested by @pmverma on #10887 , this PR makes it possible for liquibase, in a maven-based project, to use jhipster's custom dialects.

I also created a new project with gradle and repeated the same steps mentioned in that issue. Liquibase with gradle had no problems finding the dialect, so I didn't change anything there.