### PR TITLE
Polish spacing and fix one broken license header in Angular

### DIFF
--- a/generators/client/templates/angular/.huskyrc.ejs
+++ b/generators/client/templates/angular/.huskyrc.ejs
@@ -18,6 +18,6 @@
 -%>
 {
   "hooks": {
-     "pre-commit": "lint-staged"
+    "pre-commit": "lint-staged"
   }
 }

--- a/generators/client/templates/angular/angular.json.ejs
+++ b/generators/client/templates/angular/angular.json.ejs
@@ -48,7 +48,7 @@
     }
   },
   "defaultProject": "<%= dasherizedBaseName %>",
-   "cli": {
-     "packageManager": "<%= clientPackageManager %>"
-   }
+  "cli": {
+    "packageManager": "<%= clientPackageManager %>"
+  }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/audits/audits.component.ts.ejs
@@ -26,8 +26,8 @@ import { Audit } from './audit.model';
 import { AuditsService } from './audits.service';
 
 @Component({
-  selector: '<%= jhiPrefixDashed %>-audit',
-  templateUrl: './audits.component.html'
+    selector: '<%= jhiPrefixDashed %>-audit',
+    templateUrl: './audits.component.html'
 })
 export class AuditsComponent implements OnInit {
     audits?: Audit[];

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
@@ -62,8 +62,8 @@ export interface Health {
 }
 
 export interface HealthDetails {
-  status: HealthStatus;
-  details: any;
+    status: HealthStatus;
+    details: any;
 }
 
 @Injectable({providedIn: 'root'})

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/log.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/log.model.ts.ejs
@@ -19,13 +19,13 @@
 export type Level = 'TRACE' | 'DEBUG' | 'INFO' | 'WARN' | 'ERROR' | 'OFF';
 
 export interface Logger {
-  configuredLevel: Level | null;
-  effectiveLevel: Level;
+    configuredLevel: Level | null;
+    effectiveLevel: Level;
 }
 
 export interface LoggersResponse {
-  levels: Level[];
-  loggers: { [key: string]: Logger };
+    levels: Level[];
+    loggers: { [key: string]: Logger };
 }
 
 export class Log {

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -83,26 +83,26 @@ export class AccountService {
     identity(force?: boolean): Observable<Account | null> {
         if (!this.accountCache$ || force || !this.isAuthenticated()) {
             this.accountCache$ = this.fetch().pipe(
-              catchError(() => {
-                return of(null);
-              }),
-              tap((account: Account | null) => {
-                this.authenticate(account);
+                catchError(() => {
+                    return of(null);
+                }),
+                tap((account: Account | null) => {
+                    this.authenticate(account);
 
-                <%_ if (enableTranslation) { _%>
-                // After retrieve the account info, the language will be changed to
-                // the user's preferred language configured in the account setting
-                if (account && account.langKey) {
-                  const langKey = this.sessionStorage.retrieve('locale') || account.langKey;
-                  this.languageService.changeLanguage(langKey);
-                }
-                <%_ } _%>
+                    <%_ if (enableTranslation) { _%>
+                    // After retrieve the account info, the language will be changed to
+                    // the user's preferred language configured in the account setting
+                    if (account && account.langKey) {
+                        const langKey = this.sessionStorage.retrieve('locale') || account.langKey;
+                        this.languageService.changeLanguage(langKey);
+                    }
+                    <%_ } _%>
 
-                if (account) {
-                    this.navigateToStoredUrl();
-                }
-              }),
-              shareReplay()
+                    if (account) {
+                        this.navigateToStoredUrl();
+                    }
+                }),
+                shareReplay()
             );
         }
         return this.accountCache$;

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -29,7 +29,7 @@ import { Login } from 'app/core/login/login.model';
 
 <%_ if (authenticationType !== 'uaa') { _%>
 type JwtToken = {
-  id_token: string;
+    id_token: string;
 };
 <%_ } else { _%>
 export const LOGOUT_URL = SERVER_API_URL + 'auth/logout';

--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker-activity.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker-activity.model.ts.ejs
@@ -1,4 +1,3 @@
 export class TrackerActivity {
     constructor(public sessionId: string, public userLogin: string, public ipAddress: string, public page: string, public time: string) {}
-  }
-  
+}

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.component.ts.ejs
@@ -65,7 +65,7 @@ export class ErrorComponent implements OnInit<% if (enableTranslation) { %>, OnD
     private getErrorMessageTranslation(): void {
         this.errorMessage = '';
         if (this.errorKey) {
-          this.translateService.get(this.errorKey).subscribe(translatedErrorMessage => (this.errorMessage = translatedErrorMessage));
+            this.translateService.get(this.errorKey).subscribe(translatedErrorMessage => (this.errorMessage = translatedErrorMessage));
         }
     }
     <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -146,15 +146,15 @@
             <%_ } _%>
             <li ngbDropdown class="nav-item dropdown pointer" display="dynamic" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
                 <a class="nav-link dropdown-toggle" ngbDropdownToggle href="javascript:void(0);" id="account-menu">
-                  <span *ngIf="!getImageUrl()">
-                    <fa-icon icon="user"></fa-icon>
-                    <span jhiTranslate="global.menu.account.main">
-                      Account
+                    <span *ngIf="!getImageUrl()">
+                        <fa-icon icon="user"></fa-icon>
+                        <span jhiTranslate="global.menu.account.main">
+                            Account
+                        </span>
                     </span>
-                  </span>
-                  <span *ngIf="getImageUrl()">
-                      <img [src]="getImageUrl()" class="profile-image rounded-circle" alt="Avatar">
-                  </span>
+                    <span *ngIf="getImageUrl()">
+                        <img [src]="getImageUrl()" class="profile-image rounded-circle" alt="Avatar">
+                    </span>
                 </a>
                 <ul class="dropdown-menu" ngbDropdownMenu aria-labelledby="account-menu">
                     <%_ if (!skipUserManagement) { _%>

--- a/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/global.scss.ejs
@@ -1,17 +1,21 @@
-<%#Copyright 2013-2020 the original author or authors from the JHipster project.
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
- This file is part of the JHipster project, see https://www.jhipster.tech/ for
-        more information. Licensed under the Apache License,
-    Version 2 (the "License");
-youmay not use this file except in compliance with the License.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
  You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0 Unless
-        required by applicable law or agreed to in writing,
-    software distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
-    either express or implied. See the License for the specific language
-        governing permissions and limitations under the License. -%>
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 @import "bootstrap-variables";
 @import '~bootstrap/scss/functions';
 <%_ if (clientTheme !== 'none') { _%>

--- a/generators/client/templates/angular/src/main/webapp/manifest.webapp.ejs
+++ b/generators/client/templates/angular/src/main/webapp/manifest.webapp.ejs
@@ -2,26 +2,26 @@
   "name": "<%= angularXAppName %>",
   "short_name": "<%= angularXAppName %>",
   "icons": [
-      {
-          "src": "./content/images/<%= hipster %>_head-192.png",
-          "sizes": "192x192",
-          "type": "image/png"
-      },
-      {
-          "src": "./content/images/<%= hipster %>_head-256.png",
-          "sizes": "256x256",
-          "type": "image/png"
-      },
-      {
-          "src": "./content/images/<%= hipster %>_head-384.png",
-          "sizes": "384x384",
-          "type": "image/png"
-      },
-      {
-          "src": "./content/images/<%= hipster %>_head-512.png",
-          "sizes": "512x512",
-          "type": "image/png"
-      }
+    {
+      "src": "./content/images/<%= hipster %>_head-192.png",
+      "sizes": "192x192",
+      "type": "image/png"
+    },
+    {
+      "src": "./content/images/<%= hipster %>_head-256.png",
+      "sizes": "256x256",
+      "type": "image/png"
+    },
+    {
+      "src": "./content/images/<%= hipster %>_head-384.png",
+      "sizes": "384x384",
+      "type": "image/png"
+    },
+    {
+      "src": "./content/images/<%= hipster %>_head-512.png",
+      "sizes": "512x512",
+      "type": "image/png"
+    }
   ],
   "theme_color": "#000000",
   "background_color": "#e0e0e0",

--- a/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
+++ b/generators/client/templates/angular/src/test/javascript/jest.conf.js.ejs
@@ -31,28 +31,28 @@ module.exports = {
 function mapTypescriptAliasToJestAlias(alias = {}) {
     const jestAliases = { ...alias };
     if (!tsconfig.compilerOptions.paths) {
-      return jestAliases;
+        return jestAliases;
     }
     Object.entries(tsconfig.compilerOptions.paths)
-      .filter(([key, value]) => {
-        // use Typescript alias in Jest only if this has value
-        if (value.length) {
-          return true;
-        }
-        return false;
-      })
-      .map(([key, value]) => {
-        // if Typescript alias ends with /* then in Jest:
-        // - alias key must end with /(.*)
-        // - alias value must end with /$1
-        const regexToReplace = /(.*)\/\*$/;
-        const aliasKey = key.replace(regexToReplace, '$1/(.*)');
-        const aliasValue = value[0].replace(regexToReplace, '$1/$$1');
-        return [aliasKey, `<rootDir>/${aliasValue}`];
-      })
-      .reduce((aliases, [key, value]) => {
-        aliases[key] = value;
-        return aliases;
-      }, jestAliases);
+        .filter(([key, value]) => {
+            // use Typescript alias in Jest only if this has value
+            if (value.length) {
+                return true;
+            }
+            return false;
+        })
+        .map(([key, value]) => {
+            // if Typescript alias ends with /* then in Jest:
+            // - alias key must end with /(.*)
+            // - alias value must end with /$1
+            const regexToReplace = /(.*)\/\*$/;
+            const aliasKey = key.replace(regexToReplace, '$1/(.*)');
+            const aliasValue = value[0].replace(regexToReplace, '$1/$$1');
+            return [aliasKey, `<rootDir>/${aliasValue}`];
+        })
+        .reduce((aliases, [key, value]) => {
+            aliases[key] = value;
+            return aliases;
+        }, jestAliases);
     return jestAliases;
-  }
+}

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts.ejs
@@ -54,7 +54,7 @@ describe('Component Tests', () => {
                 expect(comp.measureStrength('Aa090(**)+-07365')).toBeGreaterThanOrEqual(comp.measureStrength('Aa090(**)'));
             });
 
-             it('should change the color based on strength', () => {
+            it('should change the color based on strength', () => {
                 expect(comp.getColor(0).color).toBe(comp.colors[0]);
                 expect(comp.getColor(11).color).toBe(comp.colors[1]);
                 expect(comp.getColor(22).color).toBe(comp.colors[2]);

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
@@ -40,7 +40,7 @@ describe('Component Tests', () => {
             login: 'john',
             authorities: [],
             imageUrl: ''
-          };
+        };
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/audits/audits.component.spec.ts.ejs
@@ -37,12 +37,12 @@ function getDate(isToday = true): string {
         // Today + 1 day - needed if the current day must be included
         date.setDate(date.getDate() + 1);
     } else {
-      // get last month
-      if (date.getMonth() === 0) {
-        date = new Date(date.getFullYear() - 1, 11, date.getDate());
-      } else {
-        date = new Date(date.getFullYear(), date.getMonth() - 1, date.getDate());
-      }
+        // get last month
+        if (date.getMonth() === 0) {
+            date = new Date(date.getFullYear() - 1, 11, date.getDate());
+        } else {
+            date = new Date(date.getFullYear(), date.getMonth() - 1, date.getDate());
+        }
     }
     const monthString = build2DigitsDatePart(date.getMonth() + 1);
     const dateString = build2DigitsDatePart(date.getDate());

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -23,16 +23,16 @@ import { MockRouter } from '../../../helpers/mock-route.service';
 import { MockStateStorageService } from '../../../helpers/mock-state-storage.service';
 
 function accountWithAuthorities(authorities: string[]): Account {
-  return {
-    activated: true,
-    authorities,
-    email: '',
-    firstName: '',
-    langKey: '',
-    lastName: '',
-    login: '',
-    imageUrl: ''
-  };
+    return {
+        activated: true,
+        authorities,
+        email: '',
+        firstName: '',
+        langKey: '',
+        lastName: '',
+        login: '',
+        imageUrl: ''
+    };
 }
 
 describe('Service Tests', () => {
@@ -44,7 +44,7 @@ describe('Service Tests', () => {
         <%_ if (websocket === 'spring-websocket') { _%>
         let trackerService: TrackerService;
         <%_ } _%>
-    
+
         beforeEach(() => {
             TestBed.configureTestingModule({
                 imports: [

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
@@ -1,20 +1,20 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-This file is part of the JHipster project, see https://www.jhipster.tech/
-for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
@@ -45,6 +45,7 @@ describe('Component Tests', () => {
                 expect(comp.alerts.length).toBe(1);
                 expect(comp.alerts[0].msg).toBe(<% if (enableTranslation) { %>'error.server.not.reachable'<% } else { %>'Server not reachable'<% } %>);
             });
+
             it('Should display an alert on status 404', () => {
                 // GIVEN
                 eventManager.broadcast({name: '<%= angularAppName %>.httpError', content: {status: 404}});
@@ -52,6 +53,7 @@ describe('Component Tests', () => {
                 expect(comp.alerts.length).toBe(1);
                 expect(comp.alerts[0].msg).toBe(<% if (enableTranslation) { %>'error.url.not.found'<% } else { %>'Not found'<% } %>);
             });
+
             it('Should display an alert on generic error', () => {
                 // GIVEN
                 eventManager.broadcast({name: '<%= angularAppName %>.httpError', content: {error: {message: "Error Message"}}});
@@ -61,39 +63,42 @@ describe('Component Tests', () => {
                 expect(comp.alerts[0].msg).toBe('Error Message');
                 expect(comp.alerts[1].msg).toBe('Second Error Message');
             });
-           it('Should display an alert on status 400 for generic error', () => {
+
+            it('Should display an alert on status 400 for generic error', () => {
                 // GIVEN
                 const response = new HttpErrorResponse({
-                   url: "http://localhost:8080/api/foos",
-                   headers: new HttpHeaders(),
-                   status: 400,
-                   statusText: 'Bad Request',
-                   error: {
-                       "type":"https://www.jhipster.tech/problem/constraint-violation",
-                       "title":"Bad Request",
-                       "status":400,
-                       "path":"/api/foos",
-                       "message":"error.validation"
-                   }
+                    url: "http://localhost:8080/api/foos",
+                    headers: new HttpHeaders(),
+                    status: 400,
+                    statusText: 'Bad Request',
+                    error: {
+                        "type":"https://www.jhipster.tech/problem/constraint-violation",
+                        "title":"Bad Request",
+                        "status":400,
+                        "path":"/api/foos",
+                        "message":"error.validation"
+                    }
                 });
                 eventManager.broadcast({name: '<%= angularAppName %>.httpError', content: response});
                 // THEN
                 expect(comp.alerts.length).toBe(1);
                 expect(comp.alerts[0].msg).toBe('error.validation');
             });
-           it('Should display an alert on status 400 for generic error without message', () => {
+
+            it('Should display an alert on status 400 for generic error without message', () => {
                 // GIVEN
                 const response = new HttpErrorResponse({
-                   url: "http://localhost:8080/api/foos",
-                   headers: new HttpHeaders(),
-                   status: 400,
-                   error: "Bad Request"
+                    url: "http://localhost:8080/api/foos",
+                    headers: new HttpHeaders(),
+                    status: 400,
+                    error: "Bad Request"
                 });
                 eventManager.broadcast({name: '<%= angularAppName %>.httpError', content: response});
                 // THEN
                 expect(comp.alerts.length).toBe(1);
                 expect(comp.alerts[0].msg).toBe('Bad Request');
             });
+
             it('Should display an alert on status 400 for invalid parameters', () => {
                 // GIVEN
                 const response = new HttpErrorResponse({
@@ -115,6 +120,7 @@ describe('Component Tests', () => {
                 expect(comp.alerts.length).toBe(1);
                 expect(comp.alerts[0].msg).toBe(<% if (enableTranslation) { %>'error.Size'<% } else { %>'Error on field "MinField"'<% } %>);
             });
+
             it('Should display an alert on status 400 for error headers', () => {
                 // GIVEN
                 const response = new HttpErrorResponse({

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/login/login.component.spec.ts.ejs
@@ -1,20 +1,20 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-This file is part of the JHipster project, see https://www.jhipster.tech/
-for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-     http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
 import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';

--- a/generators/client/templates/angular/webpack/utils.js.ejs
+++ b/generators/client/templates/angular/webpack/utils.js.ejs
@@ -21,8 +21,8 @@ const path = require('path');
 const tsconfig = require('../tsconfig.json');
 
 module.exports = {
-    root,
-    mapTypescriptAliasToWebpackAlias
+  root,
+  mapTypescriptAliasToWebpackAlias
 };
 
 const _root = path.resolve(__dirname, '..');

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -91,7 +91,7 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                 {
                     loader: 'cache-loader',
                     options: {
-                      cacheDirectory: path.resolve('<%= BUILD_DIR %>cache-loader')
+                        cacheDirectory: path.resolve('<%= BUILD_DIR %>cache-loader')
                     }
                 },
                 {

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -165,9 +165,9 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
             debug: false
         }),
         new WorkboxPlugin.GenerateSW({
-          clientsClaim: true,
-          skipWaiting: true,
-          exclude: [/swagger-ui/]
+            clientsClaim: true,
+            skipWaiting: true,
+            exclude: [/swagger-ui/]
         })
     ],
     mode: 'production'

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -275,7 +275,7 @@ _%>
 
     private createFromForm(): I<%= entityAngularName %> {
         return {
-                       ...new <%= entityAngularName %>(),
+            ...new <%= entityAngularName %>(),
             id: this.editForm.get(['id'])!.value,
     <%_ for (idx in fields) {
         const fieldName = fields[idx].fieldName;

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -99,7 +99,7 @@ describe('<%= entityClass %> e2e test', () => {
         await <%= entityInstance %>UpdatePage.cancel();
     });
 
-   <%= openBlockComment %>it('should create and save <%= entityClassPlural %>', async () => {
+    <%= openBlockComment %>it('should create and save <%= entityClassPlural %>', async () => {
         const nbButtonsBeforeCreate = await <%= entityInstance %>ComponentsPage.countDeleteButtons();
 
         await <%= entityInstance %>ComponentsPage.clickOnCreateButton();


### PR DESCRIPTION
This PR:
* tries to achieve consistent 2 or 4 space indentation inside each specific file to make templates as readable as possible
* fixes one corrupted licence header
* uses standard spacing in 2 differently spaced license headers

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
