### PR TITLE
use lower case package instead of snake case one

### DIFF
--- a/generators/openapi-client/files.js
+++ b/generators/openapi-client/files.js
@@ -54,7 +54,7 @@ function writeFiles() {
                 let command;
                 if (generatorName === 'spring') {
                     this.log(chalk.green(`\n\nGenerating java client code for client ${cliName} (${inputSpec})`));
-                    const cliPackage = `${this.packageName}.client.${_.snakeCase(cliName)}`;
+                    const cliPackage = `${this.packageName}.client.${_.toLower(cliName)}`;
                     const clientPackageLocation = path.resolve('src', 'main', 'java', ...cliPackage.split('.'));
                     if (shelljs.test('-d', clientPackageLocation)) {
                         this.log(`cleanup generated java code for client ${cliName} in directory ${clientPackageLocation}`);

--- a/generators/openapi-client/files.js
+++ b/generators/openapi-client/files.js
@@ -54,12 +54,19 @@ function writeFiles() {
                 let command;
                 if (generatorName === 'spring') {
                     this.log(chalk.green(`\n\nGenerating java client code for client ${cliName} (${inputSpec})`));
-                    const cliPackage = `${this.packageName}.client.${_.toLower(cliName)}`;
-                    const clientPackageLocation = path.resolve('src', 'main', 'java', ...cliPackage.split('.'));
-                    if (shelljs.test('-d', clientPackageLocation)) {
-                        this.log(`cleanup generated java code for client ${cliName} in directory ${clientPackageLocation}`);
-                        shelljs.rm('-rf', clientPackageLocation);
-                    }
+                    const baseCliPackage = `${this.packageName}.client.`;
+                    const cliPackage = `${baseCliPackage}${_.toLower(cliName)}`;
+                    const snakeCaseCliPackage = `${baseCliPackage}${_.snakeCase(cliName)}`;
+                    const cleanOldDirectory = cliPackage => {
+                        const clientPackageLocation = path.resolve('src', 'main', 'java', ...cliPackage.split('.'));
+                        if (shelljs.test('-d', clientPackageLocation)) {
+                            this.log(`cleanup generated java code for client ${cliName} in directory ${clientPackageLocation}`);
+                            shelljs.rm('-rf', clientPackageLocation);
+                        }
+                    };
+
+                    cleanOldDirectory(snakeCaseCliPackage);
+                    cleanOldDirectory(cliPackage);
 
                     JAVA_OPTS = ' -Dmodels -Dapis -DsupportingFiles=ApiKeyRequestInterceptor.java,ClientConfiguration.java ';
 


### PR DESCRIPTION
When using the openapi client generator and fill the project name in camel case it transform to snake case (with underscores) to named the java package.

We should use a lower case version to match with java naming convention. underscore are not forbidden but reserved to special case like when there is a special character, digit or reserved java keywords.

source: https://docs.oracle.com/javase/tutorial/java/package/namingpkgs.html

 

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
