### PR TITLE
Add number pattern to entity tests

### DIFF
--- a/test-integration/samples/.jhipster/FieldTestEntity.json
+++ b/test-integration/samples/.jhipster/FieldTestEntity.json
@@ -39,6 +39,25 @@
             "fieldValidateRulesPatternJava": "^[a-zA-Z0-9]*$"
         },
         {
+            "fieldName": "numberPatternTom",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "pattern"
+            ],
+            "fieldValidateRulesPattern": "^[0-9]+$",
+            "fieldValidateRulesPatternJava": "^[0-9]+$"
+        },
+        {
+            "fieldName": "numberPatternRequiredTom",
+            "fieldType": "String",
+            "fieldValidateRules": [
+                "pattern",
+                "required"
+            ],
+            "fieldValidateRulesPattern": "^[0-9]+$",
+            "fieldValidateRulesPatternJava": "^[0-9]+$"
+        },
+        {
             "fieldName": "integerTom",
             "fieldType": "Integer"
         },


### PR DESCRIPTION
This PR adds test cases for pattern fields which doesn't allow only alphabetical symbols.

These tests will break PR #10921 and would have broken #10892 (which was fixed by #10897).

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

-->
