### PR TITLE
Revert "Add OAuth 2.0 Support for Reactive Monoliths"

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -123,11 +123,11 @@ function askForServerSideOpts(meta) {
                         name: 'HTTP Session Authentication (stateful, default Spring Security mechanism)'
                     });
                 }
-                opts.push({
-                    value: 'oauth2',
-                    name: 'OAuth 2.0 / OIDC Authentication (stateful, works with Keycloak and Okta)'
-                });
                 if (!reactive) {
+                    opts.push({
+                        value: 'oauth2',
+                        name: 'OAuth 2.0 / OIDC Authentication (stateful, works with Keycloak and Okta)'
+                    });
                     if (['gateway', 'microservice'].includes(applicationType)) {
                         opts.push({
                             value: 'uaa',

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -33,6 +33,7 @@ import io.github.jhipster.web.filter.reactive.CookieCsrfFilter;
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 <%_ } _%>
 import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.HttpMethod;
 <%_ if (authenticationType === 'session') { _%>
@@ -81,6 +82,7 @@ import reactor.core.publisher.Mono;
 
 import static org.springframework.security.web.server.util.matcher.ServerWebExchangeMatchers.pathMatchers;
 
+@Configuration
 @EnableWebFluxSecurity
 @EnableReactiveMethodSecurity
 @Import(SecurityProblemSupport.class)


### PR DESCRIPTION
This reverts jhipster/generator-jhipster#11049 since OAuth 2.0 support is not ready for reactive options. See https://github.com/mraible/jhipster-reactive-monolith-oauth2/pull/1 for current work-in-progress and issues.