### PR TITLE
Add Core/Regular Contributor Guidelines [ci skip]

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -382,5 +382,19 @@ see http://spring.io/blog/2014/09/26/spring-boot-1-1-7-released
 Fix #1234
 ```
 
+### Regular Contributor Guidelines
+
+These are some of the guidelines that we would like to emphasize if you are a regular contributor to the project
+or joined the [JHipster team](https://www.jhipster.tech/team/).
+
+-  We recommend not to committing directly to master, but always submit changes through PRs.
+-  Before merging try to get at least one review on the PR.
+-  Add appropriate labels to issues and PRs that you create (if you have permission to do so).
+-  Follow [project policies](https://www.jhipster.tech/policies/#-policies).
+-  Follow project [Code of Conduct](https://github.com/jhipster/generator-jhipster/blob/master/CODE_OF_CONDUCT.md)
+and be polite and helpful to users when answering questions/bug reports and when reviewing PRs.
+-  We work on our free time so we have no obligations or commitments. Work life balance is important, so don't 
+feel tempted to put in all your free time fixing something.
+
 [issue-template]: https://github.com/jhipster/generator-jhipster/issues/new?template=BUG_REPORT.md
 [feature-template]: https://github.com/jhipster/generator-jhipster/issues/new?template=FEATURE_REQUEST.md


### PR DESCRIPTION
Add a small blob to highlight guidelines for regular contributors and core team members. This was discussed through our mailing list; https://groups.google.com/forum/?utm_medium=email&utm_source=footer#!msg/jhipster-dev/xfrODe_g14U/YSoDESxUAAAJ

Fixes #11471

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
