### PR TITLE
Update prettier version

### DIFF
--- a/generators/aws-containers/index.js
+++ b/generators/aws-containers/index.js
@@ -139,9 +139,15 @@ module.exports = class extends BaseGenerator {
                 awsClient.initAwsStuff();
             },
             setOutputs() {
-                dockerCli.setOutputs(data => this.log(chalk.white(data.toString().trim())), data => this.log.error(data.toString().trim()));
+                dockerCli.setOutputs(
+                    data => this.log(chalk.white(data.toString().trim())),
+                    data => this.log.error(data.toString().trim())
+                );
 
-                awsClient.CF().setOutputs(message => this.log(message), message => this.log.error(message));
+                awsClient.CF().setOutputs(
+                    message => this.log(message),
+                    message => this.log.error(message)
+                );
             },
             fetchRegion() {
                 if (this.abort) return;

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -154,7 +154,10 @@ const files = {
     reactMain: [
         {
             path: REACT_DIR,
-            templates: [{ file: 'modules/home/home.tsx', method: 'processJsx' }, { file: 'modules/login/logout.tsx', method: 'processJsx' }]
+            templates: [
+                { file: 'modules/home/home.tsx', method: 'processJsx' },
+                { file: 'modules/login/logout.tsx', method: 'processJsx' }
+            ]
         },
         {
             condition: generator => generator.authenticationType !== 'oauth2',

--- a/generators/client/prompts.js
+++ b/generators/client/prompts.js
@@ -174,7 +174,11 @@ function askForClientThemeVariant(meta) {
 
     const skipClient = this.skipClient;
 
-    const choices = [{ value: 'primary', name: 'Primary' }, { value: 'dark', name: 'Dark' }, { value: 'light', name: 'Light' }];
+    const choices = [
+        { value: 'primary', name: 'Primary' },
+        { value: 'dark', name: 'Dark' },
+        { value: 'light', name: 'Light' }
+    ];
 
     const PROMPT = {
         type: 'list',

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -544,7 +544,7 @@ function checkStringInFile(path, search, generator) {
  */
 function loadBlueprintsFromConfiguration(config) {
     // handle both config based on yeoman's Storage object, and direct configuration loaded from .yo-rc.json
-    const configuration = config && (config.getAll && typeof config.getAll === 'function') ? config.getAll() || {} : config;
+    const configuration = config && config.getAll && typeof config.getAll === 'function' ? config.getAll() || {} : config;
     // load blueprints from config file
     const blueprints = configuration.blueprints || [];
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -4968,9 +4968,9 @@
             "integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw="
         },
         "prettier": {
-            "version": "1.18.2",
-            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.18.2.tgz",
-            "integrity": "sha512-OeHeMc0JhFE9idD4ZdtNibzY0+TPHSpSSb9h8FqtP+YnoZZ1sl8Vc9b1sasjfymH3SonAF4QcA2+mzHPhMvIiw=="
+            "version": "1.19.1",
+            "resolved": "https://registry.npmjs.org/prettier/-/prettier-1.19.1.tgz",
+            "integrity": "sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew=="
         },
         "prettier-linter-helpers": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -70,7 +70,7 @@
         "os-locale": "3.1.0",
         "parse-gitignore": "1.0.1",
         "pluralize": "7.0.0",
-        "prettier": "1.18.2",
+        "prettier": "1.19.1",
         "progress": "2.0.3",
         "randexp": "0.5.3",
         "semver": "5.6.0",


### PR DESCRIPTION
After Prettier upgrade in Angular to 1.19.1 `page-ribbon.component.ts` is formatted differently. So updating Prettier version in generator to achieve consistent regeneration.

2 commits: upgrading Prettier version and `npm run lint-fix` result.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
