### PR TITLE
Use the .yo-rc.json to generate the app when no cache provider is configured

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -256,7 +256,6 @@ module.exports = class extends BaseBlueprintGenerator {
                     this.packageName !== undefined &&
                     this.authenticationType !== undefined &&
                     this.cacheProvider !== undefined &&
-                    this.enableHibernateCache !== undefined &&
                     this.websocket !== undefined &&
                     this.databaseType !== undefined &&
                     this.devDatabaseType !== undefined &&


### PR DESCRIPTION
If we generate a jhipster application with no cache: `"cacheProvider": "no"` in `.yo-rc.json` (note that there is no `this.enableHibernateCache` field)

And then if we run again `jhipster` to regenerate the app with this config, there is the prompt and we have to answer the questions from "yeoman form" again.

This means that the statement....
`this.enableHibernateCache = configuration.get('enableHibernateCache') && !['no', 'memcached'].includes(this.cacheProvider);`

...We have `this.enableHibernateCache` assigned to `undefined` (`undefined` && `false` gives `undefined`)

So in this PR I don't take into consideration `enableHibernateCache` to compute `serverConfigFound` (used to display the prompt or not)

I'm not sure if it is the right way to solve this.
We could also think to do something else like this:
`this.enableHibernateCache = !!configuration.get('enableHibernateCache') && !['no', 'memcached'].includes(this.cacheProvider);`
So `this.enableHibernateCache` will be either `true` or `false` (not `undefined` anymore)

