### PR TITLE
Add OAuth 2.0 Support for Reactive Monoliths

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -123,11 +123,11 @@ function askForServerSideOpts(meta) {
                         name: 'HTTP Session Authentication (stateful, default Spring Security mechanism)'
                     });
                 }
+                opts.push({
+                    value: 'oauth2',
+                    name: 'OAuth 2.0 / OIDC Authentication (stateful, works with Keycloak and Okta)'
+                });
                 if (!reactive) {
-                    opts.push({
-                        value: 'oauth2',
-                        name: 'OAuth 2.0 / OIDC Authentication (stateful, works with Keycloak and Okta)'
-                    });
                     if (['gateway', 'microservice'].includes(applicationType)) {
                         opts.push({
                             value: 'uaa',

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -33,7 +33,6 @@ import io.github.jhipster.web.filter.reactive.CookieCsrfFilter;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 <%_ } _%>
 import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 <%_ if (authenticationType === 'session') { _%>
@@ -82,7 +81,6 @@ import reactor.core.publisher.Mono;
 
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
-@Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @Import(SecurityProblemSupport.class)


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

This is a work-in-progress. I created a new project with this branch and made it so login works. See https://github.com/mraible/jhipster-reactive-monolith-oauth2/pull/1 for remaining TODOs.

This PR will eventually contribute to the OAuth / OIDC support for reactive apps, which is being tracked by https://github.com/jhipster/generator-jhipster/issues/7608.