### PR TITLE
Change cli logger.error behavior and implement logger.fatal.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -44,7 +44,7 @@ const runYoCommand = (cmd, args, options, opts) => {
     try {
         env.run(command, options, done);
     } catch (e) {
-        logger.error(e.message, e);
+        logger.fatal(e.message, e);
     }
 };
 

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -86,7 +86,7 @@ function importJDL(jdlImporter) {
             const errorMessage = error.message || '';
             logger.log(chalk.red(`${errorName} ${errorMessage}`));
         }
-        logger.error(`Error while parsing applications and entities from the JDL ${error}`, error);
+        logger.fatal(`Error while parsing applications and entities from the JDL ${error}`, error);
     }
     return importState;
 }
@@ -334,7 +334,7 @@ class JDLProcessor {
                 );
                 previousApp = getBaseName(application);
             } catch (error) {
-                logger.error(`Error while generating applications from the parsed JDL\n${error}`, error);
+                logger.fatal(`Error while generating applications from the parsed JDL\n${error}`, error);
             }
         };
         this.importState.exportedApplications.forEach(application => {
@@ -377,7 +377,7 @@ class JDLProcessor {
                     );
                     previousDeployment = getDeploymentType(deployment);
                 } catch (error) {
-                    logger.error(`Error while generating deployments from the parsed JDL\n${error}`, error);
+                    logger.fatal(`Error while generating deployments from the parsed JDL\n${error}`, error);
                 }
             };
             this.importState.exportedDeployments.forEach(deployment => {
@@ -436,7 +436,7 @@ class JDLProcessor {
                 );
             });
         } catch (error) {
-            logger.error(`Error while generating entities from the parsed JDL\n${error}`, error);
+            logger.fatal(`Error while generating entities from the parsed JDL\n${error}`, error);
         }
     }
 }
@@ -445,7 +445,7 @@ const validateFiles = jdlFiles => {
     if (jdlFiles) {
         jdlFiles.forEach(key => {
             if (!shelljs.test('-f', key)) {
-                logger.error(chalk.red(`\nCould not find ${key}, make sure the path is correct.\n`));
+                logger.fatal(chalk.red(`\nCould not find ${key}, make sure the path is correct.\n`));
             }
         });
     }
@@ -477,6 +477,6 @@ module.exports = (args, options, env, forkProcess = fork) => {
         jdlImporter.generateEntities(env, forkProcess);
         jdlImporter.generateDeployments(forkProcess);
     } catch (e) {
-        logger.error(`Error during import-jdl: ${e.message}`, e);
+        logger.fatal(`Error during import-jdl: ${e.message}`, e);
     }
 };

--- a/cli/jhipster.js
+++ b/cli/jhipster.js
@@ -26,7 +26,7 @@ const currentNodeVersion = process.versions.node;
 const minimumNodeVersion = packageJson.engines.node;
 
 if (!semver.satisfies(currentNodeVersion, minimumNodeVersion)) {
-    logger.error(
+    logger.fatal(
         `You are running Node version ${currentNodeVersion}\nJHipster requires Node version ${minimumNodeVersion}\nPlease update your version of Node.`
     );
 }

--- a/cli/run-yeoman-process.js
+++ b/cli/run-yeoman-process.js
@@ -34,4 +34,5 @@ try {
     });
 } catch (e) {
     logger.error(e.message, e);
+    process.exitCode = 1;
 }

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -47,6 +47,19 @@ const error = function(msg, trace) {
     if (trace) {
         console.log(trace);
     }
+    process.exitCode = 1;
+};
+
+/**
+ *  Use with carefull.
+ *  process.exit is not recommended by Node.js.
+ *  Refer to https://nodejs.org/api/process.html#process_process_exit_code.
+ */
+const fatal = function(msg, trace) {
+    console.error(`${chalk.red(msg)}`);
+    if (trace) {
+        console.log(trace);
+    }
     process.exit(1);
 };
 
@@ -66,7 +79,8 @@ const logger = {
     debug,
     info,
     log,
-    error
+    error,
+    fatal
 };
 
 const toString = item => {
@@ -183,7 +197,7 @@ const getCommandOptions = (pkg, argv) => {
 
 const done = errorMsg => {
     if (errorMsg) {
-        logger.error(`${chalk.red.bold('ERROR!')} ${errorMsg}`);
+        logger.fatal(`${chalk.red.bold('ERROR!')} ${errorMsg}`);
     } else {
         logger.info(chalk.green.bold('Congratulations, JHipster execution is complete!'));
     }


### PR DESCRIPTION
Part of https://github.com/jhipster/generator-jhipster/issues/10963
- error behavior changed from terminate the process to don't terminate.
- fatal has the old error behavior.
- Changed all uses of logger.error to logger.fatal.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
