### PR TITLE
Make reactive microservices stateless

### DIFF
--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -115,6 +115,9 @@ import org.springframework.security.web.server.authentication.logout.HttpStatusR
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
 <%_ } _%>
 import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter;
+<%_ if (applicationType === 'microservice') _%>
+import org.springframework.security.web.server.savedrequest.NoOpServerRequestCache;
+<%_ } _%>
 import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;
 import org.springframework.security.web.server.util.matcher.OrServerWebExchangeMatcher;
 <%_ if (skipUserManagement && authenticationType !== 'oauth2') { _%>
@@ -256,6 +259,11 @@ public class SecurityConfiguration {
                 .featurePolicy("geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; fullscreen 'self'; payment 'none'")
             .and()
                 .frameOptions().disable()
+        <%_ if (applicationType === 'microservice') _%>
+        .and()
+            .requestCache()
+            .requestCache(NoOpServerRequestCache.getInstance())
+        <%_ } _%>
         .and()
             .authorizeExchange()
             <%_ if (!skipClient) { _%>

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -115,7 +115,7 @@ import org.springframework.security.web.server.authentication.logout.HttpStatusR
 import org.springframework.security.web.server.csrf.CookieServerCsrfTokenRepository;
 <%_ } _%>
 import org.springframework.security.web.server.header.ReferrerPolicyServerHttpHeadersWriter;
-<%_ if (applicationType === 'microservice') _%>
+<%_ if (applicationType === 'microservice') { _%>
 import org.springframework.security.web.server.savedrequest.NoOpServerRequestCache;
 <%_ } _%>
 import org.springframework.security.web.server.util.matcher.NegatedServerWebExchangeMatcher;

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -259,7 +259,7 @@ public class SecurityConfiguration {
                 .featurePolicy("geolocation 'none'; midi 'none'; sync-xhr 'none'; microphone 'none'; camera 'none'; magnetometer 'none'; gyroscope 'none'; speaker 'none'; fullscreen 'self'; payment 'none'")
             .and()
                 .frameOptions().disable()
-        <%_ if (applicationType === 'microservice') _%>
+        <%_ if (applicationType === 'microservice') { _%>
         .and()
             .requestCache()
             .requestCache(NoOpServerRequestCache.getInstance())


### PR DESCRIPTION
This fixes an issue @murdos surfaced when implementing entity generation for reactive apps.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
