### PR TITLE
Add Gitter Channel Links to Reply Templates [ci-skip]

### DIFF
--- a/.github/MAINTAINERS_REPLY_TEMPLATES/DONT_COMMENT_ON_OLD_ISSUE.md
+++ b/.github/MAINTAINERS_REPLY_TEMPLATES/DONT_COMMENT_ON_OLD_ISSUE.md
@@ -6,3 +6,5 @@ If you think this issue still applies, please [create a new ticket](https://gith
 -   This will increase your chances to get an answer
 -   Answers will be of higher quality, as there is a voting system
 -   This will also help other users who might have the same issue, as questions are tagged and easily searchable
+
+Finally, you can also use [our chat room on gitter](https://gitter.im/jhipster/generator-jhipster).

--- a/.github/MAINTAINERS_REPLY_TEMPLATES/GUIDELINES_NOT_FOLLOWED.md
+++ b/.github/MAINTAINERS_REPLY_TEMPLATES/GUIDELINES_NOT_FOLLOWED.md
@@ -16,3 +16,5 @@ Issues opened without proper details will be closed without explanation.
 -   This will increase your chances to get an answer
 -   Answers will be of higher quality, as there is a voting system
 -   This will also help other users who might have the same issue, as questions are tagged and easily searchable
+
+Finally, you can also use [our chat room on gitter](https://gitter.im/jhipster/generator-jhipster).

--- a/.github/MAINTAINERS_REPLY_TEMPLATES/USE_STACK_OVERFLOW.md
+++ b/.github/MAINTAINERS_REPLY_TEMPLATES/USE_STACK_OVERFLOW.md
@@ -4,3 +4,5 @@ This is not a **bug** or **feature request** and hence this is not the correct f
 -   This will increase your chances to get an answer
 -   Answers will be of higher quality, as there is a voting system
 -   This will also help other users who might have the same issue, as questions are tagged and easily searchable
+
+Finally, you can also use [our chat room on gitter](https://gitter.im/jhipster/generator-jhipster).


### PR DESCRIPTION
This adds a Gitter channel link to our reply templates 😄 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
