### PR TITLE
Add property to use Redis Cluster

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -103,7 +103,7 @@ const serverFiles = {
         {
             condition: generator => generator.cacheProvider === 'redis',
             path: DOCKER_DIR,
-            templates: ['redis.yml']
+            templates: ['redis.yml', 'redis-cluster.yml', 'redis/Redis-Cluster.Dockerfile', 'redis/connectRedisCluster.sh']
         },
         {
             condition: generator => generator.searchEngine === 'elasticsearch',

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -247,7 +247,7 @@ function askForServerSideOpts(meta) {
                 },
                 {
                     value: 'redis',
-                    name: 'Yes, with the Redis implementation (single server)'
+                    name: 'Yes, with the Redis implementation'
                 },
                 {
                     value: 'no',

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -60,6 +60,9 @@ services:
             <%_ } _%>
             <%_ if (cacheProvider === 'redis') { _%>
             - JHIPSTER_CACHE_REDIS_SERVER=redis://<%= baseName.toLowerCase() %>-redis:6379
+            - JHIPSTER_CACHE_REDIS_CLUSTER=false
+            # - JHIPSTER_CACHE_REDIS_SERVER=redis://<%= baseName.toLowerCase() %>-redis:6379
+            # - JHIPSTER_CACHE_REDIS_CLUSTER=true
             <%_ } _%>
             <%_ if (authenticationType === 'oauth2') { _%>
             - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster

--- a/generators/server/templates/src/main/docker/redis-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/redis-cluster.yml.ejs
@@ -1,0 +1,86 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+      http://www.apache.org/licenses/LICENSE-2.0
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
+services:
+    <%= baseName.toLowerCase() %>-redis:
+        image: <%= DOCKER_REDIS %>
+        command:
+            - "redis-server"
+            - "--port 6379"
+            - "--cluster-enabled yes"
+            - "--cluster-config-file nodes.conf"
+            - "--cluster-node-timeout 5000"
+            - "--appendonly yes"
+        ports:
+            - "6379:6379"
+    <%= baseName.toLowerCase() %>-redis-1:
+        image: <%= DOCKER_REDIS %>
+        command:
+            - "redis-server"
+            - "--port 6379"
+            - "--cluster-enabled yes"
+            - "--cluster-config-file nodes.conf"
+            - "--cluster-node-timeout 5000"
+            - "--appendonly yes"
+        ports:
+            - "16379:6379"
+    <%= baseName.toLowerCase() %>-redis-2:
+        image: <%= DOCKER_REDIS %>
+        command:
+            - "redis-server"
+            - "--port 6379"
+            - "--cluster-enabled yes"
+            - "--cluster-config-file nodes.conf"
+            - "--cluster-node-timeout 5000"
+            - "--appendonly yes"
+        ports:
+            - "26379:6379"
+    <%= baseName.toLowerCase() %>-redis-3:
+        image: <%= DOCKER_REDIS %>
+        command:
+            - "redis-server"
+            - "--port 6379"
+            - "--cluster-enabled yes"
+            - "--cluster-config-file nodes.conf"
+            - "--cluster-node-timeout 5000"
+            - "--appendonly yes"
+        ports:
+            - "36379:6379"
+    <%= baseName.toLowerCase() %>-redis-4:
+        image: <%= DOCKER_REDIS %>
+        command:
+            - "redis-server"
+            - "--port 6379"
+            - "--cluster-enabled yes"
+            - "--cluster-config-file nodes.conf"
+            - "--cluster-node-timeout 5000"
+            - "--appendonly yes"
+        ports:
+            - "46379:6379"
+    <%= baseName.toLowerCase() %>-redis-5:
+        image: <%= DOCKER_REDIS %>
+        command:
+            - "redis-server"
+            - "--port 6379"
+            - "--cluster-enabled yes"
+            - "--cluster-config-file nodes.conf"
+            - "--cluster-node-timeout 5000"
+            - "--appendonly yes"
+        ports:
+            - "56379:6379"
+    <%= baseName.toLowerCase() %>-redis-cluster-builder:
+        build:
+            context: .
+            dockerfile: redis/Redis-Cluster.Dockerfile

--- a/generators/server/templates/src/main/docker/redis/Redis-Cluster.Dockerfile.ejs
+++ b/generators/server/templates/src/main/docker/redis/Redis-Cluster.Dockerfile.ejs
@@ -1,0 +1,6 @@
+FROM <%= DOCKER_REDIS %>
+RUN apt update && \
+    apt install dnsutils -y
+ADD redis/connectRedisCluster.sh /usr/local/bin/connectRedisCluster
+RUN chmod 755 /usr/local/bin/connectRedisCluster
+ENTRYPOINT ["connectRedisCluster"]

--- a/generators/server/templates/src/main/docker/redis/connectRedisCluster.sh.ejs
+++ b/generators/server/templates/src/main/docker/redis/connectRedisCluster.sh.ejs
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+
+function log {
+  echo "[$(date)]: $*"
+}
+
+log "Start Redis Cluster builder"
+sleep 5
+
+log "Connect all Redis containers"
+redis-cli \
+  --cluster-replicas 1 \
+  --cluster-yes \
+  --cluster create \
+    $(host <%= baseName.toLowerCase() %>-redis|awk '{print $4}'):6379 \
+    $(host <%= baseName.toLowerCase() %>-redis-1|awk '{print $4}'):6379 \
+    $(host <%= baseName.toLowerCase() %>-redis-2|awk '{print $4}'):6379 \
+    $(host <%= baseName.toLowerCase() %>-redis-3|awk '{print $4}'):6379 \
+    $(host <%= baseName.toLowerCase() %>-redis-4|awk '{print $4}'):6379 \
+    $(host <%= baseName.toLowerCase() %>-redis-5|awk '{print $4}'):6379

--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -726,7 +726,11 @@ public class CacheConfiguration {
     public javax.cache.configuration.Configuration<Object, Object> jcacheConfiguration(JHipsterProperties jHipsterProperties) {
         MutableConfiguration<Object, Object> jcacheConfig = new MutableConfiguration<>();
         Config config = new Config();
-        config.useSingleServer().setAddress(jHipsterProperties.getCache().getRedis().getServer());
+        if (jHipsterProperties.getCache().getRedis().isCluster()) {
+            config.useClusterServers().addNodeAddress(jHipsterProperties.getCache().getRedis().getServer());
+        } else {
+            config.useSingleServer().setAddress(jHipsterProperties.getCache().getRedis().getServer()[0]);
+        }
         jcacheConfig.setStatisticsEnabled(true);
         jcacheConfig.setExpiryPolicyFactory(CreatedExpiryPolicy.factoryOf(new Duration(TimeUnit.SECONDS, jHipsterProperties.getCache().getRedis().getExpiration())));
         return RedissonConfiguration.fromInstance(Redisson.create(config), jcacheConfig);

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -295,6 +295,10 @@ jhipster:
         <%_ if (cacheProvider === 'redis') { _%>
         redis: # Redis configuration
             expiration: 3600 # By default objects stay 1 hour (in seconds) in the cache
+            server: redis://localhost:6379
+            cluster: false
+            # server: redis://localhost:6379,redis://localhost:16379,redis://localhost:26379
+            # cluster: true
         <%_ } _%>
     <%_ } _%>
     <%_ if (applicationType !== 'microservice') { _%>

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -301,6 +301,9 @@ jhipster:
         redis: # Redis configuration
             expiration: 3600 # By default objects stay 1 hour (in seconds) in the cache
             server: redis://localhost:6379
+            cluster: false
+            # server: redis://localhost:6379,redis://localhost:16379,redis://localhost:26379
+            # cluster: true
         <%_ } _%>
     <%_ } _%>
     <%_ if (authenticationType === 'jwt') { _%>

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -252,6 +252,9 @@ const expectedFiles = {
     redis: [
         `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/CacheConfiguration.java`,
         `${DOCKER_DIR}redis.yml`,
+        `${DOCKER_DIR}redis-cluster.yml`,
+        `${DOCKER_DIR}redis/connectRedisCluster.sh`,
+        `${DOCKER_DIR}redis/Redis-Cluster.Dockerfile`,
         `${SERVER_TEST_SRC_DIR}/com/mycompany/myapp/RedisTestContainerExtension.java`
     ],
 


### PR DESCRIPTION
It's the dev part of https://github.com/jhipster/generator-jhipster/issues/11129
Depends on: https://github.com/jhipster/jhipster/pull/571

By default, it will use the single node. You need to update the application-dev.yml or application-prod.yml to use Redis Cluster. The related properties are commented.

Once it's enabled, you can start the cluster, using `docker-compose -f src/main/docker/redis-cluster.yml up -d` :

![docker-compose-redis-cluster](https://user-images.githubusercontent.com/9156882/74090993-e97ae180-4ab2-11ea-98ac-95b402d85496.png)

Here when playing with the application, and check the different KEYS in my :hamburger: Redis Cluster : 

![docker-compose-redis-keys](https://user-images.githubusercontent.com/9156882/74090995-eed82c00-4ab2-11ea-87d2-94333f23694c.png)


_____

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
