### PR TITLE
Polish templates

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -257,11 +257,14 @@ You should see your changes reflected in the generated project.
 
 Note: The generated project might not build properly in case the generator is using a
 snapshot version of [jhipster/jhipster](https://github.com/jhipster/jhipster). This issue is mentioned in; https://github.com/jhipster/generator-jhipster/issues/9571. In
-this case clone the jhipster/jhipster project and build it using: 
+this case clone the jhipster/jhipster project and build it using:
+
 ```shell script
 ./mvnw clean install -Dgpg.skip=true
 ```
+
 or on Windows:
+
 ```
 .\mvnw.cmd clean install -D"gpg.skip=true"
 ```

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -49,9 +49,9 @@ export class RegisterComponent implements AfterViewInit {
     });
 
     constructor(
-<%_ if (enableTranslation) { _%>
+        <%_ if (enableTranslation) { _%>
         private languageService: JhiLanguageService,
-<%_ } _%>
+        <%_ } _%>
         private loginModalService: LoginModalService,
         private registerService: RegisterService,
         private renderer: Renderer,

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.ts.ejs
@@ -47,8 +47,10 @@ export class SettingsComponent implements OnInit {
 
     constructor(
         private accountService: AccountService,
-        private fb: FormBuilder<% if (enableTranslation) { %>,
-        private languageService: JhiLanguageService<% } %>
+        private fb: FormBuilder,
+        <%_ if (enableTranslation) { _%>
+        private languageService: JhiLanguageService
+        <%_ } _%>
     ) {}
 
     ngOnInit(): void {
@@ -80,8 +82,8 @@ export class SettingsComponent implements OnInit {
             this.success = true;
 
             this.accountService.authenticate(this.account);
-            <%_ if (enableTranslation) { _%>
 
+            <%_ if (enableTranslation) { _%>
             if (this.account.langKey !== this.languageService.getCurrentLanguage()) {
                 this.languageService.changeLanguage(this.account.langKey);
             }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -79,8 +79,10 @@ export class UserManagementUpdateComponent implements OnInit {
         this.updateUser(this.user);
         if (this.user.id !== undefined) {
             this.userService.update(this.user).subscribe(() => this.onSaveSuccess(), () => this.onSaveError());
-        } else {<% if (!enableTranslation) { %>
-            this.user.langKey = 'en';<% } %>
+        } else {
+            <%_ if (!enableTranslation) { _%>
+            this.user.langKey = 'en';
+            <%_ } _%>
             this.userService.create(this.user).subscribe(() => this.onSaveSuccess(), () => this.onSaveError());
         }
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -104,8 +104,8 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     trackIdentity(index: number, item: User): any {
         return item.id;
     }
-    <%_ if (databaseType !== 'cassandra') { _%>
 
+    <%_ if (databaseType !== 'cassandra') { _%>
     loadPage(page: number): void {
         if (page !== this.previousPage) {
             this.previousPage = page;
@@ -138,8 +138,8 @@ export class UserManagementComponent implements OnInit, OnDestroy {
                 (res: HttpResponse<User[]>) => this.onSuccess(res.body<% if (databaseType !== 'cassandra') { %>, res.headers<% } %>)
         );
     }
-    <%_ if (databaseType !== 'cassandra') { _%>
 
+    <%_ if (databaseType !== 'cassandra') { _%>
     private sort(): string[] {
         const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -49,13 +49,13 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
                 }
                 <%_ } _%>
                 this.stateStorageService.storeUrl(this.router.routerState.snapshot.url);
-<%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
+                <%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
                 this.loginService.logout();
                 this.router.navigate(['']);
                 this.loginModalService.open();
-<%_ } else { _%>
+                <%_ } else { _%>
                 this.loginService.login();
-<%_ } _%>
+                <%_ } _%>
             }
         }));
     }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth.interceptor.ts.ejs
@@ -45,5 +45,4 @@ export class AuthInterceptor implements HttpInterceptor {
         }
         return next.handle(request);
     }
-
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -51,8 +51,8 @@ export class AccountService  {
         private stateStorageService: StateStorageService,
         private router: Router
     ) {}
-    <%_ if (!skipUserManagement) { _%>
 
+    <%_ if (!skipUserManagement) { _%>
     save(account: Account): Observable<{}> {
         return this.http.post(SERVER_API_URL + '<%- apiUaaPath %>api/account', account);
     }
@@ -88,8 +88,8 @@ export class AccountService  {
               }),
               tap((account: Account | null) => {
                 this.authenticate(account);
-                <%_ if (enableTranslation) { _%>
 
+                <%_ if (enableTranslation) { _%>
                 // After retrieve the account info, the language will be changed to
                 // the user's preferred language configured in the account setting
                 if (account && account.langKey) {

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -31,21 +31,22 @@ import { Login } from 'app/core/login/login.model';
 type JwtToken = {
   id_token: string;
 };
-
 <%_ } else { _%>
 export const LOGOUT_URL = SERVER_API_URL + 'auth/logout';
-
 <%_ } _%>
+
 @Injectable({providedIn: 'root'})
 export class AuthServerProvider {
     constructor(
-        private http: HttpClient<%_ if (authenticationType !== 'uaa') { _%>,
+        private http: HttpClient,
+        <%_ if (authenticationType !== 'uaa') { _%>
         private $localStorage: LocalStorageService,
         private $sessionStorage: SessionStorageService
-<%_ } _%>
+        <%_ } _%>
     ) {}
 
-<%_ if (authenticationType === 'uaa') { _%>
+    <%_ if (authenticationType === 'uaa') { _%>
+
     login(credentials: Login): Observable<any> {
         return this.http.post(SERVER_API_URL + 'auth/login', credentials);
     }
@@ -53,7 +54,9 @@ export class AuthServerProvider {
     logout(): Observable<{}> {
         return this.http.post(LOGOUT_URL, null);
     }
-<% } else { %>
+
+    <%_ } else { _%>
+
     getToken(): string {
         return this.$localStorage.retrieve('authenticationToken') || this.$sessionStorage.retrieve('authenticationToken') || '';
     }
@@ -80,5 +83,6 @@ export class AuthServerProvider {
             this.$sessionStorage.store('authenticationToken', jwt);
         }
     }
-<%_ } _%>
+
+    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
@@ -37,7 +37,8 @@ export class AuthServerProvider {
     constructor(
         private http: HttpClient
     ) {}
-<%_ if (authenticationType !== 'oauth2') { _%>
+
+    <%_ if (authenticationType !== 'oauth2') { _%>
 
     login(credentials: Login): Observable<{}> {
         const data =
@@ -60,10 +61,12 @@ export class AuthServerProvider {
             })
         );
     }
-<%_ } else { _%>
+
+    <%_ } else { _%>
 
     logout(): Observable<Logout> {
         return this.http.post<Logout>(SERVER_API_URL + 'api/logout', {});
     }
-<%_ } _%>
+
+    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/core.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/core.module.ts.ejs
@@ -64,11 +64,11 @@ import { fontAwesomeIcons } from './icons/font-awesome-icons';
         Title,
         {
             provide: LOCALE_ID,
-        <%_ if (skipLanguageForLocale(nativeLanguage)) { _%>
+            <%_ if (skipLanguageForLocale(nativeLanguage)) { _%>
             useValue: 'en'
-        <%_ } else { _%>
+            <%_ } else { _%>
             useValue: '<%= localeId %>'
-        <%_ } _%>
+            <%_ } _%>
         },
         { provide: NgbDateAdapter, useClass: NgbDateMomentAdapter},
         <%_ if (enableI18nRTL) { _%>

--- a/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/language/language.helper.ts.ejs
@@ -38,14 +38,14 @@ export class LanguageHelper {
 
         this.translateService.onLangChange.subscribe((langChangeEvent: LangChangeEvent) => {
             this.renderer.setAttribute(document.querySelector('html'), 'lang', langChangeEvent.lang);
-            <%_ if (enableI18nRTL) { _%>
 
+            <%_ if (enableI18nRTL) { _%>
             this.updatePageDirection();
             <%_ } _%>
         });
     }
-    <%_ if (enableI18nRTL) { _%>
 
+    <%_ if (enableI18nRTL) { _%>
     private updatePageDirection(): void {
         this.renderer.setAttribute(document.querySelector('html'), 'dir', this.findLanguageFromKeyPipe.isRTL(this.translateService.currentLang) ? 'rtl' : 'ltr');
     }

--- a/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.ts.ejs
@@ -29,8 +29,8 @@ export class UserService {
     public resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/users';
 
     constructor(private http: HttpClient) {}
-<%_ if (authenticationType !== 'oauth2') { _%>
 
+    <%_ if (authenticationType !== 'oauth2') { _%>
     create(user: IUser): Observable<IUser> {
         return this.http.post<IUser>(this.resourceUrl, user);
     }
@@ -42,23 +42,24 @@ export class UserService {
     find(login: string): Observable<IUser> {
         return this.http.get<IUser>(`${this.resourceUrl}/${login}`);
     }
-<% } %>
+    <%_ } _%>
+
     query(req?: Pagination): Observable<HttpResponse<IUser[]>> {
         const options = createRequestOption(req);
         return this.http.get<IUser[]>(this.resourceUrl, { params: options, observe: 'response' });
     }
-<%_ if (authenticationType !== 'oauth2') { _%>
 
+    <%_ if (authenticationType !== 'oauth2') { _%>
     delete(login: string): Observable<{}> {
         return this.http.delete(`${this.resourceUrl}/${login}`);
     }
 
     authorities(): Observable<string[]> {
-<%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
+        <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
         return this.http.get<string[]>(SERVER_API_URL + '<%- apiUaaPath %>api/users/authorities');
-<%_ } else { _%>
+        <%_ } else { _%>
         return of(['ROLE_USER', 'ROLE_ADMIN']);
-<%_ } _%>
+        <%_ } _%>
     }
-<% } %>
+    <%_ } _%>
 }

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.ts.ejs
@@ -74,7 +74,7 @@ export class HomeComponent implements OnInit <%_ if (authenticationType !== 'oau
 
     <%_ if (authenticationType !== 'oauth2') { _%>
     ngOnDestroy(): void {
-        if(this.authSubscription) {
+        if (this.authSubscription) {
             this.authSubscription.unsubscribe();
         }
     }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
@@ -54,8 +54,8 @@ export class ErrorComponent implements OnInit<% if (enableTranslation) { %>, OnD
             }
         });
     }
-    <%_ if (enableTranslation) { _%>
 
+    <%_ if (enableTranslation) { _%>
     ngOnDestroy(): void {
         if (this.langChangeSubscription) {
             this.langChangeSubscription.unsubscribe();

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -51,8 +51,8 @@ export class MainComponent implements OnInit {
                 this.router.navigate(['/404']);
             }
         });
-        <%_ if (enableTranslation) { _%>
 
+        <%_ if (enableTranslation) { _%>
         this.translateService.onLangChange.subscribe(() => this.updateTitle());
         <%_ } _%>
     }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/active-menu.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/active-menu.directive.ts.ejs
@@ -17,9 +17,7 @@
  limitations under the License.
 -%>
 import { Directive, OnInit, ElementRef, Renderer, Input} from '@angular/core';
-<%_ if (enableTranslation) { _%>
 import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
-<%_ } _%>
 
 @Directive({
     selector: '[<%=jhiPrefix%>ActiveMenu]'
@@ -27,21 +25,21 @@ import { TranslateService, LangChangeEvent } from '@ngx-translate/core';
 export class ActiveMenuDirective implements OnInit {
     @Input() <%=jhiPrefix%>ActiveMenu?: string;
 
-    constructor(private el: ElementRef, private renderer: Renderer<% if (enableTranslation) { %>, private translateService: TranslateService<% } %>) {}
+    constructor(private el: ElementRef, private renderer: Renderer, private translateService: TranslateService) {}
 
     ngOnInit(): void {
-<%_ if (enableTranslation) { _%>
-      this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
-         this.updateActiveFlag(event.lang);
-      });
-      this.updateActiveFlag(this.translateService.currentLang);<% } %>
+        this.translateService.onLangChange.subscribe((event: LangChangeEvent) => {
+            this.updateActiveFlag(event.lang);
+        });
+
+        this.updateActiveFlag(this.translateService.currentLang);
     }
 
     updateActiveFlag(selectedLanguage: string): void {
-      if (this.<%=jhiPrefix%>ActiveMenu === selectedLanguage) {
-          this.renderer.setElementClass(this.el.nativeElement, 'active', true);
-      } else {
-          this.renderer.setElementClass(this.el.nativeElement, 'active', false);
-      }
+        if (this.<%=jhiPrefix%>ActiveMenu === selectedLanguage) {
+            this.renderer.setElementClass(this.el.nativeElement, 'active', true);
+        } else {
+            this.renderer.setElementClass(this.el.nativeElement, 'active', false);
+        }
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
@@ -78,8 +78,8 @@ export class NavbarComponent implements OnInit {
         this.sessionStorage.store('locale', languageKey);
         this.languageService.changeLanguage(languageKey);
     }
-
     <%_ } _%>
+
     collapseNavbar(): void {
         this.isNavbarCollapsed = true;
     }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -132,8 +132,8 @@ export class AlertErrorComponent implements OnDestroy {
     addErrorAlert(message: string<% if (enableTranslation) { %>, key?: string, data?: any<% } %>): void {
         <%_ if (enableTranslation) { _%>
         message = (key && key !== null) ? key : message;
-
         <%_ } _%>
+
         const newAlert: JhiAlert = {
             type: 'danger',
             msg: message,

--- a/generators/client/templates/angular/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/language/find-language-from-key.pipe.ts.ejs
@@ -27,8 +27,8 @@ export class FindLanguageFromKeyPipe implements PipeTransform {
     transform(lang: string): string {
         return this.languages[lang].name;
     }
-    <%_ if (enableI18nRTL) { _%>
 
+    <%_ if (enableI18nRTL) { _%>
     isRTL(lang: string): boolean {
         return Boolean(this.languages[lang].rtl);
     }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.ts.ejs
@@ -67,17 +67,20 @@ export class LoginModalComponent implements AfterViewInit {
             username: this.loginForm.get('username')!.value,
             password: this.loginForm.get('password')!.value,
             rememberMe: this.loginForm.get('rememberMe')!.value
-        }).subscribe(() => {
-            this.authenticationError = false;
-            this.activeModal.close();
-            if (
-                this.router.url === '/account/register' ||
-                this.router.url.startsWith('/account/activate') ||
-                this.router.url.startsWith('/account/reset/')
-            ) {
-                this.router.navigate(['']);
-            }
-        }, () => this.authenticationError = true);
+        }).subscribe(
+            () => {
+                this.authenticationError = false;
+                this.activeModal.close();
+                if (
+                    this.router.url === '/account/register' ||
+                    this.router.url.startsWith('/account/activate') ||
+                    this.router.url.startsWith('/account/reset/')
+                ) {
+                    this.router.navigate(['']);
+                }
+            },
+            () => this.authenticationError = true
+        );
     }
 
     register(): void {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/util/request-util.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/util/request-util.ts.ejs
@@ -30,17 +30,20 @@ export interface SearchWithPagination extends Search, Pagination {}
 
 export const createRequestOption = (req?: any): HttpParams => {
     let options: HttpParams = new HttpParams();
+
     if (req) {
         Object.keys(req).forEach((key) => {
             if (key !== 'sort') {
                 options = options.set(key, req[key]);
             }
         });
+
         if (req.sort) {
             req.sort.forEach((val: string) => {
                 options = options.append('sort', val);
             });
         }
     }
+
     return options;
 };

--- a/generators/client/templates/angular/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/index.html.ejs
@@ -56,12 +56,12 @@
                     <li>You installed a Node.js version that doesn't work with JHipster: please use an LTS (long-term support) version, as it's the only version we support.</li>
                 </ol>
                 <h2>Building the client side code again</h2>
-                <p>If you want to go fast, run <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle'){ %>./gradlew<% } %></code> to build and run everything.</p>
+                <p>If you want to go fast, run <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle') { %>./gradlew<% } %></code> to build and run everything.</p>
                 <p>If you want to have more control, so you can debug your issue more easily, you should follow the following steps:</p>
                 <ol>
                     <li>Install npm dependencies with the command <code style="color:red"><%= clientPackageManager %> install</code></li>
                     <li>Build the client with the command <code style="color:red"><%= clientPackageManager %> run webpack:build</code> or <code style="color:red"><%= clientPackageManager %> start</code></li>
-                    <li>Start the server with <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle'){ %>./gradlew<% } %></code> or using your IDE</li>
+                    <li>Start the server with <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle') { %>./gradlew<% } %></code> or using your IDE</li>
                 </ol>
 
                 <h2>Getting more help</h2>

--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -76,7 +76,7 @@ describe('account', () => {
     });
 
     it('should login successfully with admin account', async () => {
-        <%_ if (authenticationType !== 'oauth2') { _%>
+    <%_ if (authenticationType !== 'oauth2') { _%>
         await browser.get('/');
         signInPage = await navBarPage.getSignInPage();
 
@@ -88,9 +88,9 @@ describe('account', () => {
         const value1 = await element(by.className('username-label')).<%- elementGetter %>;
         expect(value1).to.eq(expect1);
         await signInPage.autoSignInUsing('admin', 'admin');
-        <%_ } else {_%>
+    <%_ } else { _%>
         await signInPage.loginWithOAuth('', 'admin');
-        <%_ } _%>
+    <%_ } _%>
 
         <%_ if (enableTranslation) { _%>
         const expect2 = 'home.logged.message';

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -94,7 +94,7 @@ describe('administration', () => {
         expect(value1).to.eq(expect1);
     });
 
-<%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
+    <%_ if ((databaseType !== 'no' || authenticationType === 'uaa') && databaseType !== 'cassandra') { _%>
     it('should load audits', async () => {
         await navBarPage.clickOnAdmin('audits');
         await browser.sleep(500);
@@ -106,8 +106,8 @@ describe('administration', () => {
         const value1 = await element(by.id('audits-page-heading')).<%- elementGetter %>;
         expect(value1).to.eq(expect1);
     });
+    <%_ } _%>
 
-<%_ } _%>
     it('should load logs', async () => {
         await navBarPage.clickOnAdmin('logs');
         await browser.sleep(500);

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -67,6 +67,7 @@ export class NavBarPage {
         await this.clickOnSignIn();
         return new SignInPage();
     }
+
     <%_ if (!skipUserManagement) { _%>
     async getPasswordPage(): Promise<PasswordPage> {
         await this.clickOnAccountMenu();
@@ -136,15 +137,14 @@ export class SignInPage {
     async clearPassword(): Promise<void> {
         await this.password.clear();
     }
-    <%_ if (authenticationType !== 'oauth2') { _%>
 
+    <%_ if (authenticationType !== 'oauth2') { _%>
     async autoSignInUsing(username: string, password: string): Promise<void> {
         await this.setUserName(username);
         await this.setPassword(password);
         await this.login();
     }
     <%_ } else { _%>
-
     async loginWithOAuth(username: string, password: string): Promise<void> {
         // Entering non angular site, tell webdriver to switch to synchronous mode.
         await browser.waitForAngularEnabled(false);
@@ -166,6 +166,7 @@ export class SignInPage {
         await this.loginButton.click();
     }
 }
+
 <%_ if (!skipUserManagement) { _%>
 export class PasswordPage {
     currentPassword = element(by.id('currentPassword'));

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.service.spec.ts.ejs
@@ -86,5 +86,4 @@ describe('Service Tests', () => {
             });
         });
     });
-
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
@@ -72,5 +72,4 @@ describe('Component Tests', () => {
             );
         });
     });
-
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
@@ -54,5 +54,4 @@ describe('Component Tests', () => {
             });
         });
     });
-
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
@@ -118,5 +118,4 @@ describe('Component Tests', () => {
             );
         });
     });
-
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -98,5 +98,4 @@ describe('Component Tests', () => {
             );
         });
     });
-
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
@@ -81,8 +81,8 @@ describe('Service Tests', () => {
                 req.flush(['ROLE_USER', 'ROLE_ADMIN']);
                 expect(expectedResult).toEqual(['ROLE_USER', 'ROLE_ADMIN']);
             });
-
             <%_ } _%>
+
             it('should propagate not found response', () => {
                 let expectedResult = 0;
 
@@ -98,5 +98,4 @@ describe('Service Tests', () => {
             });
         });
     });
-
 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
@@ -158,8 +158,8 @@ describe('Component Tests', () => {
           expect(titleService.setTitle).toHaveBeenCalledWith(parentRoutePageTitle<% if (enableTranslation) { %> + ' translated'<% } %>);
         });
       });
-      <%_ if (enableTranslation) { _%>
 
+      <%_ if (enableTranslation) { _%>
       describe('language change', () => {
         it('should set page title to default title if pageTitle is missing on routes', () => {
           // WHEN

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
@@ -103,7 +103,6 @@ describe('Component Tests', () => {
                 rememberMe: false
             };
 
-
             // WHEN
             comp.cancel();
 

--- a/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-account.service.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/helpers/mock-account.service.ts.ejs
@@ -43,5 +43,5 @@ export class MockAccountService extends SpyObject {
     setIdentityResponse(account: Account | null): void {
         this.identitySpy = this.spy('identity').andReturn(of(account));
         this.getAuthenticationStateSpy = this.spy('getAuthenticationState').andReturn(of(account));
-      }
+    }
 }

--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -22,8 +22,9 @@ const CopyWebpackPlugin = require('copy-webpack-plugin');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require("merge-jsons-webpack-plugin");
-<%_ } if (buildTool === undefined) { _%>
+<%_ } _%>
 
+<%_ if (buildTool === undefined) { _%>
 const packageJson = require('./../package.json');
 <%_ } _%>
 const utils = require('./utils.js');
@@ -77,12 +78,12 @@ module.exports = (options) => ({
             'process.env': {
                 NODE_ENV: `'${options.env}'`,
                 BUILD_TIMESTAMP: `'${new Date().getTime()}'`,
-<%_ if (buildTool === undefined) { _%>
+                <%_ if (buildTool === undefined) { _%>
                 VERSION: `'${packageJson.version}'`,
-<%_ } else { _%>
+                <%_ } else { _%>
                 // APP_VERSION is passed as an environment variable from the Gradle / Maven build tasks.
                 VERSION: `'${process.env.hasOwnProperty('APP_VERSION') ? process.env.APP_VERSION : 'DEV'}'`,
-<%_ } _%>
+                <%_ } _%>
                 DEBUG_INFO_ENABLED: options.env === 'development',
                 // The root URL for API calls, ending with a '/' - for example: `"https://www.jhipster.tech:8081/myservice/"`.
                 // If this URL is left empty (""), then it will be relative to the current context.

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -43,9 +43,11 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                 '/management',
                 '/swagger-resources',
                 '/v2/api-docs',
-                '/h2-console',<% if (authenticationType === 'oauth2') { %>
+                '/h2-console',
+                <%_ if (authenticationType === 'oauth2') { _%>
                 '/oauth2',
-                '/login',<% } %>
+                '/login',
+                <%_ } _%>
                 '/auth'
             ],
             target: `http${options.tls ? 's' : ''}://localhost:<%= serverPort %>`,
@@ -141,8 +143,10 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
             host: 'localhost',
             port: 9000,
             proxy: {
-                target: `http${options.tls ? 's' : ''}://localhost:9060`<% if (websocket === 'spring-websocket') { %>,
-                ws: true<% } %>,
+                target: `http${options.tls ? 's' : ''}://localhost:9060`,
+                <%_ if (websocket === 'spring-websocket') { _%>
+                ws: true,
+                <%_ } _%>
                 proxyOptions: {
                     changeOrigin: false  //pass the Host header to the backend unchanged  https://github.com/Browsersync/browser-sync/issues/430
                 }

--- a/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/notification-middleware.ts.ejs
@@ -95,7 +95,7 @@ export default () => next => action => {
               if (errorHeader) {
                 const entityName = <% if (enableTranslation) { %>translate(
                   'global.menu.entities.' + entityKey
-                )<% }else{ %>entityKey<% } %>;
+                )<% } else { %>entityKey<% } %>;
                 addErrorAlert(errorHeader, errorHeader, { entityName });
               } else if (data !== '' && data.fieldErrors) {
                 const fieldErrors = data.fieldErrors;

--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -56,12 +56,12 @@
                     <li>You installed a Node.js version that doesn't work with JHipster: please use an LTS (long-term support) version, as it's the only version we support.</li>
                 </ol>
                 <h2>Building the client side code again</h2>
-                <p>If you want to go fast, run <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle'){ %>./gradlew<% } %></code> to build and run everything.</p>
+                <p>If you want to go fast, run <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle') { %>./gradlew<% } %></code> to build and run everything.</p>
                 <p>If you want to have more control, so you can debug your issue more easily, you should follow the following steps:</p>
                 <ol>
                     <li>Install npm dependencies with the command <code style="color:red"><%= clientPackageManager %> install</code></li>
                     <li>Build the client with the command <code style="color:red"><%= clientPackageManager %> run webpack:build</code> or <code style="color:red"><%= clientPackageManager %> start</code></li>
-                    <li>Start the server with <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle'){ %>./gradlew<% } %></code> or using your IDE</li>
+                    <li>Start the server with <code style="color:red"><% if (buildTool === 'maven') { %>./mvnw<% } else if (buildTool === 'gradle') { %>./gradlew<% } %></code> or using your IDE</li>
                 </ol>
 
                 <h2>Getting more help</h2>

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -46,7 +46,7 @@ This application is configured for Service Discovery and Configuration with <% i
 <%_ if (skipClient) { _%>
 To start your application in the dev profile, run:
 
-    <% if (buildTool === 'maven') { %>./mvnw<% } %><% if (buildTool === 'gradle'){ %>./gradlew<% } %>
+    <% if (buildTool === 'maven') { %>./mvnw<% } %><% if (buildTool === 'gradle') { %>./gradlew<% } %>
 
 <%_ } _%>
 <%_ if (!skipClient) { _%>
@@ -66,7 +66,7 @@ You will only need to run this command when dependencies change in [package.json
 
 We use <%= clientPackageManager %> scripts and [Webpack][] as our build system.
 
-<%_ if(['hazelcast', 'memcached', 'redis'].includes(cacheProvider)) { _%>
+<%_ if (['hazelcast', 'memcached', 'redis'].includes(cacheProvider)) { _%>
 If you are using <%= cacheProvider %> as a cache, you will have to launch a cache server.
 To start your cache server, run:
 ```
@@ -317,7 +317,7 @@ If you need to re-run the Sonar phase, please be sure to specify at least the `i
 ./mvnw initialize sonar:sonar
 ```
 or
-<%_ } else if(buildTool === 'gradle') { _%>
+<%_ } else if (buildTool === 'gradle') { _%>
 ```
 ./gradlew -Pprod clean check jacocoTestReport sonarqube
 ```

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.ts.ejs
@@ -50,8 +50,8 @@ export class <%= entityAngularName %>DetailComponent implements OnInit {
     openFile(contentType: string, base64String: string): void {
         this.dataUtils.openFile(contentType, base64String);
     }
-
     <%_ } _%>
+
     previousState(): void {
         window.history.back();
     }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -114,7 +114,7 @@ for ( const idx in variables ) { %>
     const fieldName = fields[idx].fieldName;
     const fieldType = fields[idx].fieldType;
     const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent; _%>
-        <%= fieldName %>: [<% if (fields[idx].fieldValidate === true) { %>null,[<% if(fields[idx].fieldValidateRules.includes('required')) { %>Validators.required,<% } %><% if(fields[idx].fieldValidateRules.includes('minlength')) { %>Validators.minLength(<%= fields[idx].fieldValidateRulesMinlength %>),<% } %><% if(fields[idx].fieldValidateRules.includes('maxlength')) { %>Validators.maxLength(<%= fields[idx].fieldValidateRulesMaxlength %>),<% } %><% if(fields[idx].fieldValidateRules.includes('min')) { %>Validators.min(<%= fields[idx].fieldValidateRulesMin %>),<% } %><% if(fields[idx].fieldValidateRules.includes('max')) { %>Validators.max(<%= fields[idx].fieldValidateRulesMax %>),<% } %><% if(fields[idx].fieldValidateRules.includes('pattern')) { %>Validators.pattern('<%= fields[idx].fieldValidateRulesPattern.replace(/\\/g, '\\\\') %>'),<% } %>]<% } %>],
+        <%= fieldName %>: [<% if (fields[idx].fieldValidate === true) { %>null,[<% if (fields[idx].fieldValidateRules.includes('required')) { %>Validators.required,<% } %><% if (fields[idx].fieldValidateRules.includes('minlength')) { %>Validators.minLength(<%= fields[idx].fieldValidateRulesMinlength %>),<% } %><% if (fields[idx].fieldValidateRules.includes('maxlength')) { %>Validators.maxLength(<%= fields[idx].fieldValidateRulesMaxlength %>),<% } %><% if (fields[idx].fieldValidateRules.includes('min')) { %>Validators.min(<%= fields[idx].fieldValidateRulesMin %>),<% } %><% if (fields[idx].fieldValidateRules.includes('max')) { %>Validators.max(<%= fields[idx].fieldValidateRulesMax %>),<% } %><% if (fields[idx].fieldValidateRules.includes('pattern')) { %>Validators.pattern('<%= fields[idx].fieldValidateRulesPattern.replace(/\\/g, '\\\\') %>'),<% } %>]<% } %>],
     <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
         <%= fieldName %>ContentType: [],
     <%_ } _%>
@@ -127,12 +127,12 @@ for ( const idx in variables ) { %>
     const relationshipRequired = relationships[idx].relationshipRequired; _%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
         <%_ if (dto === 'no') { _%>
-        <%=relationshipName %>: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
+        <%= relationshipName %>: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
         <%_ } else { _%>
-        <%=relationshipName %>Id: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
+        <%= relationshipName %>Id: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
         <%_ } _%>
     <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
-        <%=relationshipFieldNamePlural %>: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
+        <%= relationshipFieldNamePlural %>: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
     <%_ } _%>
 <%_ } _%>
 
@@ -232,9 +232,9 @@ _%>
             this.elementRef.nativeElement.querySelector('#' + idInput).value = null;
         }
     }
-
     <%_ } _%>
 <%_ } _%>
+
     previousState(): void {
         window.history.back();
     }
@@ -299,14 +299,14 @@ _%>
     protected onSaveError(): void {
         this.isSaving = false;
     }
-<%_ if (selectableEntitiesType) { _%>
 
+<%_ if (selectableEntitiesType) { _%>
     trackById(index: number, item: <%= selectableEntitiesType %>): any {
         return item.id;
     }
 <%_ } _%>
-<%_ if (selectableManyToManyEntitiesType) { _%>
 
+<%_ if (selectableManyToManyEntitiesType) { _%>
     getSelected(selectedVals: <%= selectableManyToManyEntitiesType %>[], option: <%= selectableManyToManyEntitiesType %>): <%= selectableManyToManyEntitiesType %> {
         if (selectedVals) {
             for (let i = 0; i < selectedVals.length; i++) {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -64,8 +64,8 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
         // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
         return item.id!;
     }
-    <%_ if (fieldsContainBlob) { _%>
 
+    <%_ if (fieldsContainBlob) { _%>
     byteSize(base64String: string): string {
         return this.dataUtils.byteSize(base64String);
     }
@@ -74,26 +74,28 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
         return this.dataUtils.openFile(contentType, base64String);
     }
     <%_ } _%>
+
     <%_
     let eventCallBack = 'this.loadAll()';
     if (pagination === 'pagination') {
         eventCallBack = 'this.loadPage()';
     } else if (pagination === 'infinite-scroll') {
         eventCallBack = 'this.reset()';
-    } _%>
+    }
+    _%>
 
     registerChangeIn<%= entityClassPlural %>(): void {
         this.eventSubscriber = this.eventManager.subscribe('<%= entityInstance %>ListModification', () => <%= eventCallBack %>);
     }
-    <%_ if (!readOnly) { _%>
 
+    <%_ if (!readOnly) { _%>
     delete(<%= entityInstance %>: I<%= entityAngularName %>): void {
         const modalRef = this.modalService.open(<%= entityAngularName %>DeleteDialogComponent, { size: 'lg', backdrop: 'static' });
         modalRef.componentInstance.<%= entityInstance %> = <%= entityInstance %>;
     }
     <%_ } _%>
-    <%_ if (pagination !== 'no') { _%>
 
+<%_ if (pagination !== 'no') { _%>
     sort(): string[] {
         const result = [this.predicate + ',' + (this.ascending ? 'asc' : 'desc')];
         if (this.predicate !== 'id') {
@@ -101,7 +103,8 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
         }
         return result;
     }
-        <%_ if (pagination === 'pagination') { _%>
+
+    <%_ if (pagination === 'pagination') { _%>
 
     protected onSuccess(data: I<%= entityAngularName %>[] | null, headers: HttpHeaders, page: number): void {
         this.totalItems = Number(headers.get('X-Total-Count'));
@@ -125,7 +128,8 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
     protected onError(): void {
         this.ngbPaginationPage = this.page;
     }
-        <%_ } else if (pagination === 'infinite-scroll') { _%>
+
+    <%_ } else if (pagination === 'infinite-scroll') { _%>
 
     protected paginate<%= entityClassPlural %>(data: I<%= entityAngularName %>[] | null, headers: HttpHeaders): void {
         const headersLink = headers.get('link');
@@ -136,6 +140,7 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
             }
         }
     }
-        <%_ } _%>
+
     <%_ } _%>
+<%_ } _%>
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -41,11 +41,11 @@ import { <%= entityInstance %>Route } from './<%= entityFileName %>.route';
         <%= entityAngularName %>DeleteDialogComponent,
         <%_ } %>
     ],
+    <%_ if (!readOnly) { _%>
     entryComponents: [
-        <%_ if (!readOnly) { _%>
         <%= entityAngularName %>DeleteDialogComponent
-        <%_ } _%>
     ]
+    <%_ } _%>
 })
 export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
@@ -56,25 +56,25 @@ export class <%= entityAngularName %>Resolve implements Resolve<I<%= entityAngul
     }
 }
 
-
 export const <%= entityInstance %>Route: Routes = [
     {
         path: '',
         component: <%= entityAngularName %>Component,
-        <%_ if (pagination === 'pagination'){ _%>
+        <%_ if (pagination === 'pagination') { _%>
         resolve: {
             'pagingParams': JhiResolvePagingParams
         },
         <%_ } _%>
         data: {
             authorities: ['ROLE_USER'],
-            <%_ if (pagination === 'pagination'){ _%>
+            <%_ if (pagination === 'pagination') { _%>
             defaultSort: 'id,asc',
             <%_ } _%>
-            pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
+            pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
-    }, {
+    },
+    {
         path: ':id/view',
         component: <%= entityAngularName %>DetailComponent,
         resolve: {
@@ -82,7 +82,7 @@ export const <%= entityInstance %>Route: Routes = [
         },
         data: {
             authorities: ['ROLE_USER'],
-            pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
+            pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
     },
@@ -95,7 +95,7 @@ export const <%= entityInstance %>Route: Routes = [
         },
         data: {
             authorities: ['ROLE_USER'],
-            pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
+            pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
     },
@@ -107,7 +107,7 @@ export const <%= entityInstance %>Route: Routes = [
         },
         data: {
             authorities: ['ROLE_USER'],
-            pageTitle: <% if (enableTranslation){ %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% }else{ %>'<%= entityClassPlural %>'<% } %>
+            pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
     },

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
@@ -51,7 +51,7 @@ export class <%= entityAngularName %>Service {
 
     constructor(protected http: HttpClient) {}
 
-<%_ if (!readOnly) { _%>
+    <%_ if (!readOnly) { _%>
     create(<%= entityInstance %>: I<%= entityAngularName %>): Observable<EntityResponseType> {
         <%_ if (fieldsContainDate) { _%>
         const copy = this.convertDateFromClient(<%= entityInstance %>);
@@ -71,7 +71,7 @@ export class <%= entityAngularName %>Service {
                     { observe: 'response' })
             <% if (fieldsContainDate) { %>.pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)))<% } %>;
     }
-<%_ } _%>
+    <%_ } _%>
 
     find(id: <%= tsKeyType %>): Observable<EntityResponseType> {
         return this.http.get<I<%= entityAngularName %>>(`${this.resourceUrl}/${id}`, { observe: 'response'})
@@ -84,11 +84,11 @@ export class <%= entityAngularName %>Service {
             <% if (fieldsContainDate) { %>.pipe(map((res: EntityArrayResponseType) => this.convertDateArrayFromServer(res)))<% } %>;
     }
 
-<%_ if (!readOnly) { _%>
+    <%_ if (!readOnly) { _%>
     delete(id: <%= tsKeyType %>): Observable<HttpResponse<{}>> {
         return this.http.delete(`${this.resourceUrl}/${id}`, { observe: 'response'});
     }
-<%_ } _%>
+    <%_ } _%>
 
     <%_ if (searchEngine === 'elasticsearch') { _%>
     search(req: <%= searchType %>): Observable<EntityArrayResponseType> {
@@ -136,5 +136,5 @@ export class <%= entityAngularName %>Service {
         }
         return res;
     }
-    <%_ } _%>
+<%_ } _%>
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/infinite-scroll-template.ejs
@@ -56,7 +56,7 @@
     }
 
     loadAll(): void {
-    <%_ if (searchEngine === 'elasticsearch') { _%>
+        <%_ if (searchEngine === 'elasticsearch') { _%>
         if (this.currentSearch) {
             this.<%= entityInstance %>Service.search({
                 query: this.currentSearch,
@@ -68,7 +68,8 @@
             );
             return;
         }
-    <%_ } _%>
+        <%_ } _%>
+
         this.<%= entityInstance %>Service.query({
             page: this.page,
             size: this.itemsPerPage,
@@ -88,8 +89,8 @@
         this.page = page;
         this.loadAll();
     }
-    <%_ if (searchEngine === 'elasticsearch') { _%>
 
+    <%_ if (searchEngine === 'elasticsearch') { _%>
     search(query: string): void {
         this.<%= entityInstancePlural %> = [];
         this.links = {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/no-pagination-template.ejs
@@ -52,12 +52,13 @@
             return;
         }
         <%_ } _%>
+
         this.<%= entityInstance %>Service.query().subscribe(
             (res: HttpResponse<I<%= entityAngularName %>[]>) => this.<%= entityInstancePlural %> = res.body || []
         );
     }
-    <%_ if (searchEngine === 'elasticsearch') { _%>
 
+    <%_ if (searchEngine === 'elasticsearch') { _%>
     search(query: string): void {
         this.currentSearch = query;
         this.loadAll();

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -48,6 +48,7 @@
 
     loadPage(page?: number): void {
         const pageToLoad: number = page || this.page;
+
         <%_ if (searchEngine === 'elasticsearch') { _%>
         if (this.currentSearch) {
             this.<%= entityInstance %>Service.search({
@@ -61,6 +62,7 @@
             return;
         }
         <%_ } _%>
+
         this.<%= entityInstance %>Service.query({
             page: pageToLoad - 1,
             size: this.itemsPerPage,
@@ -69,8 +71,8 @@
                 () => this.onError()
             );
     }
-    <%_ if (searchEngine === 'elasticsearch') { _%>
 
+    <%_ if (searchEngine === 'elasticsearch') { _%>
     search(query: string): void {
         this.currentSearch = query;
         this.loadPage(1);

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -39,7 +39,7 @@ export class <%= entityClass %>ComponentsPage {
     <%_ } _%>
     title = element.all(by.css('<%= jhiPrefixDashed %>-<%= entityFileName %> div h2#page-heading span')).first();
 
-<%_ if (!readOnly) { _%>
+    <%_ if (!readOnly) { _%>
     async clickOnCreateButton(): Promise<void> {
         await this.createButton.click();
     }
@@ -51,7 +51,7 @@ export class <%= entityClass %>ComponentsPage {
     async countDeleteButtons(): Promise<number> {
         return this.deleteButtons.count();
     }
-<%_ } _%>
+    <%_ } _%>
 
     async getTitle(): Promise<string> {
         return this.title.<%- elementGetter %>;
@@ -103,11 +103,12 @@ export class <%= entityClass %>UpdatePage {
             let fieldInputType = 'text';
             let ngModelOption = '';
     _%>
-            <%_ if (fieldType === 'Boolean') { _%>
+    <%_ if (fieldType === 'Boolean') { _%>
     get<%= fieldNameCapitalized %>Input(): ElementFinder {
         return this.<%= fieldName %>Input;
     }
-            <%_ } else if (fieldIsEnum) { _%>
+
+    <%_ } else if (fieldIsEnum) { _%>
     async set<%= fieldNameCapitalized %>Select(<%= fieldName %>: string): Promise<void> {
         await this.<%= fieldName %>Select.sendKeys(<%= fieldName %>);
     }

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -124,7 +124,7 @@ describe('<%= entityClass %> e2e test', () => {
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath),
             <%_ } else if (fieldIsEnum) { _%>
             <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption(),
-            <%_ } else if (fieldType === 'UUID'){ _%>
+            <%_ } else if (fieldType === 'UUID') { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974'),
             <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldValidateSampleString %>'),
@@ -174,7 +174,7 @@ describe('<%= entityClass %> e2e test', () => {
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>', 'Expected <%=fieldNameCapitalized%> value to be equals to <%=fieldName%>');
             <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.endsWith(fileNameToUpload, 'Expected <%=fieldNameCapitalized%> value to be end with ' + fileNameToUpload);
-            <%_ } else if (fieldType === 'UUID'){ _%>
+            <%_ } else if (fieldType === 'UUID') { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('64c99148-3908-465d-8c4a-e510e3ade974', 'Expected <%=fieldNameCapitalized%> value to be equals to 64c99148-3908-465d-8c4a-e510e3ade974');
             <%_ } else if (!fieldIsEnum) { _%>
         expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>', 'Expected <%=fieldNameCapitalized%> value to be equals to <%= fieldName %>');

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
@@ -84,5 +84,4 @@ describe('Component Tests', () => {
             });
         });
     });
-
 });

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
@@ -66,37 +66,36 @@ describe('Component Tests', () => {
                 expect(comp.<%= entityInstance %>).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
             });
         });
+
         <%_ if (fieldsContainBlob) { _%>
+        describe('byteSize', () => {
+            it('Should call byteSize from JhiDataUtils', () => {
+                // GIVEN
+                spyOn(dataUtils, 'byteSize');
+                const fakeBase64 = 'fake base64';
 
-            describe('byteSize', () => {
-                it('Should call byteSize from JhiDataUtils', () => {
-                    // GIVEN
-                    spyOn(dataUtils, 'byteSize');
-                    const fakeBase64 = 'fake base64';
+                // WHEN
+                comp.byteSize(fakeBase64);
 
-                    // WHEN
-                    comp.byteSize(fakeBase64);
-
-                    // THEN
-                    expect(dataUtils.byteSize).toBeCalledWith(fakeBase64);
-                });
+                // THEN
+                expect(dataUtils.byteSize).toBeCalledWith(fakeBase64);
             });
+        });
 
-            describe('openFile', () => {
-                it('Should call openFile from JhiDataUtils', () => {
-                    // GIVEN
-                    spyOn(dataUtils, 'openFile');
-                    const fakeContentType = 'fake content type';
-                    const fakeBase64 = 'fake base64';
+        describe('openFile', () => {
+            it('Should call openFile from JhiDataUtils', () => {
+                // GIVEN
+                spyOn(dataUtils, 'openFile');
+                const fakeContentType = 'fake content type';
+                const fakeBase64 = 'fake base64';
 
-                    // WHEN
-                    comp.openFile(fakeContentType, fakeBase64);
+                // WHEN
+                comp.openFile(fakeContentType, fakeBase64);
 
-                    // THEN
-                    expect(dataUtils.openFile).toBeCalledWith(fakeContentType, fakeBase64);
-                });
+                // THEN
+                expect(dataUtils.openFile).toBeCalledWith(fakeContentType, fakeBase64);
             });
+        });
         <%_ } _%>
     });
-
 });

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
@@ -84,5 +84,4 @@ describe('Component Tests', () => {
             );
         });
     });
-
 });

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
@@ -81,8 +81,8 @@ describe('Component Tests', () => {
             expect(service.query).toHaveBeenCalled();
             expect(comp.<%= entityInstancePlural %> && comp.<%= entityInstancePlural %>[0]).toEqual(jasmine.objectContaining({id: <%- tsKeyId %>}));
         });
-    <%_ if (pagination !== 'no') { _%>
 
+    <%_ if (pagination !== 'no') { _%>
         it('should load a page', () => {
             // GIVEN
             const headers = new HttpHeaders().append('link', 'link;link');
@@ -104,6 +104,7 @@ describe('Component Tests', () => {
         });
 
         <%_ if (pagination === 'infinite-scroll') { _%>
+
         it('should re-initialize the page', () => {
             // GIVEN
             const headers = new HttpHeaders().append('link', 'link;link');
@@ -148,7 +149,9 @@ describe('Component Tests', () => {
             // THEN
                 expect(result).toEqual(['name,asc', 'id']);
         });
+
         <%_ } else { _%>
+
         it('should calculate the sort attribute for an id', () => {
             // WHEN
             comp.ngOnInit();
@@ -171,6 +174,7 @@ describe('Component Tests', () => {
             // THEN
             expect(result).toEqual(['name,desc', 'id']);
         });
+
         <%_ } _%>
     <%_ } _%>
     });

--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -138,7 +138,7 @@ describe('<%= entityClass %> e2e test', () => {
             await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath);
             <%_ } else if (fieldIsEnum) { _%>
             await <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption();
-            <%_ } else if (fieldType === 'UUID'){ _%>
+            <%_ } else if (fieldType === 'UUID') { _%>
             await <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974');
             expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.match(/64c99148-3908-465d-8c4a-e510e3ade974/);
             <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>

--- a/generators/entity-i18n/templates/i18n/entity_al.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_al.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ar-ly.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ar-ly.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_bn.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_bn.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_by.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_by.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ca.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ca.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_cs.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_cs.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_da.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_da.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_de.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_de.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_el.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_el.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_en.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_en.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_es.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_es.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_et.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_et.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_fa.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_fa.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_fi.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_fi.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_fr.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_fr.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_gl.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_gl.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_hi.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_hi.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_hu.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_hu.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_hy.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_hy.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_in.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_in.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_it.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_it.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ja.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ja.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ko.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ko.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_mr.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_mr.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_my.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_my.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_nl.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_nl.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_pl.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_pl.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_pt-br.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_pt-br.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_pt-pt.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_pt-pt.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ro.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ro.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ru.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ru.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_sk.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_sk.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_sr.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_sr.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_sv.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_sv.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ta.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ta.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_te.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_te.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_th.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_th.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_tr.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_tr.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_ua.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_ua.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_uz-Cyrl-uz.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_uz-Cyrl-uz.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_uz-Latn-uz.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_uz-Latn-uz.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_vi.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_vi.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_zh-cn.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_zh-cn.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-i18n/templates/i18n/entity_zh-tw.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_zh-tw.json.ejs
@@ -38,7 +38,7 @@ let helpBlocks = 0; %>
             }<% for (idx in fields) {
             if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
             "<%=fields[idx].fieldName%>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
-            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0){%>,
+            "<%=relationships[idx].relationshipName%>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
             "help": {<% for (idx in fields) {
                 if (fields[idx].javadoc) {
                     --helpBlocks; %>

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
@@ -106,10 +106,10 @@ public class <%= entityClass %>Criteria implements Serializable, Criteria {
     private <%- filterVariable.filterType %> <%= filterVariable.name %>;
 <%_ }); _%>
 
-    public <%= entityClass %>Criteria(){
+    public <%= entityClass %>Criteria() {
     }
 
-    public <%= entityClass %>Criteria(<%= entityClass %>Criteria other){
+    public <%= entityClass %>Criteria(<%= entityClass %>Criteria other) {
 <%_ filterVariables.forEach((filterVariable) => { _%>
         this.<%= filterVariable.name %> = other.<%= filterVariable.name %> == null ? null : other.<%= filterVariable.name %>.copy();
 <%_ }); _%>

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -28,7 +28,7 @@ import org.mapstruct.*;
  */
 @Mapper(componentModel = "spring", uses = {<% var existingMappings = [];
   for (idx in relationships) {
-    if ((relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true)|| relationships[idx].relationshipType === 'many-to-one' ||(relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)){
+    if ((relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true)|| relationships[idx].relationshipType === 'many-to-one' ||(relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)) {
       // if the entity is mapped twice, we should implement the mapping once
       if (!existingMappings.includes(relationships[idx].otherEntityNameCapitalized) && asEntity(relationships[idx].otherEntityNameCapitalized) !== asEntity(entityClass)) {
           existingMappings.push(relationships[idx].otherEntityNameCapitalized);

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/fake-data/table.csv.ejs
@@ -146,7 +146,7 @@ for (lineNb = 1; lineNb <= numberOfRows; lineNb++) {
         }
         if (columnType === 'blob' || columnType === 'longblob') {
             data = '../fake-data/blob/hipster.png'
-        } else if (columnType === '${clobType}'){
+        } else if (columnType === '${clobType}') {
             data = '../fake-data/blob/hipster.txt'
         }
 

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -55,7 +55,7 @@ import <%=packageName%>.domain.<%= asEntity(entityClass) %>;
         const relationshipValidate = relationships[idx].relationshipValidate;
         const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
         const isUsingMapsIdL1 = relationships[idx].useJPADerivedIdentifier;
-        if(imported.indexOf(otherEntityNameCapitalized) === -1) {
+        if (imported.indexOf(otherEntityNameCapitalized) === -1) {
             if ((relationshipValidate !== null && relationshipValidate === true) || jpaMetamodelFiltering || (isUsingMapsIdL1 === true)) { _%>
 import <%=packageName%>.domain.<%= asEntity(otherEntityNameCapitalized) %>;
 <%_         imported.push(otherEntityNameCapitalized);

--- a/generators/kubernetes/templates/kubectl-apply.sh.ejs
+++ b/generators/kubernetes/templates/kubectl-apply.sh.ejs
@@ -20,7 +20,7 @@
 # Files are ordered in proper order with needed wait for the dependent custom resource definitions to get initialized.
 # Usage: bash kubectl-apply.sh
 
-logSummary(){
+logSummary() {
     echo ""
     echo "#####################################################"
     echo "Please find the below useful endpoints,"

--- a/generators/openshift/templates/registry/application-configmap.yml.ejs
+++ b/generators/openshift/templates/registry/application-configmap.yml.ejs
@@ -79,5 +79,5 @@ objects:
           client:
             service-url:
               # This must contain a list of all Eureka server replicas for registry HA to work correctly
-              defaultZone: <% for(let i = 0; i < registryReplicas; i++){ %>http://admin:${SPRING_SECURITY_USER_PASSWORD}@jhipster-registry-<%- i %>.jhipster-registry:8761/eureka/<% if (i < registryReplicas-1) { _%>,<% }} %>
+              defaultZone: <% for (let i = 0; i < registryReplicas; i++) { %>http://admin:${SPRING_SECURITY_USER_PASSWORD}@jhipster-registry-<%- i %>.jhipster-registry:8761/eureka/<% if (i < registryReplicas-1) { _%>,<% }} %>
       <%_ } _%>

--- a/generators/server/templates/.mvn/wrapper/MavenWrapperDownloader.java
+++ b/generators/server/templates/.mvn/wrapper/MavenWrapperDownloader.java
@@ -54,7 +54,7 @@ public class MavenWrapperDownloader {
         // wrapperUrl parameter.
         File mavenWrapperPropertyFile = new File(baseDirectory, MAVEN_WRAPPER_PROPERTIES_PATH);
         String url = DEFAULT_DOWNLOAD_URL;
-        if(mavenWrapperPropertyFile.exists()) {
+        if (mavenWrapperPropertyFile.exists()) {
             FileInputStream mavenWrapperPropertyFileInputStream = null;
             try {
                 mavenWrapperPropertyFileInputStream = new FileInputStream(mavenWrapperPropertyFile);
@@ -65,7 +65,7 @@ public class MavenWrapperDownloader {
                 System.out.println("- ERROR loading '" + MAVEN_WRAPPER_PROPERTIES_PATH + "'");
             } finally {
                 try {
-                    if(mavenWrapperPropertyFileInputStream != null) {
+                    if (mavenWrapperPropertyFileInputStream != null) {
                         mavenWrapperPropertyFileInputStream.close();
                     }
                 } catch (IOException e) {
@@ -76,8 +76,8 @@ public class MavenWrapperDownloader {
         System.out.println("- Downloading from: " + url);
 
         File outputFile = new File(baseDirectory.getAbsolutePath(), MAVEN_WRAPPER_JAR_PATH);
-        if(!outputFile.getParentFile().exists()) {
-            if(!outputFile.getParentFile().mkdirs()) {
+        if (!outputFile.getParentFile().exists()) {
+            if (!outputFile.getParentFile().mkdirs()) {
                 System.out.println(
                         "- ERROR creating output directory '" + outputFile.getParentFile().getAbsolutePath() + "'");
             }

--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -407,7 +407,7 @@ public class CacheConfiguration<% if (cacheProvider === 'hazelcast') { %> implem
     }
         <%_ } _%>
 
-    public static EmbeddedCacheManager getCacheManager(){
+    public static EmbeddedCacheManager getCacheManager() {
         return cacheManager;
     }
 
@@ -499,7 +499,7 @@ public class CacheConfiguration<% if (cacheProvider === 'hazelcast') { %> implem
      *          &#064;Autowired (or) &#064;Inject
      *          private EmbeddedCacheManager cacheManager;
      *
-     *          void cacheSample(){
+     *          void cacheSample() {
      *              cacheManager.getCache("dist-app-data").put("hi", "there");
      *          }
      *          </pre>

--- a/generators/server/templates/src/main/java/package/config/GatewayConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/GatewayConfiguration.java.ejs
@@ -37,7 +37,7 @@ public class GatewayConfiguration {
     public static class SwaggerBasePathRewritingConfiguration {
 
         @Bean
-        public SwaggerBasePathRewritingFilter swaggerBasePathRewritingFilter(){
+        public SwaggerBasePathRewritingFilter swaggerBasePathRewritingFilter() {
             return new SwaggerBasePathRewritingFilter();
         }
     }
@@ -46,7 +46,7 @@ public class GatewayConfiguration {
     public static class AccessControlFilterConfiguration {
 
         @Bean
-        public AccessControlFilter accessControlFilter(RouteLocator routeLocator, JHipsterProperties jHipsterProperties){
+        public AccessControlFilter accessControlFilter(RouteLocator routeLocator, JHipsterProperties jHipsterProperties) {
             return new AccessControlFilter(routeLocator, jHipsterProperties);
         }
     }

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -160,7 +160,7 @@ public class SecurityConfiguration {
         .and()
             // See https://github.com/spring-projects/spring-security/issues/5766
             .addFilterAt(new CookieCsrfFilter(), SecurityWebFiltersOrder.REACTOR_CONTEXT)
-            <%_ } else{ _%>
+            <%_ } else { _%>
             .disable()
             <%_ } _%>
             <%_ if (authenticationType === 'jwt') { _%>

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -93,7 +93,7 @@ import static org.springframework.data.couchbase.core.mapping.id.GenerationStrat
 @Document
 <%_ } _%>
 <%_ if (databaseType === 'cassandra') { _%>
-@Table(<% if(!reactive) { %>name = <% } %>"user")
+@Table(<% if (!reactive) { %>name = <% } %>"user")
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
 @org.springframework.data.elasticsearch.annotations.Document(indexName = "user")
@@ -181,7 +181,7 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
     @Size(min = 2, max = 10)<% if (databaseType === 'sql') { %>
     @Column(name = "lang_key", length = 10)<% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase') { %>
     @Field("lang_key")<% } %><% if (databaseType === 'cassandra') { %>
-    @Column(<% if(!reactive) { %>name = <% } %>"lang_key")<% } %>
+    @Column(<% if (!reactive) { %>name = <% } %>"lang_key")<% } %>
     private String langKey;
     <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase' || databaseType === 'sql') { _%>
 
@@ -195,19 +195,19 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
     @Size(max = 20)<% if (databaseType === 'sql') { %>
     @Column(name = "activation_key", length = 20)<% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase') { %>
     @Field("activation_key")<% } %><% if (databaseType === 'cassandra') { %>
-    @Column(<% if(!reactive) { %>name = <% } %>"activation_key")<% } %>
+    @Column(<% if (!reactive) { %>name = <% } %>"activation_key")<% } %>
     @JsonIgnore
     private String activationKey;
 
     @Size(max = 20)<% if (databaseType === 'sql') { %>
     @Column(name = "reset_key", length = 20)<% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase') { %>
     @Field("reset_key")<% } %><% if (databaseType === 'cassandra') { %>
-    @Column(<% if(!reactive) { %>name = <% } %>"reset_key")<% } %>
+    @Column(<% if (!reactive) { %>name = <% } %>"reset_key")<% } %>
     @JsonIgnore
     private String resetKey;
 
     <%_ if (databaseType === 'sql' || databaseType === 'cassandra') { _%>
-    @Column(<% if(!reactive) { %>name = <% } %>"reset_date")
+    @Column(<% if (!reactive) { %>name = <% } %>"reset_date")
     <%_ } else if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
     @Field("reset_date")
     <%_ } _%>

--- a/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
@@ -189,11 +189,11 @@ public class UserRepository {
     public static final String USERS_BY_EMAIL_CACHE = "usersByEmail";
     <%_ } _%>
 
-    private final <% if(reactive) { %>Reactive<% } %>Session session;
+    private final <% if (reactive) { %>Reactive<% } %>Session session;
 
     private final Validator validator;
 
-    <%_ if(!reactive) { _%>
+    <%_ if (!reactive) { _%>
     private Mapper<<%= asEntity('User') %>> mapper;
 
     <%_ } else { _%>
@@ -210,7 +210,7 @@ public class UserRepository {
 
     private PreparedStatement insertByResetKeyStmt;
 
-    <%_ if(reactive) { _%>
+    <%_ if (reactive) { _%>
     private PreparedStatement deleteByIdStmt;
 
     <%_ } _%>
@@ -238,36 +238,36 @@ public class UserRepository {
 
     private PreparedStatement truncateByEmailStmt;
 
-    public UserRepository(<% if(reactive) { %>ReactiveCassandraTemplate cqlTemplate, Reactive<% } %>Session session, Validator validator) {
+    public UserRepository(<% if (reactive) { %>ReactiveCassandraTemplate cqlTemplate, Reactive<% } %>Session session, Validator validator) {
         this.session = session;
         this.validator = validator;
-        <%_ if(!reactive) { _%>
+        <%_ if (!reactive) { _%>
         mapper = new MappingManager(session).mapper(<%= asEntity('User') %>.class);
         <%_ } else { _%>
         this.cqlTemplate = cqlTemplate;
         <%_ } _%>
 
-        findAllStmt = session.prepare("SELECT * FROM user")<% if(reactive) { %>.block()<% } %>;
+        findAllStmt = session.prepare("SELECT * FROM user")<% if (reactive) { %>.block()<% } %>;
 
         findOneByActivationKeyStmt = session.prepare(
             "SELECT id " +
                 "FROM user_by_activation_key " +
-                "WHERE activation_key = :activation_key")<% if(reactive) { %>.block()<% } %>;
+                "WHERE activation_key = :activation_key")<% if (reactive) { %>.block()<% } %>;
 
         findOneByResetKeyStmt = session.prepare(
             "SELECT id " +
                 "FROM user_by_reset_key " +
-                "WHERE reset_key = :reset_key")<% if(reactive) { %>.block()<% } %>;
+                "WHERE reset_key = :reset_key")<% if (reactive) { %>.block()<% } %>;
 
         insertByActivationKeyStmt = session.prepare(
             "INSERT INTO user_by_activation_key (activation_key, id) " +
-                "VALUES (:activation_key, :id)")<% if(reactive) { %>.block()<% } %>;
+                "VALUES (:activation_key, :id)")<% if (reactive) { %>.block()<% } %>;
 
         insertByResetKeyStmt = session.prepare(
             "INSERT INTO user_by_reset_key (reset_key, id) " +
-                "VALUES (:reset_key, :id)")<% if(reactive) { %>.block()<% } %>;
+                "VALUES (:reset_key, :id)")<% if (reactive) { %>.block()<% } %>;
 
-        <%_ if(reactive) { _%>
+        <%_ if (reactive) { _%>
         deleteByIdStmt = session.prepare(
             "DELETE FROM user " +
                 "WHERE id = :id").block();
@@ -275,54 +275,54 @@ public class UserRepository {
         <%_ } _%>
         deleteByActivationKeyStmt = session.prepare(
             "DELETE FROM user_by_activation_key " +
-                "WHERE activation_key = :activation_key")<% if(reactive) { %>.block()<% } %>;
+                "WHERE activation_key = :activation_key")<% if (reactive) { %>.block()<% } %>;
 
         deleteByResetKeyStmt = session.prepare(
             "DELETE FROM user_by_reset_key " +
-                "WHERE reset_key = :reset_key")<% if(reactive) { %>.block()<% } %>;
+                "WHERE reset_key = :reset_key")<% if (reactive) { %>.block()<% } %>;
 
         findOneByLoginStmt = session.prepare(
             "SELECT id " +
                 "FROM user_by_login " +
-                "WHERE login = :login")<% if(reactive) { %>.block()<% } %>;
+                "WHERE login = :login")<% if (reactive) { %>.block()<% } %>;
 
         insertByLoginStmt = session.prepare(
             "INSERT INTO user_by_login (login, id) " +
-                "VALUES (:login, :id)")<% if(reactive) { %>.block()<% } %>;
+                "VALUES (:login, :id)")<% if (reactive) { %>.block()<% } %>;
 
         deleteByLoginStmt = session.prepare(
             "DELETE FROM user_by_login " +
-                "WHERE login = :login")<% if(reactive) { %>.block()<% } %>;
+                "WHERE login = :login")<% if (reactive) { %>.block()<% } %>;
 
         findOneByEmailStmt = session.prepare(
             "SELECT id " +
                 "FROM user_by_email " +
-                "WHERE email     = :email")<% if(reactive) { %>.block()<% } %>;
+                "WHERE email     = :email")<% if (reactive) { %>.block()<% } %>;
 
         insertByEmailStmt = session.prepare(
             "INSERT INTO user_by_email (email, id) " +
-                "VALUES (:email, :id)")<% if(reactive) { %>.block()<% } %>;
+                "VALUES (:email, :id)")<% if (reactive) { %>.block()<% } %>;
 
         deleteByEmailStmt = session.prepare(
             "DELETE FROM user_by_email " +
-                "WHERE email = :email")<% if(reactive) { %>.block()<% } %>;
+                "WHERE email = :email")<% if (reactive) { %>.block()<% } %>;
 
-        truncateStmt = session.prepare("TRUNCATE user")<% if(reactive) { %>.block()<% } %>;
+        truncateStmt = session.prepare("TRUNCATE user")<% if (reactive) { %>.block()<% } %>;
 
-        truncateByResetKeyStmt = session.prepare("TRUNCATE user_by_reset_key")<% if(reactive) { %>.block()<% } %>;
+        truncateByResetKeyStmt = session.prepare("TRUNCATE user_by_reset_key")<% if (reactive) { %>.block()<% } %>;
 
-        truncateByLoginStmt = session.prepare("TRUNCATE user_by_login")<% if(reactive) { %>.block()<% } %>;
+        truncateByLoginStmt = session.prepare("TRUNCATE user_by_login")<% if (reactive) { %>.block()<% } %>;
 
-        truncateByEmailStmt = session.prepare("TRUNCATE user_by_email")<% if(reactive) { %>.block()<% } %>;
+        truncateByEmailStmt = session.prepare("TRUNCATE user_by_email")<% if (reactive) { %>.block()<% } %>;
     }
 
     public <%= optionalOrMono %><<%= asEntity('User') %>> findById(String id) {
-        <%_ if(!reactive) { _%>
+        <%_ if (!reactive) { _%>
         return Optional.ofNullable(mapper.get(id));
         <%_ } else { _%>
         return cqlTemplate.selectOneById(id, User.class)
             .map(user -> {
-                if(user.getAuthorities() == null) {
+                if (user.getAuthorities() == null) {
                     user.setAuthorities(new HashSet<>());
                 }
                 return user;
@@ -360,7 +360,7 @@ public class UserRepository {
         return findOneFromIndex(stmt);
     }
 
-    <%_ if(!reactive) { _%>
+    <%_ if (!reactive) { _%>
     public List<<%= asEntity('User') %>> findAll() {
         return mapper.map(session.execute(findAllStmt.bind())).all();
     }
@@ -368,7 +368,7 @@ public class UserRepository {
     public Flux<<%= asEntity('User') %>> findAll() {
         return cqlTemplate.select(findAllStmt.bind(), User.class)
             .map(user -> {
-                if(user.getAuthorities() == null) {
+                if (user.getAuthorities() == null) {
                     user.setAuthorities(new HashSet<>());
                 }
                 return user;
@@ -376,12 +376,12 @@ public class UserRepository {
     }
 
     <%_ } _%>
-    public <% if(reactive) { %>Mono<<% } %><%= asEntity('User') %><% if(reactive) { %>><% } %> save(<%= asEntity('User') %> user) {
+    public <% if (reactive) { %>Mono<<% } %><%= asEntity('User') %><% if (reactive) { %>><% } %> save(<%= asEntity('User') %> user) {
         Set<ConstraintViolation<<%= asEntity('User') %>>> violations = validator.validate(user);
         if (violations != null && !violations.isEmpty()) {
             throw new ConstraintViolationException(violations);
         }
-        <%_ if(!reactive) { _%>
+        <%_ if (!reactive) { _%>
         <%= asEntity('User') %> oldUser = mapper.get(user.getId());
         if (oldUser != null) {
             if (!StringUtils.isEmpty(oldUser.getActivationKey()) && !oldUser.getActivationKey().equals(user.getActivationKey())) {
@@ -473,9 +473,9 @@ public class UserRepository {
         <%_ } _%>
     }
 
-    public <% if(reactive) { %>Mono<Void><% } else { %>void<% } %> delete(<%= asEntity('User') %> user) {
+    public <% if (reactive) { %>Mono<Void><% } else { %>void<% } %> delete(<%= asEntity('User') %> user) {
         BatchStatement batch = new BatchStatement();
-        batch.add(<% if(!reactive) { %>mapper.deleteQuery(user)<% } else { %>deleteByIdStmt.bind().setString("id", user.getId())<% } %>);
+        batch.add(<% if (!reactive) { %>mapper.deleteQuery(user)<% } else { %>deleteByIdStmt.bind().setString("id", user.getId())<% } %>);
         if (!StringUtils.isEmpty(user.getActivationKey())) {
             batch.add(deleteByActivationKeyStmt.bind().setString("activation_key", user.getActivationKey()));
         }
@@ -484,14 +484,14 @@ public class UserRepository {
         }
         batch.add(deleteByLoginStmt.bind().setString("login", user.getLogin()));
         batch.add(deleteByEmailStmt.bind().setString("email", user.getEmail().toLowerCase()));
-        <%_ if(!reactive) { _%>
+        <%_ if (!reactive) { _%>
         session.execute(batch);
         <%_ } else { _%>
         return session.execute(batch).then();
         <%_ } _%>
     }
 
-    <%_ if(!reactive) { _%>
+    <%_ if (!reactive) { _%>
     private Optional<<%= asEntity('User') %>> findOneFromIndex(BoundStatement stmt) {
         ResultSet rs = session.execute(stmt);
         if (rs.isExhausted()) {

--- a/generators/server/templates/src/main/java/package/security/jwt/JWTFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/jwt/JWTFilter.java.ejs
@@ -85,7 +85,7 @@ public class JWTFilter <% if (!reactive) { %>extends GenericFilterBean<% } else 
         <%_ } _%>
     }
 
-    private String resolveToken(<% if (!reactive) { %>HttpServletRequest<% } else { %>ServerHttpRequest<% } %> request){
+    private String resolveToken(<% if (!reactive) { %>HttpServletRequest<% } else { %>ServerHttpRequest<% } %> request) {
         String bearerToken = request.<% if (!reactive) { %>getHeader<% } else { %>getHeaders().getFirst<% } %>(AUTHORIZATION_HEADER);
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);

--- a/generators/server/templates/src/main/java/package/security/oauth2/AudienceValidator.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/AudienceValidator.java.ejs
@@ -41,7 +41,7 @@ public class AudienceValidator implements OAuth2TokenValidator<Jwt> {
 
     public OAuth2TokenValidatorResult validate(Jwt jwt) {
         List<String> audience = jwt.getAudience();
-        if(audience.stream().anyMatch(aud -> allowedAudience.contains(aud))) {
+        if (audience.stream().anyMatch(aud -> allowedAudience.contains(aud))) {
             return OAuth2TokenValidatorResult.success();
         } else {
             log.warn("Invalid audience: {}", audience);

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -337,7 +337,7 @@ public class UserService {
     }
 
     <%_ if (!reactive) { _%>
-    private boolean removeNonActivatedUser(<%= asEntity('User') %> existingUser){
+    private boolean removeNonActivatedUser(<%= asEntity('User') %> existingUser) {
         if (existingUser.getActivated()) {
              return false;
         }

--- a/generators/server/templates/src/main/java/package/service/mapper/UserMapper.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/mapper/UserMapper.java.ejs
@@ -88,7 +88,7 @@ public class UserMapper {
     private Set<Authority> authoritiesFromStrings(Set<String> authoritiesAsString) {
         Set<Authority> authorities = new HashSet<>();
 
-        if(authoritiesAsString != null){
+        if (authoritiesAsString != null) {
             authorities = authoritiesAsString.stream().map(string -> {
                 Authority auth = new Authority();
                 auth.setName(string);
@@ -104,7 +104,7 @@ public class UserMapper {
     private Set<String> cleanNullStringAuthorities(Set<String> authoritiesAsString) {
         Set<String> authorities = new HashSet<>();
 
-        if(authoritiesAsString != null) {
+        if (authoritiesAsString != null) {
             authorities = authoritiesAsString.stream()
                 .filter(Objects::nonNull)
                 .collect(Collectors.toSet());

--- a/generators/server/templates/src/main/resources/swagger/api.yml.ejs
+++ b/generators/server/templates/src/main/resources/swagger/api.yml.ejs
@@ -36,7 +36,7 @@ components:
                 "application/problem+json":
                     schema:
                         $ref: 'https://opensource.zalando.com/problem/schema.yaml#/Problem'
-<% if(authenticationType === 'jwt') { %>
+<% if (authenticationType === 'jwt') { %>
     securitySchemes:
         jwt:
             type: http
@@ -55,7 +55,7 @@ security:
     - basic: []
     <%_ } _%>
 <% } %>
-<% if(authenticationType === 'oauth2') { %>
+<% if (authenticationType === 'oauth2') { %>
     securitySchemes:
         oauth:
             type: oauth2
@@ -76,7 +76,7 @@ security:
     - oauth: [jhipster, email, profile]
     - openId: [jhipster, email, profile]
 <% } %>
-<% if(authenticationType === 'session') { %>
+<% if (authenticationType === 'session') { %>
     securitySchemes:
         sessionId:
             type: apiKey

--- a/generators/server/templates/src/test/java/package/RedisTestContainerExtension.java.ejs
+++ b/generators/server/templates/src/test/java/package/RedisTestContainerExtension.java.ejs
@@ -30,7 +30,7 @@ public class RedisTestContainerExtension implements BeforeAllCallback {
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
-        if(!started.get()) {
+        if (!started.get()) {
             GenericContainer redis =
                 new GenericContainer("<%= DOCKER_REDIS %>")
                     .withExposedPorts(6379);

--- a/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
+++ b/generators/server/templates/src/test/java/package/cucumber/CucumberContextConfiguration.java.ejs
@@ -30,7 +30,7 @@ import org.springframework.test.context.web.WebAppConfiguration;
 public class CucumberContextConfiguration {
 
     @Before
-    public void setup_cucumber_spring_context(){
+    public void setup_cucumber_spring_context() {
         // Dummy method so cucumber will recognize this class as glue
         // and use its context configuration.
     }

--- a/generators/server/templates/src/test/java/package/service/mapper/UserMapperTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/mapper/UserMapperTest.java.ejs
@@ -41,7 +41,7 @@ public class UserMapperTest {
     private static final String DEFAULT_LOGIN = "johndoe";
     <%_ if (databaseType === 'sql' && authenticationType !== 'oauth2') { _%>
     private static final Long DEFAULT_ID = 1L;
-    <%_ } else if (databaseType === 'couchbase'){ _%>
+    <%_ } else if (databaseType === 'couchbase') { _%>
     private static final String DEFAULT_ID = <%= asEntity('User') %>.PREFIX + DEFAULT_LOGIN;
     <%_ } else { _%>
     private static final String DEFAULT_ID = "id1";

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -129,7 +129,7 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
 
     <%_ if (databaseType === 'sql' && authenticationType !== 'oauth2') { _%>
     private static final Long DEFAULT_ID = 1L;
-    <%_ } else if (databaseType === 'couchbase'){ _%>
+    <%_ } else if (databaseType === 'couchbase') { _%>
     private static final String DEFAULT_ID = <%= asEntity('User') %>.PREFIX + DEFAULT_LOGIN;
     <%_ } else { _%>
     private static final String DEFAULT_ID = "id1";


### PR DESCRIPTION
This PR polishes templates.

Changes in Angular:
* as `active-menu.directive` is generated only if i18n is enabled then no need to use `if (enableTranslation)` constructs in template
* as Prettier is removing unnecessary blank lines then using better readable notation in templates: blank lines outside ejs if blocks
* indent ejs constructs better to achieve better readability
* don't generate empty `entryComponents` in read only entities module

Changes everywhere:
* replace `}else` with `} else`
* replace `else{` with `else {`
* replace `){` with `) {`
* replace `if(` with `if (`

CONTRIBUTING.md - formatted by `npm run lint-fix`

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
