### PR TITLE
Add Condition for Refresh Token Nearing Expiry

### DIFF
--- a/generators/server/templates/src/main/java/package/web/filter/RefreshTokenFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/filter/RefreshTokenFilter.java.ejs
@@ -107,8 +107,8 @@ public class RefreshTokenFilter extends GenericFilterBean {
             } else if (accessTokenCookie != null) {
                 log.warn("access token found, but no refresh token, stripping them all");
                 OAuth2AccessToken token = tokenStore.readAccessToken(accessTokenCookie.getValue());
-                if (token.isExpired()) {
-                    throw new InvalidTokenException("access token has expired, but there's no refresh token");
+                if (token.isExpired() || token.getExpiresIn() < REFRESH_WINDOW_SECS) {
+                    throw new InvalidTokenException("access token has expired or expires within " + REFRESH_WINDOW_SECS + " seconds, but there's no refresh token");
                 }
             }
         }


### PR DESCRIPTION
Fixes #11236

Somehow in Windows machines the token isn't expired when checking but do expire within 30 seconds after the check. So I believe we need to add this condition for throwing the `InvalidTokenException`. 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
