### PR TITLE
Increase Number of Seconds to Expiry of Access Tokens to 90 Seconds

### DIFF
--- a/generators/server/templates/src/main/java/package/web/filter/RefreshTokenFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/filter/RefreshTokenFilter.java.ejs
@@ -48,7 +48,7 @@ public class RefreshTokenFilter extends GenericFilterBean {
      * requests downstream. Otherwise, access tokens may still be valid when we check here but may then be expired
      * when relayed to another microservice a wee bit later.
      */
-    private static final int REFRESH_WINDOW_SECS = 30;
+    private static final int REFRESH_WINDOW_SECS = 90;
 
     private final Logger log = LoggerFactory.getLogger(RefreshTokenFilter.class);
 


### PR DESCRIPTION
Related to https://github.com/hipster-labs/jhipster-daily-builds/issues/28

I observed that sometimes on [Windows builds the `ms-ngx-gateway-uaa` test fails](https://dev.azure.com/hipster-labs/jhipster-daily-builds/_build?definitionId=41&_a=summary) due to the following error. 

```
[INFO] 
[ERROR] Failures: 
[ERROR]   OAuth2AuthenticationServiceTest.testRefreshGrantNoRefreshToken:221 Expected org.springframework.security.oauth2.common.exceptions.InvalidTokenException to be thrown, but nothing was thrown.
[INFO] 
[ERROR] Tests run: 66, Failures: 1, Errors: 0, Skipped: 0
[INFO] 
[INFO] ------------------------------------------------------------------------
[INFO] BUILD FAILURE
[INFO] ------------------------------------------------------------------------
[INFO] Total time:  36.589 s
[INFO] Finished at: 2020-01-20T16:44:00Z
[INFO] ------------------------------------------------------------------------
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M4:test (default-test) on project travis-default: There are test failures.
[ERROR] 
[ERROR] Please refer to C:\Users\VssAdministrator\app\target\test-results\test for the individual test results.
[ERROR] Please refer to dump files (if any exist) [date].dump, [date]-jvmRun[N].dump and [date].dumpstream.
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/MojoFailureException

##[error]Bash exited with code '1'.
```
According to my testing this seems to be corrected (at least in my local Azure builds), by increasing the refresh timeout window for the OAuth2 token. I've increased it from 30 seconds to 90 seconds. It would be interesting to see if this can be reproduced in an actual Windows machine; but unfortunately I don't have a suitable Windows machine to test that. 😢 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
