### PR TITLE
Use Correct Quotes for GAE Deployments in Gradle

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -86,7 +86,7 @@ if (project.hasProperty("gae")) {
 
     dependencyManagement {
         imports {
-            mavenBom 'io.github.jhipster:jhipster-dependencies:${jhipster_dependencies_version}'
+            mavenBom "io.github.jhipster:jhipster-dependencies:${jhipster_dependencies_version}"
         }
     }
     appengineStage.dependsOn thinResolve


### PR DESCRIPTION
Related to #11249

I've noticed that I've mistakenly committed the wrong quotes and this [gives an error](https://github.com/jhipster/generator-jhipster/issues/11249#issuecomment-583884467) in Gradle when deploying to GAE. This PR corrects that. 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
