### PR TITLE
Add authority enum to angular client application

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -360,6 +360,7 @@ const files = {
                 'shared/constants/error.constants.ts',
                 'shared/constants/input.constants.ts',
                 'shared/constants/pagination.constants.ts',
+                'shared/constants/authority.constants.ts',
                 // models
                 'shared/util/request-util.ts',
                 // alert service code

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.route.ts.ejs
@@ -20,12 +20,13 @@ import { Route } from '@angular/router';
 
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { PasswordComponent } from './password.component';
+import { Authority } from 'app/shared/constants/authority.constants';
 
 export const passwordRoute: Route = {
     path: 'password',
     component: PasswordComponent,
     data: {
-        authorities: ['ROLE_USER'],
+        authorities: [Authority.USER],
         pageTitle: 'global.menu.account.password'
     },
     canActivate: [UserRouteAccessService]

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.route.ts.ejs
@@ -18,6 +18,7 @@
 -%>
 import { Route } from '@angular/router';
 
+import { Authority } from 'app/shared/constants/authority.constants';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { SessionsComponent } from './sessions.component';
 
@@ -25,7 +26,7 @@ export const sessionsRoute: Route = {
     path: 'sessions',
     component: SessionsComponent,
     data: {
-        authorities: ['ROLE_USER'],
+        authorities: [Authority.USER],
         pageTitle: 'global.menu.account.sessions'
     },
     canActivate: [UserRouteAccessService]

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.route.ts.ejs
@@ -20,12 +20,13 @@ import { Route } from '@angular/router';
 
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { SettingsComponent } from './settings.component';
+import { Authority } from 'app/shared/constants/authority.constants';
 
 export const settingsRoute: Route = {
     path: 'settings',
     component: SettingsComponent,
     data: {
-        authorities: ['ROLE_USER'],
+        authorities: [Authority.USER],
         pageTitle: 'global.menu.account.settings'
     },
     canActivate: [UserRouteAccessService]

--- a/generators/client/templates/angular/src/main/webapp/app/app-routing.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app-routing.module.ts.ejs
@@ -21,6 +21,7 @@ import { RouterModule } from '@angular/router';
 import { errorRoute } from './layouts/error/error.route';
 import { navbarRoute } from './layouts/navbar/navbar.route';
 import { DEBUG_INFO_ENABLED } from 'app/app.constants';
+import { Authority } from 'app/shared/constants/authority.constants';
 
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 
@@ -36,7 +37,7 @@ const LAYOUT_ROUTES = [
                 {
                     path: 'admin',
                     data: {
-                        authorities: ['ROLE_ADMIN']
+                        authorities: [Authority.ADMIN]
                     },
                     canActivate: [UserRouteAccessService],
                     loadChildren: () => import('./admin/admin-routing.module').then(m => m.AdminRoutingModule)

--- a/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.ts.ejs
@@ -23,6 +23,10 @@ import { Observable<% if (databaseType !== 'sql' && databaseType !== 'mongodb' &
 import { SERVER_API_URL } from 'app/app.constants';
 import { createRequestOption, Pagination } from 'app/shared/util/request-util';
 import { IUser } from './user.model';
+<%_ if (databaseType !== 'sql' && databaseType !== 'mongodb' && databaseType !== 'couchbase') { _%>
+import { Authority } from 'app/shared/constants/authority.constants';
+<%_ } _%>
+
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
@@ -58,7 +62,7 @@ export class UserService {
         <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
         return this.http.get<string[]>(SERVER_API_URL + '<%- apiUaaPath %>api/users/authorities');
         <%_ } else { _%>
-        return of(['ROLE_USER', 'ROLE_ADMIN']);
+        return of([Authority.ADMIN, Authority.USER]);
         <%_ } _%>
     }
     <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/constants/authority.constants.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/constants/authority.constants.ts.ejs
@@ -1,0 +1,4 @@
+export enum Authority {
+    ADMIN = 'ROLE_ADMIN',
+    USER = 'ROLE_USER'
+}

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
@@ -2,6 +2,7 @@ import { ComponentFixture, TestBed, async } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
+import { Authority } from 'app/shared/constants/authority.constants';
 import { <%= angularXAppName %>TestModule } from '../../../test.module';
 import { UserManagementDetailComponent } from 'app/admin/user-management/user-management-detail.component';
 import { User } from 'app/core/user/user.model';
@@ -10,7 +11,7 @@ describe('Component Tests', () => {
     describe('User Management Detail Component', () => {
         let comp: UserManagementDetailComponent;
         let fixture: ComponentFixture<UserManagementDetailComponent>;
-        const route: ActivatedRoute = ({ data: of({ user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin') }) } as any) as ActivatedRoute;
+        const route: ActivatedRoute = ({ data: of({ user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', [Authority.USER], 'admin') }) } as any) as ActivatedRoute;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({
@@ -48,7 +49,7 @@ describe('Component Tests', () => {
                     email: 'first@last.com',
                     activated: true,
                     langKey: 'en',
-                    authorities: ['ROLE_USER'],
+                    authorities: [Authority.USER],
                     createdBy: 'admin'
                 }));
             });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
@@ -25,6 +25,7 @@ import { FormBuilder } from '@angular/forms';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
+import { Authority } from 'app/shared/constants/authority.constants';
 import { <%= angularXAppName %>TestModule } from '../../../test.module';
 import { UserManagementUpdateComponent } from 'app/admin/user-management/user-management-update.component';
 import { UserService } from 'app/core/user/user.service';
@@ -35,7 +36,7 @@ describe('Component Tests', () => {
         let comp: UserManagementUpdateComponent;
         let fixture: ComponentFixture<UserManagementUpdateComponent>;
         let service: UserService;
-        const route: ActivatedRoute = ({ data: of({ user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', ['ROLE_USER'], 'admin') }) } as any) as ActivatedRoute;
+        const route: ActivatedRoute = ({ data: of({ user: new User(1, 'user', 'first', 'last', 'first@last.com', true, 'en', [Authority.USER], 'admin') }) } as any) as ActivatedRoute;
 
         beforeEach(async(() => {
             TestBed.configureTestingModule({

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -11,6 +11,7 @@ import { NgxWebstorageModule } from 'ngx-webstorage';
 import { SERVER_API_URL } from 'app/app.constants';
 import { AccountService } from 'app/core/auth/account.service';
 import { Account } from 'app/core/user/account.model';
+import { Authority } from 'app/shared/constants/authority.constants';
 import { StateStorageService } from 'app/core/auth/state-storage.service';
 <%_ if (enableTranslation) { _%>
 import { MockLanguageService } from '../../../helpers/mock-language.service';
@@ -200,22 +201,22 @@ describe('Service Tests', () => {
         describe('hasAnyAuthority', () => {
             describe('hasAnyAuthority string parameter', () => {
                 it('should return false if user is not logged', () => {
-                    const hasAuthority = service.hasAnyAuthority('ROLE_USER');
+                    const hasAuthority = service.hasAnyAuthority(Authority.USER);
                     expect(hasAuthority).toBe(false);
                 });
 
                 it('should return false if user is logged and has not authority', () => {
-                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
+                    service.authenticate(accountWithAuthorities([Authority.USER]));
 
-                    const hasAuthority = service.hasAnyAuthority('ROLE_ADMIN');
+                    const hasAuthority = service.hasAnyAuthority(Authority.ADMIN);
 
                     expect(hasAuthority).toBe(false);
                 });
 
                 it('should return true if user is logged and has authority', () => {
-                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
+                    service.authenticate(accountWithAuthorities([Authority.USER]));
 
-                    const hasAuthority = service.hasAnyAuthority('ROLE_USER');
+                    const hasAuthority = service.hasAnyAuthority(Authority.USER);
 
                     expect(hasAuthority).toBe(true);
                 });
@@ -223,22 +224,22 @@ describe('Service Tests', () => {
 
             describe('hasAnyAuthority array parameter', () => {
                 it('should return false if user is not logged', () => {
-                    const hasAuthority = service.hasAnyAuthority(['ROLE_USER']);
+                    const hasAuthority = service.hasAnyAuthority([Authority.USER]);
                     expect(hasAuthority).toBeFalsy();
                 });
 
                 it('should return false if user is logged and has not authority', () => {
-                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
+                    service.authenticate(accountWithAuthorities([Authority.USER]));
 
-                    const hasAuthority = service.hasAnyAuthority(['ROLE_ADMIN']);
+                    const hasAuthority = service.hasAnyAuthority([Authority.ADMIN]);
 
                     expect(hasAuthority).toBe(false);
                 });
 
                 it('should return true if user is logged and has authority', () => {
-                    service.authenticate(accountWithAuthorities(['ROLE_USER']));
+                    service.authenticate(accountWithAuthorities([Authority.USER]));
 
-                    const hasAuthority = service.hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN']);
+                    const hasAuthority = service.hasAnyAuthority([Authority.USER, Authority.ADMIN]);
 
                     expect(hasAuthority).toBe(true);
                 });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
@@ -21,6 +21,7 @@ import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 import { JhiDateUtils } from 'ng-jhipster';
 
+import { Authority } from 'app/shared/constants/authority.constants';
 import { UserService } from 'app/core/user/user.service';
 import { User } from 'app/core/user/user.model';
 import { SERVER_API_URL } from 'app/app.constants';
@@ -78,8 +79,8 @@ describe('Service Tests', () => {
                 });
                 const req = httpMock.expectOne({ method: 'GET' });
 
-                req.flush(['ROLE_USER', 'ROLE_ADMIN']);
-                expect(expectedResult).toEqual(['ROLE_USER', 'ROLE_ADMIN']);
+                req.flush([Authority.USER, Authority.ADMIN]);
+                expect(expectedResult).toEqual([Authority.USER, Authority.ADMIN]);
             });
             <%_ } _%>
 

--- a/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
@@ -35,6 +35,7 @@ import userManagement, {
   reset
 } from 'app/modules/administration/user-management/user-management.reducer';
 import { defaultValue } from 'app/shared/model/user.model';
+import { AUTHORITIES } from 'app/config/constants';
 
 describe('User management reducer tests', () => {
   function isEmpty(element): boolean {
@@ -154,7 +155,7 @@ describe('User management reducer tests', () => {
     });
 
     it('should update state according to a successful fetch role request', () => {
-      const payload = { data: ['ROLE_ADMIN'] };
+      const payload = { data: [AUTHORITIES.ADMIN] };
       const toTest = userManagement(undefined, { type: SUCCESS(ACTION_TYPES.FETCH_ROLES), payload });
 
       expect(toTest).toMatchObject({

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/auth/private-route.spec.tsx.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/auth/private-route.spec.tsx.ejs
@@ -5,6 +5,7 @@ import { shallow } from 'enzyme';
 import { TranslatorContext } from 'react-jhipster';
 <%_ } _%>
 
+import { AUTHORITIES } from 'app/config/constants';
 import { PrivateRouteComponent, hasAnyAuthority } from 'app/shared/auth/private-route';
 
 const TestComp = () => <div>Test</div>;
@@ -80,24 +81,24 @@ describe('hasAnyAuthority', () => {
     expect(hasAnyAuthority(undefined, undefined)).toEqual(false);
     expect(hasAnyAuthority(null, [])).toEqual(false);
     expect(hasAnyAuthority([], [])).toEqual(false);
-    expect(hasAnyAuthority([], ['ROLE_USER'])).toEqual(false);
+    expect(hasAnyAuthority([], [AUTHORITIES.USER])).toEqual(false);
   });
 
   it('Should return true when authorities is valid and hasAnyAuthorities is empty', () => {
-    expect(hasAnyAuthority(['ROLE_USER'], [])).toEqual(true);
+    expect(hasAnyAuthority([AUTHORITIES.USER], [])).toEqual(true);
   });
 
   it('Should return true when authorities is valid and hasAnyAuthorities contains an authority', () => {
-    expect(hasAnyAuthority(['ROLE_USER'], ['ROLE_USER'])).toEqual(true);
-    expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_USER'])).toEqual(true);
-    expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_USER', 'ROLE_ADMIN'])).toEqual(true);
-    expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_USER', 'ROLEADMIN'])).toEqual(true);
-    expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_ADMIN'])).toEqual(true);
+    expect(hasAnyAuthority([AUTHORITIES.USER], [AUTHORITIES.USER])).toEqual(true);
+    expect(hasAnyAuthority([AUTHORITIES.USER, AUTHORITIES.ADMIN], [AUTHORITIES.USER])).toEqual(true);
+    expect(hasAnyAuthority([AUTHORITIES.USER, AUTHORITIES.ADMIN], [AUTHORITIES.USER, AUTHORITIES.ADMIN])).toEqual(true);
+    expect(hasAnyAuthority([AUTHORITIES.USER, AUTHORITIES.ADMIN], [AUTHORITIES.USER, 'ROLEADMIN'])).toEqual(true);
+    expect(hasAnyAuthority([AUTHORITIES.USER, AUTHORITIES.ADMIN], [AUTHORITIES.ADMIN])).toEqual(true);
   });
 
   it('Should return false when authorities is valid and hasAnyAuthorities does not contain an authority', () => {
-    expect(hasAnyAuthority(['ROLE_USER'], ['ROLE_ADMIN'])).toEqual(false);
-    expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLE_USERSS'])).toEqual(false);
-    expect(hasAnyAuthority(['ROLE_USER', 'ROLE_ADMIN'], ['ROLEUSER', 'ROLEADMIN'])).toEqual(false);
+    expect(hasAnyAuthority([AUTHORITIES.USER], [AUTHORITIES.ADMIN])).toEqual(false);
+    expect(hasAnyAuthority([AUTHORITIES.USER, AUTHORITIES.ADMIN], ['ROLE_USERSS'])).toEqual(false);
+    expect(hasAnyAuthority([AUTHORITIES.USER, AUTHORITIES.ADMIN], ['ROLEUSER', 'ROLEADMIN'])).toEqual(false);
   });
 });

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.route.ts.ejs
@@ -25,6 +25,7 @@ import { JhiResolvePagingParams } from 'ng-jhipster';
 import { Observable, of, EMPTY } from 'rxjs';
 import { flatMap } from 'rxjs/operators';
 
+import { Authority } from 'app/shared/constants/authority.constants';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access-service';
 import { I<%= entityAngularName %>, <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
@@ -66,7 +67,7 @@ export const <%= entityInstance %>Route: Routes = [
         },
         <%_ } _%>
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [Authority.USER],
             <%_ if (pagination === 'pagination') { _%>
             defaultSort: 'id,asc',
             <%_ } _%>
@@ -81,7 +82,7 @@ export const <%= entityInstance %>Route: Routes = [
             <%= entityInstance %>: <%= entityAngularName %>Resolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [Authority.USER],
             pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
@@ -94,7 +95,7 @@ export const <%= entityInstance %>Route: Routes = [
             <%= entityInstance %>: <%= entityAngularName %>Resolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [Authority.USER],
             pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
@@ -106,7 +107,7 @@ export const <%= entityInstance %>Route: Routes = [
             <%= entityInstance %>: <%= entityAngularName %>Resolve
         },
         data: {
-            authorities: ['ROLE_USER'],
+            authorities: [Authority.USER],
             pageTitle: <% if (enableTranslation) { %>'<%= angularAppName %>.<%= entityTranslationKey %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -454,6 +454,7 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}app/shared/auth/has-any-authority.directive.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/auth/state-storage.service.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/auth/user-route-access-service.ts`,
+        `${CLIENT_MAIN_SRC_DIR}app/shared/constants/authority.constants.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/constants/error.constants.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/constants/input.constants.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/constants/pagination.constants.ts`,


### PR DESCRIPTION
As requested by @pascalgrimaud [here](https://github.com/jhipster/jhipster-vuejs/pull/535#issuecomment-577047345) I took a look on how authority are handled in client applications.

While a constant is defined and used in the react application, it's still plain string in the Angular app.
This PR should fix this situation. 

I have still several question: in the react application the authorities are defined as [a javascript object](https://github.com/jhipster/generator-jhipster/blob/master/generators/client/templates/react/src/main/webapp/app/config/constants.ts.ejs). Should I change it to a typescript enumeration to have more consistency between client applications ? If I do so, should I left this constant in the constants.ts (enum and constant are quite different) or should I create another file for the enumeration ?

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed