### PR TITLE
fix: sort on users

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-delete-dialog.tsx.ejs
@@ -36,7 +36,7 @@ export const UserManagementDeleteDialog = (props: IUserManagementDeleteDialogPro
 
   const handleClose = event => {
     event.stopPropagation();
-    props.history.goBack();
+    props.history.push('/admin/user-management');
   };
 
   const confirmDelete = event => {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.tsx.ejs
@@ -39,27 +39,17 @@ export interface IUserManagementProps extends StateProps, DispatchProps, RouteCo
 export const UserManagement = (props: IUserManagementProps) => {
   const [pagination, setPagination] = useState(getSortState(props.location, ITEMS_PER_PAGE));
 
-  const getAllUsers = () =>
-    props.getUsers(pagination.activePage - 1, pagination.itemsPerPage, `${pagination.sort},${pagination.order}`);
-
   useEffect(() => {
-    getAllUsers();
-  }, []);
+    props.getUsers(pagination.activePage - 1, pagination.itemsPerPage, `${pagination.sort},${pagination.order}`)
+    props.history.push(`${props.location.pathname}?page=${pagination.activePage}&sort=${pagination.sort},${pagination.order}`);
+  }, [pagination]);
 
-  const sortUsers = () => getAllUsers();
-
-  useEffect(() => {
-    sortUsers();
-  }, [pagination.activePage, pagination.order, pagination.sort]);
-
-  const sort = p => () => {
+  const sort = p => () =>
     setPagination({
       ...pagination,
       order: pagination.order === 'asc' ? 'desc' : 'asc',
       sort: p
     });
-    props.history.push(`${props.location.pathname}?page=${pagination.activePage}&sort=${pagination.sort},${pagination.order}`);
-  };
 
   const handlePagination = currentPage =>
     setPagination({


### PR DESCRIPTION
Fix sorting users on React.

The current sort wasn't "sync" to the parameters in the URL.
When the url has 'asc', then 'desc' sorting was applied (and the opposite).

The sort is working for entities so I applied the same logic for users (just move a line).