### PR TITLE
Fix langkey react

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -193,7 +193,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
   <%_ } _%>
           <AvGroup>
             <Label for="authorities">
-              <Translate contentKey="userManagement.profiles">Language Key</Translate>
+              <Translate contentKey="userManagement.profiles">Profiles</Translate>
             </Label>
             <AvInput type="select" className="form-control" name="authorities" value={user.authorities} multiple>
               {roles.map(role => (

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -182,7 +182,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
             <Label for="langKey">
               <Translate contentKey="userManagement.langKey">Language Key</Translate>
             </Label>
-            <AvField type="select" className="form-control" name="langKey" value={user.langKey}>
+            <AvField type="select" className="form-control" name="langKey" value={user.langKey || locales[0]}>
               {locales.map(locale =>
                 <option value={locale} key={locale}>
                   {languages[locale].name}


### PR DESCRIPTION
Use the first locale available to set the langKey in user creation.
Otherwise there is an exception while saving the user (validation on langKey, which is required)