### PR TITLE
Proposal: Remove explicit definition of database platform in Spring configuration

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -143,29 +143,10 @@ spring:
             enabled: false
     <%_ } _%>
     jpa:
-        <%_ if (devDatabaseType === 'mysql') { _%>
-        database-platform: org.hibernate.dialect.MySQL8Dialect
-        <%_ } else if (devDatabaseType === 'mariadb') { _%>
-        database-platform: org.hibernate.dialect.MariaDB103Dialect
-        <%_ } else if (devDatabaseType === 'postgresql') { _%>
+        <%_ if (devDatabaseType === 'postgresql') { _%>
         database-platform: io.github.jhipster.domain.util.FixedPostgreSQL10Dialect
-        <%_ } else if (devDatabaseType === 'oracle') { _%>
-        database-platform: org.hibernate.dialect.Oracle12cDialect
-        <%_ } else if (devDatabaseType === 'mssql') { _%>
-        database-platform: org.hibernate.dialect.SQLServer2012Dialect
-        <%_ } else { _%>
+        <%_ } else if (devDatabaseType === 'h2disk' || devDatabaseType === 'h2Memory') { _%>
         database-platform: io.github.jhipster.domain.util.FixedH2Dialect
-        <%_ } _%>
-        <%_ if (devDatabaseType === 'mysql' || devDatabaseType === 'mariadb') { _%>
-        database: MYSQL
-        <%_ } else if (devDatabaseType === 'postgresql') { _%>
-        database: POSTGRESQL
-        <%_ } else if (devDatabaseType === 'oracle') { _%>
-        database: ORACLE
-        <%_ } else if (devDatabaseType === 'mssql') { _%>
-        database: SQL_SERVER
-        <%_ } else { _%>
-        database: H2
         <%_ } _%>
         show-sql: true
         properties:

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -116,29 +116,8 @@ spring:
                 useServerPrepStmts: true
         <%_ } _%>
     jpa:
-        <%_ if (prodDatabaseType === 'mysql') { _%>
-        database-platform: org.hibernate.dialect.MySQL8Dialect
-        <%_ } else if (prodDatabaseType === 'mariadb') { _%>
-        database-platform: org.hibernate.dialect.MariaDB103Dialect
-        <%_ } else if (prodDatabaseType === 'postgresql') { _%>
+        <%_ if (prodDatabaseType === 'postgresql') { _%>
         database-platform: io.github.jhipster.domain.util.FixedPostgreSQL10Dialect
-        <%_ } else if (prodDatabaseType === 'oracle') { _%>
-        database-platform: org.hibernate.dialect.Oracle12cDialect
-        <%_ } else if (prodDatabaseType === 'mssql') { _%>
-        database-platform: org.hibernate.dialect.SQLServer2012Dialect
-        <%_ } else { _%>
-        database-platform: org.hibernate.dialect.HSQLDialect
-        <%_ } _%>
-        <%_ if (prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb') { _%>
-        database: MYSQL
-        <%_ } else if (prodDatabaseType === 'postgresql') { _%>
-        database: POSTGRESQL
-        <%_ } else if (prodDatabaseType === 'oracle') { _%>
-        database: ORACLE
-        <%_ } else if (prodDatabaseType === 'mssql') { _%>
-        database: SQL_SERVER
-        <%_ } else { _%>
-        database: HSQL
         <%_ } _%>
         show-sql: false
         properties:

--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -59,7 +59,6 @@ spring:
     <%_ if (databaseType === 'sql') { _%>
     jpa:
         database-platform: io.github.jhipster.domain.util.FixedH2Dialect
-        database: H2
         open-in-view: false
         show-sql: false
         hibernate:


### PR DESCRIPTION
See https://github.com/spring-projects/spring-boot/wiki/Spring-Boot-2.2-Release-Notes : 
>  Spring Boot now lets Hibernate chose the dialect to use rather than applying a default dialect based on the detected database. If you are interested by this feature, please make sure you don’t specify the database platform explicitly (i.e. via spring.jpa.database or spring.jpa.database-platform).

> If you had a dialect configured previously, you may want to remove your customization.

I only kept the dialects that have been overridden in jhipster framework.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
