### PR TITLE
Improve randexp usage in test data generation

### DIFF
--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -270,7 +270,11 @@ function addEnumerationFiles(generator, templateDir, clientFolder) {
 function addSampleRegexTestingStrings(generator) {
     generator.fields.forEach(field => {
         if (field.fieldValidateRulesPattern !== undefined) {
-            field.fieldValidateSampleString = new Randexp(field.fieldValidateRulesPattern).gen();
+            const randExp = new Randexp(field.fieldValidateRulesPattern);
+            randExp.max = 5;
+            // In order to have consistent results with RandExp, the RNG is seeded.
+            randExp.randInt = generator.seededRandomNumberGenerator(10);
+            field.fieldValidateSampleString = randExp.gen();
         }
     });
 }

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
@@ -175,7 +175,7 @@ for (lineNb = 1; lineNb <= numberOfRows; lineNb++) {
             // test if generated data is still compatible with the regexp as we potentially modify it with min/maxLength
             if (
                 fields[idx].fieldValidateRules.includes("pattern") &&
-                !new RegExp("^" + fields[idx].fieldValidateRulesPattern + "$").test(data)
+                !new RegExp("^" + fields[idx].fieldValidateRulesPattern + "$").test(data.substring(1, data.length - 1))
             ) {
                 data = "";
             }

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -236,13 +236,15 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
                 const patternRegExp = new RegExp(fields[idx].fieldValidateRulesPattern);
                 const randExp = new this.randexp(fields[idx].fieldValidateRulesPattern);
                 // set infinite repetitions max range
-                randExp.max = 1;
-                // In order to have consistent results with RandExp, the RNG is seeded.
-                randExp.randInt = seededRandomNumberGenerator(idx)
+                randExp.max = 5;
                 if (!patternRegExp.test(sampleTextString.replace(/\\"/g, '"').replace(/\\\\/g, '\\'))) {
+                    // In order to have consistent results with RandExp, the RNG is seeded.
+                    randExp.randInt = seededRandomNumberGenerator(2 * idx);
                     sampleTextString = randExp.gen().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
                 }
                 if (!patternRegExp.test(updatedTextString.replace(/\\"/g, '"').replace(/\\\\/g, '\\'))) {
+                    // In order to have consistent results with RandExp, the RNG is seeded.
+                    randExp.randInt = seededRandomNumberGenerator(2 * idx + 1);
                     updatedTextString = randExp.gen().replace(/\\/g, '\\\\').replace(/"/g, '\\"');
                 }
             } catch (error) {


### PR DESCRIPTION
This is follow up to #10892 and includes:

* using functionality provided by #10892 generates consistent result also for front end tests pattern fields

* improves #10892 for back end tests pattern fields:
    * after #10892 `sampleTextString` and `updatedTextString` were identical and constantly was shown warning in the console that sample and update strings are equal and adding B at the end of `updatedTextString`
    * now different consistent values are generated for `sampleTextString` and `updatedTextString`

* while testing this PR found that fake data was not generated for pattern fields if pattern field doesn't allow `"`, this is now fixed, fake data is now generated even if pattern doesn't allow `"`

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
