### PR TITLE
Use Oracle Database Client libraries from Maven Central

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -126,7 +126,7 @@ const SQL_DB_OPTIONS = [
     },
     {
         value: 'oracle',
-        name: 'Oracle (Please follow our documentation to use the Oracle proprietary driver)'
+        name: 'Oracle'
     },
     {
         value: 'mssql',

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -513,14 +513,6 @@ module.exports = class extends BaseBlueprintGenerator {
     _end() {
         return {
             end() {
-                if (this.prodDatabaseType === 'oracle') {
-                    this.log('\n\n');
-                    this.warning(
-                        `${chalk.yellow.bold(
-                            'You have selected Oracle database.\n'
-                        )}Please follow our documentation on using Oracle to set up the \nOracle proprietary JDBC driver.`
-                    );
-                }
                 this.log(chalk.green.bold('\nServer application generated successfully.\n'));
 
                 let executable = 'mvnw';

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -533,8 +533,8 @@ dependencies {
     liquibaseRuntime "com.h2database:h2"
     <%_ } _%>
     <%_ if (prodDatabaseType === 'oracle') { _%>
-    implementation "com.oracle.ojdbc:ojdbc8"
-    liquibaseRuntime "com.oracle.ojdbc:ojdbc8"
+    implementation "com.oracle.database.jdbc:ojdbc8"
+    liquibaseRuntime "com.oracle.database.jdbc:ojdbc8"
     <%_ } _%>
     <%_ if (messageBroker === 'kafka') { _%>
     testImplementation "org.testcontainers:kafka"

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -389,7 +389,7 @@
 <%_ } _%>
 <%_ if (prodDatabaseType === 'oracle') { _%>
         <dependency>
-            <groupId>com.oracle.ojdbc</groupId>
+            <groupId>com.oracle.database.jdbc</groupId>
             <artifactId>ojdbc8</artifactId>
         </dependency>
 <%_ } _%>


### PR DESCRIPTION
If the JHipster team feels this is something worth switching to; I can make the required changes.

**Reference**: https://blogs.oracle.com/developers/oracle-database-client-libraries-for-java-now-on-maven-central

I believe `[jhipster-framework]` : (https://github.com/jhipster/jhipster/pull/606) will also need updating in the bom in addition to changes in the PR, however I'm sure I can use some help from core team to identify all places needing change.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

