### PR TITLE
Create a needle to add logger inside logback-spring.xml on server-side

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -819,6 +819,16 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Add a logger to the logback-spring.xml
+     *
+     * @param {string} logName - name of the log we want to track
+     * @param {string} level - tracking level
+     */
+    addLoggerForLogbackSpring(logName, level) {
+        this.needleApi.serverLog.addlog(logName, level);
+    }
+
+    /**
      * Add a remote Maven Repository to the Gradle build.
      *
      * @param {string} url - url of the repository

--- a/generators/needle-api.js
+++ b/generators/needle-api.js
@@ -26,6 +26,7 @@ const ServerMaven = require('./server/needle-api/needle-server-maven');
 const ServerGradle = require('./server/needle-api/needle-server-gradle');
 const ServerCache = require('./server/needle-api/needle-server-cache');
 const ServerLiquibase = require('./server/needle-api/needle-server-liquibase');
+const ServerLog = require('./server/needle-api/needle-server-logback-spring');
 
 module.exports = class NeedleApi {
     constructor(generator) {
@@ -39,5 +40,6 @@ module.exports = class NeedleApi {
         this.serverCache = new ServerCache(generator);
         this.serverLiquibase = new ServerLiquibase(generator);
         this.serverGradle = new ServerGradle(generator);
+        this.serverLog = new ServerLog(generator);
     }
 };

--- a/generators/server/needle-api/needle-server-logback-spring.js
+++ b/generators/server/needle-api/needle-server-logback-spring.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const chalk = require('chalk');
+const needleServer = require('./needle-server');
+const constants = require('../../generator-constants');
+
+const SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
+
+module.exports = class extends needleServer {
+    addlog(logName, level) {
+        this.addlogToMaster(logName, level, 'jhipster-needle-logback-add-log');
+    }
+
+    addlogToMaster(logName, level, needle) {
+        const errorMessage = `${chalk.yellow('Reference to ') + logName} ${chalk.yellow('not added.\n')}`;
+        const fullPath = `${SERVER_MAIN_RES_DIR}logback-spring.xml`;
+        const content = `<logger name="${logName}" level="${level}"/>`;
+
+        const rewriteFileModel = this.generateFileModel(fullPath, needle, content);
+
+        this.addBlockContentToFile(rewriteFileModel, errorMessage);
+    }
+};

--- a/generators/server/templates/src/main/resources/logback-spring.xml.ejs
+++ b/generators/server/templates/src/main/resources/logback-spring.xml.ejs
@@ -152,6 +152,7 @@
     <%_ if (cacheProvider === 'infinispan') { _%>
     <logger name="unknown.jul.logger" level="WARN"/>
     <%_ } _%>
+    <!-- jhipster-needle-logback-add-log - JHipster will add a new log with level, Do not remove -->
 
     <!-- https://logback.qos.ch/manual/configuration.html#shutdownHook and https://jira.qos.ch/browse/LOGBACK-1090 -->
     <shutdownHook class="ch.qos.logback.core.hook.DelayingShutdownHook"/>

--- a/test/needle-api/needle-server-logback-spring.spec.js
+++ b/test/needle-api/needle-server-logback-spring.spec.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const ServerGenerator = require('../../generators/server');
+const constants = require('../../generators/generator-constants');
+
+const SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
+
+const filePath = `${SERVER_MAIN_RES_DIR}logback-spring.xml`;
+
+const mockBlueprintSubGen = class extends ServerGenerator {
+    constructor(args, opts) {
+        super(args, { fromBlueprint: true, ...opts }); // fromBlueprint variable is important
+
+        const jhContext = (this.jhipsterContext = this.options.jhipsterContext);
+
+        if (!jhContext) {
+            this.error('This is a JHipster blueprint and should be used only like jhipster --blueprint myblueprint');
+        }
+
+        this.configOptions = jhContext.configOptions || {};
+        // This sets up options for this sub generator and is being reused from JHipster
+        jhContext.setupServerOptions(this, jhContext);
+    }
+
+    get initializing() {
+        return super._initializing();
+    }
+
+    get prompting() {
+        return super._prompting();
+    }
+
+    get configuring() {
+        return super._configuring();
+    }
+
+    get default() {
+        return super._default();
+    }
+
+    get writing() {
+        const phaseFromJHipster = super._writing();
+        const customPhaseSteps = {
+            addlogStep() {
+                this.addLoggerForLogbackSpring('org.test.logTest', 'OFF');
+            }
+        };
+        return { ...phaseFromJHipster, ...customPhaseSteps };
+    }
+};
+
+describe('needle API server log: JHipster server generator with blueprint', () => {
+    before(done => {
+        helpers
+            .run(path.join(__dirname, '../../generators/server'))
+            .withOptions({
+                'from-cli': true,
+                skipInstall: true,
+                blueprint: 'myblueprint',
+                skipChecks: true
+            })
+            .withGenerators([[mockBlueprintSubGen, 'jhipster-myblueprint:server']])
+            .withPrompts({
+                baseName: 'jhipster',
+                packageName: 'com.mycompany.myapp',
+                packageFolder: 'com/mycompany/myapp',
+                serviceDiscoveryType: false,
+                authenticationType: 'jwt',
+                cacheProvider: 'ehcache',
+                enableHibernateCache: true,
+                databaseType: 'sql',
+                devDatabaseType: 'h2Memory',
+                prodDatabaseType: 'mysql',
+                enableTranslation: true,
+                nativeLanguage: 'en',
+                languages: ['fr'],
+                buildTool: 'maven',
+                rememberMeKey: '5c37379956bd1242f5636c8cb322c2966ad81277',
+                serverSideOptions: []
+            })
+            .on('end', done);
+    });
+
+    it('Assert log is added to logback-spring.xml', () => {
+        assert.fileContent(filePath, '<logger name="org.test.logTest" level="OFF"/>');
+    });
+});


### PR DESCRIPTION
PR to fix #11146 

I created a public method `addLoggerForLogbackSpring()` which takes a logname and a level log into parameters to create a new logger inside logback-spring.xml with the needle` jhipster-needle-logback-add-log`.
 

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
