### PR TITLE
fix angular fontawesome tree-shaking

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/core.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/core.module.ts.ejs
@@ -3,7 +3,6 @@ import { DatePipe, registerLocaleData } from '@angular/common';
 import { <% if (enableTranslation) { %>HttpClient, <% } %>HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { Title } from '@angular/platform-browser';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
-import { fas } from '@fortawesome/free-solid-svg-icons';
 import { CookieModule } from 'ngx-cookie';
 <%_ if (enableTranslation) { _%>
 import { TranslateModule, TranslateLoader, MissingTranslationHandler } from '@ngx-translate/core';
@@ -102,7 +101,6 @@ import { fontAwesomeIcons } from './icons/font-awesome-icons';
 export class <%= angularXAppName %>CoreModule {
     constructor(iconLibrary: FaIconLibrary, dpConfig: NgbDatepickerConfig<% if (enableTranslation) { %>, languageService: JhiLanguageService<% } %>) {
         registerLocaleData(locale);
-        iconLibrary.addIconPacks(fas);
         iconLibrary.addIcons(...fontAwesomeIcons);
         dpConfig.minDate = {year: moment().year() - 100, month: 1, day: 1};
         <%_ if (enableTranslation) { _%>


### PR DESCRIPTION
We specify icons in [font-awesome-icons.ts.ejs](https://github.com/jhipster/generator-jhipster/blob/master/generators/client/templates/angular/src/main/webapp/app/core/icons/font-awesome-icons.ts) to enable tree-shaking, but we also import the entire icon pack.  The full icon pack import was added in v6.3.0 in https://github.com/jhipster/generator-jhipster/pull/10254 during a font-awesome upgrade

From the [angular-fontawesome](https://github.com/FortAwesome/angular-fontawesome/blob/master/docs/usage/icon-library.md) docs:
>You can also import entire icon styles. But be careful! This way of importing icons does not support tree-shaking, so all icons from the imported package will end up in the bundle.

With this change, we save quite a bit in the bundle
```git
-  app/main.a061895d35263ecf358b.bundle.js (1.54 MiB)
+  app/main.e96d45f22143a72dc4b1.bundle.js (989 KiB)
```
Before: [Webpack Bundle Analyzer](https://user-images.githubusercontent.com/4294623/71768716-e7879680-2ee6-11ea-8d1a-529378c0a6b9.png)
After: [Webpack Bundle Analyzer](https://user-images.githubusercontent.com/4294623/71768733-0b4adc80-2ee7-11ea-9dfa-386645231c52.png)

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
