### PR TITLE
Remove Gradle workaround for Windows

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -16,8 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import org.gradle.internal.os.OperatingSystem
-
 buildscript {
     repositories {
         mavenLocal()
@@ -100,26 +98,6 @@ eclipse {
                 srcDirs += ["build/generated/sources/annotationProcessor/java/main"]
             }
         }
-    }
-}
-
-// See https://virgo47.wordpress.com/2018/09/14/classpath-too-long-with-spring-boot-and-gradle/ for details
-// https://github.com/jhipster/generator-jhipster/issues/9713
-if (OperatingSystem.current().isWindows()) {
-    task classpathJar(type: Jar) {
-        inputs.files sourceSets.main.runtimeClasspath
-
-        archiveName = "runboot-classpath.jar"
-        doFirst {
-            manifest {
-                def classpath = sourceSets.main.runtimeClasspath.files
-                attributes "Class-Path": classpath.collect {f -> f.toURI().toString()}.join(" ")
-            }
-        }
-    }
-
-    bootRun {
-        classpath = classpathJar.outputs.files
     }
 }
 


### PR DESCRIPTION
This is the follow up to the #10750 - @atomfrede mentioned in the https://github.com/jhipster/generator-jhipster/pull/10750#issue-338838170 that Gradle 6 automatically creates classpath jar if needed and we can probably remove workaround for Windows what is doing the similar job. I tested this in Windows and in my testing this is true what is written in the Gradle 6 release notes (https://docs.gradle.org/6.0/release-notes.html#usability-improvements).

Classpath jar is automatically created if needed, messages from console in `--debug`:
```
[INFO] [org.gradle.process.internal.JavaExecHandleBuilder] Shortening Java classpath [.....] with .....\AppData\Local\Temp\gradle-javaexec-classpath5811139544298465801.jar
[INFO] [org.gradle.process.internal.DefaultExecHandle] Starting process 'command '.....\java.exe''.....-cp .....\AppData\Local\Temp\gradle-javaexec-classpath5811139544298465801.jar
```

So this PR removes workaround what is no longer needed.

FYI cofiguration with what I tested:

<details>
<summary>.yo-rc.json file</summary>
<pre>
{
  "generator-jhipster": {
    "promptValues": {
      "packageName": "com.mycompany.myapp",
      "nativeLanguage": "et"
    },
    "jhipsterVersion": "6.5.1",
    "applicationType": "gateway",
    "baseName": "jhipster",
    "packageName": "com.mycompany.myapp",
    "packageFolder": "com/mycompany/myapp",
    "serverPort": "8080",
    "authenticationType": "jwt",
    "cacheProvider": "ehcache",
    "enableHibernateCache": true,
    "websocket": "spring-websocket",
    "databaseType": "sql",
    "devDatabaseType": "h2Disk",
    "prodDatabaseType": "mysql",
    "searchEngine": "elasticsearch",
    "messageBroker": "kafka",
    "serviceDiscoveryType": "eureka",
    "buildTool": "gradle",
    "enableSwaggerCodegen": true,
    "jwtSecretKey": "bXktc2VjcmV0LXRva2VuLXRvLWNoYW5nZS1pbi1wcm9kdWN0aW9uLWFuZC10by1rZWVwLWluLWEtc2VjdXJlLXBsYWNl",
    "embeddableLaunchScript": false,
    "useSass": true,
    "clientPackageManager": "npm",
    "clientFramework": "angularX",
    "clientTheme": "none",
    "clientThemeVariant": "",
    "creationTimestamp": 1576391338852,
    "testFrameworks": ["gatling", "cucumber", "protractor"],
    "jhiPrefix": "jhi",
    "entitySuffix": "",
    "dtoSuffix": "DTO",
    "otherModules": [],
    "enableTranslation": true,
    "nativeLanguage": "et",
    "languages": ["et", "en", "ru"],
    "blueprints": []
  }
}

</pre>
</details>

FYI: if I switched Gradle version to 5.6.4 then with the same configuration (with workaround removed from the `build.gradle`) the error "`CreateProcess error=206, The filename or extension is too long`" was back.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
