### PR TITLE
Remove Explicit Calls to process.exit and Set the exitCode Instead

### DIFF
--- a/cli/run-yeoman-process.js
+++ b/cli/run-yeoman-process.js
@@ -30,7 +30,7 @@ logger.info(chalk.yellow(`Options: ${toString(options)}`));
 try {
     env.run(command, options, () => {
         done();
-        process.exit(0);
+        process.exitCode = 0;
     });
 } catch (e) {
     logger.error(e.message, e);

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -47,7 +47,7 @@ const error = function(msg, trace) {
     if (trace) {
         console.log(trace);
     }
-    process.exit(1);
+    process.exitCode = 1;
 };
 
 const init = function(program) {
@@ -99,7 +99,7 @@ const initHelp = (program, cliName) => {
             logger.info(`Did you mean ${chalk.yellow(suggestion)}?`);
         }
 
-        process.exit(1);
+        process.exitCode = 1;
     });
 };
 


### PR DESCRIPTION
As discussed in #10934, remove explicit calls to node exit command (`process.exit()) and use `process.exitCode` instead. 

Reference: https://nodejs.org/api/process.html#process_process_exit_code

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
