### PR TITLE
Expose api.yml separately from springfox generated api

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -109,6 +109,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 }
                 this.clientThemeVariant = configuration.get('clientThemeVariant');
 
+                this.enableSwaggerCodegen = configuration.get('enableSwaggerCodegen');
                 this.enableTranslation = configuration.get('enableTranslation'); // this is enabled by default to avoid conflicts for existing applications
                 this.nativeLanguage = configuration.get('nativeLanguage');
                 this.languages = configuration.get('languages');

--- a/generators/client/templates/angular/src/main/webapp/robots.txt.ejs
+++ b/generators/client/templates/angular/src/main/webapp/robots.txt.ejs
@@ -31,3 +31,6 @@ Disallow: /api/logs/
 Disallow: /api/users/
 Disallow: /management/
 Disallow: /v2/api-docs/
+<%_ if (enableSwaggerCodegen) { _%>
+Disallow: /openapi-docs
+<%_ } _%>

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -42,6 +42,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
                 '/management',
                 '/swagger-resources',
                 '/v2/api-docs',
+                <%_ if (enableSwaggerCodegen) { _%>
+                '/openapi-docs',
+                <%_ } _%>
                 '/h2-console',
                 <%_ if (authenticationType === 'oauth2') { _%>
                 '/oauth2',

--- a/generators/client/templates/react/src/main/webapp/robots.txt.ejs
+++ b/generators/client/templates/react/src/main/webapp/robots.txt.ejs
@@ -31,3 +31,6 @@ Disallow: /api/logs/
 Disallow: /api/users/
 Disallow: /management/
 Disallow: /v2/api-docs/
+<%_ if (enableSwaggerCodegen) { _%>
+Disallow: /openapi-docs
+<%_ } _%>

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -65,6 +65,9 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
         '/management',
         '/swagger-resources',
         '/v2/api-docs',
+        <%_ if (enableSwaggerCodegen) { _%>
+        '/openapi-docs',
+        <%_ } _%>
         '/h2-console',<% if (authenticationType === 'oauth2') { %>
         '/oauth2',
         '/login',<% } %>

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1090,6 +1090,16 @@ const serverFiles = {
                     renameTo: generator => `${generator.testDir}config/ElasticsearchTestConfiguration.java`
                 }
             ]
+        },
+        {
+            condition: generator => !!generator.enableSwaggerCodegen,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/config/apidoc/OpenApiSpecResourceProvider.java',
+                    renameTo: generator => `${generator.javaDir}config/apidoc/OpenApiSpecResourceProvider.java`
+                }
+            ]
         }
     ],
     serverJavaDomain: [
@@ -1166,6 +1176,16 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}config/KafkaProperties.java`
                 }
             ]
+        },
+        {
+            condition: generator => !!generator.enableSwaggerCodegen,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/service/OpenApiSpecService.java',
+                    renameTo: generator => `${generator.javaDir}service/OpenApiSpecService.java`
+                }
+            ]
         }
     ],
     serverJavaWebError: [
@@ -1209,6 +1229,16 @@ const serverFiles = {
                 {
                     file: 'package/web/rest/errors/LoginAlreadyUsedException.java',
                     renameTo: generator => `${generator.javaDir}web/rest/errors/LoginAlreadyUsedException.java`
+                }
+            ]
+        },
+        {
+            condition: generator => !!generator.enableSwaggerCodegen,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/web/rest/OpenApiSpecController.java',
+                    renameTo: generator => `${generator.javaDir}web/rest/OpenApiSpecController.java`
                 }
             ]
         }

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1098,6 +1098,10 @@ const serverFiles = {
                 {
                     file: 'package/config/apidoc/OpenApiSpecResourceProvider.java',
                     renameTo: generator => `${generator.javaDir}config/apidoc/OpenApiSpecResourceProvider.java`
+                },
+                {
+                    file: 'package/config/OpenApiConfiguration.java',
+                    renameTo: generator => `${generator.javaDir}config/OpenApiConfiguration.java`
                 }
             ]
         }

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -345,6 +345,7 @@ dependencies {
     <%_ } _%>
     <%_ if (enableSwaggerCodegen) { _%>
     implementation "org.openapitools:jackson-databind-nullable:${jackson_databind_nullable_version}"
+    implementation "com.fasterxml.jackson.dataformat:jackson-dataformat-yaml:${jackson_version}"
     <%_ } _%>
     implementation "org.apache.commons:commons-lang3"
     implementation "commons-io:commons-io"

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -38,6 +38,7 @@ archunit_junit5_version=0.13.1
 log4j2_mock_version=0.0.2
 <%_ } _%>
 <%_ if (enableSwaggerCodegen) { _%>
+jackson_version=2.10.2
 jackson_databind_nullable_version=<%= JACKSON_DATABIND_NULLABLE_VERSION %>
 <%_ } _%>
 <%_ if (cacheProvider === 'caffeine') { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -123,6 +123,9 @@
 <%_ } _%>
         <mapstruct.version>1.3.1.Final</mapstruct.version>
 <%_ if (enableSwaggerCodegen) { _%>
+        <!-- The jackson version should match the one managed by
+        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${jackson.version} -->
+        <jackson.version>2.10.2</jackson.version>
         <jackson-databind-nullable.version><%= JACKSON_DATABIND_NULLABLE_VERSION %></jackson-databind-nullable.version>
 <%_ } _%>
 <%_ if (cacheProvider === 'caffeine') { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -101,6 +101,11 @@
     <%_ if (!reactive) { _%>
         <liquibase-hibernate5.version>3.8</liquibase-hibernate5.version>
     <%_ } _%>
+    <%_ if (enableSwaggerCodegen) { _%>
+        <!-- The jackson version should match the one managed by
+        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${jackson.version} -->
+        <jackson.version>2.10.2</jackson.version>
+    <%_ } _%>
     <%_ if (devDatabaseType === 'h2Disk') { _%>
         <h2.version>1.4.200</h2.version>
     <%_ } _%>
@@ -207,7 +212,7 @@
             <groupId>com.fasterxml.jackson.datatype</groupId>
             <artifactId>jackson-datatype-hibernate5</artifactId>
         </dependency>
-    <%_ } _%> 
+    <%_ } _%>
 <%_ } _%>
         <dependency>
             <groupId>com.fasterxml.jackson.datatype</groupId>
@@ -360,6 +365,11 @@
             <groupId>org.openapitools</groupId>
             <artifactId>jackson-databind-nullable</artifactId>
             <version>${jackson-databind-nullable.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>com.fasterxml.jackson.dataformat</groupId>
+            <artifactId>jackson-dataformat-yaml</artifactId>
+            <version>${jackson.version}</version>
         </dependency>
 <%_ } _%>
         <dependency>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -101,11 +101,6 @@
     <%_ if (!reactive) { _%>
         <liquibase-hibernate5.version>3.8</liquibase-hibernate5.version>
     <%_ } _%>
-    <%_ if (enableSwaggerCodegen) { _%>
-        <!-- The jackson version should match the one managed by
-        https://mvnrepository.com/artifact/org.springframework.boot/spring-boot-dependencies/${jackson.version} -->
-        <jackson.version>2.10.2</jackson.version>
-    <%_ } _%>
     <%_ if (devDatabaseType === 'h2Disk') { _%>
         <h2.version>1.4.200</h2.version>
     <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
@@ -1,0 +1,38 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.config;
+
+import com.google.common.base.Predicates;
+import io.github.jhipster.config.JHipsterConstants;
+import io.github.jhipster.config.apidoc.customizer.SwaggerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import springfox.documentation.builders.RequestHandlerSelectors;
+
+@Configuration
+@Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
+public class OpenApiConfiguration {
+
+    @Bean
+    public SwaggerCustomizer noGeneratedControllerCustomizer() {
+        return docket -> docket.select()
+            .apis(Predicates.not(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api")));
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -276,6 +276,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
             .antMatchers("/websocket/**").permitAll()
     <%_ } _%>
+    <%_ if (enableSwaggerCodegen) { _%>
+            .antMatchers("/openapi-docs").permitAll()
+    <%_ } _%>
             .antMatchers("/management/health").permitAll()
             .antMatchers("/management/info").permitAll()
             .antMatchers("/management/prometheus").permitAll()

--- a/generators/server/templates/src/main/java/package/config/UaaConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/UaaConfiguration.java.ejs
@@ -112,6 +112,9 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter imple
                 .antMatchers("/management/health").permitAll()
                 .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
                 .antMatchers("/v2/api-docs/**").permitAll()
+                <%_ if (enableSwaggerCodegen) { _%>
+                .antMatchers("/openapi-docs").permitAll()
+                <%_ } _%>
                 .antMatchers("/swagger-resources/configuration/ui").permitAll()
                 .antMatchers("/swagger-ui/index.html").hasAuthority(AuthoritiesConstants.ADMIN);
         }

--- a/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
@@ -214,6 +214,9 @@ public class WebConfigurer implements <% if (!reactive) { %>ServletContextInitia
             source.registerCorsConfiguration("/api/**", config);
             source.registerCorsConfiguration("/management/**", config);
             source.registerCorsConfiguration("/v2/api-docs", config);
+            <%_ if (enableSwaggerCodegen) { _%>
+            source.registerCorsConfiguration("/openapi-docs", config);
+            <%_ } _%>
             <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
             source.registerCorsConfiguration("/auth/**", config);
             <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/apidoc/OpenApiSpecResourceProvider.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/apidoc/OpenApiSpecResourceProvider.java.ejs
@@ -56,8 +56,8 @@ public class OpenApiSpecResourceProvider extends InMemorySwaggerResourcesProvide
 
         SwaggerResource swaggerResource = new SwaggerResource();
         swaggerResource.setName("openapi");
-        swaggerResource.setUrl(openApiSpecService.getSpecLocation());
-        swaggerResource.setLocation(openApiSpecService.getSpecLocation());
+        swaggerResource.setUrl("/openapi-docs");
+        swaggerResource.setLocation("/openapi-docs");
         swaggerResource.setSwaggerVersion(openApiSpecService.getSpecVersion());
         swaggerResources.add(swaggerResource);
 

--- a/generators/server/templates/src/main/java/package/config/apidoc/OpenApiSpecResourceProvider.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/apidoc/OpenApiSpecResourceProvider.java.ejs
@@ -1,0 +1,68 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.config.apidoc;
+
+import io.github.jhipster.config.JHipsterConstants;
+import org.springframework.context.annotation.Primary;
+import org.springframework.context.annotation.Profile;
+import org.springframework.core.env.Environment;
+import org.springframework.stereotype.Component;
+import springfox.documentation.spring.web.DocumentationCache;
+import springfox.documentation.swagger.web.InMemorySwaggerResourcesProvider;
+import springfox.documentation.swagger.web.SwaggerResource;
+import springfox.documentation.swagger.web.SwaggerResourcesProvider;
+
+import java.util.LinkedList;
+import java.util.List;
+
+import <%=packageName%>.service.OpenApiSpecService;
+
+@Component
+@Primary
+@Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
+public class OpenApiSpecResourceProvider extends InMemorySwaggerResourcesProvider implements SwaggerResourcesProvider {
+
+    private final OpenApiSpecService openApiSpecService;
+
+    public OpenApiSpecResourceProvider(Environment environment, DocumentationCache documentationCache, OpenApiSpecService openApiSpecService) {
+        super(environment, documentationCache);
+        this.openApiSpecService = openApiSpecService;
+    }
+
+    /**
+     * Overrides springfox docket endpints list in order to add the endpoint for the static yml file to the /swagger-resources list.
+     *
+     * @return the updated swagger endpoint list
+     */
+    @Override
+    public List<SwaggerResource> get() {
+        List<SwaggerResource> swaggerResources = new LinkedList<>();
+
+        SwaggerResource swaggerResource = new SwaggerResource();
+        swaggerResource.setName("openapi");
+        swaggerResource.setUrl(openApiSpecService.getSpecLocation());
+        swaggerResource.setLocation(openApiSpecService.getSpecLocation());
+        swaggerResource.setSwaggerVersion(openApiSpecService.getSpecVersion());
+        swaggerResources.add(swaggerResource);
+
+        swaggerResources.addAll(super.get());
+        return swaggerResources;
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
@@ -1,0 +1,105 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.service;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
+import org.apache.commons.io.IOUtils;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.stereotype.Service;
+import org.springframework.beans.factory.annotation.Value;
+
+import java.io.IOException;
+
+@Service
+public class OpenApiSpecService {
+
+    public static final String OPENAPI_SPEC_FILE = "api.yml";
+
+    private final ObjectMapper ymlObjectMapper = new ObjectMapper(new YAMLFactory());
+
+    private final JsonNode ymlJsonNode;
+    private final String basePath;
+
+    public OpenApiSpecService(@Value("${openapi.<%= dasherizedBaseName %>.base-path:/api}") String basePath) {
+        this.basePath = basePath;
+        try {
+            ClassPathResource classPathResource = new ClassPathResource("swagger/" + OPENAPI_SPEC_FILE);
+            byte[] ymlContent = IOUtils.toByteArray(classPathResource.getInputStream());
+            ymlJsonNode = ymlObjectMapper.readTree(ymlContent);
+        } catch (Exception e){
+            throw new IllegalStateException("Failed to load api yml file", e);
+        }
+    }
+
+    /**
+     * Returns the yml file content. Replaces servers list to add the endpoint passed as parameter
+     * @param apiEndpoint the api endpoint to be inserted into the yml file
+     * @return the content of the yml, with the dynamically replaced server list
+     * @throws IOException
+     */
+    public byte[] getContent(String apiEndpoint) throws IOException {
+        ArrayNode servers = (ArrayNode) ymlJsonNode.get("servers");
+        if(servers != null){
+            //remove servers (if any)
+            servers.removeAll();
+        } else {
+            servers = ymlObjectMapper.createArrayNode();
+        }
+
+        ObjectNode objectNode = ymlObjectMapper.createObjectNode();
+        objectNode.put("url", apiEndpoint);
+        servers.add(objectNode);
+
+        return ymlObjectMapper.writeValueAsBytes(ymlJsonNode);
+    }
+
+
+    /**
+     * Returns the api version written into the api.yml file
+     * @return the api version
+     * @throws IOException
+     */
+    public String getApiVersion() {
+        return ymlJsonNode.get("info").get("version").textValue();
+    }
+
+    /**
+     * Openapi version (swagger 2.0, openapi 3.0)
+     * @return the spec version (swagger/openapi)
+     * @throws IOException
+     */
+    public String getSpecVersion() {
+        if(ymlJsonNode.has("openapi")) {
+            return ymlJsonNode.get("openapi").textValue();
+        } else if(ymlJsonNode.has("swagger")){
+            return ymlJsonNode.get("swagger").textValue();
+        } else {
+            return null;
+        }
+    }
+
+    public String getSpecLocation(){
+        return basePath + "/" + OPENAPI_SPEC_FILE;
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
@@ -18,7 +18,6 @@
 -%>
 package <%= packageName %>.service;
 
-import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
@@ -33,22 +32,15 @@ import java.io.IOException;
 @Service
 public class OpenApiSpecService {
 
-    public static final String OPENAPI_SPEC_FILE = "api.yml";
-
-    private final ObjectMapper ymlObjectMapper = new ObjectMapper(new YAMLFactory());
-
-    private final JsonNode ymlJsonNode;
     private final String basePath;
+    private final ObjectMapper objectMapper;
+    private final ObjectNode ymlJsonNode;
 
-    public OpenApiSpecService(@Value("${openapi.<%= dasherizedBaseName %>.base-path:/api}") String basePath) {
+    public OpenApiSpecService(@Value("${openapi.apispec-2.base-path:/api}") String basePath) throws IOException {
         this.basePath = basePath;
-        try {
-            ClassPathResource classPathResource = new ClassPathResource("swagger/" + OPENAPI_SPEC_FILE);
-            byte[] ymlContent = IOUtils.toByteArray(classPathResource.getInputStream());
-            ymlJsonNode = ymlObjectMapper.readTree(ymlContent);
-        } catch (Exception e){
-            throw new IllegalStateException("Failed to load api yml file", e);
-        }
+        objectMapper = new ObjectMapper(new YAMLFactory());
+        byte[] ymlContent = IOUtils.toByteArray(new ClassPathResource("swagger/api.yml").getInputStream());
+        ymlJsonNode = (ObjectNode) objectMapper.readTree(ymlContent);
     }
 
     /**
@@ -57,20 +49,17 @@ public class OpenApiSpecService {
      * @return the content of the yml, with the dynamically replaced server list
      * @throws IOException
      */
-    public byte[] getContent(String apiEndpoint) throws IOException {
-        ArrayNode servers = (ArrayNode) ymlJsonNode.get("servers");
-        if(servers != null){
-            //remove servers (if any)
-            servers.removeAll();
-        } else {
-            servers = ymlObjectMapper.createArrayNode();
+    public byte[] getYmlContent(String apiEndpoint) throws IOException {
+
+        ObjectNode objectNode = objectMapper.createObjectNode()
+            .put("url", apiEndpoint + basePath);
+
+        if(!ymlJsonNode.has("servers")) {
+            ymlJsonNode.set("servers", objectMapper.createArrayNode());
         }
 
-        ObjectNode objectNode = ymlObjectMapper.createObjectNode();
-        objectNode.put("url", apiEndpoint);
-        servers.add(objectNode);
-
-        return ymlObjectMapper.writeValueAsBytes(ymlJsonNode);
+        ((ArrayNode) ymlJsonNode.get("servers")).set(0, objectNode);
+        return objectMapper.writeValueAsBytes(ymlJsonNode);
     }
 
 
@@ -96,10 +85,6 @@ public class OpenApiSpecService {
         } else {
             return null;
         }
-    }
-
-    public String getSpecLocation(){
-        return basePath + "/" + OPENAPI_SPEC_FILE;
     }
 
 }

--- a/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Value;
 import java.io.IOException;
 
 @Service
+@Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
 public class OpenApiSpecService {
 
     private final String basePath;

--- a/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/OpenApiSpecService.java.ejs
@@ -19,13 +19,12 @@
 package <%= packageName %>.service;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.fasterxml.jackson.dataformat.yaml.YAMLFactory;
-import org.apache.commons.io.IOUtils;
+import io.github.jhipster.config.JHipsterConstants;
+import org.springframework.context.annotation.Profile;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Service;
-import org.springframework.beans.factory.annotation.Value;
 
 import java.io.IOException;
 
@@ -33,56 +32,40 @@ import java.io.IOException;
 @Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
 public class OpenApiSpecService {
 
-    private final String basePath;
     private final ObjectMapper objectMapper;
-    private final ObjectNode ymlJsonNode;
+    private final ObjectNode openApiSpec;
 
-    public OpenApiSpecService(@Value("${openapi.apispec-2.base-path:/api}") String basePath) throws IOException {
-        this.basePath = basePath;
+    public OpenApiSpecService() throws IOException {
         objectMapper = new ObjectMapper(new YAMLFactory());
-        byte[] ymlContent = IOUtils.toByteArray(new ClassPathResource("swagger/api.yml").getInputStream());
-        ymlJsonNode = (ObjectNode) objectMapper.readTree(ymlContent);
+        openApiSpec = (ObjectNode) objectMapper.readTree(new ClassPathResource("swagger/api.yml").getInputStream());
     }
 
     /**
-     * Returns the yml file content. Replaces servers list to add the endpoint passed as parameter
-     * @param apiEndpoint the api endpoint to be inserted into the yml file
-     * @return the content of the yml, with the dynamically replaced server list
+     * Returns the yml file content
+     * @return the content of the yml
      * @throws IOException
      */
-    public byte[] getYmlContent(String apiEndpoint) throws IOException {
-
-        ObjectNode objectNode = objectMapper.createObjectNode()
-            .put("url", apiEndpoint + basePath);
-
-        if(!ymlJsonNode.has("servers")) {
-            ymlJsonNode.set("servers", objectMapper.createArrayNode());
-        }
-
-        ((ArrayNode) ymlJsonNode.get("servers")).set(0, objectNode);
-        return objectMapper.writeValueAsBytes(ymlJsonNode);
+    public byte[] getYmlContent() throws IOException {
+        return objectMapper.writeValueAsBytes(openApiSpec);
     }
-
 
     /**
      * Returns the api version written into the api.yml file
      * @return the api version
-     * @throws IOException
      */
     public String getApiVersion() {
-        return ymlJsonNode.get("info").get("version").textValue();
+        return openApiSpec.get("info").get("version").textValue();
     }
 
     /**
      * Openapi version (swagger 2.0, openapi 3.0)
      * @return the spec version (swagger/openapi)
-     * @throws IOException
      */
     public String getSpecVersion() {
-        if(ymlJsonNode.has("openapi")) {
-            return ymlJsonNode.get("openapi").textValue();
-        } else if(ymlJsonNode.has("swagger")){
-            return ymlJsonNode.get("swagger").textValue();
+        if(openApiSpec.has("openapi")) {
+            return openApiSpec.get("openapi").textValue();
+        } else if(openApiSpec.has("swagger")){
+            return openApiSpec.get("swagger").textValue();
         } else {
             return null;
         }

--- a/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
@@ -18,21 +18,15 @@
 -%>
 package <%= packageName %>.web.rest;
 
+import <%= packageName %>.OpenApiSpecService;
 import io.github.jhipster.config.JHipsterConstants;
 import org.springframework.context.annotation.Profile;
-import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
 
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
-import java.util.Collections;
-import java.util.Map;
-
-import <%=packageName%>.service.OpenApiSpecService;
 
 /**
  * Serves the open api yml file.
@@ -48,12 +42,8 @@ public class OpenApiSpecController {
     }
 
     @GetMapping(value = "/openapi-docs")
-    public ResponseEntity<byte[]> getApis(HttpServletRequest httpServletRequest) throws IOException {
-        HttpHeaders headers = new HttpHeaders();
-        headers.add("Content-Type", "application/application+json");
-        String apiEndpoint = httpServletRequest.getRequestURL().toString()
-            .replace("/openapi-docs", "");
-        return new ResponseEntity<>(openApiSpecService.getYmlContent(apiEndpoint), headers, HttpStatus.OK);
+    public ResponseEntity<byte[]> getApis() throws IOException {
+        return new ResponseEntity<>(openApiSpecService.getYmlContent(), HttpStatus.OK);
     }
 
 }

--- a/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
@@ -26,7 +26,6 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
 
 import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
@@ -36,11 +35,9 @@ import java.util.Map;
 import <%=packageName%>.service.OpenApiSpecService;
 
 /**
- * Controller needed to serve the yml file stored into /resources/swagger/api.yml in a 'almost-static' way.
- * This allows to have the exposed yml file exactly equals as the one in the yml file and avoiding springfox to generate the documentation.
+ * Serves the open api yml file.
  */
 @Controller
-@RequestMapping("${openapi.<%= dasherizedBaseName %>.base-path:/api}")
 @Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
 public class OpenApiSpecController {
 
@@ -50,13 +47,13 @@ public class OpenApiSpecController {
         this.openApiSpecService = openApiSpecService;
     }
 
-    @GetMapping(value = "/api.yml", produces = MediaType.TEXT_PLAIN_VALUE)
+    @GetMapping(value = "/openapi-docs")
     public ResponseEntity<byte[]> getApis(HttpServletRequest httpServletRequest) throws IOException {
         HttpHeaders headers = new HttpHeaders();
         headers.add("Content-Type", "application/application+json");
         String apiEndpoint = httpServletRequest.getRequestURL().toString()
-            .replace("/api.yml", "");
-        return new ResponseEntity<>(openApiSpecService.getContent(apiEndpoint), headers, HttpStatus.OK);
+            .replace("/openapi-docs", "");
+        return new ResponseEntity<>(openApiSpecService.getYmlContent(apiEndpoint), headers, HttpStatus.OK);
     }
 
 }

--- a/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
@@ -18,7 +18,7 @@
 -%>
 package <%= packageName %>.web.rest;
 
-import <%= packageName %>.OpenApiSpecService;
+import <%= packageName %>.service.OpenApiSpecService;
 import io.github.jhipster.config.JHipsterConstants;
 import org.springframework.context.annotation.Profile;
 import org.springframework.http.HttpStatus;

--- a/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/OpenApiSpecController.java.ejs
@@ -1,0 +1,62 @@
+<%#
+ Copyright 2013-2018 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.web.rest;
+
+import io.github.jhipster.config.JHipsterConstants;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Map;
+
+import <%=packageName%>.service.OpenApiSpecService;
+
+/**
+ * Controller needed to serve the yml file stored into /resources/swagger/api.yml in a 'almost-static' way.
+ * This allows to have the exposed yml file exactly equals as the one in the yml file and avoiding springfox to generate the documentation.
+ */
+@Controller
+@RequestMapping("${openapi.<%= dasherizedBaseName %>.base-path:/api}")
+@Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
+public class OpenApiSpecController {
+
+    private final OpenApiSpecService openApiSpecService;
+
+    public OpenApiSpecController(OpenApiSpecService openApiSpecService) {
+        this.openApiSpecService = openApiSpecService;
+    }
+
+    @GetMapping(value = "/api.yml", produces = MediaType.TEXT_PLAIN_VALUE)
+    public ResponseEntity<byte[]> getApis(HttpServletRequest httpServletRequest) throws IOException {
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Content-Type", "application/application+json");
+        String apiEndpoint = httpServletRequest.getRequestURL().toString()
+            .replace("/api.yml", "");
+        return new ResponseEntity<>(openApiSpecService.getContent(apiEndpoint), headers, HttpStatus.OK);
+    }
+
+}

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -303,7 +303,7 @@ jhipster:
             duration-in-seconds: 3600
         <%_ if (!reactive) { _%>
         authorized-microservices-endpoints: # Access Control Policy, if left empty for a route, all endpoints will be accessible
-            app1: /api,/v2/api-docs # recommended dev configuration
+            app1: /api,/v2/api-docs<%_ if (enableSwaggerCodegen) { _%>,/openapi-docs<%_ } _%> # recommended dev configuration
         <%_ } _%>
     <%_ } _%>
     <%_ if (cacheProvider !== 'no') { _%>

--- a/generators/server/templates/src/main/resources/static/microservices_index.html.ejs
+++ b/generators/server/templates/src/main/resources/static/microservices_index.html.ejs
@@ -85,7 +85,7 @@
                 <li>Its default URL is <a href="http://localhost:8761/">http://localhost:8761/</a> and its default login/password is <code>admin/admin</code></li>
             </ul>
         </li>
-        <li>Swagger documentation endpoint for those APIs is at <a href="./v2/api-docs">/v2/api-docs</a>, but if you want access to the full Swagger UI, you should use a JHipster gateway or a JHipster Registry, which will serve as API developer portals.</li>
+        <li>Swagger documentation endpoint for those APIs is at <a href="./v2/api-docs">/v2/api-docs</a> <%_ if (enableSwaggerCodegen) { _%>and at <a href="./openapi-docs">/openapi-docs</a><%_ } _%>, but if you want access to the full Swagger UI, you should use a JHipster gateway or a JHipster Registry, which will serve as API developer portals.</li>
     </ul>
 
     <h2>

--- a/generators/server/templates/src/main/resources/swagger/api.yml.ejs
+++ b/generators/server/templates/src/main/resources/swagger/api.yml.ejs
@@ -23,6 +23,8 @@ info:
     title: "<%= baseName %>"
     version: 0.0.1
 servers:
+    - url: /api
+      description: Current Development Endpoint
     - url: http://localhost:<%= serverPort %>/api
       description: Development server
     - url: https://localhost:<%= serverPort %>/api


### PR DESCRIPTION
Fix #9752

work in progress

Todo:

- [X] Create a /openapi-docs that serves the api.yml file
- [X] Add provider to add the /openapi-docs endpoint to the list of available specs
- [X] Add security / CORS exception for /openapi-docs
- [ ] Handle conflict between `OpenApiSpecResourceProvider` and `GatewaySwaggerResourceProvider`
- [ ] Handle authentication in swagger UI /openapi-docs 
- [ ] find a way to exclude openapi endpoints from springfox scanning
- [ ] ? Replace oauth variables in the yml file based on application properties
- [ ] ? Publish the API version in /management/info


Default checks:

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
