### PR TITLE
use route detector on non-eureka gateways only

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -567,6 +567,17 @@ const serverFiles = {
             ]
         },
         {
+            condition: generator =>
+                generator.applicationType === 'gateway' && !generator.serviceDiscoveryType,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/web/filter/RouteDetectorFilter.java',
+                    renameTo: generator => `${generator.javaDir}web/filter/RouteDetectorFilter.java`
+                }
+            ]
+        },
+        {
             condition: generator => generator.applicationType === 'gateway' && generator.authenticationType === 'uaa',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
@@ -578,10 +589,6 @@ const serverFiles = {
                 {
                     file: 'package/web/filter/RefreshTokenFilterConfigurer.java',
                     renameTo: generator => `${generator.javaDir}web/filter/RefreshTokenFilterConfigurer.java`
-                },
-                {
-                    file: 'package/web/filter/RouteDetectorFilter.java',
-                    renameTo: generator => `${generator.javaDir}web/filter/RouteDetectorFilter.java`
                 },
                 {
                     file: 'package/config/oauth2/OAuth2AuthenticationConfiguration.java',

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -567,8 +567,7 @@ const serverFiles = {
             ]
         },
         {
-            condition: generator =>
-                generator.applicationType === 'gateway' && !generator.serviceDiscoveryType,
+            condition: generator => generator.applicationType === 'gateway' && !generator.serviceDiscoveryType,
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {


### PR DESCRIPTION
This fixes the failing e2e tests (here: https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build?definitionId=18)

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
