### PR TITLE
Fix sub-generators with app blueprint

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -233,7 +233,7 @@ module.exports = class extends BaseBlueprintGenerator {
         this.useNpm = this.configOptions.useNpm = !this.options.yarn;
         this.useYarn = !this.useNpm;
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('app');
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('app');
 
         this.isDebugEnabled = this.configOptions.isDebugEnabled = this.options.debug;
         this.experimental = this.configOptions.experimental = this.options.experimental;

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -63,7 +63,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
         this.setupClientOptions(this);
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('client');
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('client');
     }
 
     // Public API method used by the getter and also by Blueprints

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -39,7 +39,7 @@ module.exports = class extends BaseBlueprintGenerator {
         this.setupServerOptions(this);
         this.setupClientOptions(this);
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('common', { 'client-hook': !this.skipClient });
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('common', { 'client-hook': !this.skipClient });
     }
 
     // Public API method used by the getter and also by Blueprints

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -32,7 +32,7 @@ module.exports = class extends BaseBlueprintGenerator {
         this.configOptions = opts.configOptions || {};
 
         useBlueprints =
-            !opts.fromBlueprint &&
+            !this.fromBlueprint &&
             this.instantiateBlueprints('entity-client', { context: opts.context, debug: opts.context.isDebugEnabled });
     }
 

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -32,7 +32,7 @@ module.exports = class extends BaseBlueprintGenerator {
         this.configOptions = opts.configOptions || {};
 
         useBlueprints =
-            !opts.fromBlueprint && this.instantiateBlueprints('entity-i18n', { context: opts.context, debug: opts.context.isDebugEnabled });
+            !this.fromBlueprint && this.instantiateBlueprints('entity-i18n', { context: opts.context, debug: opts.context.isDebugEnabled });
     }
 
     // Public API method used by the getter and also by Blueprints

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -32,7 +32,7 @@ module.exports = class extends BaseBlueprintGenerator {
         this.configOptions = opts.configOptions || {};
 
         useBlueprints =
-            !opts.fromBlueprint &&
+            !this.fromBlueprint &&
             this.instantiateBlueprints('entity-server', { context: opts.context, debug: opts.context.isDebugEnabled });
     }
 

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -132,7 +132,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
         this.setupEntityOptions(this, this, this.context);
         this.registerPrettierTransform();
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('entity', { arguments: [this.context.name] });
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('entity', { arguments: [this.context.name] });
     }
 
     // Public API method used by the getter and also by Blueprints

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -80,7 +80,7 @@ module.exports = class extends BaseBlueprintGenerator {
         }
 
         useBlueprints =
-            !opts.fromBlueprint &&
+            !this.fromBlueprint &&
             this.instantiateBlueprints('languages', { languages: this.languages, arguments: this.options.languages });
     }
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -60,7 +60,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
         this.setupServerOptions(this);
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('server', { 'client-hook': !this.skipClient });
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('server', { 'client-hook': !this.skipClient });
 
         this.registerPrettierTransform();
     }

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -48,7 +48,7 @@ module.exports = class extends BaseBlueprintGenerator {
         });
         this.defaultOption = this.options.default;
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('spring-controller', { arguments: [this.name] });
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('spring-controller', { arguments: [this.name] });
     }
 
     // Public API method used by the getter and also by Blueprints

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -44,7 +44,7 @@ module.exports = class extends BaseBlueprintGenerator {
         });
         this.defaultOption = this.options.default;
 
-        useBlueprints = !opts.fromBlueprint && this.instantiateBlueprints('spring-service', { arguments: [this.name] });
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('spring-service', { arguments: [this.name] });
     }
 
     // Public API method used by the getter and also by Blueprints

--- a/test/blueprint/multiple-app-blueprints.spec.js
+++ b/test/blueprint/multiple-app-blueprints.spec.js
@@ -1,0 +1,115 @@
+/* eslint-disable max-classes-per-file */
+const path = require('path');
+const helpers = require('yeoman-test');
+const sinon = require('sinon');
+const AppGenerator = require('../../generators/app');
+const ClientGenerator = require('../../generators/client');
+const ServerGenerator = require('../../generators/server');
+const CommonGenerator = require('../../generators/common');
+const LanguagesGenerator = require('../../generators/languages');
+
+const createMockBlueprint = function(parent, spy) {
+    return class extends parent {
+        constructor(args, opts) {
+            super(args, { ...opts, fromBlueprint: true }); // fromBlueprint variable is important
+        }
+
+        spy() {
+            spy();
+        }
+    };
+};
+
+const mockAppBlueprintSubGen = class extends AppGenerator {
+    constructor(args, opts) {
+        super(args, { ...opts, fromBlueprint: true }); // fromBlueprint variable is important
+    }
+
+    get initializing() {
+        // Here we are not overriding this phase and hence its being handled by JHipster
+        return super._initializing();
+    }
+
+    get writing() {
+        return super._writing();
+    }
+
+    get prompting() {
+        // Here we are not overriding this phase and hence its being handled by JHipster
+        return super._prompting();
+    }
+
+    get configuring() {
+        // Here we are not overriding this phase and hence its being handled by JHipster
+        return super._configuring();
+    }
+
+    get default() {
+        // Here we are not overriding this phase and hence its being handled by JHipster
+        return super._default();
+    }
+
+    get install() {
+        // Here we are not overriding this phase and hence its being handled by JHipster
+        return super._install();
+    }
+
+    get end() {
+        // Here we are not overriding this phase and hence its being handled by JHipster
+        return super._end();
+    }
+};
+
+const options = {
+    'from-cli': true,
+    skipInstall: true,
+    skipChecks: true,
+    blueprints: 'my-blueprint'
+};
+
+const prompts = {
+    baseName: 'jhipster',
+    clientFramework: 'angularX',
+    packageName: 'com.mycompany.myapp',
+    packageFolder: 'com/mycompany/myapp',
+    serviceDiscoveryType: false,
+    authenticationType: 'jwt',
+    cacheProvider: 'ehcache',
+    enableHibernateCache: true,
+    databaseType: 'sql',
+    devDatabaseType: 'h2Memory',
+    prodDatabaseType: 'mysql',
+    enableTranslation: true,
+    nativeLanguage: 'en',
+    languages: ['fr']
+};
+
+describe('JHipster with app blueprints', () => {
+    describe('1 app blueprint', () => {
+        before(done => {
+            this.spyClient1 = sinon.spy();
+            this.spyServer1 = sinon.spy();
+            this.spyLanguages1 = sinon.spy();
+            this.spyCommon1 = sinon.spy();
+            helpers
+                .run(path.join(__dirname, '../../generators/app'))
+                .withOptions(options)
+                .withGenerators([
+                    [createMockBlueprint(ClientGenerator, this.spyClient1), 'jhipster-my-blueprint:client'],
+                    [createMockBlueprint(ServerGenerator, this.spyServer1), 'jhipster-my-blueprint:server'],
+                    [createMockBlueprint(LanguagesGenerator, this.spyLanguages1), 'jhipster-my-blueprint:languages'],
+                    [createMockBlueprint(CommonGenerator, this.spyCommon1), 'jhipster-my-blueprint:common'],
+                    [mockAppBlueprintSubGen, 'jhipster-my-blueprint:app']
+                ])
+                .withPrompts(prompts)
+                .on('end', done);
+        });
+
+        it('every sub-generator must be called once', () => {
+            sinon.assert.calledOnce(this.spyClient1);
+            sinon.assert.calledOnce(this.spyServer1);
+            sinon.assert.calledOnce(this.spyCommon1);
+            sinon.assert.calledOnce(this.spyLanguages1);
+        });
+    });
+});


### PR DESCRIPTION
Blueprinted app generator is forwarding 'options.fromBlueprint=true' to sub-generators.
This makes original generators act like they are blueprints, ignoring loading of blueprints.

This PR makes fromBlueprint option that was need by blueprint not necessary anymore.
It uses calculated fromBlueprint introduced at https://github.com/jhipster/generator-jhipster/pull/10664

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
