### PR TITLE
Fix self referencing entities in Angular

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -27,7 +27,9 @@ const enumImports = generateEntityClientEnumImports(fields);
 import { Moment } from 'moment';
 <%_ } _%>
 <%_ typeImports.forEach((importedPath, importedType) => { _%>
+    <%_ if (importedType !== `I${entityAngularName}`) { _%> 
 import { <%- importedType %> } from '<%- importedPath %>';
+    <%_ } _%>
 <%_ }); _%>
 <%_ enumImports.forEach((importedPath, importedType) => { _%>
 import { <%- importedType %> } from '<%- importedPath %>';


### PR DESCRIPTION
If using self referencing entity like
```
entity MyEntity {
    name String required
}
relationship OneToMany {
    MyEntity{childEntity} to MyEntity{parentEntity(name)}
}
```
then Visual Studio Code complains in generated file `src\main\webapp\app\shared\model\my-entity.model.ts` in generated line (self import) `import { IMyEntity } from 'app/shared/model/my-entity.model';` : **Import declaration conflicts with local declaration of 'IMyEntity'.ts(2440)**

Webpack compiles this file successfully.

But it's better not to generate self import so that Visual Studio Code doesn't show error any more.

This PR removes this self import.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
