### PR TITLE
Switch on noImplicitReturns and noFallthroughCasesInSwitch in Angular

### DIFF
--- a/generators/client/templates/angular/tsconfig-aot.json.ejs
+++ b/generators/client/templates/angular/tsconfig-aot.json.ejs
@@ -26,6 +26,8 @@
         "experimentalDecorators": true,
         "removeComments": false,
         "strict": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
         "suppressImplicitAnyIndexErrors": true,
         "skipLibCheck": true,
         "outDir": "<%= DIST_DIR %>app",

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -26,6 +26,8 @@
         "experimentalDecorators": true,
         "removeComments": false,
         "strict": true,
+        "noImplicitReturns": true,
+        "noFallthroughCasesInSwitch": true,
         "skipLibCheck": true,
         "suppressImplicitAnyIndexErrors": true,
         "outDir": "<%= DIST_DIR %>app",


### PR DESCRIPTION
This PR is motivated by this comment of @vishal423: https://github.com/jhipster/generator-jhipster/issues/10631#issuecomment-567591233

According to https://www.typescriptlang.org/docs/handbook/compiler-options.html `strict` already includes: `noImplicitAny`, `noImplicitThis` and `strictNullChecks`.

As our Angular code currently passes also `noImplicitReturns` and `noFallthroughCasesInSwitch` then I turned these rules on to keep it that way to be better prepared for Angular 9.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
