### PR TITLE
use a seeded RNG for RandExp regex generation

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
@@ -155,6 +155,8 @@ for (lineNb = 1; lineNb <= numberOfRows; lineNb++) {
             if (fields[idx].fieldValidateRules.includes('pattern')) {
                 const randExp = new this.randexp(fields[idx].fieldValidateRulesPattern)
                 randExp.max = 5;
+                // In order to have consistent results with RandExp, the RNG is seeded.
+                randExp.randInt = seededRandomNumberGenerator(lineNb);
                 data = `"${randExp.gen().replace(/"/g, '""')}"`;
             }
 

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -172,12 +172,6 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @ExtendWith(RedisTestContainerExtension.class)
 <%_ } _%>
 public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
-<%_
-    let oldSource = '';
-    try {
-        oldSource = this.fs.readFileSync(this.SERVER_TEST_SRC_DIR + packageFolder + '/web/rest/' + entityClass + 'ResourceIT.java', 'utf8');
-    } catch (e) {}
-_%>
     <%_ for (idx in fields) {
     const defaultValueName = 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase();
     const updatedValueName = 'UPDATED_' + fields[idx].fieldNameUnderscored.toUpperCase();
@@ -237,23 +231,14 @@ _%>
             updatedTextString += "B";
         }
         if (!this._.isUndefined(fields[idx].fieldValidateRulesPattern)) {
-            if (oldSource !== '') {
-                // Check for old values
-                const sampleTextStringSearchResult = new RegExp('private static final String ' + defaultValueName + ' = "(.*)";', 'm').exec(oldSource);
-                if (sampleTextStringSearchResult != null) {
-                    sampleTextString = sampleTextStringSearchResult[1];
-                }
-                const updatedTextStringSearchResult = new RegExp('private static final String ' + updatedValueName + ' = "(.*)";', 'm').exec(oldSource);
-                if (updatedTextStringSearchResult != null) {
-                    updatedTextString = updatedTextStringSearchResult[1];
-                }
-            }
             // Generate Strings, using pattern
             try {
                 const patternRegExp = new RegExp(fields[idx].fieldValidateRulesPattern);
                 const randExp = new this.randexp(fields[idx].fieldValidateRulesPattern);
                 // set infinite repetitions max range
                 randExp.max = 1;
+                // In order to have consistent results with RandExp, the RNG is seeded.
+                randExp.randInt = seededRandomNumberGenerator(idx)
                 if (!patternRegExp.test(sampleTextString.replace(/\\"/g, '"').replace(/\\\\/g, '\\'))) {
                     sampleTextString = randExp.gen().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
                 }

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1460,4 +1460,16 @@ module.exports = class extends Generator {
             );
         }
     }
+
+    /**
+     * Returns a seeded random number generator, used for RandExp regex generation.
+     * @param {number} id - seeds the random number generator
+     */
+    seededRandomNumberGenerator(id) {
+        let seed = 42 + id;
+        return (a, b) => {
+            seed = seed ** 2 % 969421;
+            return (seed % (1 + b - a)) + a;
+        };
+    }
 };

--- a/test/generator-base-private.spec.js
+++ b/test/generator-base-private.spec.js
@@ -266,4 +266,21 @@ export * from './entityFolderName/entityFileName.state';`;
             });
         });
     });
+
+    describe('seededRandomNumberGenerator', () => {
+        describe('generates the same random number when provided the same seed', () => {
+            it('generates the same random values', () => {
+                const seededRandomNumberGenerator1 = BaseGenerator.seededRandomNumberGenerator(1);
+                const seededRandomNumberGenerator2 = BaseGenerator.seededRandomNumberGenerator(1);
+                expect(seededRandomNumberGenerator1(1, 10)).to.equal(seededRandomNumberGenerator2(1, 10));
+            });
+        });
+        describe('generates a different random number when provided a different seed', () => {
+            it('generates different random values', () => {
+                const seededRandomNumberGenerator1 = BaseGenerator.seededRandomNumberGenerator(1);
+                const seededRandomNumberGenerator2 = BaseGenerator.seededRandomNumberGenerator(2);
+                expect(seededRandomNumberGenerator1(1, 10)).to.not.equal(seededRandomNumberGenerator2(1, 10));
+            });
+        });
+    });
 });


### PR DESCRIPTION
This ensures reproducible builds in the fake data generation.  Before this commit, any fields with pattern regex validation would regenerate a new value for each fake-data row, causing Liquibase checksum issues on startup.

Also removes some custom code that does the same thing in `EntityResourceIT.java.ejs`

Let me know if there's a better place to put the new method.

Related to https://github.com/jhipster/generator-jhipster/issues/10372

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
