### PR TITLE
Add Windows-only script formats to .gitattributes template

### DIFF
--- a/generators/common/templates/gitattributes.ejs
+++ b/generators/common/templates/gitattributes.ejs
@@ -8,6 +8,8 @@
 # These files are text and should be normalized (Convert crlf => lf)
 
 *.bat           text eol=crlf
+*.cmd           text eol=crlf
+*.ps1           text eol=crlf
 *.coffee        text
 *.css           text
 *.cql           text


### PR DESCRIPTION
Add CMD ( `.cmd` ) and PowerShell ( `.ps1` ) file extensions to `.gitattributes` template, forcing CRLF.

Just for Windows users who runs `mvnw.cmd` directly. 😄 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
