### PR TITLE
Angular entities: fix default datetime and polish dates and templates

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/shared/util/datepicker-adapter.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/util/datepicker-adapter.ts.ejs
@@ -26,7 +26,7 @@ import * as moment from 'moment';
 @Injectable()
 export class NgbDateMomentAdapter extends NgbDateAdapter<Moment> {
     fromModel(date: Moment): NgbDateStruct {
-        if (date != null && moment.isMoment(date) && date.isValid()) {
+        if (date && moment.isMoment(date) && date.isValid()) {
             return { year: date.year(), month: date.month() + 1, day: date.date() };
         }
         // ! can be removed after https://github.com/ng-bootstrap/ng-bootstrap/issues/1544 is resolved

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
@@ -34,7 +34,7 @@
                     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
                     <div *ngIf="<%= entityInstance %>.<%= fieldName %>">
                         <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType!, <%= entityInstance %>.<%= fieldName %>)">
-                            <img [src]="'data:' + <%=entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-width: 100%;" alt="<%=entityInstance %> image"/>
+                            <img [src]="'data:' + <%= entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-width: 100%;" alt="<%= entityInstance %> image"/>
                         </a>
                         {{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}
                     </div>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -56,14 +56,14 @@ _%>
             const values = fields[idx].fieldValues.replace(/\s/g, '').split(',');
             for (key in values) {
                 const value = values[key]; _%>
-                        <option value="<%= value %>"><% if (enableTranslation) { %>{{'<%=enumPrefix%>.<%=value%>' | translate}}<% } else { %><%=value%><% } %></option>
+                        <option value="<%= value %>"><% if (enableTranslation) { %>{{'<%= enumPrefix %>.<%= value %>' | translate}}<% } else { %><%= value %><% } %></option>
         <%_ } _%>
                     </select>
     <%_ } else { _%>
         <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
                     <div>
             <%_ if (fieldTypeBlobContent === 'image') { _%>
-                        <img [src]="'data:' + editForm.get('<%= fieldName %>ContentType')!.value + ';base64,' + editForm.get('<%= fieldName %>')!.value" style="max-height: 100px;" *ngIf="editForm.get('<%= fieldName %>')!.value" alt="<%=entityInstance %> image"/>
+                        <img [src]="'data:' + editForm.get('<%= fieldName %>ContentType')!.value + ';base64,' + editForm.get('<%= fieldName %>')!.value" style="max-height: 100px;" *ngIf="editForm.get('<%= fieldName %>')!.value" alt="<%= entityInstance %> image"/>
             <%_ } _%>
                         <div *ngIf="editForm.get('<%= fieldName %>')!.value" class="form-text text-danger clearfix">
             <%_ if (fieldTypeBlobContent === 'any') { _%>
@@ -198,7 +198,7 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
@@ -207,7 +207,7 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>Id')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
                     </select>
         <%_ } _%>
                 </div>
@@ -221,7 +221,7 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%=otherEntityName %>Option" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
@@ -230,23 +230,23 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>Id')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%=otherEntityName %>Option.id" *ngFor="let <%=otherEntityName %>Option of <%=relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id" *ngFor="let <%= otherEntityName %>Option of <%= relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
                     </select>
         <%_ } _%>
                 </div>
     <%_ } else if (relationshipType === 'many-to-many' && ownerSide === true) { _%>
                 <div class="form-group">
                     <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipFieldNamePlural %>"><%= relationshipNameHumanized %></label>
-                    <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" multiple name="<%= relationshipFieldNamePlural %>" formControlName="<%=relationshipFieldNamePlural %>">
-                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')!.value, <%=otherEntityName %>Option)" *ngFor="let <%=otherEntityName %>Option of <%=otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
+                    <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" multiple name="<%= relationshipFieldNamePlural %>" formControlName="<%= relationshipFieldNamePlural %>">
+                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')!.value, <%= otherEntityName %>Option)" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
                     </select>
                 </div>
     <%_ } _%>
     <%_ if (relationships[idx].relationshipValidate === true && (relationshipType === 'many-to-one' || ownerSide === true)) { _%>
-                <div *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')!.invalid && (editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')!.dirty || editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')!.touched)">
+                <div *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%= relationshipFieldNamePlural %><% } %>')!.invalid && (editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%= relationshipFieldNamePlural %><% } %>')!.dirty || editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%= relationshipFieldNamePlural %><% } %>')!.touched)">
         <%_ if (relationshipRequired) { _%>
                     <small class="form-text text-danger"
-                           *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%=relationshipFieldNamePlural %><% } %>')?.errors?.required" jhiTranslate="entity.validation.required">
+                           *ngIf="editForm.get('<% if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { %><%= relationshipName %><% if (dto !== 'no') { %>Id<% } %><%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%><%= relationshipFieldNamePlural %><% } %>')?.errors?.required" jhiTranslate="entity.validation.required">
                         This field is required.
                     </small>
         <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -33,11 +33,9 @@ import { Observable } from 'rxjs';
 <%_ if ( rxjsMapIsUsed ) { _%>
 import { map } from 'rxjs/operators';
 <%_ } _%>
-<%_ if ( fieldsContainDate ) { _%>
+<%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
 import * as moment from 'moment';
-    <%_ if ( fieldsContainInstant || fieldsContainZonedDateTime ) { _%>
 import { DATE_TIME_FORMAT } from 'app/shared/constants/input.constants';
-    <%_ } _%>
 <%_ } _%>
 <%_ if (fieldsContainBlob) { _%>
 import { JhiDataUtils, JhiFileLoadError, JhiEventManager, JhiEventWithContent } from 'ng-jhipster';
@@ -57,10 +55,13 @@ Object.keys(differentRelationships).forEach(key => {
 _%>
 import { IUser } from 'app/core/user/user.model';
 import { UserService } from 'app/core/user/user.service';
-<%_         } else { _%>
+<%_
+            } else {
+_%>
 import { I<%= uniqueRel.otherEntityAngularName %> } from 'app/shared/model/<%= uniqueRel.otherEntityModelName %>.model';
-import { <%= uniqueRel.otherEntityAngularName%>Service } from 'app/entities/<%= uniqueRel.otherEntityPath %>/<%= uniqueRel.otherEntityFileName %>.service';
-<%_         }
+import { <%= uniqueRel.otherEntityAngularName %>Service } from 'app/entities/<%= uniqueRel.otherEntityPath %>/<%= uniqueRel.otherEntityFileName %>.service';
+<%_
+            }
         }
     }
 });
@@ -96,35 +97,37 @@ _%>
 })
 export class <%= entityAngularName %>UpdateComponent implements OnInit {
     isSaving = false;
-<%_
-for ( const idx in variables ) { %>
+    <%_ for (const idx in variables) { _%>
     <%- variables[idx] %>
-<%_ } _%>
-<%_ for ( idx in fields ) {
+    <%_ } _%>
+<%_ for (idx in fields) {
     const fieldName = fields[idx].fieldName;
     const fieldType = fields[idx].fieldType;
-        if ( fieldType === 'LocalDate' ) { _%>
+_%>
+    <%_ if ( fieldType === 'LocalDate' ) { _%>
     <%= fieldName %>Dp: any;
-        <%_ } _%>
+    <%_ } _%>
 <%_ } _%>
 
     editForm = this.fb.group({
         id: [],
-<%_ for (idx in fields) {
-    const fieldName = fields[idx].fieldName;
-    const fieldType = fields[idx].fieldType;
-    const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent; _%>
+    <%_ for (idx in fields) {
+        const fieldName = fields[idx].fieldName;
+        const fieldType = fields[idx].fieldType;
+        const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
+    _%>
         <%= fieldName %>: [<% if (fields[idx].fieldValidate === true) { %>null,[<% if (fields[idx].fieldValidateRules.includes('required')) { %>Validators.required,<% } %><% if (fields[idx].fieldValidateRules.includes('minlength')) { %>Validators.minLength(<%= fields[idx].fieldValidateRulesMinlength %>),<% } %><% if (fields[idx].fieldValidateRules.includes('maxlength')) { %>Validators.maxLength(<%= fields[idx].fieldValidateRulesMaxlength %>),<% } %><% if (fields[idx].fieldValidateRules.includes('min')) { %>Validators.min(<%= fields[idx].fieldValidateRulesMin %>),<% } %><% if (fields[idx].fieldValidateRules.includes('max')) { %>Validators.max(<%= fields[idx].fieldValidateRulesMax %>),<% } %><% if (fields[idx].fieldValidateRules.includes('pattern')) { %>Validators.pattern('<%= fields[idx].fieldValidateRulesPattern.replace(/\\/g, '\\\\') %>'),<% } %>]<% } %>],
-    <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
+        <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
         <%= fieldName %>ContentType: [],
+        <%_ } _%>
     <%_ } _%>
-<%_ } _%>
 <%_ for (idx in relationships) {
     const relationshipType = relationships[idx].relationshipType;
     const ownerSide = relationships[idx].ownerSide;
     const relationshipName = relationships[idx].relationshipName;
     const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-    const relationshipRequired = relationships[idx].relationshipRequired; _%>
+    const relationshipRequired = relationships[idx].relationshipRequired;
+_%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
         <%_ if (dto === 'no') { _%>
         <%= relationshipName %>: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
@@ -135,27 +138,29 @@ for ( const idx in variables ) { %>
         <%= relationshipFieldNamePlural %>: [<% if (relationshipRequired) { %>null,Validators.required<% } %>],
     <%_ } _%>
 <%_ } _%>
-
     });
 
     constructor(
-<%_ if (fieldsContainBlob) { _%>
+        <%_ if (fieldsContainBlob) { _%>
         protected dataUtils: JhiDataUtils,
         protected eventManager: JhiEventManager,
-<%_ } _%>
+        <%_ } _%>
         protected <%= entityInstance %>Service: <%= entityAngularName %>Service,
-<%_ Object.keys(differentRelationships).forEach(key => {
+<%_
+Object.keys(differentRelationships).forEach(key => {
     if (differentRelationships[key].some(rel => rel.relationshipType === 'many-to-one' || rel.relationshipType === 'one-to-one' && rel.ownerSide === true || rel.relationshipType === 'many-to-many' && rel.ownerSide === true)) {
         const uniqueRel = differentRelationships[key][0];
-        if (uniqueRel.otherEntityAngularName !== entityAngularName) { _%>
+        if (uniqueRel.otherEntityAngularName !== entityAngularName) {
+_%>
         protected <%= uniqueRel.otherEntityName %>Service: <%= uniqueRel.otherEntityAngularName %>Service,
 <%_
         }
     }
-}); _%>
-<%_ if (fieldsContainImageBlob) { _%>
+});
+_%>
+        <%_ if (fieldsContainImageBlob) { _%>
         protected elementRef: ElementRef,
-<%_ } _%>
+        <%_ } _%>
         protected activatedRoute: ActivatedRoute,
         private fb: FormBuilder
     ) {}
@@ -163,52 +168,62 @@ for ( const idx in variables ) { %>
     ngOnInit(): void {
         this.activatedRoute.data.subscribe(({<%= entityInstance %>}) => {
             this.updateForm(<%= entityInstance %>);
-<%_ for (idx in queries) { _%>
+
+            <%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
+            if (!<%= entityInstance %>.id) {
+            <%_ } _%>
+            <%_ for (idx in fields) {
+                const fieldName = fields[idx].fieldName;
+                const fieldType = fields[idx].fieldType;
+            _%>
+                <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                this.<%= fieldName %>SetDefaultValue();
+                <%_ } _%>
+            <%_ } _%>
+            <%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
+            }
+            <%_ } _%>
+
+            <%_ for (idx in queries) { _%>
             <%- queries[idx] %>
-<%_ } _%>
+            <%_ } _%>
         });
-<%_ for (idx in fields) {
-        const fieldName = fields[idx].fieldName;
-        const fieldType = fields[idx].fieldType;
-    if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-        this.<%= fieldName %>SetDefaultValue();
-    <%_ } _%>
-<%_ } _%>
     }
 
     updateForm(<%= entityInstance %>: I<%= entityAngularName %>): void {
         this.editForm.patchValue({
             id: <%= entityInstance %>.id,
-<%_ for (idx in fields) {
-    const fieldName = fields[idx].fieldName;
-    const fieldType = fields[idx].fieldType;
-    const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
-_%>
-    <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-            <%= fieldName %>: <%= entityInstance %>.<%= fieldName %> != null ? <%= entityInstance %>.<%= fieldName %>.format(DATE_TIME_FORMAT) : null,
-    <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
+    <%_ for (idx in fields) {
+        const fieldName = fields[idx].fieldName;
+        const fieldType = fields[idx].fieldType;
+        const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
+    _%>
+        <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+            <%= fieldName %>: <%= entityInstance %>.<%= fieldName %> ? <%= entityInstance %>.<%= fieldName %>.format(DATE_TIME_FORMAT) : null,
+        <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
             <%= fieldName %>: <%= entityInstance %>.<%= fieldName %>,
             <%= fieldName %>ContentType: <%= entityInstance %>.<%= fieldName %>ContentType,
-    <%_ } else { _%>
-            <%= fieldName %>: <%= entityInstance %>.<%= fieldName %>,
-    <%_ } _%>
-<%_ } _%>
-<%_ for (idx in relationships) {
-    const relationshipType = relationships[idx].relationshipType;
-    const ownerSide = relationships[idx].ownerSide;
-    const relationshipName = relationships[idx].relationshipName;
-    const relationshipFieldName = relationships[idx].relationshipFieldName;
-    const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural; _%>
-    <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-        <%_ if (dto === 'no') { _%>
-            <%=relationshipName %>: <%= entityInstance %>.<%=relationshipFieldName %>,
         <%_ } else { _%>
-            <%=relationshipName %>Id: <%= entityInstance %>.<%=relationshipFieldName %>Id,
+            <%= fieldName %>: <%= entityInstance %>.<%= fieldName %>,
         <%_ } _%>
-    <%_ } else if (relationshipType === 'many-to-many' && ownerSide === true) { _%>
-            <%=relationshipFieldNamePlural %>: <%=entityInstance %>.<%=relationshipFieldNamePlural %>,
     <%_ } _%>
-<%_ } _%>
+    <%_ for (idx in relationships) {
+        const relationshipType = relationships[idx].relationshipType;
+        const ownerSide = relationships[idx].ownerSide;
+        const relationshipName = relationships[idx].relationshipName;
+        const relationshipFieldName = relationships[idx].relationshipFieldName;
+        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+    _%>
+        <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+            <%_ if (dto === 'no') { _%>
+            <%= relationshipName %>: <%= entityInstance %>.<%= relationshipFieldName %>,
+            <%_ } else { _%>
+            <%= relationshipName %>Id: <%= entityInstance %>.<%= relationshipFieldName %>Id,
+            <%_ } _%>
+        <%_ } else if (relationshipType === 'many-to-many' && ownerSide === true) { _%>
+            <%= relationshipFieldNamePlural %>: <%= entityInstance %>.<%= relationshipFieldNamePlural %>,
+        <%_ } _%>
+    <%_ } _%>
         });
     }
 
@@ -224,7 +239,7 @@ _%>
     setFileData(event: Event, field: string, isImage: boolean): void {
         this.dataUtils.loadFileToForm(event, this.editForm, field, isImage).subscribe(null, (err: JhiFileLoadError) => {
             this.eventManager.broadcast(
-                new JhiEventWithContent<AlertError>('<%=angularAppName%>.error', { <% if (enableTranslation) { %>...err, key: 'error.file.' + err.key<% } else { %>message: err.message<% } %> })
+                new JhiEventWithContent<AlertError>('<%= angularAppName %>.error', { <% if (enableTranslation) { %>...err, key: 'error.file.' + err.key<% } else { %>message: err.message<% } %> })
             );
         });
     }
@@ -268,7 +283,7 @@ _%>
         const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
     _%>
         <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-            <%= fieldName %>: this.editForm.get(['<%= fieldName %>'])!.value != null ? moment(this.editForm.get(['<%= fieldName %>'])!.value, DATE_TIME_FORMAT) : undefined,
+            <%= fieldName %>: this.editForm.get(['<%= fieldName %>'])!.value ? moment(this.editForm.get(['<%= fieldName %>'])!.value, DATE_TIME_FORMAT) : undefined,
         <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
             <%= fieldName %>ContentType: this.editForm.get(['<%= fieldName %>ContentType'])!.value,
             <%= fieldName %>: this.editForm.get(['<%= fieldName %>'])!.value,
@@ -280,7 +295,8 @@ _%>
         const relationshipType = relationships[idx].relationshipType;
         const ownerSide = relationships[idx].ownerSide;
         const relationshipName = relationships[idx].relationshipName;
-        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural; _%>
+        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+    _%>
         <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
             <%_ if (dto === 'no') { _%>
             <%= relationshipName %>: this.editForm.get(['<%= relationshipName %>'])!.value,
@@ -290,17 +306,19 @@ _%>
         <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
             <%= relationshipFieldNamePlural %>: this.editForm.get(['<%= relationshipFieldNamePlural %>'])!.value,
         <%_ } _%>
-<%_ } _%>
+    <%_ } _%>
         };
     }
+
 <%_ for (idx in fields) {
     const fieldName = fields[idx].fieldName;
     const fieldType = fields[idx].fieldType;
-    if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+_%>
 
+    <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
     private <%= fieldName %>SetDefaultValue(): void {
         const field = this.editForm.get('<%= fieldName %>');
-        if (field && field.value === null) {
+        if (field && !field.value) {
             const today = moment().startOf('day').format(DATE_TIME_FORMAT);
             field.setValue(today);
         }
@@ -321,13 +339,13 @@ _%>
         this.isSaving = false;
     }
 
-<%_ if (selectableEntitiesType) { _%>
+    <%_ if (selectableEntitiesType) { _%>
     trackById(index: number, item: <%= selectableEntitiesType %>): any {
         return item.id;
     }
-<%_ } _%>
+    <%_ } _%>
 
-<%_ if (selectableManyToManyEntitiesType) { _%>
+    <%_ if (selectableManyToManyEntitiesType) { _%>
     getSelected(selectedVals: <%= selectableManyToManyEntitiesType %>[], option: <%= selectableManyToManyEntitiesType %>): <%= selectableManyToManyEntitiesType %> {
         if (selectedVals) {
             for (let i = 0; i < selectedVals.length; i++) {
@@ -338,5 +356,5 @@ _%>
         }
         return option;
     }
-<%_ } _%>
+    <%_ } _%>
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
@@ -48,31 +48,31 @@
     </div>
     <%_ } _%>
     <br/>
-    <div class="alert alert-warning" *ngIf="<%=entityInstancePlural %>?.length === 0">
-        <span jhiTranslate="<%= i18nKeyPrefix %>.home.notFound">No <%=entityInstancePlural %> found</span>
+    <div class="alert alert-warning" *ngIf="<%= entityInstancePlural %>?.length === 0">
+        <span jhiTranslate="<%= i18nKeyPrefix %>.home.notFound">No <%= entityInstancePlural %> found</span>
     </div>
-    <div class="table-responsive" *ngIf="<%=entityInstancePlural %>?.length > 0">
+    <div class="table-responsive" *ngIf="<%= entityInstancePlural %>?.length > 0">
         <table class="table table-striped" aria-describedby="page-heading">
             <thead>
-            <tr<% if (pagination !== 'no') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="<%=pagination !== 'infinite-scroll' ? 'loadPage.bind(this)' : 'reset.bind(this)'%>"<% } %>>
+            <tr<% if (pagination !== 'no') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="<%= pagination !== 'infinite-scroll' ? 'loadPage.bind(this)' : 'reset.bind(this)'%>"<% } %>>
             <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
             <%_ for (idx in fields) { _%>
-            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= fields[idx].fieldName%>"<% } %>><span jhiTranslate="<%=`${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= fields[idx].fieldName %>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
             <%_ } _%>
             <%_ for (idx in relationships) { _%>
             <%_ if (relationships[idx].relationshipType === 'many-to-one'
             || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
             || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
-            const fieldName = dto === 'no' ? "." + relationships[idx].otherEntityField : relationships[idx].otherEntityFieldCapitalized;_%>
-            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%=relationships[idx].relationshipName + (fieldName)%>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+            const fieldName = dto === 'no' ? "." + relationships[idx].otherEntityField : relationships[idx].otherEntityFieldCapitalized; _%>
+            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= relationships[idx].relationshipName + (fieldName)%>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
             <%_ } _%>
             <%_ } _%>
             <th scope="col"></th>
             </tr>
             </thead>
             <tbody<% if (pagination === 'infinite-scroll') { %> infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']" [infiniteScrollDistance]="0"<% } %>>
-            <tr *ngFor="let <%=entityInstance %> of <%=entityInstancePlural %> ;trackBy: trackId">
-                <td><a [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view' ]">{{<%=entityInstance %>.id}}</a></td>
+            <tr *ngFor="let <%= entityInstance %> of <%= entityInstancePlural %> ;trackBy: trackId">
+                <td><a [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view' ]">{{<%= entityInstance %>.id}}</a></td>
                 <%_ for (idx in fields) {
                 const fieldName = fields[idx].fieldName;
                 const fieldNameCapitalized = fields[idx].fieldNameCapitalized;
@@ -81,7 +81,7 @@
                 <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
                 <td>
                     <a *ngIf="<%= entityInstance %>.<%= fieldName %>" (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)">
-                        <img [src]="'data:' + <%=entityInstance %>.<%=fieldName%>ContentType + ';base64,' + <%=entityInstance %>.<%=fieldName%>" style="max-height: 30px;" alt="<%=entityInstance %> image"/>
+                        <img [src]="'data:' + <%= entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-height: 30px;" alt="<%= entityInstance %> image"/>
                     </a>
                     <span *ngIf="<%= entityInstance %>.<%= fieldName %>">{{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}</span>
                 </td>
@@ -93,11 +93,11 @@
                 <%_ } else if (fields[idx].fieldIsEnum) { _%>
                 <td jhiTranslate="{{'<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>}}">{{<%= entityInstance %>.<%= fieldName %>}}</td>
                 <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                <td>{{<%=entityInstance %>.<%=fieldName%> | date:'medium'}}</td>
+                <td>{{<%= entityInstance %>.<%= fieldName %> | date:'medium'}}</td>
                 <%_ } else if (fieldType === 'LocalDate') { _%>
-                <td>{{<%=entityInstance %>.<%=fieldName%> | date:'mediumDate'}}</td>
+                <td>{{<%= entityInstance %>.<%= fieldName %> | date:'mediumDate'}}</td>
                 <%_ } else { _%>
-                <td>{{<%=entityInstance %>.<%=fieldName%>}}</td>
+                <td>{{<%= entityInstance %>.<%= fieldName %>}}</td>
                 <%_ } _%>
                 <%_ } _%>
                 <%_ for (idx in relationships) {
@@ -173,7 +173,7 @@
         </table>
     </div>
     <%_ if (pagination === 'pagination') { _%>
-    <div *ngIf="<%=entityInstancePlural %>?.length > 0">
+    <div *ngIf="<%= entityInstancePlural %>?.length > 0">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.module.ts.ejs
@@ -47,5 +47,4 @@ import { <%= entityInstance %>Route } from './<%= entityFileName %>.route';
     ]
     <%_ } _%>
 })
-export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {
-}
+export class <%= locals.microserviceName ? upperFirstCamelCase(locals.microserviceName) : angularXAppName %><%= entityAngularName %>Module {}

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -26,10 +26,10 @@ const enumImports = generateEntityClientEnumImports(fields);
 <%_ if (fieldsContainInstant || fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 import { Moment } from 'moment';
 <%_ } _%>
-<%_ typeImports.forEach( (importedPath, importedType) => { _%>
+<%_ typeImports.forEach((importedPath, importedType) => { _%>
 import { <%- importedType %> } from '<%- importedPath %>';
 <%_ }); _%>
-<%_ enumImports.forEach( (importedPath, importedType) => { _%>
+<%_ enumImports.forEach((importedPath, importedType) => { _%>
 import { <%- importedType %> } from '<%- importedPath %>';
 <%_ }); _%>
 
@@ -40,9 +40,13 @@ export interface I<%= entityAngularName %> {
 }
 
 export class <%= entityAngularName %> implements I<%= entityAngularName %> {
-    constructor(<% variablesWithTypes.forEach(variablesWithType => { %>
-        public <%- variablesWithType %>,<% }); %>
-    ) {<% for (idx in defaultVariablesValues) { %>
-        <%- defaultVariablesValues[idx] %><% } %>
+    constructor(
+        <%_ variablesWithTypes.forEach(variablesWithType => { _%>
+        public <%- variablesWithType %>,
+        <%_ }); _%>
+    ) {
+        <%_ for (idx in defaultVariablesValues) { _%>
+        <%- defaultVariablesValues[idx] %>
+        <%_ } _%>
     }
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
@@ -31,8 +31,7 @@ import { map } from 'rxjs/operators';
 import * as moment from 'moment';
 <%_ } _%>
 
-<%_ if (fieldsContainDate) { _%>
-// eslint-disable-next-line @typescript-eslint/no-unused-vars
+<%_ if (fieldsContainLocalDate) { _%>
 import { DATE_FORMAT } from 'app/shared/constants/input.constants';
 <%_ } _%>
 import { SERVER_API_URL } from 'app/app.constants';
@@ -56,20 +55,20 @@ export class <%= entityAngularName %>Service {
         <%_ if (fieldsContainDate) { _%>
         const copy = this.convertDateFromClient(<%= entityInstance %>);
         <%_ } _%>
-            return this.http.post<I<%= entityAngularName %>>(this.resourceUrl,
-                    <% if (fieldsContainDate) { %> copy <% } else { %> <%= entityInstance %> <% } %>,
-                    { observe: 'response' })
-            <% if (fieldsContainDate) { %>.pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)))<% } %>;
+        return this.http.post<I<%= entityAngularName %>>(this.resourceUrl,
+                <% if (fieldsContainDate) { %> copy <% } else { %> <%= entityInstance %> <% } %>,
+                { observe: 'response' })
+        <% if (fieldsContainDate) { %>.pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)))<% } %>;
     }
 
     update(<%= entityInstance %>: I<%= entityAngularName %>): Observable<EntityResponseType> {
         <%_ if (fieldsContainDate) { _%>
         const copy = this.convertDateFromClient(<%= entityInstance %>);
         <%_ } _%>
-            return this.http.put<I<%= entityAngularName %>>(this.resourceUrl,
-                    <% if (fieldsContainDate) { %> copy <% } else { %> <%= entityInstance %> <% } %>,
-                    { observe: 'response' })
-            <% if (fieldsContainDate) { %>.pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)))<% } %>;
+        return this.http.put<I<%= entityAngularName %>>(this.resourceUrl,
+                <% if (fieldsContainDate) { %> copy <% } else { %> <%= entityInstance %> <% } %>,
+                { observe: 'response' })
+        <% if (fieldsContainDate) { %>.pipe(map((res: EntityResponseType) => this.convertDateFromServer(res)))<% } %>;
     }
     <%_ } _%>
 
@@ -115,11 +114,11 @@ export class <%= entityAngularName %>Service {
 
     protected convertDateFromServer(res: EntityResponseType): EntityResponseType {
         if (res.body) {
-    <%_ for (idx in fields) { _%>
-        <%_ if ( ['Instant', 'ZonedDateTime', 'LocalDate'].includes(fields[idx].fieldType) ) { _%>
+        <%_ for (idx in fields) { _%>
+            <%_ if ( ['Instant', 'ZonedDateTime', 'LocalDate'].includes(fields[idx].fieldType) ) { _%>
             res.body.<%= fields[idx].fieldName %> = res.body.<%= fields[idx].fieldName %> ? moment(res.body.<%= fields[idx].fieldName %>) : undefined;
+            <%_ } _%>
         <%_ } _%>
-    <%_ } _%>
         }
         return res;
     }
@@ -127,11 +126,11 @@ export class <%= entityAngularName %>Service {
     protected convertDateArrayFromServer(res: EntityArrayResponseType): EntityArrayResponseType {
         if (res.body) {
             res.body.forEach ((<%= entityInstance %>: I<%= entityAngularName %>) => {
-    <%_ for (idx in fields) { _%>
-        <%_ if ( ['Instant', 'ZonedDateTime', 'LocalDate'].includes(fields[idx].fieldType) ) { _%>
+            <%_ for (idx in fields) { _%>
+                <%_ if ( ['Instant', 'ZonedDateTime', 'LocalDate'].includes(fields[idx].fieldType) ) { _%>
                 <%= entityInstance %>.<%= fields[idx].fieldName %> = <%= entityInstance %>.<%= fields[idx].fieldName %> ? moment(<%= entityInstance %>.<%= fields[idx].fieldName %>) : undefined;
-        <%_ } _%>
-    <%_ } _%>
+                <%_ } _%>
+            <%_ } _%>
             });
         }
         return res;

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs
@@ -18,10 +18,10 @@
 -%>
 export const enum <%= enumName %> {
 <% enumsWithCustomValue.forEach((enumWithCustomValue, index) => { %>
-<% if (!enumWithCustomValue.value) { %>
+  <% if (!enumWithCustomValue.value) { %>
   <%= enumWithCustomValue.name %>
-<% } else {%>
+  <% } else { %>
   <%= enumWithCustomValue.name %> = '<%= enumWithCustomValue.value %>'
-<% } %><% if (index < enumsWithCustomValue.length - 1) { %>,<% } %>
-<%}); %>
+  <% } %><% if (index < enumsWithCustomValue.length - 1) { %>,<% } %>
+<% }); %>
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/ng_validators.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/ng_validators.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%#	Returns a string of all angular validators required for the input field. -%>
-<%
+<%_
 const field = fields[idx];
 let result = '';
 
@@ -54,5 +54,5 @@ if (field.fieldValidate === true) {
 
     result = validators.join(' ');
 }
--%>
+_%>
 <%- result -%>

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity-page-object.ts.ejs
@@ -20,18 +20,10 @@ import { element, by<% if (!readOnly) { %>, ElementFinder<% } %> } from 'protrac
 
 <%_
 let elementGetter = `getText()`;
-let openBlockComment = ``;
-let closeBlockComment = ``;
 if (enableTranslation) {
     elementGetter = `getAttribute('jhiTranslate')`;
 }
-for (let relationship of relationships) {
-    if (relationship.relationshipRequired) {
-        openBlockComment = `/*`;
-        closeBlockComment = `*/`;
-        break;
-    }
-} _%>
+_%>
 export class <%= entityClass %>ComponentsPage {
     <%_ if (!readOnly) { _%>
     createButton = element(by.id('jh-create-entity'));
@@ -59,16 +51,18 @@ export class <%= entityClass %>ComponentsPage {
 }
 
 <%_ if (!readOnly) { _%>
+
 export class <%= entityClass %>UpdatePage {
     pageTitle = element(by.id('<%= jhiPrefixDashed %>-<%= entityFileName %>-heading'));
     saveButton = element(by.id('save-entity'));
     cancelButton = element(by.id('cancel-save'));
-    <%_ fields.forEach((field) => {
-            const fieldName = field.fieldName;
-            const fieldType = field.fieldType;
-            const fieldIsEnum = field.fieldIsEnum;
-            const fieldTypeBlobContent = field.fieldTypeBlobContent;
-    _%>
+
+<%_ fields.forEach((field) => {
+    const fieldName = field.fieldName;
+    const fieldType = field.fieldType;
+    const fieldIsEnum = field.fieldIsEnum;
+    const fieldTypeBlobContent = field.fieldTypeBlobContent;
+_%>
     <%_ if (fieldIsEnum) { _%>
     <%= fieldName %>Select = element(by.id('field_<%= fieldName %>'));
     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
@@ -78,31 +72,33 @@ export class <%= entityClass %>UpdatePage {
     <%_ } else { _%>
     <%= fieldName %>Input = element(by.id('field_<%= fieldName %>'));
     <%_ } _%>
-    <%_ }); _%>
-    <%_ relationships.forEach((relationship) => {
-        const relationshipType = relationship.relationshipType;
-        const ownerSide = relationship.ownerSide;
-        const relationshipName = relationship.relationshipName;
-        const relationshipFieldName = relationship.relationshipFieldName; _%>
+<%_ }); _%>
+
+<%_ relationships.forEach((relationship) => {
+    const relationshipType = relationship.relationshipType;
+    const ownerSide = relationship.ownerSide;
+    const relationshipName = relationship.relationshipName;
+    const relationshipFieldName = relationship.relationshipFieldName;
+_%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-    <%=relationshipName %>Select = element(by.id('field_<%= relationshipName %>'));
+    <%= relationshipName %>Select = element(by.id('field_<%= relationshipName %>'));
     <%_ } _%>
-    <%_ }); _%>
+<%_ }); _%>
 
     async getPageTitle(): Promise<string> {
         return this.pageTitle.<%- elementGetter %>;
     }
 
-    <%_ fields.forEach((field) => {
-            const fieldName = field.fieldName;
-            const fieldNameCapitalized = field.fieldNameCapitalized;
-            const fieldNameHumanized = field.fieldNameHumanized;
-            const fieldType = field.fieldType;
-            const fieldTypeBlobContent = field.fieldTypeBlobContent;
-            const fieldIsEnum = field.fieldIsEnum;
-            let fieldInputType = 'text';
-            let ngModelOption = '';
-    _%>
+<%_ fields.forEach((field) => {
+    const fieldName = field.fieldName;
+    const fieldNameCapitalized = field.fieldNameCapitalized;
+    const fieldNameHumanized = field.fieldNameHumanized;
+    const fieldType = field.fieldType;
+    const fieldTypeBlobContent = field.fieldTypeBlobContent;
+    const fieldIsEnum = field.fieldIsEnum;
+    let fieldInputType = 'text';
+    let ngModelOption = '';
+_%>
     <%_ if (fieldType === 'Boolean') { _%>
     get<%= fieldNameCapitalized %>Input(): ElementFinder {
         return this.<%= fieldName %>Input;
@@ -117,8 +113,8 @@ export class <%= entityClass %>UpdatePage {
         return await this.<%= fieldName %>Select.element(by.css('option:checked')).getText();
     }
 
-    async <%=fieldName %>SelectLastOption(): Promise<void> {
-        await this.<%=fieldName %>Select.all(by.tagName('option')).last().click();
+    async <%= fieldName %>SelectLastOption(): Promise<void> {
+        await this.<%= fieldName %>Select.all(by.tagName('option')).last().click();
     }
 
     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
@@ -140,33 +136,35 @@ export class <%= entityClass %>UpdatePage {
     }
 
     <%_ } _%>
-    <%_ }); _%>
-    <%_ relationships.forEach((relationship) => {
-        const relationshipType = relationship.relationshipType;
-        const ownerSide = relationship.ownerSide;
-        const relationshipName = relationship.relationshipName;
-        const relationshipFieldName = relationship.relationshipFieldName;
-        const relationshipNameCapitalized = relationship.relationshipNameCapitalized; _%>
+<%_ }); _%>
 
+<%_ relationships.forEach((relationship) => {
+    const relationshipType = relationship.relationshipType;
+    const ownerSide = relationship.ownerSide;
+    const relationshipName = relationship.relationshipName;
+    const relationshipFieldName = relationship.relationshipFieldName;
+    const relationshipNameCapitalized = relationship.relationshipNameCapitalized;
+_%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-    async <%=relationshipName %>SelectLastOption(): Promise<void> {
-        await this.<%=relationshipName %>Select.all(by.tagName('option')).last().click();
+    async <%= relationshipName %>SelectLastOption(): Promise<void> {
+        await this.<%= relationshipName %>Select.all(by.tagName('option')).last().click();
     }
 
-    async <%=relationshipName %>SelectOption(option: string): Promise<void> {
-        await this.<%=relationshipName %>Select.sendKeys(option);
+    async <%= relationshipName %>SelectOption(option: string): Promise<void> {
+        await this.<%= relationshipName %>Select.sendKeys(option);
     }
 
-    get<%=relationshipNameCapitalized %>Select(): ElementFinder {
-        return this.<%=relationshipName %>Select;
+    get<%= relationshipNameCapitalized %>Select(): ElementFinder {
+        return this.<%= relationshipName %>Select;
     }
 
-    async get<%=relationshipNameCapitalized %>SelectedOption(): Promise<string> {
-        return await this.<%=relationshipName %>Select.element(by.css('option:checked')).getText();
+    async get<%= relationshipNameCapitalized %>SelectedOption(): Promise<string> {
+        return await this.<%= relationshipName %>Select.element(by.css('option:checked')).getText();
     }
 
     <%_ } _%>
-    <%_ }); _%>
+<%_ }); _%>
+
     async save(): Promise<void> {
         await this.saveButton.click();
     }
@@ -192,4 +190,5 @@ export class <%= entityClass %>DeleteDialog {
         await this.confirmButton.click();
     }
 }
+
 <%_ } _%>

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -33,10 +33,11 @@ for (let relationship of relationships) {
 import { browser, ExpectedConditions as ec <% if (!readOnly) { %><%= openBlockComment %><% if ( fieldsContainInstant || fieldsContainZonedDateTime ) { %>, protractor<% } %>, promise<%= closeBlockComment %><% } %> } from 'protractor';
 import { NavBarPage, SignInPage } from '../../<%= entityParentPathAddition %>page-objects/jhi-page-objects';
 
-import { <%= entityClass %>ComponentsPage,
+import {
+    <%= entityClass %>ComponentsPage,
     <%_ if (!readOnly) { _%>
-    <%= openBlockComment %><%= entityClass %>DeleteDialog,
-    <%= closeBlockComment %> <%= entityClass %>UpdatePage
+    <%= openBlockComment %><%= entityClass %>DeleteDialog,<%= closeBlockComment %>
+    <%= entityClass %>UpdatePage
     <%_ } _%>
 } from './<%= entityFileName %>.page-object';
 <%_ if (fieldsContainBlobOrImage) { _%>
@@ -98,10 +99,11 @@ describe('<%= entityClass %> e2e test', () => {
         await <%= entityInstance %>UpdatePage.cancel();
     });
 
-   <%= openBlockComment %> it('should create and save <%= entityClassPlural %>', async () => {
+   <%= openBlockComment %>it('should create and save <%= entityClassPlural %>', async () => {
         const nbButtonsBeforeCreate = await <%= entityInstance %>ComponentsPage.countDeleteButtons();
 
         await <%= entityInstance %>ComponentsPage.clickOnCreateButton();
+
         await promise.all([
         <%_ fields.forEach((field) => {
             const fieldName = field.fieldName;
@@ -110,7 +112,8 @@ describe('<%= entityClass %> e2e test', () => {
             const fieldTypeBlobContent = field.fieldTypeBlobContent;
             const fieldIsEnum = field.fieldIsEnum;
             const fieldValidateSampleString = field.fieldValidateSampleString;
-            if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
+        _%>
+            <%_ if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('5'),
             <%_ } else if (fieldType === 'LocalDate') { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('2000-12-31'),
@@ -123,7 +126,7 @@ describe('<%= entityClass %> e2e test', () => {
             <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input(absolutePath),
             <%_ } else if (fieldIsEnum) { _%>
-            <%= entityInstance %>UpdatePage.<%=fieldName %>SelectLastOption(),
+            <%= entityInstance %>UpdatePage.<%= fieldName %>SelectLastOption(),
             <%_ } else if (fieldType === 'UUID') { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('64c99148-3908-465d-8c4a-e510e3ade974'),
             <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
@@ -131,62 +134,66 @@ describe('<%= entityClass %> e2e test', () => {
             <%_ } else if (fieldType !== 'Boolean') { _%>
             <%= entityInstance %>UpdatePage.set<%= fieldNameCapitalized %>Input('<%= fieldName %>'),
             <%_ } _%>
-            <%_ }); _%>
-            <%_ relationships.forEach((relationship) => {
-                const relationshipType = relationship.relationshipType;
-                const ownerSide = relationship.ownerSide;
-                const relationshipName = relationship.relationshipName;
-                const relationshipFieldName = relationship.relationshipFieldName;
-                if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-            <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption(),
+        <%_ }); _%>
+        <%_ relationships.forEach((relationship) => {
+            const relationshipType = relationship.relationshipType;
+            const ownerSide = relationship.ownerSide;
+            const relationshipName = relationship.relationshipName;
+            const relationshipFieldName = relationship.relationshipFieldName;
+        _%>
+            <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+            <%= entityInstance %>UpdatePage.<%= relationshipName %>SelectLastOption(),
             <%_ } else if ((relationshipType === 'many-to-many' && ownerSide === true)) { _%>
-            // <%= entityInstance %>UpdatePage.<%=relationshipName %>SelectLastOption(),
+            // <%= entityInstance %>UpdatePage.<%= relationshipName %>SelectLastOption(),
             <%_ } _%>
         <%_ }); _%>
         ]);
-        <%_ fields.forEach((field) => {
-            const fieldName = field.fieldName;
-            const fieldNameCapitalized = field.fieldNameCapitalized;
-            const fieldType = field.fieldType;
-            const fieldTypeBlobContent = field.fieldTypeBlobContent;
-            const fieldIsEnum = field.fieldIsEnum;
-            const fieldValidateSampleString = field.fieldValidateSampleString;
-            if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('5', 'Expected <%=fieldName%> value to be equals to 5');
-            <%_ } else if (fieldType === 'LocalDate') { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('2000-12-31', 'Expected <%=fieldName%> value to be equals to 2000-12-31');
-            <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('2001-01-01T02:30', 'Expected <%=fieldName%> value to be equals to 2000-12-31');
-            <%_ } else if (fieldType === 'Duration') { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('12', 'Expected <%=fieldName%> value to be equals to 12');
-            <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldValidateSampleString %>', 'Expected <%=fieldNameCapitalized%> value to be equals to <%= fieldValidateSampleString %>');
-            <%_ } else if (fieldType === 'Boolean') { _%>
+
+    <%_ fields.forEach((field) => {
+        const fieldName = field.fieldName;
+        const fieldNameCapitalized = field.fieldNameCapitalized;
+        const fieldType = field.fieldType;
+        const fieldTypeBlobContent = field.fieldTypeBlobContent;
+        const fieldIsEnum = field.fieldIsEnum;
+        const fieldValidateSampleString = field.fieldValidateSampleString;
+    _%>
+        <%_ if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('5', 'Expected <%= fieldName %> value to be equals to 5');
+        <%_ } else if (fieldType === 'LocalDate') { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('2000-12-31', 'Expected <%= fieldName %> value to be equals to 2000-12-31');
+        <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('2001-01-01T02:30', 'Expected <%= fieldName %> value to be equals to 2000-12-31');
+        <%_ } else if (fieldType === 'Duration') { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.contain('12', 'Expected <%= fieldName %> value to be equals to 12');
+        <%_ } else if (fieldType === 'String' && fieldValidateSampleString) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldValidateSampleString %>', 'Expected <%= fieldNameCapitalized %> value to be equals to <%= fieldValidateSampleString %>');
+        <%_ } else if (fieldType === 'Boolean') { _%>
         const selected<%= fieldNameCapitalized %> = <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input();
         if (await selected<%= fieldNameCapitalized %>.isSelected()) {
             await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
-            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected(), 'Expected <%=fieldName%> not to be selected').to.be.false;
+            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected(), 'Expected <%= fieldName %> not to be selected').to.be.false;
         } else {
             await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().click();
-            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected(), 'Expected <%=fieldName%> to be selected').to.be.true;
+            expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input().isSelected(), 'Expected <%= fieldName %> to be selected').to.be.true;
         }
-            <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>', 'Expected <%=fieldNameCapitalized%> value to be equals to <%=fieldName%>');
-            <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.endsWith(fileNameToUpload, 'Expected <%=fieldNameCapitalized%> value to be end with ' + fileNameToUpload);
-            <%_ } else if (fieldType === 'UUID') { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('64c99148-3908-465d-8c4a-e510e3ade974', 'Expected <%=fieldNameCapitalized%> value to be equals to 64c99148-3908-465d-8c4a-e510e3ade974');
-            <%_ } else if (!fieldIsEnum) { _%>
-        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>', 'Expected <%=fieldNameCapitalized%> value to be equals to <%= fieldName %>');
-            <%_ } _%>
-        <%_ }); _%>
+        <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'text') { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>', 'Expected <%= fieldNameCapitalized %> value to be equals to <%= fieldName %>');
+        <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.endsWith(fileNameToUpload, 'Expected <%= fieldNameCapitalized %> value to be end with ' + fileNameToUpload);
+        <%_ } else if (fieldType === 'UUID') { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('64c99148-3908-465d-8c4a-e510e3ade974', 'Expected <%= fieldNameCapitalized %> value to be equals to 64c99148-3908-465d-8c4a-e510e3ade974');
+        <%_ } else if (!fieldIsEnum) { _%>
+        expect(await <%= entityInstance %>UpdatePage.get<%= fieldNameCapitalized %>Input()).to.eq('<%= fieldName %>', 'Expected <%= fieldNameCapitalized %> value to be equals to <%= fieldName %>');
+        <%_ } _%>
+    <%_ }); _%>
+
         await <%= entityInstance %>UpdatePage.save();
         expect(await <%= entityInstance %>UpdatePage.getSaveButton().isPresent(), 'Expected save button disappear').to.be.false;
 
         expect(await <%= entityInstance %>ComponentsPage.countDeleteButtons()).to.eq(nbButtonsBeforeCreate + 1, 'Expected one more entry in the table');
     });<%= closeBlockComment %>
 
-    <%= openBlockComment %> it('should delete last <%= entityClass %>', async () => {
+    <%= openBlockComment %>it('should delete last <%= entityClass %>', async () => {
         const nbButtonsBeforeDelete = await <%= entityInstance %>ComponentsPage.countDeleteButtons();
         await <%= entityInstance %>ComponentsPage.clickOnLastDeleteButton();
 

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
@@ -25,7 +25,7 @@ import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
 import { JhiEventManager } from 'ng-jhipster';
 
-import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
+import { <%= angularXAppName %>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
 import { MockEventManager } from '../../../<%= entityParentPathAddition %>helpers/mock-event-manager.service';
 import { MockActiveModal } from '../../../<%= entityParentPathAddition %>helpers/mock-active-modal.service';
 import { <%= entityAngularName %>DeleteDialogComponent } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>-delete-dialog.component';
@@ -41,7 +41,7 @@ describe('Component Tests', () => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [<%=angularXAppName%>TestModule],
+                imports: [<%= angularXAppName %>TestModule],
                 declarations: [<%= entityAngularName %>DeleteDialogComponent]
             })
             .overrideTemplate(<%= entityAngularName %>DeleteDialogComponent, '')
@@ -71,6 +71,7 @@ describe('Component Tests', () => {
                     })
                 )
             );
+
             it('Should not call delete service on clear', () => {
                 // GIVEN
                 spyOn(service, 'delete');

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
@@ -27,7 +27,7 @@ import { of } from 'rxjs';
 import { JhiDataUtils } from 'ng-jhipster';
 <%_ } _%>
 
-import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
+import { <%= angularXAppName %>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
 import { <%= entityAngularName %>DetailComponent } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>-detail.component';
 import { <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 
@@ -42,7 +42,7 @@ describe('Component Tests', () => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [<%=angularXAppName%>TestModule],
+                imports: [<%= angularXAppName %>TestModule],
                 declarations: [<%= entityAngularName %>DetailComponent],
                 providers: [
                     {provide: ActivatedRoute, useValue: route}

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
@@ -25,7 +25,7 @@ import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
 import { of } from 'rxjs';
 
-import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
+import { <%= angularXAppName %>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
 import { <%= entityAngularName %>UpdateComponent } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>-update.component';
 import { <%= entityAngularName %>Service } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.service';
 import { <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
@@ -38,7 +38,7 @@ describe('Component Tests', () => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [<%=angularXAppName%>TestModule],
+                imports: [<%= angularXAppName %>TestModule],
                 declarations: [<%= entityAngularName %>UpdateComponent],
                 providers: [FormBuilder]
             })

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
@@ -27,7 +27,7 @@ import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { ActivatedRoute, Data } from '@angular/router';
 <%_ } _%>
 
-import { <%=angularXAppName%>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
+import { <%= angularXAppName %>TestModule } from '../../../<%= entityParentPathAddition %>test.module';
 import { <%= entityAngularName %>Component } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.component';
 import { <%= entityAngularName %>Service } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.service';
 import { <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
@@ -40,7 +40,7 @@ describe('Component Tests', () => {
 
         beforeEach(() => {
             TestBed.configureTestingModule({
-                imports: [<%=angularXAppName%>TestModule],
+                imports: [<%= angularXAppName %>TestModule],
                 declarations: [<%= entityAngularName %>Component],
                 providers: [
                     <% if (pagination !== 'no') { %> {

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -24,10 +24,9 @@ const enumImports = generateEntityClientEnumImports(fields);
 _%>
 import { TestBed, getTestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
-import { take, map } from 'rxjs/operators';
 <%_ if (fieldsContainDate) { _%>
 import * as moment from 'moment';
-import { <%_ if (fieldsContainLocalDate) { _%>DATE_FORMAT,<%_ } if (fieldsContainInstant || fieldsContainZonedDateTime) {_%> DATE_TIME_FORMAT<%_ } _%> } from 'app/shared/constants/input.constants';
+import { <% if (fieldsContainLocalDate) { %>DATE_FORMAT,<% } if (fieldsContainInstant || fieldsContainZonedDateTime) { %> DATE_TIME_FORMAT<% } %> } from 'app/shared/constants/input.constants';
 <%_ } _%>
 import { <%= entityAngularName %>Service } from 'app/entities/<%= entityFolderName %>/<%= entityFileName %>.service';
 import { I<%= entityAngularName %>, <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
@@ -66,43 +65,44 @@ describe('Service Tests', () => {
                 <%_ } else { _%>
                 0,
                 <%_ } _%>
-                <%_ fields.forEach((field) => {
-                    const fieldType = field.fieldType; _%>
-                    <%_ if (field.fieldIsEnum) { _%>
+            <%_ fields.forEach((field) => {
+                const fieldType = field.fieldType;
+            _%>
+                <%_ if (field.fieldIsEnum) { _%>
                 <%= fieldType + '.' + field.fieldValues.split(',')[0].replace(/(.+?)\(.*/, (match, firstGroup) => firstGroup) %>,
-                    <%_ } else if (fieldType === 'Boolean') { _%>
+                <%_ } else if (fieldType === 'Boolean') { _%>
                 false,
-                    <%_ } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal', 'Duration'].includes(fieldType)) { _%>
+                <%_ } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal', 'Duration'].includes(fieldType)) { _%>
                 0,
-                    <%_ } else if (fieldType === 'String' || fieldType === 'UUID') { _%>
+                <%_ } else if (fieldType === 'String' || fieldType === 'UUID') { _%>
                 'AAAAAAA',
-                    <%_ } else if (['LocalDate', 'Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                <%_ } else if (['LocalDate', 'Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
                 currentDate,
-                    <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && field.fieldTypeBlobContent !== 'text') { _%>
+                <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && field.fieldTypeBlobContent !== 'text') { _%>
                 'image/png',
                 'AAAAAAA',
-                    <%_ } else { // (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'any' || (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'image' || fieldType === 'LocalDate' _%>
+                <%_ } else { // (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'any' || (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'image' || fieldType === 'LocalDate' _%>
                 'AAAAAAA',
-                    <%_ } _%>
-                <%_ }) _%>
-            )
+                <%_ } _%>
+            <%_ }) _%>
+            );
         });
 
         describe('Service methods', () => {
             it('should find an element', () => {
                 const returnedFromService = Object.assign({
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_FORMAT),
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_TIME_FORMAT),
-    <%_ } _%>
-<%_ }) _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_FORMAT),
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_TIME_FORMAT),
+                    <%_ } _%>
+                <%_ }) _%>
                 }, elemDefault);
-                service
-                    .find(<%- tsKeyId %>)
-                    .pipe(take(1)).subscribe(resp => expectedResult = resp.body);
+
+                service.find(<%- tsKeyId %>).subscribe(resp => expectedResult = resp.body);
 
                 const req  = httpMock.expectOne({ method: 'GET' });
                 req.flush(returnedFromService);
@@ -112,33 +112,36 @@ describe('Service Tests', () => {
         <%_ if (!readOnly) { _%>
             it('should create a <%= entityAngularName %>', () => {
                 const returnedFromService = Object.assign({
-<%_ if (pkType === 'String' || pkType === 'UUID') { _%>
+                    <%_ if (pkType === 'String' || pkType === 'UUID') { _%>
                     id: 'ID',
-<%_ } else { _%>
+                    <%_ } else { _%>
                     id: 0,
-<%_ } _%>
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_FORMAT),
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_TIME_FORMAT),
-    <%_ } _%>
-<%_ }) _%>
+                    <%_ } _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_FORMAT),
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_TIME_FORMAT),
+                    <%_ } _%>
+                <%_ }) _%>
                 }, elemDefault);
+
                 const expected = Object.assign({
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate,
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate,
-    <%_ } _%>
-<%_ }) _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate,
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate,
+                    <%_ } _%>
+                <%_ }) _%>
                 }, returnedFromService);
-                service
-                    .create(new <%= entityAngularName %>())
-                    .pipe(take(1)).subscribe(resp => expectedResult = resp.body);
+
+                service.create(new <%= entityAngularName %>()).subscribe(resp => expectedResult = resp.body);
+
                 const req  = httpMock.expectOne({ method: 'POST' });
                 req.flush(returnedFromService);
                 expect(expectedResult).toMatchObject(expected);
@@ -146,37 +149,39 @@ describe('Service Tests', () => {
 
             it('should update a <%= entityAngularName %>', () => {
                 const returnedFromService = Object.assign({
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (fieldType === 'Boolean') { _%>
-                    <%= field.fieldName%>: true,
-    <%_ } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: 1,
-    <%_ } else if (fieldType === 'String' || fieldType === 'UUID') { _%>
-                    <%= field.fieldName%>: 'BBBBBB',
-    <%_ } else if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_FORMAT),
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_TIME_FORMAT),
-    <%_ } else { _%>
-                    <%= field.fieldName%>: 'BBBBBB',
-    <%_ } _%>
-<%_ }) _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (fieldType === 'Boolean') { _%>
+                    <%= field.fieldName %>: true,
+                    <%_ } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: 1,
+                    <%_ } else if (fieldType === 'String' || fieldType === 'UUID') { _%>
+                    <%= field.fieldName %>: 'BBBBBB',
+                    <%_ } else if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_FORMAT),
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_TIME_FORMAT),
+                    <%_ } else { _%>
+                    <%= field.fieldName %>: 'BBBBBB',
+                    <%_ } _%>
+                <%_ }) _%>
                 }, elemDefault);
 
                 const expected = Object.assign({
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate,
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate,
-    <%_ } _%>
-<%_ }) _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate,
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate,
+                    <%_ } _%>
+                <%_ }) _%>
                 }, returnedFromService);
-                service
-                    .update(expected)
-                    .pipe(take(1)).subscribe(resp => expectedResult = resp.body);
+
+                service.update(expected).subscribe(resp => expectedResult = resp.body);
+
                 const req  = httpMock.expectOne({ method: 'PUT' });
                 req.flush(returnedFromService);
                 expect(expectedResult).toMatchObject(expected);
@@ -185,46 +190,46 @@ describe('Service Tests', () => {
 
             it('should return a list of <%= entityAngularName %>', () => {
                 const returnedFromService = Object.assign({
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (fieldType === 'Boolean') { _%>
-                    <%= field.fieldName%>: true,
-    <%_ } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: 1,
-    <%_ } else if (fieldType === 'String' || fieldType === 'UUID') { _%>
-                    <%= field.fieldName%>: 'BBBBBB',
-    <%_ } else if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_FORMAT),
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate.format(DATE_TIME_FORMAT),
-    <%_ } else { // (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'any' || (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'image' || fieldType === 'LocalDate' _%>
-                    <%= field.fieldName%>: 'BBBBBB',
-    <%_ } _%>
-<%_ }) _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (fieldType === 'Boolean') { _%>
+                    <%= field.fieldName %>: true,
+                    <%_ } else if (['Integer', 'Long', 'Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: 1,
+                    <%_ } else if (fieldType === 'String' || fieldType === 'UUID') { _%>
+                    <%= field.fieldName %>: 'BBBBBB',
+                    <%_ } else if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_FORMAT),
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate.format(DATE_TIME_FORMAT),
+                    <%_ } else { // (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'any' || (fieldType === 'byte[]' || fieldType === 'ByteBuffer') && fieldTypeBlobContent === 'image' || fieldType === 'LocalDate' _%>
+                    <%= field.fieldName %>: 'BBBBBB',
+                    <%_ } _%>
+                <%_ }) _%>
                 }, elemDefault);
+
                 const expected = Object.assign({
-<%_ fields.forEach((field) => {
-    const fieldType = field.fieldType; _%>
-    <%_ if (['LocalDate'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate,
-    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                    <%= field.fieldName%>: currentDate,
-    <%_ } _%>
-<%_ }) _%>
+                <%_ fields.forEach((field) => {
+                    const fieldType = field.fieldType;
+                _%>
+                    <%_ if (['LocalDate'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate,
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <%= field.fieldName %>: currentDate,
+                    <%_ } _%>
+                <%_ }) _%>
                 }, returnedFromService);
-                service
-                    .query()
-                    .pipe(
-                        take(1),
-                        map(resp => resp.body)
-                    ).subscribe(body  => expectedResult = body);
+
+                service.query().subscribe(resp  => expectedResult = resp.body);
+
                 const req  = httpMock.expectOne({ method: 'GET' });
                 req.flush([returnedFromService]);
                 httpMock.verify();
                 expect(expectedResult).toContainEqual(expected);
             });
 
-        <%_ if (!readOnly) { _%>
+            <%_ if (!readOnly) { _%>
             it('should delete a <%= entityAngularName %>', () => {
                 service.delete(<%- tsKeyId %>).subscribe(resp => expectedResult = resp.ok);
 
@@ -232,7 +237,7 @@ describe('Service Tests', () => {
                 req.flush({ status: 200 });
                 expect(expectedResult);
             });
-        <%_ } _%>
+            <%_ } _%>
         });
 
         afterEach(() => {


### PR DESCRIPTION
This PR fixes default datetime problem introduced by #11043 and polishes entites in Angular:

* after #11043 `Instant` and `ZonedDateTime` fields are populated with default value both if creating and if updating entity
    * this seems to affect only Angular part, in React default value is assigned only if `isNew` is `true`
    * correct is to assign default value only if creating entity also in Angular
    * moved `Instant` and `ZonedDateTime` default value assignments inside route subscription and assigning these default values only if creating entity in Angular, using condition `if (!entity.id) {`

* removes one `eslint-disable` after applying correct `ejs` if condition

* fixes `eslint` warning if entity contains `LocalDate` field and doesn't contain neither `Instant` nor `ZonedDateTime` field

* simplifies date related if constructs

* polishes and makes entity templates better readable

* removes unnecessary `take(1)` from `HttpClient` related methods in `entity-management.service.spec` because `HttpClient` related methods always complete after emitting value

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
