### PR TITLE
Entity subgen: Refactoring of determination of entity key type

### DIFF
--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -37,6 +37,20 @@ module.exports = class extends BaseBlueprintGenerator {
     }
 
     // Public API method used by the getter and also by Blueprints
+    _configuring() {
+        return {
+            setup() {
+                this.tsKeyType = this.getTypescriptKeyType(this.getPkTypeBasedOnDBAndAssociation(this.authenticationType, this.databaseType, this.relationships));
+            }
+        };
+    }
+
+    get configuring() {
+        if (useBlueprints) return;
+        return this._configuring();
+    }
+
+    // Public API method used by the getter and also by Blueprints
     _writing() {
         return writeFiles();
     }

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -40,7 +40,7 @@ module.exports = class extends BaseBlueprintGenerator {
     _configuring() {
         return {
             setup() {
-                this.tsKeyType = this.getTypescriptKeyType(this.getPkTypeBasedOnDBAndAssociation(this.authenticationType, this.databaseType, this.relationships));
+                this.tsKeyType = this.getTypescriptKeyType(this.primaryKeyType);
             }
         };
     }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
@@ -16,9 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_
-const tsKeyType = getTypescriptKeyType(getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships));
-_%>
 import { Component } from '@angular/core';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { JhiEventManager } from 'ng-jhipster';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -16,9 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_
-const tsKeyType = getTypescriptKeyType(getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships));
-_%>
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { <%_ if (pagination !== 'no') { _%>HttpHeaders, <% } %>HttpResponse } from '@angular/common/http';
 <%_ if (pagination === 'pagination') { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,8 +17,7 @@
  limitations under the License.
 -%>
 <%
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.service.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyType = getTypescriptKeyType(getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships));
 let searchType = 'Search';
 if (pagination === 'pagination' || pagination === 'infinite-scroll') {
     searchType = 'SearchWithPagination';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const tsKeyId = generateTestEntityId(primaryKeyType);
 _%>
 import { ComponentFixture, TestBed, inject, fakeAsync, tick } from '@angular/core/testing';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-detail.component.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const tsKeyId = generateTestEntityId(primaryKeyType);
 _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-update.component.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const tsKeyId = generateTestEntityId(primaryKeyType);
 _%>
 import { ComponentFixture, TestBed, fakeAsync, tick } from '@angular/core/testing';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.component.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const tsKeyId = generateTestEntityId(primaryKeyType);
 _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -19,7 +19,7 @@
 <%_
 const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const tsKeyId = generateTestEntityId(primaryKeyType);
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
 const enumImports = generateEntityClientEnumImports(fields);
 _%>
 import { TestBed, getTestBed } from '@angular/core/testing';
@@ -60,7 +60,7 @@ describe('Service Tests', () => {
             <%_ } _%>
 
             elemDefault = new <%= entityAngularName %>(
-                <%_ if (primaryKeyType === 'String' || primaryKeyType === 'UUID') { _%>
+                <%_ if (tsKeyType === 'string') { _%>
                 'ID',
                 <%_ } else { _%>
                 0,

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -112,7 +112,7 @@ describe('Service Tests', () => {
         <%_ if (!readOnly) { _%>
             it('should create a <%= entityAngularName %>', () => {
                 const returnedFromService = Object.assign({
-                    <%_ if (pkType === 'String' || pkType === 'UUID') { _%>
+                    <%_ if (tsKeyType === 'string') { _%>
                     id: 'ID',
                     <%_ } else { _%>
                     id: 0,

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -17,7 +17,6 @@
  limitations under the License.
 -%>
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const tsKeyId = generateTestEntityId(primaryKeyType);
 const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management.service.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 <%_
 const tsKeyId = generateTestEntityId(primaryKeyType);
-const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
 const enumImports = generateEntityClientEnumImports(fields);
 _%>
 import { TestBed, getTestBed } from '@angular/core/testing';

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -23,10 +23,6 @@ for (const idx in fields) {
         i18nToLoad.push(fields[idx].enumInstance);
     }
 }
-// const query = generateEntityQueries(relationships, entityInstance, dto);
-// const queries = query.queries;
-// const variables = query.variables;
-// let hasManyToMany = query.hasManyToMany;
 _%>
 import React, { useState, useEffect } from 'react';
 import { connect } from 'react-redux';

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,8 +17,7 @@
  limitations under the License.
 -%>
 <%
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields, 'react');
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(tsKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields, 'react');
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity-update-page-object.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity-update-page-object.ts.ejs
@@ -116,7 +116,6 @@ export default class <%= entityClass %>UpdatePage {
         const relationshipType = relationship.relationshipType;
         const ownerSide = relationship.ownerSide;
         const relationshipName = relationship.relationshipName;
-        const relationshipFieldName = relationship.relationshipFieldName;
         const relationshipNameCapitalized = relationship.relationshipNameCapitalized; _%>
     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'many-to-many' && ownerSide === true) || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
     async <%= relationshipName %>SelectLastOption() {

--- a/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
@@ -19,7 +19,6 @@
 <%_
 let entityActionName = entityInstance.toUpperCase();
 let entityActionNamePlural = entityInstancePlural.toUpperCase();
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 _%>
 import axios from 'axios';
 

--- a/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
@@ -27,7 +27,6 @@ let resultEntity;
 let mapsIdEntityInstance;
 let mapsIdRepoInstance;
 let otherEntityName;
-let dataTypeName = (isUsingMapsId === true && mapsIdAssoc.otherEntityName === 'user' && authenticationType === 'oauth2') ? 'String' : 'long';
 
 if (isUsingMapsId === true) {
     mapsIdEntityInstance = mapsIdAssoc.otherEntityNameCapitalized.charAt(0).toLowerCase() + mapsIdAssoc.otherEntityNameCapitalized.slice(1);
@@ -44,7 +43,7 @@ if (!viaService) {
         resultEntity = asEntity(entityInstance); _%>
         <%= asEntity(entityClass) %> <%= asEntity(entityInstance) %> = <%= dtoToEntity %>(<%= instanceName %>);
         <%_ if (isUsingMapsId === true) { _%>
-        <%= dataTypeName %> <%= otherEntityName %>Id = <%= instanceName %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>Id();
+        <%= mapsIdAssoc.otherEntityPrimaryKeyType %> <%= otherEntityName %>Id = <%= instanceName %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>Id();
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= asEntity(entityInstance) %>::<%_ if (fluentMethods === false) { _%>set<%= mapsIdAssoc.relationshipNameCapitalized %> <%_ } else { _%><%= mapsIdAssoc.relationshipName %><%_ } _%>);
         <%_ } _%>
         <%_ if (!reactive) { _%>
@@ -56,7 +55,7 @@ if (!viaService) {
         <%_ } _%>
     <%_ } else { resultEntity = 'result'; _%>
         <%_ if (isUsingMapsId === true) { _%>
-        <%= dataTypeName %> <%= otherEntityName %>Id = <%= instanceName %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>().getId();
+        <%= mapsIdAssoc.otherEntityPrimaryKeyType %> <%= otherEntityName %>Id = <%= instanceName %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>().getId();
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= instanceName %>::<%_ if (fluentMethods === false) { _%>set<%= mapsIdAssoc.relationshipNameCapitalized %> <%_ } else { _%><%= otherEntityName %><%_ } _%>);
         <%_ } _%>
         <%= returnPrefix %> <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>);
@@ -66,7 +65,7 @@ if (!viaService) {
         return result;
     <%_ }}} else { _%>
         <%_ if (isUsingMapsId === true && isController === false) { _%>
-        <%= dataTypeName %> <%= otherEntityName %>Id = <%= entityInstance %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>().getId();
+        <%= mapsIdAssoc.otherEntityPrimaryKeyType %> <%= otherEntityName %>Id = <%= entityInstance %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>().getId();
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= entityInstance %>::<%_ if (fluentMethods === false) { _%>set<%= mapsIdAssoc.relationshipNameCapitalized %> <%_ } else { _%><%= otherEntityName %><%_ } _%>);
         <%_ } _%>
         <%= returnPrefix %> <%= entityInstance %>Service.save(<%= instanceName %>);

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -25,7 +25,6 @@ let importJsonIgnoreProperties = false;
 let importSet = false;
 let hasDto = dto === 'mapstruct';
 let isUsingMapsId = false;
-let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 let hasTextBlob = false;
 let hasRelationship = relationships.length !== 0;
 const uniqueEnums = {};

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -25,7 +25,7 @@ let importJsonIgnoreProperties = false;
 let importSet = false;
 let hasDto = dto === 'mapstruct';
 let isUsingMapsId = false;
-let primaryKeyType = pkType;
+let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 let hasTextBlob = false;
 let hasRelationship = relationships.length !== 0;
 const uniqueEnums = {};
@@ -34,11 +34,9 @@ _%>
 <%_
 for (idx in relationships) {
     isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if ( isUsingMapsId === true) {
-        primaryKeyType = (relationships[idx].otherEntityName === 'user'  && authenticationType === 'oauth2') ? 'String' : pkType;
+    if (isUsingMapsId === true) {
         break;
     }
-    isUsingMapsId = false;
 }
 for (idx in fields) {
     if (prodDatabaseType === 'postgresql' && fields[idx].fieldTypeBlobContent === 'text') {

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -33,8 +33,8 @@ _%>
 <%- include imports -%>
 <%_
 for (idx in relationships) {
-    isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if (isUsingMapsId === true) {
+    isUsingMapsId = relationships[idx].useJPADerivedIdentifier === true;
+    if (isUsingMapsId) {
         break;
     }
 }

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepository.java.ejs
@@ -18,9 +18,6 @@
 -%>
 package <%= packageName %>.repository;
 
-<%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
-_%>
 import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
 <%_ if (databaseType === 'cassandra') { _%>
 import org.springframework.data.cassandra.repository.ReactiveCassandraRepository;

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -18,9 +18,6 @@
 -%>
 package <%= packageName %>.repository;
 
-<%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
-_%>
 import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
 
 <%_ if (fieldsContainOwnerManyToMany) { _%>

--- a/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
@@ -18,9 +18,6 @@
 -%>
 package <%= packageName %>.repository.search;
 
-<%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
-_%>
 import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
 import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;<% if (databaseType === 'cassandra') { %>
 

--- a/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
@@ -29,7 +29,6 @@ const entityListToDto = mapper + '.' + 'toDto';
 const entityToDtoReference = mapper + '::'+ 'toDto';
 const repository = entityInstance  + 'Repository';
 const criteria = entityClass + 'Criteria';
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 _%>
 import java.util.List;
 

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -19,7 +19,6 @@
 package <%= packageName %>.service;
 
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const instanceType = (dto === 'mapstruct') ? asDto(entityClass) : asEntity(entityClass);
 const instanceName = (dto === 'mapstruct') ? asDto(entityInstance) : asEntity(entityInstance);
 const optionalOrMono = (reactive === true) ? 'Mono' : 'Optional';

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
@@ -33,7 +33,6 @@ import io.github.jhipster.service.filter.ZonedDateTimeFilter;
 <%_ } _%>
 
 <%_
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 const referenceFilterType = '' + primaryKeyType + 'Filter';
 var filterVariables = [{name:'id', type: primaryKeyType, filterType:referenceFilterType,fieldInJavaBeanMethod:'Id' } ];
 var extraFilters = {};

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -24,7 +24,6 @@ let importJsonIgnore = false;
 let importJsonIgnoreProperties = false;
 let importSet = false;
 const uniqueEnums = {};
-const primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 _%>
 <%- include ../../domain/imports -%>
 <%_ if (typeof javadoc != 'undefined') { _%>

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -119,11 +119,10 @@ public class <%= asDto(entityClass) %> implements Serializable {
         <%_ } _%>
     <%_ } _%>
     <%_ for (idx in relationships) {
-        const otherEntityRelationshipName = relationships[idx].otherEntityRelationshipName;
         const relationshipFieldName = relationships[idx].relationshipFieldName;
         const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
         const relationshipType = relationships[idx].relationshipType;
-        const otherEntityName = relationships[idx].otherEntityName;
+        const otherEntityPrimaryKeyType = relationships[idx].otherEntityPrimaryKeyType;
         const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
         const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
         const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
@@ -139,7 +138,7 @@ public class <%= asDto(entityClass) %> implements Serializable {
     private <%= asDto(otherEntityNameCapitalized) %> <%= relationshipFieldName %>;
     <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
 
-    private <% if (otherEntityName === 'user' && authenticationType === 'oauth2') { %>String<% } else { %><%= primaryKeyType %><% } %> <%= relationshipFieldName %>Id;
+    private <%= otherEntityPrimaryKeyType %> <%= relationshipFieldName %>Id;
     <%_ if (otherEntityFieldCapitalized !== 'Id' && otherEntityFieldCapitalized !== '') { _%>
 
     private String <%= relationshipFieldName %><%= otherEntityFieldCapitalized %>;
@@ -187,17 +186,18 @@ public class <%= asDto(entityClass) %> implements Serializable {
         <%_ } _%>
     <%_ } _%>
     <%_ for (idx in relationships) {
-        relationshipFieldName = relationships[idx].relationshipFieldName,
-        relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural,
-        otherEntityName = relationships[idx].otherEntityName,
-        otherEntityNamePlural = relationships[idx].otherEntityNamePlural,
-        otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded,
-        relationshipType = relationships[idx].relationshipType,
-        otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized,
-        otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized,
-        relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized,
-        relationshipNameCapitalizedPlural = relationships[idx].relationshipNameCapitalizedPlural,
-        ownerSide = relationships[idx].ownerSide;
+        const relationshipFieldName = relationships[idx].relationshipFieldName;
+        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+        const otherEntityName = relationships[idx].otherEntityName;
+        const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
+        const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
+        const otherEntityPrimaryKeyType = relationships[idx].otherEntityPrimaryKeyType;
+        const relationshipType = relationships[idx].relationshipType;
+        const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
+        const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+        const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
+        const relationshipNameCapitalizedPlural = relationships[idx].relationshipNameCapitalizedPlural;
+        const ownerSide = relationships[idx].ownerSide;
         if ((relationshipType === 'many-to-many' && ownerSide === true)
                 || (relationshipType === 'one-to-many' && otherEntityIsEmbedded)) { _%>
 
@@ -220,15 +220,15 @@ public class <%= asDto(entityClass) %> implements Serializable {
     <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
 
     <%_ if (relationshipNameCapitalized.length > 1) { _%>
-    public <% if (otherEntityName === 'user' && authenticationType === 'oauth2') { %>String<% } else { %><%= primaryKeyType %><% } %> get<%= relationshipNameCapitalized %>Id() {
+    public <%= otherEntityPrimaryKeyType %> get<%= relationshipNameCapitalized %>Id() {
         return <%= relationshipFieldName %>Id;
     }
 
-    public void set<%= relationshipNameCapitalized %>Id(<% if (otherEntityName === 'user' && authenticationType === 'oauth2') { %>String<% } else { %><%= primaryKeyType %><% } %> <%= otherEntityName %>Id) {
+    public void set<%= relationshipNameCapitalized %>Id(<%= otherEntityPrimaryKeyType %> <%= otherEntityName %>Id) {
         this.<%= relationshipFieldName %>Id = <%= otherEntityName %>Id;
     }
     <%_ } else { // special case when the entity name has one character _%>
-    public <%= primaryKeyType %> get<%= relationshipNameCapitalized.toLowerCase() %>Id() {
+    public <%= otherEntityPrimaryKeyType %> get<%= relationshipNameCapitalized.toLowerCase() %>Id() {
         return <%= relationshipFieldName %>Id;
     }
 
@@ -294,9 +294,9 @@ public class <%= asDto(entityClass) %> implements Serializable {
                 const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
                 const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
                 const relationshipNameCapitalizedPlural = relationships[idx].relationshipNameCapitalizedPlural;
-                const otherEntityName = relationships[idx].otherEntityName;
                 const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
                 const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
+                const otherEntityPrimaryKeyType = relationships[idx].otherEntityPrimaryKeyType;
                 const ownerSide = relationships[idx].ownerSide; _%>
                 <%_ if ((relationshipType === 'many-to-many' && ownerSide === true)
                         || (relationshipType === 'one-to-many' && otherEntityIsEmbedded)) { _%>
@@ -304,7 +304,7 @@ public class <%= asDto(entityClass) %> implements Serializable {
                 <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true && otherEntityIsEmbedded) { _%>
             ", <%= relationshipFieldName %>='" + get<%= relationshipNameCapitalized %>() + "'" +
                 <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
-            ", <%= relationshipFieldName %>Id=<% if (otherEntityName === 'user' && authenticationType === 'oauth2') { %>'<% } %>" + get<%= relationshipNameCapitalized %>Id() <% if (otherEntityName === 'user' && authenticationType === 'oauth2') { %>+ "'" <% } %>+
+            ", <%= relationshipFieldName %>Id=<% if (otherEntityPrimaryKeyType === 'String') { %>'<% } %>" + get<%= relationshipNameCapitalized %>Id() <% if (otherEntityPrimaryKeyType === 'String') { %>+ "'" <% } %>+
                     <%_ if (otherEntityFieldCapitalized !== 'Id' && otherEntityFieldCapitalized !== '') { _%>
             ", <%= relationshipFieldName %><%= otherEntityFieldCapitalized %>='" + get<%= relationshipNameCapitalized %><%= otherEntityFieldCapitalized %>() + "'" +
             <%_ } } } _%>

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -32,17 +32,15 @@ const entityToDto = 'toDto';
 const entityToDtoReference = mapper + '::'+ 'toDto';
 const repository = entityInstance  + 'Repository';
 const searchRepository = entityInstance  + 'SearchRepository';
+let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 let isUsingMapsId = false;
-let primaryKeyType = pkType;
 let mapsIdAssoc;
 for (idx in relationships) {
     isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if ( isUsingMapsId === true) {
+    if (isUsingMapsId === true) {
         mapsIdAssoc = relationships[idx];
-        primaryKeyType = (relationships[idx].otherEntityName === 'user'  && authenticationType === 'oauth2') ? 'String' : pkType;
         break;
     }
-    isUsingMapsId = false;
 }
 _%>
 <%_ if (service === 'serviceImpl') { _%>

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -36,8 +36,8 @@ let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType
 let isUsingMapsId = false;
 let mapsIdAssoc;
 for (idx in relationships) {
-    isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if (isUsingMapsId === true) {
+    isUsingMapsId = relationships[idx].useJPADerivedIdentifier === true;
+    if (isUsingMapsId) {
         mapsIdAssoc = relationships[idx];
         break;
     }

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -32,7 +32,6 @@ const entityToDto = 'toDto';
 const entityToDtoReference = mapper + '::'+ 'toDto';
 const repository = entityInstance  + 'Repository';
 const searchRepository = entityInstance  + 'SearchRepository';
-let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 let isUsingMapsId = false;
 let mapsIdAssoc;
 for (idx in relationships) {

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -85,7 +85,6 @@ _%>
 // DTO -> entity mapping
 var renMapAnotDto = false;  //Render Mapping Annotation during DTO to Entity conversion?
 // var hasOAuthUser = false; // if OAuthUser, use a String id in fromId() method
-let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 for (idx in relationships) {
     const relationshipType = relationships[idx].relationshipType;
     const relationshipName = relationships[idx].relationshipName;

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -85,17 +85,14 @@ _%>
 // DTO -> entity mapping
 var renMapAnotDto = false;  //Render Mapping Annotation during DTO to Entity conversion?
 // var hasOAuthUser = false; // if OAuthUser, use a String id in fromId() method
-let primaryKeyType = pkType;
+let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 for (idx in relationships) {
     const relationshipType = relationships[idx].relationshipType;
     const relationshipName = relationships[idx].relationshipName;
-    const otherEntityName = relationships[idx].otherEntityName;
     const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
     const relationshipNamePlural = relationships[idx].relationshipNamePlural;
     const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
     const ownerSide = relationships[idx].ownerSide;
-    const isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    primaryKeyType = (isUsingMapsId === true && otherEntityName === 'user' && authenticationType === 'oauth2') ? 'String' : primaryKeyType;
     if ((relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true) && !otherEntityIsEmbedded)) {
         renMapAnotDto = true;
 _%>

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -24,8 +24,8 @@ let isUsingMapsId = false;
 let mapsIdAssoc;
 let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 for (idx in relationships) {
-    isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if (isUsingMapsId === true) {
+    isUsingMapsId = relationships[idx].useJPADerivedIdentifier === true;
+    if (isUsingMapsId) {
         mapsIdAssoc = relationships[idx];
         break;
     }

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -22,7 +22,6 @@ package <%= packageName %>.web.rest;
 const viaService = service !== 'no';
 let isUsingMapsId = false;
 let mapsIdAssoc;
-let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 for (idx in relationships) {
     isUsingMapsId = relationships[idx].useJPADerivedIdentifier === true;
     if (isUsingMapsId) {

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -22,15 +22,13 @@ package <%= packageName %>.web.rest;
 const viaService = service !== 'no';
 let isUsingMapsId = false;
 let mapsIdAssoc;
-let primaryKeyType = pkType;
+let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, pkType, relationships);
 for (idx in relationships) {
     isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if ( isUsingMapsId === true) {
+    if (isUsingMapsId === true) {
         mapsIdAssoc = relationships[idx];
-        primaryKeyType = (relationships[idx].otherEntityName === 'user'  && authenticationType === 'oauth2') ? 'String' : pkType;
         break;
     }
-    isUsingMapsId = false;
 }
 let manyToManyWithUser = false;
 for (idx in relationships) {
@@ -202,14 +200,14 @@ public class <%= entityClass %>Resource {
         <%_ if (!reactive) { _%>
 <%- include('../../common/save_template', {asEntity, asDto, viaService: viaService, returnDirectly: false, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: true}); -%>
         return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.getId()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (pkType !== 'String') { %>.toString()<% } %>))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
             .body(result);
         <%_ } else { _%>
 <%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: viaService}); -%>
             .map(result -> {
                 try {
                     return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.getId()))
-                        .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (pkType !== 'String') { %>.toString()<% } %>))
+                        .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
                         .body(result);
                 } catch (URISyntaxException e) {
                     throw new RuntimeException(e);
@@ -249,13 +247,13 @@ public class <%= entityClass %>Resource {
     <%_ if (!reactive) { _%>
 <%- include('../../common/save_template', {asEntity, asDto, viaService: viaService, returnDirectly: false, isUsingMapsId: false, mapsIdAssoc: mapsIdAssoc}); -%>
         return ResponseEntity.ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.getId()<% if (pkType !== 'String') { %>.toString()<% } %>))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
             .body(result);
     <%_ } else { _%>
 <%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: viaService}); -%>
             .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND)))
             .map(result -> ResponseEntity.ok()
-                .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (pkType !== 'String') { %>.toString()<% } %>))
+                .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
                 .body(result)
             );
     <%_ } _%>
@@ -336,11 +334,11 @@ public class <%= entityClass %>Resource {
         log.debug("REST request to delete <%= entityClass %> : {}", id);
     <%_ if (!reactive) { _%>
 <%- include('../../common/delete_template', {viaService: viaService}); -%>
-        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (pkType !== 'String') { %>.toString()<% } %>)).build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build();
     <%_ } else { _%>
         return <%= entityInstance %><%= service !== 'no' ? 'Service.delete' : 'Repository.deleteById' %>(id)
             .map(result -> ResponseEntity.noContent()
-                .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (pkType !== 'String') { %>.toString()<% } %>)).build()
+                .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build()
             );
     <%_ } _%>
     }

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -24,15 +24,8 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-<%= LIQUIBASE_DTD_VERSION %>.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
-    <% let autoIncrementValue = true;
-        let primaryKeyType = 'bigint';
-        for (idx in relationships) {
-            if (relationships[idx].useJPADerivedIdentifier === true) {
-                primaryKeyType = (relationships[idx].otherEntityName === 'user' && authenticationType === 'oauth2') ? 'varchar(100)' : primaryKeyType;
-                autoIncrementValue = false;
-                break;
-            }
-        }
+    <% let autoIncrementValue = primaryKeyType !== 'String';
+        let databasePKType = primaryKeyType !== 'String' ? 'bigint' : 'varchar(100)';
         const isAutoIncrementDB = prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb';
     _%>
     <%_ if (isAutoIncrementDB) { _%>
@@ -48,7 +41,7 @@
         <%_ } else { _%>
         <createTable tableName="<%= entityTableName %>" remarks="<%- formatAsLiquibaseRemarks(javadoc) %>">
         <%_ } _%>
-            <column name="id" type="<%= primaryKeyType %>" <%_ if (primaryKeyType === 'varchar(100)' ) { _%> <% } else if (isAutoIncrementDB) { %> autoIncrement="${autoIncrement}" <%_ } %>>
+            <column name="id" type="<%= databasePKType %>" <%_ if (primaryKeyType === 'String' ) { _%> <% } else if (isAutoIncrementDB) { %> autoIncrement="${autoIncrement}" <%_ } %>>
                 <constraints primaryKey="true" nullable="false"/>
             </column>
             <%_ for (idx in fields) {

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -121,7 +121,7 @@
                 let nullable_relation = true,
                 relationshipType = relationships[idx].relationshipType,
                 relationshipName = relationships[idx].relationshipName,
-                relationshipColumnType = relationships[idx].otherEntityName === 'user' && authenticationType === 'oauth2' ? 'varchar(100)' : 'bigint';
+                relationshipColumnType = relationships[idx].otherEntityPrimaryKeyType === 'String' ? 'varchar(100)' : 'bigint';
                 if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired) {
                     nullable_relation = false;
                 }
@@ -153,7 +153,7 @@
             relationshipName = relationships[idx].relationshipName,
             ownerSide = relationships[idx].ownerSide,
             otherEntityName = relationships[idx].otherEntityName;
-            const relationshipColumnType = otherEntityName === 'user' && authenticationType === 'oauth2' ? 'varchar(100)' : 'bigint';
+            const relationshipColumnType = relationships[idx].otherEntityPrimaryKeyType === 'String' ? 'varchar(100)' : 'bigint';
             if (relationshipType === 'many-to-many' && ownerSide) {
                 const joinTableName = getJoinTableName(entityTableName, relationshipName, prodDatabaseType);
           _%>
@@ -214,18 +214,16 @@
                 <%_ } _%>
             <%_ } _%>
             <%_ for (idx in relationships) {
-                    let loadColumnType = 'numeric';
+                    let loadColumnType = relationships[idx].otherEntityPrimaryKeyType === 'String' ? 'varchar(100)' : 'numeric';
                     if (relationships[idx].relationshipValidate === true && relationships[idx].relationshipRequired
                         && (relationships[idx].relationshipType === "many-to-one"
                             || (relationships[idx].relationshipType === "one-to-one" && relationships[idx].ownerSide === true
                                 && (relationships[idx].useJPADerivedIdentifier == null || relationships[idx].useJPADerivedIdentifier === false))
                     )) {
                         let baseColumnName = getColumnName(relationships[idx].relationshipName) + '_id';
-                        if (relationships[idx].otherEntityNameCapitalized === 'User' && authenticationType === 'oauth2') {
-                            loadColumnType = 'varchar(100)';
-                        } _%>
+                        _%>
             <column name="<%= baseColumnName %>" type="<%= loadColumnType %>"/>
-                <%_ } _%>
+                    <%_ } _%>
             <%_  } _%>
             <!-- jhipster-needle-liquibase-add-loadcolumn - JHipster (and/or extensions) can add load columns here, do not remove-->
         </loadData>

--- a/generators/entity-server/templates/src/test/java/package/domain/EntityTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/domain/EntityTest.java.ejs
@@ -24,8 +24,8 @@ import <%= packageName %>.web.rest.TestUtil;
 <%_
 let hasOauthUser = false;
 for (idx in relationships) {
-    isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if (isUsingMapsId === true) {
+    isUsingMapsId = relationships[idx].useJPADerivedIdentifier === true;
+    if (isUsingMapsId) {
         hasOauthUser = relationships[idx].otherEntityName === 'user' && authenticationType === 'oauth2';
         break;
     }

--- a/generators/entity-server/templates/src/test/java/package/service/dto/EntityDTOTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/service/dto/EntityDTOTest.java.ejs
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 import <%= packageName %>.web.rest.TestUtil;
 <%_
-let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 let id1 = getPrimaryKeyValue(primaryKeyType, databaseType, '1');
 let id2 = getPrimaryKeyValue(primaryKeyType, databaseType, '2');
 _%>

--- a/generators/entity-server/templates/src/test/java/package/service/mapper/EntityMapperTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/service/mapper/EntityMapperTest.java.ejs
@@ -22,7 +22,6 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;
 <%_
-let primaryKeyType = getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships);
 let id = getPrimaryKeyValue(primaryKeyType, databaseType, '1');
 _%>
 <%_ if (id.includes('UUID')) { _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -26,8 +26,8 @@ let mapsIdEntityInstance;
 let mapsIdRepoInstance;
 let hasOauthUser = false;
 for (idx in relationships) {
-    isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-    if ( isUsingMapsId === true) {
+    isUsingMapsId = relationships[idx].useJPADerivedIdentifier === true;
+    if (isUsingMapsId) {
         mapsIdAssoc = relationships[idx];
         mapsIdEntity = mapsIdAssoc.otherEntityNameCapitalized;
         mapsIdEntityInstance =  mapsIdEntity.charAt(0).toLowerCase() + mapsIdEntity.slice(1);

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -894,6 +894,11 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     }
                     const jhiTablePrefix = context.jhiTablePrefix;
 
+                    relationship.otherEntityPrimaryKeyType =
+                        relationship.otherEntityName === 'user' && context.authenticationType === 'oauth2'
+                            ? 'String'
+                            : this.getPkType(context.databaseType);
+
                     // Look for fields at the other other side of the relationship
                     if (otherEntityData && otherEntityData.relationships) {
                         if (relationship.relationshipType === 'many-to-one' || relationship.relationshipType === 'many-to-many') {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1128,6 +1128,9 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     context.databaseType,
                     context.relationships
                 );
+                // Deprecated: kept for compatibility, should be removed in next major release
+                context.pkType = context.primaryKeyType;
+                context.hasUserField = hasUserField;
             },
 
             insight() {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -879,7 +879,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                         context.validation = true;
                     }
                 });
-                context.hasUserField = context.saveUserSnapshot = false;
+                let hasUserField = false;
                 // Load in-memory data for relationships
                 context.relationships.forEach(relationship => {
                     const otherEntityName = relationship.otherEntityName;
@@ -994,7 +994,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
 
                     if (otherEntityName === 'user') {
                         relationship.otherEntityTableName = `${jhiTablePrefix}_user`;
-                        context.hasUserField = true;
+                        hasUserField = true;
                     } else {
                         relationship.otherEntityTableName = otherEntityData ? otherEntityData.entityTableName : null;
                         if (!relationship.otherEntityTableName) {
@@ -1005,11 +1005,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                             relationship.otherEntityTableName = `${jhiTablePrefix}_${otherEntityTableName}`;
                         }
                     }
-                    context.saveUserSnapshot =
-                        context.applicationType === 'microservice' &&
-                        context.authenticationType === 'oauth2' &&
-                        context.hasUserField &&
-                        context.dto === 'no';
 
                     if (_.isUndefined(relationship.otherEntityNamePlural)) {
                         relationship.otherEntityNamePlural = pluralize(relationship.otherEntityName);
@@ -1116,6 +1111,12 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     }
                     context.differentRelationships[entityType].push(relationship);
                 });
+
+                context.saveUserSnapshot =
+                    context.applicationType === 'microservice' &&
+                    context.authenticationType === 'oauth2' &&
+                    hasUserField &&
+                    context.dto === 'no';
 
                 context.primaryKeyType = this.getPkTypeBasedOnDBAndAssociation(
                     context.authenticationType,

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -1117,7 +1117,11 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     context.differentRelationships[entityType].push(relationship);
                 });
 
-                context.pkType = this.getPkType(context.databaseType);
+                context.primaryKeyType = this.getPkTypeBasedOnDBAndAssociation(
+                    context.authenticationType,
+                    context.databaseType,
+                    context.relationships
+                );
             },
 
             insight() {

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1461,7 +1461,7 @@ module.exports = class extends Generator {
      *
      * @param {string} authenticationType - the auth type
      * @param {string} databaseType - the database type
-     * @param {any} relationships - relationships
+     * @param {T[]} relationships - relationships
      */
     getPkTypeBasedOnDBAndAssociation(authenticationType, databaseType, relationships) {
         let hasFound = false;

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1142,15 +1142,16 @@ module.exports = class extends Generator {
     /**
      * Generate Entity Client Field Declarations
      *
-     * @param {string} tsKeyType - key type in Typescript
+     * @param {string} pkType - type of primary key
      * @param {Array|Object} fields - array of fields
      * @param {Array|Object} relationships - array of relationships
      * @param {string} dto - dto
      * @param {boolean} embedded - either the actual entity is embedded or not
      * @returns variablesWithTypes: Array
      */
-    generateEntityClientFields(tsKeyType, fields, relationships, dto, customDateType = 'Moment', embedded = false) {
+    generateEntityClientFields(pkType, fields, relationships, dto, customDateType = 'Moment', embedded = false) {
         const variablesWithTypes = [];
+        const tsKeyType = this.getTypescriptKeyType(pkType);
         if (!embedded) {
             variablesWithTypes.push(`id?: ${tsKeyType}`);
         }

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1142,16 +1142,15 @@ module.exports = class extends Generator {
     /**
      * Generate Entity Client Field Declarations
      *
-     * @param {string} pkType - type of primary key
+     * @param {string} tsKeyType - key type in Typescript
      * @param {Array|Object} fields - array of fields
      * @param {Array|Object} relationships - array of relationships
      * @param {string} dto - dto
      * @param {boolean} embedded - either the actual entity is embedded or not
      * @returns variablesWithTypes: Array
      */
-    generateEntityClientFields(pkType, fields, relationships, dto, customDateType = 'Moment', embedded = false) {
+    generateEntityClientFields(tsKeyType, fields, relationships, dto, customDateType = 'Moment', embedded = false) {
         const variablesWithTypes = [];
-        const tsKeyType = this.getTypescriptKeyType(pkType);
         if (!embedded) {
             variablesWithTypes.push(`id?: ${tsKeyType}`);
         }


### PR DESCRIPTION
Content of this PR:
- Factored the definition of Java key type of the entity (string or numeric, depending on datatabase type, auth and use of mapsId) 
- Factored the definition of TypeScript key type of the entity (string or numeric, depending on datatabase type, auth, ...) 
- Factored, for each relationship, the computing of the other entity primary key type


-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
