### PR TITLE
refactor: remove cassandra unit

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -495,9 +495,6 @@ dependencies {
     <%_ } _%>
     annotationProcessor "org.springframework.boot:spring-boot-configuration-processor:${spring_boot_version}"
     <%_ if (databaseType === 'cassandra') { _%>
-    testImplementation ("org.cassandraunit:cassandra-unit-spring") {
-        exclude(group: "org.slf4j")
-    }
     testImplementation "org.testcontainers:database-commons"
     <%_ } _%>
     <%_ if (cucumberTests) { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -383,11 +383,6 @@
 <%_ } _%>
 <%_ if (databaseType === 'cassandra') { _%>
         <dependency>
-            <groupId>org.cassandraunit</groupId>
-            <artifactId>cassandra-unit-spring</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.testcontainers</groupId>
             <artifactId>database-commons</artifactId>
             <scope>test</scope>

--- a/generators/server/templates/src/test/java/package/AbstractCassandraTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/AbstractCassandraTest.java.ejs
@@ -18,29 +18,27 @@
 -%>
 package <%= packageName %>;
 
-import io.github.jhipster.config.JHipsterConstants;
-
 import com.datastax.driver.core.Cluster;
 import com.datastax.driver.core.Session;
-import org.apache.cassandra.exceptions.ConfigurationException;
-import org.apache.thrift.transport.TTransportException;
-import org.cassandraunit.CQLDataLoader;
-import org.cassandraunit.dataset.cql.ClassPathCQLDataSet;
+import io.github.jhipster.config.JHipsterConstants;
+import org.apache.commons.io.IOUtils;
+import org.apache.commons.lang3.StringUtils;
 import org.junit.jupiter.api.BeforeAll;
 import org.springframework.test.context.ActiveProfiles;
-import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.Wait;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.DirectoryStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.time.Duration;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 
@@ -50,13 +48,13 @@ import java.util.List;
 @ActiveProfiles(JHipsterConstants.SPRING_PROFILE_TEST)
 public class AbstractCassandraTest {
 
-    public static final String CASSANDRA_UNIT_KEYSPACE = "cassandra_unit_keyspace";
+    public static final String CASSANDRA_TEST_KEYSPACE = "cassandra_test_keyspace";
     public static GenericContainer CASSANDRA_CONTAINER = null;
     public static final int CASSANDRA_TEST_PORT = 9042;
     private static boolean started = false;
 
     @BeforeAll
-    public static void startServer() throws TTransportException, ConfigurationException, IOException, URISyntaxException {
+    public static void startServer() throws IOException, URISyntaxException {
         if (!started) {
             startTestcontainer();
             Cluster cluster = new Cluster.Builder()
@@ -68,13 +66,12 @@ public class AbstractCassandraTest {
 
             Session session = cluster.connect();
             createTestKeyspace(session);
-            CQLDataLoader dataLoader = new CQLDataLoader(session);
-            applyScripts(dataLoader, "config/cql/changelog/", "*.cql");
+            applyScripts(session, "config/cql/changelog/", "*.cql");
             started = true;
         }
     }
 
-    private static void startTestcontainer() throws TTransportException, IOException {
+    private static void startTestcontainer() {
         CASSANDRA_CONTAINER =
             new GenericContainer("<%= DOCKER_CASSANDRA %>")
                 .waitingFor(Wait.forListeningPort().withStartupTimeout(Duration.ofSeconds(30)))
@@ -84,13 +81,13 @@ public class AbstractCassandraTest {
     }
 
     private static void createTestKeyspace(Session session) {
-        String createQuery = "CREATE KEYSPACE " + CASSANDRA_UNIT_KEYSPACE + " WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1}";
+        String createQuery = "CREATE KEYSPACE " + CASSANDRA_TEST_KEYSPACE + " WITH replication={'class' : 'SimpleStrategy', 'replication_factor':1}";
         session.execute(createQuery);
-        String useKeyspaceQuery = "USE " + CASSANDRA_UNIT_KEYSPACE;
+        String useKeyspaceQuery = "USE " + CASSANDRA_TEST_KEYSPACE;
         session.execute(useKeyspaceQuery);
     }
 
-    private static void applyScripts(CQLDataLoader dataLoader, String cqlDir, String pattern) throws IOException, URISyntaxException {
+    private static void applyScripts(Session session, String cqlDir, String pattern) throws IOException, URISyntaxException {
         URL dirUrl = ClassLoader.getSystemResource(cqlDir);
         if (dirUrl == null) { // protect for empty directory
             return;
@@ -105,7 +102,13 @@ public class AbstractCassandraTest {
         Collections.sort(scripts);
 
         for (String fileName : scripts) {
-            dataLoader.load(new ClassPathCQLDataSet(cqlDir + fileName, false, false, CASSANDRA_UNIT_KEYSPACE));
+            String cqlFileAsString = IOUtils.toString(AbstractCassandraTest.class.getResourceAsStream("/" + cqlDir + fileName), StandardCharsets.UTF_8);
+            String[] statements = StringUtils.split(cqlFileAsString, ";");
+
+            Arrays.stream(statements)
+                .map(StringUtils::normalizeSpace)
+                .filter(StringUtils::isNotBlank)
+                .forEach(cql -> session.execute(cql + ";"));
         }
     }
 }

--- a/generators/server/templates/src/test/java/package/CassandraKeyspaceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/CassandraKeyspaceIT.java.ejs
@@ -42,8 +42,8 @@ public class CassandraKeyspaceIT extends AbstractCassandraTest {
     private Session session;
 
     @Test
-    public void shouldListCassandraUnitKeyspace() throws Exception {
+    public void shouldListCassandraTestKeyspace() {
         Metadata metadata = session.getCluster().getMetadata();
-        assertThat(metadata.getKeyspace(CASSANDRA_UNIT_KEYSPACE)).isNotNull();
+        assertThat(metadata.getKeyspace(CASSANDRA_TEST_KEYSPACE)).isNotNull();
     }
 }

--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -90,7 +90,7 @@ spring:
             port: 0
             protocolVersion: V4
             compression: NONE
-            keyspaceName: cassandra_unit_keyspace
+            keyspaceName: cassandra_test_keyspace
     <%_ } _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
         elasticsearch:


### PR DESCRIPTION
Remove cassandra unit dependency.

Historically, `EmbeddedCassandraServerHelper.startEmbeddedCassandra()` feature was used and it was the way to have a running cassandra to perform tests.

Then; testcontainers has been used to start a cassandra instance (jhipster/generator-jhipster@9951387)

Today the only feature we use from cassandra unit is to load CQL files through `dataLoader.load(new ClassPathCQLDataSet(cqlDir + fileName, false, false, CASSANDRA_UNIT_KEYSPACE));`

This dependency is quite heavy, it pulls `org.apache.cassandra:cassandra-all` which is the whole cassandra server that we don't use .


