### PR TITLE
Strict Typescript option in shared module in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/blocks/config/prod.config.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/config/prod.config.ts.ejs
@@ -19,7 +19,7 @@
 import { enableProdMode } from '@angular/core';
 import { DEBUG_INFO_ENABLED } from 'app/app.constants';
 
-export function ProdConfig() {
+export function ProdConfig(): void {
     // disable debug data on prod profile to improve performance
     if (!DEBUG_INFO_ENABLED) {
         enableProdMode();

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 import { Component, OnDestroy, OnInit } from '@angular/core';
-import { JhiAlertService } from 'ng-jhipster';
+import { JhiAlertService, JhiAlert } from 'ng-jhipster';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-alert',
@@ -30,24 +30,25 @@ import { JhiAlertService } from 'ng-jhipster';
             </div>
         </div>`
 })
-export class <%=jhiPrefixCapitalized%>AlertComponent implements OnInit, OnDestroy {
-    alerts: any[];
+export class AlertComponent implements OnInit, OnDestroy {
+    alerts: JhiAlert[] = [];
 
     constructor(private alertService: JhiAlertService) { }
 
-    ngOnInit() {
+    ngOnInit(): void {
         this.alerts = this.alertService.get();
     }
 
-    setClasses(alert) {
-        return {
-            'jhi-toast': alert.toast,
-            [alert.position]: true
-        };
-    }
-
-    ngOnDestroy() {
-        this.alerts = [];
+    setClasses(alert: JhiAlert): { [key: string]: boolean } {
+        const classes = { 'jhi-toast': !!alert.toast };
+        if (alert.position) {
+          return { ...classes, [alert.position]: true };
+        }
+        return classes;
+      }
+    
+    ngOnDestroy(): void {
+        this.alertService.clear();
     }
 
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
@@ -40,7 +40,7 @@ export class AlertComponent implements OnInit, OnDestroy {
     }
 
     setClasses(alert: JhiAlert): { [key: string]: boolean } {
-        const classes = { 'jhi-toast': !!alert.toast };
+        const classes = { 'jhi-toast': Boolean(alert.toast) };
         if (alert.position) {
           return { ...classes, [alert.position]: true };
         }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/auth/has-any-authority.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/auth/has-any-authority.directive.ts.ejs
@@ -16,7 +16,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { Directive, Input, TemplateRef, ViewContainerRef } from '@angular/core';
+import { Directive, Input, TemplateRef, ViewContainerRef, OnDestroy } from '@angular/core';
+import { Subscription } from 'rxjs';
+
 import { AccountService } from 'app/core/auth/account.service';
 
 /**
@@ -33,9 +35,9 @@ import { AccountService } from 'app/core/auth/account.service';
 @Directive({
     selector: '[<%=jhiPrefix%>HasAnyAuthority]'
 })
-export class HasAnyAuthorityDirective {
-
-    private authorities: string[];
+export class HasAnyAuthorityDirective implements OnDestroy {
+    private authorities: string[] = [];
+    private authenticationSubscription?: Subscription;
 
     constructor(private accountService: AccountService, private templateRef: TemplateRef<any>, private viewContainerRef: ViewContainerRef) {
     }
@@ -45,7 +47,7 @@ export class HasAnyAuthorityDirective {
         this.authorities = typeof value === 'string' ? [ value ] : value;
         this.updateView();
         // Get notified each time authentication state changes.
-        this.accountService.getAuthenticationState().subscribe(() => this.updateView());
+        this.authenticationSubscription = this.accountService.getAuthenticationState().subscribe(() => this.updateView());
     }
 
     private updateView(): void {
@@ -55,4 +57,10 @@ export class HasAnyAuthorityDirective {
             this.viewContainerRef.createEmbeddedView(this.templateRef);
         }
     }
+
+    ngOnDestroy(): void {
+        if (this.authenticationSubscription) {
+            this.authenticationSubscription.unsubscribe();
+        }
+      }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
@@ -20,7 +20,7 @@ import { Pipe, PipeTransform } from '@angular/core';
 
 @Pipe({name: 'findLanguageFromKey'})
 export class FindLanguageFromKeyPipe implements PipeTransform {
-    private languages: any = {
+    private languages: { [key: string]: { name: string, rtl?: boolean } } = {
         // jhipster-needle-i18n-language-key-pipe - JHipster will add/remove languages in this object
     };
     transform(lang: string): string {
@@ -28,7 +28,7 @@ export class FindLanguageFromKeyPipe implements PipeTransform {
     }
     <%_ if (enableI18nRTL) { _%>
     isRTL(lang: string): boolean {
-        return this.languages[lang].rtl;
+        return !!this.languages[lang].rtl;
     }
     <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
@@ -28,7 +28,7 @@ export class FindLanguageFromKeyPipe implements PipeTransform {
     }
     <%_ if (enableI18nRTL) { _%>
     isRTL(lang: string): boolean {
-        return !!this.languages[lang].rtl;
+        return Boolean(this.languages[lang].rtl);
     }
     <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/shared.module.ts.ejs
@@ -21,7 +21,7 @@ import { <%=angularXAppName%>SharedLibsModule } from './shared-libs.module';
 <%_ if (enableTranslation) { _%>
 import { FindLanguageFromKeyPipe } from './language/find-language-from-key.pipe';
 <%_ } _%>
-import { <%=jhiPrefixCapitalized%>AlertComponent } from './alert/alert.component';
+import { AlertComponent } from './alert/alert.component';
 import { <%=jhiPrefixCapitalized%>AlertErrorComponent } from './alert/alert-error.component';
 <%_ if (authenticationType !== 'oauth2') { _%>
 import { <%=jhiPrefixCapitalized%>LoginModalComponent } from './login/login.component';
@@ -36,7 +36,7 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         <%_ if (enableTranslation) { _%>
         FindLanguageFromKeyPipe,
         <%_ } _%>
-        <%=jhiPrefixCapitalized%>AlertComponent,
+        AlertComponent,
         <%=jhiPrefixCapitalized%>AlertErrorComponent,
         <%_ if (authenticationType !== 'oauth2') { _%>
         <%=jhiPrefixCapitalized%>LoginModalComponent,
@@ -51,7 +51,7 @@ import { HasAnyAuthorityDirective } from './auth/has-any-authority.directive';
         <%_ if (enableTranslation) { _%>
         FindLanguageFromKeyPipe,
         <%_ } _%>
-        <%=jhiPrefixCapitalized%>AlertComponent,
+        AlertComponent,
         <%=jhiPrefixCapitalized%>AlertErrorComponent,
         <%_ if (authenticationType !== 'oauth2') { _%>
         <%=jhiPrefixCapitalized%>LoginModalComponent,

--- a/generators/client/templates/angular/src/main/webapp/app/shared/util/datepicker-adapter.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/util/datepicker-adapter.ts.ejs
@@ -30,10 +30,12 @@ export class NgbDateMomentAdapter extends NgbDateAdapter<Moment> {
         if (date != null && moment.isMoment(date) && date.isValid()) {
             return { year: date.year(), month: date.month() + 1, day: date.date() };
         }
-        return null;
+        // ! can be removed after https://github.com/ng-bootstrap/ng-bootstrap/issues/1544 is resolved
+        return null!;
     }
 
     toModel(date: NgbDateStruct): Moment {
-        return date ? moment(date.year + '-' + date.month + '-' + date.day, 'YYYY-MM-DD') : null;
+        // ! can be removed after https://github.com/ng-bootstrap/ng-bootstrap/issues/1544 is resolved
+        return date ? moment(date.year + '-' + date.month + '-' + date.day, 'YYYY-MM-DD') : null!;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/util/datepicker-adapter.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/util/datepicker-adapter.ts.ejs
@@ -35,7 +35,7 @@ export class NgbDateMomentAdapter extends NgbDateAdapter<Moment> {
     }
 
     toModel(date: NgbDateStruct): Moment {
-        // ! can be removed after https://github.com/ng-bootstrap/ng-bootstrap/issues/1544 is resolved
+        // ! after null can be removed after https://github.com/ng-bootstrap/ng-bootstrap/issues/1544 is resolved
         return date ? moment(date.year + '-' + date.month + '-' + date.day, 'YYYY-MM-DD') : null!;
     }
 }


### PR DESCRIPTION
This is shared module for #10631

Some notes:

* `alert.component.ts` - in `ngOnDestroy()` was tried to clear messages by `this.alerts = [];` but this doesn't clear messages and the same success message is shown in another form if user quickly navigates to other form, substituted this with `this.alertService.clear();` and now are messages cleared and not shown in another form

* removed memory leak from `has-any-authority.directive.ts`, this happened because not unsubscribed from observable:
    * this occurred if using this directive in some component which can created multiple times while navigating in and out, for example if adding to home component: `<p *jhiHasAnyAuthority="'ROLE_ADMIN'">Only for admin</p>`
    * in generated code this is used only in navbar so if user didn't use this in any other place then no memory leak

* in` datepicker-adapter` added `!` to `null` return to suppress compiler errors, this can be removed after this is resolved: https://github.com/ng-bootstrap/ng-bootstrap/issues/1544

* according to #10220 removed prefix from `AlertComponent`

* login folder is cleaned by layouts PR and request-util is cleaned by entities PR

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
