### PR TITLE
rectify the non-string parameter value in openshift deployment template

### DIFF
--- a/generators/openshift/templates/deployment.yml.ejs
+++ b/generators/openshift/templates/deployment.yml.ejs
@@ -128,7 +128,7 @@ objects:
                     done
               containerName: ${APPLICATION_NAME}
         resources:
-      replicas: "1"
+      replicas: 1
       template:
         metadata:
           labels:
@@ -156,7 +156,7 @@ objects:
             - name: SPRING_CLOUD_CONSUL_HOST
               value: ${APPLICATION_NAME}-consul
             - name: SPRING_CLOUD_CONSUL_PORT
-              value: "8500"
+              value: 8500
             <%_ } _%>
             <%_ if (app.prodDatabaseType === 'mysql') { _%>
             - name: SPRING_DATASOURCE_URL
@@ -274,7 +274,7 @@ objects:
             <%_ } _%>
             ports:
             - name: http
-              containerPort: "${APP_PORT}"
+              containerPort: ${{APP_PORT}}
   -
     apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
     kind: Service
@@ -295,7 +295,7 @@ objects:
       type: LoadBalancer
       ports:
       - name: http
-        port: "${APP_PORT}"
+        port: ${{APP_PORT}}
   -
     apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
     kind: Route
@@ -305,7 +305,7 @@ objects:
       to:
         kind: Service
         name: ${APPLICATION_NAME}
-        weight: "100"
+        weight: 100
       port:
         targetPort: "http"
       wildcardPolicy: None


### PR DESCRIPTION
Processing the openshift template throw **"Error from server: unrecognized type: int32"**

Openshift templates support non-string parameters. They are represented by double curly braces (e.g. ${{APP_PORT}})

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
