### PR TITLE
fix hazelcast mancenter context path [ci skip]

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -275,7 +275,7 @@ jhipster:
             management-center: # Full reference is available at: http://docs.hazelcast.org/docs/management-center/3.9/manual/html/Deploying_and_Starting.html
                 enabled: false
                 update-interval: 3
-                url: http://localhost:8180/mancenter
+                url: http://localhost:8180/hazelcast-mancenter
         <%_ } _%>
         <%_ if (cacheProvider === 'ehcache') { _%>
         ehcache: # Ehcache configuration


### PR DESCRIPTION
>**Management Center Default Context Path**
Before version 3.10, default context path was /mancenter, so you would access Hazelcast Management Center by using http://localhost:8080/mancenter. Starting with version 3.10, it is changed to /hazelcast-mancenter, so you can access it by using http://localhost:8080/hazelcast-mancenter.
https://hub.docker.com/r/hazelcast/management-center/

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
