### PR TITLE
add gradle wrapper validation step to generated ci

### DIFF
--- a/generators/ci-cd/templates/github-ci.yml.ejs
+++ b/generators/ci-cd/templates/github-ci.yml.ejs
@@ -19,6 +19,14 @@
 name: Application CI
 on: [push, pull_request]
 jobs:
+    <%_ if (buildTool === 'gradle') { _%>
+    validation:
+        name: "Gradle Wrapper Validation"
+        runs-on: ubuntu-latest
+        steps:
+            - uses: actions/checkout@v2
+            - uses: gradle/wrapper-validation-action@v1
+    <%_ } _%>   
     pipeline:
         name: <%= baseName %> pipeline
         runs-on: ubuntu-latest


### PR DESCRIPTION
This add a validation action to our generated github actions which validates the gradle wrapper checksum. Will see if we can do it for the generator too. For details see here https://github.com/gradle/wrapper-validation-action

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
