### PR TITLE
Add Maven  --batch-mode option to improve CI readability in GitHub Actions

### DIFF
--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -13,7 +13,7 @@ if [[ "$JHI_REPO" == *"/jhipster" ]]; then
     cd "$JHI_HOME"
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
 
-    ./mvnw -ntp clean install -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true
+    ./mvnw -ntp clean install -DskipTests -Dmaven.javadoc.skip=true -Dgpg.skip=true --batch-mode
 
 elif [[ "$JHI_LIB_BRANCH" == "release" ]]; then
     echo "*** jhipster: use release version"
@@ -32,7 +32,7 @@ else
 
     test-integration/scripts/10-replace-version-jhipster.sh
 
-    ./mvnw -ntp clean install -DskipTests  -Dmaven.javadoc.skip=true -Dgpg.skip=true
+    ./mvnw -ntp clean install -DskipTests  -Dmaven.javadoc.skip=true -Dgpg.skip=true --batch-mode
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-framework/
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-dependencies/
     ls -al ~/.m2/repository/io/github/jhipster/jhipster-parent/

--- a/test-integration/scripts/21-tests-backend.sh
+++ b/test-integration/scripts/21-tests-backend.sh
@@ -8,7 +8,7 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 cd "$JHI_FOLDER_APP"
 if [ -f "mvnw" ]; then
-    ./mvnw -ntp enforcer:display-info
+    ./mvnw -ntp enforcer:display-info --batch-mode
 elif [ -f "gradlew" ]; then
     ./gradlew -v
 fi
@@ -25,7 +25,7 @@ fi
 # Check Javadoc generation
 #-------------------------------------------------------------------------------
 if [ -f "mvnw" ]; then
-    ./mvnw -ntp javadoc:javadoc
+    ./mvnw -ntp javadoc:javadoc --batch-mode
 elif [ -f "gradlew" ]; then
     ./gradlew javadoc $JHI_GRADLE_EXCLUDE_WEBPACK
 fi
@@ -34,7 +34,7 @@ fi
 # Check no-http
 #-------------------------------------------------------------------------------
 if [ -f "mvnw" ]; then
-    ./mvnw -ntp checkstyle:check
+    ./mvnw -ntp checkstyle:check --batch-mode
 elif [ -f "gradlew" ]; then
     ./gradlew checkstyleNohttp $JHI_GRADLE_EXCLUDE_WEBPACK
 fi
@@ -44,7 +44,7 @@ fi
 #-------------------------------------------------------------------------------
 if [[ "$JHI_APP" == *"uaa"* ]]; then
     cd "$JHI_FOLDER_UAA"
-    ./mvnw -ntp verify
+    ./mvnw -ntp verify --batch-mode
 fi
 
 #-------------------------------------------------------------------------------
@@ -52,7 +52,7 @@ fi
 #-------------------------------------------------------------------------------
 cd "$JHI_FOLDER_APP"
 if [ -f "mvnw" ]; then
-    ./mvnw -ntp -P-webpack verify \
+    ./mvnw -ntp -P-webpack verify --batch-mode \
         -Dlogging.level.ROOT=OFF \
         -Dlogging.level.org.zalando=OFF \
         -Dlogging.level.io.github.jhipster=OFF \

--- a/test-integration/scripts/23-package.sh
+++ b/test-integration/scripts/23-package.sh
@@ -8,7 +8,7 @@ source $(dirname $0)/00-init-env.sh
 #-------------------------------------------------------------------------------
 if [[ "$JHI_APP" == *"uaa"* ]]; then
     cd "$JHI_FOLDER_UAA"
-    ./mvnw -ntp verify -DskipTests -Pdev
+    ./mvnw -ntp verify -DskipTests -Pdev --batch-mode
     mv target/*.jar app.jar
 fi
 
@@ -27,7 +27,7 @@ fi
 #-------------------------------------------------------------------------------
 if [ "$JHI_WAR" == 1 ]; then
     if [ -f "mvnw" ]; then
-        ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE",war
+        ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE",war --batch-mode
         mv target/*.war app.war
     elif [ -f "gradlew" ]; then
         ./gradlew bootWar -P"$JHI_PROFILE" -Pwar -x test
@@ -42,7 +42,7 @@ if [ "$JHI_WAR" == 1 ]; then
     fi
 else
     if [ -f "mvnw" ]; then
-        ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE"
+        ./mvnw -ntp verify -DskipTests -P"$JHI_PROFILE" --batch-mode
         mv target/*.jar app.jar
     elif [ -f "gradlew" ]; then
         ./gradlew bootJar -P"$JHI_PROFILE" -x test

--- a/test-integration/scripts/25-sonar-analyze.sh
+++ b/test-integration/scripts/25-sonar-analyze.sh
@@ -9,7 +9,7 @@ cd "$JHI_FOLDER_APP"
 
 if [[ "$JHI_APP" = "ngx-default" && "$GITHUB_REPOSITORY" = "jhipster/generator-jhipster" && "$GITHUB_REF" = "refs/heads/master" ]]; then
     echo "*** Sonar analyze for master branch"
-    ./mvnw -ntp initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+    ./mvnw -ntp --batch-mode initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.projectKey=jhipster-sample-application \
         -Dsonar.organization=jhipster \
@@ -17,7 +17,7 @@ if [[ "$JHI_APP" = "ngx-default" && "$GITHUB_REPOSITORY" = "jhipster/generator-j
 
 elif [[ $JHI_SONAR = 1 ]]; then
     echo "*** Sonar analyze locally"
-    ./mvnw -ntp initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
+    ./mvnw -ntp --batch-mode initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=http://localhost:9001 \
         -Dsonar.projectKey=JHipsterSonar
         


### PR DESCRIPTION
This should remove all the "downloading artefact" clutter in the console log, if this works this is going to be a lot better for reading the logs