### PR TITLE
fix (issue-11519) : remove related options to old storage engine mmapv1

### DIFF
--- a/generators/server/templates/src/main/docker/mongodb-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/mongodb-cluster.yml.ejs
@@ -22,7 +22,7 @@ services:
         image: <%= DOCKER_MONGODB %>
         ports:
             - "27017:27017"
-        command: mongos --configdb csvr/<%= baseName.toLowerCase() %>-mongodb-config
+        command: mongos --configdb csvr/<%= baseName.toLowerCase() %>-mongodb-config --bind_ip 0.0.0.0
     <%= baseName.toLowerCase() %>-mongodb-node:
         build:
             context: .

--- a/generators/server/templates/src/main/docker/mongodb-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/mongodb-cluster.yml.ejs
@@ -22,13 +22,13 @@ services:
         image: <%= DOCKER_MONGODB %>
         ports:
             - "27017:27017"
-        command: mongos --configdb <%= baseName.toLowerCase() %>-mongodb-config
+        command: mongos --configdb csvr/<%= baseName.toLowerCase() %>-mongodb-config
     <%= baseName.toLowerCase() %>-mongodb-node:
         build:
             context: .
             dockerfile: mongodb/MongoDB.Dockerfile
-        command: mongod --replSet rs1 --noprealloc --smallfiles
+        command: mongod --shardsvr --replSet rs1
     <%= baseName.toLowerCase() %>-mongodb-config:
         image: <%= DOCKER_MONGODB %>
         container_name: <%= baseName.toLowerCase() %>-mongodb-config
-        command: mongod --noprealloc --smallfiles --configsvr --dbpath /data/db
+        command: mongod --configsvr --dbpath /data/db --replSet csvr

--- a/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js.ejs
+++ b/generators/server/templates/src/main/docker/mongodb/scripts/init_replicaset.js.ejs
@@ -4,8 +4,8 @@ if (status.errmsg === 'no replset config has been received') {
 }
 for (var i = 1; i <= param; i++) {
     if (i!==1)
-        rs.add(folder+"_<%= baseName.toLowerCase() %>-mongodb-node_" + i + ":27017");
+        rs.add(folder+"_<%= baseName.toLowerCase() %>-mongodb-node_" + i + ":27018");
 }
-cfg = rs.conf();
-cfg.members[0].host = folder+"_<%= baseName.toLowerCase() %>-mongodb-node_1:27017";
+var cfg = rs.conf();
+cfg.members[0].host = folder+"_<%= baseName.toLowerCase() %>-mongodb-node_1:27018";
 rs.reconfig(cfg);

--- a/test/templates/compose/04-mongo/src/main/docker/mongodb-cluster.yml
+++ b/test/templates/compose/04-mongo/src/main/docker/mongodb-cluster.yml
@@ -4,7 +4,7 @@ services:
         image: mongo:4.2.5
         ports:
             - "27017:27017"
-        command: mongos --configdb csvr/msmongodb-mongodb-config
+        command: mongos --configdb csvr/msmongodb-mongodb-config --bind_ip 0.0.0.0
     msmongodb-mongodb-node:
         build:
             context: .

--- a/test/templates/compose/04-mongo/src/main/docker/mongodb-cluster.yml
+++ b/test/templates/compose/04-mongo/src/main/docker/mongodb-cluster.yml
@@ -1,15 +1,15 @@
 version: '2'
 services:
     msmongodb-mongodb:
-        image: mongo:4.2.3
+        image: mongo:4.2.5
         ports:
             - "27017:27017"
-        command: mongos --configdb msmongodb-mongodb-config
+        command: mongos --configdb csvr/msmongodb-mongodb-config
     msmongodb-mongodb-node:
         build:
             context: .
             dockerfile: mongodb/MongoDB.Dockerfile
-        command: mongod --replSet rs1 --noprealloc --smallfiles
+        command: mongod --shardsvr --replSet rs1
     msmongodb-mongodb-config:
         image: mongo:4.2.3
-        command: mongod --noprealloc --smallfiles --configsvr --dbpath /data/db
+        command: mongod --configsvr --dbpath /data/db --replSet csvr


### PR DESCRIPTION

others points fixed in purpose testing and running the project generated :
  - add replica set to configserver => to be able to attach configdb to mongo router
  - start node with --shardsvr => to be able to register replicate to mongodb.
  - and modify init_replicateset.js to handle the port 27018 (default port for shardsvr)

fix #11519

-   Please make sure the below checklist is followed for Pull Requests.

-   [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
