### PR TITLE
Fix auto login in Angular for JWT, session and UAA authentication

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -23,12 +23,15 @@ import { Router, ActivatedRouteSnapshot, NavigationEnd, NavigationError } from '
 import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
 
+import { AccountService } from 'app/core/auth/account.service';
+
 @Component({
     selector: '<%= jhiPrefixDashed %>-main',
     templateUrl: './main.component.html'
 })
 export class MainComponent implements OnInit {
     constructor(
+        private accountService: AccountService,
         <%_ if (enableTranslation) { _%>
         private translateService: TranslateService,
         <%_ } _%>
@@ -37,6 +40,9 @@ export class MainComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
+        // try to log in automatically
+        this.accountService.identity().subscribe();
+
         this.router.events.subscribe(event => {
             if (event instanceof NavigationEnd) {
                 this.updateTitle();

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -186,6 +186,18 @@ describe('account', () => {
     });
 <%_ } _%>
 
+    it('should navigate to 404 not found error page on non existing route and show user own navbar if valid authentication exists', async () => {
+        // don't sign out and refresh page with non existing route
+        await browser.get('/this-is-link-to-non-existing-page');
+
+        // should navigate to 404 not found page
+        const url = await browser.getCurrentUrl();
+        expect(url).to.endWith('404');
+
+        // as user is admin then should show admin menu to user
+        await navBarPage.clickOnAdminMenu();
+    });
+
     after(async () => {
         await navBarPage.autoSignOut();
     });


### PR DESCRIPTION
This fixes regression from #10836 - if user has valid authentication (valid JWT in session storage or valid cookie) then UI shows in home page like user is not logged in.  
That's because no more is executed `accountService.identity()` in `HomeComponent.ngOnInit()`.

This PR fixes that and makes logic better than this was before #10836 - now `accountService.identity()` is executed on app loading in `MainComponent.ngOnInint()` and this has the following advantage:

* this is a central place which is always executed on application loading and if user initially enters some other page than `HomeComponent` then auto login is always tried, even if initially entered component has not `accountService.identity()` in it's `ngOnInit()` method

* it's useful for pages which are not protected (for protected pages `UserRouteAccessService` executes `accountService.identity()` while checking rights) - when entering initially to such page then navbar is now correct, shows that user is logged in

It's useful also for `oauth2` authentication - if user changes redirect URI to some other unprotected page then now is correct navbar shown also in these cases.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
