### PR TITLE
FIX string enum initialization on angular

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/enumerations/enum.model.ts.ejs
@@ -19,7 +19,7 @@
 export const enum <%= enumName %> {
 <% enumsWithCustomValue.forEach((enumWithCustomValue, index) => { %>
   <% if (!enumWithCustomValue.value) { %>
-  <%= enumWithCustomValue.name %>
+  <%= enumWithCustomValue.name %> = '<%= enumWithCustomValue.name %>'
   <% } else { %>
   <%= enumWithCustomValue.name %> = '<%= enumWithCustomValue.value %>'
   <% } %><% if (index < enumsWithCustomValue.length - 1) { %>,<% } %>


### PR DESCRIPTION
String enums should be initialized to avoid problems when comparing them with backend enums, even when no custom value is specified.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
