### PR TITLE
Replace obsolete webpack-visualizer-plugin by webpack-bundle-analyzer.

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -154,11 +154,11 @@
     "webdriver-manager": "12.1.7",
     <%_ } _%>
     "webpack": "4.41.2",
+    "webpack-bundle-analyzer": "3.6.0",
     "webpack-cli": "3.3.10",
     "webpack-dev-server": "3.9.0",
     "webpack-merge": "4.2.2",
     "webpack-notifier": "1.8.0",
-    "webpack-visualizer-plugin": "0.1.11",
     "workbox-webpack-plugin": "4.3.1",
     "write-file-webpack-plugin": "4.5.1"
   },

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -20,7 +20,7 @@ const webpack = require('webpack');
 const webpackMerge = require('webpack-merge');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
-const Visualizer = require('webpack-visualizer-plugin');
+const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;
 const MomentLocalesPlugin = require('moment-locales-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
@@ -151,9 +151,11 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
                 // jhipster-needle-i18n-language-moment-webpack - JHipster will add/remove languages in this array
             ]
         }),
-        new Visualizer({
+        new BundleAnalyzerPlugin({
+            analyzerMode: 'static',
+            openAnalyzer: false,
             // Webpack statistics in target folder
-            filename: '../stats.html'
+            reportFilename: '../stats.html'
         }),
         new AngularCompilerPlugin({
             mainPath: utils.root('<%= MAIN_SRC_DIR %>app/app.main.ts'),


### PR DESCRIPTION
webpack-visualizer-plugin is no longer maintained for last 3 years and it raises warnings during `npm install`:

~~~
npm WARN deprecated core-js@1.2.7: core-js@<2.6.5 is no longer maintained. Please, upgrade to core-js@3 or at least to actual version of core-js@2.
npm WARN deprecated core-js@2.6.11: core-js@<3 is no longer maintained and not recommended for usage due to the number of issues. Please, upgrade your dependencies to the actual version of core-js@3.
npm WARN deprecated cross-spawn-async@2.2.5: cross-spawn no longer requires a build toolchain, use it instead
~~~

Fix #11265

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
