### PR TITLE
GitHub Actions: split Angular and React builds

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -1,0 +1,160 @@
+#
+# Copyright 2013-2019 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Angular
+on: [push, pull_request]
+env:
+  JHI_RUN_APP: 1
+  JHI_JDK: 11
+  JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
+  JHI_LIB_BRANCH: master
+  JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
+  JHI_GEN_BRANCH: master
+  SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
+  SPRING_JPA_SHOW_SQL: false
+  JHI_DISABLE_WEBPACK_LOGS: true
+  JHI_E2E_HEADLESS: true
+  JHI_SCRIPTS: ./test-integration/scripts
+  NG_CLI_ANALYTICS: 'false'
+  JHI_GITHUB_CI: true
+jobs:
+  applications:
+    name: ${{ matrix.app-type }}
+    runs-on: ${{ matrix.os }}
+    if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+    timeout-minutes: 40
+    strategy:
+      fail-fast: false
+      matrix:
+        node_version: [12.13.1]
+        os: [ubuntu-latest]
+        app-type:
+          - ngx-default
+          - ngx-psql-es-noi18n-mapsid
+          - ngx-mariadb-oauth2-infinispan
+          - ngx-mongodb-kafka-cucumber
+          - ngx-h2mem-ws-nol2
+          - ngx-gradle-fr
+          - ngx-gradle-psql-es-noi18n-mapsid
+          - ngx-gradle-mariadb-oauth2-infinispan
+          - ngx-gradle-mongodb-kafka-cucumber
+          - ngx-gradle-yarn-h2disk-ws-nocache
+        include:
+          - app-type: ngx-default
+            entity: sql
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-psql-es-noi18n-mapsid
+            entity: sqlfull
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-mariadb-oauth2-infinispan
+            entity: sql
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-mongodb-kafka-cucumber
+            entity: mongodb
+            profile: dev
+            war: 0
+            protractor: 1
+          - app-type: ngx-h2mem-ws-nol2
+            entity: sql
+            profile: dev
+            war: 0 # TODO: need change to 1, when maven+war is fixed
+            protractor: 1
+          - app-type: ngx-gradle-fr
+            entity: sql
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-gradle-psql-es-noi18n-mapsid
+            entity: sqlfull
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-gradle-mariadb-oauth2-infinispan
+            entity: sql
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-gradle-mongodb-kafka-cucumber
+            entity: mongodb
+            profile: prod
+            war: 0
+            protractor: 1
+          - app-type: ngx-gradle-yarn-h2disk-ws-nocache
+            entity: sql
+            profile: dev
+            war: 1
+            protractor: 1
+    env:
+      JHI_ENTITY: ${{ matrix.entity }}
+      JHI_APP: ${{ matrix.app-type }}
+      JHI_PROFILE: ${{ matrix.profile }}
+      JHI_WAR: ${{ matrix.war }}
+      JHI_PROTRACTOR: ${{ matrix.protractor }}
+    steps:
+      #----------------------------------------------------------------------
+      # Install all tools and check configuration
+      #----------------------------------------------------------------------
+      - uses: actions/checkout@v1
+      - uses: actions/setup-node@v1
+        with:
+            node-version: ${{ matrix.node_version }}
+      - uses: actions/setup-java@v1
+        with:
+            java-version: '11.x'
+      - name: 'TOOLS: configure tools installed by the system'
+        run: $JHI_SCRIPTS/03-system.sh
+      - name: 'TOOLS: configure git'
+        run: $JHI_SCRIPTS/04-git-config.sh
+      #----------------------------------------------------------------------
+      # Install JHipster and generate project+entities
+      #----------------------------------------------------------------------
+      - name: 'GENERATION: install JHipster'
+        run: $JHI_SCRIPTS/10-install-jhipster.sh
+      - name: 'GENERATION: entities'
+        run: $JHI_SCRIPTS/11-generate-entities.sh
+      - name: 'GENERATION: project'
+        run: $JHI_SCRIPTS/12-generate-project.sh
+      - name: 'GENERATION: replace version in generated project'
+        run: $JHI_SCRIPTS/13-replace-version-generated-project.sh
+      - name: 'GENERATION: jhipster info'
+        run: $JHI_SCRIPTS/14-jhipster-info.sh
+      #----------------------------------------------------------------------
+      # Launch tests
+      #----------------------------------------------------------------------
+      - name: 'TESTS: Start docker-compose containers'
+        run: $JHI_SCRIPTS/20-docker-compose.sh
+      - name: 'TESTS: backend'
+        run: $JHI_SCRIPTS/21-tests-backend.sh
+      - name: 'TESTS: frontend'
+        run: $JHI_SCRIPTS/22-tests-frontend.sh
+      - name: 'TESTS: packaging'
+        run: $JHI_SCRIPTS/23-package.sh
+      - name: 'TESTS: End-to-End'
+        run: $JHI_SCRIPTS/24-tests-e2e.sh
+      - name: 'TESTS: Sonar analysis'
+        run: $JHI_SCRIPTS/25-sonar-analyze.sh
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -17,7 +17,7 @@
 # limitations under the License.
 #
 
-name: Applications
+name: React
 on: [push, pull_request]
 env:
   JHI_RUN_APP: 1
@@ -45,16 +45,6 @@ jobs:
         node_version: [12.13.1]
         os: [ubuntu-latest]
         app-type:
-          - ngx-default
-          - ngx-psql-es-noi18n-mapsid
-          - ngx-mariadb-oauth2-infinispan
-          - ngx-mongodb-kafka-cucumber
-          - ngx-h2mem-ws-nol2
-          - ngx-gradle-fr
-          - ngx-gradle-psql-es-noi18n-mapsid
-          - ngx-gradle-mariadb-oauth2-infinispan
-          - ngx-gradle-mongodb-kafka-cucumber
-          - ngx-gradle-yarn-h2disk-ws-nocache
           - react-default
           - react-maven-psql-es-noi18n-mapsid
           - react-maven-h2mem-memcached

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![NPM version][npm-image]][npm-url] [![Dependency Status][daviddm-image]][daviddm-url] [![Downloads][npmcharts-image]][npmcharts-url]
 
-[![Generator Build Status][github-actions-generator-image]][github-actions-url] [![Applications Build Status][github-actions-applications-image]][github-actions-url] [![Azure DevOps Build Status][azure-devops-image]][azure-devops-url-main]
+[![Generator Build Status][github-actions-generator-image]][github-actions-url] [![Angular Build Status][github-actions-angular-image]][github-actions-url] [![React Build Status][github-actions-react-image]][github-actions-url] [![Azure DevOps Build Status][azure-devops-image]][azure-devops-url-main]
 
 Greetings, Java Hipster!
 
@@ -223,7 +223,8 @@ Additional builds at [hipster-labs/jhipster-daily-builds](https://github.com/hip
 [azure-devops-image]: https://dev.azure.com/jhipster/generator-jhipster/_apis/build/status/jhipster.generator-jhipster?branchName=master
 [azure-devops-url-main]: https://dev.azure.com/jhipster/generator-jhipster/_build
 [github-actions-generator-image]: https://github.com/jhipster/generator-jhipster/workflows/Generator/badge.svg
-[github-actions-applications-image]: https://github.com/jhipster/generator-jhipster/workflows/Applications/badge.svg
+[github-actions-angular-image]: https://github.com/jhipster/generator-jhipster/workflows/Angular/badge.svg
+[github-actions-react-image]: https://github.com/jhipster/generator-jhipster/workflows/React/badge.svg
 [github-actions-url]: https://github.com/jhipster/generator-jhipster/actions
 [daviddm-image]: https://david-dm.org/jhipster/generator-jhipster.svg?theme=shields.io
 [daviddm-url]: https://david-dm.org/jhipster/generator-jhipster


### PR DESCRIPTION
As the builds for React are too flacky, compared to Angular, I prefer to split them.
So it will be easier to restart only React builds.

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
