### PR TITLE
Remove ByteBuffer and ZonedDateTime from Cassandra test JDLs

### DIFF
--- a/test-integration/samples/.jhipster/CassBankAccount.json
+++ b/test-integration/samples/.jhipster/CassBankAccount.json
@@ -44,18 +44,6 @@
             "fieldType": "Boolean"
         },
         {
-            "fieldName": "picture",
-            "fieldType": "ByteBuffer",
-            "fieldTypeBlobContent": "image",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
-            "fieldName": "operationsFile",
-            "fieldType": "ByteBuffer"
-        },
-        {
             "fieldName": "accountType",
             "fieldType": "AccountTypeEnum",
             "fieldValues": "STANDARD,PREMIUM"

--- a/test-integration/samples/.jhipster/CassTestEntity.json
+++ b/test-integration/samples/.jhipster/CassTestEntity.json
@@ -177,17 +177,6 @@
             ]
         },
         {
-            "fieldName": "zonedDateTimeField",
-            "fieldType": "ZonedDateTime"
-        },
-        {
-            "fieldName": "zonedDateTimeRequiredField",
-            "fieldType": "ZonedDateTime",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
             "fieldName": "booleanField",
             "fieldType": "Boolean"
         },
@@ -197,18 +186,6 @@
             "fieldValidateRules": [
                 "required"
             ]
-        },
-        {
-            "fieldName": "picture",
-            "fieldType": "ByteBuffer",
-            "fieldTypeBlobContent": "image",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
-            "fieldName": "operationsFile",
-            "fieldType": "ByteBuffer"
         }
     ],
     "changelogDate": "20160208184031",

--- a/test-integration/samples/.jhipster/CassTestMapstructEntity.json
+++ b/test-integration/samples/.jhipster/CassTestMapstructEntity.json
@@ -177,17 +177,6 @@
             ]
         },
         {
-            "fieldName": "zonedDateTimeField",
-            "fieldType": "ZonedDateTime"
-        },
-        {
-            "fieldName": "zonedDateTimeRequiredField",
-            "fieldType": "ZonedDateTime",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
             "fieldName": "booleanField",
             "fieldType": "Boolean"
         },
@@ -197,18 +186,6 @@
             "fieldValidateRules": [
                 "required"
             ]
-        },
-        {
-            "fieldName": "picture",
-            "fieldType": "ByteBuffer",
-            "fieldTypeBlobContent": "image",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
-            "fieldName": "operationsFile",
-            "fieldType": "ByteBuffer"
         }
     ],
     "changelogDate": "20160208184031",

--- a/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
@@ -177,17 +177,6 @@
             ]
         },
         {
-            "fieldName": "zonedDateTimeField",
-            "fieldType": "ZonedDateTime"
-        },
-        {
-            "fieldName": "zonedDateTimeRequiredField",
-            "fieldType": "ZonedDateTime",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
             "fieldName": "booleanField",
             "fieldType": "Boolean"
         },
@@ -197,18 +186,6 @@
             "fieldValidateRules": [
                 "required"
             ]
-        },
-        {
-            "fieldName": "picture",
-            "fieldType": "ByteBuffer",
-            "fieldTypeBlobContent": "image",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
-            "fieldName": "operationsFile",
-            "fieldType": "ByteBuffer"
         }
     ],
     "changelogDate": "20160208184031",

--- a/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
@@ -177,17 +177,6 @@
             ]
         },
         {
-            "fieldName": "zonedDateTimeField",
-            "fieldType": "ZonedDateTime"
-        },
-        {
-            "fieldName": "zonedDateTimeRequiredField",
-            "fieldType": "ZonedDateTime",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
             "fieldName": "booleanField",
             "fieldType": "Boolean"
         },
@@ -197,18 +186,6 @@
             "fieldValidateRules": [
                 "required"
             ]
-        },
-        {
-            "fieldName": "picture",
-            "fieldType": "ByteBuffer",
-            "fieldTypeBlobContent": "image",
-            "fieldValidateRules": [
-                "required"
-            ]
-        },
-        {
-            "fieldName": "operationsFile",
-            "fieldType": "ByteBuffer"
         }
     ],
     "changelogDate": "20160208184031",


### PR DESCRIPTION
Fixes #11178

We do not support these two data types for Cassandra and therefore there's no use of trying to test them.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
