### PR TITLE
Strict Typescript option in configuration module in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -16,35 +16,35 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<div *ngIf="allConfiguration && configuration">
+<div *ngIf="allBeans">
     <h2 id="configuration-page-heading" jhiTranslate="configuration.title">Configuration</h2>
 
-    <span jhiTranslate="configuration.filter">Filter (by prefix)</span> <input type="text" [(ngModel)]="filter" class="form-control">
+    <span jhiTranslate="configuration.filter">Filter (by prefix)</span> <input type="text" [(ngModel)]="beansFilter" (ngModelChange)="filterAndSortBeans()" class="form-control">
     <h3 id="spring-configuration">Spring configuration</h3>
     <table class="table table-striped table-bordered table-responsive d-table" aria-describedby="spring-configuration">
         <thead>
-        <tr>
-            <th scope="col" class="w-40" (click)="orderProp = 'prefix'; reverse=!reverse"><span jhiTranslate="configuration.table.prefix">Prefix</span></th>
-            <th scope="col" class="w-60" (click)="orderProp = 'properties'; reverse=!reverse"><span jhiTranslate="configuration.table.properties">Properties</span></th>
+        <tr jhiSort predicate="prefix" [(ascending)]="beansAscending" [callback]="filterAndSortBeans.bind(this)">
+            <th jhiSortBy="prefix" scope="col" class="w-40"><span jhiTranslate="configuration.table.prefix">Prefix</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+            <th scope="col" class="w-60"><span jhiTranslate="configuration.table.properties">Properties</span></th>
         </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let entry of (configuration | pureFilter:filter:'prefix' | orderBy:orderProp:reverse)">
-            <td><span>{{entry.prefix}}</span></td>
+        <tr *ngFor="let bean of beans">
+            <td><span>{{ bean.prefix }}</span></td>
             <td>
-                <div class="row" *ngFor="let key of keys(entry.properties)">
-                    <div class="col-md-4">{{key}}</div>
+                <div class="row" *ngFor="let property of bean.properties | keys">
+                    <div class="col-md-4">{{ property.key }}</div>
                     <div class="col-md-8">
-                        <span class="float-right badge-secondary break">{{entry.properties[key] | json}}</span>
+                        <span class="float-right badge-secondary break">{{ property.value | json }}</span>
                     </div>
                 </div>
             </td>
         </tr>
         </tbody>
     </table>
-    <div *ngFor="let key of keys(allConfiguration); let i = index">
-        <h4 [id]="key + '_' + i"><span>{{key}}</span></h4>
-        <table class="table table-sm table-striped table-bordered table-responsive d-table" [attr.aria-describedby]="key + '_' + i">
+    <div *ngFor="let propertySource of propertySources; let i = index">
+        <h4 [id]="'property-source-' + i"><span>{{ propertySource.name }}</span></h4>
+        <table class="table table-sm table-striped table-bordered table-responsive d-table" [attr.aria-describedby]="'property-source-' + i">
             <thead>
             <tr>
                 <th scope="col" class="w-40">Property</th>
@@ -52,10 +52,10 @@
             </tr>
             </thead>
             <tbody>
-            <tr *ngFor="let item of allConfiguration[key]">
-                <td class="break">{{item.key}}</td>
+            <tr *ngFor="let property of propertySource.properties | keys">
+                <td class="break">{{ property.key }}</td>
                 <td class="break">
-                    <span class="float-right badge-secondary break">{{item.val}}</span>
+                    <span class="float-right badge-secondary break">{{ property.value.value }}</span>
                 </td>
             </tr>
             </tbody>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
@@ -18,14 +18,14 @@
 -%>
 import { Component, OnInit } from '@angular/core';
 
-import { ConfigurationService, Beans, Bean, PropertySource } from './configuration.service';
+import { ConfigurationService, Bean, PropertySource } from './configuration.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-configuration',
     templateUrl: './configuration.component.html'
 })
 export class ConfigurationComponent implements OnInit {
-    allBeans!: Beans;
+    allBeans!: Bean[];
     beans: Bean[] = [];
     beansFilter = '';
     beansAscending = true;
@@ -45,14 +45,8 @@ export class ConfigurationComponent implements OnInit {
     }
 
     filterAndSortBeans(): void {
-        this.beans = [];
-
-        Object.keys(this.allBeans).forEach(beanKey => {
-            if (!this.beansFilter || this.allBeans[beanKey].prefix.toLowerCase().includes(this.beansFilter.toLowerCase())) {
-                this.beans.push(this.allBeans[beanKey]);
-            }
-        });
-
-        this.beans.sort((a, b) => (a.prefix < b.prefix ? (this.beansAscending ? -1 : 1) : this.beansAscending ? 1 : -1));
+        this.beans = this.allBeans
+            .filter(bean => !this.beansFilter || bean.prefix.toLowerCase().includes(this.beansFilter.toLowerCase()))
+            .sort((a, b) => (a.prefix < b.prefix ? (this.beansAscending ? -1 : 1) : this.beansAscending ? 1 : -1));
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
@@ -18,13 +18,13 @@
 -%>
 import { Component, OnInit } from '@angular/core';
 
-import { <%=jhiPrefixCapitalized%>ConfigurationService } from './configuration.service';
+import { ConfigurationService } from './configuration.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-configuration',
     templateUrl: './configuration.component.html'
 })
-export class <%=jhiPrefixCapitalized%>ConfigurationComponent implements OnInit {
+export class ConfigurationComponent implements OnInit {
     allConfiguration: any = null;
     configuration: any = null;
     configKeys: any[];
@@ -33,7 +33,7 @@ export class <%=jhiPrefixCapitalized%>ConfigurationComponent implements OnInit {
     reverse: boolean;
 
     constructor(
-        private configurationService: <%=jhiPrefixCapitalized%>ConfigurationService
+        private configurationService: ConfigurationService
     ) {
         this.configKeys = [];
         this.filter = '';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.ts.ejs
@@ -18,46 +18,41 @@
 -%>
 import { Component, OnInit } from '@angular/core';
 
-import { ConfigurationService } from './configuration.service';
+import { ConfigurationService, Beans, Bean, PropertySource } from './configuration.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-configuration',
     templateUrl: './configuration.component.html'
 })
 export class ConfigurationComponent implements OnInit {
-    allConfiguration: any = null;
-    configuration: any = null;
-    configKeys: any[];
-    filter: string;
-    orderProp: string;
-    reverse: boolean;
+    allBeans!: Beans;
+    beans: Bean[] = [];
+    beansFilter = '';
+    beansAscending = true;
+    propertySources: PropertySource[] = [];
 
     constructor(
         private configurationService: ConfigurationService
-    ) {
-        this.configKeys = [];
-        this.filter = '';
-        this.orderProp = 'prefix';
-        this.reverse = false;
+    ) {}
+
+    ngOnInit(): void {
+        this.configurationService.getBeans().subscribe(beans => {
+            this.allBeans = beans;
+            this.filterAndSortBeans();
+        });
+
+        this.configurationService.getPropertySources().subscribe(propertySources => (this.propertySources = propertySources));
     }
 
-    keys(dict): string[] {
-        return (dict === undefined) ? [] : Object.keys(dict);
-    }
+    filterAndSortBeans(): void {
+        this.beans = [];
 
-    ngOnInit() {
-        this.configurationService.get().subscribe((configuration) => {
-            this.configuration = configuration;
-
-            for (const config of configuration) {
-                if (config.properties !== undefined) {
-                    this.configKeys.push(Object.keys(config.properties));
-                }
+        Object.keys(this.allBeans).forEach(beanKey => {
+            if (!this.beansFilter || this.allBeans[beanKey].prefix.toLowerCase().includes(this.beansFilter.toLowerCase())) {
+                this.beans.push(this.allBeans[beanKey]);
             }
         });
 
-        this.configurationService.getEnv().subscribe((configuration) => {
-            this.allConfiguration = configuration;
-        });
+        this.beans.sort((a, b) => (a.prefix < b.prefix ? (this.beansAscending ? -1 : 1) : this.beansAscending ? 1 : -1));
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.module.ts.ejs
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
 
-import { <%=jhiPrefixCapitalized%>ConfigurationComponent } from './configuration.component';
+import { ConfigurationComponent } from './configuration.component';
 
 import { configurationRoute } from './configuration.route';
 
@@ -11,6 +11,6 @@ import { configurationRoute } from './configuration.route';
     <%=angularXAppName%>SharedModule,
     RouterModule.forChild([configurationRoute])
   ],
-  declarations: [<%=jhiPrefixCapitalized%>ConfigurationComponent]
+  declarations: [ConfigurationComponent]
 })
 export class ConfigurationModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.route.ts.ejs
@@ -18,11 +18,11 @@
 -%>
 import { Route } from '@angular/router';
 
-import { <%=jhiPrefixCapitalized%>ConfigurationComponent } from './configuration.component';
+import { ConfigurationComponent } from './configuration.component';
 
 export const configurationRoute: Route = {
     path: '',
-    component: <%=jhiPrefixCapitalized%>ConfigurationComponent,
+    component: ConfigurationComponent,
     data: {
         pageTitle: 'configuration.title'
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
@@ -17,70 +17,79 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-import { HttpClient, HttpResponse } from '@angular/common/http';
+import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
 import { SERVER_API_URL } from 'app/app.constants';
 
+export interface ConfigProps {
+    contexts: Contexts;
+}
+
+export interface Contexts {
+    [key: string]: Context;
+}
+
+export interface Context {
+    beans: Beans;
+    parentId?: any;
+}
+
+export interface Beans {
+    [key: string]: Bean;
+}
+
+export interface Bean {
+    prefix: string;
+    properties: any;
+}
+
+export interface Env {
+    activeProfiles?: string[];
+    propertySources: PropertySource[];
+}
+
+export interface PropertySource {
+    name: string;
+    properties: Properties;
+}
+
+export interface Properties {
+    [key: string]: Property;
+}
+
+export interface Property {
+    value: string;
+    origin?: string;
+}
+
 @Injectable({providedIn: 'root'})
 export class ConfigurationService {
+    constructor(private http: HttpClient) {}
 
-    constructor(private http: HttpClient) {
-    }
-
-    get(): Observable<any> {
-        return this.http.get(SERVER_API_URL + 'management/configprops', { observe: 'response' }).pipe(
-            map((res: HttpResponse<any>) => {
-                const properties: any[] = [];
-                const propertiesObject = this.getConfigPropertiesObjects(res.body);
-                for (const key in propertiesObject) {
-                    if (Object.prototype.hasOwnProperty.call(propertiesObject, key)) {
-                        properties.push(propertiesObject[key]);
+    getBeans(): Observable<Beans> {
+        return this.http.get<ConfigProps>(SERVER_API_URL + 'management/configprops').pipe(
+            map(configProps => {
+                // This code is for Spring Boot 2
+                for (const key in configProps.contexts) {
+                    // If the key is not bootstrap, it will be the ApplicationContext Id
+                    // For default app, it is baseName
+                    // For microservice, it is baseName-1
+                    if (!key.startsWith('bootstrap')) {
+                        return configProps.contexts[key].beans;
                     }
                 }
-
-                return properties.sort((propertyA, propertyB) => {
-                    return (propertyA.prefix === propertyB.prefix) ? 0 : propertyA.prefix < propertyB.prefix ? -1 : 1;
-                });
+                // by default, use the default ApplicationContext Id
+                return configProps.contexts['<%= baseName %>'].beans;
             })
         );
     }
 
-    getConfigPropertiesObjects(res: Record<string, any> ) {
-        // This code is for Spring Boot 2
-        if (res['contexts'] !== undefined) {
-            for (const key in res['contexts']) {
-                // If the key is not bootstrap, it will be the ApplicationContext Id
-                // For default app, it is baseName
-                // For microservice, it is baseName-1
-                if (!key.startsWith('bootstrap')) {
-                    return res['contexts'][key]['beans'];
-                }
-            }
-        }
-        // by default, use the default ApplicationContext Id
-        return res['contexts']['<%= baseName %>']['beans'];
-    }
-
-    getEnv(): Observable<any> {
-        return this.http.get(SERVER_API_URL + 'management/env', { observe: 'response' }).pipe(
-            map((res: HttpResponse<any>) => {
-                const properties: any = {};
-                const propertySources = res.body['propertySources'];
-
-                for (const propertyObject of propertySources) {
-                    const name = propertyObject['name'];
-                    const detailProperties = propertyObject['properties'];
-                    const vals: any[] = [];
-                    for (const keyDetail in detailProperties) {
-                        if (Object.prototype.hasOwnProperty.call(detailProperties, keyDetail)) {
-                            vals.push({key: keyDetail, val: detailProperties[keyDetail]['value']});
-                        }
-                    }
-                    properties[name] = vals;
-                }
-                return properties;
+    getPropertySources(): Observable<PropertySource[]> {
+        return this.http.get<Env>(SERVER_API_URL + 'management/env').pipe(
+            map(env => {
+                return env.propertySources;
             })
         );
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
@@ -24,7 +24,7 @@ import { map } from 'rxjs/operators';
 import { SERVER_API_URL } from 'app/app.constants';
 
 @Injectable({providedIn: 'root'})
-export class <%=jhiPrefixCapitalized%>ConfigurationService {
+export class ConfigurationService {
 
     constructor(private http: HttpClient) {
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
@@ -68,29 +68,19 @@ export interface Property {
 export class ConfigurationService {
     constructor(private http: HttpClient) {}
 
-    getBeans(): Observable<Beans> {
+    getBeans(): Observable<Bean[]> {
         return this.http.get<ConfigProps>(SERVER_API_URL + 'management/configprops').pipe(
-            map(configProps => {
-                // This code is for Spring Boot 2
-                for (const key in configProps.contexts) {
-                    // If the key is not bootstrap, it will be the ApplicationContext Id
-                    // For default app, it is baseName
-                    // For microservice, it is baseName-1
-                    if (!key.startsWith('bootstrap')) {
-                        return configProps.contexts[key].beans;
-                    }
-                }
-                // by default, use the default ApplicationContext Id
-                return configProps.contexts['<%= baseName %>'].beans;
-            })
+            map(configProps =>
+                Object.values(
+                    Object.values(configProps.contexts)
+                        .map(context => context.beans)
+                        .reduce((allBeans: Beans, contextBeans: Beans) => ({ ...allBeans, ...contextBeans }))
+                )
+            )
         );
     }
 
     getPropertySources(): Observable<PropertySource[]> {
-        return this.http.get<Env>(SERVER_API_URL + 'management/env').pipe(
-            map(env => {
-                return env.propertySources;
-            })
-        );
+        return this.http.get<Env>(SERVER_API_URL + 'management/env').pipe(map(env => env.propertySources));
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -20,29 +20,29 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
-import { <%=jhiPrefixCapitalized%>ConfigurationComponent } from 'app/admin/configuration/configuration.component';
-import { <%=jhiPrefixCapitalized%>ConfigurationService } from 'app/admin/configuration/configuration.service';
+import { ConfigurationComponent } from 'app/admin/configuration/configuration.component';
+import { ConfigurationService } from 'app/admin/configuration/configuration.service';
 
 describe('Component Tests', () => {
-    describe('<%=jhiPrefixCapitalized%>ConfigurationComponent', () => {
-        let comp: <%=jhiPrefixCapitalized%>ConfigurationComponent;
-        let fixture: ComponentFixture<<%=jhiPrefixCapitalized%>ConfigurationComponent>;
-        let service: <%=jhiPrefixCapitalized%>ConfigurationService;
+    describe('ConfigurationComponent', () => {
+        let comp: ConfigurationComponent;
+        let fixture: ComponentFixture<ConfigurationComponent>;
+        let service: ConfigurationService;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
                 imports: [<%=angularXAppName%>TestModule],
-                declarations: [<%=jhiPrefixCapitalized%>ConfigurationComponent],
-                providers: [<%=jhiPrefixCapitalized%>ConfigurationService]
+                declarations: [ConfigurationComponent],
+                providers: [ConfigurationService]
             })
-                .overrideTemplate(<%=jhiPrefixCapitalized%>ConfigurationComponent, '')
+                .overrideTemplate(ConfigurationComponent, '')
                 .compileComponents();
         }));
 
         beforeEach(() => {
-            fixture = TestBed.createComponent(<%=jhiPrefixCapitalized%>ConfigurationComponent);
+            fixture = TestBed.createComponent(ConfigurationComponent);
             comp = fixture.componentInstance;
-            service = fixture.debugElement.injector.get(<%=jhiPrefixCapitalized%>ConfigurationService);
+            service = fixture.debugElement.injector.get(ConfigurationService);
         });
 
         describe('OnInit', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -21,7 +21,7 @@ import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { ConfigurationComponent } from 'app/admin/configuration/configuration.component';
-import { ConfigurationService, Beans, PropertySource } from 'app/admin/configuration/configuration.service';
+import { ConfigurationService, Bean, PropertySource } from 'app/admin/configuration/configuration.service';
 
 describe('Component Tests', () => {
     describe('ConfigurationComponent', () => {
@@ -48,8 +48,8 @@ describe('Component Tests', () => {
         describe('OnInit', () => {
             it('Should call load all on init', () => {
                 // GIVEN
-                const beans: Beans = {
-                    'io.github.jhipster.config.JHipsterProperties': {
+                const beans: Bean[] = [
+                    {
                         prefix: 'jhipster',
                         properties: {
                             clientApp: {
@@ -57,7 +57,7 @@ describe('Component Tests', () => {
                             }
                         }
                     }
-                };
+                ];
                 const propertySources: PropertySource[] = [
                     {
                         name: 'server.ports',
@@ -78,16 +78,7 @@ describe('Component Tests', () => {
                 expect(service.getBeans).toHaveBeenCalled();
                 expect(service.getPropertySources).toHaveBeenCalled();
                 expect(comp.allBeans).toEqual(beans);
-                expect(comp.beans).toEqual([
-                    {
-                        prefix: 'jhipster',
-                        properties: {
-                            clientApp: {
-                                name: 'jhipsterApp'
-                            }
-                        }
-                    }
-                ]);
+                expect(comp.beans).toEqual(beans);
                 expect(comp.propertySources).toEqual(propertySources);
             });
         });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -21,7 +21,7 @@ import { of } from 'rxjs';
 
 import { <%=angularXAppName%>TestModule } from '../../../test.module';
 import { ConfigurationComponent } from 'app/admin/configuration/configuration.component';
-import { ConfigurationService } from 'app/admin/configuration/configuration.service';
+import { ConfigurationService, Beans, PropertySource } from 'app/admin/configuration/configuration.service';
 
 describe('Component Tests', () => {
     describe('ConfigurationComponent', () => {
@@ -46,40 +46,49 @@ describe('Component Tests', () => {
         });
 
         describe('OnInit', () => {
-            it('should set all default values correctly', () => {
-                expect(comp.configKeys).toEqual([]);
-                expect(comp.filter).toBe('');
-                expect(comp.orderProp).toBe('prefix');
-                expect(comp.reverse).toBe(false);
-            });
             it('Should call load all on init', () => {
                 // GIVEN
-                const body = [{config: 'test', properties: 'test'}, {config: 'test2'}]
-                const envConfig = {envConfig: 'test'}
-                spyOn(service, 'get').and.returnValue(of(body));
-                spyOn(service, 'getEnv').and.returnValue(of(envConfig));
+                const beans: Beans = {
+                    'io.github.jhipster.config.JHipsterProperties': {
+                        prefix: 'jhipster',
+                        properties: {
+                            clientApp: {
+                                name: 'jhipsterApp'
+                            }
+                        }
+                    }
+                };
+                const propertySources: PropertySource[] = [
+                    {
+                        name: 'server.ports',
+                        properties: {
+                            'local.server.port': {
+                                value: '8080'
+                            }
+                        }
+                    }
+                ];
+                spyOn(service, 'getBeans').and.returnValue(of(beans));
+                spyOn(service, 'getPropertySources').and.returnValue(of(propertySources));
 
                 // WHEN
                 comp.ngOnInit();
 
                 // THEN
-                expect(service.get).toHaveBeenCalled();
-                expect(service.getEnv).toHaveBeenCalled();
-                expect(comp.configKeys).toEqual([["0", "1", "2", "3"]]);
-                expect(comp.allConfiguration).toEqual(envConfig);
-            });
-        });
-        describe('keys method', () => {
-            it('should return the keys of an Object', () => {
-                // GIVEN
-                const data = {
-                    key1: 'test',
-                    key2: 'test2'
-                }
-
-                // THEN
-                expect(comp.keys(data)).toEqual(['key1', 'key2']);
-                expect(comp.keys(undefined)).toEqual([]);
+                expect(service.getBeans).toHaveBeenCalled();
+                expect(service.getPropertySources).toHaveBeenCalled();
+                expect(comp.allBeans).toEqual(beans);
+                expect(comp.beans).toEqual([
+                    {
+                        prefix: 'jhipster',
+                        properties: {
+                            clientApp: {
+                                name: 'jhipsterApp'
+                            }
+                        }
+                    }
+                ]);
+                expect(comp.propertySources).toEqual(propertySources);
             });
         });
     });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -44,7 +44,7 @@ describe('Service Tests', () => {
 
         describe('Service methods', () => {
             it('should call correct URL', () => {
-                service.getBeans().subscribe(() => {});
+                service.getBeans().subscribe();
 
                 const req = httpMock.expectOne({ method: 'GET' });
                 const resourceUrl = SERVER_API_URL + 'management/configprops';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -17,23 +17,23 @@ distributed under the License is distributed on an "AS IS" BASIS,
 limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
-
-import { ConfigurationService } from 'app/admin/configuration/configuration.service';
-import { SERVER_API_URL } from 'app/app.constants';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
+
+import { ConfigurationService, ConfigProps, Env, Beans, PropertySource } from 'app/admin/configuration/configuration.service';
+import { SERVER_API_URL } from 'app/app.constants';
 
 describe('Service Tests', () => {
     describe('Logs Service', () => {
         let service: ConfigurationService;
-        let httpMock;
-        let expectedResult;
+        let httpMock: HttpTestingController;
+        let expectedResult: Beans | PropertySource[] | null;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule]
             });
 
-            expectedResult = {};
+            expectedResult = null;
             service = TestBed.get(ConfigurationService);
             httpMock = TestBed.get(HttpTestingController);
         });
@@ -44,7 +44,7 @@ describe('Service Tests', () => {
 
         describe('Service methods', () => {
             it('should call correct URL', () => {
-                service.get().subscribe(() => {});
+                service.getBeans().subscribe(() => {});
 
                 const req = httpMock.expectOne({ method: 'GET' });
                 const resourceUrl = SERVER_API_URL + 'management/configprops';
@@ -52,44 +52,45 @@ describe('Service Tests', () => {
             });
 
             it('should get the config', () => {
-                const angularConfig = {
-                    contexts: {
-                        angular: {
-                            beans: [
-                                'test2'
-                            ]
+                const beans: Beans = {
+                    'io.github.jhipster.config.JHipsterProperties': {
+                        prefix: 'jhipster',
+                        properties: {
+                            clientApp: {
+                                name: 'jhipsterApp'
+                            }
                         }
                     }
-                }
-                service.get().subscribe(received => {
-                    expectedResult = received;
-                });
+                };
+                const configProps: ConfigProps = {
+                    contexts: {
+                        jhipster: { beans }
+                    }
+                };
+                service.getBeans().subscribe(received => (expectedResult = received));
 
                 const req = httpMock.expectOne({ method: 'GET' });
-                req.flush(angularConfig);
-                expect(expectedResult).toEqual(['test2']);
+                req.flush(configProps);
+                expect(expectedResult).toEqual(beans);
             });
 
             it('should get the env', () => {
-                const propertySources = {
-                    propertySources: [
-                        {
+                const propertySources: PropertySource[] = [
+                    {
                         name: 'server.ports',
                         properties: {
                             'local.server.port': {
-                            value: 8080
+                                value: '8080'
                             }
                         }
-                        }
-                    ]
-                };
-                service.getEnv().subscribe(received => {
-                    expectedResult = received;
-                });
+                    }
+                ];
+                const env: Env = { propertySources };
+                service.getPropertySources().subscribe(received => (expectedResult = received));
 
                 const req = httpMock.expectOne({ method: 'GET' });
-                req.flush(propertySources);
-                expect(expectedResult).toEqual({ 'server.ports': [{ key: 'local.server.port', val: 8080 }] });
+                req.flush(env);
+                expect(expectedResult).toEqual(propertySources);
             });
         });
     });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -19,14 +19,14 @@ limitations under the License.
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { ConfigurationService, ConfigProps, Env, Beans, PropertySource } from 'app/admin/configuration/configuration.service';
+import { ConfigurationService, ConfigProps, Env, Bean, PropertySource } from 'app/admin/configuration/configuration.service';
 import { SERVER_API_URL } from 'app/app.constants';
 
 describe('Service Tests', () => {
     describe('Logs Service', () => {
         let service: ConfigurationService;
         let httpMock: HttpTestingController;
-        let expectedResult: Beans | PropertySource[] | null;
+        let expectedResult: Bean[] | PropertySource[] | null;
 
         beforeEach(() => {
             TestBed.configureTestingModule({
@@ -52,26 +52,28 @@ describe('Service Tests', () => {
             });
 
             it('should get the config', () => {
-                const beans: Beans = {
-                    'io.github.jhipster.config.JHipsterProperties': {
-                        prefix: 'jhipster',
-                        properties: {
-                            clientApp: {
-                                name: 'jhipsterApp'
-                            }
+                const bean: Bean = {
+                    prefix: 'jhipster',
+                    properties: {
+                        clientApp: {
+                            name: 'jhipsterApp'
                         }
                     }
                 };
                 const configProps: ConfigProps = {
                     contexts: {
-                        jhipster: { beans }
+                        jhipster: {
+                            beans: {
+                                'io.github.jhipster.config.JHipsterProperties': bean
+                            }
+                        }
                     }
                 };
                 service.getBeans().subscribe(received => (expectedResult = received));
 
                 const req = httpMock.expectOne({ method: 'GET' });
                 req.flush(configProps);
-                expect(expectedResult).toEqual(beans);
+                expect(expectedResult).toEqual([bean]);
             });
 
             it('should get the env', () => {

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -18,13 +18,13 @@ limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
 
-import { <%=jhiPrefixCapitalized%>ConfigurationService } from 'app/admin/configuration/configuration.service';
+import { ConfigurationService } from 'app/admin/configuration/configuration.service';
 import { SERVER_API_URL } from 'app/app.constants';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
 describe('Service Tests', () => {
     describe('Logs Service', () => {
-        let service: <%=jhiPrefixCapitalized%>ConfigurationService;
+        let service: ConfigurationService;
         let httpMock;
         let expectedResult;
 
@@ -34,7 +34,7 @@ describe('Service Tests', () => {
             });
 
             expectedResult = {};
-            service = TestBed.get(<%=jhiPrefixCapitalized%>ConfigurationService);
+            service = TestBed.get(ConfigurationService);
             httpMock = TestBed.get(HttpTestingController);
         });
 


### PR DESCRIPTION
This is a configuration module PR for the #10631

Some notes:

* As according to https://angular.io/guide/pipes#appendix-no-filterpipe-or-orderbypipe it's not recommended to perform filtering or ordering with pipe then now filtering and ordering is done in the component method when filter or order change event occurs.

* UI previously didn't show to user that it's possible to order by prefix. Now UI uses standard `jhiSort` + `jhiSortBy` directives to show that.

* According to #10220 removed prefix from configuration service and component.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
