### PR TITLE
Strict Typescript option in health module in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
@@ -17,14 +17,14 @@
  limitations under the License.
 -%>
 <div class="modal-header">
-    <h4 class="modal-title" id="showHealthLabel" *ngIf="healthKey"><% if (enableTranslation) { %>
-        {{ 'health.indicator.' + healthKey | translate }}<% } else { %><span class="text-capitalize">{{ healthKey }}</span><% } %>
+    <h4 class="modal-title" id="showHealthLabel" *ngIf="health"><% if (enableTranslation) { %>
+        {{ 'health.indicator.' + health.key | translate }}<% } else { %><span class="text-capitalize">{{ health.key }}</span><% } %>
     </h4>
     <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="dismiss()"><span aria-hidden="true">&times;</span>
     </button>
 </div>
 <div class="modal-body pad">
-    <div *ngIf="healthDetails">
+    <div *ngIf="health">
         <h5 jhiTranslate="health.details.properties">Properties</h5>
         <div class="table-responsive">
             <table class="table table-striped" aria-describedby="showHealthLabel">
@@ -35,9 +35,9 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr *ngFor="let key of detailsKeys()">
-                        <td class="text-left">{{ key }}</td>
-                        <td class="text-left">{{ readableValue(healthDetails[key]) }}</td>
+                    <tr *ngFor="let healthDetail of health.value.details | keys">
+                        <td class="text-left">{{ healthDetail.key }}</td>
+                        <td class="text-left">{{ readableValue(healthDetail.value) }}</td>
                     </tr>
                 </tbody>
             </table>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
@@ -17,15 +17,14 @@
  limitations under the License.
 -%>
 <div class="modal-header">
-    <h4 class="modal-title" id="showHealthLabel"><% if (enableTranslation) { %>
-		{{'health.indicator.' + baseName(currentHealth.name) | translate}}<% } else { %><span class="text-capitalize">{{ baseName(currentHealth.name) }}</span><% } %>
-        {{subSystemName(currentHealth.name)}}
+    <h4 class="modal-title" id="showHealthLabel" *ngIf="healthKey"><% if (enableTranslation) { %>
+        {{ 'health.indicator.' + healthKey | translate }}<% } else { %><span class="text-capitalize">{{ healthKey }}</span><% } %>
     </h4>
-    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="activeModal.dismiss('closed')"><span aria-hidden="true">&times;</span>
+    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="dismiss()"><span aria-hidden="true">&times;</span>
     </button>
 </div>
 <div class="modal-body pad">
-    <div *ngIf="currentHealth.details">
+    <div *ngIf="healthDetails">
         <h5 jhiTranslate="health.details.properties">Properties</h5>
         <div class="table-responsive">
             <table class="table table-striped" aria-describedby="showHealthLabel">
@@ -36,19 +35,15 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr *ngFor="let entry of currentHealth.details.details | keys">
-                        <td class="text-left">{{entry.key}}</td>
-                        <td class="text-left">{{readableValue(entry.value)}}</td>
+                    <tr *ngFor="let key of detailsKeys()">
+                        <td class="text-left">{{ key }}</td>
+                        <td class="text-left">{{ readableValue(healthDetails[key]) }}</td>
                     </tr>
                 </tbody>
             </table>
         </div>
     </div>
-    <div *ngIf="currentHealth.error">
-        <h4 jhiTranslate="health.details.error">Error</h4>
-            <pre>{{currentHealth.error}}</pre>
-    </div>
 </div>
 <div class="modal-footer">
-    <button data-dismiss="modal" class="btn btn-secondary float-left" type="button" (click)="activeModal.dismiss('closed')">Done</button>
+    <button data-dismiss="modal" class="btn btn-secondary float-left" type="button" (click)="dismiss()">Done</button>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.ts.ejs
@@ -19,27 +19,19 @@
 import { Component } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { HealthKey } from './health.service';
+import { HealthKey, HealthDetails } from './health.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-health-modal',
     templateUrl: './health-modal.component.html'
 })
 export class HealthModalComponent {
-    healthKey?: HealthKey;
-    healthDetails: any;
+    health?: { key: HealthKey; value: HealthDetails };
 
     constructor(public activeModal: NgbActiveModal) {}
 
-    detailsKeys(): string[] {
-        if (this.healthDetails) {
-            return Object.keys(this.healthDetails);
-        }
-        return [];
-    }
-
     readableValue(value: any): string {
-        if (this.healthKey === 'diskSpace') {
+        if (this.health && this.health.key === 'diskSpace') {
             // Should display storage space in an human readable unit
             const val = value / 1073741824;
             if (val > 1) { // Value

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.ts.ejs
@@ -19,28 +19,27 @@
 import { Component } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { <%=jhiPrefixCapitalized%>HealthService } from './health.service';
+import { HealthKey } from './health.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-health-modal',
     templateUrl: './health-modal.component.html'
 })
-export class <%=jhiPrefixCapitalized%>HealthModalComponent {
+export class HealthModalComponent {
+    healthKey?: HealthKey;
+    healthDetails: any;
 
-    currentHealth: any;
+    constructor(public activeModal: NgbActiveModal) {}
 
-    constructor(private healthService: <%=jhiPrefixCapitalized%>HealthService, public activeModal: NgbActiveModal) {}
-
-    baseName(name) {
-        return this.healthService.getBaseName(name);
+    detailsKeys(): string[] {
+        if (this.healthDetails) {
+            return Object.keys(this.healthDetails);
+        }
+        return [];
     }
 
-    subSystemName(name) {
-        return this.healthService.getSubSystemName(name);
-    }
-
-    readableValue(value: number) {
-        if (this.currentHealth.name === 'diskSpace') {
+    readableValue(value: any): string {
+        if (this.healthKey === 'diskSpace') {
             // Should display storage space in an human readable unit
             const val = value / 1073741824;
             if (val > 1) { // Value
@@ -55,5 +54,9 @@ export class <%=jhiPrefixCapitalized%>HealthModalComponent {
         } else {
             return value.toString();
         }
+    }
+
+    dismiss(): void {
+        this.activeModal.dismiss();
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -33,15 +33,15 @@
                 </tr>
             </thead>
             <tbody>
-                <tr *ngFor="let health of healthData">
-                    <td><% if (enableTranslation) { %>{{'health.indicator.' + baseName(health.name) | translate}}<% } else { %><span class="text-capitalize">{{ baseName(health.name) }}</span><% } %> {{subSystemName(health.name)}}</td>
+                <tr *ngFor="let healthKey of healthKeys()">
+                    <td><% if (enableTranslation) { %>{{'health.indicator.' + healthKey | translate}}<% } else { %><span class="text-capitalize">{{ healthKey }}</span><% } %></td>
                     <td class="text-center">
-                        <span class="badge" [ngClass]="getBadgeClass(health.status)" jhiTranslate="{{'health.status.' + health.status}}">
-                            {{health.status}}
+                        <span class="badge" [ngClass]="getBadgeClass(healthData.details[healthKey].status)" jhiTranslate="{{'health.status.' + healthData.details[healthKey].status}}">
+                            {{ healthData.details[healthKey].status }}
                         </span>
                     </td>
                     <td class="text-center">
-                        <a class="hand" (click)="showHealth(health)" *ngIf="health.details || health.error">
+                        <a class="hand" (click)="showHealth(healthKey, healthData.details[healthKey].details)" *ngIf="healthData.details[healthKey].details">
                             <fa-icon [icon]="'eye'"></fa-icon>
                         </a>
                     </td>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -32,16 +32,16 @@
                     <th scope="col" class="text-center" jhiTranslate="health.details.details">Details</th>
                 </tr>
             </thead>
-            <tbody>
-                <tr *ngFor="let healthKey of healthKeys()">
-                    <td><% if (enableTranslation) { %>{{'health.indicator.' + healthKey | translate}}<% } else { %><span class="text-capitalize">{{ healthKey }}</span><% } %></td>
+            <tbody *ngIf="health">
+                <tr *ngFor="let componentHealth of health.details | keys">
+                    <td><% if (enableTranslation) { %>{{'health.indicator.' + componentHealth.key | translate}}<% } else { %><span class="text-capitalize">{{ componentHealth.key }}</span><% } %></td>
                     <td class="text-center">
-                        <span class="badge" [ngClass]="getBadgeClass(healthData.details[healthKey].status)" jhiTranslate="{{'health.status.' + healthData.details[healthKey].status}}">
-                            {{ healthData.details[healthKey].status }}
+                        <span class="badge" [ngClass]="getBadgeClass(componentHealth.value.status)" jhiTranslate="{{'health.status.' + componentHealth.value.status}}">
+                            {{ componentHealth.value.status }}
                         </span>
                     </td>
                     <td class="text-center">
-                        <a class="hand" (click)="showHealth(healthKey, healthData.details[healthKey].details)" *ngIf="healthData.details[healthKey].details">
+                        <a class="hand" (click)="showHealth(componentHealth)" *ngIf="componentHealth.value.details">
                             <fa-icon [icon]="'eye'"></fa-icon>
                         </a>
                     </td>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
@@ -20,7 +20,7 @@ import { Component, OnInit } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { HealthService, HealthStatus, Health, HealthKey } from './health.service';
+import { HealthService, HealthStatus, Health, HealthKey, HealthDetails } from './health.service';
 import { HealthModalComponent } from './health-modal.component';
 
 @Component({
@@ -28,7 +28,7 @@ import { HealthModalComponent } from './health-modal.component';
     templateUrl: './health.component.html'
 })
 export class HealthComponent implements OnInit {
-    healthData?: Health;
+    health?: Health;
 
     constructor(
         private modalService: NgbModal,
@@ -37,13 +37,6 @@ export class HealthComponent implements OnInit {
 
     ngOnInit(): void {
         this.refresh();
-    }
-
-    healthKeys(): string[] {
-        if (this.healthData) {
-            return Object.keys(this.healthData.details);
-        }
-        return [];
     }
 
     getBadgeClass(statusState: HealthStatus): string {
@@ -56,18 +49,17 @@ export class HealthComponent implements OnInit {
 
     refresh(): void {
         this.healthService.checkHealth().subscribe(
-            health => (this.healthData = health),
+            health => (this.health = health),
             (error: HttpErrorResponse) => {
                 if (error.status === 503) {
-                    this.healthData = error.error;
+                    this.health = error.error;
                 }
             }
         );
     }
 
-    showHealth(healthKey: HealthKey, healthDetails: any): void {
+    showHealth(health: { key: HealthKey; value: HealthDetails }): void {
         const modalRef  = this.modalService.open(HealthModalComponent);
-        modalRef.componentInstance.healthKey = healthKey;
-        modalRef.componentInstance.healthDetails = healthDetails;
+        modalRef.componentInstance.health = health;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
@@ -17,35 +17,36 @@
  limitations under the License.
 -%>
 import { Component, OnInit } from '@angular/core';
+import { HttpErrorResponse } from '@angular/common/http';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { <%=jhiPrefixCapitalized%>HealthService } from './health.service';
-import { <%=jhiPrefixCapitalized%>HealthModalComponent } from './health-modal.component';
+import { HealthService, HealthStatus, Health, HealthKey } from './health.service';
+import { HealthModalComponent } from './health-modal.component';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-health',
     templateUrl: './health.component.html'
 })
-export class <%=jhiPrefixCapitalized%>HealthCheckComponent implements OnInit {
-    healthData: any;
-    updatingHealth: boolean;
+export class HealthComponent implements OnInit {
+    healthData?: Health;
 
     constructor(
         private modalService: NgbModal,
-        private healthService: <%=jhiPrefixCapitalized%>HealthService
-    ) {
+        private healthService: HealthService
+    ) {}
 
-    }
-
-    ngOnInit() {
+    ngOnInit(): void {
         this.refresh();
     }
 
-    baseName(name: string) {
-        return this.healthService.getBaseName(name);
+    healthKeys(): string[] {
+        if (this.healthData) {
+            return Object.keys(this.healthData.details);
+        }
+        return [];
     }
 
-    getBadgeClass(statusState) {
+    getBadgeClass(statusState: HealthStatus): string {
         if (statusState === 'UP') {
             return 'badge-success';
         } else {
@@ -53,27 +54,20 @@ export class <%=jhiPrefixCapitalized%>HealthCheckComponent implements OnInit {
         }
     }
 
-    refresh() {
-        this.updatingHealth = true;
-
-        this.healthService.checkHealth().subscribe((health) => {
-            this.healthData = this.healthService.transformHealthData(health);
-            this.updatingHealth = false;
-        }, (error) => {
-            if (error.status === 503) {
-                this.healthData = this.healthService.transformHealthData(error.error);
-                this.updatingHealth = false;
+    refresh(): void {
+        this.healthService.checkHealth().subscribe(
+            health => (this.healthData = health),
+            (error: HttpErrorResponse) => {
+                if (error.status === 503) {
+                    this.healthData = error.error;
+                }
             }
-        });
+        );
     }
 
-    showHealth(health: any) {
-        const modalRef  = this.modalService.open(<%=jhiPrefixCapitalized%>HealthModalComponent);
-        modalRef.componentInstance.currentHealth = health;
+    showHealth(healthKey: HealthKey, healthDetails: any): void {
+        const modalRef  = this.modalService.open(HealthModalComponent);
+        modalRef.componentInstance.healthKey = healthKey;
+        modalRef.componentInstance.healthDetails = healthDetails;
     }
-
-    subSystemName(name: string) {
-        return this.healthService.getSubSystemName(name);
-    }
-
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.module.ts.ejs
@@ -2,8 +2,8 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
 
-import { <%=jhiPrefixCapitalized%>HealthCheckComponent } from './health.component';
-import { <%=jhiPrefixCapitalized%>HealthModalComponent } from './health-modal.component';
+import { HealthComponent } from './health.component';
+import { HealthModalComponent } from './health-modal.component';
 
 import { healthRoute } from './health.route';
 
@@ -12,7 +12,7 @@ import { healthRoute } from './health.route';
     <%=angularXAppName%>SharedModule,
     RouterModule.forChild([healthRoute])
   ],
-  declarations: [<%=jhiPrefixCapitalized%>HealthCheckComponent, <%=jhiPrefixCapitalized%>HealthModalComponent],
-  entryComponents: [<%=jhiPrefixCapitalized%>HealthModalComponent]
+  declarations: [HealthComponent, HealthModalComponent],
+  entryComponents: [HealthModalComponent]
 })
 export class HealthModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.route.ts.ejs
@@ -18,11 +18,11 @@
 -%>
 import { Route } from '@angular/router';
 
-import { <%=jhiPrefixCapitalized%>HealthCheckComponent } from './health.component';
+import { HealthComponent } from './health.component';
 
 export const healthRoute: Route = {
     path: '',
-    component: <%=jhiPrefixCapitalized%>HealthCheckComponent,
+    component: HealthComponent,
     data: {
         pageTitle: 'health.title'
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
@@ -22,131 +22,54 @@ import { Observable } from 'rxjs';
 
 import { SERVER_API_URL } from 'app/app.constants';
 
+export type HealthStatus = 'UP' | 'DOWN' | 'UNKNOWN' | 'OUT_OF_SERVICE';
+
+export type HealthKey =
+    <%_ if (messageBroker === 'kafka') { _%>
+    | 'binders'
+    <%_ } _%>
+    <%_ if (applicationType === 'gateway' || serviceDiscoveryType) { _%>
+    | 'discoveryComposite'
+    | 'refreshScope'
+    | 'clientConfigServer'
+    | 'hystrix'
+    <%_ } _%>
+    <%_ if (serviceDiscoveryType === 'consul') { _%>
+    | 'consul'
+    <%_ } _%>
+    | 'diskSpace'
+    | 'mail'
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+    | 'elasticsearch'
+    <%_ } _%>
+    <%_ if (databaseType === 'sql') { _%>
+    | 'db'
+    <%_ } else if (databaseType === 'mongodb') { _%>
+    | 'mongo'
+    <%_ } else if (databaseType === 'cassandra') { _%>
+    | 'cassandra'
+    <%_ } else if (databaseType === 'couchbase') { _%>
+    | 'couchbase'
+    <%_ } _%>
+    ;
+
+export interface Health {
+    status: HealthStatus;
+    details: {
+        [key in HealthKey]?: HealthDetails;
+    };
+}
+
+export interface HealthDetails {
+  status: HealthStatus;
+  details: any;
+}
+
 @Injectable({providedIn: 'root'})
-export class <%=jhiPrefixCapitalized%>HealthService {
+export class HealthService {
+    constructor(private http: HttpClient) {}
 
-    separator: string;
-
-    constructor(private http: HttpClient) {
-        this.separator = '.';
-    }
-
-    checkHealth(): Observable<any> {
-        return this.http.get(SERVER_API_URL + 'management/health');
-    }
-
-    transformHealthData(data): any {
-        const response = [];
-        this.flattenHealthData(response, null, data.details);
-        return response;
-    }
-
-    getBaseName(name): string {
-        if (name) {
-            const split = name.split('.');
-            return split[0];
-        }
-    }
-
-    getSubSystemName(name): string {
-        if (name) {
-            const split = name.split('.');
-            split.splice(0, 1);
-            const remainder = split.join('.');
-            return remainder ? ' - ' + remainder : '';
-        }
-    }
-
-    /* private methods */
-    private addHealthObject(result, isLeaf, healthObject, name): any {
-        const healthData: any = {
-            name
-        };
-
-        const details = {};
-        let hasDetails = false;
-
-        for (const key in healthObject) {
-            if (Object.prototype.hasOwnProperty.call(healthObject, key)) {
-                const value = healthObject[key];
-                if (key === 'status' || key === 'error') {
-                    healthData[key] = value;
-                } else {
-                    if (!this.isHealthObject(value)) {
-                        details[key] = value;
-                        hasDetails = true;
-                    }
-                }
-            }
-        }
-
-        // Add the details
-        if (hasDetails) {
-            healthData.details = details;
-        }
-
-        // Only add nodes if they provide additional information
-        if (isLeaf || hasDetails || healthData.error) {
-            result.push(healthData);
-        }
-        return healthData;
-    }
-
-    private flattenHealthData(result, path, data): any {
-        for (const key in data) {
-            if (Object.prototype.hasOwnProperty.call(data, key)) {
-                const value = data[key];
-                if (this.isHealthObject(value)) {
-                    if (this.hasSubSystem(value)) {
-                        this.addHealthObject(result, false, value, this.getModuleName(path, key));
-                        this.flattenHealthData(result, this.getModuleName(path, key), value);
-                    } else {
-                        this.addHealthObject(result, true, value, this.getModuleName(path, key));
-                    }
-                }
-            }
-        }
-        return result;
-    }
-
-    private getModuleName(path, name): string {
-        let result;
-        if (path && name) {
-            result = path + this.separator + name;
-        }  else if (path) {
-            result = path;
-        } else if (name) {
-            result = name;
-        } else {
-            result = '';
-        }
-        return result;
-    }
-
-    private hasSubSystem(healthObject): boolean {
-        let result = false;
-
-        for (const key in healthObject) {
-            if (Object.prototype.hasOwnProperty.call(healthObject, key)) {
-                const value = healthObject[key];
-                if (value && value.status) {
-                    result = true;
-                }
-            }
-        }
-        return result;
-    }
-
-    private isHealthObject(healthObject): boolean {
-        let result = false;
-
-        for (const key in healthObject) {
-            if (Object.prototype.hasOwnProperty.call(healthObject, key)) {
-                if (key === 'status') {
-                    result = true;
-                }
-            }
-        }
-        return result;
+    checkHealth(): Observable<Health> {
+        return this.http.get<Health>(SERVER_API_URL + 'management/health');
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
@@ -59,28 +59,28 @@ describe('Component Tests', () => {
         describe('refresh', () => {
             it('should call refresh on init', () => {
                 // GIVEN
-                const healthData: Health = { status: 'UP', details: { mail: { status: 'UP', details: 'mailDetails' } } };
-                spyOn(service, 'checkHealth').and.returnValue(of(healthData));
+                const health: Health = { status: 'UP', details: { mail: { status: 'UP', details: 'mailDetails' } } };
+                spyOn(service, 'checkHealth').and.returnValue(of(health));
 
                 // WHEN
                 comp.ngOnInit()
 
                 // THEN
                 expect(service.checkHealth).toHaveBeenCalled();
-                expect(comp.healthData).toEqual(healthData);
+                expect(comp.health).toEqual(health);
             });
 
             it('should handle a 503 on refreshing health data', () => {
                 // GIVEN
-                const healthData: Health = { status: 'DOWN', details: { mail: { status: 'DOWN', details: 'mailDetails' } } };
-                spyOn(service, 'checkHealth').and.returnValue(throwError(new HttpErrorResponse({ status: 503, error: healthData })));
+                const health: Health = { status: 'DOWN', details: { mail: { status: 'DOWN', details: 'mailDetails' } } };
+                spyOn(service, 'checkHealth').and.returnValue(throwError(new HttpErrorResponse({ status: 503, error: health })));
 
                 // WHEN
                 comp.refresh();
 
                 // THEN
                 expect(service.checkHealth).toHaveBeenCalled();
-                expect(comp.healthData).toEqual(healthData);
+                expect(comp.health).toEqual(health);
             });
         });
     });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
@@ -17,287 +17,34 @@
  limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async } from '@angular/core/testing';
-import { HttpResponse, HttpErrorResponse } from '@angular/common/http';
+import { HttpErrorResponse } from '@angular/common/http';
 import { of, throwError } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
-import { <%=jhiPrefixCapitalized%>HealthCheckComponent } from 'app/admin/health/health.component';
-import { <%=jhiPrefixCapitalized%>HealthService } from 'app/admin/health/health.service';
+import { HealthComponent } from 'app/admin/health/health.component';
+import { HealthService, Health } from 'app/admin/health/health.service';
 
 describe('Component Tests', () => {
 
-    describe('<%=jhiPrefixCapitalized%>HealthCheckComponent', () => {
+    describe('HealthComponent', () => {
 
-        let comp: <%=jhiPrefixCapitalized%>HealthCheckComponent;
-        let fixture: ComponentFixture<<%=jhiPrefixCapitalized%>HealthCheckComponent>;
-        let service: <%=jhiPrefixCapitalized%>HealthService;
+        let comp: HealthComponent;
+        let fixture: ComponentFixture<HealthComponent>;
+        let service: HealthService;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
-                declarations: [<%=jhiPrefixCapitalized%>HealthCheckComponent]
+                declarations: [HealthComponent]
             })
-            .overrideTemplate(<%=jhiPrefixCapitalized%>HealthCheckComponent, '')
+            .overrideTemplate(HealthComponent, '')
             .compileComponents();
         }));
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(<%=jhiPrefixCapitalized%>HealthCheckComponent);
+            fixture = TestBed.createComponent(HealthComponent);
             comp = fixture.componentInstance;
-            service = fixture.debugElement.injector.get(<%=jhiPrefixCapitalized%>HealthService);
-        });
-
-        describe('baseName and subSystemName', () => {
-            it('should return the basename when it has no sub system', () => {
-                expect(comp.baseName('base')).toBe('base');
-            });
-
-            it('should return the basename when it has sub systems', () => {
-                expect(comp.baseName('base.subsystem.system')).toBe('base');
-            });
-
-            it('should return the sub system name', () => {
-                expect(comp.subSystemName('subsystem')).toBe('');
-            });
-
-            it('should return the subsystem when it has multiple keys', () => {
-                expect(comp.subSystemName('subsystem.subsystem.system')).toBe(' - subsystem.system');
-            });
-        });
-
-        describe('transformHealthData', () => {
-            it('should flatten empty health data', () => {
-                const data = {};
-                const expected = [];
-                expect(service.transformHealthData(data)).toEqual(expected);
-            });
-
-            it('should flatten health data with no subsystems', () => {
-                const data = {
-                    details: {
-                        status: 'UP',
-                        db: {
-                            status: 'UP',
-                            database: 'H2',
-                            hello: '1'
-                        },
-                        mail: {
-                            status: 'UP',
-                            error: 'mail.a.b.c'
-                        }
-                    }
-                };
-                const expected = [
-                    {
-                        name: 'db',
-                        status: 'UP',
-                        details: {
-                            database: 'H2',
-                            hello: '1'
-                        }
-                    },
-                    {
-                        name: 'mail',
-                        error: 'mail.a.b.c',
-                        status: 'UP'
-                    }
-                ];
-                expect(service.transformHealthData(data)).toEqual(expected);
-            });
-
-            it('should flatten health data with subsystems at level 1, main system has no additional information', () => {
-                const data = {
-                    details: {
-                        status: 'UP',
-                        db: {
-                            status: 'UP',
-                            database: 'H2',
-                            hello: '1'
-                        },
-                        mail: {
-                            status: 'UP',
-                            error: 'mail.a.b.c'
-                        },
-                        system: {
-                            status: 'DOWN',
-                            subsystem1: {
-                                status: 'UP',
-                                property1: 'system.subsystem1.property1'
-                            },
-                            subsystem2: {
-                                status: 'DOWN',
-                                error: 'system.subsystem1.error',
-                                property2: 'system.subsystem2.property2'
-                            }
-                        }
-                    }
-                };
-                const expected = [
-                    {
-                        name: 'db',
-                        status: 'UP',
-                        details: {
-                            database: 'H2',
-                            hello: '1'
-                        }
-                    },
-                    {
-                        name: 'mail',
-                        error: 'mail.a.b.c',
-                        status: 'UP'
-                    },
-                    {
-                        name: 'system.subsystem1',
-                        status: 'UP',
-                        details: {
-                            property1: 'system.subsystem1.property1'
-                        }
-                    },
-                    {
-                        name: 'system.subsystem2',
-                        error: 'system.subsystem1.error',
-                        status: 'DOWN',
-                        details: {
-                            property2: 'system.subsystem2.property2'
-                        }
-                    }
-                ];
-                expect(service.transformHealthData(data)).toEqual(expected);
-            });
-
-            it('should flatten health data with subsystems at level 1, main system has additional information', () => {
-                const data = {
-                    details: {
-                        status: 'UP',
-                        db: {
-                            status: 'UP',
-                            database: 'H2',
-                            hello: '1'
-                        },
-                        mail: {
-                            status: 'UP',
-                            error: 'mail.a.b.c'
-                        },
-                        system: {
-                            status: 'DOWN',
-                            property1: 'system.property1',
-                            subsystem1: {
-                                status: 'UP',
-                                property1: 'system.subsystem1.property1'
-                            },
-                            subsystem2: {
-                                status: 'DOWN',
-                                error: 'system.subsystem1.error',
-                                property2: 'system.subsystem2.property2'
-                            }
-                        }
-                    }
-                };
-                const expected = [
-                    {
-                        name: 'db',
-                        status: 'UP',
-                        details: {
-                            database: 'H2',
-                            hello: '1'
-                        }
-                    },
-                    {
-                        name: 'mail',
-                        error: 'mail.a.b.c',
-                        status: 'UP'
-                    },
-                    {
-                        name: 'system',
-                        status: 'DOWN',
-                        details: {
-                            property1: 'system.property1'
-                        }
-                    },
-                    {
-                        name: 'system.subsystem1',
-                        status: 'UP',
-                        details: {
-                            property1: 'system.subsystem1.property1'
-                        }
-                    },
-                    {
-                        name: 'system.subsystem2',
-                        error: 'system.subsystem1.error',
-                        status: 'DOWN',
-                        details: {
-                            property2: 'system.subsystem2.property2'
-                        }
-                    }
-                ];
-                expect(service.transformHealthData(data)).toEqual(expected);
-            });
-
-            it('should flatten health data with subsystems at level 1, main system has additional error', () => {
-                const data = {
-                    details: {
-                        status: 'UP',
-                        db: {
-                            status: 'UP',
-                            database: 'H2',
-                            hello: '1'
-                        },
-                        mail: {
-                            status: 'UP',
-                            error: 'mail.a.b.c'
-                        },
-                        system: {
-                            status: 'DOWN',
-                            error: 'show me',
-                            subsystem1: {
-                                status: 'UP',
-                                property1: 'system.subsystem1.property1'
-                            },
-                            subsystem2: {
-                                status: 'DOWN',
-                                error: 'system.subsystem1.error',
-                                property2: 'system.subsystem2.property2'
-                            }
-                        }
-                    }
-                };
-                const expected = [
-                    {
-                        name: 'db',
-                        status: 'UP',
-                        details: {
-                            database: 'H2',
-                            hello: '1'
-                        }
-                    },
-                    {
-                        name: 'mail',
-                        error: 'mail.a.b.c',
-                        status: 'UP'
-                    },
-                    {
-                        name: 'system',
-                        error: 'show me',
-                        status: 'DOWN'
-                    },
-                    {
-                        name: 'system.subsystem1',
-                        status: 'UP',
-                        details: {
-                            property1: 'system.subsystem1.property1'
-                        }
-                    },
-                    {
-                        name: 'system.subsystem2',
-                        error: 'system.subsystem1.error',
-                        status: 'DOWN',
-                        details: {
-                            property2: 'system.subsystem2.property2'
-                        }
-                    }
-                ];
-                expect(service.transformHealthData(data)).toEqual(expected);
-            });
+            service = fixture.debugElement.injector.get(HealthService);
         });
 
         describe('getBadgeClass', () => {
@@ -312,31 +59,29 @@ describe('Component Tests', () => {
         describe('refresh', () => {
             it('should call refresh on init', () => {
                 // GIVEN
-                spyOn(service, 'checkHealth').and.returnValue(of(new HttpResponse()));
-                spyOn(service, 'transformHealthData').and.returnValue({ data: 'test' });
+                const healthData: Health = { status: 'UP', details: { mail: { status: 'UP', details: 'mailDetails' } } };
+                spyOn(service, 'checkHealth').and.returnValue(of(healthData));
 
                 // WHEN
                 comp.ngOnInit()
 
                 // THEN
                 expect(service.checkHealth).toHaveBeenCalled();
-                expect(service.transformHealthData).toHaveBeenCalled();
-                expect(comp.healthData).toEqual({data: 'test'});
+                expect(comp.healthData).toEqual(healthData);
             });
+
             it('should handle a 503 on refreshing health data', () => {
                 // GIVEN
-                spyOn(service, 'checkHealth').and.returnValue(throwError(new HttpErrorResponse({status: 503, error: 'Mail down'})));
-                spyOn(service, 'transformHealthData').and.returnValue({ health: 'down' });
+                const healthData: Health = { status: 'DOWN', details: { mail: { status: 'DOWN', details: 'mailDetails' } } };
+                spyOn(service, 'checkHealth').and.returnValue(throwError(new HttpErrorResponse({ status: 503, error: healthData })));
 
                 // WHEN
                 comp.refresh();
 
                 // THEN
                 expect(service.checkHealth).toHaveBeenCalled();
-                expect(service.transformHealthData).toHaveBeenCalled();
-                expect(comp.healthData).toEqual({health: 'down'});
+                expect(comp.healthData).toEqual(healthData);
             });
         });
     });
 });
-


### PR DESCRIPTION
This is a health module for the #10631 

Health checking API in Spring Boot changes in version 2.2, new API version V3 will be used, ATM in Spring Boot 2.1 we are using API version V2:
* Spring Boot 2.1: https://docs.spring.io/spring-boot/docs/2.1.10.RELEASE/actuator-api/html/#health
* Spring Boot 2.2: https://docs.spring.io/spring-boot/docs/2.2.1.RELEASE/actuator-api/html/#health

So if we switch to Spring Boot 2.2 then this health checking module needs to be aligned to the health checking API version V3. Or act as described in the referenced Spring Boot 2.2 API documentation: _If you need to return V2 JSON you should use an accept header or application/vnd.spring-boot.actuator.v2+json_.

In this PR I removed all code that processed result from actuator health endpoint and I see identical result in the UI. Some thoughts about removed code:
* this health component code is 3+ years old, maybe 3+ years ago this logic was needed (Spring Boot <= 1.4)
* in `health.component` test cases the input to tests is different from what it comes currently from API V2 - so maybe this was needed for API V1, then just lucky case that this API V1 code at all works for API V2 and something is shown
* tried to get API V1 result from health endpoint (to see how it looks like) with current master code (added `Accept` header `application/vnd.spring-boot.actuator.v1+json`) and got error: HTTP 406 - Could not find acceptable representation
* using `Accept` header `application/vnd.spring-boot.actuator.v2+json` returned correct result so seems that API V1 is so old that Spring Boot 2.1 doesn't support that any more
* health modal contained `h4` element for error, in current implementation this is not shown, if I made it visible for key error in the new version then it looked really ugly for mail service, long scrollbar appeared to modal, so I just removed that because this is not shown in the current master version

In Spring Boot 2.2 this version of `checkHealth()` in `health.service` should work with currently defined data model (we should get API V2 result) and we can migrate later to API V3 response:
```
  checkHealth(): Observable<Health> {
    let headers = new HttpHeaders();
    headers = headers.append('Accept', 'application/vnd.spring-boot.actuator.v2+json');
    return this.http.get<Health>(SERVER_API_URL + 'management/health', { headers });
  }
```

Additional note: removed prefix and aligned component name according to #10220

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
