### PR TITLE
Fix duplicate email adress.

### DIFF
--- a/generators/server/templates/src/main/resources/config/couchmove/changelog/V0.1__initial_setup/user__anonymoususer.json.ejs
+++ b/generators/server/templates/src/main/resources/config/couchmove/changelog/V0.1__initial_setup/user__anonymoususer.json.ejs
@@ -5,7 +5,7 @@
     <% } %>
     "first_name": "Anonymous",
     "last_name": "User",
-    "email": "admin@localhost",
+    "email": "anonymous@localhost",
     "activated": true,
     "lang_key": "<%= nativeLanguage %>",
     "created_by": "system",


### PR DESCRIPTION
The initial changeset for CouchBD contains the same email address for the administrative and the anonymous user. This PR fixes it.