### PR TITLE
WIP: Refactoring of entity subgenerators: dispatch configuration in entity-server or entity-client

### DIFF
--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -58,6 +58,18 @@ module.exports = class extends BaseBlueprintGenerator {
                     if (!['Instant', 'ZonedDateTime', 'Boolean'].includes(field.fieldType)) {
                         this.fieldsIsReactAvField = true;
                     }
+
+                    if (_.isUndefined(field.fieldValidateRulesPatternAngular)) {
+                        field.fieldValidateRulesPatternAngular = field.fieldValidateRulesPattern
+                            ? field.fieldValidateRulesPattern.replace(/"/g, '&#34;')
+                            : field.fieldValidateRulesPattern;
+                    }
+
+                    if (_.isUndefined(field.fieldValidateRulesPatternReact)) {
+                        field.fieldValidateRulesPatternReact = field.fieldValidateRulesPattern
+                            ? field.fieldValidateRulesPattern.replace(/'/g, "\\'")
+                            : field.fieldValidateRulesPattern;
+                    }
                 });
             },
             relationshipsSetup() {

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -46,10 +46,10 @@ module.exports = class extends BaseBlueprintGenerator {
                     this.clientRootFolder ? `${this.clientRootFolder}-${this.entityStateName}` : this.entityStateName
                 );
                 this.i18nKeyPrefix = `${this.angularAppName}.${this.entityTranslationKey}`;
-                this.i18nToLoad = [this.entityInstance];
             },
             fieldsSetup() {
                 // Load in-memory data for fields
+                this.i18nToLoad = [this.entityInstance];
                 this.fields.forEach(field => {
                     if (field.fieldIsEnum === true) {
                         this.i18nToLoad.push(field.enumInstance);
@@ -70,11 +70,6 @@ module.exports = class extends BaseBlueprintGenerator {
                             ? field.fieldValidateRulesPattern.replace(/'/g, "\\'")
                             : field.fieldValidateRulesPattern;
                     }
-                });
-            },
-            relationshipsSetup() {
-                // Load in-memory data for relationships
-                this.relationships.forEach(relationship => {
                 });
             }
         };

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -779,40 +779,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                         field.fieldNameHumanized = _.startCase(field.fieldName);
                     }
 
-                    if (_.isUndefined(field.fieldInJavaBeanMethod)) {
-                        // Handle the specific case when the second letter is capitalized
-                        // See http://stackoverflow.com/questions/2948083/naming-convention-for-getters-setters-in-java
-                        if (field.fieldName.length > 1) {
-                            const firstLetter = field.fieldName.charAt(0);
-                            const secondLetter = field.fieldName.charAt(1);
-                            if (firstLetter === firstLetter.toLowerCase() && secondLetter === secondLetter.toUpperCase()) {
-                                field.fieldInJavaBeanMethod = firstLetter.toLowerCase() + field.fieldName.slice(1);
-                            } else {
-                                field.fieldInJavaBeanMethod = _.upperFirst(field.fieldName);
-                            }
-                        } else {
-                            field.fieldInJavaBeanMethod = _.upperFirst(field.fieldName);
-                        }
-                    }
-
-                    if (_.isUndefined(field.fieldValidateRulesPatternJava)) {
-                        field.fieldValidateRulesPatternJava = field.fieldValidateRulesPattern
-                            ? field.fieldValidateRulesPattern.replace(/\\/g, '\\\\').replace(/"/g, '\\"')
-                            : field.fieldValidateRulesPattern;
-                    }
-
-                    if (_.isUndefined(field.fieldValidateRulesPatternAngular)) {
-                        field.fieldValidateRulesPatternAngular = field.fieldValidateRulesPattern
-                            ? field.fieldValidateRulesPattern.replace(/"/g, '&#34;')
-                            : field.fieldValidateRulesPattern;
-                    }
-
-                    if (_.isUndefined(field.fieldValidateRulesPatternReact)) {
-                        field.fieldValidateRulesPatternReact = field.fieldValidateRulesPattern
-                            ? field.fieldValidateRulesPattern.replace(/'/g, "\\'")
-                            : field.fieldValidateRulesPattern;
-                    }
-
                     field.fieldValidate = _.isArray(field.fieldValidateRules) && field.fieldValidateRules.length >= 1;
 
                     if (fieldType === 'ZonedDateTime') {
@@ -860,7 +826,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                             relationship.otherEntityIsEmbedded = true;
                         }
                     }
-                    const jhiTablePrefix = context.jhiTablePrefix;
 
                     // Look for fields at the other other side of the relationship
                     if (otherEntityData && otherEntityData.relationships) {
@@ -959,25 +924,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                             );
                         }
                     }
-
-                    if (otherEntityName === 'user') {
-                        relationship.otherEntityTableName = `${jhiTablePrefix}_user`;
-                        context.hasUserField = true;
-                    } else {
-                        relationship.otherEntityTableName = otherEntityData ? otherEntityData.entityTableName : null;
-                        if (!relationship.otherEntityTableName) {
-                            relationship.otherEntityTableName = this.getTableName(otherEntityName);
-                        }
-                        if (jhiCore.isReservedTableName(relationship.otherEntityTableName, context.prodDatabaseType) && jhiTablePrefix) {
-                            const otherEntityTableName = relationship.otherEntityTableName;
-                            relationship.otherEntityTableName = `${jhiTablePrefix}_${otherEntityTableName}`;
-                        }
-                    }
-                    context.saveUserSnapshot =
-                        context.applicationType === 'microservice' &&
-                        context.authenticationType === 'oauth2' &&
-                        context.hasUserField &&
-                        context.dto === 'no';
 
                     if (_.isUndefined(relationship.otherEntityNamePlural)) {
                         relationship.otherEntityNamePlural = pluralize(relationship.otherEntityName);


### PR DESCRIPTION
Entity subgen is quite big and setup all context for server and client.
This PR moves configuration context that is specific to only one subgen (client or server) to the subgenerator.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
