### PR TITLE
remove mention to Travis in the PR template [skip ci]

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,5 +8,5 @@
 <!--
 Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)
 
-Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
+Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
 -->


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   N/A: ~[ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green~
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip Travis tests
-->
