### PR TITLE
jaxb dependencies for liquibase

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1189,6 +1189,11 @@
                             <artifactId>spring-beans</artifactId>
                             <version>${spring.version}</version>
                         </dependency>
+                        <dependency>
+                            <groupId>jakarta.xml.bind</groupId>
+                            <artifactId>jakarta.xml.bind-api</artifactId>
+                            <version>${jaxb-runtime.version}</version>
+                        </dependency>
                     </dependencies>
                 </plugin>
 <%_ } _%>


### PR DESCRIPTION
Jaxb B dependency is mandatory to execute liquibase.
Looks like it's not in the main dependencies anymore

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
