### PR TITLE
Refactor Unit Tests: Remove deleteAll calls for Cassandra

### DIFF
--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -509,7 +509,7 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
         <%_ if (databaseType === 'couchbase') { _%>
         mockAuthentication();
         <%_ } _%>
-        <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase' || databaseType === 'cassandra') { _%>
+        <%_ if (databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
         <%= entityInstance %>Repository.deleteAll();
         <%_ } _%>
         <%= asEntity(entityInstance) %> = createEntity(<% if (databaseType === 'sql') { %>em<% } %>);
@@ -553,6 +553,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Validate the <%= entityClass %> in Elasticsearch
         verify(mock<%= entityClass %>SearchRepository, times(1)).save(test<%= entityClass %>);
+        <%_ } _%>
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(test<%= entityClass %>);
         <%_ } _%>
     }
 
@@ -640,11 +644,14 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
         <%_ if (searchEngine === 'elasticsearch') { _%>
 
         // Validate the <%= entityClass %> in Elasticsearch
-        <%_ if (service !== 'no' && dto !== 'mapstruct') { _%>
+            <%_ if (service !== 'no' && dto !== 'mapstruct') { _%>
         verify(mock<%= entityClass %>SearchRepository, times(2)).save(<%= asEntity(entityInstance) %>);
-<%_ } else { _%>
+            <%_ } else { _%>
         verify(mock<%= entityClass %>SearchRepository, times(1)).save(<%= asEntity(entityInstance) %>);
-<%_ } _%>
+            <%_ } _%>
+        <%_ } _%>
+        <% if (databaseType === 'cassandra') { %>
+        <%= entityInstance %>Repository.delete(test<%= asEntity(entityInstance) %>);
         <%_ } _%>
     }
 <%_ } _%>
@@ -696,6 +703,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
             .andExpect(jsonPath("$.[*].<%= fields[idx].fieldName %>ContentType").value(hasItem(<%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %>_CONTENT_TYPE)))
             <%_ } _%>
             .andExpect(jsonPath("$.[*].<%= fields[idx].fieldName %>").value(hasItem(<% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %>Base64Utils.encodeToString(<% } else if (fields[idx].fieldType === 'ZonedDateTime') { %>sameInstant(<% } %><%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %><% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType === 'Integer') { %><% } else if (fields[idx].fieldType === 'Long') { %>.intValue()<% } else if (fields[idx].fieldType === 'Float' || fields[idx].fieldType === 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType === 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType === 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType === 'ZonedDateTime') { %>)<% } else if (fields[idx].fieldType !== 'String') { %>.toString()<% } %>)))<% } %>;
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
     <% if (fieldsContainOwnerManyToMany === true) { %>
     @SuppressWarnings({"unchecked"})
@@ -771,6 +782,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
             .andExpect(jsonPath("$.<%= fields[idx].fieldName %>ContentType").value(<%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %>_CONTENT_TYPE))
             <%_ } _%>
             .andExpect(jsonPath("$.<%= fields[idx].fieldName %>").value(<% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %>Base64Utils.encodeToString(<% } else if (fields[idx].fieldType === 'ZonedDateTime') { %>sameInstant(<% } %><%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %><% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType === 'Integer') { %><% } else if (fields[idx].fieldType === 'Long') { %>.intValue()<% } else if (fields[idx].fieldType === 'Float' || fields[idx].fieldType === 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType === 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType === 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType === 'ZonedDateTime') { %>)<% } else if (fields[idx].fieldType !== 'String') { %>.toString()<% } %>))<% } %>;
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 <%_ if (jpaMetamodelFiltering) {  %>
 
@@ -790,6 +805,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         default<%= entityClass %>ShouldBeFound("id.lessThanOrEqual=" + id);
         default<%= entityClass %>ShouldNotBeFound("id.lessThan=" + id);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
 <%_
@@ -809,6 +828,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> equals to <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
         default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.equals=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -822,6 +845,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> not equals to <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
         default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.notEquals=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -835,6 +862,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> equals to <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
         default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.in=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -848,6 +879,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is null
         default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.specified=false");
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 <%_
             }
@@ -864,6 +899,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> contains <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
         default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.contains=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -877,6 +916,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> does not contain <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>
         default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.doesNotContain=" + <%= 'UPDATED_' + searchBy.fieldNameUnderscored.toUpperCase() %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
 <%_
@@ -910,6 +953,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is greater than or equal to <%= biggerValue %>
         default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.greaterThanOrEqual=" + <%= biggerValue %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -923,6 +970,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is less than or equal to <%= smallerValue %>
         default<%= entityClass %>ShouldNotBeFound("<%= searchBy.fieldName %>.lessThanOrEqual=" + <%= smallerValue %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -936,6 +987,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is less than <%= biggerValue %>
         default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.lessThan=" + <%= biggerValue %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
     @Test<% if (databaseType === 'sql') { %>
@@ -949,6 +1004,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= searchBy.fieldName %> is greater than <%= smallerValue %>
         default<%= entityClass %>ShouldBeFound("<%= searchBy.fieldName %>.greaterThan=" + <%= smallerValue %>);
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
 <%_         } _%>
@@ -984,6 +1043,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Get all the <%= entityInstance %>List where <%= relationship.relationshipFieldName %> equals to <%= relationship.relationshipFieldName %>Id + 1
         default<%= entityClass %>ShouldNotBeFound("<%= relationship.relationshipFieldName %>Id.equals=" + (<%= relationship.relationshipFieldName %>Id + 1));
+        <% if (databaseType === 'cassandra' && !(relationship.relationshipValidate === true || relationship.useJPADerivedIdentifier === true)) { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
 
 <%_ }); _%>
@@ -1067,6 +1130,10 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
         <%_ } else { _%>
         assertThat(test<%= entityClass %>.get<%= fields[idx].fieldInJavaBeanMethod %>()).isEqualTo(<%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %>);
         <%_ }} _%>
+        <% if (databaseType === 'cassandra') { %>
+
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityInstance) %>);
+        <%_ } _%>
     }
     <%_  } _%>
 
@@ -1141,6 +1208,9 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
 
         // Validate the <%= entityClass %> in Elasticsearch
         verify(mock<%= entityClass %>SearchRepository, times(1)).save(test<%= entityClass %>);
+        <%_ } _%>
+        <% if (databaseType === 'cassandra') { %>
+        <%= entityInstance %>Repository.delete(test<%= asEntity(entityClass) %>);
         <%_ } _%>
     }
 
@@ -1231,6 +1301,9 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') {
             .andExpect(jsonPath("$.[*].<%= fields[idx].fieldName %>ContentType").value(hasItem(<%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %>_CONTENT_TYPE)))
             <%_ } _%>
             .andExpect(jsonPath("$.[*].<%= fields[idx].fieldName %>").value(hasItem(<% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %>Base64Utils.encodeToString(<% } else if (fields[idx].fieldType === 'ZonedDateTime') { %>sameInstant(<% } %><%= 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase() %><% if ((fields[idx].fieldType === 'byte[]' || fields[idx].fieldType === 'ByteBuffer') && fields[idx].fieldTypeBlobContent !== 'text') { %><% if (databaseType === 'cassandra') { %>.array()<% } %>)<% } else if (fields[idx].fieldType === 'Integer') { %><% } else if (fields[idx].fieldType === 'Long') { %>.intValue()<% } else if (fields[idx].fieldType === 'Float' || fields[idx].fieldType === 'Double') { %>.doubleValue()<% } else if (fields[idx].fieldType === 'BigDecimal') { %>.intValue()<% } else if (fields[idx].fieldType === 'Boolean') { %>.booleanValue()<% } else if (fields[idx].fieldType === 'ZonedDateTime') { %>)<% } else if (fields[idx].fieldType !== 'String') { %>.toString()<% } %>)))<% } %>;
+        <% if (databaseType === 'cassandra') { %>
+        <%= entityInstance %>Repository.delete(<%= asEntity(entityClass) %>);
+        <%_ } _%>
     }
     <%_ } _%>
 }

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -51,6 +51,9 @@ import <%= packageName %>.web.rest.vm.ManagedUserVM;
 <%_ } _%>
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
+<%_ if (databaseType === 'cassandra') { _%>
+import org.junit.jupiter.api.AfterEach;
+<%_ } _%>
 import org.junit.jupiter.api.Test;
 <%_ if (cacheProvider === 'redis') { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -267,6 +270,7 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         return user;
     }
 
+    <%_ if (databaseType !== 'cassandra') { _%>
     @BeforeEach
     public void initTest() {
         <%_ if (databaseType === 'couchbase') { _%>
@@ -282,6 +286,20 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         user.setEmail(DEFAULT_EMAIL);
         <%_ } _%>
     }
+    <%_ } _%>
+    <%_ if (databaseType === 'cassandra') { _%>
+
+    @BeforeEach
+    public void initTest() {
+        user = createEntity();
+        userRepository.save(user);
+    }
+
+    @AfterEach
+    public void cleanup() {
+        userRepository.delete(user);
+    }
+    <%_ } _%>
 <%_ if (authenticationType !== 'oauth2') { _%>
 
     @Test
@@ -294,11 +312,19 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
 
         // Create the User
         ManagedUserVM managedUserVM = new ManagedUserVM();
+        <%_ if (databaseType === 'cassandra') { _%>
+        managedUserVM.setLogin("anotheruser");
+        <%_ } else { _%>
         managedUserVM.setLogin(DEFAULT_LOGIN);
+        <%_ } _%>
         managedUserVM.setPassword(DEFAULT_PASSWORD);
         managedUserVM.setFirstName(DEFAULT_FIRSTNAME);
         managedUserVM.setLastName(DEFAULT_LASTNAME);
+        <%_ if (databaseType === 'cassandra') { _%>
+        managedUserVM.setEmail("anotheremail@jhipster.com");
+        <%_ } else { _%>
         managedUserVM.setEmail(DEFAULT_EMAIL);
+        <%_ } _%>
         managedUserVM.setActivated(true);
         <%_ if (databaseType !== 'cassandra') { _%>
         managedUserVM.setImageUrl(DEFAULT_IMAGEURL);
@@ -322,15 +348,27 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         // Validate the User in the database
         List<<%= asEntity('User') %>> userList = userRepository.findAll()<% if (reactive) { %>.collectList().block()<% } %>;
         assertThat(userList).hasSize(databaseSizeBeforeCreate + 1);
+        <%_ if (databaseType === 'cassandra') { _%>
+        User testUser = userRepository.findOneByLogin("anotheruser").get();
+        assertThat(testUser.getLogin()).isEqualTo("anotheruser");
+        <%_ } else { _%>
         <%= asEntity('User') %> testUser = userList.get(userList.size() - 1);
         assertThat(testUser.getLogin()).isEqualTo(DEFAULT_LOGIN);
+        <%_ } _%>
         assertThat(testUser.getFirstName()).isEqualTo(DEFAULT_FIRSTNAME);
         assertThat(testUser.getLastName()).isEqualTo(DEFAULT_LASTNAME);
+        <%_ if (databaseType === 'cassandra') { _%>
+        assertThat(testUser.getEmail()).isEqualTo("anotheremail@jhipster.com");
+        <%_ } else { _%>
         assertThat(testUser.getEmail()).isEqualTo(DEFAULT_EMAIL);
+        <%_ } _%>
         <%_ if (databaseType !== 'cassandra') { _%>
         assertThat(testUser.getImageUrl()).isEqualTo(DEFAULT_IMAGEURL);
         <%_ } _%>
         assertThat(testUser.getLangKey()).isEqualTo(DEFAULT_LANGKEY);
+        <%_ if (databaseType === 'cassandra') { _%>
+        userRepository.delete(testUser);
+        <%_ } _%>
     }
 
     @Test
@@ -385,8 +423,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void createUserWithExistingLogin() throws Exception {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -430,8 +470,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void createUserWithExistingEmail() throws Exception {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -476,8 +518,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void getAllUsers()<% if (!reactive) { %> throws Exception<% } %> {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -520,8 +564,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void getUser()<% if (!reactive) { %> throws Exception<% } %> {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -589,8 +635,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void updateUser() throws Exception {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -636,7 +684,11 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         // Validate the User in the database
         List<<%= asEntity('User') %>> userList = userRepository.findAll()<% if (reactive) { %>.collectList().block()<% } %>;
         assertThat(userList).hasSize(databaseSizeBeforeUpdate);
+        <%_ if (databaseType === 'cassandra') { _%>
+        User testUser = userRepository.findById(managedUserVM.getId()).get();
+        <%_ } else { _%>
         <%= asEntity('User') %> testUser = userList.get(userList.size() - 1);
+        <%_ } _%>
         assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
         assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
         assertThat(testUser.getEmail()).isEqualTo(UPDATED_EMAIL);
@@ -651,8 +703,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void updateUserLogin() throws Exception {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -698,7 +752,11 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         // Validate the User in the database
         List<<%= asEntity('User') %>> userList = userRepository.findAll()<% if (reactive) { %>.collectList().block()<% } %>;
         assertThat(userList).hasSize(databaseSizeBeforeUpdate);
+        <%_ if (databaseType === 'cassandra') { _%>
+        User testUser = userRepository.findById(user.getId()).get();
+        <%_ } else { _%>
         <%= asEntity('User') %> testUser = userList.get(userList.size() - 1);
+        <%_ } _%>
         assertThat(testUser.getLogin()).isEqualTo(UPDATED_LOGIN);
         assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
         assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
@@ -714,8 +772,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void updateUserExistingEmail() throws Exception {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database with 2 users
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -727,7 +787,7 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         anotherUser.setLogin("jhipster");
         anotherUser.setPassword(RandomStringUtils.random(60));
         anotherUser.setActivated(true);
-        anotherUser.setEmail("jhipster@localhost");
+        anotherUser.setEmail("jhipster@localhost.com");
         anotherUser.setFirstName("java");
         anotherUser.setLastName("hipster");
         <%_ if (databaseType !== 'cassandra') { _%>
@@ -748,7 +808,7 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
         managedUserVM.setPassword(updatedUser.getPassword());
         managedUserVM.setFirstName(updatedUser.getFirstName());
         managedUserVM.setLastName(updatedUser.getLastName());
-        managedUserVM.setEmail("jhipster@localhost");// this email should already be used by anotherUser
+        managedUserVM.setEmail("jhipster@localhost.com");// this email should already be used by anotherUser
         managedUserVM.setActivated(updatedUser.getActivated());
         <%_ if (databaseType !== 'cassandra') { _%>
         managedUserVM.setImageUrl(updatedUser.getImageUrl());
@@ -774,6 +834,9 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
             .exchange()
             .expectStatus().isBadRequest();
         <%_ } _%>
+        <%_ if (databaseType === 'cassandra') { _%>
+        userRepository.delete(anotherUser);
+        <%_ } _%>
     }
 
     @Test
@@ -781,8 +844,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void updateUserExistingLogin() throws Exception {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>
@@ -841,6 +906,9 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
             .exchange()
             .expectStatus().isBadRequest();
         <%_ } _%>
+        <%_ if (databaseType === 'cassandra') { _%>
+        userRepository.delete(anotherUser);
+        <%_ } _%>
     }
 
     @Test
@@ -848,8 +916,10 @@ public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends Abs
     @Transactional
     <%_ } _%>
     public void deleteUser()<% if (!reactive) { %> throws Exception<% } %> {
+        <%_ if (databaseType !== 'cassandra') { _%>
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
+        <%_ } _%>
         <%_ if (searchEngine === 'elasticsearch') { _%>
         mockUserSearchRepository.save(user);
         <%_ } _%>


### PR DESCRIPTION
This refactors UserResourceIT.java.ejs and EntityResourceIT.java.ejs so that `deleteAll` is removed from the `beforeEach` block. 

Fixes #11169

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
