### PR TITLE
Better solution for formatting .yo-rc.json

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -18,7 +18,6 @@
  */
 /* eslint-disable consistent-return */
 const chalk = require('chalk');
-const fs = require('fs');
 const _ = require('lodash');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const cleanup = require('../cleanup');
@@ -26,7 +25,6 @@ const prompts = require('./prompts');
 const packagejs = require('../../package.json');
 const statistics = require('../statistics');
 const jhipsterUtils = require('../utils');
-const generatorTransforms = require('../generator-transforms');
 
 let useBlueprints;
 
@@ -574,12 +572,6 @@ module.exports = class extends BaseBlueprintGenerator {
 
     _end() {
         return {
-            prettierYeomanConfig() {
-                fs.writeFileSync(
-                    '.yo-rc.json',
-                    generatorTransforms.prettierFormat(fs.readFileSync('.yo-rc.json', { encoding: 'utf-8' }), { parser: 'json' })
-                );
-            },
             gitCommit() {
                 if (!this.options['skip-git']) {
                     this.debug('Committing files to git');

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1505,7 +1505,7 @@ module.exports = class extends Generator {
      */
     registerPrettierTransform(generator = this) {
         // Prettier is clever, it uses correct rules and correct parser according to file extension.
-        const prettierFilter = filter(['{,**/}*.{md,json,ts,tsx,scss,css,yml}'], { restore: true });
+        const prettierFilter = filter(['.yo-rc.json', '{,**/}*.{md,json,ts,tsx,scss,css,yml}'], { restore: true });
         // this pipe will pass through (restore) anything that doesn't match typescriptFilter
         generator.registerTransformStream([prettierFilter, prettierTransform(prettierOptions), prettierFilter.restore]);
     }


### PR DESCRIPTION
As referenced by @mshima the cleaner way exists to format `.yo-rc.json`: https://github.com/jhipster/generator-jhipster/pull/10904#issuecomment-567473449

This PR implements that.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
