### PR TITLE
Polish Angular templates

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.component.html.ejs
@@ -29,7 +29,6 @@
             <div class="alert alert-danger" *ngIf="error" jhiTranslate="activate.messages.error">
                 <strong>Your user could not be activated.</strong> Please use the registration form to sign up.
             </div>
-
         </div>
     </div>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.component.html.ejs
@@ -26,17 +26,17 @@
             </div>
 
             <div class="alert alert-warning" *ngIf="key && !success">
-                <p jhiTranslate="reset.finish.messages.info">Choose a new password</p>
+                <span jhiTranslate="reset.finish.messages.info">Choose a new password</span>
             </div>
 
             <div class="alert alert-danger" *ngIf="error">
-                <p jhiTranslate="reset.finish.messages.error">Your password couldn't be reset. Remember a password request is only valid for 24 hours.</p>
+                <span jhiTranslate="reset.finish.messages.error">Your password couldn't be reset. Remember a password request is only valid for 24 hours.</span>
             </div>
 
-            <p class="alert alert-success" *ngIf="success">
+            <div class="alert alert-success" *ngIf="success">
                 <span jhiTranslate="reset.finish.messages.success"><strong>Your password has been reset.</strong> Please </span>
                 <a class="alert-link" (click)="login()" jhiTranslate="global.messages.info.authenticated.link">sign in</a>.
-            </p>
+            </div>
 
             <div class="alert alert-danger" *ngIf="doNotMatch" jhiTranslate="global.messages.error.dontmatch">
                 The password and its confirmation do not match!
@@ -47,49 +47,62 @@
                     <div class="form-group">
                         <label class="form-control-label" for="newPassword" jhiTranslate="global.form.newpassword.label">New password</label>
                         <input type="password" class="form-control" id="newPassword" name="newPassword"
-                               placeholder="{{'global.form.newpassword.placeholder' | translate}}"
+                               placeholder="{{ 'global.form.newpassword.placeholder' | translate }}"
                                formControlName="newPassword" #newPassword>
+
                         <div *ngIf="passwordForm.get('newPassword')!.invalid && (passwordForm.get('newPassword')!.dirty || passwordForm.get('newPassword')!.touched)">
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword')?.errors?.required" jhiTranslate="global.messages.validate.newpassword.required">
+                                   *ngIf="passwordForm.get('newPassword')?.errors?.required"
+                                   jhiTranslate="global.messages.validate.newpassword.required">
                                 Your password is required.
                             </small>
+
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
+                                   *ngIf="passwordForm.get('newPassword')?.errors?.minlength"
+                                   jhiTranslate="global.messages.validate.newpassword.minlength">
                                 Your password is required to be at least 4 characters.
                             </small>
+
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('newPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
+                                   *ngIf="passwordForm.get('newPassword')?.errors?.maxlength"
+                                   jhiTranslate="global.messages.validate.newpassword.maxlength">
                                 Your password cannot be longer than 50 characters.
                             </small>
                         </div>
+
                         <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')!.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                     </div>
 
                     <div class="form-group">
                         <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
                         <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
-                               placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
+                               placeholder="{{ 'global.form.confirmpassword.placeholder' | translate }}"
                                formControlName="confirmPassword">
+
                         <div *ngIf="passwordForm.get('confirmPassword')!.invalid && (passwordForm.get('confirmPassword')!.dirty || passwordForm.get('confirmPassword')!.touched)">
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword')?.errors?.required" jhiTranslate="global.messages.validate.confirmpassword.required">
+                                   *ngIf="passwordForm.get('confirmPassword')?.errors?.required"
+                                   jhiTranslate="global.messages.validate.confirmpassword.required">
                                 Your password confirmation is required.
                             </small>
+
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
+                                   *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength"
+                                   jhiTranslate="global.messages.validate.confirmpassword.minlength">
                                 Your password confirmation is required to be at least 4 characters.
                             </small>
+
                             <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
+                                   *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength"
+                                   jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                                 Your password confirmation cannot be longer than 50 characters.
                             </small>
                         </div>
                     </div>
+
                     <button type="submit" [disabled]="passwordForm.invalid" class="btn btn-primary" jhiTranslate="reset.finish.form.button">Reset Password</button>
                 </form>
             </div>
-
         </div>
     </div>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.component.html.ejs
@@ -24,37 +24,46 @@
             <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
 
             <div class="alert alert-warning" *ngIf="!success">
-                <p jhiTranslate="reset.request.messages.info">Enter the email address you used to register.</p>
+                <span jhiTranslate="reset.request.messages.info">Enter the email address you used to register.</span>
             </div>
 
             <div class="alert alert-success" *ngIf="success">
-                <p jhiTranslate="reset.request.messages.success">Check your emails for details on how to reset your password.</p>
+                <span jhiTranslate="reset.request.messages.success">Check your emails for details on how to reset your password.</span>
             </div>
 
             <form *ngIf="!success" name="form" role="form" (ngSubmit)="requestReset()" [formGroup]="resetRequestForm">
                 <div class="form-group">
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
+                    <input type="email" class="form-control" id="email" name="email" placeholder="{{ 'global.form.email.placeholder' | translate }}"
                            formControlName="email" #email>
+
                     <div *ngIf="resetRequestForm.get('email')!.invalid && (resetRequestForm.get('email')!.dirty || resetRequestForm.get('email')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors?.required" jhiTranslate="global.messages.validate.email.required">
+                               *ngIf="resetRequestForm.get('email')?.errors?.required"
+                               jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors?.email" jhiTranslate="global.messages.validate.email.invalid">
+                               *ngIf="resetRequestForm.get('email')?.errors?.email"
+                               jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors?.minlength" jhiTranslate="global.messages.validate.email.minlength">
+                               *ngIf="resetRequestForm.get('email')?.errors?.minlength"
+                               jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="resetRequestForm.get('email')?.errors?.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
+                               *ngIf="resetRequestForm.get('email')?.errors?.maxlength"
+                               jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>
                 </div>
+
                 <button type="submit" [disabled]="resetRequestForm.invalid" class="btn btn-primary" jhiTranslate="reset.request.form.button">Reset</button>
             </form>
         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.component.html.ejs
@@ -19,12 +19,13 @@
 <div>
     <div class="row justify-content-center">
         <div class="col-md-8" *ngIf="account$ | async as account">
-            <h2 jhiTranslate="password.title" [translateValues]="{username: account.login}">Password for [<strong>{{account.login}}</strong>]</h2>
+            <h2 jhiTranslate="password.title" [translateValues]="{ username: account.login }">Password for [<strong>{{ account.login }}</strong>]</h2>
 
             <div class="alert alert-success" *ngIf="success" jhiTranslate="password.messages.success">
                 <strong>Password changed!</strong>
             </div>
-            <div class="alert alert-danger" *ngIf="error"  jhiTranslate="password.messages.error">
+
+            <div class="alert alert-danger" *ngIf="error" jhiTranslate="password.messages.error">
                 <strong>An error has occurred!</strong> The password could not be changed.
             </div>
 
@@ -33,60 +34,77 @@
             </div>
 
             <form name="form" role="form" (ngSubmit)="changePassword()" [formGroup]="passwordForm">
-
                 <div class="form-group">
                     <label class="form-control-label" for="currentPassword" jhiTranslate="global.form.currentpassword.label">Current password</label>
                     <input type="password" class="form-control" id="currentPassword" name="currentPassword"
-                           placeholder="{{'global.form.currentpassword.placeholder' | translate}}"
+                           placeholder="{{ 'global.form.currentpassword.placeholder' | translate }}"
                            formControlName="currentPassword">
+
                     <div *ngIf="passwordForm.get('currentPassword')!.invalid && (passwordForm.get('currentPassword')!.dirty || passwordForm.get('currentPassword')!.touched)" >
                         <small class="form-text text-danger"
-                               *ngIf="passwordForm.get('currentPassword')?.errors?.required" jhiTranslate="global.messages.validate.newpassword.required">
+                               *ngIf="passwordForm.get('currentPassword')?.errors?.required"
+                               jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="newPassword" jhiTranslate="global.form.newpassword.label">New password</label>
                     <input type="password" class="form-control" id="newPassword" name="newPassword"
-                           placeholder="{{'global.form.newpassword.placeholder' | translate}}"
+                           placeholder="{{ 'global.form.newpassword.placeholder' | translate }}"
                            formControlName="newPassword">
+
                     <div *ngIf="passwordForm.get('newPassword')!.invalid && (passwordForm.get('newPassword')!.dirty || passwordForm.get('newPassword')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword')?.errors?.required" jhiTranslate="global.messages.validate.newpassword.required">
+                               *ngIf="passwordForm.get('newPassword')?.errors?.required"
+                               jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.newpassword.minlength">
+                               *ngIf="passwordForm.get('newPassword')?.errors?.minlength"
+                               jhiTranslate="global.messages.validate.newpassword.minlength">
                             Your password is required to be at least 4 characters.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('newPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.newpassword.maxlength">
+                               *ngIf="passwordForm.get('newPassword')?.errors?.maxlength"
+                               jhiTranslate="global.messages.validate.newpassword.maxlength">
                             Your password cannot be longer than 50 characters.
                         </small>
                     </div>
+
                     <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="passwordForm.get('newPassword')!.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
                     <input type="password" class="form-control" id="confirmPassword" name="confirmPassword"
-                           placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
+                           placeholder="{{ 'global.form.confirmpassword.placeholder' | translate }}"
                            formControlName="confirmPassword">
+
                     <div *ngIf="passwordForm.get('confirmPassword')!.invalid && (passwordForm.get('confirmPassword')!.dirty || passwordForm.get('confirmPassword')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword')?.errors?.required" jhiTranslate="global.messages.validate.confirmpassword.required">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors?.required"
+                               jhiTranslate="global.messages.validate.confirmpassword.required">
                             Your confirmation password is required.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength" jhiTranslate="global.messages.validate.confirmpassword.minlength">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors?.minlength"
+                               jhiTranslate="global.messages.validate.confirmpassword.minlength">
                             Your confirmation password is required to be at least 4 characters.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength" jhiTranslate="global.messages.validate.confirmpassword.maxlength">
+                               *ngIf="passwordForm.get('confirmPassword')?.errors?.maxlength"
+                               jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                             Your confirmation password cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>
+
                 <button type="submit" [disabled]="passwordForm.invalid" class="btn btn-primary" jhiTranslate="password.form.button">Save</button>
             </form>
         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.html.ejs
@@ -42,89 +42,122 @@
             </div>
         </div>
     </div>
+
     <div class="row justify-content-center">
         <div class="col-md-8">
             <form name="form" role="form" (ngSubmit)="register()" [formGroup]="registerForm" *ngIf="!success">
                 <div class="form-group">
-
                     <label class="form-control-label" for="login" jhiTranslate="global.form.username.label">Username</label>
-                    <input type="text" class="form-control" id="login" name="login" placeholder="{{'global.form.username.placeholder' | translate}}"
+                    <input type="text" class="form-control" id="login" name="login" placeholder="{{ 'global.form.username.placeholder' | translate }}"
                            formControlName="login" #login>
+
                     <div *ngIf="registerForm.get('login')!.invalid && (registerForm.get('login')!.dirty || registerForm.get('login')!.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.required" jhiTranslate="register.messages.validate.login.required">
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('login')?.errors?.required"
+                               jhiTranslate="register.messages.validate.login.required">
                             Your username is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.minlength"
-                                jhiTranslate="register.messages.validate.login.minlength">
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('login')?.errors?.minlength"
+                               jhiTranslate="register.messages.validate.login.minlength">
                             Your username is required to be at least 1 character.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.maxlength"
-                                jhiTranslate="register.messages.validate.login.maxlength">
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('login')?.errors?.maxlength"
+                               jhiTranslate="register.messages.validate.login.maxlength">
                             Your username cannot be longer than 50 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('login')?.errors?.pattern"
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('login')?.errors?.pattern"
                                jhiTranslate="register.messages.validate.login.pattern">
                             Your username can only contain letters and digits.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
+                    <input type="email" class="form-control" id="email" name="email" placeholder="{{ 'global.form.email.placeholder' | translate }}"
                              formControlName="email">
+
                     <div *ngIf="registerForm.get('email')!.invalid && (registerForm.get('email')!.dirty || registerForm.get('email')!.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.required"
-                                jhiTranslate="global.messages.validate.email.required">
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('email')?.errors?.required"
+                               jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.invalid"
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('email')?.errors?.invalid"
                                jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.minlength"
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('email')?.errors?.minlength"
                                jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('email')?.errors?.maxlength"
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('email')?.errors?.maxlength"
                                jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="password" jhiTranslate="global.form.newpassword.label">New password</label>
-                    <input type="password" class="form-control" id="password" name="password" placeholder="{{'global.form.newpassword.placeholder' | translate}}"
+                    <input type="password" class="form-control" id="password" name="password" placeholder="{{ 'global.form.newpassword.placeholder' | translate }}"
                             formControlName="password">
+
                     <div *ngIf="registerForm.get('password')!.invalid && (registerForm.get('password')!.dirty || registerForm.get('password')!.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.required"
-                                jhiTranslate="global.messages.validate.newpassword.required">
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('password')?.errors?.required"
+                               jhiTranslate="global.messages.validate.newpassword.required">
                             Your password is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.minlength"
-                                jhiTranslate="global.messages.validate.newpassword.minlength">
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('password')?.errors?.minlength"
+                               jhiTranslate="global.messages.validate.newpassword.minlength">
                             Your password is required to be at least 4 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('password')?.errors?.maxlength"
-                                jhiTranslate="global.messages.validate.newpassword.maxlength">
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('password')?.errors?.maxlength"
+                               jhiTranslate="global.messages.validate.newpassword.maxlength">
                             Your password cannot be longer than 50 characters.
                         </small>
                     </div>
+
                     <<%= jhiPrefixDashed %>-password-strength-bar [passwordToCheck]="registerForm.get('password')!.value"></<%= jhiPrefixDashed %>-password-strength-bar>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="confirmPassword" jhiTranslate="global.form.confirmpassword.label">New password confirmation</label>
-                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="{{'global.form.confirmpassword.placeholder' | translate}}"
+                    <input type="password" class="form-control" id="confirmPassword" name="confirmPassword" placeholder="{{ 'global.form.confirmpassword.placeholder' | translate }}"
                             formControlName="confirmPassword">
+
                     <div *ngIf="registerForm.get('confirmPassword')!.invalid && (registerForm.get('confirmPassword')!.dirty || registerForm.get('confirmPassword')!.touched)">
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors?.required"
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('confirmPassword')?.errors?.required"
                                jhiTranslate="global.messages.validate.confirmpassword.required">
                             Your confirmation password is required.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors?.minlength"
-                              jhiTranslate="global.messages.validate.confirmpassword.minlength">
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('confirmPassword')?.errors?.minlength"
+                               jhiTranslate="global.messages.validate.confirmpassword.minlength">
                             Your confirmation password is required to be at least 4 characters.
                         </small>
-                        <small class="form-text text-danger" *ngIf="registerForm.get('confirmPassword')?.errors?.maxlength"
+
+                        <small class="form-text text-danger"
+                               *ngIf="registerForm.get('confirmPassword')?.errors?.maxlength"
                                jhiTranslate="global.messages.validate.confirmpassword.maxlength">
                             Your confirmation password cannot be longer than 50 characters.
                         </small>
@@ -133,8 +166,8 @@
 
                 <button type="submit" [disabled]="registerForm.invalid" class="btn btn-primary" jhiTranslate="register.form.button">Register</button>
             </form>
-            <p></p>
-            <div class="alert alert-warning">
+
+            <div class="mt-3 alert alert-warning">
                 <span jhiTranslate="global.messages.info.authenticated.prefix">If you want to </span>
                 <a class="alert-link" (click)="openLogin()" jhiTranslate="global.messages.info.authenticated.link">sign in</a><span jhiTranslate="global.messages.info.authenticated.suffix">, you can try the default accounts:<br/>- Administrator (login="admin" and password="admin") <br/>- User (login="user" and password="user").</span>
             </div>

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.html.ejs
@@ -17,11 +17,12 @@
  limitations under the License.
 -%>
 <div>
-    <h2 id="session-page-heading" jhiTranslate="sessions.title" [translateValues]="{username: account.login}" *ngIf="account">Active sessions for [<b>{{account.login}}</b>]</h2>
+    <h2 id="session-page-heading" jhiTranslate="sessions.title" [translateValues]="{ username: account.login }" *ngIf="account">Active sessions for [<b>{{ account.login }}</b>]</h2>
 
     <div class="alert alert-success" *ngIf="success" jhiTranslate="sessions.messages.success">
         <strong>Session invalidated!</strong>
     </div>
+
     <div class="alert alert-danger" *ngIf="error" jhiTranslate="sessions.messages.error">
         <strong>An error has occurred!</strong> The session could not be invalidated.
     </div>
@@ -38,14 +39,15 @@
             </thead>
             <tbody>
                 <tr *ngFor="let session of sessions">
-                    <td>{{session.ipAddress}}</td>
-                    <td>{{session.userAgent}}</td>
-                    <td>{{session.tokenDate | date:'longDate'}}</td>
+                    <td>{{ session.ipAddress }}</td>
+                    <td>{{ session.userAgent }}</td>
+                    <td>{{ session.tokenDate | date:'longDate' }}</td>
                     <td>
                         <button type="submit"
                                 class="btn btn-primary"
-                                (click)="invalidate(session.series)" jhiTranslate="sessions.table.button">
-                                 Invalidate
+                                (click)="invalidate(session.series)"
+                                jhiTranslate="sessions.table.button">
+                            Invalidate
                         </button>
                     </td>
                 </tr>

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
@@ -19,7 +19,7 @@
 <div>
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <h2 jhiTranslate="settings.title" <% if (enableTranslation) { %>[translateValues]="{username: account.login}"<% } %> *ngIf="account">User settings for [<b>{{ account.login }}</b>]</h2>
+            <h2 jhiTranslate="settings.title" [translateValues]="{ username: account.login }" *ngIf="account">User settings for [<b>{{ account.login }}</b>]</h2>
 
             <div class="alert alert-success" *ngIf="success" jhiTranslate="settings.messages.success">
                 <strong>Settings saved!</strong>
@@ -28,79 +28,101 @@
             <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
 
             <form name="form" role="form" (ngSubmit)="save()" [formGroup]="settingsForm" *ngIf="account" novalidate>
-
                 <div class="form-group">
                     <label class="form-control-label" for="firstName" jhiTranslate="settings.form.firstname">First Name</label>
-                    <input type="text" class="form-control" id="firstName" name="firstName" placeholder="{{'settings.form.firstname.placeholder' | translate}}"
+                    <input type="text" class="form-control" id="firstName" name="firstName" placeholder="{{ 'settings.form.firstname.placeholder' | translate }}"
                            formControlName="firstName">
+
                     <div *ngIf="settingsForm.get('firstName')!.invalid && (settingsForm.get('firstName')!.dirty || settingsForm.get('firstName')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName')?.errors?.required" jhiTranslate="settings.messages.validate.firstname.required">
+                               *ngIf="settingsForm.get('firstName')?.errors?.required"
+                               jhiTranslate="settings.messages.validate.firstname.required">
                             Your first name is required.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName')?.errors?.minlength" jhiTranslate="settings.messages.validate.firstname.minlength">
+                               *ngIf="settingsForm.get('firstName')?.errors?.minlength"
+                               jhiTranslate="settings.messages.validate.firstname.minlength">
                             Your first name is required to be at least 1 character.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('firstName')?.errors?.maxlength" jhiTranslate="settings.messages.validate.firstname.maxlength">
+                               *ngIf="settingsForm.get('firstName')?.errors?.maxlength"
+                               jhiTranslate="settings.messages.validate.firstname.maxlength">
                             Your first name cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="lastName" jhiTranslate="settings.form.lastname">Last Name</label>
-                    <input type="text" class="form-control" id="lastName" name="lastName" placeholder="{{'settings.form.lastname.placeholder' | translate}}"
+                    <input type="text" class="form-control" id="lastName" name="lastName" placeholder="{{ 'settings.form.lastname.placeholder' | translate }}"
                            formControlName="lastName">
+
                     <div *ngIf="settingsForm.get('lastName')!.invalid && (settingsForm.get('lastName')!.dirty || settingsForm.get('lastName')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName')?.errors?.required" jhiTranslate="settings.messages.validate.lastname.required">
+                               *ngIf="settingsForm.get('lastName')?.errors?.required"
+                               jhiTranslate="settings.messages.validate.lastname.required">
                             Your last name is required.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName')?.errors?.minlength" jhiTranslate="settings.messages.validate.lastname.minlength">
+                               *ngIf="settingsForm.get('lastName')?.errors?.minlength"
+                               jhiTranslate="settings.messages.validate.lastname.minlength">
                             Your last name is required to be at least 1 character.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('lastName')?.errors?.maxlength" jhiTranslate="settings.messages.validate.lastname.maxlength">
+                               *ngIf="settingsForm.get('lastName')?.errors?.maxlength"
+                               jhiTranslate="settings.messages.validate.lastname.maxlength">
                             Your last name cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" for="email" jhiTranslate="global.form.email.label">Email</label>
-                    <input type="email" class="form-control" id="email" name="email" placeholder="{{'global.form.email.placeholder' | translate}}"
+                    <input type="email" class="form-control" id="email" name="email" placeholder="{{ 'global.form.email.placeholder' | translate }}"
                            formControlName="email">
+
                     <div *ngIf="settingsForm.get('email')!.invalid && (settingsForm.get('email')!.dirty || settingsForm.get('email')!.touched)">
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors?.required" jhiTranslate="global.messages.validate.email.required">
+                               *ngIf="settingsForm.get('email')?.errors?.required"
+                               jhiTranslate="global.messages.validate.email.required">
                             Your email is required.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors?.email" jhiTranslate="global.messages.validate.email.invalid">
+                               *ngIf="settingsForm.get('email')?.errors?.email"
+                               jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors?.minlength" jhiTranslate="global.messages.validate.email.minlength">
+                               *ngIf="settingsForm.get('email')?.errors?.minlength"
+                               jhiTranslate="global.messages.validate.email.minlength">
                             Your email is required to be at least 5 characters.
                         </small>
+
                         <small class="form-text text-danger"
-                           *ngIf="settingsForm.get('email')?.errors?.maxlength" jhiTranslate="global.messages.validate.email.maxlength">
+                               *ngIf="settingsForm.get('email')?.errors?.maxlength"
+                               jhiTranslate="global.messages.validate.email.maxlength">
                             Your email cannot be longer than 100 characters.
                         </small>
                     </div>
                 </div>
                 <%_ if (enableTranslation) { _%>
+
                 <div class="form-group" *ngIf="languages && languages.length > 0">
                     <label for="langKey" jhiTranslate="settings.form.language">Language</label>
                     <select class="form-control" id="langKey" name="langKey" formControlName="langKey">
-                        <option *ngFor="let language of languages" [value]="language">{{language | findLanguageFromKey}}</option>
+                        <option *ngFor="let language of languages" [value]="language">{{ language | findLanguageFromKey }}</option>
                     </select>
                 </div>
                 <%_ } _%>
+
                 <button type="submit" [disabled]="settingsForm.invalid" class="btn btn-primary" jhiTranslate="settings.form.button">Save</button>
             </form>
         </div>
     </div>
-
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.html.ejs
@@ -24,6 +24,7 @@
     <div class="row">
         <div class="col-md-5">
             <h4 jhiTranslate="audits.filter.title">Filter by date</h4>
+
             <div class="input-group mb-3">
                 <div class="input-group-prepend">
                     <span class="input-group-text" jhiTranslate="audits.filter.from">from</span>
@@ -43,31 +44,31 @@
     </div>
 
     <div class="table-responsive" *ngIf="audits?.length > 0">
-        <table class="table table-sm table-striped"  aria-describedby="audits-page-heading">
+        <table class="table table-sm table-striped" aria-describedby="audits-page-heading">
             <thead [ngSwitch]="canLoad()">
-            <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)" *ngSwitchCase="true">
-                <th scope="col" jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" jhiSortBy="auditEventType"><span jhiTranslate="audits.table.header.status">State</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col"><span jhiTranslate="audits.table.header.data">Extra data</span></th>
-            </tr>
-            <tr *ngSwitchCase="false">
-                <th scope="col"><span jhiTranslate="audits.table.header.date">Date</span></th>
-                <th scope="col"><span jhiTranslate="audits.table.header.principal">User</span></th>
-                <th scope="col"><span jhiTranslate="audits.table.header.status">State</span></th>
-                <th scope="col"><span jhiTranslate="audits.table.header.data">Extra data</span></th>
-            </tr>
+                <tr jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)" *ngSwitchCase="true">
+                    <th scope="col" jhiSortBy="auditEventDate"><span jhiTranslate="audits.table.header.date">Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th scope="col" jhiSortBy="principal"><span jhiTranslate="audits.table.header.principal">User</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th scope="col" jhiSortBy="auditEventType"><span jhiTranslate="audits.table.header.status">State</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th scope="col"><span jhiTranslate="audits.table.header.data">Extra data</span></th>
+                </tr>
+                <tr *ngSwitchCase="false">
+                    <th scope="col"><span jhiTranslate="audits.table.header.date">Date</span></th>
+                    <th scope="col"><span jhiTranslate="audits.table.header.principal">User</span></th>
+                    <th scope="col"><span jhiTranslate="audits.table.header.status">State</span></th>
+                    <th scope="col"><span jhiTranslate="audits.table.header.data">Extra data</span></th>
+                </tr>
             </thead>
             <tbody>
-            <tr *ngFor="let audit of audits">
-                <td><span>{{audit.timestamp| date:'medium'}}</span></td>
-                <td><small>{{audit.principal}}</small></td>
-                <td>{{audit.type}}</td>
-                <td>
-                    <span *ngIf="audit.data" ng-show="audit.data.message">{{audit.data.message}}</span>
-                    <span *ngIf="audit.data" ng-show="audit.data.remoteAddress"><span jhiTranslate="audits.table.data.remoteAddress">Remote Address</span> {{audit.data.remoteAddress}}</span>
-                </td>
-            </tr>
+                <tr *ngFor="let audit of audits">
+                    <td><span>{{ audit.timestamp | date:'medium' }}</span></td>
+                    <td><small>{{ audit.principal }}</small></td>
+                    <td>{{ audit.type }}</td>
+                    <td>
+                        <span *ngIf="audit.data" ng-show="audit.data.message">{{ audit.data.message }}</span>
+                        <span *ngIf="audit.data" ng-show="audit.data.remoteAddress"><span jhiTranslate="audits.table.data.remoteAddress">Remote Address</span> {{ audit.data.remoteAddress }}</span>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>
@@ -76,6 +77,7 @@
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
+
         <div class="row justify-content-center">
             <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)" [disabled]="!canLoad()"></ngb-pagination>
         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.service.ts.ejs
@@ -30,7 +30,7 @@ export interface AuditsQuery extends Pagination {
 }
 
 @Injectable({providedIn: 'root'})
-export class AuditsService  {
+export class AuditsService {
     constructor(private http: HttpClient) {}
 
     query(req: AuditsQuery): Observable<HttpResponse<Audit[]>> {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -20,44 +20,48 @@
     <h2 id="configuration-page-heading" jhiTranslate="configuration.title">Configuration</h2>
 
     <span jhiTranslate="configuration.filter">Filter (by prefix)</span> <input type="text" [(ngModel)]="beansFilter" (ngModelChange)="filterAndSortBeans()" class="form-control">
+
     <h3 id="spring-configuration">Spring configuration</h3>
+
     <table class="table table-striped table-bordered table-responsive d-table" aria-describedby="spring-configuration">
         <thead>
-        <tr jhiSort predicate="prefix" [(ascending)]="beansAscending" [callback]="filterAndSortBeans.bind(this)">
-            <th jhiSortBy="prefix" scope="col" class="w-40"><span jhiTranslate="configuration.table.prefix">Prefix</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-            <th scope="col" class="w-60"><span jhiTranslate="configuration.table.properties">Properties</span></th>
-        </tr>
+            <tr jhiSort predicate="prefix" [(ascending)]="beansAscending" [callback]="filterAndSortBeans.bind(this)">
+                <th jhiSortBy="prefix" scope="col" class="w-40"><span jhiTranslate="configuration.table.prefix">Prefix</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                <th scope="col" class="w-60"><span jhiTranslate="configuration.table.properties">Properties</span></th>
+            </tr>
         </thead>
         <tbody>
-        <tr *ngFor="let bean of beans">
-            <td><span>{{ bean.prefix }}</span></td>
-            <td>
-                <div class="row" *ngFor="let property of bean.properties | keys">
-                    <div class="col-md-4">{{ property.key }}</div>
-                    <div class="col-md-8">
-                        <span class="float-right badge-secondary break">{{ property.value | json }}</span>
+            <tr *ngFor="let bean of beans">
+                <td><span>{{ bean.prefix }}</span></td>
+                <td>
+                    <div class="row" *ngFor="let property of bean.properties | keys">
+                        <div class="col-md-4">{{ property.key }}</div>
+                        <div class="col-md-8">
+                            <span class="float-right badge-secondary break">{{ property.value | json }}</span>
+                        </div>
                     </div>
-                </div>
-            </td>
-        </tr>
-        </tbody>
-    </table>
-    <div *ngFor="let propertySource of propertySources; let i = index">
-        <h4 [id]="'property-source-' + i"><span>{{ propertySource.name }}</span></h4>
-        <!-- //NOSONAR --><table class="table table-sm table-striped table-bordered table-responsive d-table" [attr.aria-describedby]="'property-source-' + i">
-            <thead>
-            <tr>
-                <th scope="col" class="w-40">Property</th>
-                <th scope="col" class="w-60">Value</th>
-            </tr>
-            </thead>
-            <tbody>
-            <tr *ngFor="let property of propertySource.properties | keys">
-                <td class="break">{{ property.key }}</td>
-                <td class="break">
-                    <span class="float-right badge-secondary break">{{ property.value.value }}</span>
                 </td>
             </tr>
+        </tbody>
+    </table>
+
+    <div *ngFor="let propertySource of propertySources; let i = index">
+        <h4 [id]="'property-source-' + i"><span>{{ propertySource.name }}</span></h4>
+
+        <table class="table table-sm table-striped table-bordered table-responsive d-table" [attr.aria-describedby]="'property-source-' + i"><!-- //NOSONAR -->
+            <thead>
+                <tr>
+                    <th scope="col" class="w-40">Property</th>
+                    <th scope="col" class="w-60">Value</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr *ngFor="let property of propertySource.properties | keys">
+                    <td class="break">{{ property.key }}</td>
+                    <td class="break">
+                        <span class="float-right badge-secondary break">{{ property.value.value }}</span>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/docs/docs.component.html.ejs
@@ -17,4 +17,4 @@
  limitations under the License.
 -%>
 <iframe src="swagger-ui/index.html" width="100%" height="900" seamless
-    target="_top" title="Swagger UI" class="border-0"></iframe>
+        target="_top" title="Swagger UI" class="border-0"></iframe>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
@@ -19,41 +19,45 @@
 <div>
     <h2>
         <span id="gateway-page-heading" jhiTranslate="gateway.title">Gateway</span>
+
         <button class="btn btn-primary float-right" (click)="refresh()" (disabled)="updatingRoutes">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="gateway.refresh.button">Refresh</span>
         </button>
     </h2>
+
     <h3 jhiTranslate="gateway.routes.title">Current routes</h3>
+
     <div class="table-responsive">
         <table class="table table-striped" aria-describedby="gateway-page-heading">
             <thead>
-            <tr>
-                <th scope="col" jhiTranslate="gateway.routes.url">URL</th>
-                <th scope="col" jhiTranslate="gateway.routes.service">Service</th>
-                <th scope="col" jhiTranslate="gateway.routes.servers">Available servers</th>
-            </tr>
+                <tr>
+                    <th scope="col" jhiTranslate="gateway.routes.url">URL</th>
+                    <th scope="col" jhiTranslate="gateway.routes.service">Service</th>
+                    <th scope="col" jhiTranslate="gateway.routes.servers">Available servers</th>
+                </tr>
             </thead>
             <tbody>
                 <tr *ngFor="let route of gatewayRoutes">
-                    <td>{{route.path}}</td>
-                    <td>{{route.serviceId}}</td>
+                    <td>{{ route.path }}</td>
+                    <td>{{ route.serviceId }}</td>
                     <td>
                         <div *ngIf="route.serviceInstances.length === 0" class="label label-danger" jhiTranslate="gateway.routes.error">
                             Warning: no server available!
                         </div>
+
                         <div class="table-responsive">
                             <table class="table table-striped" *ngIf="route">
                                 <tr *ngFor="let instance of route.serviceInstances">
-                                    <td><a href="{{instance.uri}}" target="_blank">{{instance.uri}}</a></td>
+                                    <td><a href="{{ instance.uri }}" target="_blank">{{ instance.uri }}</a></td>
                                     <td>
-                                        <div *ngIf="instance.instanceInfo" class="badge badge-{{instance.instanceInfo.status === 'UP'?'success':'danger'}}">{{instance.instanceInfo.status}}</div>
+                                        <div *ngIf="instance.instanceInfo" class="badge badge-{{ instance.instanceInfo.status === 'UP' ? 'success' : 'danger' }}">{{ instance.instanceInfo.status }}</div>
                                         <div *ngIf="!instance.instanceInfo" class="badge badge-warning">?</div>
                                     </td>
                                     <td>
                                         <span *ngFor="let entry of (instance.metadata | keys )">
                                             <span class="badge badge-default font-weight-normal">
-                                                <span class="badge badge-pill badge-info font-weight-normal">{{entry.key}}</span>
-                                                {{entry.value}}
+                                                <span class="badge badge-pill badge-info font-weight-normal">{{ entry.key }}</span>
+                                                {{ entry.value }}
                                             </span>
                                         </span>
                                     </td>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
@@ -17,15 +17,23 @@
  limitations under the License.
 -%>
 <div class="modal-header">
-    <h4 class="modal-title" id="showHealthLabel" *ngIf="health"><% if (enableTranslation) { %>
-        {{ 'health.indicator.' + health.key | translate }}<% } else { %><span class="text-capitalize">{{ health.key }}</span><% } %>
+    <h4 class="modal-title" id="showHealthLabel" *ngIf="health">
+        <%_ if (enableTranslation) { _%>
+        {{ 'health.indicator.' + health.key | translate }}
+        <%_ } else { _%>
+        <span class="text-capitalize">{{ health.key }}</span>
+        <%_ } _%>
     </h4>
-    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="dismiss()"><span aria-hidden="true">&times;</span>
+
+    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="dismiss()">
+        <span aria-hidden="true">&times;</span>
     </button>
 </div>
+
 <div class="modal-body pad">
     <div *ngIf="health">
         <h5 jhiTranslate="health.details.properties">Properties</h5>
+
         <div class="table-responsive">
             <table class="table table-striped" aria-describedby="showHealthLabel">
                 <thead>
@@ -44,6 +52,7 @@
         </div>
     </div>
 </div>
+
 <div class="modal-footer">
     <button data-dismiss="modal" class="btn btn-secondary float-left" type="button" (click)="dismiss()">Done</button>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -19,10 +19,12 @@
 <div>
     <h2>
         <span id="health-page-heading" jhiTranslate="health.title">Health Checks</span>
+
         <button class="btn btn-primary float-right" (click)="refresh()">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="health.refresh.button">Refresh</span>
         </button>
     </h2>
+
     <div class="table-responsive">
         <table id="healthCheck" class="table table-striped" aria-describedby="health-page-heading">
             <thead>
@@ -34,9 +36,15 @@
             </thead>
             <tbody *ngIf="health">
                 <tr *ngFor="let componentHealth of health.components | keys">
-                    <td><% if (enableTranslation) { %>{{'health.indicator.' + componentHealth.key | translate}}<% } else { %><span class="text-capitalize">{{ componentHealth.key }}</span><% } %></td>
+                    <td>
+                        <%_ if (enableTranslation) { _%>
+                        {{ 'health.indicator.' + componentHealth.key | translate }}
+                        <%_ } else { _%>
+                        <span class="text-capitalize">{{ componentHealth.key }}</span>
+                        <%_ } _%>
+                    </td>
                     <td class="text-center">
-                        <span class="badge" [ngClass]="getBadgeClass(componentHealth.value.status)" jhiTranslate="{{'health.status.' + componentHealth.value.status}}">
+                        <span class="badge" [ngClass]="getBadgeClass(componentHealth.value.status)" jhiTranslate="{{ 'health.status.' + componentHealth.value.status }}">
                             {{ componentHealth.value.status }}
                         </span>
                     </td>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
@@ -59,7 +59,7 @@ export class HealthComponent implements OnInit {
     }
 
     showHealth(health: { key: HealthKey; value: HealthDetails }): void {
-        const modalRef  = this.modalService.open(HealthModalComponent);
+        const modalRef = this.modalService.open(HealthModalComponent);
         modalRef.componentInstance.health = health;
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -19,20 +19,20 @@
 <div class="table-responsive" *ngIf="loggers">
     <h2 id="logs-page-heading" jhiTranslate="logs.title">Logs</h2>
 
-    <p jhiTranslate="logs.nbloggers" [translateValues]="{total: loggers.length}">There are {{ loggers.length }} loggers.</p>
+    <p jhiTranslate="logs.nbloggers" [translateValues]="{ total: loggers.length }">There are {{ loggers.length }} loggers.</p>
 
     <span jhiTranslate="logs.filter">Filter</span> <input type="text" [(ngModel)]="filter" class="form-control">
 
     <table class="table table-sm table-striped table-bordered" aria-describedby="logs-page-heading">
         <thead>
-        <tr title="click to order">
-            <th scope="col" (click)="orderProp = 'name'; reverse=!reverse"><span jhiTranslate="logs.table.name">Name</span></th>
-            <th scope="col" (click)="orderProp = 'level'; reverse=!reverse"><span jhiTranslate="logs.table.level">Level</span></th>
-        </tr>
+            <tr title="click to order">
+                <th scope="col" (click)="orderProp = 'name'; reverse=!reverse"><span jhiTranslate="logs.table.name">Name</span></th>
+                <th scope="col" (click)="orderProp = 'level'; reverse=!reverse"><span jhiTranslate="logs.table.level">Level</span></th>
+            </tr>
         </thead>
 
         <tr *ngFor="let logger of (loggers | pureFilter:filter:'name' | orderBy:orderProp:reverse)">
-            <td><small>{{logger.name | slice:0:140}}</small></td>
+            <td><small>{{ logger.name | slice:0:140 }}</small></td>
             <td>
                 <button (click)="changeLevel(logger.name, 'TRACE')" [ngClass]="(logger.level=='TRACE') ? 'btn-primary' : 'btn-light'" class="btn btn-sm">TRACE</button>
                 <button (click)="changeLevel(logger.name, 'DEBUG')" [ngClass]="(logger.level=='DEBUG') ? 'btn-success' : 'btn-light'" class="btn btn-sm">DEBUG</button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.html.ejs
@@ -19,19 +19,26 @@
 <div>
     <h2>
         <span id="metrics-page-heading" jhiTranslate="metrics.title">Application Metrics</span>
+
         <button class="btn btn-primary float-right" (click)="refresh()">
             <fa-icon [icon]="'sync'"></fa-icon> <span jhiTranslate="metrics.refresh.button">Refresh</span>
         </button>
     </h2>
 
     <h3 jhiTranslate="metrics.jvm.title">JVM Metrics</h3>
+
     <div class="row" *ngIf="metrics && !updatingMetrics">
         <jhi-jvm-memory
             class="col-md-4"
             [updating]="updatingMetrics"
             [jvmMemoryMetrics]="metrics.jvm">
         </jhi-jvm-memory>
-        <jhi-jvm-threads class="col-md-4" [threadData]="threads"></jhi-jvm-threads>
+
+        <jhi-jvm-threads
+            class="col-md-4"
+            [threadData]="threads">
+        </jhi-jvm-threads>
+
         <jhi-metrics-system
             class="col-md-4"
             [updating]="updatingMetrics"
@@ -41,7 +48,11 @@
 
     <div *ngIf="metrics && metricsKeyExists('garbageCollector')">
         <h3 jhiTranslate="metrics.jvm.gc.title">Garbage collector statistics</h3>
-        <jhi-metrics-garbagecollector [updating]="updatingMetrics" [garbageCollectorMetrics]="metrics.garbageCollector"></jhi-metrics-garbagecollector>
+
+        <jhi-metrics-garbagecollector
+            [updating]="updatingMetrics"
+            [garbageCollectorMetrics]="metrics.garbageCollector">
+        </jhi-metrics-garbagecollector>
     </div>
 
     <div class="well well-lg" *ngIf="updatingMetrics" jhiTranslate="metrics.updating">Updating...</div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/tracker/tracker.component.html.ejs
@@ -20,7 +20,7 @@
     <h2 id="tracker-page-heading" jhiTranslate="tracker.title">Real-time user activities</h2>
 
     <div class="table-responsive">
-        <table class="table table-striped"  aria-describedby="tracker-page-heading">
+        <table class="table table-striped" aria-describedby="tracker-page-heading">
             <thead>
                 <tr>
                     <th scope="col" jhiTranslate="tracker.table.userlogin">User</th>
@@ -32,10 +32,10 @@
             </thead>
             <tbody>
                 <tr *ngFor="let activity of activities">
-                    <td>{{activity.userLogin}}</td>
-                    <td>{{activity.ipAddress}}</td>
-                    <td>{{activity.page}}</td>
-                    <td>{{activity.time | date:'yyyy-MM-dd HH:mm:ss'}}</td>
+                    <td>{{ activity.userLogin }}</td>
+                    <td>{{ activity.ipAddress }}</td>
+                    <td>{{ activity.page }}</td>
+                    <td>{{ activity.time | date:'yyyy-MM-dd HH:mm:ss' }}</td>
                 </tr>
             </tbody>
         </table>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.html.ejs
@@ -19,17 +19,21 @@
 <form *ngIf="user" name="deleteForm" (ngSubmit)="confirmDelete(user.login!)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
-        <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-            (click)="clear()">&times;</button>
+
+        <button type="button" class="close" data-dismiss="modal" aria-hidden="true" (click)="cancel()">&times;</button>
     </div>
+
     <div class="modal-body">
         <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
-        <p jhiTranslate="userManagement.delete.question" [translateValues]="{login: user.login}">Are you sure you want to delete this User?</p>
+
+        <p jhiTranslate="userManagement.delete.question" [translateValues]="{ login: user.login }">Are you sure you want to delete this User?</p>
     </div>
+
     <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="cancel()">
             <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
+
         <button type="submit" class="btn btn-danger">
             <fa-icon [icon]="'times'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
         </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-delete-dialog.component.ts.ejs
@@ -36,7 +36,7 @@ export class UserManagementDeleteDialogComponent {
         private eventManager: JhiEventManager
     ) {}
 
-    clear(): void {
+    cancel(): void {
         this.activeModal.dismiss();
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-detail.component.html.ejs
@@ -20,12 +20,13 @@
     <div class="col-8">
         <div *ngIf="user">
             <h2>
-                <span jhiTranslate="userManagement.detail.title">User</span> [<b>{{user.login}}</b>]
+                <span jhiTranslate="userManagement.detail.title">User</span> [<b>{{ user.login }}</b>]
             </h2>
+
             <dl class="row-md jh-entity-details">
                 <dt><span jhiTranslate="userManagement.login">Login</span></dt>
                 <dd>
-                    <span>{{user.login}}</span>
+                    <span>{{ user.login }}</span>
                     <jhi-boolean
                         [value]="user.activated"
                     <%_ if (enableTranslation) { _%>
@@ -37,37 +38,45 @@
                     <%_ } _%>
                     </jhi-boolean>
                 </dd>
+
                 <dt><span jhiTranslate="userManagement.firstName">First Name</span></dt>
-                <dd>{{user.firstName}}</dd>
+                <dd>{{ user.firstName }}</dd>
+
                 <dt><span jhiTranslate="userManagement.lastName">Last Name</span></dt>
-                <dd>{{user.lastName}}</dd>
+                <dd>{{ user.lastName }}</dd>
+
                 <dt><span jhiTranslate="userManagement.email">Email</span></dt>
-                <dd>{{user.email}}</dd>
+                <dd>{{ user.email }}</dd>
                 <%_ if (enableTranslation) { _%>
+
                 <dt><span jhiTranslate="userManagement.langKey">Lang Key</span></dt>
-                <dd>{{user.langKey}}</dd>
+                <dd>{{ user.langKey }}</dd>
                 <%_ } _%>
+
                 <dt><span jhiTranslate="userManagement.createdBy">Created By</span></dt>
-                <dd>{{user.createdBy}}</dd>
+                <dd>{{ user.createdBy }}</dd>
+
                 <dt><span jhiTranslate="userManagement.createdDate">Created Date</span></dt>
-                <dd>{{user.createdDate | date:'dd/MM/yy HH:mm' }}</dd>
+                <dd>{{ user.createdDate | date:'dd/MM/yy HH:mm' }}</dd>
+
                 <dt><span jhiTranslate="userManagement.lastModifiedBy">Last Modified By</span></dt>
-                <dd>{{user.lastModifiedBy}}</dd>
+                <dd>{{ user.lastModifiedBy }}</dd>
+
                 <dt><span jhiTranslate="userManagement.lastModifiedDate">Last Modified Date</span></dt>
-                <dd>{{user.lastModifiedDate | date:'dd/MM/yy HH:mm'}}</dd>
+                <dd>{{ user.lastModifiedDate | date:'dd/MM/yy HH:mm' }}</dd>
+
                 <dt><span jhiTranslate="userManagement.profiles">Profiles</span></dt>
                 <dd>
                     <ul class="list-unstyled">
                         <li *ngFor="let authority of user.authorities">
-                            <span class="badge badge-info">{{authority}}</span>
+                            <span class="badge badge-info">{{ authority }}</span>
                         </li>
                     </ul>
                 </dd>
             </dl>
-            <button type="submit"
-                    routerLink="../../"
-                    class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
+
+            <button type="submit" routerLink="../../" class="btn btn-info">
+                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back">Back</span>
             </button>
         </div>
     </div>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.html.ejs
@@ -22,8 +22,10 @@
             <h2 id="myUserLabel" jhiTranslate="userManagement.home.createOrEditLabel">
                 Create or edit a User
             </h2>
+
             <div *ngIf="user">
                 <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
+
                 <div class="form-group" [hidden]="!user.id">
                     <label jhiTranslate="global.field.id">ID</label>
                     <input type="text" class="form-control" name="id" formControlName="id" readonly>
@@ -36,22 +38,26 @@
 
                     <div *ngIf="editForm.get('login')!.invalid && (editForm.get('login')!.dirty || editForm.get('login')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login')?.errors?.required" jhiTranslate="entity.validation.required">
+                               *ngIf="editForm.get('login')?.errors?.required"
+                               jhiTranslate="entity.validation.required">
                             This field is required.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
-                        [translateValues]="{max: 50}">
+                               *ngIf="editForm.get('login')?.errors?.maxlength"
+                               jhiTranslate="entity.validation.maxlength"
+                               [translateValues]="{ max: 50 }">
                             This field cannot be longer than 50 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('login')?.errors?.pattern" jhiTranslate="entity.validation.patternLogin">
+                               *ngIf="editForm.get('login')?.errors?.pattern"
+                               jhiTranslate="entity.validation.patternLogin">
                             This field can only contain letters, digits and e-mail addresses.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="userManagement.firstName">First Name</label>
                     <input type="text" class="form-control" name="firstName"
@@ -59,81 +65,92 @@
 
                     <div *ngIf="editForm.get('firstName')!.invalid && (editForm.get('firstName')!.dirty || editForm.get('firstName')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('firstName')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
-                        [translateValues]="{max: 50}">
+                               *ngIf="editForm.get('firstName')?.errors?.maxlength"
+                               jhiTranslate="entity.validation.maxlength"
+                               [translateValues]="{ max: 50 }">
                             This field cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label jhiTranslate="userManagement.lastName">Last Name</label>
                     <input type="text" class="form-control" name="lastName"
-                        formControlName="lastName">
+                           formControlName="lastName">
 
                     <div *ngIf="editForm.get('lastName')!.invalid && (editForm.get('lastName')!.dirty || editForm.get('lastName')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('lastName')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
-                        [translateValues]="{max: 50}">
+                               *ngIf="editForm.get('lastName')?.errors?.maxlength"
+                               jhiTranslate="entity.validation.maxlength"
+                               [translateValues]="{ max: 50 }">
                             This field cannot be longer than 50 characters.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="userManagement.email">Email</label>
                     <input type="email" class="form-control" name="email" formControlName="email">
 
                     <div *ngIf="editForm.get('email')!.invalid && (editForm.get('email')!.dirty || editForm.get('email')!.touched)">
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors?.required" jhiTranslate="entity.validation.required">
+                               *ngIf="editForm.get('email')?.errors?.required"
+                               jhiTranslate="entity.validation.required">
                             This field is required.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors?.maxlength" jhiTranslate="entity.validation.maxlength"
-                        [translateValues]="{max: 100}">
+                               *ngIf="editForm.get('email')?.errors?.maxlength"
+                               jhiTranslate="entity.validation.maxlength"
+                               [translateValues]="{ max: 100 }">
                             This field cannot be longer than 100 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors?.minlength" jhiTranslate="entity.validation.minlength"
-                        [translateValues]="{min: 5}">
+                               *ngIf="editForm.get('email')?.errors?.minlength"
+                               jhiTranslate="entity.validation.minlength"
+                               [translateValues]="{ min: 5 }">
                             This field is required to be at least 5 characters.
                         </small>
 
                         <small class="form-text text-danger"
-                        *ngIf="editForm.get('email')?.errors?.email" jhiTranslate="global.messages.validate.email.invalid">
+                               *ngIf="editForm.get('email')?.errors?.email"
+                               jhiTranslate="global.messages.validate.email.invalid">
                             Your email is invalid.
                         </small>
                     </div>
                 </div>
+
                 <div class="form-check">
                     <label class="form-check-label" for="activated">
                         <input class="form-check-input" [attr.disabled]="user.id === undefined ? 'disabled' : null"
-                        type="checkbox" id="activated" name="activated" formControlName="activated">
+                               type="checkbox" id="activated" name="activated" formControlName="activated">
                         <span jhiTranslate="userManagement.activated">Activated</span>
                     </label>
                 </div>
-
                 <%_ if (enableTranslation) { _%>
+
                 <div class="form-group" *ngIf="languages && languages.length > 0">
                     <label jhiTranslate="userManagement.langKey">Lang Key</label>
                     <select class="form-control" id="langKey" name="langKey" formControlName="langKey">
-                        <option *ngFor="let language of languages" [value]="language">{{language | findLanguageFromKey}}</option>
+                        <option *ngFor="let language of languages" [value]="language">{{ language | findLanguageFromKey }}</option>
                     </select>
                 </div>
                 <%_ } _%>
+
                 <div class="form-group">
                     <label jhiTranslate="userManagement.profiles">Profiles</label>
                     <select class="form-control" multiple name="authority" formControlName="authorities">
-                        <option *ngFor="let authority of authorities" [value]="authority">{{authority}}</option>
+                        <option *ngFor="let authority of authorities" [value]="authority">{{ authority }}</option>
                     </select>
                 </div>
             </div>
+
             <div *ngIf="user">
                 <button type="button" class="btn btn-secondary" (click)="previousState()">
-                    <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span
-                    jhiTranslate="entity.action.cancel">Cancel</span>
+                    <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
                 </button>
+
                 <button type="submit" [disabled]="editForm.invalid || isSaving" class="btn btn-primary">
                     <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
                 </button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.html.ejs
@@ -19,85 +19,95 @@
 <div>
     <h2>
         <span id="user-management-page-heading" jhiTranslate="userManagement.home.title">Users</span>
+
         <button class="btn btn-primary float-right jh-create-entity" [routerLink]="['./new']">
             <fa-icon [icon]="'plus'"></fa-icon> <span jhiTranslate="userManagement.home.createLabel">Create a new User</span>
         </button>
     </h2>
+
     <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
+
     <<%= jhiPrefixDashed %>-alert></<%= jhiPrefixDashed %>-alert>
+
     <div class="table-responsive" *ngIf="users">
         <table class="table table-striped" aria-describedby="user-management-page-heading">
             <thead>
-            <tr<% if (databaseType !== 'cassandra') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"<% } %>>
-                <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-                <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="login"<% } %>><span jhiTranslate="userManagement.login">Login</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-                <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="email"<% } %>><span jhiTranslate="userManagement.email">Email</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-                <th scope="col"></th>
-                <%_ if (enableTranslation) { _%>
-                <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="langKey"<% } %>> <span jhiTranslate="userManagement.langKey">Lang Key</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-                <%_ } _%>
-                <th scope="col"><span jhiTranslate="userManagement.profiles">Profiles</span></th>
-                <%_ if (databaseType !== 'cassandra') { _%>
-                <th scope="col" jhiSortBy="createdDate"><span jhiTranslate="userManagement.createdDate">Created Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" jhiSortBy="lastModifiedBy"><span jhiTranslate="userManagement.lastModifiedBy">Last Modified By</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-                <th scope="col" jhiSortBy="lastModifiedDate"><span jhiTranslate="userManagement.lastModifiedDate">Last Modified Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
-                <%_ } _%>
-                <th scope="col"></th>
-            </tr>
+                <tr<% if (databaseType !== 'cassandra') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"<% } %>>
+                    <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                    <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="login"<% } %>><span jhiTranslate="userManagement.login">Login</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                    <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="email"<% } %>><span jhiTranslate="userManagement.email">Email</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                    <th scope="col"></th>
+                    <%_ if (enableTranslation) { _%>
+                    <th scope="col" <% if (databaseType !== 'cassandra') { %> jhiSortBy="langKey"<% } %>> <span jhiTranslate="userManagement.langKey">Lang Key</span><% if (databaseType !== 'cassandra') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                    <%_ } _%>
+                    <th scope="col"><span jhiTranslate="userManagement.profiles">Profiles</span></th>
+                    <%_ if (databaseType !== 'cassandra') { _%>
+                    <th scope="col" jhiSortBy="createdDate"><span jhiTranslate="userManagement.createdDate">Created Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th scope="col" jhiSortBy="lastModifiedBy"><span jhiTranslate="userManagement.lastModifiedBy">Last Modified By</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <th scope="col" jhiSortBy="lastModifiedDate"><span jhiTranslate="userManagement.lastModifiedDate">Last Modified Date</span> <fa-icon [icon]="'sort'"></fa-icon></th>
+                    <%_ } _%>
+                    <th scope="col"></th>
+                </tr>
             </thead>
-            <tbody *ngIf ="users">
-            <tr *ngFor="let user of users; trackBy: trackIdentity">
-                <td><a [routerLink]="['./', user.login, 'view']">{{user.id}}</a></td>
-                <td>{{user.login}}</td>
-                <td>{{user.email}}</td>
-                <td>
-                    <button class="btn btn-danger btn-sm" (click)="setActive(user, true)" *ngIf="!user.activated"
-                            jhiTranslate="userManagement.deactivated">Deactivated</button>
-                    <button class="btn btn-success btn-sm" (click)="setActive(user, false)" *ngIf="user.activated"
-                            [disabled]="!currentAccount || currentAccount.login === user.login" jhiTranslate="userManagement.activated">Activated</button>
-                </td>
-                <% if (enableTranslation) { %><td>{{user.langKey}}</td><% } %>
-                <td>
-                    <div *ngFor="let authority of user.authorities">
-                        <span class="badge badge-info">{{ authority }}</span>
-                    </div>
-                </td>
-                <%_ if (databaseType !== 'cassandra') { _%>
-                <td>{{user.createdDate | date:'dd/MM/yy HH:mm'}}</td>
-                <td>{{user.lastModifiedBy}}</td>
-                <td>{{user.lastModifiedDate | date:'dd/MM/yy HH:mm'}}</td>
-                <%_ } _%>
-                <td class="text-right">
-                    <div class="btn-group">
-                        <button type="submit"
-                                [routerLink]="['./', user.login, 'view']"
-                                class="btn btn-info btn-sm">
-                            <fa-icon [icon]="'eye'"></fa-icon>
-                            <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
-                        </button>
-                        <button type="submit"
-                                [routerLink]="['./', user.login, 'edit']"
-                                queryParamsHandling="merge"
-                                class="btn btn-primary btn-sm">
-                            <fa-icon [icon]="'pencil-alt'"></fa-icon>
-                            <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
-                        </button>
-                        <button type="button" (click)="deleteUser(user)"
-                                class="btn btn-danger btn-sm" [disabled]="!currentAccount || currentAccount.login === user.login">
-                            <fa-icon [icon]="'times'"></fa-icon>
-                            <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
-                        </button>
-                    </div>
-                </td>
-            </tr>
+            <tbody *ngIf="users">
+                <tr *ngFor="let user of users; trackBy: trackIdentity">
+                    <td><a [routerLink]="['./', user.login, 'view']">{{ user.id }}</a></td>
+                    <td>{{ user.login }}</td>
+                    <td>{{ user.email }}</td>
+                    <td>
+                        <button class="btn btn-danger btn-sm" (click)="setActive(user, true)" *ngIf="!user.activated"
+                                jhiTranslate="userManagement.deactivated">Deactivated</button>
+                        <button class="btn btn-success btn-sm" (click)="setActive(user, false)" *ngIf="user.activated"
+                                [disabled]="!currentAccount || currentAccount.login === user.login" jhiTranslate="userManagement.activated">Activated</button>
+                    </td>
+                    <%_ if (enableTranslation) { _%>
+                    <td>{{ user.langKey }}</td>
+                    <%_ } _%>
+                    <td>
+                        <div *ngFor="let authority of user.authorities">
+                            <span class="badge badge-info">{{ authority }}</span>
+                        </div>
+                    </td>
+                    <%_ if (databaseType !== 'cassandra') { _%>
+                    <td>{{ user.createdDate | date:'dd/MM/yy HH:mm' }}</td>
+                    <td>{{ user.lastModifiedBy }}</td>
+                    <td>{{ user.lastModifiedDate | date:'dd/MM/yy HH:mm' }}</td>
+                    <%_ } _%>
+                    <td class="text-right">
+                        <div class="btn-group">
+                            <button type="submit"
+                                    [routerLink]="['./', user.login, 'view']"
+                                    class="btn btn-info btn-sm">
+                                <fa-icon [icon]="'eye'"></fa-icon>
+                                <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
+                            </button>
+
+                            <button type="submit"
+                                    [routerLink]="['./', user.login, 'edit']"
+                                    queryParamsHandling="merge"
+                                    class="btn btn-primary btn-sm">
+                                <fa-icon [icon]="'pencil-alt'"></fa-icon>
+                                <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
+                            </button>
+
+                            <button type="button" (click)="deleteUser(user)"
+                                    class="btn btn-danger btn-sm" [disabled]="!currentAccount || currentAccount.login === user.login">
+                                <fa-icon [icon]="'times'"></fa-icon>
+                                <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
+                            </button>
+                        </div>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>
     <%_ if (databaseType !== 'cassandra') { _%>
+
     <div *ngIf="users">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
+
         <div class="row justify-content-center">
             <ngb-pagination [collectionSize]="totalItems" [(page)]="page" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage(page)"></ngb-pagination>
         </div>

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -34,7 +34,7 @@ import { TrackerService } from '../tracker/tracker.service';
 <%_ } _%>
 
 @Injectable({providedIn: 'root'})
-export class AccountService  {
+export class AccountService {
     private userIdentity: Account | null = null;
     private authenticationState = new ReplaySubject<Account | null>(1);
     private accountCache$?: Observable<Account | null>;

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.component.html.ejs
@@ -20,14 +20,16 @@
     <div class="col-md-3">
         <span class="hipster img-fluid rounded"></span>
     </div>
+
     <div class="col-md-9">
         <h1 class="display-4" jhiTranslate="home.title">Welcome, Java Hipster!</h1>
+
         <p class="lead" jhiTranslate="home.subtitle">This is your homepage</p>
 
         <div [ngSwitch]="isAuthenticated()">
             <div class="alert alert-success" *ngSwitchCase="true">
                 <span id="home-logged-message" *ngIf="account" jhiTranslate="home.logged.message"
-                    [translateValues]="{username: account.login}"> You are logged in as user "{{account.login}}". </span>
+                    [translateValues]="{ username: account.login }">You are logged in as user "{{ account.login }}".</span>
             </div>
 
             <div class="alert alert-warning" *ngSwitchCase="false">
@@ -35,6 +37,7 @@
                 <a class="alert-link" (click)="login()" jhiTranslate="global.messages.info.authenticated.link">sign in</a><span jhiTranslate="global.messages.info.authenticated.suffix">, you can try the default accounts:<br/>- Administrator (login="admin" and password="admin") <br/>- User (login="user" and password="user").</span>
             </div>
             <%_ if (!skipUserManagement) { _%>
+
             <div class="alert alert-warning" *ngSwitchCase="false">
                 <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>&nbsp;
                 <a class="alert-link" routerLink="account/register" jhiTranslate="global.messages.info.register.link">Register a new account</a>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.html.ejs
@@ -21,6 +21,7 @@
         <div class="col-md-4">
             <span class="hipster img-fluid rounded"></span>
         </div>
+
         <div class="col-md-8">
             <h1 jhiTranslate="error.title">Error Page!</h1>
 

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.html.ejs
@@ -17,12 +17,15 @@
  limitations under the License.
 -%>
 <<%= jhiPrefixDashed %>-page-ribbon></<%= jhiPrefixDashed %>-page-ribbon>
+
 <div>
     <router-outlet name="navbar"></router-outlet>
 </div>
+
 <div class="container-fluid">
     <div class="card jh-card">
         <router-outlet></router-outlet>
     </div>
+
     <<%= jhiPrefixDashed %>-footer></<%= jhiPrefixDashed %>-footer>
 </div>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -19,7 +19,7 @@
 <nav class="navbar navbar-<% if (clientTheme === 'none') { %>dark<% } else { %><%= clientThemeVariant %><% } %> navbar-expand-md <% if (clientTheme === 'none') { %>bg-dark<% } else { %>bg-<%= clientThemeVariant %><% } %>">
     <a class="navbar-brand logo" routerLink="/" (click)="collapseNavbar()">
         <span class="logo-img"></span>
-        <span jhiTranslate="global.title" class="navbar-title"><%= capitalizedBaseName %></span> <span class="navbar-version">{{version}}</span>
+        <span jhiTranslate="global.title" class="navbar-title"><%= capitalizedBaseName %></span> <span class="navbar-version">{{ version }}</span>
     </a>
     <a class="navbar-toggler d-lg-none" href="javascript:void(0);" data-toggle="collapse" data-target="#navbarResponsive" aria-controls="navbarResponsive" aria-expanded="false" aria-label="Toggle navigation" (click)="toggleNavbar()">
         <fa-icon icon="bars"></fa-icon>
@@ -139,7 +139,7 @@
                 </a>
                 <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="languagesnavBarDropdown">
                     <li *ngFor="let language of languages">
-                        <a class="dropdown-item" [<%= jhiPrefix %>ActiveMenu]="language" href="javascript:void(0);" (click)="changeLanguage(language);collapseNavbar();">{{language | findLanguageFromKey}}</a>
+                        <a class="dropdown-item" [<%= jhiPrefix %>ActiveMenu]="language" href="javascript:void(0);" (click)="changeLanguage(language);collapseNavbar();">{{ language | findLanguageFromKey }}</a>
                     </li>
                 </ul>
             </li>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/login/login.component.html.ejs
@@ -18,9 +18,12 @@
 -%>
 <div class="modal-header">
     <h4 class="modal-title" jhiTranslate="login.title">Sign in</h4>
-    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="activeModal.dismiss('closed')"><span aria-hidden="true">x</span>
+
+    <button aria-label="Close" data-dismiss="modal" class="close" type="button" (click)="activeModal.dismiss('closed')">
+        <span aria-hidden="true">x</span>
     </button>
 </div>
+
 <div class="modal-body">
     <div class="row justify-content-center">
         <div class="col-md-8">
@@ -28,31 +31,36 @@
                 <strong>Failed to sign in!</strong> Please check your credentials and try again.
             </div>
         </div>
+
         <div class="col-md-8">
             <form class="form" role="form" (ngSubmit)="login()" [formGroup]="loginForm">
                 <div class="form-group">
                     <label class="username-label" for="username" jhiTranslate="global.form.username.label">Login</label>
-                    <input type="text" class="form-control" name="username" id="username" placeholder="{{'global.form.username.placeholder' | translate}}"
+                    <input type="text" class="form-control" name="username" id="username" placeholder="{{ 'global.form.username.placeholder' | translate }}"
                            formControlName="username" #username>
                 </div>
+
                 <div class="form-group">
                     <label for="password" jhiTranslate="login.form.password">Password</label>
-                    <input type="password" class="form-control" name="password" id="password" placeholder="{{'login.form.password.placeholder' | translate}}"
+                    <input type="password" class="form-control" name="password" id="password" placeholder="{{ 'login.form.password.placeholder' | translate }}"
                            formControlName="password">
                 </div>
+
                 <div class="form-check"<% if (authenticationType === 'session' && databaseType === 'no') { %> hidden<% } %>>
                     <label class="form-check-label" for="rememberMe">
                         <input class="form-check-input" type="checkbox" name="rememberMe" id="rememberMe" formControlName="rememberMe">
                         <span jhiTranslate="login.form.rememberme">Remember me</span>
                     </label>
                 </div>
+
                 <button type="submit" class="btn btn-primary" jhiTranslate="login.form.button">Sign in</button>
             </form>
-            <p></p>
             <%_ if (!skipUserManagement) { _%>
-            <div class="alert alert-warning">
+
+            <div class="mt-3 alert alert-warning">
                 <a class="alert-link" (click)="requestResetPassword()" jhiTranslate="login.password.forgot">Did you forget your password?</a>
             </div>
+
             <div class="alert alert-warning">
                 <span jhiTranslate="global.messages.info.register.noaccount">You don't have an account yet?</span>
                 <a class="alert-link" (click)="register()" jhiTranslate="global.messages.info.register.link">Register a new account</a>

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -204,7 +204,7 @@ describe('Service Tests', () => {
                     expect(hasAuthority).toBe(false);
                 });
 
-                it('should return false if user is logged and has not authority',  () => {
+                it('should return false if user is logged and has not authority', () => {
                     service.authenticate(accountWithAuthorities(['ROLE_USER']));
 
                     const hasAuthority = service.hasAnyAuthority('ROLE_ADMIN');

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
@@ -52,7 +52,7 @@ describe('Service Tests', () => {
             it('should call correct URL', () => {
                 service.find('user').subscribe();
 
-                const req  = httpMock.expectOne({ method: 'GET' });
+                const req = httpMock.expectOne({ method: 'GET' });
                 const resourceUrl = SERVER_API_URL + '<%- apiUaaPath %>api/users';
                 expect(req.request.url).toEqual(`${resourceUrl}/user`);
             });
@@ -90,7 +90,7 @@ describe('Service Tests', () => {
                     expectedResult = error.status;
                 });
 
-                const req  = httpMock.expectOne({ method: 'GET' });
+                const req = httpMock.expectOne({ method: 'GET' });
                 req.flush('Invalid request parameters', {
                     status: 404, statusText: 'Bad Request'
                 });

--- a/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/test.module.ts.ejs
@@ -52,7 +52,7 @@ _%>
         <%_ } _%>
         {
             provide: JhiEventManager,
-            useClass:  MockEventManager
+            useClass: MockEventManager
         },
         {
             provide: NgbActiveModal,

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.html.ejs
@@ -19,17 +19,22 @@
 <form *ngIf="<%= entityInstance %>" name="deleteForm" (ngSubmit)="confirmDelete(<%= entityInstance %>.id!)">
     <div class="modal-header">
         <h4 class="modal-title" jhiTranslate="entity.delete.title">Confirm delete operation</h4>
+
         <button type="button" class="close" data-dismiss="modal" aria-hidden="true"
-                (click)="clear()">&times;</button>
+                (click)="cancel()">&times;</button>
     </div>
+
     <div class="modal-body">
         <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
-        <p id="<%= jhiPrefixDashed %>-delete-<%= entityInstance %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.delete.question" [translateValues]="{id: <%= entityInstance %>.id}">Are you sure you want to delete this <%= entityClassHumanized %>?</p>
+
+        <p id="<%= jhiPrefixDashed %>-delete-<%= entityInstance %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.delete.question" [translateValues]="{ id: <%= entityInstance %>.id }">Are you sure you want to delete this <%= entityClassHumanized %>?</p>
     </div>
+
     <div class="modal-footer">
-        <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="clear()">
+        <button type="button" class="btn btn-secondary" data-dismiss="modal" (click)="cancel()">
             <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
         </button>
+
         <button id="<%= jhiPrefixDashed %>-confirm-delete-<%= entityInstance %>" type="submit" class="btn btn-danger">
             <fa-icon [icon]="'times'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.delete">Delete</span>
         </button>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
@@ -38,7 +38,7 @@ export class <%= entityAngularName %>DeleteDialogComponent {
         protected eventManager: JhiEventManager
     ) {}
 
-    clear(): void {
+    cancel(): void {
         this.activeModal.dismiss();
     }
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-detail.component.html.ejs
@@ -19,96 +19,104 @@
 <div class="row justify-content-center">
     <div class="col-8">
         <div *ngIf="<%= entityInstance %>">
-            <h2><span jhiTranslate="<%= i18nKeyPrefix %>.detail.title"><%= entityClassHumanized %></span> {{<%= entityInstance %>.id}}</h2>
+            <h2><span jhiTranslate="<%= i18nKeyPrefix %>.detail.title"><%= entityClassHumanized %></span> {{ <%= entityInstance %>.id }}</h2>
+
             <hr>
+
             <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
+
             <dl class="row-md jh-entity-details">
                 <%_ for (idx in fields) {
-                const fieldName = fields[idx].fieldName;
-                const fieldType = fields[idx].fieldType;
-                const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent; _%>
+                    const fieldName = fields[idx].fieldName;
+                    const fieldType = fields[idx].fieldType;
+                    const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
+                _%>
                 <dt><span jhiTranslate="<%= i18nKeyPrefix %>.<%= fieldName %>"<% if (fields[idx].javadoc) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= fields[idx].javadoc %>"<% } } %>><%= fields[idx].fieldNameHumanized %></span></dt>
                 <dd>
                     <%_ if (fields[idx].fieldIsEnum) { _%>
-                    <span jhiTranslate="{{'<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>}}">{{<%= entityInstance %>.<%= fieldName %>}}</span>
+                    <span jhiTranslate="{{ '<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %> }}">{{ <%= entityInstance %>.<%= fieldName %> }}</span>
                     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
                     <div *ngIf="<%= entityInstance %>.<%= fieldName %>">
                         <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType!, <%= entityInstance %>.<%= fieldName %>)">
                             <img [src]="'data:' + <%= entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-width: 100%;" alt="<%= entityInstance %> image"/>
                         </a>
-                        {{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}
+                        {{ <%= entityInstance %>.<%= fieldName %>ContentType }}, {{ byteSize(<%= entityInstance %>.<%= fieldName %>) }}
                     </div>
                     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'any') { _%>
                     <div *ngIf="<%= entityInstance %>.<%= fieldName %>">
                         <a (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType!, <%= entityInstance %>.<%= fieldName %>)" jhiTranslate="entity.action.open">open</a>
-                        {{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}
+                        {{ <%= entityInstance %>.<%= fieldName %>ContentType }}, {{ byteSize(<%= entityInstance %>.<%= fieldName %>) }}
                     </div>
                     <%_ } else { _%>
-                    <span>{{<%= entityInstance %>.<%= fieldName %>}}</span>
+                    <span>{{ <%= entityInstance %>.<%= fieldName %> }}</span>
                     <%_ } _%>
                 </dd>
                 <%_ } _%>
-                <%_ for (idx in relationships) {
-                const relationshipType = relationships[idx].relationshipType;
-                const ownerSide = relationships[idx].ownerSide;
-                const relationshipName = relationships[idx].relationshipName;
-                const relationshipFieldName = relationships[idx].relationshipFieldName;
-                const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
-                const otherEntityName = relationships[idx].otherEntityName;
-                const otherEntityStateName = relationships[idx].otherEntityStateName;
-                const otherEntityField = relationships[idx].otherEntityField;
-                const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
-                if (relationshipType === 'many-to-one'
-                || (relationshipType === 'one-to-one' && ownerSide === true)
-                || (relationshipType === 'many-to-many' && ownerSide === true)) { _%>
+                <%_
+                for (idx in relationships) {
+                    const relationshipType = relationships[idx].relationshipType;
+                    const ownerSide = relationships[idx].ownerSide;
+                    const relationshipName = relationships[idx].relationshipName;
+                    const relationshipFieldName = relationships[idx].relationshipFieldName;
+                    const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+                    const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
+                    const otherEntityName = relationships[idx].otherEntityName;
+                    const otherEntityStateName = relationships[idx].otherEntityStateName;
+                    const otherEntityField = relationships[idx].otherEntityField;
+                    const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+                    if (relationshipType === 'many-to-one'
+                        || (relationshipType === 'one-to-one' && ownerSide === true)
+                        || (relationshipType === 'many-to-many' && ownerSide === true)) {
+                _%>
                 <dt><span jhiTranslate="<%= i18nKeyPrefix %>.<%= relationshipName %>"><%= relationshipNameHumanized %></span></dt>
                 <dd>
                     <%_ if (otherEntityName === 'user') { _%>
-                    <%_ if (relationshipType === 'many-to-many') { _%>
+                        <%_ if (relationshipType === 'many-to-many') { _%>
                     <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>; let last = last">
-                        {{<%= relationshipFieldName %>.<%= otherEntityField %>}}{{last ? '' : ', '}}
+                        {{ <%= relationshipFieldName %>.<%= otherEntityField %> }}{{ last ? '' : ', ' }}
                     </span>
+                        <%_ } else { _%>
+                            <%_ if (dto === 'no') { _%>
+                    {{ <%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %> }}
+                            <%_ } else { _%>
+                    {{ <%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> }}
+                            <%_ } _%>
+                        <%_ } _%>
                     <%_ } else { _%>
-                    <%_ if (dto === 'no') { _%>
-                    {{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}
-                    <%_ } else { _%>
-                    {{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}
-                    <%_ } _%>
-                    <%_ } _%>
-                    <%_ } else { _%>
-                    <%_ if (relationshipType === 'many-to-many') { _%>
+                        <%_ if (relationshipType === 'many-to-many') { _%>
                     <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>; let last = last">
-                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= relationshipFieldName %>?.id, 'view' ]">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{last ? '' : ', '}}
+                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= relationshipFieldName %>?.id, 'view']">{{ <%= relationshipFieldName %>.<%= otherEntityField %> }}</a>{{ last ? '' : ', ' }}
                     </span>
-                    <%_ } else { _%>
-                    <%_ if (dto === 'no') { _%>
+                        <%_ } else { _%>
+                            <%_ if (dto === 'no') { _%>
                     <div *ngIf="<%= entityInstance + '.' + relationshipFieldName %>">
-                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + '.' + relationshipFieldName + '?.id' %>, 'view']">{{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}</a>
+                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + '.' + relationshipFieldName + '?.id' %>, 'view']">{{ <%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %> }}</a>
                     </div>
-                    <%_ } else { _%>
+                            <%_ } else { _%>
                     <div *ngIf="<%= entityInstance + '.' + relationshipFieldName + "Id" %>">
-                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + '.' + relationshipFieldName + "Id" %>, 'view']">{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
+                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + '.' + relationshipFieldName + "Id" %>, 'view']">{{ <%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> }}</a>
                     </div>
-                    <%_ } _%>
-                    <%_ } _%>
+                            <%_ } _%>
+                        <%_ } _%>
                     <%_ } _%>
                 </dd>
-                <%_ } _%>
-                <%_ } _%>
+                <%_
+                    }
+                }
+                _%>
             </dl>
 
             <button type="submit"
                     (click)="previousState()"
                     class="btn btn-info">
-                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back"> Back</span>
+                <fa-icon [icon]="'arrow-left'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.back">Back</span>
             </button>
-
             <%_ if (!readOnly) { _%>
+
             <button type="button"
                     [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'edit']"
                     class="btn btn-primary">
-                <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit"> Edit</span>
+                <fa-icon [icon]="'pencil-alt'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.edit">Edit</span>
             </button>
             <%_ } _%>
         </div>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.html.ejs
@@ -20,12 +20,13 @@
     <div class="col-8">
         <form name="editForm" role="form" novalidate (ngSubmit)="save()" [formGroup]="editForm">
             <h2 id="<%= jhiPrefixDashed %>-<%= entityFileName %>-heading" jhiTranslate="<%= i18nKeyPrefix %>.home.createOrEditLabel">Create or edit a <%= entityClassHumanized %></h2>
+
             <div>
                 <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
+
                 <div class="form-group" [hidden]="!editForm.get('id')!.value">
                     <label for="id" jhiTranslate="global.field.id">ID</label>
-                    <input type="text" class="form-control" id="id" name="id" formControlName="id"
-                        readonly />
+                    <input type="text" class="form-control" id="id" name="id" formControlName="id" readonly />
                 </div>
 <%_ for (idx in fields) {
     const fieldName = fields[idx].fieldName;
@@ -48,6 +49,7 @@
         fieldInputType = 'hidden';
     }
 _%>
+
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= fieldName %>"<% if (fields[idx].javadoc) { if (enableTranslation) { %> [ngbTooltip]="'<%= i18nKeyPrefix %>.help.<%= fieldName %>' | translate"<% } else { %> ngbTooltip="<%= fields[idx].javadoc %>"<% } } %>><%= fieldNameHumanized %></label>
     <%_ if (fields[idx].fieldIsEnum) { _%>
@@ -56,7 +58,7 @@ _%>
             const values = fields[idx].fieldValues.replace(/\s/g, '').split(',');
             for (key in values) {
                 const value = values[key]; _%>
-                        <option value="<%= value %>"><% if (enableTranslation) { %>{{'<%= enumPrefix %>.<%= value %>' | translate}}<% } else { %><%= value %><% } %></option>
+                        <option value="<%= value %>"><% if (enableTranslation) { %>{{ '<%= enumPrefix %>.<%= value %>' | translate }}<% } else { %><%= value %><% } %></option>
         <%_ } _%>
                     </select>
     <%_ } else { _%>
@@ -68,9 +70,9 @@ _%>
                         <div *ngIf="editForm.get('<%= fieldName %>')!.value" class="form-text text-danger clearfix">
             <%_ if (fieldTypeBlobContent === 'any') { _%>
                             <a class="pull-left" (click)="openFile(editForm.get('<%= fieldName %>ContentType')!.value, editForm.get('<%= fieldName %>')!.value)" jhiTranslate="entity.action.open">open</a><br>
-                            <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType')!.value}}, {{byteSize(editForm.get('<%= fieldName %>')!.value)}}</span>
+                            <span class="pull-left">{{ editForm.get('<%= fieldName %>ContentType')!.value }}, {{ byteSize(editForm.get('<%= fieldName %>')!.value) }}</span>
             <%_ } else { _%>
-                            <span class="pull-left">{{editForm.get('<%= fieldName %>ContentType')!.value}}, {{byteSize(editForm.get('<%= fieldName %>')!.value)}}</span>
+                            <span class="pull-left">{{ editForm.get('<%= fieldName %>ContentType')!.value }}, {{ byteSize(editForm.get('<%= fieldName %>')!.value) }}</span>
             <%_ } _%>
             <%_ if (fieldTypeBlobContent === 'image') { _%>
                             <button type="button" (click)="clearInputImage('<%= fieldName %>', '<%= fieldName %>ContentType', 'file_<%= fieldName %>')" class="btn btn-secondary btn-xs pull-right">
@@ -86,7 +88,7 @@ _%>
         <%_ } _%>
         <%_ if (fieldType === 'LocalDate') { _%>
                     <div class="input-group">
-                        <input id="field_<%= fieldName %>" type="text" class="form-control" name="<%= fieldName %>" ngbDatepicker  #<%= fieldName %>Dp="ngbDatepicker" formControlName="<%= fieldName %>"/>
+                        <input id="field_<%= fieldName %>" type="text" class="form-control" name="<%= fieldName %>" ngbDatepicker #<%= fieldName %>Dp="ngbDatepicker" formControlName="<%= fieldName %>"/>
                         <span class="input-group-append">
                             <button type="button" class="btn btn-secondary" (click)="<%= fieldName %>Dp.toggle()"><fa-icon [icon]="'calendar-alt'"></fa-icon></button>
                         </span>
@@ -173,22 +175,23 @@ _%>
     <%_ } _%>
                 </div>
 <%_ } _%>
-
 <%_ for (idx in relationships) {
-const relationshipType = relationships[idx].relationshipType;
-const ownerSide = relationships[idx].ownerSide;
-const otherEntityName = relationships[idx].otherEntityName;
-const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-const relationshipName = relationships[idx].relationshipName;
-const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
-const relationshipFieldName = relationships[idx].relationshipFieldName;
-const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-const otherEntityField = relationships[idx].otherEntityField;
-const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
-const relationshipRequired = relationships[idx].relationshipRequired;
-const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
+    const relationshipType = relationships[idx].relationshipType;
+    const ownerSide = relationships[idx].ownerSide;
+    const otherEntityName = relationships[idx].otherEntityName;
+    const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
+    const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
+    const relationshipName = relationships[idx].relationshipName;
+    const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
+    const relationshipFieldName = relationships[idx].relationshipFieldName;
+    const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+    const otherEntityField = relationships[idx].otherEntityField;
+    const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+    const relationshipRequired = relationships[idx].relationshipRequired;
+    const translationKey = `${i18nKeyPrefix}.${relationshipName}`;
+_%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true && otherEntityName === 'user')) { _%>
+
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
         <%_ if (dto === 'no') { _%>
@@ -198,7 +201,7 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%= otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{ <%= otherEntityName %>Option.<%= otherEntityField %> }}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
@@ -207,11 +210,12 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>Id')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%= otherEntityName %>Option.id" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{ <%= otherEntityName %>Option.<%= otherEntityField %> }}</option>
                     </select>
         <%_ } _%>
                 </div>
     <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true) { _%>
+
                 <div class="form-group">
                     <label class="form-control-label" jhiTranslate="<%= translationKey %>" for="field_<%= relationshipName %>"><%= relationshipNameHumanized %></label>
         <%_ if (dto === 'no') { _%>
@@ -221,7 +225,7 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%= otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id === editForm.get('<%= relationshipFieldName %>')!.value?.id ? editForm.get('<%= relationshipFieldName %>')!.value : <%= otherEntityName %>Option" *ngFor="let <%= otherEntityName %>Option of <%= relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{ <%= otherEntityName %>Option.<%= otherEntityField %> }}</option>
                     </select>
         <%_ } else { _%>
                     <select class="form-control" id="field_<%= relationshipName %>" name="<%= relationshipName %>" formControlName="<%= relationshipName %>Id">
@@ -230,15 +234,16 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
             <%_ } else { _%>
                         <option *ngIf="!editForm.get('<%= relationshipName %>Id')!.value" [ngValue]="null" selected></option>
             <%_ } _%>
-                        <option [ngValue]="<%= otherEntityName %>Option.id" *ngFor="let <%= otherEntityName %>Option of <%= relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
+                        <option [ngValue]="<%= otherEntityName %>Option.id" *ngFor="let <%= otherEntityName %>Option of <%= relationshipFieldNamePlural.toLowerCase() %>; trackBy: trackById">{{ <%= otherEntityName %>Option.<%= otherEntityField %> }}</option>
                     </select>
         <%_ } _%>
                 </div>
     <%_ } else if (relationshipType === 'many-to-many' && ownerSide === true) { _%>
+
                 <div class="form-group">
                     <label jhiTranslate="<%= translationKey %>" for="field_<%= relationshipFieldNamePlural %>"><%= relationshipNameHumanized %></label>
                     <select class="form-control" id="field_<%= relationshipFieldNamePlural %>" multiple name="<%= relationshipFieldNamePlural %>" formControlName="<%= relationshipFieldNamePlural %>">
-                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')!.value, <%= otherEntityName %>Option)" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{<%= otherEntityName %>Option.<%= otherEntityField %>}}</option>
+                        <option [ngValue]="getSelected(editForm.get('<%= relationshipFieldNamePlural %>')!.value, <%= otherEntityName %>Option)" *ngFor="let <%= otherEntityName %>Option of <%= otherEntityNamePlural.toLowerCase() %>; trackBy: trackById">{{ <%= otherEntityName %>Option.<%= otherEntityField %> }}</option>
                     </select>
                 </div>
     <%_ } _%>
@@ -254,10 +259,12 @@ const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
     <%_ } _%>
 <%_ } _%>
             </div>
+
             <div>
-                <button type="button" id="cancel-save" class="btn btn-secondary"  (click)="previousState()">
+                <button type="button" id="cancel-save" class="btn btn-secondary" (click)="previousState()">
                     <fa-icon [icon]="'ban'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.cancel">Cancel</span>
                 </button>
+
                 <button type="submit" id="save-entity" [disabled]="editForm.invalid || isSaving" class="btn btn-primary">
                     <fa-icon [icon]="'save'"></fa-icon>&nbsp;<span jhiTranslate="entity.action.save">Save</span>
                 </button>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.html.ejs
@@ -20,6 +20,7 @@
     <h2 id="page-heading">
         <span jhiTranslate="<%= i18nKeyPrefix %>.home.title"><%= entityClassPluralHumanized %></span>
         <%_ if (!readOnly) { _%>
+
         <button id="jh-create-entity" class="btn btn-primary float-right jh-create-entity create-<%= entityUrl %>" [routerLink]="['/<%= entityUrl %>/new']">
             <fa-icon [icon]="'plus'"></fa-icon>
             <span <% if (searchEngine === 'elasticsearch') { %>class="hidden-sm-down" <% } %> jhiTranslate="<%= i18nKeyPrefix %>.home.createLabel">
@@ -28,17 +29,22 @@
         </button>
         <%_ } _%>
     </h2>
+
     <<%= jhiPrefixDashed %>-alert-error></<%= jhiPrefixDashed %>-alert-error>
+
     <<%= jhiPrefixDashed %>-alert></<%= jhiPrefixDashed %>-alert>
     <%_ if (searchEngine === 'elasticsearch') { _%>
+
     <div class="row">
         <div class="col-sm-12">
             <form name="searchForm" class="form-inline">
                 <div class="input-group w-100 mt-3">
                     <input type="text" class="form-control" [(ngModel)]="currentSearch" id="currentSearch" name="currentSearch" placeholder="<% if (enableTranslation) { %>{{ '<%= i18nKeyPrefix %>.home.search' | translate }}<% } else { %>Query<% } %>">
+
                     <button class="input-group-append btn btn-info" (click)="search(currentSearch)">
                         <fa-icon [icon]="'search'"></fa-icon>
                     </button>
+
                     <button class="input-group-append btn btn-danger" (click)="search('')" *ngIf="currentSearch">
                         <fa-icon [icon]="'trash-alt'"></fa-icon>
                     </button>
@@ -47,136 +53,145 @@
         </div>
     </div>
     <%_ } _%>
-    <br/>
+
     <div class="alert alert-warning" *ngIf="<%= entityInstancePlural %>?.length === 0">
         <span jhiTranslate="<%= i18nKeyPrefix %>.home.notFound">No <%= entityInstancePlural %> found</span>
     </div>
+
     <div class="table-responsive" *ngIf="<%= entityInstancePlural %>?.length > 0">
         <table class="table table-striped" aria-describedby="page-heading">
             <thead>
-            <tr<% if (pagination !== 'no') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="<%= pagination !== 'infinite-scroll' ? 'loadPage.bind(this)' : 'reset.bind(this)'%>"<% } %>>
-            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-            <%_ for (idx in fields) { _%>
-            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= fields[idx].fieldName %>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-            <%_ } _%>
-            <%_ for (idx in relationships) { _%>
-            <%_ if (relationships[idx].relationshipType === 'many-to-one'
-            || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
-            || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
-            const fieldName = dto === 'no' ? "." + relationships[idx].otherEntityField : relationships[idx].otherEntityFieldCapitalized; _%>
-            <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= relationships[idx].relationshipName + (fieldName) %>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
-            <%_ } _%>
-            <%_ } _%>
-            <th scope="col"></th>
-            </tr>
-            </thead>
-            <tbody<% if (pagination === 'infinite-scroll') { %> infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']" [infiniteScrollDistance]="0"<% } %>>
-            <tr *ngFor="let <%= entityInstance %> of <%= entityInstancePlural %> ;trackBy: trackId">
-                <td><a [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view' ]">{{<%= entityInstance %>.id}}</a></td>
-                <%_ for (idx in fields) {
-                const fieldName = fields[idx].fieldName;
-                const fieldNameCapitalized = fields[idx].fieldNameCapitalized;
-                const fieldType = fields[idx].fieldType;
-                const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent; _%>
-                <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
-                <td>
-                    <a *ngIf="<%= entityInstance %>.<%= fieldName %>" (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)">
-                        <img [src]="'data:' + <%= entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-height: 30px;" alt="<%= entityInstance %> image"/>
-                    </a>
-                    <span *ngIf="<%= entityInstance %>.<%= fieldName %>">{{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}</span>
-                </td>
-                <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'any') { _%>
-                <td>
-                    <a *ngIf="<%= entityInstance %>.<%= fieldName %>" (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)" jhiTranslate="entity.action.open">open</a>
-                    <span *ngIf="<%= entityInstance %>.<%= fieldName %>">{{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}</span>
-                </td>
-                <%_ } else if (fields[idx].fieldIsEnum) { _%>
-                <td jhiTranslate="{{'<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>}}">{{<%= entityInstance %>.<%= fieldName %>}}</td>
-                <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
-                <td>{{<%= entityInstance %>.<%= fieldName %> | date:'medium'}}</td>
-                <%_ } else if (fieldType === 'LocalDate') { _%>
-                <td>{{<%= entityInstance %>.<%= fieldName %> | date:'mediumDate'}}</td>
-                <%_ } else { _%>
-                <td>{{<%= entityInstance %>.<%= fieldName %>}}</td>
-                <%_ } _%>
-                <%_ } _%>
-                <%_ for (idx in relationships) {
-                const relationshipType = relationships[idx].relationshipType;
-                const ownerSide = relationships[idx].ownerSide;
-                const relationshipFieldName = relationships[idx].relationshipFieldName;
-                const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                const otherEntityName = relationships[idx].otherEntityName;
-                const otherEntityStateName = relationships[idx].otherEntityStateName;
-                const otherEntityField = relationships[idx].otherEntityField;
-                const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized; _%>
-                <%_ if (relationshipType === 'many-to-one'
-                || (relationshipType === 'one-to-one' && ownerSide === true)
-                || (relationshipType === 'many-to-many' && ownerSide === true && pagination === 'no')) { _%>
-                <td>
-                    <%_ if (otherEntityName === 'user') { _%>
-                        <%_ if (relationshipType === 'many-to-many') { _%>
-                    <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>; let last = last">
-                            {{<%= relationshipFieldName %>.<%= otherEntityField %>}}{{last ? '' : ', '}}
-                        </span>
-                        <%_ } else { _%>
-                            <%_ if (dto === 'no') { _%>
-                    {{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}
-                            <%_ } else { _%>
-                    {{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}
-                            <%_ } _%>
-                        <%_ } _%>
-                    <%_ } else { _%>
-                        <%_ if (relationshipType === 'many-to-many') { _%>
-                    <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>; let last = last">
-                            <a class="form-control-static" [routerLink]="['/<%= otherEntityStateName %>', <%= relationshipFieldName %>?.id, 'view' ]">{{<%= relationshipFieldName %>.<%= otherEntityField %>}}</a>{{last ? '' : ', '}}
-                        </span>
-                        <%_ } else { _%>
-                            <%_ if (dto === 'no') { _%>
-                    <div *ngIf="<%= entityInstance + "." + relationshipFieldName %>">
-                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "?.id" %>, 'view' ]" >{{<%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %>}}</a>
-                    </div>
-                        <%_ } else { _%>
-                    <div *ngIf="<%= entityInstance + "." + relationshipFieldName + "Id" %>">
-                        <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "Id" %> %>, 'view' ]" >{{<%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %>}}</a>
-                    </div>
-                            <%_ } _%>
+                <tr<% if (pagination !== 'no') { %> jhiSort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="<%= pagination !== 'infinite-scroll' ? 'loadPage.bind(this)' : 'reset.bind(this)'%>"<% } %>>
+                    <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="id"<% } %>><span jhiTranslate="global.field.id">ID</span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                    <%_ for (idx in fields) { _%>
+                    <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= fields[idx].fieldName %>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
+                    <%_ } _%>
+                    <%_ for (idx in relationships) { _%>
+                        <%_ if (relationships[idx].relationshipType === 'many-to-one'
+                                || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
+                                || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
+                            const fieldName = dto === 'no' ? "." + relationships[idx].otherEntityField : relationships[idx].otherEntityFieldCapitalized;
+                        _%>
+                    <th scope="col" <% if (pagination !== 'no') { %> jhiSortBy="<%= relationships[idx].relationshipName + (fieldName) %>"<% } %>><span jhiTranslate="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <fa-icon [icon]="'sort'"></fa-icon><% } %></th>
                         <%_ } _%>
                     <%_ } _%>
-                </td>
+                    <th scope="col"></th>
+                </tr>
+            </thead>
+            <tbody<% if (pagination === 'infinite-scroll') { %> infinite-scroll (scrolled)="loadPage(page + 1)" [infiniteScrollDisabled]="page >= links['last']" [infiniteScrollDistance]="0"<% } %>>
+                <tr *ngFor="let <%= entityInstance %> of <%= entityInstancePlural %> ;trackBy: trackId">
+                    <td><a [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view']">{{ <%= entityInstance %>.id }}</a></td>
+                <%_ for (idx in fields) {
+                    const fieldName = fields[idx].fieldName;
+                    const fieldNameCapitalized = fields[idx].fieldNameCapitalized;
+                    const fieldType = fields[idx].fieldType;
+                    const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
+                _%>
+                    <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
+                    <td>
+                        <a *ngIf="<%= entityInstance %>.<%= fieldName %>" (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)">
+                            <img [src]="'data:' + <%= entityInstance %>.<%= fieldName %>ContentType + ';base64,' + <%= entityInstance %>.<%= fieldName %>" style="max-height: 30px;" alt="<%= entityInstance %> image"/>
+                        </a>
+                        <span *ngIf="<%= entityInstance %>.<%= fieldName %>">{{ <%= entityInstance %>.<%= fieldName %>ContentType }}, {{ byteSize(<%= entityInstance %>.<%= fieldName %>) }}</span>
+                    </td>
+                    <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'any') { _%>
+                    <td>
+                        <a *ngIf="<%= entityInstance %>.<%= fieldName %>" (click)="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)" jhiTranslate="entity.action.open">open</a>
+                        <span *ngIf="<%= entityInstance %>.<%= fieldName %>">{{ <%= entityInstance %>.<%= fieldName %>ContentType }}, {{ byteSize(<%= entityInstance %>.<%= fieldName %>) }}</span>
+                    </td>
+                    <%_ } else if (fields[idx].fieldIsEnum) { _%>
+                    <td jhiTranslate="{{ '<%= angularAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %> }}">{{ <%= entityInstance %>.<%= fieldName %> }}</td>
+                    <%_ } else if (['Instant', 'ZonedDateTime'].includes(fieldType)) { _%>
+                    <td>{{ <%= entityInstance %>.<%= fieldName %> | date:'medium' }}</td>
+                    <%_ } else if (fieldType === 'LocalDate') { _%>
+                    <td>{{ <%= entityInstance %>.<%= fieldName %> | date:'mediumDate' }}</td>
+                    <%_ } else { _%>
+                    <td>{{ <%= entityInstance %>.<%= fieldName %> }}</td>
+                    <%_ } _%>
                 <%_ } _%>
-                <%_ } _%>
-                <td class="text-right">
-                    <div class="btn-group">
-                        <button type="submit"
-                                [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view' ]"
-                                class="btn btn-info btn-sm">
-                            <fa-icon [icon]="'eye'"></fa-icon>
-                            <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
-                        </button>
-                        <%_ if (!readOnly) { _%>
-                        <button type="submit"
-                                [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'edit']"
-                                class="btn btn-primary btn-sm">
-                            <fa-icon [icon]="'pencil-alt'"></fa-icon>
-                            <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
-                        </button>
-                        <button type="submit" (click)="delete(<%= entityInstance %>)"
-                                class="btn btn-danger btn-sm">
-                            <fa-icon [icon]="'times'"></fa-icon>
-                            <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
-                        </button>
+                <%_ for (idx in relationships) {
+                    const relationshipType = relationships[idx].relationshipType;
+                    const ownerSide = relationships[idx].ownerSide;
+                    const relationshipFieldName = relationships[idx].relationshipFieldName;
+                    const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+                    const otherEntityName = relationships[idx].otherEntityName;
+                    const otherEntityStateName = relationships[idx].otherEntityStateName;
+                    const otherEntityField = relationships[idx].otherEntityField;
+                    const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+                _%>
+                    <%_ if (relationshipType === 'many-to-one'
+                            || (relationshipType === 'one-to-one' && ownerSide === true)
+                            || (relationshipType === 'many-to-many' && ownerSide === true && pagination === 'no')) {
+                    _%>
+                    <td>
+                        <%_ if (otherEntityName === 'user') { _%>
+                            <%_ if (relationshipType === 'many-to-many') { _%>
+                        <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>; let last = last">
+                            {{ <%= relationshipFieldName %>.<%= otherEntityField %> }}{{ last ? '' : ', ' }}
+                        </span>
+                            <%_ } else { _%>
+                                <%_ if (dto === 'no') { _%>
+                        {{ <%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %> }}
+                                <%_ } else { _%>
+                        {{ <%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> }}
+                                <%_ } _%>
+                            <%_ } _%>
+                        <%_ } else { _%>
+                            <%_ if (relationshipType === 'many-to-many') { _%>
+                        <span *ngFor="let <%= relationshipFieldName %> of <%= entityInstance %>.<%= relationshipFieldNamePlural %>; let last = last">
+                            <a class="form-control-static" [routerLink]="['/<%= otherEntityStateName %>', <%= relationshipFieldName %>?.id, 'view']">{{ <%= relationshipFieldName %>.<%= otherEntityField %> }}</a>{{ last ? '' : ', ' }}
+                        </span>
+                            <%_ } else { _%>
+                                <%_ if (dto === 'no') { _%>
+                        <div *ngIf="<%= entityInstance + "." + relationshipFieldName %>">
+                            <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "?.id" %>, 'view']" >{{ <%= entityInstance + "." + relationshipFieldName + "?." + otherEntityField %> }}</a>
+                        </div>
+                            <%_ } else { _%>
+                        <div *ngIf="<%= entityInstance + "." + relationshipFieldName + "Id" %>">
+                            <a [routerLink]="['/<%= otherEntityStateName %>', <%= entityInstance + "." + relationshipFieldName + "Id" %> %>, 'view']" >{{ <%= entityInstance + "." + relationshipFieldName + otherEntityFieldCapitalized %> }}</a>
+                        </div>
+                                <%_ } _%>
+                            <%_ } _%>
                         <%_ } _%>
-                    </div>
-                </td>
-            </tr>
+                    </td>
+                    <%_ } _%>
+                <%_ } _%>
+                    <td class="text-right">
+                        <div class="btn-group">
+                            <button type="submit"
+                                    [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'view']"
+                                    class="btn btn-info btn-sm">
+                                <fa-icon [icon]="'eye'"></fa-icon>
+                                <span class="d-none d-md-inline" jhiTranslate="entity.action.view">View</span>
+                            </button>
+                            <%_ if (!readOnly) { _%>
+
+                            <button type="submit"
+                                    [routerLink]="['/<%= entityUrl %>', <%= entityInstance %>.id, 'edit']"
+                                    class="btn btn-primary btn-sm">
+                                <fa-icon [icon]="'pencil-alt'"></fa-icon>
+                                <span class="d-none d-md-inline" jhiTranslate="entity.action.edit">Edit</span>
+                            </button>
+
+                            <button type="submit" (click)="delete(<%= entityInstance %>)"
+                                    class="btn btn-danger btn-sm">
+                                <fa-icon [icon]="'times'"></fa-icon>
+                                <span class="d-none d-md-inline" jhiTranslate="entity.action.delete">Delete</span>
+                            </button>
+                            <%_ } _%>
+                        </div>
+                    </td>
+                </tr>
             </tbody>
         </table>
     </div>
     <%_ if (pagination === 'pagination') { _%>
+
     <div *ngIf="<%= entityInstancePlural %>?.length > 0">
         <div class="row justify-content-center">
             <jhi-item-count [page]="page" [total]="totalItems" [itemsPerPage]="itemsPerPage"></jhi-item-count>
         </div>
+
         <div class="row justify-content-center">
             <ngb-pagination [collectionSize]="totalItems" [(page)]="ngbPaginationPage" [pageSize]="itemsPerPage" [maxSize]="5" [rotate]="true" [boundaryLinks]="true" (pageChange)="loadPage($event)"></ngb-pagination>
         </div>

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
@@ -77,7 +77,7 @@ describe('Component Tests', () => {
                 spyOn(service, 'delete');
 
                 // WHEN
-                comp.clear();
+                comp.cancel();
 
                 // THEN
                 expect(service.delete).not.toHaveBeenCalled();

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -104,7 +104,7 @@ describe('Service Tests', () => {
 
                 service.find(<%- tsKeyId %>).subscribe(resp => expectedResult = resp.body);
 
-                const req  = httpMock.expectOne({ method: 'GET' });
+                const req = httpMock.expectOne({ method: 'GET' });
                 req.flush(returnedFromService);
                 expect(expectedResult).toMatchObject(elemDefault);
             });
@@ -142,7 +142,7 @@ describe('Service Tests', () => {
 
                 service.create(new <%= entityAngularName %>()).subscribe(resp => expectedResult = resp.body);
 
-                const req  = httpMock.expectOne({ method: 'POST' });
+                const req = httpMock.expectOne({ method: 'POST' });
                 req.flush(returnedFromService);
                 expect(expectedResult).toMatchObject(expected);
             });
@@ -182,7 +182,7 @@ describe('Service Tests', () => {
 
                 service.update(expected).subscribe(resp => expectedResult = resp.body);
 
-                const req  = httpMock.expectOne({ method: 'PUT' });
+                const req = httpMock.expectOne({ method: 'PUT' });
                 req.flush(returnedFromService);
                 expect(expectedResult).toMatchObject(expected);
             });
@@ -221,9 +221,9 @@ describe('Service Tests', () => {
                 <%_ }) _%>
                 }, returnedFromService);
 
-                service.query().subscribe(resp  => expectedResult = resp.body);
+                service.query().subscribe(resp => expectedResult = resp.body);
 
-                const req  = httpMock.expectOne({ method: 'GET' });
+                const req = httpMock.expectOne({ method: 'GET' });
                 req.flush([returnedFromService]);
                 httpMock.verify();
                 expect(expectedResult).toContainEqual(expected);
@@ -233,7 +233,7 @@ describe('Service Tests', () => {
             it('should delete a <%= entityAngularName %>', () => {
                 service.delete(<%- tsKeyId %>).subscribe(resp => expectedResult = resp.ok);
 
-                const req  = httpMock.expectOne({ method: 'DELETE' });
+                const req = httpMock.expectOne({ method: 'DELETE' });
                 req.flush({ status: 200 });
                 expect(expectedResult);
             });

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -872,10 +872,10 @@ module.exports = class extends PrivateBase {
             case 'stripHtml':
                 regex = new RegExp(
                     [
-                        /( (data-t|jhiT)ranslate="([a-zA-Z0-9 +{}'_](\.)?)+")/, // data-translate or jhiTranslate
-                        /( \[translate(-v|V)alues\]="\{([a-zA-Z]|\d|:|\{|\}|\[|\]|-|'|\s|\.|_)*?\}")/, // translate-values or translateValues
-                        /( translate-compile)/, // translate-compile
-                        /( translate-value-max="[0-9{}()|]*")/ // translate-value-max
+                        /([\s\n\r]+(data-t|jhiT)ranslate="([a-zA-Z0-9 +{}'_](\.)?)+")/, // data-translate or jhiTranslate
+                        /([\s\n\r]+\[translate(-v|V)alues\]="\{([a-zA-Z]|\d|:|\{|\}|\[|\]|-|'|\s|\.|_)*?\}")/, // translate-values or translateValues
+                        /([\s\n\r]+translate-compile)/, // translate-compile
+                        /([\s\n\r]+translate-value-max="[0-9{}()|]*")/ // translate-value-max
                     ]
                         .map(r => r.source)
                         .join('|'),

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -286,7 +286,7 @@ function replaceTranslationKeysWithText(body, generator, regex) {
  * @returns string with placeholders replaced
  */
 function replacePlaceholders(body, generator) {
-    const re = /placeholder=['|"]([{]{2}['|"]([a-zA-Z0-9.\-_]+)['|"][\s][|][\s](translate)[}]{2})['|"]/g;
+    const re = /placeholder=['|"]([{]{2}\s*['|"]([a-zA-Z0-9.\-_]+)['|"][\s][|][\s](translate)\s*[}]{2})['|"]/g;
     let match;
 
     // eslint-disable-next-line no-cond-assign


### PR DESCRIPTION
This PR polishes mostly Angular html templates.

Some notes about changes:

* in alerts changed `<p>` to `<span>` to avoid extra space at the bottom of the alert

* moved `<!-- //NOSONAR -->` at the end of the line to make code better readable

* if i18n is disabled then fixed generated html formatting, now all whitespaces (including newlines) are removed before deleted translation attributes

* after adding spaces to placeholders in templates, `utils.`js needed to adjust so that if i18n is disabled then generate correct forms

* replaced `<p></p>` with bootstrap class `mt-3` (https://getbootstrap.com/docs/4.4/utilities/spacing/) - this generates the same spacing as class `form-group`

* in user management and in entity delete dialogs rename method `clear()` to `cancel()` because `x` doesn't mean clearing value there but cancels deletion

* as `translateValues` attributes are removed by generator if i18n is disabled then no need to use `if (enableTranslation) {` in `settings.component.html`


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
