### PR TITLE
Fix needles with multiple lines in Windows if Git autocrlf is used

### DIFF
--- a/generators/utils.js
+++ b/generators/utils.js
@@ -118,7 +118,8 @@ function escapeRegExp(str) {
  */
 function rewrite(args) {
     // check if splicable is already in the body text
-    const re = new RegExp(args.splicable.map(line => `\\s*${escapeRegExp(line)}`).join('\n'));
+    // replacing \r\n with \n as this replacement is done also in haystack to resolve Windows Git autocrlf issue
+    const re = new RegExp(args.splicable.map(line => `\\s*${escapeRegExp(line.replace(/\r\n/g, '\n'))}`).join('\n'));
 
     // if in Windows is Git autocrlf used then need to replace \r\n with \n to avoid multiple additions
     if (re.test(args.haystack.replace(/\r\n/g, '\n'))) {

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -120,7 +120,8 @@ function rewrite(args) {
     // check if splicable is already in the body text
     const re = new RegExp(args.splicable.map(line => `\\s*${escapeRegExp(line)}`).join('\n'));
 
-    if (re.test(args.haystack)) {
+    // if in Windows is Git autocrlf used then need to replace \r\n with \n to avoid multiple additions
+    if (re.test(args.haystack.replace(/\r\n/g, '\n'))) {
         return args.haystack;
     }
 


### PR DESCRIPTION
If in Windows is used Git `autocrlf` and project is regenerated after committing to Git then those needles which content has more than 1 line are added multiple times to templates.

This PR fixes that.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
