### PR TITLE
Simplify Maven and Gradle Deployment Commands in GAE Subgenerator

### DIFF
--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -773,16 +773,10 @@ module.exports = class extends BaseGenerator {
 
                 if (this.buildTool === 'maven') {
                     this.log(chalk.bold('\nRun App Engine DevServer Locally: ./mvnw package appengine:run -DskipTests'));
-                    this.log(
-                        chalk.bold('Deploy to App Engine: ./mvnw package appengine:deploy -DskipTests -Pgae,prod-gae')
-                    );
+                    this.log(chalk.bold('Deploy to App Engine: ./mvnw package appengine:deploy -DskipTests -Pgae,prod-gae'));
                 } else if (this.buildTool === 'gradle') {
                     this.log(chalk.bold('\nRun App Engine DevServer Locally: ./gradlew appengineRun'));
-                    this.log(
-                        chalk.bold(
-                            'Deploy to App Engine: ./gradlew appengineDeploy -Pgae -Pprod-gae'
-                        )
-                    );
+                    this.log(chalk.bold('Deploy to App Engine: ./gradlew appengineDeploy -Pgae -Pprod-gae'));
                 }
                 /*
                 if (this.gcpSkipBuild || this.gcpDeployType === 'git') {

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -774,13 +774,13 @@ module.exports = class extends BaseGenerator {
                 if (this.buildTool === 'maven') {
                     this.log(chalk.bold('\nRun App Engine DevServer Locally: ./mvnw package appengine:run -DskipTests'));
                     this.log(
-                        chalk.bold('Deploy to App Engine: ./mvnw clean && ./mvnw package appengine:deploy -DskipTests -Pgae,prod-gae')
+                        chalk.bold('Deploy to App Engine: ./mvnw package appengine:deploy -DskipTests -Pgae,prod-gae')
                     );
                 } else if (this.buildTool === 'gradle') {
                     this.log(chalk.bold('\nRun App Engine DevServer Locally: ./gradlew appengineRun'));
                     this.log(
                         chalk.bold(
-                            'Deploy to App Engine: ./gradlew thinResolve -Pgae -Pprod-gae && ./gradlew appengineDeploy -Pgae -Pprod-gae'
+                            'Deploy to App Engine: ./gradlew appengineDeploy -Pgae -Pprod-gae'
                         )
                     );
                 }


### PR DESCRIPTION
I realized that there's two unnecessary commands printed to the logs when we run the GAE sub-generator. The `maven clean` and `gradle thinReslove` goals not necessary anymore. 

Related to #10420

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
