### PR TITLE
Strict Typescript option in layouts in Angular

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -422,6 +422,7 @@ const files = {
                 'spec/app/admin/metrics/metrics.component.spec.ts',
                 'spec/app/admin/metrics/metrics.service.spec.ts',
                 'spec/app/core/user/account.service.spec.ts',
+                'spec/app/layouts/main/main.component.spec.ts',
                 'spec/helpers/spyobject.ts',
                 'spec/helpers/mock-account.service.ts',
                 'spec/helpers/mock-route.service.ts',
@@ -496,11 +497,6 @@ const files = {
         {
             condition: generator => generator.protractorTests,
             templates: ['tsconfig.e2e.json']
-        },
-        {
-            condition: generator => generator.authenticationType === 'oauth2',
-            path: TEST_SRC_DIR,
-            templates: ['spec/app/layouts/main/main.component.spec.ts']
         }
     ]
 };

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -25,7 +25,7 @@ import { JhiLanguageService } from 'ng-jhipster';
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/user/account.model';
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
+import { LANGUAGES } from 'app/core/language/language.constants';
 <%_ } _%>
 
 @Component({
@@ -36,7 +36,7 @@ export class SettingsComponent implements OnInit {
     account!: Account;
     success = false;
     <%_ if (enableTranslation) { _%>
-    languages: string[];
+    languages = LANGUAGES;
     <%_ } _%>
     settingsForm = this.fb.group({
         firstName: [undefined, [Validators.required, Validators.minLength(1), Validators.maxLength(50)]],
@@ -48,13 +48,8 @@ export class SettingsComponent implements OnInit {
     constructor(
         private accountService: AccountService,
         private fb: FormBuilder<% if (enableTranslation) { %>,
-        private languageService: JhiLanguageService,
-        private languageHelper: JhiLanguageHelper<% } %>
-    ) {
-        <%_ if (enableTranslation) { _%>
-        this.languages = this.languageHelper.getAll();
-        <%_ } _%>
-    }
+        private languageService: JhiLanguageService<% } %>
+    ) {}
 
     ngOnInit(): void {
         this.accountService.identity().subscribe((account) => {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/admin-routing.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/admin-routing.module.ts.ejs
@@ -28,7 +28,10 @@ import { RouterModule } from '@angular/router';
         <%_ if (!skipUserManagement) { _%>
         {
           path: 'user-management',
-          loadChildren: () => import('./user-management/user-management.module').then(m => m.UserManagementModule)
+          loadChildren: () => import('./user-management/user-management.module').then(m => m.UserManagementModule),
+          data: {
+            pageTitle: 'userManagement.home.title'
+          }
         },
         <%_ } _%>
         <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -21,7 +21,7 @@ import { FormBuilder, Validators } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
+import { LANGUAGES } from 'app/core/language/language.constants';
 <%_ } _%>
 import { User } from 'app/core/user/user.model';
 import { UserService } from 'app/core/user/user.service';
@@ -34,7 +34,7 @@ export class UserManagementUpdateComponent implements OnInit {
 
     user!: User;
     <%_ if (enableTranslation) { _%>
-    languages: string[];
+    languages = LANGUAGES;
     <%_ } _%>
     authorities: string[] = [];
     isSaving = false;
@@ -51,17 +51,10 @@ export class UserManagementUpdateComponent implements OnInit {
     });
 
     constructor(
-        <%_ if (enableTranslation) { _%>
-        private languageHelper: JhiLanguageHelper,
-        <%_ } _%>
         private userService: UserService,
         private route: ActivatedRoute,
         private fb: FormBuilder
-    ) {
-        <%_ if (enableTranslation) { _%>
-        this.languages = this.languageHelper.getAll();
-        <%_ } _%>
-    }
+    ) {}
 
     ngOnInit(): void {
         this.route.data.subscribe(({user}) => {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.route.ts.ejs
@@ -48,7 +48,6 @@ export const userManagementRoute: Routes = [
             'pagingParams': JhiResolvePagingParams
         },
         data: {
-            pageTitle: 'userManagement.home.title',
             defaultSort: 'id,asc'
         }
     },
@@ -57,9 +56,6 @@ export const userManagementRoute: Routes = [
         component: UserManagementDetailComponent,
         resolve: {
             user: UserManagementResolve
-        },
-        data: {
-            pageTitle: 'userManagement.home.title'
         }
     },
     {
@@ -67,9 +63,6 @@ export const userManagementRoute: Routes = [
         component: UserManagementUpdateComponent,
         resolve: {
             user: UserManagementResolve
-        },
-        data: {
-            pageTitle: 'userManagement.home.title'
         }
     },
     {
@@ -77,9 +70,6 @@ export const userManagementRoute: Routes = [
         component: UserManagementUpdateComponent,
         resolve: {
             user: UserManagementResolve
-        },
-        data: {
-            pageTitle: 'userManagement.home.title'
         }
     }
 ];

--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -26,7 +26,7 @@ import { <%=angularXAppName%>AppRoutingModule} from './app-routing.module';
 import { <%=angularXAppName%>HomeModule } from './home/home.module';
 import { <%=angularXAppName%>EntityModule } from './entities/entity.module';
 // jhipster-needle-angular-add-module-import JHipster will add new module here
-import { <%=jhiPrefixCapitalized%>MainComponent } from './layouts/main/main.component';
+import { MainComponent } from './layouts/main/main.component';
 import { NavbarComponent } from './layouts/navbar/navbar.component';
 import { FooterComponent } from './layouts/footer/footer.component';
 import { PageRibbonComponent } from './layouts/profiles/page-ribbon.component';
@@ -46,7 +46,7 @@ import { ErrorComponent } from './layouts/error/error.component';
         <%=angularXAppName%>AppRoutingModule
     ],
     declarations: [
-        <%=jhiPrefixCapitalized%>MainComponent,
+        MainComponent,
         NavbarComponent,
         ErrorComponent,
         PageRibbonComponent,
@@ -55,6 +55,6 @@ import { ErrorComponent } from './layouts/error/error.component';
         <%_ } _%>
         FooterComponent
     ],
-    bootstrap: [ <%=jhiPrefixCapitalized%>MainComponent ]
+    bootstrap: [ MainComponent ]
 })
 export class <%=angularXAppName%>AppModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -17,6 +17,7 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
+import { Router } from '@angular/router';
 import { HttpClient } from '@angular/common/http';
 <%_ if (enableTranslation) { _%>
 import { JhiLanguageService } from 'ng-jhipster';
@@ -24,6 +25,7 @@ import { SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
 import { Observable, ReplaySubject, of } from 'rxjs';
 import { shareReplay, tap, catchError } from 'rxjs/operators';
+import { StateStorageService } from 'app/core/auth/state-storage.service';
 
 import { SERVER_API_URL } from 'app/app.constants';
 import { Account } from 'app/core/user/account.model';
@@ -42,16 +44,23 @@ export class AccountService  {
         private languageService: JhiLanguageService,
         private sessionStorage: SessionStorageService,
         <%_ } _%>
-        private http: HttpClient<% if (websocket === 'spring-websocket') { %>,
-        private trackerService: TrackerService<% } %>) { }
+        private http: HttpClient,
+        <%_ if (websocket === 'spring-websocket') { _%>
+        private trackerService: TrackerService,
+        <%_ } _%>
+        private stateStorageService: StateStorageService,
+        private router: Router
+    ) {}
 
     private fetch(): Observable<Account> {
         return this.http.get<Account>(SERVER_API_URL + '<%- apiUaaPath %>api/account');
     }
+    <%_ if (!skipUserManagement) { _%>
 
     save(account: Account): Observable<{}> {
         return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account', account);
     }
+    <%_ } _%>
 
     authenticate(identity: Account | null): void {
         this.userIdentity = identity;
@@ -84,6 +93,7 @@ export class AccountService  {
               tap((account: Account | null) => {
                 this.authenticate(account);
                 <%_ if (enableTranslation) { _%>
+
                 // After retrieve the account info, the language will be changed to
                 // the user's preferred language configured in the account setting
                 if (account && account.langKey) {
@@ -91,6 +101,10 @@ export class AccountService  {
                   this.languageService.changeLanguage(langKey);
                 }
                 <%_ } _%>
+
+                if (account) {
+                    this.navigateToStoredUrl();
+                }
               }),
               shareReplay()
             );
@@ -98,6 +112,16 @@ export class AccountService  {
         return this.accountCache$;
     }
 
+    private navigateToStoredUrl(): void {
+        // previousState can be set in the authExpiredInterceptor and in the userRouteAccessService
+        // if login is successful, go to stored previousState and clear previousState
+        const previousUrl = this.stateStorageService.getUrl();
+        if (previousUrl) {
+            this.stateStorageService.clearUrl();
+            this.router.navigateByUrl(previousUrl);
+        }
+    }
+    
     isAuthenticated(): boolean {
         return this.userIdentity !== null;
     }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/state-storage.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/state-storage.service.ts.ejs
@@ -21,15 +21,21 @@ import { SessionStorageService } from 'ngx-webstorage';
 
 @Injectable({providedIn: 'root'})
 export class StateStorageService {
+    private previousUrlKey = 'previousUrl';
+
     constructor(
         private $sessionStorage: SessionStorageService
     ) {}
 
     storeUrl(url: string): void {
-        this.$sessionStorage.store('previousUrl', url);
+        this.$sessionStorage.store(this.previousUrlKey, url);
     }
 
-    getUrl(): string {
-        return this.$sessionStorage.retrieve('previousUrl');
+    getUrl(): string | null | undefined {
+        return this.$sessionStorage.retrieve(this.previousUrlKey);
+    }
+
+    clearUrl(): void {
+        this.$sessionStorage.clear(this.previousUrlKey);
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -17,17 +17,14 @@
  limitations under the License.
 -%>
 import { Injectable, RendererFactory2, Renderer2 } from '@angular/core';
-import { Title } from '@angular/platform-browser';
-import { Router, ActivatedRouteSnapshot } from '@angular/router';
-import { TranslateService } from '@ngx-translate/core';
-
-import { LANGUAGES } from 'app/core/language/language.constants';
+import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
 <%_ if (enableI18nRTL) { _%>
+
 import { FindLanguageFromKeyPipe } from 'app/shared/language/find-language-from-key.pipe';
 <%_ } _%>
 
 @Injectable({providedIn: 'root'})
-export class JhiLanguageHelper {
+export class LanguageHelper {
     private renderer: Renderer2;
 
     constructor(
@@ -35,51 +32,17 @@ export class JhiLanguageHelper {
         <%_ if (enableI18nRTL) { _%>
         private findLanguageFromKeyPipe: FindLanguageFromKeyPipe,
         <%_ } _%>
-        private titleService: Title,
-        private router: Router,
         rootRenderer: RendererFactory2
     ) {
         this.renderer = rootRenderer.createRenderer(document.querySelector('html'), null);
-        this.init();
-    }
 
-    getAll(): string[] {
-        return LANGUAGES;
-    }
-
-    /**
-     * Update the window title using params in the following
-     * order:
-     * 1. titleKey parameter
-     * 2. $state.$current.data.pageTitle (current state page title)
-     * 3. 'global.title'
-     */
-    updateTitle(titleKey?: string): void {
-        if (!titleKey) {
-             titleKey = this.getPageTitle(this.router.routerState.snapshot.root);
-        }
-
-        this.translateService.get(titleKey).subscribe((title) => {
-            this.titleService.setTitle(title);
-        });
-    }
-
-    private init(): void {
-        this.translateService.onLangChange.subscribe(() => {
-            this.renderer.setAttribute(document.querySelector('html'), 'lang', this.translateService.currentLang);
-            this.updateTitle();
+        this.translateService.onLangChange.subscribe((langChangeEvent: LangChangeEvent) => {
+            this.renderer.setAttribute(document.querySelector('html'), 'lang', langChangeEvent.lang);
             <%_ if (enableI18nRTL) { _%>
+
             this.updatePageDirection();
             <%_ } _%>
         });
-    }
-
-    private getPageTitle(routeSnapshot: ActivatedRouteSnapshot): string {
-        let title: string = (routeSnapshot.data && routeSnapshot.data['pageTitle']) ? routeSnapshot.data['pageTitle'] : '<%= angularAppName %>';
-        if (routeSnapshot.firstChild) {
-            title = this.getPageTitle(routeSnapshot.firstChild) || title;
-        }
-        return title;
     }
     <%_ if (enableI18nRTL) { _%>
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login-modal.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login-modal.service.ts.ejs
@@ -19,22 +19,20 @@
 import { Injectable } from '@angular/core';
 import { NgbModal, NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
 
-import { <%=jhiPrefixCapitalized%>LoginModalComponent } from 'app/shared/login/login.component';
+import { LoginModalComponent } from 'app/shared/login/login.component';
 
 @Injectable({providedIn: 'root'})
 export class LoginModalService {
     private isOpen = false;
-    constructor(
-        private modalService: NgbModal,
-    ) {}
 
-    open(): NgbModalRef {
+    constructor(private modalService: NgbModal) {}
+
+    open(): void {
         if (this.isOpen) {
             return;
         }
         this.isOpen = true;
-        const modalRef = this.modalService.open(<%=jhiPrefixCapitalized%>LoginModalComponent);
+        const modalRef: NgbModalRef = this.modalService.open(LoginModalComponent);
         modalRef.result.finally(() => (this.isOpen = false));
-        return modalRef;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.html.ejs
@@ -24,7 +24,7 @@
         <div class="col-md-8">
             <h1 jhiTranslate="error.title">Error Page!</h1>
 
-            <div [hidden]="!errorMessage">
+            <div *ngIf="errorMessage">
                 <div class="alert alert-danger">{{ errorMessage }}</div>
             </div>
         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.html.ejs
@@ -25,12 +25,7 @@
             <h1 jhiTranslate="error.title">Error Page!</h1>
 
             <div [hidden]="!errorMessage">
-                <div class="alert alert-danger">{{errorMessage}}
-                </div>
-            </div>
-            <div [hidden]="!error403" class="alert alert-danger" jhiTranslate="error.http.403">You are not authorized to access this page.
-            </div>
-            <div [hidden]="!error404" class="alert alert-danger" jhiTranslate="error.http.404">The page does not exist.
+                <div class="alert alert-danger">{{ errorMessage }}</div>
             </div>
         </div>
     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
@@ -57,7 +57,10 @@ export class ErrorComponent implements OnInit<% if (enableTranslation) { %>, OnD
     <%_ if (enableTranslation) { _%>
 
     private getErrorMessageTranslation(): void {
-        this.translateService.get(this.errorKey).subscribe(translatedErrorMessage => this.errorMessage = translatedErrorMessage);
+        this.errorMessage = '';
+        if (this.errorKey) {
+          this.translateService.get(this.errorKey).subscribe(translatedErrorMessage => (this.errorMessage = translatedErrorMessage));
+        }
     }
 
     ngOnDestroy(): void {

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
@@ -16,34 +16,54 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, OnInit } from '@angular/core';
+import { Component, OnInit<% if (enableTranslation) { %>, OnDestroy<% } %> } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
+<%_ if (enableTranslation) { _%>
+import { Subscription } from 'rxjs';
+import { TranslateService } from '@ngx-translate/core';
+<%_ } _%>
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-error',
     templateUrl: './error.component.html'
 })
-export class ErrorComponent implements OnInit {
-    errorMessage: string;
-    error403: boolean;
-    error404: boolean;
+export class ErrorComponent implements OnInit<% if (enableTranslation) { %>, OnDestroy<% } %> {
+    errorMessage?: string;
+    <%_ if (enableTranslation) { _%>
+    errorKey?: string;
+    langChangeSubscription?: Subscription;
+    <%_ } _%>
 
     constructor(
+        <%_ if (enableTranslation) { _%>
+        private translateService: TranslateService,
+        <%_ } _%>
         private route: ActivatedRoute
-    ) {
-    }
+       ) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.route.data.subscribe((routeData) => {
-            if (routeData.error403) {
-                this.error403 = routeData.error403;
-            }
-            if (routeData.error404) {
-                this.error404 = routeData.error404;
-            }
             if (routeData.errorMessage) {
+                <%_ if (enableTranslation) { _%>
+                this.errorKey = routeData.errorMessage;
+                this.setErrorMessage();
+                this.langChangeSubscription = this.translateService.onLangChange.subscribe(() => this.setErrorMessage());
+                <%_ } else { _%>
                 this.errorMessage = routeData.errorMessage;
+                <%_ } _%>
             }
         });
     }
+    <%_ if (enableTranslation) { _%>
+
+    private setErrorMessage(): void {
+        this.translateService.get(this.errorKey).subscribe(translatedErrorMessage => this.errorMessage = translatedErrorMessage);
+    }
+
+    ngOnDestroy(): void {
+        if (this.langChangeSubscription) {
+            this.langChangeSubscription.unsubscribe();
+        }
+    }
+    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
@@ -46,8 +46,8 @@ export class ErrorComponent implements OnInit<% if (enableTranslation) { %>, OnD
             if (routeData.errorMessage) {
                 <%_ if (enableTranslation) { _%>
                 this.errorKey = routeData.errorMessage;
-                this.setErrorMessage();
-                this.langChangeSubscription = this.translateService.onLangChange.subscribe(() => this.setErrorMessage());
+                this.getErrorMessageTranslation();
+                this.langChangeSubscription = this.translateService.onLangChange.subscribe(() => this.getErrorMessageTranslation());
                 <%_ } else { _%>
                 this.errorMessage = routeData.errorMessage;
                 <%_ } _%>
@@ -56,7 +56,7 @@ export class ErrorComponent implements OnInit<% if (enableTranslation) { %>, OnD
     }
     <%_ if (enableTranslation) { _%>
 
-    private setErrorMessage(): void {
+    private getErrorMessageTranslation(): void {
         this.translateService.get(this.errorKey).subscribe(translatedErrorMessage => this.errorMessage = translatedErrorMessage);
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.route.ts.ejs
@@ -35,7 +35,7 @@ export const errorRoute: Routes = [
         data: {
             authorities: [],
             pageTitle: 'error.title',
-            error403: true
+            errorMessage: 'error.http.403'
         },
     },
     {
@@ -44,7 +44,7 @@ export const errorRoute: Routes = [
         data: {
             authorities: [],
             pageTitle: 'error.title',
-            error404: true
+            errorMessage: 'error.http.404'
         },
     },
     {

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -36,6 +36,21 @@ export class MainComponent implements OnInit {
         private router: Router
     ) {}
 
+    ngOnInit(): void {
+        this.router.events.subscribe(event => {
+            if (event instanceof NavigationEnd) {
+                this.updateTitle();
+            }
+            if (event instanceof NavigationError && event.error.status === 404) {
+                this.router.navigate(['/404']);
+            }
+        });
+        <%_ if (enableTranslation) { _%>
+
+        this.translateService.onLangChange.subscribe(() => this.updateTitle());
+        <%_ } _%>
+    }
+
     private getPageTitle(routeSnapshot: ActivatedRouteSnapshot): string {
         let title: string = (routeSnapshot.data && routeSnapshot.data['pageTitle']) ? routeSnapshot.data['pageTitle'] : '';
         if (routeSnapshot.firstChild) {
@@ -53,21 +68,6 @@ export class MainComponent implements OnInit {
         this.translateService.get(pageTitle).subscribe(title => this.titleService.setTitle(title));
         <%_ } else { _%>
         this.titleService.setTitle(pageTitle);
-        <%_ } _%>
-    }
-
-    ngOnInit(): void {
-        this.router.events.subscribe(event => {
-            if (event instanceof NavigationEnd) {
-                this.updateTitle();
-            }
-            if (event instanceof NavigationError && event.error.status === 404) {
-                this.router.navigate(['/404']);
-            }
-        });
-        <%_ if (enableTranslation) { _%>
-
-        this.translateService.onLangChange.subscribe(() => this.updateTitle());
         <%_ } _%>
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -16,96 +16,58 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component,<%_ if (authenticationType === 'oauth2') { _%> OnDestroy,<%_ } _%> OnInit } from '@angular/core';
-<%_ if (!enableTranslation) { _%>
+import { Component, OnInit } from '@angular/core';
 import { Title } from '@angular/platform-browser';
-<%_ } _%>
 import { Router, ActivatedRouteSnapshot, NavigationEnd, NavigationError } from '@angular/router';
-<%_ if (authenticationType === 'oauth2') { _%>
-import { Subject } from 'rxjs';
-import { takeUntil } from 'rxjs/operators';
-<%_ } _%>
-
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
-<%_ } _%>
-<%_ if (authenticationType === 'oauth2') { _%>
-import { Account } from 'app/core/user/account.model';
-import { AccountService } from 'app/core/auth/account.service';
-import { StateStorageService } from 'app/core/auth/state-storage.service';
+import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-main',
     templateUrl: './main.component.html'
 })
-export class <%=jhiPrefixCapitalized%>MainComponent implements OnInit<%_ if (authenticationType === 'oauth2') { _%>, OnDestroy<%_ } _%> {
-    <%_ if (authenticationType === 'oauth2') { _%>
-    _cleanup: Subject<any> = new Subject<any>();
-    <%_ } _%>
-
+export class MainComponent implements OnInit {
     constructor(
-        <%_ if (authenticationType === 'oauth2') { _%>
-        private accountService: AccountService,
-        private stateStorageService: StateStorageService,
-        <%_ } _%>
         <%_ if (enableTranslation) { _%>
-        private jhiLanguageHelper: JhiLanguageHelper,
-        <%_ } else { _%>
-        private titleService: Title,
+        private translateService: TranslateService,
         <%_ } _%>
+        private titleService: Title,
         private router: Router
     ) {}
 
-    private getPageTitle(routeSnapshot: ActivatedRouteSnapshot) {
-        let title: string = (routeSnapshot.data && routeSnapshot.data['pageTitle']) ? routeSnapshot.data['pageTitle'] : '<%= angularAppName %>';
+    private getPageTitle(routeSnapshot: ActivatedRouteSnapshot): string {
+        let title: string = (routeSnapshot.data && routeSnapshot.data['pageTitle']) ? routeSnapshot.data['pageTitle'] : '';
         if (routeSnapshot.firstChild) {
             title = this.getPageTitle(routeSnapshot.firstChild) || title;
         }
         return title;
     }
 
-    ngOnInit() {
-        this.router.events.subscribe((event) => {
+    private updateTitle(): void {
+        let pageTitle = this.getPageTitle(this.router.routerState.snapshot.root);
+        if (!pageTitle) {
+            pageTitle = '<% if (enableTranslation) { %>global.title<% } else { %><%= capitalizedBaseName %><% } %>';
+        }
+        <%_ if (enableTranslation) { _%>
+        this.translateService.get(pageTitle).subscribe(title => this.titleService.setTitle(title));
+        <%_ } else { _%>
+        this.titleService.setTitle(pageTitle);
+        <%_ } _%>
+    }
+
+    ngOnInit(): void {
+        this.router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
-                <%_ if (enableTranslation) { _%>
-                this.jhiLanguageHelper.updateTitle(this.getPageTitle(this.router.routerState.snapshot.root));
-                <%_ } else { _%>
-                this.titleService.setTitle(this.getPageTitle(this.router.routerState.snapshot.root));
-                <%_ } _%>
+                this.updateTitle();
             }
             if (event instanceof NavigationError && event.error.status === 404) {
                 this.router.navigate(['/404']);
             }
         });
-        <%_ if (authenticationType === 'oauth2') { _%>
-        this.subscribeToLoginEvents();
+        <%_ if (enableTranslation) { _%>
+
+        this.translateService.onLangChange.subscribe(() => this.updateTitle());
         <%_ } _%>
     }
-    <%_ if (authenticationType === 'oauth2') { _%>
-
-    ngOnDestroy() {
-        this._cleanup.next();
-        this._cleanup.complete();
-      }
-
-    private subscribeToLoginEvents() {
-        this.accountService
-            .getAuthenticationState()
-            .pipe(takeUntil(this._cleanup))
-            .subscribe((account: Account) => {
-                if (account) {
-                    this.navigateToStoredUrl();
-                }
-            });
-      }
-
-    private navigateToStoredUrl() {
-        const previousUrl = this.stateStorageService.getUrl();
-        if (previousUrl) {
-            this.stateStorageService.storeUrl(null);
-            this.router.navigateByUrl(previousUrl);
-        }
-    }
-    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/active-menu.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/active-menu.directive.ts.ejs
@@ -25,11 +25,11 @@ import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
     selector: '[<%=jhiPrefix%>ActiveMenu]'
 })
 export class ActiveMenuDirective implements OnInit {
-    @Input() <%=jhiPrefix%>ActiveMenu: string;
+    @Input() <%=jhiPrefix%>ActiveMenu?: string;
 
     constructor(private el: ElementRef, private renderer: Renderer<% if (enableTranslation) { %>, private translateService: TranslateService<% } %>) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
 <%_ if (enableTranslation) { _%>
       this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
          this.updateActiveFlag(event.lang);
@@ -37,7 +37,7 @@ export class ActiveMenuDirective implements OnInit {
       this.updateActiveFlag(this.translateService.currentLang);<% } %>
     }
 
-    updateActiveFlag(selectedLanguage) {
+    updateActiveFlag(selectedLanguage: string): void {
       if (this.<%=jhiPrefix%>ActiveMenu === selectedLanguage) {
           this.renderer.setElementClass(this.el.nativeElement, 'active', true);
       } else {

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
@@ -18,17 +18,14 @@
 -%>
 import { Component, OnInit } from '@angular/core';
 import { Router } from '@angular/router';
-<%_ if (authenticationType !== 'oauth2') { _%>
-import { NgbModalRef } from '@ng-bootstrap/ng-bootstrap';
-<%_ } _%>
-import { JhiLanguageService } from 'ng-jhipster';
 <%_ if (enableTranslation) { _%>
+import { JhiLanguageService } from 'ng-jhipster';
 import { SessionStorageService } from 'ngx-webstorage';
 <%_ } _%>
 
 import { VERSION } from 'app/app.constants';
 <%_ if (enableTranslation) { _%>
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
+import { LANGUAGES } from 'app/core/language/language.constants';
 <%_ } _%>
 import { AccountService } from 'app/core/auth/account.service';
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -45,22 +42,18 @@ import { ProfileService } from 'app/layouts/profiles/profile.service';
     ]
 })
 export class NavbarComponent implements OnInit {
-    inProduction: boolean;
-    isNavbarCollapsed: boolean;
+    inProduction?: boolean;
+    isNavbarCollapsed = true;
     <%_ if (enableTranslation) { _%>
-    languages: any[];
+    languages = LANGUAGES;
     <%_ } _%>
-    swaggerEnabled: boolean;
-    <%_ if (authenticationType !== 'oauth2') { _%>
-    modalRef: NgbModalRef;
-    <%_ } _%>
+    swaggerEnabled?: boolean;
     version: string;
 
     constructor(
         private loginService: LoginService,
         <%_ if (enableTranslation) { _%>
         private languageService: JhiLanguageService,
-        private languageHelper: JhiLanguageHelper,
         private sessionStorage: SessionStorageService,
         <%_ } _%>
         private accountService: AccountService,
@@ -71,14 +64,9 @@ export class NavbarComponent implements OnInit {
         private router: Router
     ) {
         this.version = VERSION ? (VERSION.toLowerCase().startsWith('v') ? VERSION : 'v' + VERSION) : '';
-        this.isNavbarCollapsed = true;
     }
 
-    ngOnInit() {
-        <%_ if (enableTranslation) { _%>
-        this.languages = this.languageHelper.getAll();
-
-        <%_ } _%>
+    ngOnInit(): void {
         this.profileService.getProfileInfo().subscribe((profileInfo) => {
             this.inProduction = profileInfo.inProduction;
             this.swaggerEnabled = profileInfo.swaggerEnabled;
@@ -86,39 +74,39 @@ export class NavbarComponent implements OnInit {
     }
 
     <%_ if (enableTranslation) { _%>
-    changeLanguage(languageKey: string) {
+    changeLanguage(languageKey: string): void {
         this.sessionStorage.store('locale', languageKey);
         this.languageService.changeLanguage(languageKey);
     }
 
     <%_ } _%>
-    collapseNavbar() {
+    collapseNavbar(): void {
         this.isNavbarCollapsed = true;
     }
 
-    isAuthenticated() {
+    isAuthenticated(): boolean {
         return this.accountService.isAuthenticated();
     }
 
-    login() {
+    login(): void {
         <%_ if (authenticationType !== 'oauth2') { _%>
-        this.modalRef = this.loginModalService.open();
+        this.loginModalService.open();
         <%_ } else { _%>
         this.loginService.login();
         <%_ } _%>
     }
 
-    logout() {
+    logout(): void {
         this.collapseNavbar();
         this.loginService.logout();
         this.router.navigate(['']);
     }
 
-    toggleNavbar() {
+    toggleNavbar(): void {
         this.isNavbarCollapsed = !this.isNavbarCollapsed;
     }
 
-    getImageUrl() {
-        return this.isAuthenticated() ? this.accountService.getImageUrl() : null;
+    getImageUrl(): string {
+        return this.isAuthenticated() ? this.accountService.getImageUrl() : '';
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/page-ribbon.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/page-ribbon.component.ts.ejs
@@ -33,11 +33,11 @@ import { ProfileService } from './profile.service';
     ]
 })
 export class PageRibbonComponent implements OnInit {
-    ribbonEnv$: Observable<string>;
+    ribbonEnv$?: Observable<string | undefined>;
 
     constructor(private profileService: ProfileService) {}
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.ribbonEnv$ = this.profileService.getProfileInfo().pipe(map(profileInfo => profileInfo.ribbonEnv));
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile-info.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile-info.model.ts.ejs
@@ -16,9 +16,19 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-export class ProfileInfo {
-    activeProfiles: string[];
-    ribbonEnv: string;
-    inProduction: boolean;
-    swaggerEnabled: boolean;
-}
+export interface InfoResponse {
+    'display-ribbon-on-profiles'?: string;
+    git?: any;
+    build?: any;
+    activeProfiles?: string[];
+  }
+  
+  export class ProfileInfo {
+    constructor(
+        public activeProfiles?: string[],
+        public ribbonEnv?: string,
+        public inProduction?: boolean,
+        public swaggerEnabled?: boolean
+    ) {}
+  }
+  

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -22,13 +22,13 @@ import { map, shareReplay } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
 import { SERVER_API_URL } from 'app/app.constants';
-import { ProfileInfo } from './profile-info.model';
+import { ProfileInfo, InfoResponse } from './profile-info.model';
 
 @Injectable({providedIn: 'root'})
 export class ProfileService {
 
     private infoUrl = SERVER_API_URL + 'management/info';
-    private profileInfo$: Observable<ProfileInfo>;
+    private profileInfo$!: Observable<ProfileInfo>;
 
     constructor(private http: HttpClient) { }
 
@@ -37,20 +37,23 @@ export class ProfileService {
             return this.profileInfo$;
         }
 
-        this.profileInfo$ = this.http.get<ProfileInfo>(this.infoUrl).pipe(
-            map((profileInfo: ProfileInfo) => {
-                const pi = new ProfileInfo();
-                pi.activeProfiles = profileInfo.activeProfiles;
-                const displayRibbonOnProfiles = profileInfo['display-ribbon-on-profiles'].split(',');
-                if (pi.activeProfiles) {
-                    const ribbonProfiles = displayRibbonOnProfiles.filter(profile => pi.activeProfiles.includes(profile));
-                    if (ribbonProfiles.length !== 0) {
-                        pi.ribbonEnv = ribbonProfiles[0];
+        this.profileInfo$ = this.http.get<InfoResponse>(this.infoUrl).pipe(
+            map((response: InfoResponse) => {
+                const profileInfo: ProfileInfo = {
+                    activeProfiles: response.activeProfiles,
+                    inProduction: response.activeProfiles && response.activeProfiles.includes('prod'),
+                    swaggerEnabled: response.activeProfiles && response.activeProfiles.includes('swagger')
+                };
+                if (response.activeProfiles && response['display-ribbon-on-profiles']) {
+                    const displayRibbonOnProfiles = response['display-ribbon-on-profiles'].split(',');
+                    const ribbonProfiles = displayRibbonOnProfiles.filter(
+                        profile => response.activeProfiles && response.activeProfiles.includes(profile)
+                    );
+                    if (ribbonProfiles.length > 0) {
+                        profileInfo.ribbonEnv = ribbonProfiles[0];
                     }
-                    pi.inProduction = pi.activeProfiles.includes('prod');
-                    pi.swaggerEnabled = pi.activeProfiles.includes('swagger');
                 }
-                return pi;
+                return profileInfo;
             }),
             shareReplay()
         );

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
@@ -33,7 +33,7 @@
                 <div class="form-group">
                     <label class="username-label" for="username" jhiTranslate="global.form.username.label">Login</label>
                     <input type="text" class="form-control" name="username" id="username" placeholder="{{'global.form.username.placeholder' | translate}}"
-                           formControlName="username">
+                           formControlName="username" #username>
                 </div>
                 <div class="form-group">
                     <label for="password" jhiTranslate="login.form.password">Password</label>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -16,20 +16,22 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Component, AfterViewInit, Renderer, ElementRef } from '@angular/core';
+import { Component, AfterViewInit, Renderer, ElementRef, ViewChild } from '@angular/core';
 import { FormBuilder } from '@angular/forms';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { Router } from '@angular/router';
 
 import { LoginService } from 'app/core/login/login.service';
-import { StateStorageService } from 'app/core/auth/state-storage.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-login-modal',
     templateUrl: './login.component.html'
 })
-export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewInit {
-    authenticationError: boolean;
+export class LoginModalComponent implements AfterViewInit {
+    @ViewChild('username', { static: false })
+    username?: ElementRef;
+
+    authenticationError = false;
 
     loginForm = this.fb.group({
         username: [''],
@@ -39,20 +41,20 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
 
     constructor(
         private loginService: LoginService,
-        private stateStorageService: StateStorageService,
         private elementRef: ElementRef,
         private renderer: Renderer,
         private router: Router,
         public activeModal: NgbActiveModal,
         private fb: FormBuilder
-    ) {
+    ) {}
+
+    ngAfterViewInit(): void {
+        if (this.username) {
+            this.renderer.invokeElementMethod(this.username.nativeElement, 'focus', []);
+        }
     }
 
-    ngAfterViewInit() {
-        setTimeout(() => this.renderer.invokeElementMethod(this.elementRef.nativeElement.querySelector('#username'), 'focus', []), 0);
-    }
-
-    cancel() {
+    cancel(): void {
         this.authenticationError = false;
         this.loginForm.patchValue({
             username: '',
@@ -61,35 +63,30 @@ export class <%=jhiPrefixCapitalized%>LoginModalComponent implements AfterViewIn
         this.activeModal.dismiss('cancel');
     }
 
-    login() {
+    login(): void {
         this.loginService.login({
-            username: this.loginForm.get('username').value,
-            password: this.loginForm.get('password').value,
-            rememberMe: this.loginForm.get('rememberMe').value
+            username: this.loginForm.get('username')!.value,
+            password: this.loginForm.get('password')!.value,
+            rememberMe: this.loginForm.get('rememberMe')!.value
         }).subscribe(() => {
             this.authenticationError = false;
-            this.activeModal.dismiss('login success');
-            if (this.router.url === '/account/register' || this.router.url.startsWith('/account/activate') ||
-this.router.url.startsWith('/account/reset/')) {
+            this.activeModal.close();
+            if (
+                this.router.url === '/account/register' ||
+                this.router.url.startsWith('/account/activate') ||
+                this.router.url.startsWith('/account/reset/')
+            ) {
                 this.router.navigate(['']);
-            }
-
-            // previousState was set in the authExpiredInterceptor before being redirected to login modal.
-            // since login is successful, go to stored previousState and clear previousState
-            const redirect = this.stateStorageService.getUrl();
-            if (redirect) {
-                this.stateStorageService.storeUrl(null);
-                this.router.navigateByUrl(redirect);
             }
         }, () => this.authenticationError = true);
     }
 
-    register() {
+    register(): void {
         this.activeModal.dismiss('to state register');
         this.router.navigate(['/account/register']);
     }
 
-    requestResetPassword() {
+    requestResetPassword(): void {
         this.activeModal.dismiss('to state requestReset');
         this.router.navigate(['/account/reset', 'request']);
     }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
@@ -24,7 +24,7 @@ import { FindLanguageFromKeyPipe } from './language/find-language-from-key.pipe'
 import { <%=jhiPrefixCapitalized%>AlertComponent } from './alert/alert.component';
 import { <%=jhiPrefixCapitalized%>AlertErrorComponent } from './alert/alert-error.component';
 <%_ if (authenticationType !== 'oauth2') { _%>
-import { <%=jhiPrefixCapitalized%>LoginModalComponent } from './login/login.component';
+import { LoginModalComponent } from './login/login.component';
 <%_ } _%>
 import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
 
@@ -39,12 +39,12 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         <%=jhiPrefixCapitalized%>AlertComponent,
         <%=jhiPrefixCapitalized%>AlertErrorComponent,
         <%_ if (authenticationType !== 'oauth2') { _%>
-        <%=jhiPrefixCapitalized%>LoginModalComponent,
+        LoginModalComponent,
         <%_ } _%>
         HasAnyAuthorityDirective
     ],
     <%_ if (authenticationType !== 'oauth2') { _%>
-    entryComponents: [<%=jhiPrefixCapitalized%>LoginModalComponent],
+    entryComponents: [LoginModalComponent],
     <%_ } _%>
     exports: [
         <%=angularXAppName%>SharedLibsModule,
@@ -54,7 +54,7 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         <%=jhiPrefixCapitalized%>AlertComponent,
         <%=jhiPrefixCapitalized%>AlertErrorComponent,
         <%_ if (authenticationType !== 'oauth2') { _%>
-        <%=jhiPrefixCapitalized%>LoginModalComponent,
+        LoginModalComponent,
         <%_ } _%>
         HasAnyAuthorityDirective
     ]

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
@@ -26,15 +26,9 @@ import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
-<%_ if (enableTranslation) { _%>
-import { MockLanguageHelper } from '../../../helpers/mock-language.service';
-<%_ } _%>
 import { UserManagementUpdateComponent } from 'app/admin/user-management/user-management-update.component';
 import { UserService } from 'app/core/user/user.service';
 import { User } from 'app/core/user/user.model';
-<%_ if (enableTranslation) { _%>
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
-<%_ } _%>
 
 describe('Component Tests', () => {
 
@@ -42,9 +36,6 @@ describe('Component Tests', () => {
         let comp: UserManagementUpdateComponent;
         let fixture: ComponentFixture<UserManagementUpdateComponent>;
         let service: UserService;
-        <%_ if (enableTranslation) { _%>
-        let mockLanguageHelper: MockLanguageHelper;
-        <%_ } _%>
         const route: ActivatedRoute = ({data: of({user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin')})} as any) as ActivatedRoute;
 
         beforeEach(async(() => {
@@ -67,9 +58,6 @@ describe('Component Tests', () => {
             fixture = TestBed.createComponent(UserManagementUpdateComponent);
             comp = fixture.componentInstance;
             service = fixture.debugElement.injector.get(UserService);
-            <%_ if (enableTranslation) { _%>
-            mockLanguageHelper = TestBed.get(JhiLanguageHelper);
-            <%_ } _%>
         });
 
         describe('OnInit', () => {
@@ -85,9 +73,6 @@ describe('Component Tests', () => {
                         // THEN
                         expect(service.authorities).toHaveBeenCalled();
                         expect(comp.authorities).toEqual(['USER']);
-                        <%_ if (enableTranslation) { _%>
-                        expect(mockLanguageHelper.getAllSpy).toHaveBeenCalled();
-                        <%_ } _%>
                     })
                 )
             );

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -1,3 +1,4 @@
+import { Router } from '@angular/router';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { TestBed } from '@angular/core/testing';
 <%_ if (websocket === 'spring-websocket') { _%>
@@ -13,12 +14,15 @@ import { NgxWebstorageModule } from 'ngx-webstorage';
 import { SERVER_API_URL } from 'app/app.constants';
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/user/account.model';
+import { StateStorageService } from 'app/core/auth/state-storage.service';
 <%_ if (enableTranslation) { _%>
 import { MockLanguageService } from '../../../helpers/mock-language.service';
 <%_ } _%>
 <%_ if (websocket === 'spring-websocket') { _%>
 import { MockTrackerService } from '../../../helpers/mock-tracker.service';
 <%_ } _%>
+import { MockRouter } from '../../../helpers/mock-route.service';
+import { MockStateStorageService } from '../../../helpers/mock-state-storage.service';
 
 function accountWithAuthorities(authorities: string[]): Account {
   return {
@@ -37,7 +41,12 @@ describe('Service Tests', () => {
     describe('Account Service', () => {
         let service: AccountService;
         let httpMock: HttpTestingController;
-
+        let storageService: MockStateStorageService;
+        let router: MockRouter;
+        <%_ if (websocket === 'spring-websocket') { _%>
+        let trackerService: TrackerService;
+        <%_ } _%>
+    
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [
@@ -56,20 +65,70 @@ describe('Service Tests', () => {
                     {
                         provide: TrackerService,
                         useClass: MockTrackerService
-                    }
+                    },
                     <%_ } _%>
+                    {
+                        provide: StateStorageService,
+                        useClass: MockStateStorageService
+                    },
+                    {
+                        provide: Router,
+                        useClass: MockRouter
+                    }
                 ]
             });
 
             service = TestBed.get(AccountService);
             httpMock = TestBed.get(HttpTestingController);
+            storageService = TestBed.get(StateStorageService);
+            router = TestBed.get(Router);
+            <%_ if (websocket === 'spring-websocket') { _%>
+            trackerService = TestBed.get(TrackerService);
+            <%_ } _%>
         });
 
         afterEach(() => {
             httpMock.verify();
         });
 
-        describe('Service methods', () => {
+        describe('authenticate', () => {
+            it('authenticationState should emit null if input is null', () => {
+                // GIVEN
+                let userIdentity: Account | null = accountWithAuthorities([]);
+                service.getAuthenticationState().subscribe(account => (userIdentity = account));
+
+                // WHEN
+                service.authenticate(null);
+
+                // THEN
+                expect(userIdentity).toBeNull();
+                expect(service.isAuthenticated()).toBe(false);
+                <%_ if (websocket === 'spring-websocket') { _%>
+                expect(trackerService.disconnect).toHaveBeenCalled();
+                expect(trackerService.connect).not.toHaveBeenCalled();
+                <%_ } _%>
+            });
+
+            it('authenticationState should emit the same account as was in input parameter', () => {
+                // GIVEN
+                const expectedResult = accountWithAuthorities([]);
+                let userIdentity: Account | null = null;
+                service.getAuthenticationState().subscribe(account => (userIdentity = account));
+
+                // WHEN
+                service.authenticate(expectedResult);
+
+                // THEN
+                expect(userIdentity).toEqual(expectedResult);
+                expect(service.isAuthenticated()).toBe(true);
+                <%_ if (websocket === 'spring-websocket') { _%>
+                expect(trackerService.connect).toHaveBeenCalled();
+                expect(trackerService.disconnect).not.toHaveBeenCalled();
+                <%_ } _%>
+            });
+        });
+
+        describe('identity', () => {
             it('should call /account if user is undefined', () => {
                 service.identity().subscribe();
                 const req = httpMock.expectOne({ method: 'GET' });
@@ -81,10 +140,7 @@ describe('Service Tests', () => {
             it('should call /account only once if not logged out after first authentication and should call /account again if user has logged out', () => {
                 // Given the user is authenticated
                 service.identity().subscribe();
-                const req = httpMock.expectOne({ method: 'GET' });
-                req.flush({
-                    firstName: 'Unimportant'
-                });
+                httpMock.expectOne({ method: 'GET' }).flush({});
 
                 // When I call
                 service.identity().subscribe();
@@ -101,6 +157,49 @@ describe('Service Tests', () => {
                 httpMock.expectOne({ method: 'GET' });
             });
 
+            describe('navigateToStoredUrl', () => {
+                it('should navigate to the previous stored url post successful authentication', () => {
+                    // GIVEN
+                    storageService.setResponse('admin/users?page=0');
+
+                    // WHEN
+                    service.identity().subscribe();
+                    httpMock.expectOne({ method: 'GET' }).flush({});
+
+                    // THEN
+                    expect(storageService.getUrlSpy).toHaveBeenCalledTimes(1);
+                    expect(storageService.clearUrlSpy).toHaveBeenCalledTimes(1);
+                    expect(router.navigateByUrlSpy).toHaveBeenCalledWith('admin/users?page=0');
+                });
+
+                it('should not navigate to the previous stored url when authentication fails', () => {
+                    // WHEN
+                    service.identity().subscribe();
+                    httpMock.expectOne({ method: 'GET' }).error(new ErrorEvent(''));
+
+                    // THEN
+                    expect(storageService.getUrlSpy).not.toHaveBeenCalled();
+                    expect(storageService.clearUrlSpy).not.toHaveBeenCalled();
+                    expect(router.navigateByUrlSpy).not.toHaveBeenCalled();
+                });
+
+                it('should not navigate to the previous stored url when no such url exists post successful authentication', () => {
+                    // GIVEN
+                    storageService.setResponse(null);
+
+                    // WHEN
+                    service.identity().subscribe();
+                    httpMock.expectOne({ method: 'GET' }).flush({});
+
+                    // THEN
+                    expect(storageService.getUrlSpy).toHaveBeenCalledTimes(1);
+                    expect(storageService.clearUrlSpy).not.toHaveBeenCalled();
+                    expect(router.navigateByUrlSpy).not.toHaveBeenCalled();
+                });
+            });
+        });
+
+        describe('hasAnyAuthority', () => {
             describe('hasAnyAuthority string parameter', () => {
                 it('should return false if user is not logged', () => {
                     const hasAuthority = service.hasAnyAuthority('ROLE_USER');

--- a/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
@@ -17,84 +17,211 @@
  limitations under the License.
 -%>
 import { async, ComponentFixture, TestBed } from '@angular/core/testing';
-import { NavigationCancel, Router } from '@angular/router';
+import { Router, RouterEvent, NavigationEnd } from '@angular/router';
+import { Title } from '@angular/platform-browser';
+import { Subject<% if (enableTranslation) { %>, of<% } %> } from 'rxjs';
+<%_ if (enableTranslation) { _%>
+import { TranslateModule, TranslateService, LangChangeEvent } from '@ngx-translate/core';
+<%_ } _%>
 
-import { AccountService } from 'app/core/auth/account.service';
-import { StateStorageService } from 'app/core/auth/state-storage.service';
-import { <%=jhiPrefixCapitalized%>MainComponent } from 'app/layouts/main/main.component';
-import { MockStateStorageService } from '../../../helpers/mock-state-storage.service';
+import { MainComponent } from 'app/layouts/main/main.component';
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
+import { MockRouter } from '../../../helpers/mock-route.service';
 
 describe('Component Tests', () => {
   describe('MainComponent', () => {
-    let comp: <%=jhiPrefixCapitalized%>MainComponent;
-    let fixture: ComponentFixture<<%=jhiPrefixCapitalized%>MainComponent>;
-    let accountService: any;
-    let storageService: any;
-    let router: any;
-
+    let comp: MainComponent;
+    let fixture: ComponentFixture<MainComponent>;
+    let router: MockRouter;
+    const routerEventsSubject = new Subject<RouterEvent>();
+    let titleService: Title;
+    <%_ if (enableTranslation) { _%>
+    let translateService: TranslateService;
+    <%_ } _%>
+  
     beforeEach(async(() => {
       TestBed.configureTestingModule({
-        imports: [<%=angularXAppName%>TestModule],
-        declarations: [<%=jhiPrefixCapitalized%>MainComponent],
-        providers: [
-          {
-            provide: StateStorageService,
-            useClass: MockStateStorageService
-          }
-        ]
+        imports: [
+          <%=angularXAppName%>TestModule,
+          <%_ if (enableTranslation) { _%>
+          TranslateModule.forRoot(),
+          <%_ } _%>
+        ],
+        declarations: [MainComponent],
+        providers: [Title]
       })
-        .overrideTemplate(<%=jhiPrefixCapitalized%>MainComponent, '')
+        .overrideTemplate(MainComponent, '')
         .compileComponents();
     }));
 
     beforeEach(() => {
-      fixture = TestBed.createComponent(<%=jhiPrefixCapitalized%>MainComponent);
+      fixture = TestBed.createComponent(MainComponent);
       comp = fixture.componentInstance;
-      accountService = fixture.debugElement.injector.get(AccountService);
-      storageService = fixture.debugElement.injector.get(StateStorageService);
-      router = fixture.debugElement.injector.get(Router);
+      router = TestBed.get(Router);
+      router.setEvents(routerEventsSubject.asObservable());
+      titleService = TestBed.get(Title);
+      <%_ if (enableTranslation) { _%>
+      translateService = TestBed.get(TranslateService);
+      <%_ } _%>
     });
 
-    it('should navigate to the previous stored url post successful authentication', () => {
-      accountService.setIdentityResponse({ firstName: 'John' });
-      storageService.setResponse('admin/users?page=0');
-      router.setRouterEvent(new NavigationCancel(0, 'http://localhost:9000', 'cancel'));
+    describe('page title', () => {
+      let routerState: any;
+      const defaultPageTitle = '<% if (enableTranslation) { %>global.title<% } else { %><%= capitalizedBaseName %><% } %>';
+      const parentRoutePageTitle = 'parentTitle';
+      const childRoutePageTitle = 'childTitle';
+      const navigationEnd = new NavigationEnd(1, '', '');
+      <%_ if (enableTranslation) { _%>
+      const langChangeEvent: LangChangeEvent = { lang: 'en', translations: null };
+      <%_ } _%>
 
-      // WHEN/
-      comp.ngOnInit();
+      beforeEach(() => {
+        routerState = { snapshot: { root: {} } };
+        router.setRouterState(routerState);
+        <%_ if (enableTranslation) { _%>
+        spyOn(translateService, 'get').and.callFake((key: string) => {
+          return of(key + ' translated');
+        });
+        <%_ } _%>
+        spyOn(titleService, 'setTitle');
+        comp.ngOnInit();
+      });
 
-      // THEN
-      expect(storageService.getUrlSpy).toHaveBeenCalledTimes(1);
-      expect(storageService.storeUrlSpy).toHaveBeenCalledWith(null);
-      expect(router.navigateByUrlSpy).toHaveBeenCalledWith('admin/users?page=0');
-    });
+      describe('navigation end', () => {
+        it('should set page title to default title if pageTitle is missing on routes', () => {
+          // WHEN
+          routerEventsSubject.next(navigationEnd);
 
-    it('should not navigate to the previous stored url when authentication fails', () => {
-      accountService.setIdentityResponse();
-      router.setRouterEvent(new NavigationCancel(0, 'http://localhost:9000', 'cancel'));
+          // THEN
+          <%_ if (enableTranslation) { _%>
+          expect(translateService.get).toHaveBeenCalledWith(defaultPageTitle);
+          <%_ } _%>
+          expect(titleService.setTitle).toHaveBeenCalledWith(defaultPageTitle<% if (enableTranslation) { %> + ' translated'<% } %>);
+        });
 
-      // WHEN/
-      comp.ngOnInit();
+        it('should set page title to root route pageTitle if there is no child routes', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
 
-      // THEN
-      expect(storageService.getUrlSpy).not.toHaveBeenCalled();
-      expect(storageService.storeUrlSpy).not.toHaveBeenCalled();
-      expect(router.navigateByUrlSpy).not.toHaveBeenCalled();
-    });
+          // WHEN
+          routerEventsSubject.next(navigationEnd);
 
-    it('should not navigate to the previous stored url when no such url exists post successful authentication', () => {
-      accountService.setIdentityResponse({ firstName: 'John' });
-      storageService.setResponse(undefined);
-      router.setRouterEvent(new NavigationCancel(0, 'http://localhost:9000', 'cancel'));
+          // THEN
+          <%_ if (enableTranslation) { _%>
+          expect(translateService.get).toHaveBeenCalledWith(parentRoutePageTitle);
+          <%_ } _%>
+          expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle<% if (enableTranslation) { %> + ' translated'<% } %>);
+        });
 
-      // WHEN/
-      comp.ngOnInit();
+        it('should set page title to child route pageTitle if child routes exist and pageTitle is set for child route', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+          routerState.snapshot.root.firstChild = { data: { pageTitle: childRoutePageTitle } };
 
-      // THEN
-      expect(storageService.getUrlSpy).toHaveBeenCalledTimes(1);
-      expect(storageService.storeUrlSpy).not.toHaveBeenCalled();
-      expect(router.navigateByUrlSpy).not.toHaveBeenCalled();
+          // WHEN
+          routerEventsSubject.next(navigationEnd);
+
+          // THEN
+          <%_ if (enableTranslation) { _%>
+          expect(translateService.get).toHaveBeenCalledWith(childRoutePageTitle);
+          <%_ } _%>
+          expect(titleService.setTitle).toHaveBeenCalledWith(childRoutePageTitle<% if (enableTranslation) { %> + ' translated'<% } %>);
+        });
+
+        it('should set page title to parent route pageTitle if child routes exists but pageTitle is not set for child route data', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+          routerState.snapshot.root.firstChild = { data: {} };
+
+          // WHEN
+          routerEventsSubject.next(navigationEnd);
+
+          // THEN
+          <%_ if (enableTranslation) { _%>
+          expect(translateService.get).toHaveBeenCalledWith(parentRoutePageTitle);
+          <%_ } _%>
+          expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle<% if (enableTranslation) { %> + ' translated'<% } %>);
+        });
+
+        it('should set page title to parent route pageTitle if child routes exists but data is not set for child route', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+          routerState.snapshot.root.firstChild = {};
+
+          // WHEN
+          routerEventsSubject.next(navigationEnd);
+
+          // THEN
+          <%_ if (enableTranslation) { _%>
+          expect(translateService.get).toHaveBeenCalledWith(parentRoutePageTitle);
+          <%_ } _%>
+          expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle<% if (enableTranslation) { %> + ' translated'<% } %>);
+        });
+      });
+      <%_ if (enableTranslation) { _%>
+
+      describe('language change', () => {
+        it('should set page title to default title if pageTitle is missing on routes', () => {
+          // WHEN
+          translateService.onLangChange.emit(langChangeEvent);
+
+          // THEN
+          expect(translateService.get).toHaveBeenCalledWith(defaultPageTitle);
+          expect(titleService.setTitle).toHaveBeenCalledWith(defaultPageTitle + ' translated');
+        });
+
+        it('should set page title to root route pageTitle if there is no child routes', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+
+          // WHEN
+          translateService.onLangChange.emit(langChangeEvent);
+
+          // THEN
+          expect(translateService.get).toHaveBeenCalledWith(parentRoutePageTitle);
+          expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle + ' translated');
+        });
+
+        it('should set page title to child route pageTitle if child routes exist and pageTitle is set for child route', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+          routerState.snapshot.root.firstChild = { data: { pageTitle: childRoutePageTitle } };
+
+          // WHEN
+          translateService.onLangChange.emit(langChangeEvent);
+
+          // THEN
+          expect(translateService.get).toHaveBeenCalledWith(childRoutePageTitle);
+          expect(titleService.setTitle).toHaveBeenCalledWith(childRoutePageTitle + ' translated');
+        });
+
+        it('should set page title to parent route pageTitle if child routes exists but pageTitle is not set for child route data', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+          routerState.snapshot.root.firstChild = { data: {} };
+
+          // WHEN
+          translateService.onLangChange.emit(langChangeEvent);
+
+          // THEN
+          expect(translateService.get).toHaveBeenCalledWith(parentRoutePageTitle);
+          expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle + ' translated');
+        });
+
+        it('should set page title to parent route pageTitle if child routes exists but data is not set for child route', () => {
+          // GIVEN
+          routerState.snapshot.root.data = { pageTitle: parentRoutePageTitle };
+          routerState.snapshot.root.firstChild = {};
+
+          // WHEN
+          translateService.onLangChange.emit(langChangeEvent);
+
+          // THEN
+          expect(translateService.get).toHaveBeenCalledWith(parentRoutePageTitle);
+          expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle + ' translated');
+        });
+      });
+      <%_ } _%>
     });
   });
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
@@ -22,53 +22,46 @@ import { Router } from '@angular/router';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
 import { LoginService } from 'app/core/login/login.service';
-import { <%=jhiPrefixCapitalized%>LoginModalComponent } from 'app/shared/login/login.component';
-import { StateStorageService } from 'app/core/auth/state-storage.service';
+import { LoginModalComponent } from 'app/shared/login/login.component';
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { MockLoginService } from '../../../helpers/mock-login.service';
-import { MockStateStorageService } from '../../../helpers/mock-state-storage.service';
+import { MockRouter } from '../../../helpers/mock-route.service';
+import { MockActiveModal } from '../../../helpers/mock-active-modal.service';
 
 describe('Component Tests', () => {
 
     describe('LoginComponent', () => {
-
-        let comp: <%=jhiPrefixCapitalized%>LoginModalComponent;
-        let fixture: ComponentFixture<<%=jhiPrefixCapitalized%>LoginModalComponent>;
-        let mockLoginService: any;
-        let mockStateStorageService: any;
-        let mockRouter: any;
-        let mockActiveModal: any;
+        let comp: LoginModalComponent;
+        let fixture: ComponentFixture<LoginModalComponent>;
+        let mockLoginService: MockLoginService;
+        let mockRouter: MockRouter;
+        let mockActiveModal: MockActiveModal;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
-                declarations: [<%=jhiPrefixCapitalized%>LoginModalComponent],
+                declarations: [LoginModalComponent],
                 providers : [
                     FormBuilder,
                     {
                         provide: LoginService,
                         useClass: MockLoginService
-                    },
-                    {
-                        provide: StateStorageService,
-                        useClass: MockStateStorageService
                     }
                 ]
             })
-            .overrideTemplate(<%=jhiPrefixCapitalized%>LoginModalComponent, '')
+            .overrideTemplate(LoginModalComponent, '')
             .compileComponents();
         }));
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(<%=jhiPrefixCapitalized%>LoginModalComponent);
+            fixture = TestBed.createComponent(LoginModalComponent);
             comp = fixture.componentInstance;
-            mockLoginService = fixture.debugElement.injector.get(LoginService);
-            mockStateStorageService = fixture.debugElement.injector.get(StateStorageService);
-            mockRouter = fixture.debugElement.injector.get(Router);
-            mockActiveModal = fixture.debugElement.injector.get(NgbActiveModal);
+            mockLoginService = TestBed.get(LoginService);
+            mockRouter = TestBed.get(Router);
+            mockActiveModal = TestBed.get(NgbActiveModal);
         });
 
-        it('should authenticate the user upon login when previous state was set',
+        it('should authenticate the user',
             inject([],
                 fakeAsync(() => {
                     // GIVEN
@@ -84,7 +77,6 @@ describe('Component Tests', () => {
                         rememberMe: true
                     });
                     mockLoginService.setResponse({});
-                    mockStateStorageService.setResponse('admin/users?page=0');
                     mockRouter.url = '/admin/metrics';
 
                     // WHEN/
@@ -93,51 +85,14 @@ describe('Component Tests', () => {
 
                     // THEN
                     expect(comp.authenticationError).toEqual(false);
-                    expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('login success');
+                    expect(mockActiveModal.closeSpy).toHaveBeenCalled();
                     expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
-                    expect(mockStateStorageService.getUrlSpy).toHaveBeenCalledTimes(1);
-                    expect(mockStateStorageService.storeUrlSpy).toHaveBeenCalledWith(null);
-                    expect(mockRouter.navigateByUrlSpy).toHaveBeenCalledWith('admin/users?page=0');
-                })
-            )
-        );
-
-        it('should authenticate the user upon login when previous state was not set',
-            inject([],
-                fakeAsync(() => {
-                    // GIVEN
-                    const credentials = {
-                        username: 'admin',
-                        password: 'admin',
-                        rememberMe: true
-                    };
-                    comp.loginForm.patchValue({
-                        username: 'admin',
-                        password: 'admin',
-                        rememberMe: true
-                    });
-                    mockLoginService.setResponse({});
-                    mockStateStorageService.setResponse(null);
-                    mockRouter.url = '/admin/metrics';
-
-                    // WHEN
-                    comp.login();
-                    tick(); // simulate async
-
-                    // THEN
-                    expect(comp.authenticationError).toEqual(false);
-                    expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('login success');
-                    expect(mockLoginService.loginSpy).toHaveBeenCalledWith(credentials);
-                    expect(mockStateStorageService.getUrlSpy).toHaveBeenCalledTimes(1);
-                    expect(mockStateStorageService.storeUrlSpy).not.toHaveBeenCalled();
-                    expect(mockRouter.navigateSpy).not.toHaveBeenCalled();
                 })
             )
         );
 
         it('should empty the credentials upon cancel', () => {
             // GIVEN
-
             comp.loginForm.patchValue({
                 username: 'admin',
                 password: 'admin'
@@ -155,9 +110,9 @@ describe('Component Tests', () => {
 
             // THEN
             expect(comp.authenticationError).toEqual(false);
-            expect(comp.loginForm.get('username').value).toEqual(expected.username);
-            expect(comp.loginForm.get('password').value).toEqual(expected.password);
-            expect(comp.loginForm.get('rememberMe').value).toEqual(expected.rememberMe);
+            expect(comp.loginForm.get('username')!.value).toEqual(expected.username);
+            expect(comp.loginForm.get('password')!.value).toEqual(expected.password);
+            expect(comp.loginForm.get('rememberMe')!.value).toEqual(expected.rememberMe);
             expect(mockActiveModal.dismissSpy).toHaveBeenCalledWith('cancel');
         });
 

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-language.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-language.service.ts.ejs
@@ -18,27 +18,14 @@
 -%>
 import { SpyObject } from './spyobject';
 import { JhiLanguageService } from 'ng-jhipster';
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
 import Spy = jasmine.Spy;
 
 export class MockLanguageService extends SpyObject {
     getCurrentLanguageSpy: Spy;
-    fakeResponse: string;
 
     constructor() {
         super(JhiLanguageService);
 
-        this.fakeResponse = '<%= nativeLanguage %>';
-        this.getCurrentLanguageSpy = this.spy('getCurrentLanguage').andReturn(this.fakeResponse);
-    }
-}
-
-export class MockLanguageHelper extends SpyObject {
-    getAllSpy: Spy;
-
-    constructor() {
-        super(JhiLanguageHelper);
-
-        this.getAllSpy = this.spy('getAll').andReturn(Promise.resolve(['en', 'fr']));
+        this.getCurrentLanguageSpy = this.spy('getCurrentLanguage').andReturn('<%= nativeLanguage %>');
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
@@ -48,11 +48,11 @@ export class MockRouter extends SpyObject {
         this.navigateByUrlSpy = this.spy('navigateByUrl');
     }
 
-    setEvents(events: Observable<RouterEvent>) {
+    setEvents(events: Observable<RouterEvent>): void {
         this.events = events;
     }
 
-    setRouterState(routerState: any) {
+    setRouterState(routerState: any): void {
         this.routerState = routerState;
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-route.service.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { ActivatedRoute, Router } from '@angular/router';
+import { ActivatedRoute, Router, RouterEvent } from '@angular/router';
 import { SpyObject } from './spyobject';
 import { Observable, of } from 'rxjs';
 import Spy = jasmine.Spy;
@@ -38,7 +38,9 @@ export class MockActivatedRoute extends ActivatedRoute {
 export class MockRouter extends SpyObject {
     navigateSpy: Spy;
     navigateByUrlSpy: Spy;
-    events: Observable<any>;
+    events: Observable<RouterEvent> | null = null;
+    routerState: any;
+    url = '';
 
     constructor() {
         super(Router);
@@ -46,7 +48,11 @@ export class MockRouter extends SpyObject {
         this.navigateByUrlSpy = this.spy('navigateByUrl');
     }
 
-    setRouterEvent(event: any) {
-        this.events = of(event);
+    setEvents(events: Observable<RouterEvent>) {
+        this.events = events;
+    }
+
+    setRouterState(routerState: any) {
+        this.routerState = routerState;
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-state-storage.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-state-storage.service.ts.ejs
@@ -21,21 +21,18 @@ import { StateStorageService } from 'app/core/auth/state-storage.service';
 import Spy = jasmine.Spy;
 
 export class MockStateStorageService extends SpyObject {
-
     getUrlSpy: Spy;
     storeUrlSpy: Spy;
+    clearUrlSpy: Spy;
 
     constructor() {
         super(StateStorageService);
-        this.setUrlSpy({});
+        this.getUrlSpy = this.spy('getUrl').andReturn(null);
         this.storeUrlSpy = this.spy('storeUrl').andReturn(this);
+        this.clearUrlSpy = this.spy('clearUrl').andReturn(this);
     }
 
-    setUrlSpy(json) {
-        this.getUrlSpy = this.spy('getUrl').andReturn(json);
-    }
-
-    setResponse(json: any): void {
-        this.setUrlSpy(json);
+    setResponse(previousUrl: string | null): void {
+        this.getUrlSpy = this.spy('getUrl').andReturn(previousUrl);
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-tracker.service.ts.ejs
@@ -16,16 +16,19 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+import Spy = jasmine.Spy;
+
 import { SpyObject } from './spyobject';
 import { TrackerService } from 'app/core/tracker/tracker.service';
 
 export class MockTrackerService extends SpyObject {
+    connectSpy: Spy;
+    disconnectSpy: Spy;
 
     constructor() {
         super(TrackerService);
+
+        this.connectSpy = this.spy('connect').andReturn(this);
+        this.disconnectSpy = this.spy('disconnect').andReturn(this);
     }
-
-    connect() {}
-
-    disconnect() {}
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
@@ -24,8 +24,7 @@ import { NgbActiveModal, NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { <% if (enableTranslation) { %>JhiLanguageService, <% } %>JhiDataUtils, JhiDateUtils, JhiEventManager, JhiAlertService, JhiParseLinks } from 'ng-jhipster';
 
 <%_ if (enableTranslation) { _%>
-import { MockLanguageService, MockLanguageHelper } from './helpers/mock-language.service';
-import { JhiLanguageHelper } from 'app/core/language/language.helper';
+import { MockLanguageService } from './helpers/mock-language.service';
 <%_ } _%>
 import { AccountService } from 'app/core/auth/account.service';
 <%_ if (authenticationType !== 'oauth2') { _%>
@@ -49,10 +48,6 @@ _%>
         {
             provide: JhiLanguageService,
             useClass: MockLanguageService
-        },
-        {
-            provide: JhiLanguageHelper,
-            useClass: MockLanguageHelper
         },
         <%_ } _%>
         {

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -183,6 +183,9 @@ function copyWebResource(source, dest, regex, type, generator, opt = {}, templat
                     break;
                 case 'js':
                     body = replaceTitle(body, generator);
+                    if (dest.endsWith('error.route.ts')) {
+                        body = replaceErrorMessage(body, generator);
+                    }
                     break;
                 case 'jsx':
                     body = replaceTranslation(body, generator);
@@ -221,11 +224,33 @@ function renderContent(source, generator, context, options, cb) {
  * @returns string with pageTitle replaced
  */
 function replaceTitle(body, generator) {
-    const re = /pageTitle[\s]*:[\s]*['|"]([a-zA-Z0-9.\-_]+)['|"]/g;
+    const regex = /pageTitle[\s]*:[\s]*['|"]([a-zA-Z0-9.\-_]+)['|"]/g;
+    return replaceTranslationKeysWithText(body, generator, regex);
+}
+
+/**
+ *
+ * @param {string} body html body
+ * @param {object} generator reference to the generator
+ * @returns string with pageTitle replaced
+ */
+function replaceErrorMessage(body, generator) {
+    const regex = /errorMessage[\s]*:[\s]*['|"]([a-zA-Z0-9.\-_]+)['|"]/g;
+    return replaceTranslationKeysWithText(body, generator, regex);
+}
+
+/**
+ *
+ * @param {string} body html body
+ * @param {object} generator reference to the generator
+ * @param {object} regex regular expression to find keys
+ * @returns string with pageTitle replaced
+ */
+function replaceTranslationKeysWithText(body, generator, regex) {
     let match;
 
     // eslint-disable-next-line no-cond-assign
-    while ((match = re.exec(body)) !== null) {
+    while ((match = regex.exec(body)) !== null) {
         // match is now the next match, in array form and our key is at index 1, index 1 is replace target.
         const key = match[1];
         const target = key;
@@ -305,27 +330,39 @@ function replaceTranslation(body, generator) {
  */
 function geti18nJson(key, generator) {
     const i18nDirectory = `${LANGUAGES_MAIN_SRC_DIR}i18n/en/`;
-    let name = _.kebabCase(key.split('.')[0]);
-    if (['entity', 'error', 'footer'].includes(name)) {
-        name = 'global';
+    const names = [];
+    let result;
+    const namePrefix = _.kebabCase(key.split('.')[0]);
+    if (['entity', 'error', 'footer'].includes(namePrefix)) {
+        names.push('global');
+        if (namePrefix === 'error') {
+            names.push('error');
+        }
+    } else {
+        names.push(namePrefix);
     }
-    let filename = `${i18nDirectory + name}.json`;
-    let render;
-    if (!shelljs.test('-f', filename)) {
-        filename = `${filename}.ejs`;
-        render = true;
+    for (let i = 0; i < names.length; i++) {
+        let filename = `${i18nDirectory + names[i]}.json`;
+        let render;
+        if (!shelljs.test('-f', filename)) {
+            filename = `${filename}.ejs`;
+            render = true;
+        }
+        try {
+            let file = generator.fs.read(filename);
+            file = render ? ejs.render(file, generator, {}) : file;
+            file = JSON.parse(file);
+            if (result === undefined) {
+                result = file;
+            } else {
+                result = { ...result, ...file };
+            }
+        } catch (err) {
+            generator.log(err);
+            generator.log(`Error in file: ${filename}`);
+        }
     }
-    try {
-        let file = generator.fs.read(filename);
-        file = render ? ejs.render(file, generator, {}) : file;
-        file = JSON.parse(file);
-        return file;
-    } catch (err) {
-        generator.log(err);
-        generator.log(`Error in file: ${filename}`);
-        // 'Error reading translation file!'
-        return undefined;
-    }
+    return result;
 }
 
 /**

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -513,6 +513,7 @@ const expectedFiles = {
         `${CLIENT_TEST_SRC_DIR}spec/app/admin/metrics/metrics.component.spec.ts`,
         `${CLIENT_TEST_SRC_DIR}spec/app/admin/metrics/metrics.service.spec.ts`,
         `${CLIENT_TEST_SRC_DIR}spec/app/core/user/account.service.spec.ts`,
+        `${CLIENT_TEST_SRC_DIR}spec/app/layouts/main/main.component.spec.ts`,
         `${CLIENT_TEST_SRC_DIR}spec/app/shared/alert/alert-error.component.spec.ts`,
         `${CLIENT_TEST_SRC_DIR}spec/app/shared/login/login.component.spec.ts`,
         `${CLIENT_TEST_SRC_DIR}spec/helpers/mock-account.service.ts`,


### PR DESCRIPTION
This is layouts folder for #10631

Some comments.

* Code for redirecting to stored url and related tests were in 2 different places (for oauth2 in `main.component` and for others in `login.component`), now moved redirect code and related tests to `AccountService.identity`, this:
    * simplified generated code
    * simplified templates
    * removed duplicated code and duplicated tests
    * and to me seems that `account.service` is more logical place for that redirect logic

* Page title setting code was duplicated in 2 different places (for i18n in `language.helper` and for no i18n in `main.component`), now this code is only in `main.component` and I added also full unit tests to page title setting and these unit tests found errors in page title setter and fixed them and made some improvements:
    * if `pageTitle` was missing then in i18n enabled was searched translation for key `<%= angularAppName %>` but such key doesn't exist and page title was "translation-not-found...", changed that:
        * for i18n enabled: `global.title`
        * for i18n disabled: `<%= capitalizedBaseName %>`
    * if parent route had `pageTitle` in route data and child route had not then due to error in logic was used `<%= angularAppName %>`, now is used `pageTitle` from parent route data

* As changes touched `language.helper` then removed also `getAll()` from there - this returned `LANGUAGES` constant, now using this directly as all other constants are used (without getter around the constant).

* As `login-modal.service` from `core` and `login.component` from `shared` were related then cleaned also these.

* According to #10220 removed prefix from `MainComponent`, `LoginModalComponent` and `LanguageHelper`

* `errorMessage` in `error.component` was unused so removed that to avoid confusion in code readers

* in `profile.service` was declared that profile info coming from server is `ProfileInfo` but this is not true, so declared correct model `InfoResponse` for server response

* using `ViewChild` and removed `setTimeout` from login modal username focus - working fine

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
