### PR TITLE
add caching support for Maven artefact on Azure Spring Cloud

### DIFF
--- a/generators/azure-spring-cloud/templates/github/workflows/azure-spring-cloud.yml.ejs
+++ b/generators/azure-spring-cloud/templates/github/workflows/azure-spring-cloud.yml.ejs
@@ -14,6 +14,13 @@ jobs:
       uses: actions/setup-java@v1
       with:
         java-version: 11
+    - name: Cache Maven archetypes
+      uses: actions/cache@v1
+      with:
+        path: ~/.m2/repository
+        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
+        restore-keys: |
+          ${{ runner.os }}-maven-
     - name: Test with Maven
       run: mvn test
     - name: Build with Maven


### PR DESCRIPTION
When deploying with GitHub Actions to Azure Spring Cloud, cache Maven archetypes to speed up the build