### PR TITLE
kustomize template support

### DIFF
--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -122,6 +122,10 @@ function writeFiles() {
 
         writeKustomize() {
             this.template('kustomize/kustomization.yml.ejs', 'kustomization.yml');
+            if (this.istio) {
+                this.template('kustomize/patch/istio-label.yml.ejs', 'patch/istio-label.yml');
+                this.template('kustomize/patch/istio-namespace.yml.ejs', 'patch/istio-namespace.yml');
+            }
         }
     };
 }

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -126,6 +126,10 @@ function writeFiles() {
                 this.template('kustomize/patch/istio-label.yml.ejs', 'patch/istio-label.yml');
                 this.template('kustomize/patch/istio-namespace.yml.ejs', 'patch/istio-namespace.yml');
             }
+        },
+
+        writeSkaffold() {
+            this.template('skaffold/skaffold.yml.ejs', 'skaffold.yml');
         }
     };
 }

--- a/generators/kubernetes/files.js
+++ b/generators/kubernetes/files.js
@@ -118,6 +118,10 @@ function writeFiles() {
             this.template('istio/gateway/grafana-gateway.yml.ejs', 'istio/grafana-gateway.yml');
             this.template('istio/gateway/zipkin-gateway.yml.ejs', 'istio/zipkin-gateway.yml');
             this.template('istio/gateway/kiali-gateway.yml.ejs', 'istio/kiali-gateway.yml');
+        },
+
+        writeKustomize() {
+            this.template('kustomize/kustomization.yml.ejs', 'kustomization.yml');
         }
     };
 }

--- a/generators/kubernetes/index.js
+++ b/generators/kubernetes/index.js
@@ -126,8 +126,11 @@ module.exports = class extends BaseDockerGenerator {
             });
         }
 
-        this.log('\nYou can deploy all your apps by running the following script:');
-        this.log(`  ${chalk.cyan('bash kubectl-apply.sh')}`);
+        this.log('\nYou can deploy all your apps by running the following kubectl command:');
+        this.log(`  ${chalk.cyan('bash kubectl-apply.sh -f')}`);
+        this.log('\n[OR]');
+        this.log('\nIf you want to use kustomize configuration, then run the following command:');
+        this.log(`  ${chalk.cyan('bash kubectl-apply.sh -k')}`);
         if (this.gatewayNb + this.monolithicNb >= 1) {
             const namespaceSuffix = this.kubernetesNamespace === 'default' ? '' : ` -n ${this.kubernetesNamespace}`;
             this.log("\nUse these commands to find your application's IP addresses:");

--- a/generators/kubernetes/templates/README-KUBERNETES.md.ejs
+++ b/generators/kubernetes/templates/README-KUBERNETES.md.ejs
@@ -18,7 +18,7 @@ $ <%= dockerPushCommand %> <%= appConfigs[i].targetImageName %>
 You can deploy all your apps by running the below bash command:
 
 ```
-./kubectl-apply.sh
+./kubectl-apply.sh -f (default option)  [or] ./kubectl-apply.sh -k (kustomize option)
 ```
 
 ## Exploring your services

--- a/generators/kubernetes/templates/README-KUBERNETES.md.ejs
+++ b/generators/kubernetes/templates/README-KUBERNETES.md.ejs
@@ -18,7 +18,19 @@ $ <%= dockerPushCommand %> <%= appConfigs[i].targetImageName %>
 You can deploy all your apps by running the below bash command:
 
 ```
-./kubectl-apply.sh -f (default option)  [or] ./kubectl-apply.sh -k (kustomize option)
+./kubectl-apply.sh -f (default option)  [or] ./kubectl-apply.sh -k (kustomize option) [or] ./kubectl-apply.sh -s (skaffold run)
+```
+
+If you want to apply kustomize manifest directly using kubectl, then run
+
+```
+kubectl apply -k ./
+```
+
+If you want to deploy using skaffold binary, then run
+
+```
+skaffold run [or] skaffold deploy
 ```
 
 ## Exploring your services

--- a/generators/kubernetes/templates/kubectl-apply.sh.ejs
+++ b/generators/kubernetes/templates/kubectl-apply.sh.ejs
@@ -20,6 +20,22 @@
 # Files are ordered in proper order with needed wait for the dependent custom resource definitions to get initialized.
 # Usage: bash kubectl-apply.sh
 
+usage(){
+ cat << EOF
+
+ Usage: $0 -f
+ Description: To apply k8s manifests using the default \`kubectl apply -f\` command
+[OR]
+ Usage: $0 -k
+ Description: To apply k8s manifests using the kustomize \`kubectl apply -k\` command
+[OR]
+ Usage: $0 -s
+ Description: To apply k8s manifests using the skaffold binary \`skaffold run\` command
+
+EOF
+exit 0
+}
+
 logSummary() {
     echo ""
     echo "#####################################################"
@@ -32,9 +48,9 @@ logSummary() {
     <%_ } _%>
     <%_ if (kubernetesServiceType === 'Ingress') { _%>
     <%_ appConfigs.forEach((appConfig) =>  { _%>
-    <%_ if (appConfig.applicationType === 'gateway') { _%>
+    <%_ if (appConfig.applicationType === 'gateway') {_%>
     echo "Gateway - http://<%= appConfig.baseName.toLowerCase() %>.<%= kubernetesNamespace %>.<%= ingressDomain %>"
-    <%_ } _%><%_ if (appConfig.applicationType === 'monolith') { _%>
+    <%_ } _%><%_ if (appConfig.applicationType === 'monolith') {_%>
     echo "<%= appConfig.baseName %> - http://<%= appConfig.baseName.toLowerCase() %>.<%= kubernetesNamespace %>.<%= ingressDomain %>"
     <%_ } _%>
     <%_ }) _%>
@@ -47,31 +63,55 @@ logSummary() {
     echo "#####################################################"
 }
 
-<%_ if (kubernetesNamespace !== 'default') { _%>
-kubectl apply -f namespace.yml
-<%_ } _%> <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
-kubectl apply -f registry/
-<%_ } _%> <%_ if (istio) { _%>
-kubectl label namespace <%- kubernetesNamespace %> istio-injection=enabled --overwrite=true
-<%_ } _%> <%_ appConfigs.forEach((appConfig, index) =>  { _%>
-kubectl apply -f <%- appConfig.baseName.toLowerCase() %>/
-<%_ }) _%>
-<%_ if (useKafka === true) { _%>
-kubectl apply -f messagebroker/
-<%_ } _%> <%_ if (monitoring === 'elk') { _%>
-kubectl apply -f console/
-<%_ } _%> <%_ if (monitoring === 'prometheus') { _%>
-kubectl apply -f monitoring/jhipster-prometheus-crd.yml
-until [ $(kubectl get crd prometheuses.monitoring.coreos.com 2>>/dev/null | wc -l) -ge 2 ]; do
-    echo "Waiting for the custom resource prometheus operator to get initialised";
-    sleep 5;
-done
-kubectl apply -f monitoring/jhipster-prometheus-cr.yml
-kubectl apply -f monitoring/jhipster-grafana.yml
-kubectl apply -f monitoring/jhipster-grafana-dashboard.yml
-<%_ } _%>
+default() {
+    <%_ if (kubernetesNamespace !== 'default') { _%>
+    kubectl apply -f namespace.yml
+    <%_ } _%> <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
+    kubectl apply -f registry/
+    <%_ } _%> <%_ if (istio) { _%>
+    kubectl label namespace <%-kubernetesNamespace%> istio-injection=enabled --overwrite=true
+    <%_ } _%> <%_ appConfigs.forEach((appConfig, index) =>  { _%>
+    kubectl apply -f <%- appConfig.baseName.toLowerCase() %>/
+    <%_ }) _%>
+    <%_ if (useKafka === true) { _%>
+    kubectl apply -f messagebroker/
+    <%_ } _%> <%_ if (monitoring === 'elk') { _%>
+    kubectl apply -f console/
+    <%_ } _%> <%_ if (monitoring === 'prometheus') { _%>
+    kubectl apply -f monitoring/jhipster-prometheus-crd.yml
+    until [ $(kubectl get crd prometheuses.monitoring.coreos.com 2>>/dev/null | wc -l) -ge 2 ]; do
+        echo "Waiting for the custom resource prometheus operator to get initialised";
+        sleep 5;
+    done
+    kubectl apply -f monitoring/jhipster-prometheus-cr.yml
+    kubectl apply -f monitoring/jhipster-grafana.yml
+    kubectl apply -f monitoring/jhipster-grafana-dashboard.yml
+    <%_ } _%>
 
-<%_ if (istio && kubernetesServiceType === 'Ingress') { _%>
-kubectl apply -f istio/
-<%_ } _%>
+    <%_ if (istio && kubernetesServiceType === 'Ingress') { _%>
+    kubectl apply -f istio/
+    <%_ } _%>
+}
+
+kustomize() {
+    kubectl apply -k ./
+}
+
+scaffold() {
+    // this will build the source and apply the manifests the K8s target. To turn the working directory
+    // into a CI/CD space, initilaize it with `skaffold dev`
+    skaffold run
+}
+
+[[ "$@" =~ ^-[fks]{1}$ ]]  || usage;
+
+while getopts ":fks" opt; do
+    case ${opt} in
+    f ) echo "Applying default \`kubectl apply -f\`"; default ;;
+    k ) echo "Applying kustomize \`kubectl apply -k\`"; kustomize ;;
+    s ) echo "Applying using skaffold \`skaffold run\`"; scaffold ;;
+    \? | * ) usage ;;
+    esac
+done
+
 logSummary

--- a/generators/kubernetes/templates/kustomize/kustomization.yml.ejs
+++ b/generators/kubernetes/templates/kustomize/kustomization.yml.ejs
@@ -1,8 +1,5 @@
 commonLabels:
   app.kubernetes.io/genereted-by: JHipster
-  <%_ if (istio) { _%>
-  istio-injection: enabled
-  <%_ } _%>
 
 <%_ if (kubernetesNamespace !== 'default') { _%>
 namespace: <%= kubernetesNamespace %>
@@ -83,4 +80,55 @@ const appName = appConfig.baseName.toLowerCase(); _%>
 - istio/grafana-gateway.yml
 - istio/zipkin-gateway.yml
 - istio/kiali-gateway.yml
+<%_ } _%>
+
+patchesJson6902:
+<%_ if (istio) { _%>
+- target:
+    version: v1
+    kind: Namespace
+    name: <%= kubernetesNamespace %>
+  path: patch/istio-label.yml
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: Gateway
+    name: grafana-observability-gateway
+    namespace: <%= kubernetesNamespace %>
+  path: patch/istio-namespace.yml
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    name: grafana-gw-virtualservice
+    kind: VirtualService
+    namespace: <%= kubernetesNamespace %>
+  path: patch/istio-namespace.yml
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: Gateway
+    name: kiali-observability-gateway
+    namespace: <%= kubernetesNamespace %>
+  path: patch/istio-namespace.yml
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    name: kiali-gw-virtualservice
+    kind: VirtualService
+    namespace: <%= kubernetesNamespace %>
+  path: patch/istio-namespace.yml
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    kind: Gateway
+    name: zipkin-observability-gateway
+    namespace: <%= kubernetesNamespace %>
+  path: patch/istio-namespace.yml
+- target:
+    group: networking.istio.io
+    version: v1alpha3
+    name: zipkin-gw-virtualservice
+    kind: VirtualService
+    namespace: <%= kubernetesNamespace %>
+  path: patch/istio-namespace.yml
 <%_ } _%>

--- a/generators/kubernetes/templates/kustomize/kustomization.yml.ejs
+++ b/generators/kubernetes/templates/kustomize/kustomization.yml.ejs
@@ -44,6 +44,10 @@ const appName = appConfig.baseName.toLowerCase(); _%>
 - <%= appName %>/<%= appName %>-virtual-service.yml
 <%_  } _%>
 <%_ }) _%>
+<%_ if (useKafka) { _%>
+# messagebroker
+- messagebroker/kafka.yml
+<%_ } _%>
 <%_ if (monitoring === 'elk') { _%>
 # monitoring elk
 - console/jhipster-elasticsearch.yml

--- a/generators/kubernetes/templates/kustomize/kustomization.yml.ejs
+++ b/generators/kubernetes/templates/kustomize/kustomization.yml.ejs
@@ -1,0 +1,82 @@
+commonLabels:
+  app.kubernetes.io/genereted-by: JHipster
+  <%_ if (istio) { _%>
+  istio-injection: enabled
+  <%_ } _%>
+
+<%_ if (kubernetesNamespace !== 'default') { _%>
+namespace: <%= kubernetesNamespace %>
+<%_ } _%>
+
+resources:
+<%_
+if (kubernetesNamespace !== 'default') { _%>
+- namespace.yml
+<%_ } _%>
+# Individual apps
+<%_
+appConfigs.forEach((appConfig) =>  {
+const appName = appConfig.baseName.toLowerCase(); _%>
+- <%= appName %>/<%= appName %>-deployment.yml
+- <%= appName %>/<%= appName %>-service.yml
+<%_
+  if (appConfig.prodDatabaseType !== 'no') { _%>
+- <%= appName %>/<%= appName %>-<%= appConfig.prodDatabaseType %>.yml
+<%_  }
+  if (appConfig.searchEngine === 'elasticsearch') { _%>
+- <%= appName %>/<%= appName %>-elasticsearch.yml
+<%_  }
+  if (appConfig.applicationType === 'gateway' || appConfig.applicationType === 'monolith') {
+    if (istio) { _%>
+- <%= appName %>/<%= appName %>-gateway.yml
+<%_    } else if (kubernetesServiceType === 'Ingress') { _%>
+- <%= appName %>/<%= appName %>-ingress.yml
+<%_    }
+  }
+  if (!appConfig.serviceDiscoveryType && appConfig.authenticationType === 'jwt') { _%>
+- <%= appName %>/jwt-secret.yml
+<%_  }
+  if (monitoring === 'prometheus') { _%>
+- <%= appName %>/<%= appName %>-prometheus-sm.yml
+<%_  }
+  if (istio) { _%>
+- <%= appName %>/<%= appName %>-destination-rule.yml
+- <%= appName %>/<%= appName %>-virtual-service.yml
+<%_  } _%>
+<%_ }) _%>
+<%_ if (monitoring === 'elk') { _%>
+# monitoring elk
+- console/jhipster-elasticsearch.yml
+- console/jhipster-logstash.yml
+- console/jhipster-console.yml
+- console/jhipster-dashboard-console.yml
+<%_ if (deploymentApplicationType === 'microservice') { _%>
+- console/jhipster-zipkin.yml
+<%_ } _%>
+<%_ if (istio) { _%>
+- console/jhipster-console-gateway.yml
+<%_ } } _%>
+<%_ if (monitoring === 'prometheus') { _%>
+# monitoring prometheus
+- monitoring/jhipster-prometheus-cr.yml
+- monitoring/jhipster-prometheus-crd.yml
+- monitoring/jhipster-grafana.yml
+- monitoring/jhipster-grafana-dashboard.yml
+<%_ if (istio) { _%>
+- monitoring/jhipster-grafana-gateway.yml
+<%_ } } _%>
+# service discovery eureka/consul
+<%_ if (serviceDiscoveryType === 'eureka') { _%>
+- registry/jhipster-registry.yml
+- registry/application-configmap.yml
+<%_ }  else if (serviceDiscoveryType === 'consul') { _%>
+- registry/consul.yml
+- registry/consul-config-loader.yml
+- registry/application-configmap.yml
+<%_ } _%>
+<%_ if (istio) { _%>
+# istio
+- istio/grafana-gateway.yml
+- istio/zipkin-gateway.yml
+- istio/kiali-gateway.yml
+<%_ } _%>

--- a/generators/kubernetes/templates/kustomize/patch/istio-label.yml.ejs
+++ b/generators/kubernetes/templates/kustomize/patch/istio-label.yml.ejs
@@ -1,0 +1,3 @@
+- op: add
+  path: "/metadata/labels/istio-injection"
+  value: "enabled"

--- a/generators/kubernetes/templates/kustomize/patch/istio-namespace.yml.ejs
+++ b/generators/kubernetes/templates/kustomize/patch/istio-namespace.yml.ejs
@@ -1,0 +1,3 @@
+- op: replace
+  path: "/metadata/namespace"
+  value: "istio-system"

--- a/generators/kubernetes/templates/registry/consul.yml.ejs
+++ b/generators/kubernetes/templates/registry/consul.yml.ejs
@@ -83,6 +83,8 @@ metadata:
   name: consul
   namespace: <%= kubernetesNamespace %>
 spec:
+  # added to circumvent kustomize bug
+  volumeClaimTemplates: []
   serviceName: consul
   replicas: 3
   template:

--- a/generators/kubernetes/templates/registry/jhipster-registry.yml.ejs
+++ b/generators/kubernetes/templates/registry/jhipster-registry.yml.ejs
@@ -62,6 +62,8 @@ metadata:
   name: jhipster-registry
   namespace: <%= kubernetesNamespace %>
 spec:
+  # added to circumvent kustomize bug
+  volumeClaimTemplates: []
   serviceName: jhipster-registry
   replicas: 2
   selector:

--- a/generators/kubernetes/templates/skaffold/skaffold.yml.ejs
+++ b/generators/kubernetes/templates/skaffold/skaffold.yml.ejs
@@ -1,0 +1,17 @@
+apiVersion: skaffold/v2alpha1
+kind: Config
+build:
+  artifacts:
+<%_
+appConfigs.forEach((appConfig) =>  {
+  if(appConfig.baseName.toLowerCase() === appConfig.appFolder) {
+  _%>
+  - image: <%= appConfig.targetImageName %>
+    context: <%= `${directoryPath + appConfig.appFolder}` %>
+    jib: {}
+  tagPolicy:
+    envTemplate:
+      template: "<%= appConfig.targetImageName %>:latest"
+<%_ }}) _%>
+deploy:
+  kustomize: {}

--- a/generators/kubernetes/templates/skaffold/skaffold.yml.ejs
+++ b/generators/kubernetes/templates/skaffold/skaffold.yml.ejs
@@ -1,4 +1,4 @@
-apiVersion: skaffold/v2alpha1
+apiVersion: skaffold/v1
 kind: Config
 build:
   artifacts:

--- a/generators/kubernetes/templates/skaffold/skaffold.yml.ejs
+++ b/generators/kubernetes/templates/skaffold/skaffold.yml.ejs
@@ -2,16 +2,13 @@ apiVersion: skaffold/v2alpha1
 kind: Config
 build:
   artifacts:
-<%_
-appConfigs.forEach((appConfig) =>  {
-  if(appConfig.baseName.toLowerCase() === appConfig.appFolder) {
-  _%>
+<%_appConfigs.forEach((appConfig) =>  { _%>
   - image: <%= appConfig.targetImageName %>
     context: <%= `${directoryPath + appConfig.appFolder}` %>
     jib: {}
+<%_ }) _%>
   tagPolicy:
     envTemplate:
-      template: "<%= appConfig.targetImageName %>:latest"
-<%_ }}) _%>
+      template: "{{.IMAGE_NAME}}:latest"
 deploy:
   kustomize: {}


### PR DESCRIPTION
- this doesn't change the existing flow
- kustomize template support is added on top (way to externalize things)
- apply changes through either -f or -k or -s option
- added support for skaffold 
- running skaffold dev turns the cwd to a CI/CD space 
- skaffold will use jib for build and kustomize for deploy