### PR TITLE
When using openapi-client with date field the java.time.LocalDate is not imported

### DIFF
--- a/generators/openapi-client/files.js
+++ b/generators/openapi-client/files.js
@@ -71,7 +71,7 @@ function writeFiles() {
                         ` --model-package ${cliPackage}.model` +
                         ' --type-mappings DateTime=OffsetDateTime,Date=LocalDate ' +
                         ' --import-mappings OffsetDateTime=java.time.OffsetDateTime,LocalDate=java.time.LocalDate' +
-                        ` -DdateLibrary=custom,basePackage=${this.packageName}.client,configPackage=${cliPackage},` +
+                        ` -DbasePackage=${this.packageName}.client,configPackage=${cliPackage},` +
                         `title=${_.camelCase(cliName)}`;
 
                     if (this.clientsToGenerate[cliName].useServiceDiscovery) {

--- a/generators/openapi-client/files.js
+++ b/generators/openapi-client/files.js
@@ -69,8 +69,6 @@ function writeFiles() {
                         ' --library spring-cloud ' +
                         ` -i ${inputSpec} --artifact-id ${_.camelCase(cliName)} --api-package ${cliPackage}.api` +
                         ` --model-package ${cliPackage}.model` +
-                        ' --type-mappings DateTime=OffsetDateTime,Date=LocalDate ' +
-                        ' --import-mappings OffsetDateTime=java.time.OffsetDateTime,LocalDate=java.time.LocalDate' +
                         ` -DbasePackage=${this.packageName}.client,configPackage=${cliPackage},` +
                         `title=${_.camelCase(cliName)}`;
 


### PR DESCRIPTION
For this given api.yaml
```
definitions:
  student:
    type: 'object'
    properties:
      id:
        type: 'integer'
        format: 'int64'
      firstname:
        type: 'string'
      lastname:
        type: 'string'
      birthday:
        type: 'string'
        format: 'date'
      teacher:
        $ref: '#/definitions/teacher'
```

We have a Student model generated with a birthday date field. With our current configuration 
```
--type-mappings DateTime=OffsetDateTime,Date=LocalDate 
--import-mappings OffsetDateTime=java.time.OffsetDateTime,LocalDate=java.time.LocalDate
```
The generated field is a LocalDate one (as expected) but the import is not present and the file can't be compiled.

We have to change the DateLibrary value, use as parameter `-DdateLibrary=custom`, by removing it or use another value like 'java8'.
According to this issue https://github.com/swagger-api/swagger-codegen/issues/7795 we have some options to use but many of them seems to be legacy compliant.

I know @cbornet you also contribute to the swagger-codegen project and you probably have an idea to what is the best value for us. 

Thanks :)

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
