### PR TITLE
Add Support for Pull Request CI Skipping for GitHub Actions

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -37,7 +37,7 @@ jobs:
     applications:
         name: ${{ matrix.app-type }}
         runs-on: ${{ matrix.os }}
-        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.pull_request.title, '[skip ci]') && !contains(github.pull_request.title, '[ci skip]')"
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -23,7 +23,7 @@ jobs:
     generator-jhipster:
         name: npm test
         runs-on: ${{ matrix.os }}
-        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.pull_request.title, '[skip ci]') && !contains(github.pull_request.title, '[ci skip]')"
         timeout-minutes: 20
         strategy:
             fail-fast: false

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -24,7 +24,7 @@ jobs:
     validation:
         name: 'Validation'
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.pull_request.title, '[skip ci]') && !contains(github.pull_request.title, '[ci skip]')"
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -37,7 +37,7 @@ jobs:
     applications:
         name: ${{ matrix.app-type }}
         runs-on: ${{ matrix.os }}
-        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.pull_request.title, '[skip ci]') && !contains(github.pull_request.title, '[ci skip]')"
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -89,6 +89,9 @@ jobs:
           #----------------------------------------------------------------------
           # Install all tools and check configuration
           #----------------------------------------------------------------------
+          - bash: exit 0
+            condition: or(contains(variables['Build.SourceVersionMessage'], '[skip ci]'), contains(variables['Build.SourceVersionMessage'], '[ci skip]'))
+            displayName: 'CHECK: check if commit contains CI skip'
           - task: NodeTool@0
             inputs:
                 versionSpec: '12.14.0'

--- a/generators/ci-cd/templates/github-ci.yml.ejs
+++ b/generators/ci-cd/templates/github-ci.yml.ejs
@@ -26,11 +26,11 @@ jobs:
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1
-    <%_ } _%>   
+    <%_ } _%>
     pipeline:
         name: <%= baseName %> pipeline
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]')"
+        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.pull_request.title, '[skip ci]') && !contains(github.pull_request.title, '[ci skip]')"
         timeout-minutes: 40
         env:
             <%_ if (!skipClient) { _%>


### PR DESCRIPTION
Sometime back I've added support for `[skip ci]` and `[ci skip]` in our GitHub CI builds. But I've overlooked the fact that pull request builds should be handled a bit differently. I noticed this once @pascalgrimaud pointed this out at; https://github.com/jhipster/generator-jhipster/pull/11291#issuecomment-585116946

This commit corrects that and now when you add [skip ci] or [ci skip] in the pull request title the GitHub Actions will not be triggered. 

If you see any issues with this feel free to ping me again. :smile: 

@pascalgrimaud 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
