### PR TITLE
Add CircleCI back to the Main Generator

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -159,7 +159,7 @@ module.exports = class extends BaseGenerator {
             this.template('.gitlab-ci.yml.ejs', '.gitlab-ci.yml');
         }
         if (this.pipeline === 'circle') {
-            this.template('circle.yml.ejs', 'circle.yml');
+            this.template('circle.yml.ejs', '.circleci/config.yml');
         }
         if (this.pipeline === 'travis') {
             this.template('travis.yml.ejs', '.travis.yml');

--- a/generators/ci-cd/prompts.js
+++ b/generators/ci-cd/prompts.js
@@ -70,7 +70,8 @@ function askPipeline() {
                 { name: 'Azure Pipelines', value: 'azure' },
                 { name: 'GitLab CI', value: 'gitlab' },
                 { name: 'GitHub Actions', value: 'github' },
-                { name: 'Travis CI', value: 'travis' }
+                { name: 'Travis CI', value: 'travis' },
+                { name: 'CircleCI', value: 'circle' }
             ]
         }
     ];
@@ -122,7 +123,7 @@ function askIntegrations() {
     if (['jenkins', 'github'].includes(this.pipeline)) {
         integrationChoices.push({ name: `Build and publish a ${chalk.yellow('*Docker*')} image`, value: 'publishDocker' });
     }
-    if (['jenkins', 'gitlab', 'travis', 'github'].includes(this.pipeline)) {
+    if (['jenkins', 'gitlab', 'travis', 'github', 'circle'].includes(this.pipeline)) {
         integrationChoices.push({
             name: `Deploy to ${chalk.yellow('*Heroku*')} (requires HEROKU_API_KEY set on CI service)`,
             value: 'heroku'

--- a/generators/ci-cd/templates/circle.yml.ejs
+++ b/generators/ci-cd/templates/circle.yml.ejs
@@ -16,62 +16,139 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-machine:
-    services:
-        - docker
-    java:
-        version: oraclejdk8
-    node:
-        version: <%= NODE_VERSION %>
-dependencies:
-    cache_directories:
-        - node
-        - node_modules
-<%_ if (buildTool === 'maven') { _%>
-        - ~/.m2
-<%_ } else if (buildTool === 'gradle') { _%>
-        - ~/.gradle
-<%_ } _%>
-<%_ if (clientPackageManager === 'yarn') { _%>
-        - $HOME/.yarn-cache
-<%_ } _%>
-    override:
-        - java -version
-<%_ if (clientPackageManager === 'npm') { _%>
-        - npm install -g npm
-        - node -v
-        - npm -v
-        - java -version
-        - npm install
-<%_ } else if (clientPackageManager === 'yarn') { _%>
-        # Repo for Yarn
-        - curl -o- -L https://yarnpkg.com/install.sh | bash
-        - export PATH=$HOME/.yarn/bin:$PATH
-        - yarn install
-<%_ } _%>
-test:
-    override:
-<%_ if (buildTool === 'maven') { _%>
-        - chmod +x mvnw
-        - ./mvnw -ntp checkstyle:check
-        - ./mvnw -ntp clean verify
-<%_ } else if (buildTool === 'gradle') { _%>
-        - chmod +x gradlew
-        - ./gradlew checkstyleNohttp --no-daemon
-        - ./gradlew clean test integrationTest --no-daemon
-<%_ } _%>
-<%_ if (!skipClient) { _%>
-        - <%= clientPackageManager %> run <%= frontTestCommand %>
-<%_ } _%>
-<%_ if (buildTool === 'maven') { _%>
-    <%_ if (cicdIntegrations.includes('circle')) { _%>
-        - ./mvnw -ntp com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.buildpacks=heroku/jvm -Dheroku.appName=<%= herokuAppName %>
-    <%_ } else { _%>
-        - ./mvnw -ntp verify -Pprod -DskipTests
-    <%_ } _%>
-<%_ } else if (buildTool === 'gradle') { _%>
-        - ./gradlew bootJar -Pprod -x test --no-daemon
-    <%_ if (heroku.includes('circle')) { _%>
-        - ./gradlew deployHeroku --no-daemon
-    <%_ } _%>
-<%_ } _%>
+version: 2.1
+jobs:
+    build:
+        machine:
+            image: circleci/classic:201808-01
+        steps:
+            - checkout
+
+            # Download and cache dependencies
+            - restore_cache:
+                keys:
+                    <%_ if (buildTool === 'maven' && clientPackageManager === 'npm') { _%>
+                    - v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "package-lock.json" }}
+                    <%_ } else if (buildTool === 'maven' && clientPackageManager === 'yarn') { _%>
+                    - v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "yarn.lock" }}
+                    <%_ } else if (buildTool === 'gradle' && clientPackageManager === 'npm') { _%>
+                    - v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "package-lock.json" }}
+                    <%_ } else if (buildTool === 'gradle' && clientPackageManager === 'yarn') { _%>
+                    - v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "yarn.lock" }}
+                    <%_ } _%>
+                    # Perform a Partial Cache Restore (https://circleci.com/docs/2.0/caching/#restoring-cache)
+                    - v1-dependencies-
+            - run:
+                name: Install OpenJDK 11
+                command: |
+                    sudo rm /var/lib/apt/lists/lock
+                    sudo rm /var/cache/apt/archives/lock
+                    sudo rm /var/lib/dpkg/lock
+                    sudo apt install openjdk-11-jdk
+                    echo 'export PATH="/usr/lib/jvm/java-11-openjdk-amd64/bin:$PATH"' >> $BASH_ENV
+            - run:
+                name: Setup NVM
+                command: |
+                    echo 'export NVM_DIR="/opt/circleci/.nvm"' >> $BASH_ENV
+                    echo '[ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"' >> $BASH_ENV
+            - run:
+                name: Install Node <%= NODE_VERSION %>
+                command: |
+                    nvm install <%= NODE_VERSION %>
+                    nvm alias default <%= NODE_VERSION %>
+            <%_ if (clientPackageManager === 'yarn') { _%>
+            - run:
+                name: Set URL for Yarn
+                command: 'curl -o- -L https://yarnpkg.com/install.sh | bash'
+            - run:
+                name: Set PATH
+                command: echo 'export PATH="$HOME/.yarn/bin:$PATH"' >> $BASH_ENV
+            <%_ } _%>
+            - run:
+                name: Print Java Version
+                command: 'java -version'
+            - run:
+                name: Print Node Version
+                command: 'node -v'
+            <%_ if (clientPackageManager === 'npm') { _%>
+            - run:
+                name: Print NPM Version
+                command: 'npm -v'
+            <%_ } _%>
+            - run:
+                name: Install Node Modules
+                <%_ if (clientPackageManager === 'npm') { _%>
+                command: 'npm install'
+                <%_ } else if (clientPackageManager === 'yarn') { _%>
+                command: 'yarn install'
+                <%_ } _%>
+
+            - save_cache:
+                paths:
+                    - node
+                    - node_modules
+                    <%_ if (buildTool === 'maven') { _%>
+                    - ~/.m2
+                    <%_ } else if (buildTool === 'gradle') { _%>
+                    - ~/.gradle
+                    <%_ } _%>
+                <%_ if (clientPackageManager === 'npm') { _%>
+                    <%_ if (buildTool === 'maven') { _%>
+                key: v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "package-lock.json" }}
+                    <%_ } else if (buildTool === 'gradle') { _%>
+                key: v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "package-lock.json" }}
+                    <%_ } _%>
+                <%_ } else if (clientPackageManager === 'yarn') { _%>
+                    - $HOME/.yarn-cache
+                    <%_ if (buildTool === 'maven') { _%>
+                key: v1-dependencies-{{ checksum "pom.xml" }}-{{ checksum "yarn.lock" }}
+                    <%_ } else if (buildTool === 'gradle') { _%>
+                key: v1-dependencies-{{ checksum "build.gradle" }}-{{ checksum "yarn.lock" }}
+                    <%_ } _%>
+                <%_ } _%>
+
+            <%_ if (buildTool === 'maven') { _%>
+            - run:
+                name: Give Executable Power
+                command: 'chmod +x mvnw'
+            - run:
+                name: Run Style Checks
+                command: './mvnw -ntp checkstyle:check'
+            - run:
+                name: Clean and Verify
+                command: './mvnw -ntp clean verify'
+            <%_ } else if (buildTool === 'gradle') { _%>
+            - run:
+                name: Give Executable Power
+                command: 'chmod +x gradlew'
+            - run:
+                name: Run Style Checks
+                command: './gradlew checkstyleNohttp --no-daemon'
+            - run:
+                name: Clean and Verify
+                command: './gradlew clean test integrationTest --no-daemon'
+            <%_ } _%>
+            <%_ if (!skipClient) { _%>
+            - run:
+                name: Run Front End Tests
+                command: <%= clientPackageManager %> run <%= frontTestCommand %>
+            <%_ } _%>
+            <%_ if (buildTool === 'maven') { _%>
+            - run:
+                name: Verify with Prod Profile
+                command: './mvnw -ntp verify -Pprod -DskipTests'
+                <%_ if (cicdIntegrations.includes('heroku')) { _%>
+            - run:
+                name: Deploy to Heroku
+                command: './mvnw -ntp com.heroku.sdk:heroku-maven-plugin:2.0.5:deploy -DskipTests -Pprod -Dheroku.buildpacks=heroku/jvm -Dheroku.appName=<%= herokuAppName %>'
+                <%_ } _%>
+            <%_ } else if (buildTool === 'gradle') { _%>
+            - run:
+                name: Verify with Prod Profile
+                command: './gradlew bootJar -Pprod -x test --no-daemon'
+                <%_ if (cicdIntegrations.includes('heroku')) { _%>
+            -run:
+                name: Deploy to Heroku
+                command: './gradlew deployHeroku --no-daemon'
+                <%_ } _%>
+            <%_ } _%>

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -7,7 +7,7 @@ const expectedFiles = {
     travis: ['.travis.yml'],
     jenkins: ['Jenkinsfile', 'src/main/docker/jenkins.yml', 'src/main/resources/idea.gdsl'],
     gitlab: ['.gitlab-ci.yml'],
-    circle: ['circle.yml'],
+    circle: ['.circleci/config.yml'],
     azure: ['azure-pipelines.yml'],
     github: ['.github/workflows/github-ci.yml'],
     dockerRegistry: ['src/main/docker/docker-registry.yml']
@@ -755,6 +755,28 @@ describe('JHipster CI-CD Sub Generator', () => {
         });
         it('creates expected files', () => {
             assert.file(expectedFiles.github);
+        });
+    });
+
+    describe('Circle CI', () => {
+        beforeEach(done => {
+            helpers
+                .run(require.resolve('../generators/ci-cd'))
+                .inTmpDir(dir => {
+                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-yarn'), dir);
+                })
+                .withOptions({ skipChecks: true })
+                .withPrompts({
+                    pipeline: 'circle',
+                    cicdIntegrations: []
+                })
+                .on('end', done);
+        });
+        it('creates expected files', () => {
+            assert.file(expectedFiles.circle);
+            assert.noFile(expectedFiles.jenkins);
+            assert.noFile(expectedFiles.travis);
+            assert.noFile(expectedFiles.gitlab);
         });
     });
 });


### PR DESCRIPTION
This adds support for generation of CircleCI 2.0 configurations.

Fixes #10671

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
