### PR TITLE
use Mono.error instead of throwing in flatmap

### DIFF
--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -280,7 +280,7 @@ public class UserService {
                     <%_ } _%>
                     return userRepository.delete(existingUser);
                 } else {
-                    throw new UsernameAlreadyUsedException();
+                    return Mono.error(new UsernameAlreadyUsedException());
                 }
             })
             .then(userRepository.findOneByEmailIgnoreCase(userDTO.getEmail()))
@@ -291,7 +291,7 @@ public class UserService {
                     <%_ } _%>
                     return userRepository.delete(existingUser);
                 } else {
-                    throw new EmailAlreadyUsedException();
+                    return Mono.error(new EmailAlreadyUsedException());
                 }
             })
             .thenReturn(new <%= asEntity('User') %>())
@@ -601,7 +601,7 @@ public class UserService {
             .<% if (reactive) { %>flatMap<% } else { %>ifPresent<% } %>(user -> {
                 String currentEncryptedPassword = user.getPassword();
                 if (!passwordEncoder.matches(currentClearTextPassword, currentEncryptedPassword)) {
-                    throw new InvalidPasswordException();
+                    <% if (reactive) { %>return Mono.error(new InvalidPasswordException());<% } else { %>throw new InvalidPasswordException();<% } %>
                 }
                 String encryptedPassword = passwordEncoder.encode(newPassword);
                 user.setPassword(encryptedPassword);

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -194,15 +194,15 @@ public class UserResource {
         return userRepository.findOneByLogin(userDTO.getLogin().toLowerCase())
             .hasElement()
             .flatMap(loginExists -> {
-                if (loginExists) {
-                    throw new LoginAlreadyUsedException();
+                if (Boolean.TRUE.equals(loginExists)) {
+                    return Mono.error(new LoginAlreadyUsedException());
                 }
                 return userRepository.findOneByEmailIgnoreCase(userDTO.getEmail());
             })
             .hasElement()
             .flatMap(emailExists -> {
-                if (emailExists) {
-                    throw new EmailAlreadyUsedException();
+                if (Boolean.TRUE.equals(emailExists)) {
+                    return Mono.error(new EmailAlreadyUsedException());
                 }
                 return userService.createUser(userDTO);
             })
@@ -251,16 +251,16 @@ public class UserResource {
             .filter(user -> !user.getId().equals(userDTO.getId()))
             .hasElement()
             .flatMap(emailExists -> {
-                if (emailExists) {
-                    throw new EmailAlreadyUsedException();
+                if (Boolean.TRUE.equals(emailExists)) {
+                    return Mono.error(new EmailAlreadyUsedException());
                 }
                 return userRepository.findOneByLogin(userDTO.getLogin().toLowerCase());
             })
             .filter(user -> !user.getId().equals(userDTO.getId()))
             .hasElement()
             .flatMap(loginExists -> {
-                if (loginExists) {
-                    throw new LoginAlreadyUsedException();
+                if (Boolean.TRUE.equals(loginExists)) {
+                    return Mono.error(new LoginAlreadyUsedException());
                 }
                 return userService.updateUser(userDTO);
             })


### PR DESCRIPTION
While working on the neo support and trying reactive option idea and sonar pointed out some issues. This fixes 
* Throwing instead of returning a mono in flatmap
*  (sonar) using primitive boolean if statement with boolean objects (for real there won't be a npe but aiming for a A grade in sonar)

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
