### PR TITLE
separate springfox specs for jhipster and openapi controllers

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -549,6 +549,16 @@ const serverFiles = {
                     renameTo: generator => `${generator.javaDir}web/rest/UserJWTController.java`
                 }
             ]
+        },
+        {
+            condition: generator => !!generator.enableSwaggerCodegen,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/config/OpenApiConfiguration.java',
+                    renameTo: generator => `${generator.javaDir}config/OpenApiConfiguration.java`
+                }
+            ]
         }
     ],
     serverJavaGateway: [

--- a/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
@@ -1,0 +1,90 @@
+<%#
+Copyright 2013-2020 the original author or authors from the JHipster project.
+
+This file is part of the JHipster project, see https://www.jhipster.tech/
+for more information.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-%>
+package <%= packageName %>.config;
+
+import com.google.common.base.Predicates;
+import io.github.jhipster.config.JHipsterConstants;
+import io.github.jhipster.config.JHipsterProperties;
+import io.github.jhipster.config.apidoc.customizer.SwaggerCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.data.domain.Pageable;
+import org.springframework.http.ResponseEntity;
+import springfox.documentation.builders.RequestHandlerSelectors;
+import springfox.documentation.service.ApiInfo;
+import springfox.documentation.service.Contact;
+import springfox.documentation.spi.DocumentationType;
+import springfox.documentation.spring.web.plugins.Docket;
+
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+
+import static springfox.documentation.builders.PathSelectors.regex;
+
+@Configuration
+@Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
+public class OpenApiConfiguration {
+
+    @Bean
+    public SwaggerCustomizer noApiFirstCustomizer() {
+        return docket -> docket.select()
+            .apis(Predicates.not(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api")));
+    }
+
+    @Bean
+    public Docket apiFirstDocket(JHipsterProperties jHipsterProperties) {
+        JHipsterProperties.Swagger properties = jHipsterProperties.getSwagger();
+        Contact contact = new Contact(
+            properties.getContactName(),
+            properties.getContactUrl(),
+            properties.getContactEmail()
+        );
+
+        ApiInfo apiInfo = new ApiInfo(
+            "API First " + properties.getTitle(),
+            properties.getDescription(),
+            properties.getVersion(),
+            properties.getTermsOfServiceUrl(),
+            contact,
+            properties.getLicense(),
+            properties.getLicenseUrl(),
+            new ArrayList<>()
+        );
+
+        return new Docket(DocumentationType.SWAGGER_2)
+            .groupName("openapi")
+            .host(properties.getHost())
+            .protocols(new HashSet<>(Arrays.asList(properties.getProtocols())))
+            .apiInfo(apiInfo)
+            .useDefaultResponseMessages(properties.isUseDefaultResponseMessages())
+            .forCodeGeneration(true)
+            .directModelSubstitute(ByteBuffer.class, String.class)
+            .genericModelSubstitutes(ResponseEntity.class)
+            .ignoredParameterTypes(Pageable.class)
+            .select()
+            .apis(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api"))
+            .paths(regex(properties.getDefaultIncludePattern()))
+            .build();
+    }
+
+
+}

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -604,7 +604,7 @@ const expectedFiles = {
         `${DOCKER_DIR}kafka.yml`
     ],
 
-    swaggerCodegen: [`${SERVER_MAIN_RES_DIR}swagger/api.yml`],
+    swaggerCodegen: [`${SERVER_MAIN_RES_DIR}swagger/api.yml`, `${SERVER_MAIN_SRC_DIR}com/mycompany/myapp/config/OpenApiConfiguration.java`],
 
     swaggerCodegenGradle: ['gradle/swagger.gradle'],
 


### PR DESCRIPTION
Fixes #9752

By using springfox `RequestHandlerSelectors` it is possible to separate scaffolded endpoints from openapi filtering by base java package. Even if they are sharing the same prefix (`/api`) this configuration will 2 different specs in the swagger ui dropdown menu.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
