### PR TITLE
CI: don't start Cassandra containers before launching tests

### DIFF
--- a/test-integration/scripts/20-docker-compose.sh
+++ b/test-integration/scripts/20-docker-compose.sh
@@ -20,7 +20,9 @@ if [ -a src/main/docker/consul.yml ]; then
     docker-compose -f src/main/docker/consul.yml up -d
 fi
 if [ -a src/main/docker/cassandra.yml ]; then
-    docker-compose -f src/main/docker/cassandra.yml up -d
+    # this container can't be started otherwise, as it will take a lot of memory
+    # so here, only prepare the image
+    docker-compose -f src/main/docker/cassandra.yml build
 fi
 if [ -a src/main/docker/mongodb.yml ]; then
     docker-compose -f src/main/docker/mongodb.yml up -d

--- a/test-integration/scripts/24-tests-e2e.sh
+++ b/test-integration/scripts/24-tests-e2e.sh
@@ -11,6 +11,11 @@ if [ -a src/main/docker/couchbase.yml ]; then
     sleep 20
     docker ps -a
 fi
+if [ -a src/main/docker/cassandra.yml ]; then
+    docker-compose -f src/main/docker/cassandra.yml up -d
+    sleep 30
+    docker ps -a
+fi
 
 #-------------------------------------------------------------------------------
 # Functions


### PR DESCRIPTION
Cassandra containers took a lot of memory
and as the integration tests use testcontainers,
it's not good to start Cassandra 2 times

Related to https://github.com/jhipster/generator-jhipster/issues/11169

_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
