### PR TITLE
Make webpack copyExternalAssets needle function usable

### DIFF
--- a/generators/client/needle-api/needle-client-webpack.js
+++ b/generators/client/needle-api/needle-client-webpack.js
@@ -19,18 +19,15 @@
 const needleClient = require('./needle-client');
 const constants = require('../../generator-constants');
 
-const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 const CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
 
 module.exports = class extends needleClient {
-    copyExternalAssets(sourceFolder, targetFolder) {
+    copyExternalAssets(source, target) {
         const errorMessage = 'Resource path not added to JHipster app.';
-        const from = `${CLIENT_MAIN_SRC_DIR}content/${sourceFolder}/`;
-        const to = `content/${targetFolder}/`;
         const webpackDevPath = `${CLIENT_WEBPACK_DIR}/webpack.common.js`;
         let assetBlock = '';
-        if (sourceFolder && targetFolder) {
-            assetBlock = `{ from: './${from}', to: '${to}' },`;
+        if (source && target) {
+            assetBlock = `{ from: '${source}', to: '${target}' },`;
         }
         const rewriteFileModel = this.generateFileModel(webpackDevPath, 'jhipster-needle-add-assets-to-webpack', assetBlock);
 

--- a/test/needle-api/needle-client-webpack.spec.js
+++ b/test/needle-api/needle-client-webpack.spec.js
@@ -4,7 +4,6 @@ const helpers = require('yeoman-test');
 const ClientGenerator = require('../../generators/client');
 const constants = require('../../generators/generator-constants');
 
-const CLIENT_MAIN_SRC_DIR = constants.CLIENT_MAIN_SRC_DIR;
 const CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
 const assetFrom = 'source';
 const assetTo = 'target';
@@ -75,9 +74,6 @@ describe('needle API Webpack: JHipster client generator with blueprint', () => {
             .on('end', done);
     });
     it('Assert external asset is added to webpack.common.js', () => {
-        const from = `${CLIENT_MAIN_SRC_DIR}content/${assetFrom}/`;
-        const to = `content/${assetTo}/`;
-
-        assert.fileContent(`${CLIENT_WEBPACK_DIR}/webpack.common.js`, `{ from: './${from}', to: '${to}' },`);
+        assert.fileContent(`${CLIENT_WEBPACK_DIR}/webpack.common.js`, `{ from: '${assetFrom}', to: '${assetTo}' },`);
     });
 });


### PR DESCRIPTION
Closes #11037

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
