### PR TITLE
Use the same background color as jhipster.tech

### DIFF
--- a/generators/server/templates/src/main/resources/static/microservices_index.html.ejs
+++ b/generators/server/templates/src/main/resources/static/microservices_index.html.ejs
@@ -19,7 +19,7 @@
             font-size: 20px;
             line-height: 1.4;
             color: #737373;
-            background: #262c31;
+            background: #3E8ACC;
             -webkit-text-size-adjust: 100%;
             -ms-text-size-adjust: 100%;
         }


### PR DESCRIPTION
Use the same background color (blue) as jhipster.tech for the microservices homepage:

- The current color is dark and sad
- It's more consistent
