### PR TITLE
CI-CD: disable flaky Protractor tests with React

### DIFF
--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -55,56 +55,6 @@ jobs:
           - react-gradle-cassandra-session-redis
           - react-gradle-couchbase-caffeine
         include:
-          - app-type: ngx-default
-            entity: sql
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-psql-es-noi18n-mapsid
-            entity: sqlfull
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-mariadb-oauth2-infinispan
-            entity: sql
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-mongodb-kafka-cucumber
-            entity: mongodb
-            profile: dev
-            war: 0
-            protractor: 1
-          - app-type: ngx-h2mem-ws-nol2
-            entity: sql
-            profile: dev
-            war: 0 # TODO: need change to 1, when maven+war is fixed
-            protractor: 1
-          - app-type: ngx-gradle-fr
-            entity: sql
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-gradle-psql-es-noi18n-mapsid
-            entity: sqlfull
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-gradle-mariadb-oauth2-infinispan
-            entity: sql
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-gradle-mongodb-kafka-cucumber
-            entity: mongodb
-            profile: prod
-            war: 0
-            protractor: 1
-          - app-type: ngx-gradle-yarn-h2disk-ws-nocache
-            entity: sql
-            profile: dev
-            war: 1
-            protractor: 1
           - app-type: react-default
             entity: sql
             profile: prod
@@ -129,7 +79,7 @@ jobs:
             entity: couchbase
             profile: prod
             war: 0
-            protractor: 1
+            protractor: 0
           - app-type: react-gradle-psql-es-noi18n-mapsid
             entity: sql # TODO: need change to sqlfull, when react is fixed
             profile: prod

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -62,12 +62,12 @@ jobs:
                   JHI_APP: ms-react-gateway-consul-jwt
                   JHI_ENTITY: sqllight
                   JHI_PROFILE: prod
-                  JHI_PROTRACTOR: 1
+                  JHI_PROTRACTOR: 0
               ms-react-gateway-consul-oauth2:
                   JHI_APP: ms-react-gateway-consul-oauth2
                   JHI_ENTITY: sqllight
                   JHI_PROFILE: prod
-                  JHI_PROTRACTOR: 1
+                  JHI_PROTRACTOR: 0
               jdl-default:
                   JHI_APP: jdl-default
                   JHI_ENTITY: jdl


### PR DESCRIPTION
As our current Protractor tests with React are too flaky, it's better to disable it.
So no need to restart and restart and restart each PRs...

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
