### PR TITLE
Fix getEntityParentPathAddition logic and tests in Windows

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1522,7 +1522,7 @@ module.exports = class extends Generator {
             }
             this.error(message);
         }
-        const entityFolderPathAddition = relative.replace(/[/]?..\/entities/, '').replace('entities', '..');
+        const entityFolderPathAddition = relative.replace(/[/|\\]?..[/|\\]entities/, '').replace('entities', '..');
         if (!entityFolderPathAddition) {
             return '';
         }

--- a/test/generator-base-private.spec.js
+++ b/test/generator-base-private.spec.js
@@ -1,3 +1,4 @@
+const path = require('path');
 const expect = require('chai').expect;
 // using base generator which extends the private base
 const BaseGenerator = require('../generators/generator-base').prototype;
@@ -295,7 +296,7 @@ export * from './entityFolderName/entityFileName.state';`;
         });
         describe('when passing foo/bar', () => {
             it('returns ../../', () => {
-                expect(BaseGenerator.getEntityParentPathAddition('foo/bar')).to.equal('../../');
+                expect(BaseGenerator.getEntityParentPathAddition('foo/bar')).to.equal(`..${path.sep}../`);
             });
         });
         describe('when passing ../foo', () => {
@@ -310,7 +311,7 @@ export * from './entityFolderName/entityFileName.state';`;
         });
         describe('when passing ../foo/bar/foo2', () => {
             it('returns ../../', () => {
-                expect(BaseGenerator.getEntityParentPathAddition('../foo/bar/foo2')).to.equal('../../');
+                expect(BaseGenerator.getEntityParentPathAddition('../foo/bar/foo2')).to.equal(`..${path.sep}../`);
             });
         });
         describe('when passing ../../foo', () => {


### PR DESCRIPTION
If cloning `generator-jhipster` current master in Windows and running `npm test` (tested in Git Bash) then tests are failing with error:
```
  853 passing (14m)
  4 failing

  1) Generator Base Private
       getEntityParentPathAddition
         when passing foo/bar
           returns ../../:

      AssertionError: expected '..\\../' to equal '../../'
      + expected - actual

      -..\../
      +../../

      at Context.<anonymous> (test\generator-base-private.spec.js:295:81)
      at processImmediate (internal/timers.js:439:21)

  2) Generator Base Private
       getEntityParentPathAddition
         when passing ../foo
           returns an empty string:

      AssertionError: expected '..\\../' to equal ''
      + expected - actual

      -..\../

      at Context.<anonymous> (test\generator-base-private.spec.js:300:80)
      at processImmediate (internal/timers.js:439:21)

  3) Generator Base Private
       getEntityParentPathAddition
         when passing ../foo/bar
           returns ../:

      AssertionError: expected '..\\..\\../' to equal '../'
      + expected - actual

      -..\..\../
      +../

      at Context.<anonymous> (test\generator-base-private.spec.js:305:84)
      at processImmediate (internal/timers.js:439:21)

  4) Generator Base Private
       getEntityParentPathAddition
         when passing ../foo/bar/foo2
           returns ../../:

      AssertionError: expected '..\\..\\..\\../' to equal '../../'
      + expected - actual

      -..\..\..\../
      +../../

      at Context.<anonymous> (test\generator-base-private.spec.js:310:89)
      at processImmediate (internal/timers.js:439:21)
```

Problem is that in Windows is path separator `\` instead of `/`.

This PR fixes logic and tests. Relying on: https://nodejs.org/api/path.html#path_path_sep which states: "On Windows, both the forward slash (`/`) and backward slash (`\`) are accepted as path segment separators; however, the path methods only add backward slashes (`\`).".

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
