### PR TITLE
Fix default Instant/ZonedDateTime Sonar code smell in Angular

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -167,22 +167,23 @@ _%>
 
     ngOnInit(): void {
         this.activatedRoute.data.subscribe(({<%= entityInstance %>}) => {
-            this.updateForm(<%= entityInstance %>);
-
             <%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
             if (!<%= entityInstance %>.id) {
+                const today = moment().startOf('day');
             <%_ } _%>
             <%_ for (idx in fields) {
                 const fieldName = fields[idx].fieldName;
                 const fieldType = fields[idx].fieldType;
             _%>
                 <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                this.<%= fieldName %>SetDefaultValue();
+                <%= entityInstance %>.<%= fieldName %> = today;
                 <%_ } _%>
             <%_ } _%>
             <%_ if (fieldsContainInstant || fieldsContainZonedDateTime) { _%>
             }
             <%_ } _%>
+
+            this.updateForm(<%= entityInstance %>);
 
             <%_ for (idx in queries) { _%>
             <%- queries[idx] %>
@@ -309,22 +310,6 @@ _%>
     <%_ } _%>
         };
     }
-
-<%_ for (idx in fields) {
-    const fieldName = fields[idx].fieldName;
-    const fieldType = fields[idx].fieldType;
-_%>
-
-    <%_ if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-    private <%= fieldName %>SetDefaultValue(): void {
-        const field = this.editForm.get('<%= fieldName %>');
-        if (field && !field.value) {
-            const today = moment().startOf('day').format(DATE_TIME_FORMAT);
-            field.setValue(today);
-        }
-    }
-    <%_ } _%>
-<%_ } _%>
 
     protected subscribeToSaveResponse(result: Observable<HttpResponse<I<%= entityAngularName %>>>): void {
         result.subscribe(() => this.onSaveSuccess(), () => this.onSaveError());


### PR DESCRIPTION
PR #11043 introduced Sonar code smell "Functions should not have identical implementations" for Angular part (default datetime setter functions) for entities that have more than 1 `Instant`/`ZonedDateTime` field.

For React part #11043 didn't create helping functions. This PR changes Angular part implementation similar to React part implementation and this removes code smell from Angular part.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
