### PR TITLE
fix: check activated on user creation and fix activated state handling

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -174,7 +174,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
           </AvGroup>
           <AvGroup check>
             <Label>
-              <AvInput type="checkbox" name="activated" value={user.activated} /> <Translate contentKey="userManagement.activated">Activated</Translate>
+              <AvInput type="checkbox" name="activated" value={user.activated} checked={user.activated} disabled={!user.id} /> <Translate contentKey="userManagement.activated">Activated</Translate>
             </Label>
           </AvGroup>
   <%_ if (enableTranslation) { _%>

--- a/generators/client/templates/react/src/main/webapp/app/shared/model/user.model.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/model/user.model.ts.ejs
@@ -39,7 +39,7 @@ export const defaultValue: Readonly<IUser> = {
   firstName: '',
   lastName: '',
   email: '',
-  activated: false,
+  activated: true,
   langKey: '',
   authorities: [],
   createdBy: '',


### PR DESCRIPTION
1)
When we create a new user, the "activated" checkbox should be checked and disabled (as in angular version). In the backend the activated field from a user is set to `true` during creation.

2)
This also fix (by using checked={user.activated} a bug when we first "view" a deactivated user and then go to the user creation page. The activated checkbox state is the previous one. I'm not sure this is the best way to fix this though.. (The user state in Redux is updated many times... causing this bug I think).