### PR TITLE
fix websocket fallback paths in ClientForwardController

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/ClientForwardController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/ClientForwardController.java.ejs
@@ -28,7 +28,11 @@ public class ClientForwardController {
      * Forwards any unmapped paths (except those containing a period) to the client {@code index.html}.
      * @return forward to client {@code index.html}.
      */
-    @GetMapping(value = "/**/{path:<% if (websocket === 'spring-websocket') { %>^(?!websocket)<% } %>[^\\.]*}")
+    <%_ if (websocket === 'spring-websocket') { _%>
+    @GetMapping(value = {"/{path:[^\\.]*}", "/{path:^(?!websocket).*}/**/{path:[^\\.]*}"})
+    <%_ } else { _%>
+    @GetMapping(value = "/**/{path:[^\\.]*}")
+    <%_ } _%>
     public String forward() {
         return "forward:/";
     }

--- a/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/ClientForwardControllerTest.java.ejs
@@ -70,6 +70,26 @@ public class ClientForwardControllerTest {
             .andExpect(forwardedUrl("/"));
     }
 
+    <%_ if (websocket === 'spring-websocket') { _%>
+    @Test
+    public void getWebsocketInfoEndpoint() throws Exception {
+        restMockMvc.perform(get("/websocket/info"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void getWebsocketEndpoint() throws Exception {
+        restMockMvc.perform(get("/websocket/tracker/308/sessionId/websocket"))
+            .andExpect(status().isNotFound());
+    }
+
+    @Test
+    public void getWebsocketFallbackEndpoint() throws Exception {
+        restMockMvc.perform(get("/websocket/tracker/308/sessionId/xhr_streaming"))
+            .andExpect(status().isNotFound());
+    }
+    <%_ } _%>
+
     @RestController
     public static class TestController {
 


### PR DESCRIPTION
Ensures that websocket fallbacks, such as `xhr_streaming` and `eventsource`, receive requests as expected rather than forwarding to the client.

The issue fixed here was that the regex for `websocket` was searching the end of the path rather than the beginning, due to the prefix of `/**/`.  When websockets don't work, they fallback to other options such as `xhr_streaming` and `eventsource` (URLs end with the method name).    Regular websockets work because the websocket URL ends in `websocket`

Before this PR, request for fallback methods would result in a `405 Method Not Allowed` because they are POST requests going to the client at `/` ([screenshot](https://user-images.githubusercontent.com/4294623/70653256-f725ff00-1c08-11ea-8a1e-8083f5bd7026.png))

Improved version of https://github.com/jhipster/generator-jhipster/pull/9593, based off [this StackOverflow](https://stackoverflow.com/questions/48565550/map-all-requests-instead-of-specific-pattern-in-spring-boot/48622614#48622614)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
