### PR TITLE
Remove prefix from DocsComponent in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.component.ts.ejs
@@ -22,7 +22,7 @@ import { Component } from '@angular/core';
     selector: '<%= jhiPrefixDashed %>-docs',
     templateUrl: './docs.component.html'
 })
-export class <%=jhiPrefixCapitalized%>DocsComponent {
+export class DocsComponent {
     constructor(
     ) {
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.module.ts.ejs
@@ -2,7 +2,7 @@ import { NgModule } from '@angular/core';
 import { RouterModule } from '@angular/router';
 import { <%=angularXAppName%>SharedModule } from 'app/shared/shared.module';
 
-import { <%=jhiPrefixCapitalized%>DocsComponent } from './docs.component';
+import { DocsComponent } from './docs.component';
 
 import { docsRoute } from './docs.route';
 
@@ -11,6 +11,6 @@ import { docsRoute } from './docs.route';
     <%=angularXAppName%>SharedModule,
     RouterModule.forChild([docsRoute])
   ],
-  declarations: [<%=jhiPrefixCapitalized%>DocsComponent]
+  declarations: [DocsComponent]
 })
 export class DocsModule {}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.route.ts.ejs
@@ -18,11 +18,11 @@
 -%>
 import { Route } from '@angular/router';
 
-import { <%=jhiPrefixCapitalized%>DocsComponent } from './docs.component';
+import { DocsComponent } from './docs.component';
 
 export const docsRoute: Route = {
     path: '',
-    component: <%=jhiPrefixCapitalized%>DocsComponent,
+    component: DocsComponent,
     data: {
         pageTitle: 'global.menu.admin.apidocs'
     }


### PR DESCRIPTION
Docs module doesn't have errors if enabling Typescript strict option but according to #10220 removed prefix from component name.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
