### PR TITLE
Fix maven build with NoSQL and OAuth2 options

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -680,6 +680,8 @@
             <groupId>org.springframework.security</groupId>
             <artifactId>spring-security-jwt</artifactId>
         </dependency>
+<%_ } _%>
+<%_ if (authenticationType === 'uaa') { _%>
         <dependency>
             <groupId>org.glassfish.jaxb</groupId>
             <artifactId>jaxb-runtime</artifactId>


### PR DESCRIPTION
The Maven build is broken with NoSQL and OAuth2 options.
I suggest to remove the org.glassfish.jaxb:jaxb-runtime dependency with these options.
Related to https://github.com/jhipster/generator-jhipster/commit/2fb2684fb973e795d735a290713a8280b2682b9d cc @xetys 

```
➜  accountancy git:(master) ✗ ./mvnw -ntp
[INFO] Scanning for projects...
[ERROR] [ERROR] Some problems were encountered while processing the POMs:
[ERROR] 'dependencies.dependency.version' for org.glassfish.jaxb:jaxb-runtime:jar must be a valid version but is '${jaxb-runtime.version}'. @ line 261, column 22
 @
[ERROR] The build could not read 1 project -> [Help 1]
[ERROR]
[ERROR]   The project io.jsadaoui.trainning:accountancy:0.0.1-SNAPSHOT (/Users/julien/Development/jhipster/jhipster-training/jhipster-microservice-oauth2/accountancy/pom.xml) has 1 error
[ERROR]     'dependencies.dependency.version' for org.glassfish.jaxb:jaxb-runtime:jar must be a valid version but is '${jaxb-runtime.version}'. @ line 261, column 22
[ERROR]
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR]
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/ProjectBuildingException
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
