### PR TITLE
Fix DefaultProfileUtil.java and RandomUtil.java cleanup

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -219,11 +219,11 @@ function cleanupOldServerFiles(generator, javaDir, testDir, mainResourceDir, tes
         generator.removeFile(`${javaDir}service/${generator.upperFirstCamelCase(generator.baseName)}KafkaConsumer.java`);
         generator.removeFile(`${javaDir}service/${generator.upperFirstCamelCase(generator.baseName)}KafkaProducer.java`);
         generator.removeFile(`${testDir}web/rest/ClientForwardControllerIT.java`);
-        generator.removeFile(`${javaDir}package/config/DefaultProfileUtil.java`);
-        generator.removeFolder(`${javaDir}package/service/util`);
     }
     if (generator.isJhipsterVersionLessThan('6.6.1')) {
         generator.removeFile(`${javaDir}web/rest/errors/EmailNotFoundException.java`);
+        generator.removeFile(`${javaDir}config/DefaultProfileUtil.java`);
+        generator.removeFolder(`${javaDir}service/util`);
     }
 }
 


### PR DESCRIPTION
In v6.6.0 cleanup references to `DefaultProfileUtil.java` and `RandomUtil.java` include extra redundant `package` subfolder and these files are not deleted. This PR fixes paths in cleanup so that in the next version of the JHipster these files are deleted.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
