### PR TITLE
Workaround for ShellJS Directory Creation Problem on Windows

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1518,6 +1518,7 @@ module.exports = class extends PrivateBase {
             try {
                 shelljs.mkdir('-p', `${SERVER_MAIN_RES_DIR}config/tls`);
             } catch (error) {
+                // noticed that on windows the shelljs.mkdir tends to sometimes fail
                 fs.mkdir(`${SERVER_MAIN_RES_DIR}config/tls/keystore.p12`, { recursive: true }, err => {
                     if (err) throw err;
                 });

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1515,7 +1515,13 @@ module.exports = class extends PrivateBase {
             this.log(chalk.cyan(`\nKeyStore '${keyStoreFile}' already exists. Leaving unchanged.\n`));
             done();
         } else {
-            shelljs.mkdir('-p', `${SERVER_MAIN_RES_DIR}config/tls`);
+            try {
+                shelljs.mkdir('-p', `${SERVER_MAIN_RES_DIR}config/tls`);
+            } catch (error) {
+                fs.mkdir(`${SERVER_MAIN_RES_DIR}config/tls/keystore.p12`, { recursive: true }, err => {
+                    if (err) throw err;
+                });
+            }
             const javaHome = shelljs.env.JAVA_HOME;
             let keytoolPath = '';
             if (javaHome) {


### PR DESCRIPTION
Related to https://github.com/hipster-labs/jhipster-daily-builds/issues/28 and https://github.com/hipster-labs/jhipster-daily-builds/pull/37

Trying to get the Windows Daily build working, I noticed that sometimes ShellJS fails when trying to create the keystore directory. This is a workaround to address that. For reference, the error that could be seen is,

```
events.js:187
      throw er; // Unhandled 'error' event
      ^

Error [ShellJSInternalError]: EEXIST: file already exists, mkdir 'C:\Users\VssAdministrator\app\src\main\resources'
    at Object.mkdirSync (fs.js:823:3)
    at mkdirSyncRecursive (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:32:6)
    at mkdirSyncRecursive (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:29:3)
    at mkdirSyncRecursive (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:29:3)
    at C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:81:9
    at Array.forEach (<anonymous>)
    at Object._mkdir (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\mkdir.js:59:8)
    at Object.mkdir (C:\Users\VssAdministrator\generator-jhipster\node_modules\shelljs\src\common.js:384:25)
    at module.exports.generateKeyStore (C:\Users\VssAdministrator\generator-jhipster\generators\generator-base.js:1518:21)
    at module.exports.setUp (C:\Users\VssAdministrator\generator-jhipster\generators\server\files.js:1816:18)
Emitted 'error' event on Generator instance at:
    at Immediate.<anonymous> (C:\Users\VssAdministrator\generator-jhipster\node_modules\yeoman-generator\lib\index.js:451:18)
    at processImmediate (internal/timers.js:439:21) {
  errno: -4075,
  syscall: 'mkdir',
  code: 'EEXIST',
  path: 'C:\\Users\\VssAdministrator\\app\\src\\main\\resources',
  name: 'ShellJSInternalError'
}

##[error]Bash exited with code '1'.

```

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
