### PR TITLE
Pass filterPaths option to lookup

### DIFF
--- a/cli/utils.js
+++ b/cli/utils.js
@@ -210,7 +210,7 @@ const createYeomanEnv = packagePatterns => {
     env.lookup({ packagePaths: [path.join(__dirname, '..')] });
     if (packagePatterns) {
         // Lookup for blueprints.
-        env.lookup({ packagePatterns });
+        env.lookup({ filterPaths: true, packagePatterns });
     }
     return env;
 };

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -97,7 +97,7 @@ module.exports = class extends BaseGenerator {
                 const packagePatterns = blueprints
                     .filter(bp => !this.env.isPackageRegistered(jhipsterUtils.packageNameToNamespace(bp.name)))
                     .map(bp => bp.name);
-                this.env.lookup({ packagePatterns });
+                this.env.lookup({ filterPaths: true, packagePatterns });
 
                 if (!this.options.skipChecks) {
                     const namespaces = blueprints.map(bp => jhipsterUtils.packageNameToNamespace(bp.name));


### PR DESCRIPTION
Current yeoman-environment lookup looks for generators at __dirname's '../../' and '../../../../'.
At the worst case, when running jhipster locally installed it will look at:
- {cwd}/node_modules/yeoman-environment/lib/../../../../
 => {cwd}/../*

So it will lookup for generators/blueprint at current folder siblings.
This can be useful for development but I don't think we should have this behavior by default.
With filterPath it will only consider '../../' and '../../../../' if and only if they are inside node_modules folder.
Ex:
- {cwd}/node_modules/yeoman-environment/lib/../../
 => {cwd}/node_modules/*
- {cwd}/node_modules/generator-jhipster/node_modules/yeoman-environment/lib/../../../../
 => {cwd}/node_modules/*
- {cwd}/node_modules/yeoman-environment/lib/../../../../
 => node_modules/{cwd}/../*

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
