### PR TITLE
Create auto labeler workflow for PRs [skip ci]

### DIFF
--- a/.github/labeler.yml
+++ b/.github/labeler.yml
@@ -1,0 +1,61 @@
+"theme: cli":
+    - cli/*
+
+"theme: CI Builds":
+    - .github/workflows/*
+    - azure-pipelines.yml
+
+"theme: dependencies":
+    - package.json
+    - package-lock.json
+
+"theme: front":
+    - generators/client/index.js
+    - generators/client/prompts.js
+    - generators/needle-api/*
+    - generators/entity-client/*
+
+"theme: angular":
+    - generators/client/files-angular.js
+    - generators/client/templates/angular/**/*
+    - generators/entity-client/templates/angular/**/*
+
+"theme: react":
+    - generators/client/files-react.js
+    - generators/client/templates/react/**/*
+    - generators/entity-client/templates/react/**/*
+
+"theme: jhipster-internals":
+    - generators/generator-*.js
+    - generators/statistics.js
+    - generators/utils.js
+    # client/server common
+    - generators/app/**/*.js
+    - generators/common/**/*.js
+    - generators/needle-*.js
+    - generators/cleanup.js
+    - generators/entity/**/*
+
+"theme: i18n":
+    - generators/languages/**/*
+    - generators/entity-i18n/**/*
+
+"theme: java":
+    - generators/server/**/*
+    - generators/entity-server/**/*
+
+"theme: upgrade":
+    - generators/upgrade/**/*
+
+"theme: docker :whale:":
+    - generators/docker*.js
+    - generators/docker-compose/**/*
+
+"theme: aws":
+    - generators/aws/**/*
+    - generators/aws-containers/**/*
+
+"theme: kubernetes":
+    - generators/kubernetes/**/*
+    - generators/kubernetes-helm/**/*
+    - generators/kubernetes-knative/**/*

--- a/.github/workflows/labeler.yml
+++ b/.github/workflows/labeler.yml
@@ -1,0 +1,13 @@
+name: "Pull Request Labeler"
+on:
+    schedule:
+        # * is a special character in YAML so you have to quote this string
+        - cron:  '*/5 * * * *'
+
+jobs:
+    triage:
+        runs-on: ubuntu-latest
+        steps:
+            - uses: mshima/labeler@v2
+              with:
+                  repo-token: "${{ secrets.GITHUB_TOKEN }}"


### PR DESCRIPTION
Following https://github.com/jhipster/generator-jhipster/issues/11283

This PR creates a workflow for auto labeling PRs based on the files changes.

It uses scheduled runs and tags PRs that aren't tagged yet.
Why don't use on pull_request? https://github.com/actions/labeler/issues/12
Once this bug is resolved, we should switch to on pull_request.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
