### PR TITLE
Strict Typescript option in HTML templates in Angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html.ejs
@@ -49,21 +49,21 @@
                         <input type="password" class="form-control" id="newPassword" name="newPassword"
                                placeholder="{{'global.form.newpassword.placeholder' | translate}}"
                                formControlName="newPassword" #newPassword>
-                        <div *ngIf="passwordForm.get('newPassword').invalid && (passwordForm.get('newPassword').dirty || passwordForm.get('newPassword').touched)">
+                        <div *ngIf="passwordForm.get('newPassword')?.invalid && (passwordForm.get('newPassword')?.dirty || passwordForm.get('newPassword')?.touched)">
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword').errors.required" jhiTranslate="global.messages.validate.newpassword.required">
+                               *ngIf="passwordForm.get('newPassword')?.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
                                 Your password is required.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword').errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
+                               *ngIf="passwordForm.get('newPassword')?.errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
                                 Your password is required to be at least 4 characters.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword').errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
+                               *ngIf="passwordForm.get('newPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
                                 Your password cannot be longer than 50 characters.
                             </small>
                         </div>
-                        <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword').value"></<%= jhiPrefixDashed %>-password-strength-bar>
+                        <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')?.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                     </div>
 
                     <div class="form-group">
@@ -71,17 +71,17 @@
                         <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
                                placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
                                formControlName="confirmPassword">
-                        <div *ngIf="passwordForm.get('confirmPassword').invalid && (passwordForm.get('confirmPassword').dirty || passwordForm.get('confirmPassword').touched)">
+                        <div *ngIf="passwordForm.get('confirmPassword')?.invalid && (passwordForm.get('confirmPassword')?.dirty || passwordForm.get('confirmPassword')?.touched)">
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword').errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
                                 Your password confirmation is required.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword').errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
                                 Your password confirmation is required to be at least 4 characters.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword').errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                                 Your password confirmation cannot be longer than 50 characters.
                             </small>
                         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html.ejs
@@ -49,21 +49,21 @@
                         <input type="password" class="form-control" id="newPassword" name="newPassword"
                                placeholder="{{'global.form.newpassword.placeholder' | translate}}"
                                formControlName="newPassword" #newPassword>
-                        <div *ngIf="passwordForm.get('newPassword')?.invalid && (passwordForm.get('newPassword')?.dirty || passwordForm.get('newPassword')?.touched)">
+                        <div *ngIf="passwordForm.get('newPassword')!.invalid && (passwordForm.get('newPassword')!.dirty || passwordForm.get('newPassword')!.touched)">
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword')?.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
+                               *ngIf="passwordForm.get('newPassword')?.errors?.required" jhiTranslate="global.messages.validate.newpassword.required">
                                 Your password is required.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword')?.errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
+                               *ngIf="passwordForm.get('newPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
                                 Your password is required to be at least 4 characters.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
+                               *ngIf="passwordForm.get('newPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
                                 Your password cannot be longer than 50 characters.
                             </small>
                         </div>
-                        <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')?.value"></<%= jhiPrefixDashed %>-password-strength-bar>
+                        <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')!.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                     </div>
 
                     <div class="form-group">
@@ -71,17 +71,17 @@
                         <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
                                placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
                                formControlName="confirmPassword">
-                        <div *ngIf="passwordForm.get('confirmPassword')?.invalid && (passwordForm.get('confirmPassword')?.dirty || passwordForm.get('confirmPassword')?.touched)">
+                        <div *ngIf="passwordForm.get('confirmPassword')!.invalid && (passwordForm.get('confirmPassword')!.dirty || passwordForm.get('confirmPassword')!.touched)">
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword')?.errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors?.required" jhiTranslate="global.messages.validate.confirmpassword.required">
                                 Your password confirmation is required.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword')?.errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
                                 Your password confirmation is required to be at least 4 characters.
                             </small>
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                                 Your password confirmation cannot be longer than 50 characters.
                             </small>
                         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
@@ -42,21 +42,21 @@
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
                            formControlName="email" #email>
-                    <div *ngIf="resetRequestForm.get('email').invalid && (resetRequestForm.get('email').dirty || resetRequestForm.get('email').touched)">
+                    <div *ngIf="resetRequestForm.get('email')?.invalid && (resetRequestForm.get('email')?.dirty || resetRequestForm.get('email')?.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email').errors.required" jhiTranslate="global.messages.validate.email.required">
+                           *ngIf="resetRequestForm.get('email')?.errors.required" jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email').errors.email" jhiTranslate="global.messages.validate.email.invalid">
+                           *ngIf="resetRequestForm.get('email')?.errors.email" jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email').errors.minlength" jhiTranslate="global.messages.validate.email.minlength">
+                           *ngIf="resetRequestForm.get('email')?.errors.minlength" jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email').errors.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
+                           *ngIf="resetRequestForm.get('email')?.errors.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
@@ -42,21 +42,21 @@
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
                            formControlName="email" #email>
-                    <div *ngIf="resetRequestForm.get('email')?.invalid && (resetRequestForm.get('email')?.dirty || resetRequestForm.get('email')?.touched)">
+                    <div *ngIf="resetRequestForm.get('email')!.invalid && (resetRequestForm.get('email')!.dirty || resetRequestForm.get('email')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors.required" jhiTranslate="global.messages.validate.email.required">
+                           *ngIf="resetRequestForm.get('email')?.errors?.required" jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors.email" jhiTranslate="global.messages.validate.email.invalid">
+                           *ngIf="resetRequestForm.get('email')?.errors?.email" jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors.minlength" jhiTranslate="global.messages.validate.email.minlength">
+                           *ngIf="resetRequestForm.get('email')?.errors?.minlength" jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
+                           *ngIf="resetRequestForm.get('email')?.errors?.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
@@ -39,9 +39,9 @@
                     <input type="password" class="form-control" id="currentPassword" name="currentPassword"
                            placeholder="{{'global.form.currentpassword.placeholder' | translate}}"
                            formControlName="currentPassword">
-                    <div *ngIf="passwordForm.get('currentPassword').invalid && (passwordForm.get('currentPassword').dirty || passwordForm.get('currentPassword').touched)" >
+                    <div *ngIf="passwordForm.get('currentPassword')?.invalid && (passwordForm.get('currentPassword')?.dirty || passwordForm.get('currentPassword')?.touched)" >
                         <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('currentPassword').errors.required" jhiTranslate="global.messages.validate.newpassword.required">
+                               *ngIf="passwordForm.get('currentPassword')?.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
                     </div>
@@ -51,38 +51,38 @@
                     <input type="password" class="form-control" id="newPassword" name="newPassword"
                            placeholder="{{'global.form.newpassword.placeholder' | translate}}"
                            formControlName="newPassword">
-                    <div *ngIf="passwordForm.get('newPassword').invalid && (passwordForm.get('newPassword').dirty || passwordForm.get('newPassword').touched)">
+                    <div *ngIf="passwordForm.get('newPassword')?.invalid && (passwordForm.get('newPassword')?.dirty || passwordForm.get('newPassword')?.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword').errors.required" jhiTranslate="global.messages.validate.newpassword.required">
+                           *ngIf="passwordForm.get('newPassword')?.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword').errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
+                           *ngIf="passwordForm.get('newPassword')?.errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
                             Your password is required to be at least 4 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword').errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
+                           *ngIf="passwordForm.get('newPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
                             Your password cannot be longer than 50 characters.
                         </small>
                     </div>
-                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword').value"></<%= jhiPrefixDashed %>-password-strength-bar>
+                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')?.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
                     <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
                            placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
                            formControlName="confirmPassword">
-                    <div *ngIf="passwordForm.get('confirmPassword').invalid && (passwordForm.get('confirmPassword').dirty || passwordForm.get('confirmPassword').touched)">
+                    <div *ngIf="passwordForm.get('confirmPassword')?.invalid && (passwordForm.get('confirmPassword')?.dirty || passwordForm.get('confirmPassword')?.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword').errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
+                           *ngIf="passwordForm.get('confirmPassword')?.errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
                             Your confirmation password is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword').errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
+                           *ngIf="passwordForm.get('confirmPassword')?.errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
                             Your confirmation password is required to be at least 4 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword').errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
+                           *ngIf="passwordForm.get('confirmPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                             Your confirmation password cannot be longer than 50 characters.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
@@ -39,9 +39,9 @@
                     <input type="password" class="form-control" id="currentPassword" name="currentPassword"
                            placeholder="{{'global.form.currentpassword.placeholder' | translate}}"
                            formControlName="currentPassword">
-                    <div *ngIf="passwordForm.get('currentPassword')?.invalid && (passwordForm.get('currentPassword')?.dirty || passwordForm.get('currentPassword')?.touched)" >
+                    <div *ngIf="passwordForm.get('currentPassword')!.invalid && (passwordForm.get('currentPassword')!.dirty || passwordForm.get('currentPassword')!.touched)" >
                         <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('currentPassword')?.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
+                               *ngIf="passwordForm.get('currentPassword')?.errors?.required" jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
                     </div>
@@ -51,38 +51,38 @@
                     <input type="password" class="form-control" id="newPassword" name="newPassword"
                            placeholder="{{'global.form.newpassword.placeholder' | translate}}"
                            formControlName="newPassword">
-                    <div *ngIf="passwordForm.get('newPassword')?.invalid && (passwordForm.get('newPassword')?.dirty || passwordForm.get('newPassword')?.touched)">
+                    <div *ngIf="passwordForm.get('newPassword')!.invalid && (passwordForm.get('newPassword')!.dirty || passwordForm.get('newPassword')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword')?.errors.required" jhiTranslate="global.messages.validate.newpassword.required">
+                           *ngIf="passwordForm.get('newPassword')?.errors?.required" jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword')?.errors.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
+                           *ngIf="passwordForm.get('newPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
                             Your password is required to be at least 4 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
+                           *ngIf="passwordForm.get('newPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
                             Your password cannot be longer than 50 characters.
                         </small>
                     </div>
-                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')?.value"></<%= jhiPrefixDashed %>-password-strength-bar>
+                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')!.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
                     <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
                            placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
                            formControlName="confirmPassword">
-                    <div *ngIf="passwordForm.get('confirmPassword')?.invalid && (passwordForm.get('confirmPassword')?.dirty || passwordForm.get('confirmPassword')?.touched)">
+                    <div *ngIf="passwordForm.get('confirmPassword')!.invalid && (passwordForm.get('confirmPassword')!.dirty || passwordForm.get('confirmPassword')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword')?.errors.required" jhiTranslate="global.messages.validate.confirmpassword.required">
+                           *ngIf="passwordForm.get('confirmPassword')?.errors?.required" jhiTranslate="global.messages.validate.confirmpassword.required">
                             Your confirmation password is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword')?.errors.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
+                           *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
                             Your confirmation password is required to be at least 4 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword')?.errors.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
+                           *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                             Your confirmation password cannot be longer than 50 characters.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.html.ejs
@@ -50,19 +50,19 @@
                     <label class="form-control-label" for="login" jhiTranslate="global.form.username.label">Username</label>
                     <input type="text" class="form-control" id="login" name="login" placeholder="{{'global.form.username.placeholder' | translate}}"
                            formControlName="login" #login>
-                    <div *ngIf="registerForm.get('login')?.invalid && (registerForm.get('login')?.dirty || registerForm.get('login')?.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.required" jhiTranslate="register.messages.validate.login.required">
+                    <div *ngIf="registerForm.get('login')!.invalid && (registerForm.get('login')!.dirty || registerForm.get('login')!.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.required" jhiTranslate="register.messages.validate.login.required">
                             Your username is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.minlength"
                                 jhiTranslate="register.messages.validate.login.minlength">
                             Your username is required to be at least 1 character.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.maxlength"
                                 jhiTranslate="register.messages.validate.login.maxlength">
                             Your username cannot be longer than 50 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.pattern"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.pattern"
                                jhiTranslate="register.messages.validate.login.pattern">
                             Your username can only contain letters and digits.
                         </small>
@@ -72,20 +72,20 @@
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
                              formControlName="email">
-                    <div *ngIf="registerForm.get('email')?.invalid && (registerForm.get('email')?.dirty || registerForm.get('email')?.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.required"
+                    <div *ngIf="registerForm.get('email')!.invalid && (registerForm.get('email')!.dirty || registerForm.get('email')!.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.required"
                                 jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.invalid"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.invalid"
                                jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.minlength"
                                jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.maxlength"
                                jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
@@ -95,36 +95,36 @@
                     <label class="form-control-label" for="password" jhiTranslate="global.form.newpassword.label">New password</label>
                     <input type="password" class="form-control" id="password" name="password" placeholder="{{'global.form.newpassword.placeholder' | translate}}"
                             formControlName="password">
-                    <div *ngIf="registerForm.get('password')?.invalid && (registerForm.get('password')?.dirty || registerForm.get('password')?.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors.required"
+                    <div *ngIf="registerForm.get('password')!.invalid && (registerForm.get('password')!.dirty || registerForm.get('password')!.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.required"
                                 jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.minlength"
                                 jhiTranslate="global.messages.validate.newpassword.minlength">
                             Your password is required to be at least 4 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.maxlength"
                                 jhiTranslate="global.messages.validate.newpassword.maxlength">
                             Your password cannot be longer than 50 characters.
                         </small>
                     </div>
-                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="registerForm.get('password')?.value"></<%= jhiPrefixDashed %>-password-strength-bar>
+                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="registerForm.get('password')!.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
                     <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
                             formControlName="confirmPassword">
-                    <div *ngIf="registerForm.get('confirmPassword')?.invalid && (registerForm.get('confirmPassword')?.dirty || registerForm.get('confirmPassword')?.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors.required"
+                    <div *ngIf="registerForm.get('confirmPassword')!.invalid && (registerForm.get('confirmPassword')!.dirty || registerForm.get('confirmPassword')!.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors?.required"
                                jhiTranslate="global.messages.validate.confirmpassword.required">
                             Your confirmation password is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors?.minlength"
                               jhiTranslate="global.messages.validate.confirmpassword.minlength">
                             Your confirmation password is required to be at least 4 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors?.maxlength"
                                jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                             Your confirmation password cannot be longer than 50 characters.
                         </small>

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.html.ejs
@@ -50,19 +50,19 @@
                     <label class="form-control-label" for="login" jhiTranslate="global.form.username.label">Username</label>
                     <input type="text" class="form-control" id="login" name="login" placeholder="{{'global.form.username.placeholder' | translate}}"
                            formControlName="login" #login>
-                    <div *ngIf="registerForm.get('login').invalid && (registerForm.get('login').dirty || registerForm.get('login').touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login').errors.required" jhiTranslate="register.messages.validate.login.required">
+                    <div *ngIf="registerForm.get('login')?.invalid && (registerForm.get('login')?.dirty || registerForm.get('login')?.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.required" jhiTranslate="register.messages.validate.login.required">
                             Your username is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login').errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.minlength"
                                 jhiTranslate="register.messages.validate.login.minlength">
                             Your username is required to be at least 1 character.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login').errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.maxlength"
                                 jhiTranslate="register.messages.validate.login.maxlength">
                             Your username cannot be longer than 50 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login').errors.pattern"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors.pattern"
                                jhiTranslate="register.messages.validate.login.pattern">
                             Your username can only contain letters and digits.
                         </small>
@@ -72,20 +72,20 @@
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
                              formControlName="email">
-                    <div *ngIf="registerForm.get('email').invalid && (registerForm.get('email').dirty || registerForm.get('email').touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email').errors.required"
+                    <div *ngIf="registerForm.get('email')?.invalid && (registerForm.get('email')?.dirty || registerForm.get('email')?.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.required"
                                 jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email').errors.invalid"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.invalid"
                                jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email').errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.minlength"
                                jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email').errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors.maxlength"
                                jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
@@ -95,36 +95,36 @@
                     <label class="form-control-label" for="password" jhiTranslate="global.form.newpassword.label">New password</label>
                     <input type="password" class="form-control" id="password" name="password" placeholder="{{'global.form.newpassword.placeholder' | translate}}"
                             formControlName="password">
-                    <div *ngIf="registerForm.get('password').invalid && (registerForm.get('password').dirty || registerForm.get('password').touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password').errors.required"
+                    <div *ngIf="registerForm.get('password')?.invalid && (registerForm.get('password')?.dirty || registerForm.get('password')?.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors.required"
                                 jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password').errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors.minlength"
                                 jhiTranslate="global.messages.validate.newpassword.minlength">
                             Your password is required to be at least 4 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password').errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors.maxlength"
                                 jhiTranslate="global.messages.validate.newpassword.maxlength">
                             Your password cannot be longer than 50 characters.
                         </small>
                     </div>
-                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="registerForm.get('password').value"></<%= jhiPrefixDashed %>-password-strength-bar>
+                    <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="registerForm.get('password')?.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                 </div>
                 <div class="form-group">
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
                     <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
                             formControlName="confirmPassword">
-                    <div *ngIf="registerForm.get('confirmPassword').invalid && (registerForm.get('confirmPassword').dirty || registerForm.get('confirmPassword').touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword').errors.required"
+                    <div *ngIf="registerForm.get('confirmPassword')?.invalid && (registerForm.get('confirmPassword')?.dirty || registerForm.get('confirmPassword')?.touched)">
+                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors.required"
                                jhiTranslate="global.messages.validate.confirmpassword.required">
                             Your confirmation password is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword').errors.minlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors.minlength"
                               jhiTranslate="global.messages.validate.confirmpassword.minlength">
                             Your confirmation password is required to be at least 4 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword').errors.maxlength"
+                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors.maxlength"
                                jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                             Your confirmation password cannot be longer than 50 characters.
                         </small>

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
@@ -33,17 +33,17 @@
                     <label class="form-control-label" for="firstName" jhiTranslate="settings.form.firstname">First Name</label>
                     <input type="text" class="form-control" id="firstName" name="firstName" placeholder="{{'settings.form.firstname.placeholder' | translate}}"
                            formControlName="firstName">
-                    <div *ngIf="settingsForm.get('firstName').invalid && (settingsForm.get('firstName').dirty || settingsForm.get('firstName').touched)">
+                    <div *ngIf="settingsForm.get('firstName')?.invalid && (settingsForm.get('firstName')?.dirty || settingsForm.get('firstName')?.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName').errors.required" jhiTranslate="settings.messages.validate.firstname.required">
+                           *ngIf="settingsForm.get('firstName')?.errors.required" jhiTranslate="settings.messages.validate.firstname.required">
                             Your first name is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName').errors.minlength" jhiTranslate="settings.messages.validate.firstname.minlength">
+                           *ngIf="settingsForm.get('firstName')?.errors.minlength" jhiTranslate="settings.messages.validate.firstname.minlength">
                             Your first name is required to be at least 1 character.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName').errors.maxlength" jhiTranslate="settings.messages.validate.firstname.maxlength">
+                           *ngIf="settingsForm.get('firstName')?.errors.maxlength" jhiTranslate="settings.messages.validate.firstname.maxlength">
                             Your first name cannot be longer than 50 characters.
                         </small>
                     </div>
@@ -52,17 +52,17 @@
                     <label class="form-control-label" for="lastName" jhiTranslate="settings.form.lastname">Last Name</label>
                     <input type="text" class="form-control" id="lastName" name="lastName" placeholder="{{'settings.form.lastname.placeholder' | translate}}"
                            formControlName="lastName">
-                    <div *ngIf="settingsForm.get('lastName').invalid && (settingsForm.get('lastName').dirty || settingsForm.get('lastName').touched)">
+                    <div *ngIf="settingsForm.get('lastName')?.invalid && (settingsForm.get('lastName')?.dirty || settingsForm.get('lastName')?.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName').errors.required" jhiTranslate="settings.messages.validate.lastname.required">
+                           *ngIf="settingsForm.get('lastName')?.errors.required" jhiTranslate="settings.messages.validate.lastname.required">
                             Your last name is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName').errors.minlength" jhiTranslate="settings.messages.validate.lastname.minlength">
+                           *ngIf="settingsForm.get('lastName')?.errors.minlength" jhiTranslate="settings.messages.validate.lastname.minlength">
                             Your last name is required to be at least 1 character.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName').errors.maxlength" jhiTranslate="settings.messages.validate.lastname.maxlength">
+                           *ngIf="settingsForm.get('lastName')?.errors.maxlength" jhiTranslate="settings.messages.validate.lastname.maxlength">
                             Your last name cannot be longer than 50 characters.
                         </small>
                     </div>
@@ -71,21 +71,21 @@
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
                            formControlName="email">
-                    <div *ngIf="settingsForm.get('email').invalid && (settingsForm.get('email').dirty || settingsForm.get('email').touched)">
+                    <div *ngIf="settingsForm.get('email')?.invalid && (settingsForm.get('email')?.dirty || settingsForm.get('email')?.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email').errors.required" jhiTranslate="global.messages.validate.email.required">
+                           *ngIf="settingsForm.get('email')?.errors.required" jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email').errors.email" jhiTranslate="global.messages.validate.email.invalid">
+                           *ngIf="settingsForm.get('email')?.errors.email" jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email').errors.minlength" jhiTranslate="global.messages.validate.email.minlength">
+                           *ngIf="settingsForm.get('email')?.errors.minlength" jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email').errors.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
+                           *ngIf="settingsForm.get('email')?.errors.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
@@ -33,17 +33,17 @@
                     <label class="form-control-label" for="firstName" jhiTranslate="settings.form.firstname">First Name</label>
                     <input type="text" class="form-control" id="firstName" name="firstName" placeholder="{{'settings.form.firstname.placeholder' | translate}}"
                            formControlName="firstName">
-                    <div *ngIf="settingsForm.get('firstName')?.invalid && (settingsForm.get('firstName')?.dirty || settingsForm.get('firstName')?.touched)">
+                    <div *ngIf="settingsForm.get('firstName')!.invalid && (settingsForm.get('firstName')!.dirty || settingsForm.get('firstName')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName')?.errors.required" jhiTranslate="settings.messages.validate.firstname.required">
+                           *ngIf="settingsForm.get('firstName')?.errors?.required" jhiTranslate="settings.messages.validate.firstname.required">
                             Your first name is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName')?.errors.minlength" jhiTranslate="settings.messages.validate.firstname.minlength">
+                           *ngIf="settingsForm.get('firstName')?.errors?.minlength" jhiTranslate="settings.messages.validate.firstname.minlength">
                             Your first name is required to be at least 1 character.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName')?.errors.maxlength" jhiTranslate="settings.messages.validate.firstname.maxlength">
+                           *ngIf="settingsForm.get('firstName')?.errors?.maxlength" jhiTranslate="settings.messages.validate.firstname.maxlength">
                             Your first name cannot be longer than 50 characters.
                         </small>
                     </div>
@@ -52,17 +52,17 @@
                     <label class="form-control-label" for="lastName" jhiTranslate="settings.form.lastname">Last Name</label>
                     <input type="text" class="form-control" id="lastName" name="lastName" placeholder="{{'settings.form.lastname.placeholder' | translate}}"
                            formControlName="lastName">
-                    <div *ngIf="settingsForm.get('lastName')?.invalid && (settingsForm.get('lastName')?.dirty || settingsForm.get('lastName')?.touched)">
+                    <div *ngIf="settingsForm.get('lastName')!.invalid && (settingsForm.get('lastName')!.dirty || settingsForm.get('lastName')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName')?.errors.required" jhiTranslate="settings.messages.validate.lastname.required">
+                           *ngIf="settingsForm.get('lastName')?.errors?.required" jhiTranslate="settings.messages.validate.lastname.required">
                             Your last name is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName')?.errors.minlength" jhiTranslate="settings.messages.validate.lastname.minlength">
+                           *ngIf="settingsForm.get('lastName')?.errors?.minlength" jhiTranslate="settings.messages.validate.lastname.minlength">
                             Your last name is required to be at least 1 character.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName')?.errors.maxlength" jhiTranslate="settings.messages.validate.lastname.maxlength">
+                           *ngIf="settingsForm.get('lastName')?.errors?.maxlength" jhiTranslate="settings.messages.validate.lastname.maxlength">
                             Your last name cannot be longer than 50 characters.
                         </small>
                     </div>
@@ -71,21 +71,21 @@
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
                     <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
                            formControlName="email">
-                    <div *ngIf="settingsForm.get('email')?.invalid && (settingsForm.get('email')?.dirty || settingsForm.get('email')?.touched)">
+                    <div *ngIf="settingsForm.get('email')!.invalid && (settingsForm.get('email')!.dirty || settingsForm.get('email')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors.required" jhiTranslate="global.messages.validate.email.required">
+                           *ngIf="settingsForm.get('email')?.errors?.required" jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors.email" jhiTranslate="global.messages.validate.email.invalid">
+                           *ngIf="settingsForm.get('email')?.errors?.email" jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors.minlength" jhiTranslate="global.messages.validate.email.minlength">
+                           *ngIf="settingsForm.get('email')?.errors?.minlength" jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
+                           *ngIf="settingsForm.get('email')?.errors?.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -25,7 +25,7 @@
     </h2>
 
     <h3 jhiTranslate="metrics.jvm.title">JVM Metrics</h3>
-    <div class="row" *ngIf="!updatingMetrics">
+    <div class="row" *ngIf="metrics && !updatingMetrics">
         <jhi-jvm-memory
             class="col-md-4"
             [updating]="updatingMetrics"
@@ -39,7 +39,7 @@
         </jhi-metrics-system>
     </div>
 
-    <div *ngIf="metricsKeyExists('garbageCollector')">
+    <div *ngIf="metrics && metricsKeyExists('garbageCollector')">
         <h3 jhiTranslate="metrics.jvm.gc.title">Garbage collector statistics</h3>
         <jhi-metrics-garbagecollector [updating]="updatingMetrics" [garbageCollectorMetrics]="metrics.garbageCollector"></jhi-metrics-garbagecollector>
     </div>
@@ -47,25 +47,25 @@
     <div class="well well-lg" *ngIf="updatingMetrics" jhiTranslate="metrics.updating">Updating...</div>
 
     <jhi-metrics-request
-        *ngIf="metricsKeyExists('http.server.requests')"
+        *ngIf="metrics && metricsKeyExists('http.server.requests')"
         [updating]="updatingMetrics"
         [requestMetrics]="metrics['http.server.requests']">
     </jhi-metrics-request>
 
     <jhi-metrics-endpoints-requests
-        *ngIf="metricsKeyExists('services')"
+        *ngIf="metrics && metricsKeyExists('services')"
         [updating]="updatingMetrics"
         [endpointsRequestsMetrics]="metrics.services">
     </jhi-metrics-endpoints-requests>
 
     <jhi-metrics-cache
-        *ngIf="metricsKeyExists('cache')"
+        *ngIf="metrics && metricsKeyExists('cache')"
         [updating]="updatingMetrics"
         [cacheMetrics]="metrics.cache">
     </jhi-metrics-cache>
 
     <jhi-metrics-datasource
-        *ngIf="metricsKeyExistsAndObjectNotEmpty('databases')"
+        *ngIf="metrics && metricsKeyExistsAndObjectNotEmpty('databases')"
         [updating]="updatingMetrics"
         [datasourceMetrics]="metrics.databases">
     </jhi-metrics-datasource>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<form *ngIf="user" name="deleteForm" (ngSubmit)="confirmDelete(user.login)">
+<form *ngIf="user" name="deleteForm" (ngSubmit)="confirmDelete(user.login!)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true"

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
@@ -34,20 +34,20 @@
                     <input type="text" class="form-control" name="login"
                            formControlName="login">
 
-                    <div *ngIf="editForm.get('login')?.invalid && (editForm.get('login')?.dirty || editForm.get('login')?.touched)">
+                    <div *ngIf="editForm.get('login')!.invalid && (editForm.get('login')!.dirty || editForm.get('login')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login')?.errors.required" jhiTranslate="entity.validation.required">
+                        *ngIf="editForm.get('login')?.errors?.required" jhiTranslate="entity.validation.required">
                             This field is required.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('login')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login')?.errors.pattern" jhiTranslate="entity.validation.patternLogin">
+                        *ngIf="editForm.get('login')?.errors?.pattern" jhiTranslate="entity.validation.patternLogin">
                             This field can only contain letters, digits and e-mail addresses.
                         </small>
                     </div>
@@ -57,9 +57,9 @@
                     <input type="text" class="form-control" name="firstName"
                            formControlName="firstName">
 
-                    <div *ngIf="editForm.get('firstName')?.invalid && (editForm.get('firstName')?.dirty || editForm.get('firstName')?.touched)">
+                    <div *ngIf="editForm.get('firstName')!.invalid && (editForm.get('firstName')!.dirty || editForm.get('firstName')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('firstName')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('firstName')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
@@ -70,9 +70,9 @@
                     <input type="text" class="form-control" name="lastName"
                         formControlName="lastName">
 
-                    <div *ngIf="editForm.get('lastName')?.invalid && (editForm.get('lastName')?.dirty || editForm.get('lastName')?.touched)">
+                    <div *ngIf="editForm.get('lastName')!.invalid && (editForm.get('lastName')!.dirty || editForm.get('lastName')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('lastName')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('lastName')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
@@ -82,26 +82,26 @@
                     <label class="form-control-label" jhiTranslate="userManagement.email">Email</label>
                     <input type="email" class="form-control" name="email" formControlName="email">
 
-                    <div *ngIf="editForm.get('email')?.invalid && (editForm.get('email')?.dirty || editForm.get('email')?.touched)">
+                    <div *ngIf="editForm.get('email')!.invalid && (editForm.get('email')!.dirty || editForm.get('email')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors.required" jhiTranslate="entity.validation.required">
+                        *ngIf="editForm.get('email')?.errors?.required" jhiTranslate="entity.validation.required">
                             This field is required.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('email')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 100}">
                             This field cannot be longer than 100 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors.minlength" jhiTranslate="entity.validation.minlength"
+                        *ngIf="editForm.get('email')?.errors?.minlength" jhiTranslate="entity.validation.minlength"
                         [translateValues]="{min: 5}">
                             This field is required to be at least 5 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors.email" jhiTranslate="global.messages.validate.email.invalid">
+                        *ngIf="editForm.get('email')?.errors?.email" jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
@@ -34,20 +34,20 @@
                     <input type="text" class="form-control" name="login"
                            formControlName="login">
 
-                    <div *ngIf="editForm.get('login').invalid && (editForm.get('login').dirty || editForm.get('login').touched)">
+                    <div *ngIf="editForm.get('login')?.invalid && (editForm.get('login')?.dirty || editForm.get('login')?.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login').errors.required" jhiTranslate="entity.validation.required">
+                        *ngIf="editForm.get('login')?.errors.required" jhiTranslate="entity.validation.required">
                             This field is required.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login').errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('login')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login').errors.pattern" jhiTranslate="entity.validation.patternLogin">
+                        *ngIf="editForm.get('login')?.errors.pattern" jhiTranslate="entity.validation.patternLogin">
                             This field can only contain letters, digits and e-mail addresses.
                         </small>
                     </div>
@@ -57,9 +57,9 @@
                     <input type="text" class="form-control" name="firstName"
                            formControlName="firstName">
 
-                    <div *ngIf="editForm.get('firstName').invalid && (editForm.get('firstName').dirty || editForm.get('firstName').touched)">
+                    <div *ngIf="editForm.get('firstName')?.invalid && (editForm.get('firstName')?.dirty || editForm.get('firstName')?.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('firstName').errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('firstName')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
@@ -70,9 +70,9 @@
                     <input type="text" class="form-control" name="lastName"
                         formControlName="lastName">
 
-                    <div *ngIf="editForm.get('lastName').invalid && (editForm.get('lastName').dirty || editForm.get('lastName').touched)">
+                    <div *ngIf="editForm.get('lastName')?.invalid && (editForm.get('lastName')?.dirty || editForm.get('lastName')?.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('lastName').errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('lastName')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 50}">
                             This field cannot be longer than 50 characters.
                         </small>
@@ -82,26 +82,26 @@
                     <label class="form-control-label" jhiTranslate="userManagement.email">Email</label>
                     <input type="email" class="form-control" name="email" formControlName="email">
 
-                    <div *ngIf="editForm.get('email').invalid && (editForm.get('email').dirty || editForm.get('email').touched)">
+                    <div *ngIf="editForm.get('email')?.invalid && (editForm.get('email')?.dirty || editForm.get('email')?.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email').errors.required" jhiTranslate="entity.validation.required">
+                        *ngIf="editForm.get('email')?.errors.required" jhiTranslate="entity.validation.required">
                             This field is required.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email').errors.maxlength" jhiTranslate="entity.validation.maxlength"
+                        *ngIf="editForm.get('email')?.errors.maxlength" jhiTranslate="entity.validation.maxlength"
                         [translateValues]="{max: 100}">
                             This field cannot be longer than 100 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email').errors.minlength" jhiTranslate="entity.validation.minlength"
+                        *ngIf="editForm.get('email')?.errors.minlength" jhiTranslate="entity.validation.minlength"
                         [translateValues]="{min: 5}">
                             This field is required to be at least 5 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email').errors.email" jhiTranslate="global.messages.validate.email.invalid">
+                        *ngIf="editForm.get('email')?.errors.email" jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
@@ -54,7 +54,7 @@
                     <button class="btn btn-danger btn-sm" (click)="setActive(user, true)" *ngIf="!user.activated"
                             jhiTranslate="userManagement.deactivated">Deactivated</button>
                     <button class="btn btn-success btn-sm" (click)="setActive(user, false)" *ngIf="user.activated"
-                            [disabled]="currentAccount.login === user.login" jhiTranslate="userManagement.activated">Activated</button>
+                            [disabled]="!currentAccount || currentAccount.login === user.login" jhiTranslate="userManagement.activated">Activated</button>
                 </td>
                 <% if (enableTranslation) { %><td>{{user.langKey}}</td><% } %>
                 <td>
@@ -83,7 +83,7 @@
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
                         </button>
                         <button type="button" (click)="deleteUser(user)"
-                                class="btn btn-danger btn-sm" [disabled]="currentAccount.login === user.login">
+                                class="btn btn-danger btn-sm" [disabled]="!currentAccount || currentAccount.login === user.login">
                             <fa-icon [icon]="'times'"></fa-icon>
                             <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
                         </button>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<form *ngIf="<%= entityInstance %>" name="deleteForm" (ngSubmit)="confirmDelete(<%= entityInstance %>.id)">
+<form *ngIf="<%= entityInstance %>" name="deleteForm" (ngSubmit)="confirmDelete(<%= entityInstance %>.id!)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true"

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
@@ -33,14 +33,14 @@
                     <span jhiTranslate="{{'<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>}}">{{<%= entityInstance %>.<%= fieldName %>}}</span>
                     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
                     <div *ngIf="<%= entityInstance %>.<%= fieldName %>">
-                        <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)">
+                        <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType!, <%= entityInstance %>.<%= fieldName %>)">
                             <img [src]="'data:' + <%=entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-width: 100%;" alt="<%=entityInstance %> image"/>
                         </a>
                         {{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}
                     </div>
                     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'any') { _%>
                     <div *ngIf="<%= entityInstance %>.<%= fieldName %>">
-                        <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)" jhiTranslate="entity.action.open">open</a>
+                        <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType!, <%= entityInstance %>.<%= fieldName %>)" jhiTranslate="entity.action.open">open</a>
                         {{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}
                     </div>
                     <%_ } else { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -22,7 +22,7 @@
             <h2 id="<%= jhiPrefixDashed %>-<%= entityFileName %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.home.createOrEditLabel">Create or edit a <%= entityClassHumanized %></h2>
             <div>
                 <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
-                <div class="form-group" [hidden]="!editForm.get('id').value">
+                <div class="form-group" [hidden]="!editForm.get('id')?.value">
                     <label for="id" jhiTranslate="global.field.id">ID</label>
                     <input type="text" class="form-control" id="id" name="id" formControlName="id"
                         readonly />
@@ -63,14 +63,14 @@ _%>
         <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
                     <div>
             <%_ if (fieldTypeBlobContent === 'image') { _%>
-                        <img [src]="'data:' + editForm.get('<%= fieldName %>ContentType').value + ';base64,' + editForm.get('<%= fieldName %>').value" style="max-height: 100px;" *ngIf="editForm.get('<%= fieldName %>').value" alt="<%=entityInstance %> image"/>
+                        <img [src]="'data:' + editForm.get('<%= fieldName %>ContentType')!.value + ';base64,' + editForm.get('<%= fieldName %>')!.value" style="max-height: 100px;" *ngIf="editForm.get('<%= fieldName %>')!.value" alt="<%=entityInstance %> image"/>
             <%_ } _%>
-                        <div *ngIf="editForm.get('<%= fieldName %>').value" class="form-text text-danger clearfix">
+                        <div *ngIf="editForm.get('<%= fieldName %>')?.value" class="form-text text-danger clearfix">
             <%_ if (fieldTypeBlobContent === 'any') { _%>
-                            <a class="pull-left" (click)="openFile(editForm.get('<%= fieldName %>ContentType').value, editForm.get('<%= fieldName %>').value)" jhiTranslate="entity.action.open">open</a><br>
-                            <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType').value}}, {{byteSize(editForm.get('<%= fieldName %>').value)}}</span>
+                            <a class="pull-left" (click)="openFile(editForm.get('<%= fieldName %>ContentType')!.value, editForm.get('<%= fieldName %>')!.value)" jhiTranslate="entity.action.open">open</a><br>
+                            <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType')!.value}}, {{byteSize(editForm.get('<%= fieldName %>')!.value)}}</span>
             <%_ } else { _%>
-                            <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType').value}}, {{byteSize(editForm.get('<%= fieldName %>').value)}}</span>
+                            <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType')!.value}}, {{byteSize(editForm.get('<%= fieldName %>')!.value)}}</span>
             <%_ } _%>
             <%_ if (fieldTypeBlobContent === 'image') { _%>
                             <button type="button" (click)="clearInputImage('<%= fieldName %>', '<%= fieldName %>ContentType', 'file_<%= fieldName %>')" class="btn btn-secondary btn-xs pull-right">
@@ -108,52 +108,52 @@ _%>
         <%_ } _%>
     <%_ } _%>
     <%_ if (fields[idx].fieldValidate === true) { _%>
-                    <div *ngIf="editForm.get('<%= fieldName %>').invalid && (editForm.get('<%= fieldName %>').dirty || editForm.get('<%= fieldName %>').touched)">
+                    <div *ngIf="editForm.get('<%= fieldName %>')?.invalid && (editForm.get('<%= fieldName %>')?.dirty || editForm.get('<%= fieldName %>')?.touched)">
         <%_ if (fields[idx].fieldValidateRules.includes('required')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.required" jhiTranslate="entity.validation.required">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.required" jhiTranslate="entity.validation.required">
                         This field is required.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('minlength')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.minlength" jhiTranslate="entity.validation.minlength" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinlength %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.minlength" jhiTranslate="entity.validation.minlength" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinlength %> }">
                         This field is required to be at least <%= fields[idx].fieldValidateRulesMinlength %> characters.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('maxlength')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.maxlength" jhiTranslate="entity.validation.maxlength" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxlength %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.maxlength" jhiTranslate="entity.validation.maxlength" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxlength %> }">
                         This field cannot be longer than <%= fields[idx].fieldValidateRulesMaxlength %> characters.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('min')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.min" jhiTranslate="entity.validation.min" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMin %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.min" jhiTranslate="entity.validation.min" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMin %> }">
                             This field should be at least <%= fields[idx].fieldValidateRulesMin %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('max')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.max" jhiTranslate="entity.validation.max" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMax %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.max" jhiTranslate="entity.validation.max" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMax %> }">
                             This field cannot be more than <%= fields[idx].fieldValidateRulesMax %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('minbytes')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.minbytes" jhiTranslate="entity.validation.minbytes" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinbytes %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.minbytes" jhiTranslate="entity.validation.minbytes" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinbytes %> }">
                             This field should be at least <%= fields[idx].fieldValidateRulesMinbytes %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('maxbytes')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.maxbytes" jhiTranslate="entity.validation.maxbytes" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxbytes %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.maxbytes" jhiTranslate="entity.validation.maxbytes" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxbytes %> }">
                             This field cannot be more than <%= fields[idx].fieldValidateRulesMaxbytes %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('pattern')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>').errors.pattern" jhiTranslate="entity.validation.pattern" [translateValues]="{ pattern: '<%= fieldNameHumanized %>' }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors.pattern" jhiTranslate="entity.validation.pattern" [translateValues]="{ pattern: '<%= fieldNameHumanized %>' }">
                             This field should follow pattern for "<%= fieldNameHumanized %>".
                         </small>
         <%_ } _%>
@@ -165,7 +165,7 @@ _%>
         <%_ } _%>
         <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
                         <small class="form-text text-danger"
-                            [hidden]="!editForm.get('<%= fieldName %>').errors?.ZonedDateTimelocal" jhiTranslate="entity.validation.ZonedDateTimelocal">
+                            [hidden]="!editForm.get('<%= fieldName %>')?.errors?.ZonedDateTimelocal" jhiTranslate="entity.validation.ZonedDateTimelocal">
                             This field should be a date and time.
                         </small>
         <%_ } _%>
@@ -196,16 +196,16 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>').value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>')?.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>').value?.id ? editForm.get('<%= relationshipFieldName %>').value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')?.value?.id ? editForm.get('<%= relationshipFieldName %>')?.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>Id').value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>Id')?.value" [ngValue]="null" selected></option>
             <%_ } _%>
                         <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
@@ -219,16 +219,16 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>').value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>')?.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>').value?.id ? editForm.get('<%= relationshipFieldName %>').value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')?.value?.id ? editForm.get('<%= relationshipFieldName %>')?.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>Id').value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>Id')?.value" [ngValue]="null" selected></option>
             <%_ } _%>
                         <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
@@ -238,15 +238,15 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
                 <div class="form-group">
                     <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipFieldNamePlural %>"><%= relationshipNameHumanized %></label>
                     <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" multiple name="<%= relationshipFieldNamePlural %>" formControlName="<%=relationshipFieldNamePlural %>">
-                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>').value, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')?.value, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
                 </div>
     <%_ } _%>
     <%_ if (relationships[idx].relationshipValidate === true && (relationshipType === 'many-to-one' || ownerSide === true)) { _%>
-                <div *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>').invalid && (editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>').dirty || editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>').touched)">
+                <div *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.invalid && (editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.dirty || editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.touched)">
         <%_ if (relationshipRequired) { _%>
                     <small class="form-text text-danger"
-                           *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>').errors.required" jhiTranslate="entity.validation.required">
+                           *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.errors.required" jhiTranslate="entity.validation.required">
                         This field is required.
                     </small>
         <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -22,7 +22,7 @@
             <h2 id="<%= jhiPrefixDashed %>-<%= entityFileName %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.home.createOrEditLabel">Create or edit a <%= entityClassHumanized %></h2>
             <div>
                 <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
-                <div class="form-group" [hidden]="!editForm.get('id')?.value">
+                <div class="form-group" [hidden]="!editForm.get('id')!.value">
                     <label for="id" jhiTranslate="global.field.id">ID</label>
                     <input type="text" class="form-control" id="id" name="id" formControlName="id"
                         readonly />
@@ -65,7 +65,7 @@ _%>
             <%_ if (fieldTypeBlobContent === 'image') { _%>
                         <img [src]="'data:' + editForm.get('<%= fieldName %>ContentType')!.value + ';base64,' + editForm.get('<%= fieldName %>')!.value" style="max-height: 100px;" *ngIf="editForm.get('<%= fieldName %>')!.value" alt="<%=entityInstance %> image"/>
             <%_ } _%>
-                        <div *ngIf="editForm.get('<%= fieldName %>')?.value" class="form-text text-danger clearfix">
+                        <div *ngIf="editForm.get('<%= fieldName %>')!.value" class="form-text text-danger clearfix">
             <%_ if (fieldTypeBlobContent === 'any') { _%>
                             <a class="pull-left" (click)="openFile(editForm.get('<%= fieldName %>ContentType')!.value, editForm.get('<%= fieldName %>')!.value)" jhiTranslate="entity.action.open">open</a><br>
                             <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType')!.value}}, {{byteSize(editForm.get('<%= fieldName %>')!.value)}}</span>
@@ -108,52 +108,52 @@ _%>
         <%_ } _%>
     <%_ } _%>
     <%_ if (fields[idx].fieldValidate === true) { _%>
-                    <div *ngIf="editForm.get('<%= fieldName %>')?.invalid && (editForm.get('<%= fieldName %>')?.dirty || editForm.get('<%= fieldName %>')?.touched)">
+                    <div *ngIf="editForm.get('<%= fieldName %>')!.invalid && (editForm.get('<%= fieldName %>')!.dirty || editForm.get('<%= fieldName %>')!.touched)">
         <%_ if (fields[idx].fieldValidateRules.includes('required')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.required" jhiTranslate="entity.validation.required">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.required" jhiTranslate="entity.validation.required">
                         This field is required.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('minlength')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.minlength" jhiTranslate="entity.validation.minlength" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinlength %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.minlength" jhiTranslate="entity.validation.minlength" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinlength %> }">
                         This field is required to be at least <%= fields[idx].fieldValidateRulesMinlength %> characters.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('maxlength')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.maxlength" jhiTranslate="entity.validation.maxlength" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxlength %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxlength %> }">
                         This field cannot be longer than <%= fields[idx].fieldValidateRulesMaxlength %> characters.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('min')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.min" jhiTranslate="entity.validation.min" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMin %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.min" jhiTranslate="entity.validation.min" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMin %> }">
                             This field should be at least <%= fields[idx].fieldValidateRulesMin %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('max')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.max" jhiTranslate="entity.validation.max" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMax %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.max" jhiTranslate="entity.validation.max" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMax %> }">
                             This field cannot be more than <%= fields[idx].fieldValidateRulesMax %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('minbytes')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.minbytes" jhiTranslate="entity.validation.minbytes" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinbytes %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.minbytes" jhiTranslate="entity.validation.minbytes" [translateValues]="{ min: <%= fields[idx].fieldValidateRulesMinbytes %> }">
                             This field should be at least <%= fields[idx].fieldValidateRulesMinbytes %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('maxbytes')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.maxbytes" jhiTranslate="entity.validation.maxbytes" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxbytes %> }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.maxbytes" jhiTranslate="entity.validation.maxbytes" [translateValues]="{ max: <%= fields[idx].fieldValidateRulesMaxbytes %> }">
                             This field cannot be more than <%= fields[idx].fieldValidateRulesMaxbytes %>.
                         </small>
         <%_ } _%>
         <%_ if (fields[idx].fieldValidateRules.includes('pattern')) { _%>
                         <small class="form-text text-danger"
-                               *ngIf="editForm.get('<%= fieldName %>')?.errors.pattern" jhiTranslate="entity.validation.pattern" [translateValues]="{ pattern: '<%= fieldNameHumanized %>' }">
+                               *ngIf="editForm.get('<%= fieldName %>')?.errors?.pattern" jhiTranslate="entity.validation.pattern" [translateValues]="{ pattern: '<%= fieldNameHumanized %>' }">
                             This field should follow pattern for "<%= fieldNameHumanized %>".
                         </small>
         <%_ } _%>
@@ -196,16 +196,16 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>')?.value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')?.value?.id ? editForm.get('<%= relationshipFieldName %>')?.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>Id')?.value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>Id')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
                         <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
@@ -219,16 +219,16 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>')?.value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')?.value?.id ? editForm.get('<%= relationshipFieldName %>')?.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
             <%_ if (!relationshipRequired) { _%>
                         <option [ngValue]="null"></option>
             <%_ } else { _%>
-                        <option *ngIf="!editForm.get('<%= relationshipName %>Id')?.value" [ngValue]="null" selected></option>
+                        <option *ngIf="!editForm.get('<%= relationshipName %>Id')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
                         <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
@@ -238,15 +238,15 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
                 <div class="form-group">
                     <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipFieldNamePlural %>"><%= relationshipNameHumanized %></label>
                     <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" multiple name="<%= relationshipFieldNamePlural %>" formControlName="<%=relationshipFieldNamePlural %>">
-                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')?.value, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')!.value, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                     </select>
                 </div>
     <%_ } _%>
     <%_ if (relationships[idx].relationshipValidate === true && (relationshipType === 'many-to-one' || ownerSide === true)) { _%>
-                <div *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.invalid && (editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.dirty || editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.touched)">
+                <div *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')!.invalid && (editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')!.dirty || editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')!.touched)">
         <%_ if (relationshipRequired) { _%>
                     <small class="form-text text-danger"
-                           *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.errors.required" jhiTranslate="entity.validation.required">
+                           *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.errors?.required" jhiTranslate="entity.validation.required">
                         This field is required.
                     </small>
         <%_ } _%>


### PR DESCRIPTION
This fixes strict problems inside HTML templates. This PR is for #10631 

After this and #10932 are merged we can try to enable strict option in Angular:
* in `tsconfig.json` and in `tsconfig-aot.json` change
```
        "noImplicitAny": false,
```
to
```
        "strict": true,
```
* add new rule into `tslint.json`: `"typedef": [true, "call-signature"]`

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
