### PR TITLE
do not expose which email exists when requesting password reset

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
@@ -443,17 +443,16 @@ public class AccountResource {
     <%_ if (!reactive) { _%>
     public void requestPasswordReset(@RequestBody String mail) {
         Optional<User> user = userService.requestPasswordReset(mail);
-            if (user.isPresent()) {
-                mailService.sendPasswordResetMail(user.get());
-            } else {
-                // Pretend the request has been successful to prevent checking which emails really exist
-                // but log that an invalid attempt has been made
-                log.warn("Password reset requested for non existing mail '{}'", mail);
-            }
+        if (user.isPresent()) {
+            mailService.sendPasswordResetMail(user.get());
+        } else {
+            // Pretend the request has been successful to prevent checking which emails really exist
+            // but log that an invalid attempt has been made
+            log.warn("Password reset requested for non existing mail '{}'", mail);
+        }
     <%_ } else { _%>
     public Mono<Void> requestPasswordReset(@RequestBody String mail) {
         return userService.requestPasswordReset(mail)
-            .log()
             .doOnSuccess(user -> {
                 if (Objects.nonNull(user)) {
                     mailService.sendPasswordResetMail(user);

--- a/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
@@ -442,15 +442,27 @@ public class AccountResource {
     @PostMapping(path = "/account/reset-password/init")
     <%_ if (!reactive) { _%>
     public void requestPasswordReset(@RequestBody String mail) {
-       mailService.sendPasswordResetMail(
-           userService.requestPasswordReset(mail)
-               .orElseThrow(EmailNotFoundException::new)
-       );
+        Optional<User> user = userService.requestPasswordReset(mail);
+            if (user.isPresent()) {
+                mailService.sendPasswordResetMail(user.get());
+            } else {
+                // Pretend the request has been successful to prevent checking which emails really exist
+                // but log that an invalid attempt has been made
+                log.warn("Password reset requested for non existing mail '{}'", mail);
+            }
     <%_ } else { _%>
     public Mono<Void> requestPasswordReset(@RequestBody String mail) {
         return userService.requestPasswordReset(mail)
-            .switchIfEmpty(Mono.error(new EmailNotFoundException()))
-            .doOnSuccess(mailService::sendPasswordResetMail)
+            .log()
+            .doOnSuccess(user -> {
+                if (Objects.nonNull(user)) {
+                    mailService.sendPasswordResetMail(user);
+                } else {
+                    // Pretend the request has been successful to prevent checking which emails really exist
+                    // but log that an invalid attempt has been made
+                    log.warn("Password reset requested for non existing mail '{}'", mail);
+                }
+            })
             .then();
     <%_ } _%>
     }

--- a/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
@@ -443,7 +443,7 @@ public class AccountResource {
     @PostMapping(path = "/account/reset-password/init")
     <%_ if (!reactive) { _%>
     public void requestPasswordReset(@RequestBody String mail) {
-        Optional<User> user = userService.requestPasswordReset(mail);
+        Optional<<%= asEntity('User') %>> user = userService.requestPasswordReset(mail);
         if (user.isPresent()) {
             mailService.sendPasswordResetMail(user.get());
         } else {

--- a/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
@@ -212,6 +212,7 @@ import java.net.URLDecoder;
 <%_ } _%>
 <%_ if (reactive) { _%>
 import java.security.Principal;
+import java.util.Objects;
 <%_ } _%>
 <%_ if (!reactive) { _%>
 import java.util.*;

--- a/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
@@ -1441,13 +1441,13 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
         restMvc.perform(
             post("/api/account/reset-password/init")
                 .content("password-reset-wrong-email@example.com"))
-            .andExpect(status().isBadRequest());
+            .andExpect(status().isOk());
     <%_ } else { _%>
     public void testRequestPasswordResetWrongEmail() {
         webTestClient.post().uri("/api/account/reset-password/init")
             .syncBody("password-reset-wrong-email@example.com")
             .exchange()
-            .expectStatus().isBadRequest();
+            .expectStatus().isOk();
     <%_ } _%>
     }
 


### PR DESCRIPTION
* Return always 200/OK even when a user with the mail doesn't exist
* Log the attempt as warning such that one could add monitoring e.g. to detect multiple attempts

@cbornet Not sure if the reactive part is the most elegant way to do that in the reactive world, but I didn't found something better. So your review is really appreciated.

closes #11019

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
