### PR TITLE
Fix typos in react test generation

### DIFF
--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/auth/private-route.spec.tsx.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/auth/private-route.spec.tsx.ejs
@@ -76,7 +76,7 @@ describe('private-route component', () => {
 
 describe('hasAnyAuthority', () => {
   // All tests will go here
-  it('Should return false when authorities is invlaid', () => {
+  it('Should return false when authorities is invalid', () => {
     expect(hasAnyAuthority(undefined, undefined)).toEqual(false);
     expect(hasAnyAuthority(null, [])).toEqual(false);
     expect(hasAnyAuthority([], [])).toEqual(false);
@@ -95,7 +95,7 @@ describe('hasAnyAuthority', () => {
     expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_ADMIN'])).toEqual(true);
   });
 
-  it('Should return false when authorities is valid and hasAnyAuthorities does not contains an authority', () => {
+  it('Should return false when authorities is valid and hasAnyAuthorities does not contain an authority', () => {
     expect(hasAnyAuthority(['ROLE_USER'], ['ROLE_ADMIN'])).toEqual(false);
     expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_USERSS'])).toEqual(false);
     expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLEUSER', 'ROLEADMIN'])).toEqual(false);


### PR DESCRIPTION
Fixed two typos in `private-route.spec.tsx.ejs`.

I think that [skip ci] should be observed with this commit as it only changes a couple of character in a test description.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
