### PR TITLE
Support Elasticsearch in reactive applications

### DIFF
--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -46,20 +46,20 @@ jobs:
                 os: [ubuntu-latest]
                 app-type:
                     - webflux-mongodb
-                    - webflux-mongodb-session
+                    - webflux-mongodb-es-session
                     - webflux-mongodb-oauth2
                     - webflux-gateway-jwt
                     - webflux-gateway-oauth2
                     - webflux-couchbase
                     - webflux-couchbase-session
-                    - webflux-couchbase-oauth2
+                    - webflux-couchbase-es-oauth2
                 include:
                     - app-type: webflux-mongodb
                       entity: mongodb
                       profile: prod
                       war: 0
                       protractor: 1
-                    - app-type: webflux-mongodb-session
+                    - app-type: webflux-mongodb-es-session
                       entity: mongodb
                       profile: prod
                       war: 0
@@ -89,7 +89,7 @@ jobs:
                       profile: prod
                       war: 0
                       protractor: 1
-                    - app-type: webflux-couchbase-oauth2
+                    - app-type: webflux-couchbase-es-oauth2
                       entity: none
                       profile: prod
                       war: 0

--- a/generators/entity-server/templates/src/main/java/package/common/delete_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/delete_template.ejs
@@ -16,11 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_ if (!viaService) { _%>
-        <% if (reactive) { %>return <% } %><%= entityInstance %>Repository.deleteById(id);
-        <%_ if (searchEngine === 'elasticsearch') { _%>
+<%_ if (reactive) { _%>
+        return <%= entityInstance %><%= viaService ? 'Service.delete' : 'Repository.deleteById' %>(id)<%_ if (!viaService && searchEngine === 'elasticsearch') { %>
+            .then(<%= entityInstance %>SearchRepository.deleteById(id))<%_ } _%><%_ if (!fromResource) { %>;<%_ } %>
+<%_ } else { %>
+        <%= entityInstance %><%= viaService ? 'Service.delete' : 'Repository.deleteById' %>(id);
+        <%_ if (!viaService && searchEngine === 'elasticsearch') { _%>
         <%= entityInstance %>SearchRepository.deleteById(id);
         <%_ } _%>
-<%_ } else { _%>
-        <%= entityInstance %>Service.delete(id);
 <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
@@ -55,11 +55,11 @@ _%>
         return <%= entityInstance %>Service.findAll()<% if (reactive) { %>.collectList()<% } %>;
         <%_ } else if (dto === 'mapstruct') { _%>
         <%= reactive ? 'Flux' : 'List' %><<%= asEntity(entityClass) %>> <%= entityInstancePlural %> = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>();
-            <% if (!reactive) { %>
+            <%_ if (!reactive) { _%>
         return <%= entityListToDtoListReference %>(<%= entityInstancePlural %>);
-            <% } else { %>
+            <%_ } else { _%>
         return <%= entityInstancePlural %>.map(<%= entityToDtoReference %>).collectList();
-            <% } %>
+            <%_ } _%>
         <%_ } else { _%>
         return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (reactive) { %>.collectList()<% } %>;
         <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/common/save_reactive_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/save_reactive_template.ejs
@@ -25,11 +25,12 @@ _%>
 <%_ if (viaService) { _%>
         return <%= entityInstance %>Service.save(<%= instanceName %>)
 <%_ } else { _%>
-        return <%= entityInstance %>Repository.save(<%if (dto === 'mapstruct') { %><%= dtoToEntity %>(<% } %><%= instanceName %>)<%if (dto === 'mapstruct') { %>)<% } %>
-    <%_ if (searchEngine === 'elasticsearch') { _%>
+        return <%= entityInstance %>Repository.save(<%if (dto === 'mapstruct') { %><%= dtoToEntity %>(<% } %><%= instanceName %>)<%if (dto === 'mapstruct') { %>)<% } -%>
+    <%_ if (searchEngine === 'elasticsearch') { %>
             .flatMap(<%= entityInstance %>SearchRepository::save)
-    <%_ } _%>
-    <%_ if (dto === 'mapstruct') { _%>
+    <%_ } -%>
+    <%_ if (dto === 'mapstruct') { %>
             .map(<%= entityToDtoReference  %>)
-    <%_ } _%>
+    <%_ } -%>
+    <%_ if (returnDirectly) { _%>;<%_ } _%>
 <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/common/save_reactive_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/save_reactive_template.ejs
@@ -23,9 +23,12 @@ const dtoToEntity = mapper + '.' + 'toEntity';
 const entityToDtoReference = mapper + '::' + 'toDto';
 _%>
 <%_ if (viaService) { _%>
-    return <%= entityInstance %>Service.save(<%= instanceName %>)
+        return <%= entityInstance %>Service.save(<%= instanceName %>)
 <%_ } else { _%>
-    return <%= entityInstance %>Repository.save(<%if (dto === 'mapstruct') { %><%= dtoToEntity %>(<% } %><%= instanceName %>)<%if (dto === 'mapstruct') { %>)<% } %>
+        return <%= entityInstance %>Repository.save(<%if (dto === 'mapstruct') { %><%= dtoToEntity %>(<% } %><%= instanceName %>)<%if (dto === 'mapstruct') { %>)<% } %>
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(<%= entityInstance %>SearchRepository::save)
+    <%_ } _%>
     <%_ if (dto === 'mapstruct') { _%>
             .map(<%= entityToDtoReference  %>)
     <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/save_template.ejs
@@ -46,13 +46,8 @@ if (!viaService) {
         <%= mapsIdAssoc.otherEntityPrimaryKeyType %> <%= otherEntityName %>Id = <%= instanceName %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>Id();
         <%= mapsIdRepoInstance %>.findById(<%= otherEntityName %>Id).ifPresent(<%= asEntity(entityInstance) %>::<%_ if (fluentMethods === false) { _%>set<%= mapsIdAssoc.relationshipNameCapitalized %> <%_ } else { _%><%= mapsIdAssoc.relationshipName %><%_ } _%>);
         <%_ } _%>
-        <%_ if (!reactive) { _%>
         <%= asEntity(entityInstance) %> = <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>);
         <%= returnPrefix %> <%= entityToDto %>(<%= asEntity(entityInstance) %>);
-        <%_ } else { _%>
-        return <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)
-            .map(<%= entityToDtoReference %>);
-        <%_ } _%>
     <%_ } else { resultEntity = 'result'; _%>
         <%_ if (isUsingMapsId === true) { _%>
         <%= mapsIdAssoc.otherEntityPrimaryKeyType %> <%= otherEntityName %>Id = <%= instanceName %>.get<%= mapsIdAssoc.relationshipNameCapitalized %>().getId();

--- a/generators/entity-server/templates/src/main/java/package/common/search_stream_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/search_stream_template.ejs
@@ -19,11 +19,18 @@
 <%_
 const mapper = entityInstance  + 'Mapper';
 const entityToDtoReference = mapper + '::' + 'toDto'; %>
-        <%_ if (!viaService) { _%>
+<%_ if (!viaService) { _%>
+    <%_ if (!reactive) { _%>
         return StreamSupport
-            .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)<% if (dto === 'mapstruct') { %>
-            .map(<%= entityToDtoReference %>)<% } %>
-            .collect(Collectors.toList());
-        <%_ } else { _%>
-        return <%= entityInstance %>Service.search(query);
+            .stream(<%= entityInstance %>SearchRepository.search(queryStringQuery(query)).spliterator(), false)
+        <%_ if (dto === 'mapstruct') { _%>
+            .map(<%= entityToDtoReference %>)
         <%_ } _%>
+            .collect(Collectors.toList());
+    <%_ } else { _%>
+        return <%= entityInstance %>SearchRepository.search(query)<%_ if (dto === 'mapstruct') { %>
+            .map(<%= entityToDtoReference %>)<%_ } %><%_ if (fromResource) { _%>.collectList()<%_ } _%>;
+    <%_ } _%>
+<%_ } else { _%>
+        return <%= entityInstance %>Service.search(query)<% if (reactive && fromResource) { %>.collectList()<% } %>;
+<%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/common/search_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/search_template.ejs
@@ -19,18 +19,29 @@
 <%_
     const instanceType = (dto === 'mapstruct') ? asDto(entityClass) : asEntity(entityClass);
     const instanceName = (dto === 'mapstruct') ? asDto(entityInstance) : asEntity(entityInstance);
+    const listOrFlux = (reactive === true) ? 'Flux' : 'List';
     const mapper = entityInstance + 'Mapper';
     const entityToDtoReference = mapper + '::' + 'toDto';
     const entityListToDtoListReference = mapper + '.' + 'toDto';
-    if (pagination === 'no') { %>
-    public List<<%= instanceType %>> search<%= entityClassPlural %>(@RequestParam String query) {
-        log.debug("REST request to search <%= entityClassPlural %> for query {}", query);<%- include('search_stream_template', {viaService: viaService}); -%>
-    <% } if (pagination !== 'no') { %>
-    public ResponseEntity<List<<%= instanceType %>>> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %>) {
-        log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);<% if (viaService) { %>
-        Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);<% } else { %>
-        Page<<%= asEntity(entityClass) %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);<% } %>
+if (pagination === 'no') { %>
+    public <% if (reactive) { %>Mono<<% } %>List<<%= instanceType %>><% if (reactive) { %>><% } %> search<%= entityClassPlural %>(@RequestParam String query) {
+        log.debug("REST request to search <%= entityClassPlural %> for query {}", query);<%- include('search_stream_template', {viaService: viaService, fromResource: true}); -%>
+<% } if (pagination !== 'no') { %>
+    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= listOrFlux %><<%= instanceType %>>><% if (reactive) { %>><% } %> search<%= entityClassPlural %>(@RequestParam String query, Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %>) {
+        log.debug("REST request to search for a page of <%= entityClassPlural %> for query {}", query);
+    <%_ if (!reactive) { _%>
+        <%_ if (viaService) { _%>
+        Page<<%= instanceType %>> page = <%= entityInstance %>Service.search(query, pageable);
+        <%_ } else { _%>
+        Page<<%= asEntity(entityClass) %>> page = <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable);
+        <%_ } _%>
         HttpHeaders headers = PaginationUtil.generatePaginationHttpHeaders(<% if (!reactive) { %>ServletUriComponentsBuilder.fromCurrentRequest()<% } else { %>UriComponentsBuilder.fromHttpRequest(request)<% } %>, page);
         return ResponseEntity.ok().headers(headers).body(<% if (!viaService && dto === 'mapstruct') { %><%= entityListToDtoListReference %>(<% } %>page.getContent()<% if (!viaService && dto === 'mapstruct') { %>)<% } %>);
+    <%_ } else { _%>
+        return <%= entityInstance %><%= viaService ? 'Service.searchCount' : 'SearchRepository.count' %>()
+            .map(total -> new PageImpl<>(new ArrayList<>(), pageable, total))
+            .map(page -> PaginationUtil.generatePaginationHttpHeaders(UriComponentsBuilder.fromHttpRequest(request), page))
+            .map(headers -> ResponseEntity.ok().headers(headers).body(<%= entityInstance %><%= viaService ? 'Service' : 'SearchRepository' %>.search(query, pageable)<% if (!viaService && dto === 'mapstruct') { %>.map(<%= entityToDtoReference %>)<% } %>));
+    <%_ } _%>
     <% } -%>
-}
+    }

--- a/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
@@ -19,12 +19,52 @@
 package <%= packageName %>.repository.search;
 
 import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;<% if (databaseType === 'cassandra') { %>
+<%_ if (reactive) { _%>
+    <%_ if (pagination !== 'no') { _%>
+import org.springframework.data.domain.Pageable;
+    <%_ } _%>
+import org.springframework.data.elasticsearch.core.ReactiveElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+<%_ } _%>
+import org.springframework.data.elasticsearch.repository.<% if (reactive) {%>Reactive<% } %>ElasticsearchRepository;
+<%_ if (reactive) { _%>
+import reactor.core.publisher.Flux;
+<%_ } _%>
+<%_ if (primaryKeyType === 'UUID') { _%>
 
-import java.util.UUID;<% } %>
+import java.util.UUID;
+<% } %>
+<%_ if (reactive) { _%>
+
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+<%_ } _%>
 
 /**
  * Spring Data Elasticsearch repository for the {@link <%= asEntity(entityClass) %>} entity.
  */
-public interface <%= entityClass %>SearchRepository extends ElasticsearchRepository<<%= asEntity(entityClass) %>, <% if (databaseType === 'sql') { %><%= primaryKeyType %><% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase') { %>String<% } %><% if (databaseType === 'cassandra') { %>UUID<% } %>> {
+public interface <%= entityClass %>SearchRepository extends <% if (reactive) {%>Reactive<% } %>ElasticsearchRepository<<%= asEntity(entityClass) %>, <%= primaryKeyType %>><% if (reactive) {%>, <%= entityClass %>SearchRepositoryInternal<% } %> {
 }
+<%_ if (reactive) { _%>
+
+interface <%= entityClass %>SearchRepositoryInternal {
+    Flux<<%= entityClass %>> search(String query<% if (pagination !== 'no') { %>, Pageable pageable<% } %>);
+}
+
+class <%= entityClass %>SearchRepositoryInternalImpl implements <%= entityClass %>SearchRepositoryInternal {
+
+    private final ReactiveElasticsearchTemplate reactiveElasticsearchTemplate;
+
+    <%= entityClass %>SearchRepositoryInternalImpl(ReactiveElasticsearchTemplate reactiveElasticsearchTemplate) {
+        this.reactiveElasticsearchTemplate = reactiveElasticsearchTemplate;
+    }
+
+    @Override
+    public Flux<<%= entityClass %>> search(String query<% if (pagination !== 'no') { %>, Pageable pageable<% } %>) {
+        NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(queryStringQuery(query));
+        <%_ if (pagination !== 'no') { _%>
+        nativeSearchQuery.setPageable(pageable);
+        <%_ } _%>
+        return reactiveElasticsearchTemplate.find(nativeSearchQuery, <%= entityClass %>.class);
+    }
+}
+<%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -96,6 +96,14 @@ public interface <%= entityClass %>Service {
     *
     */
     Mono<Long> countAll();
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+
+    /**
+    * Returns the number of <%= entityInstancePlural %> available in search repository.
+    *
+    */
+    Mono<Long> searchCount();
+    <%_  } _%>
 
 <%_  } _%>
 
@@ -122,5 +130,5 @@ public interface <%= entityClass %>Service {
      * @param pageable the pagination information.<% } %>
      * @return the list of entities.
      */
-    <% if (pagination !== 'no') { %><%= pageOrFlux %><<%= instanceType %><% } else { %>List<<%= instanceType %><% } %>> search(String query<% if (pagination !== 'no') { %>, Pageable pageable<% } %>);<% } %>
+    <% if (pagination !== 'no') { %><%= pageOrFlux %><<%= instanceType %><% } else { %><%= listOrFlux %><<%= instanceType %><% } %>> search(String query<% if (pagination !== 'no') { %>, Pageable pageable<% } %>);<% } %>
 }

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -166,6 +166,16 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     public Mono<Long> countAll() {
         return <%= entityInstance %>Repository.count();
     }
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+
+    /**
+    * Returns the number of <%= entityInstancePlural %> available in search repository.
+    *
+    */
+    public Mono<Long> searchCount() {
+        return <%= entityInstance %>SearchRepository.count();
+    }
+    <%_  } _%>
 
 <%_  } _%>
     /**
@@ -194,7 +204,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     <%_ } _%>
     public <%- reactive ? 'Mono<Void>' : 'void' %> delete(<%= primaryKeyType %> id) {
         log.debug("Request to delete <%= entityClass %> : {}", id);
-<%- include('../../common/delete_template', {viaService: viaService}); -%>
+<%- include('../../common/delete_template', {viaService: false, fromResource: false}); -%>
     }
     <%_ if (searchEngine === 'elasticsearch') { _%>
 
@@ -213,10 +223,10 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     <%_ } _%>
     public <% if (pagination !== 'no') { %><%= pageOrFlux %><<%= instanceType %><% } else { %><%= listOrFlux %><<%= instanceType %><% } %>> search(String query<% if (pagination !== 'no') { %>, Pageable pageable<% } %>) {
         <%_ if (pagination === 'no') { _%>
-        log.debug("Request to search <%= entityClassPlural %> for query {}", query);<%- include('../../common/search_stream_template', {viaService: viaService}); -%>
+        log.debug("Request to search <%= entityClassPlural %> for query {}", query);<%- include('../../common/search_stream_template', {viaService: false, fromResource: false}); -%>
         <%_ } else { _%>
         log.debug("Request to search for a page of <%= entityClassPlural %> for query {}", query);
-        return <%= entityInstance %>SearchRepository.search(queryStringQuery(query), pageable)<%_ if (dto !== 'mapstruct') { _%>;<% } else { %>
+        return <%= entityInstance %>SearchRepository.search(<%= reactive ? 'query' : 'queryStringQuery(query)' %>, pageable)<%_ if (dto !== 'mapstruct') { _%>;<% } else { %>
             .map(<%= entityToDtoReference %>);
         <%_ } } _%>
     }

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -20,7 +20,6 @@ package <%= packageName %>.service<% if (service === 'serviceImpl') { %>.impl<% 
 
 <%_
 const serviceClassName = service === 'serviceImpl' ? entityClass + 'ServiceImpl' : entityClass + 'Service';
-let viaService = false;
 const instanceType = (dto === 'mapstruct') ? asDto(entityClass) : asEntity(entityClass);
 const instanceName = (dto === 'mapstruct') ? asDto(entityInstance) : asEntity(entityInstance);
 const optionalOrMono = (reactive === true) ? 'Mono' : 'Optional';
@@ -87,10 +86,10 @@ import java.util.Optional;
 <%_ if (databaseType === 'cassandra') { _%>
 import java.util.UUID;
 <%_ } _%>
-<%_ if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && ((searchEngine === 'elasticsearch' && !viaService) || dto === 'mapstruct'))) { _%>
+<%_ if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && ((searchEngine === 'elasticsearch') || dto === 'mapstruct'))) { _%>
 import java.util.stream.Collectors;
 <%_ } _%>
-<%_ if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && searchEngine === 'elasticsearch' && !viaService)) { _%>
+<%_ if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && searchEngine === 'elasticsearch')) { _%>
 import java.util.stream.StreamSupport;
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
@@ -106,7 +105,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> implements <%= entityClass %>Service<% } %> {
 
     private final Logger log = LoggerFactory.getLogger(<%= serviceClassName %>.class);
-<%- include('../../common/inject_template', {asEntity, asDto, viaService: viaService, constructorName: serviceClassName, queryService: false, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: false}); -%>
+<%- include('../../common/inject_template', {asEntity, asDto, viaService: false, constructorName: serviceClassName, queryService: false, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: false}); -%>
 
     /**
      * Save a <%= entityInstance %>.
@@ -119,7 +118,11 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     <%_ } _%>
     public <% if (reactive) { %>Mono<<% } %><%= instanceType %><% if (reactive) { %>><% } %> save(<%= instanceType %> <%= instanceName %>) {
         log.debug("Request to save <%= entityClass %> : {}", <%= instanceName %>);
-<%- include('../../common/save_template', {asEntity, asDto, viaService: viaService, returnDirectly: true, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: false}); -%>
+        <%_ if (!reactive) { _%>
+<%- include('../../common/save_template', {asEntity, asDto, viaService: false, returnDirectly: true, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: false}); -%>
+        <%_ } else { _%>
+<%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: false, returnDirectly: true}); -%>
+        <%_ } _%>
     }
 
     /**
@@ -191,7 +194,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     @Transactional(readOnly = true)
     <%_ } _%>
     public <%= optionalOrMono %><<%= instanceType %>> findOne(<%= primaryKeyType %> id) {
-        log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {asEntity, asDto, viaService, returnDirectly:true}); -%>
+        log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {asEntity, asDto, viaService: false, returnDirectly:true}); -%>
     }
 
     /**

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -126,13 +126,13 @@ import java.util.Optional;
 <%_ if (databaseType === 'cassandra') { _%>
 import java.util.UUID;
 <%_ } _%>
-<%_ if (!viaService && (searchEngine === 'elasticsearch' || fieldsContainNoOwnerOneToOne === true)) { _%>
+<%_ if ((searchEngine === 'elasticsearch' && !reactive) || fieldsContainNoOwnerOneToOne === true) { _%>
+    <%_ if (!viaService) { _%>
 import java.util.stream.Collectors;
-<%_ } _%>
-<%_ if (searchEngine === 'elasticsearch' || fieldsContainNoOwnerOneToOne === true) { _%>
+    <%_ } _%>
 import java.util.stream.StreamSupport;
 <%_ } _%>
-<%_ if (searchEngine === 'elasticsearch') { _%>
+<%_ if (searchEngine === 'elasticsearch' && !reactive) { _%>
 
 import static org.elasticsearch.index.query.QueryBuilders.*;
 <%_ } _%>
@@ -331,11 +331,10 @@ public class <%= entityClass %>Resource {
     <%_ } _%>
     public <% if (reactive) { %>Mono<<% } %>ResponseEntity<Void><% if (reactive) { %>><% } %> delete<%= entityClass %>(@PathVariable <%= primaryKeyType %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);
+<%- include('../../common/delete_template', {viaService: viaService, fromResource: true}); -%>
     <%_ if (!reactive) { _%>
-<%- include('../../common/delete_template', {viaService: viaService}); -%>
-        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build();
+    return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build();
     <%_ } else { _%>
-        return <%= entityInstance %><%= service !== 'no' ? 'Service.delete' : 'Repository.deleteById' %>(id)
             .map(result -> ResponseEntity.noContent()
                 .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build()
             );

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -202,7 +202,7 @@ public class <%= entityClass %>Resource {
             .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
             .body(result);
         <%_ } else { _%>
-<%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: viaService}); -%>
+<%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: viaService, returnDirectly: false}); -%>
             .map(result -> {
                 try {
                     return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.getId()))
@@ -249,7 +249,7 @@ public class <%= entityClass %>Resource {
             .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
             .body(result);
     <%_ } else { _%>
-<%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: viaService}); -%>
+<%- include('../../common/save_reactive_template', {asEntity, asDto, viaService: viaService, returnDirectly: false}); -%>
             .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND)))
             .map(result -> ResponseEntity.ok()
                 .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.getId()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -114,15 +114,18 @@ import org.springframework.security.test.context.support.WithMockUser;
 <%_ if (reactiveRepositories) { _%>
 import org.springframework.test.web.reactive.server.WebTestClient;
 <%_ } _%>
+<%_ if (!reactive) { _%>
 import org.springframework.test.web.servlet.MockMvc;
+<%_ } _%>
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
 <%_ if (fieldsContainBlob === true) { _%>
 import org.springframework.util.Base64Utils;
 <%_ } _%>
-<%_ if (reactive && fieldsContainOwnerManyToMany === true) { _%>
+<%_ if (reactive && (fieldsContainOwnerManyToMany === true || searchEngine === 'elasticsearch')) { _%>
 import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>
 import javax.persistence.EntityManager;<% } %><% if (fieldsContainBigDecimal === true) { %>
@@ -138,7 +141,7 @@ import java.time.temporal.ChronoUnit;<% } %>
 <%_ if (fieldsContainOwnerManyToMany) { _%>
 import java.util.ArrayList;
 <%_ } _%>
-<%_ if (searchEngine === 'elasticsearch') { _%>
+<%_ if (searchEngine === 'elasticsearch' && !reactive) { _%>
 import java.util.Collections;
 <%_ } _%>
 import java.util.List;
@@ -150,7 +153,7 @@ import java.util.UUID;
 import static <%= packageName %>.web.rest.TestUtil.sameInstant;
 <%_ } _%>
 import static org.assertj.core.api.Assertions.assertThat;
-<%_ if (searchEngine === 'elasticsearch') { _%>
+<%_ if (searchEngine === 'elasticsearch' && !reactive) { _%>
 import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 <%_ } _%>
 import static org.hamcrest.Matchers.hasItem;
@@ -184,7 +187,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 <%_ } else { _%>
 @SpringBootTest(classes = <%= mainClass %>.class)
 <%_ } _%>
-<% if (cacheProvider === 'redis') { %>@ExtendWith({ RedisTestContainerExtension.class, MockitoExtension.class })<% } else if (searchEngine === 'elasticsearch' || fieldsContainOwnerManyToMany === true) { %>@ExtendWith(MockitoExtension.class)<% } %>
+<%_ if (cacheProvider === 'redis') { _%>
+@ExtendWith({ RedisTestContainerExtension.class, MockitoExtension.class })
+<%_ } else if (searchEngine === 'elasticsearch' || fieldsContainOwnerManyToMany === true) { _%>
+@ExtendWith(MockitoExtension.class)
+<%_ } _%>
 <%_ if (!reactive) { _%>
 @AutoConfigureMockMvc
 <%_ } else { _%>
@@ -519,7 +526,11 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
     public void create<%= entityClass %>() throws Exception {
         int databaseSizeBeforeCreate = <%= entityInstance %>Repository.findAll()<% if (reactive) { %>
             .collectList().block()<% } %>.size();
-
+    <%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+        // Configure the mock search repository
+        when(mock<%= entityClass %>SearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    <%_ } _%>
         // Create the <%= entityClass %>
         <%_ if (dto === 'mapstruct') { _%>
         <%= asDto(entityClass) %> <%= asDto(entityInstance) %> = <%= entityInstance %>Mapper.toDto(<%= asEntity(entityInstance) %>);
@@ -667,11 +678,11 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
         <%_ if (searchEngine === 'elasticsearch') { _%>
 
         // Validate the <%= entityClass %> in Elasticsearch
-        <%_ if (service !== 'no' && dto !== 'mapstruct') { _%>
+            <%_ if (service !== 'no' && dto !== 'mapstruct') { _%>
         verify(mock<%= entityClass %>SearchRepository, times(2)).save(<%= asEntity(entityInstance) %>);
-<%_ } else { _%>
+            <%_ } else { _%>
         verify(mock<%= entityClass %>SearchRepository, times(1)).save(<%= asEntity(entityInstance) %>);
-<%_ } _%>
+            <%_ } _%>
         <%_ } _%>
     }
 <%_ } _%>
@@ -1149,16 +1160,17 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void update<%= entityClass %>() throws Exception {
+    <%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+        // Configure the mock search repository
+        when(mock<%= entityClass %>SearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    <%_ } _%>
         // Initialize the database
         <%_ if (databaseType === 'cassandra') { _%>
         <%= asEntity(entityInstance) %>.setId(UUID.randomUUID());
         <%_ } _%>
 <%_ if (service !== 'no' && dto !== 'mapstruct') { _%>
         <%= entityInstance %>Service.save(<%= asEntity(entityInstance) %>)<% if (reactive) { %>.block()<% } %>;
-    <%_ if (searchEngine === 'elasticsearch') { _%>
-        // As the test used the service layer, reset the Elasticsearch mock repository
-        reset(mock<%= entityClass %>SearchRepository);
-    <%_ } _%>
 <%_ } else { _%>
         <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>)<% if (reactive) { %>.block()<% } %>;
 <%_ } _%>
@@ -1222,7 +1234,7 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
         <%_ if (searchEngine === 'elasticsearch') { _%>
 
         // Validate the <%= entityClass %> in Elasticsearch
-        verify(mock<%= entityClass %>SearchRepository, times(1)).save(test<%= entityClass %>);
+        verify(mock<%= entityClass %>SearchRepository, times(<%= service !== 'no' && dto !== 'mapstruct' ? '2' : '1' %>)).save(test<%= entityClass %>);
         <%_ } _%>
     }
 
@@ -1268,6 +1280,14 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void delete<%= entityClass %>() throws Exception {
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+        // Configure the mock search repository
+    <%_ if (service !== 'no') { _%>
+        when(mock<%= entityClass %>SearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    <%_ } _%>
+        when(mock<%= entityClass %>SearchRepository.deleteById(any<%= primaryKeyType %>())).thenReturn(Mono.empty());
+<%_ } _%>
         // Initialize the database
         <%_ if (databaseType === 'cassandra') { _%>
         <%= asEntity(entityInstance) %>.setId(UUID.randomUUID());
@@ -1312,6 +1332,14 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
     @Test<% if (databaseType === 'sql') { %>
     @Transactional<% } %>
     public void search<%= entityClass %>() throws Exception {
+        // Configure the mock search repository
+<%_ if (reactive) { _%>
+        when(mock<%= entityClass %>SearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+    <%_ if (pagination !== 'no') { _%>
+        when(mock<%= entityClass %>SearchRepository.count()).thenReturn(Mono.just(1L));
+    <%_ } _%>
+<%_ } _%>
         // Initialize the database
         <%_ if (databaseType === 'cassandra') { _%>
         <%= asEntity(entityInstance) %>.setId(UUID.randomUUID());
@@ -1321,12 +1349,17 @@ public class <%= entityClass %>ResourceIT <% if (databaseType === 'neo4j') { %>e
 <%_ } else { _%>
         <%= entityInstance %>Repository.save<% if (databaseType === 'sql') { %>AndFlush<% } %>(<%= asEntity(entityInstance) %>)<% if (reactive) { %>.block()<% } %>;
 <%_ } _%>
-<%_ if (searchEngine === 'elasticsearch' && pagination !== 'no') { _%>
+<%_ if (reactive) { _%>
+        when(mock<%= entityClass %>SearchRepository.search("id:" + <%= asEntity(entityInstance) %>.getId()<%_ if (pagination !== 'no') { _%>, PageRequest.of(0, 20)<% }%>))
+            .thenReturn(Flux.just(<%= asEntity(entityInstance) %>));
+<%_ } else { _%>
+    <%_ if (pagination !== 'no') { _%>
         when(mock<%= entityClass %>SearchRepository.search(queryStringQuery("id:" + <%= asEntity(entityInstance) %>.getId()), PageRequest.of(0, 20)))
             .thenReturn(new PageImpl<>(Collections.singletonList(<%= asEntity(entityInstance) %>), PageRequest.of(0, 1), 1));
-<%_ } else { _%>
+    <%_ } else { _%>
         when(mock<%= entityClass %>SearchRepository.search(queryStringQuery("id:" + <%= asEntity(entityInstance) %>.getId())))
             .thenReturn(Collections.singletonList(<%= asEntity(entityInstance) %>));
+    <%_ } _%>
 <%_ } _%>
 
         // Search the <%= entityInstance %>

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -243,9 +243,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                         )
                     );
                 }
-                if (this.context.reactive && this.context.searchEngine === 'elasticsearch') {
-                    this.error(chalk.red("The entity generator doesn't support reactive apps with elasticsearch at the moment"));
-                }
             },
 
             validateDbExistence() {

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -605,6 +605,7 @@
             <groupId>org.springframework.boot</groupId>
             <artifactId>spring-boot-starter-data-elasticsearch</artifactId>
         </dependency>
+        <%_ if (!reactive) { _%>
         <!-- Spring Data Jest dependencies for Elasticsearch -->
         <dependency>
             <groupId>com.github.vanroy</groupId>
@@ -616,6 +617,7 @@
                 </exclusion>
             </exclusions>
         </dependency>
+        <%_ } _%>
         <!-- log4j2-mock needed to create embedded elasticsearch instance with SLF4J -->
         <dependency>
             <groupId>de.dentrassi.elasticsearch</groupId>

--- a/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/DatabaseConfiguration.java.ejs
@@ -68,7 +68,7 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.core.convert.converter.Converter;
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
-import org.springframework.data.elasticsearch.repository.config.EnableElasticsearchRepositories;
+import org.springframework.data.elasticsearch.repository.config.Enable<% if (reactive) { %>Reactive<% } %>ElasticsearchRepositories;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
     <%_ if (!reactive) { _%>
@@ -77,13 +77,10 @@ import org.springframework.data.mongodb.config.EnableMongoAuditing;
 import org.springframework.data.mongodb.core.MongoTemplate;
 import org.springframework.data.mongodb.core.convert.MongoCustomConversions;
 import org.springframework.data.mongodb.core.mapping.event.ValidatingMongoEventListener;
-    <%_ if (searchEngine === 'elasticsearch' || reactive) { _%>
-import org.springframework.data.mongodb.repository.MongoRepository;
+    <%_ if (searchEngine === 'elasticsearch') { _%>
+import org.springframework.data.mongodb.repository.<% if (reactive) { %>Reactive<% } %>MongoRepository;
     <%_ } _%>
-import org.springframework.data.mongodb.repository.config.EnableMongoRepositories;
-    <%_ if (reactive) { _%>
-import org.springframework.data.mongodb.repository.config.EnableReactiveMongoRepositories;
-    <%_ } _%>
+import org.springframework.data.mongodb.repository.config.Enable<% if (reactive) { %>Reactive<% } %>MongoRepositories;
 <%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
 import org.springframework.data.convert.ReadingConverter;
@@ -155,11 +152,11 @@ import java.util.UUID;
 @EnableTransactionManagement
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
-@EnableElasticsearchRepositories("<%= packageName %>.repository.search")
+@Enable<% if (reactive) { %>Reactive<% } %>ElasticsearchRepositories("<%= packageName %>.repository.search")
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
-@EnableMongoRepositories(basePackages = "<%= packageName %>.repository", includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = MongoRepository.class))
+@Enable<% if (reactive) { %>Reactive<% } %>MongoRepositories(basePackages = "<%= packageName %>.repository", includeFilters = @Filter(type = FilterType.ASSIGNABLE_TYPE, value = <% if (reactive) { %>Reactive<% } %>MongoRepository.class))
     <%_ } else { _%>
 @Enable<% if (reactive) { %>Reactive<% } %>MongoRepositories("<%= packageName %>.repository")
     <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ElasticsearchConfiguration.java.ejs
@@ -21,25 +21,32 @@ package <%= packageName %>.config;
 import com.fasterxml.jackson.databind.DeserializationFeature;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.SerializationFeature;
+<%_ if (!reactive) { _%>
 import com.github.vanroy.springdata.jest.JestElasticsearchTemplate;
 import com.github.vanroy.springdata.jest.mapper.DefaultJestResultsMapper;
 import io.searchbox.client.JestClient;
+<%_ } _%>
 import org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+<%_ if (!reactive) { _%>
 import org.springframework.context.annotation.Primary;
 import org.springframework.data.elasticsearch.core.ElasticsearchOperations;
+<%_ } _%>
 import org.springframework.data.elasticsearch.core.EntityMapper;
+<%_ if (!reactive) { _%>
 import org.springframework.data.elasticsearch.core.convert.ElasticsearchConverter;
+<%_ } _%>
+<%_ if (databaseType === 'mongodb' || !reactive) { _%>
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchMappingContext;
+<%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
 import org.springframework.data.elasticsearch.core.mapping.ElasticsearchPersistentProperty;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentProperty;
 import org.springframework.data.mapping.PersistentEntity;
 import org.springframework.data.mapping.model.Property;
 import org.springframework.data.mapping.model.SimpleTypeHolder;
-import org.springframework.data.elasticsearch.core.convert.MappingElasticsearchConverter;
 import org.springframework.data.elasticsearch.core.mapping.SimpleElasticsearchPersistentEntity;
 <%_ } _%>
 import org.springframework.data.mapping.MappingException;
@@ -62,28 +69,27 @@ public class ElasticsearchConfiguration {
     public EntityMapper getEntityMapper() {
         return new CustomEntityMapper(mapper);
     }
+<%_ if (databaseType === 'mongodb') { _%>
+
+    @Bean
+    SimpleElasticsearchMappingContext mappingContext() {
+        return new CustomElasticsearchMappingContext();
+    }
+<%_ } _%>
+<%_ if (!reactive) { _%>
 
     @Bean
     @Primary
-    public ElasticsearchOperations elasticsearchTemplate(final JestClient jestClient,
-                                                         final ElasticsearchConverter elasticsearchConverter,
-        <%_ if (databaseType !== 'mongodb') { _%>
-                                                         final SimpleElasticsearchMappingContext simpleElasticsearchMappingContext,
-        <%_ } _%>
-                                                         EntityMapper mapper) {
-        <%_ if (databaseType === 'mongodb') { _%>
-        CustomElasticsearchMappingContext mappingContext = new CustomElasticsearchMappingContext();
-        <%_ } _%>
+    public ElasticsearchOperations elasticsearchTemplate(JestClient jestClient,
+                                                         ElasticsearchConverter elasticsearchConverter,
+                                                         SimpleElasticsearchMappingContext mappingContext,
+                                                         EntityMapper entityMapper) {
         return new JestElasticsearchTemplate(
             jestClient,
-            <%_ if (databaseType === 'mongodb') { _%>
-            new MappingElasticsearchConverter(mappingContext),
-            new DefaultJestResultsMapper(mappingContext, mapper));
-            <%_ } else { _%>
             elasticsearchConverter,
-            new DefaultJestResultsMapper(simpleElasticsearchMappingContext, mapper));
-            <%_ } _%>
+            new DefaultJestResultsMapper(mappingContext, entityMapper));
     }
+<%_ } _%>
 
     public class CustomEntityMapper implements EntityMapper {
 
@@ -118,7 +124,7 @@ public class ElasticsearchConfiguration {
         }
 
         @Override
-        public <T> T readObject (Map<String, Object> source, Class<T> targetType) {
+        public <T> T readObject(Map<String, Object> source, Class<T> targetType) {
             try {
                 return mapToObject(mapToString(source), targetType);
             } catch (IOException e) {
@@ -130,6 +136,9 @@ public class ElasticsearchConfiguration {
 }
 <%_ if (databaseType === 'mongodb') { _%>
 
+/**
+ * Custom mapping context in order to use the same entities for both MongoDB and Elasticsearch datasources
+ */
 class CustomElasticsearchMappingContext extends SimpleElasticsearchMappingContext {
 
     @Override

--- a/generators/server/templates/src/main/java/package/repository/search/UserSearchRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/search/UserSearchRepository.java.ejs
@@ -19,12 +19,47 @@
 package <%= packageName %>.repository.search;
 
 import <%= packageName %>.domain.<%= asEntity('User') %>;
-import org.springframework.data.elasticsearch.repository.ElasticsearchRepository;<% if (databaseType === 'cassandra') { %>
+<%_ if (reactive) { _%>
+import org.springframework.data.elasticsearch.core.ReactiveElasticsearchTemplate;
+import org.springframework.data.elasticsearch.core.query.NativeSearchQuery;
+<%_ } _%>
+import org.springframework.data.elasticsearch.repository.<% if (reactive) {%>Reactive<% } %>ElasticsearchRepository;
+<%_ if (reactive) { _%>
+import reactor.core.publisher.Flux;
+<%_ } _%>
+<%_ if (databaseType === 'cassandra') { _%>
 
-import java.util.UUID;<% } %>
+import java.util.UUID;
+<%_ } _%>
+<%_ if (reactive) { _%>
+
+import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
+<%_ } _%>
+
 
 /**
  * Spring Data Elasticsearch repository for the User entity.
  */
-public interface UserSearchRepository extends ElasticsearchRepository<<%= asEntity('User') %>, <% if (databaseType === 'sql' && authenticationType !== 'oauth2') { %>Long<% } %><% if (databaseType === 'cassandra' || databaseType === 'mongodb' || authenticationType === 'oauth2') { %>String<% } %>> {
+public interface UserSearchRepository extends <% if (reactive) {%>Reactive<% } %>ElasticsearchRepository<<%= asEntity('User') %>, <% if (databaseType === 'sql' && authenticationType !== 'oauth2') { %>Long<% } %><% if (databaseType === 'cassandra' || databaseType === 'mongodb' || authenticationType === 'oauth2') { %>String<% } %>><% if (reactive) {%>, UserSearchRepositoryInternal<% } %> {
 }
+<%_ if (reactive) { _%>
+
+interface UserSearchRepositoryInternal {
+    Flux<User> search(String query);
+}
+
+class UserSearchRepositoryInternalImpl implements UserSearchRepositoryInternal {
+
+    private final ReactiveElasticsearchTemplate reactiveElasticsearchTemplate;
+
+    UserSearchRepositoryInternalImpl(ReactiveElasticsearchTemplate reactiveElasticsearchTemplate) {
+        this.reactiveElasticsearchTemplate = reactiveElasticsearchTemplate;
+    }
+
+    @Override
+    public Flux<User> search(String query) {
+        NativeSearchQuery nativeSearchQuery = new NativeSearchQuery(queryStringQuery(query));
+        return reactiveElasticsearchTemplate.find(nativeSearchQuery, User.class);
+    }
+}
+<%_ } _%>

--- a/generators/server/templates/src/main/java/package/service/UserService.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/UserService.java.ejs
@@ -178,6 +178,9 @@ public class UserService {
             <%_ } else { _%>
                 return saveUser(user);
             })
+                <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(user -> userSearchRepository.save(user).thenReturn(user))
+                <%_ } _%>
                 <%_ if (cacheManagerIsAvailable === true) { _%>
             .doOnNext(this::clearUserCaches)
                 <%_ } _%>
@@ -294,8 +297,10 @@ public class UserService {
         authorities.add(AuthoritiesConstants.USER);
         <%_ } _%>
         newUser.setAuthorities(authorities);
-        userRepository.save(newUser);<% if (searchEngine === 'elasticsearch') { %>
-        userSearchRepository.save(newUser);<% } %>
+        userRepository.save(newUser);
+        <%_ if (searchEngine === 'elasticsearch') { _%>
+        userSearchRepository.save(newUser);
+        <%_ } _%>
         <%_ if (cacheManagerIsAvailable === true) { _%>
         this.clearUserCaches(newUser);
         <%_ } _%>
@@ -362,6 +367,9 @@ public class UserService {
                 newUser.setAuthorities(authorities);
                 return saveUser(newUser)
                 <%_ } _%>
+                    <%_ if (searchEngine === 'elasticsearch') { _%>
+                    .flatMap(user -> userSearchRepository.save(user).thenReturn(user))
+                    <%_ } _%>
                     <%_ if (cacheManagerIsAvailable === true) { _%>
                     .doOnNext(this::clearUserCaches)
                     <%_ } _%>
@@ -453,6 +461,9 @@ public class UserService {
                 return newUser;
             })
             .flatMap(this::saveUser)
+            <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(user1 -> userSearchRepository.save(user1).thenReturn(user1))
+            <%_ } _%>
             <%_ if (cacheManagerIsAvailable === true) { _%>
             .doOnNext(this::clearUserCaches)
             <%_ } _%>
@@ -536,6 +547,9 @@ public class UserService {
                 <%_ } _%>
             })
             .flatMap(this::saveUser)
+            <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(user -> userSearchRepository.save(user).thenReturn(user))
+            <%_ } _%>
             <%_ if (cacheManagerIsAvailable === true) { _%>
             .doOnNext(this::clearUserCaches)
             <%_ } _%>
@@ -564,6 +578,9 @@ public class UserService {
     public Mono<Void> deleteUser(String login) {
         return userRepository.findOneByLogin(login)
             .flatMap(user -> userRepository.delete(user).thenReturn(user))
+            <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(user -> userSearchRepository.delete(user).thenReturn(user))
+            <%_ } _%>
             <%_ if (cacheManagerIsAvailable === true) { _%>
             .doOnNext(this::clearUserCaches)
             <%_ } _%>
@@ -615,6 +632,9 @@ public class UserService {
             <%_ } else { _%>
                 return saveUser(user);
             })
+                <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(user -> userSearchRepository.save(user).thenReturn(user))
+                <%_ } _%>
                 <%_ if (cacheManagerIsAvailable === true) { _%>
             .doOnNext(this::clearUserCaches)
                 <%_ } _%>
@@ -809,6 +829,9 @@ public class UserService {
         return userRepository
             .findAllByActivatedIsFalseAndActivationKeyIsNotNullAndCreatedDateBefore(<%_ if (databaseType === 'sql') { _%>LocalDateTime.ofInstant(Instant.now().minus(3, ChronoUnit.DAYS), ZoneOffset.UTC)<%_ } else { _%>Instant.now().minus(3, ChronoUnit.DAYS)<%_ } _%>)
             .flatMap(user -> userRepository.delete(user).thenReturn(user))
+            <%_ if (searchEngine === 'elasticsearch') { _%>
+            .flatMap(user -> userSearchRepository.delete(user).thenReturn(user))
+            <%_ } _%>
             <%_ if (cacheManagerIsAvailable === true) { _%>
             .doOnNext(this::clearUserCaches)
             <%_ } _%>

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -91,7 +91,7 @@ import java.util.*;
 import java.util.ArrayList;
 import java.util.List;
 <%_ } _%>
-<%_ if (searchEngine === 'elasticsearch') { _%>
+<%_ if (searchEngine === 'elasticsearch' && !reactive) { _%>
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -367,10 +367,14 @@ public class UserResource {
      * @return the result of the search.
      */
     @GetMapping("/_search/users/{query}")
-    public List<<%= asEntity('User') %>> search(@PathVariable String query) {
+    public <% if(reactive) { %>Mono<<% } %>List<<%= asEntity('User') %>><% if(reactive) { %>><% } %> search(@PathVariable String query) {
+        <%_ if (!reactive) { _%>
         return StreamSupport
             .stream(userSearchRepository.search(queryStringQuery(query)).spliterator(), false)
             .collect(Collectors.toList());
+        <%_ } else { _%>
+        return userSearchRepository.search(query).collectList();
+        <%_ } _%>
     }
 <%_ } _%>
 }

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -25,9 +25,6 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.ConcurrencyFailureException;
 <%_ } _%>
 import org.springframework.http.ResponseEntity;
-<%_ if (reactive) { _%>
-import org.springframework.stereotype.Component;
-<%_ } _%>
 import org.springframework.validation.BindingResult;
 <%_ if (!reactive) { _%>
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -143,12 +143,19 @@ spring:
             keyspaceName: <%= baseName %>
     <%_ } _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
+        <%_ if (!reactive) { _%>
         jest:
             uri: http://localhost:9200
     # see https://docs.spring.io/spring-boot/docs/current/reference/html/boot-features-nosql.html#boot-features-connecting-to-elasticsearch-jest
     elasticsearch:
         rest:
             uris: http://localhost:9200
+        <%_ } else { _%>
+        elasticsearch:
+          client:
+            reactive:
+              endpoints: localhost:9200
+        <%_ } _%>
     <%_ } _%>
     <%_ if (databaseType === 'couchbase') { _%>
     couchbase:

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -153,7 +153,7 @@ management:
                         enabled: true
 
 spring:
-    <%_ if (searchEngine === 'elasticsearch') { _%>
+    <%_ if (searchEngine === 'elasticsearch' && !reactive) { _%>
     autoconfigure:
         exclude: <% if (databaseType === 'sql' && messageBroker === 'kafka') { %>org.springframework.boot.actuate.autoconfigure.metrics.jdbc.DataSourcePoolMetricsAutoConfiguration,<% } %>org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchAutoConfiguration,org.springframework.boot.autoconfigure.data.elasticsearch.ElasticsearchDataAutoConfiguration
     <%_ } else if (databaseType === 'sql' && messageBroker === 'kafka') { _%>

--- a/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
@@ -93,6 +93,9 @@ import org.springframework.security.test.context.support.WithAnonymousUser;
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
+<%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+import reactor.core.publisher.Mono;
+<%_ } _%>
 
 <%_ if (authenticationType !== 'oauth2' && (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'neo4j' || databaseType === 'couchbase')) { _%>
 import java.time.Instant;
@@ -131,6 +134,10 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+<%_ } _%>
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.any;
 <%_ } _%>
 <%_ if (databaseType === 'sql' && !reactive && authenticationType !== 'oauth2') { _%>
 import static org.mockito.Mockito.when;
@@ -368,6 +375,12 @@ public class UserServiceIT <% if (databaseType === 'neo4j') { %>extends Abstract
         Instant now = Instant.now();
         <%_ if (databaseType === 'sql' && !reactive) { _%>
         when(dateTimeProvider.getNow()).thenReturn(Optional.of(now.minus(4, ChronoUnit.DAYS)));
+        <%_ } _%>
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        when(mockUserSearchRepository.delete(any())).thenReturn(Mono.empty());
         <%_ } _%>
         user.setActivated(false);
         user.setActivationKey(RandomStringUtils.random(20));

--- a/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
@@ -60,6 +60,9 @@ import java.util.Collection;
 <%_ } else { _%>
 import org.springframework.security.oauth2.core.oidc.OidcIdToken;
 import org.springframework.test.web.reactive.server.WebTestClient;
+    <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+import reactor.core.publisher.Mono;
+    <%_ } _%>
 
 import java.time.Instant;
 <%_ } _%>
@@ -67,6 +70,9 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import static org.mockito.Mockito.*;
+<%_ } _%>
 import static <%= packageName %>.web.rest.AccountResourceIT.TEST_USER_LOGIN;
 import org.springframework.security.test.context.support.WithMockUser;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -170,6 +176,9 @@ public class AccountResourceIT <% if (databaseType === 'neo4j') { %>extends Abst
 import <%= packageName %>.AbstractCassandraTest;
 <%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import <%= packageName %>.repository.search.UserSearchRepository;
+<%_ } _%>
 import <%= packageName %>.security.AuthoritiesConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -193,6 +202,11 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 <%_ } else { _%>
 import org.springframework.test.web.reactive.server.WebTestClient;
 <%_ } _%>
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import reactor.core.publisher.Mono;
+
+import static org.mockito.Mockito.*;
+<%_ } _%>
 import static <%= packageName %>.web.rest.AccountResourceIT.TEST_USER_LOGIN;
 
 /**
@@ -213,6 +227,11 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
     private MockMvc restAccountMockMvc;
     <%_ } else { _%>
     private WebTestClient accountWebTestClient;
+    <%_ } _%>
+    <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+
+    @Autowired
+    private UserSearchRepository mockUserSearchRepository;
     <%_ } _%>
 
     @Test
@@ -255,6 +274,9 @@ import <%= packageName %>.repository.AuthorityRepository;
 import <%= packageName %>.repository.PersistentTokenRepository;
 <%_ } _%>
 import <%= packageName %>.repository.UserRepository;
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import <%= packageName %>.repository.search.UserSearchRepository;
+<%_ } _%>
 import <%= packageName %>.security.AuthoritiesConstants;
 import <%= packageName %>.service.UserService;
 import <%= packageName %>.service.dto.PasswordChangeDTO;
@@ -290,14 +312,20 @@ import org.springframework.test.web.servlet.MockMvc;
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import reactor.core.publisher.Mono;
+<%_ } _%>
 
 import java.time.Instant;
-<%_ if (authenticationType === 'session' && !reactive && (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'neo4j' || databaseType === 'couchbase')) { _%>
+<%_ if (authenticationType === 'session' && !reactive && ['sql', 'mongodb', 'neo4j', 'couchbase'].includes(databaseType)) { _%>
 import java.time.LocalDate;
 <%_ } _%>
 import java.util.*;
 
 import static org.assertj.core.api.Assertions.assertThat;
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import static org.mockito.Mockito.*;
+<%_ } _%>
 <%_ if (authenticationType === 'session' && !reactive) { _%>
 import static org.hamcrest.Matchers.hasItem;
 <%_ } _%>
@@ -340,6 +368,11 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
     @Autowired
     private PersistentTokenRepository persistentTokenRepository;
 <%_ } _%>
+    <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+
+    @Autowired
+    private UserSearchRepository mockUserSearchRepository;
+    <%_ } _%>
 
     @Autowired
     private PasswordEncoder passwordEncoder;
@@ -407,6 +440,12 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
 
     @Test
     public void testGetExistingAccount()<% if (!reactive) { %> throws Exception<% } %> {
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         Set<String> authorities = new HashSet<>();
         authorities.add(AuthoritiesConstants.ADMIN);
 
@@ -473,6 +512,12 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
     @Test<% if (databaseType === 'sql' && !reactive) { %>
     @Transactional<% } %>
     public void testRegisterValid() throws Exception {
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         ManagedUserVM validUser = new ManagedUserVM();
         validUser.setLogin("test-register-valid");
         validUser.setPassword("password");
@@ -647,6 +692,12 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
     @Test<% if (databaseType === 'sql' && !reactive) { %>
     @Transactional<% } %>
     public void testRegisterDuplicateLogin() throws Exception {
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         // First registration
         ManagedUserVM firstUser = new ManagedUserVM();
         firstUser.setLogin("alice");
@@ -736,6 +787,12 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
     @Test<% if (databaseType === 'sql' && !reactive) { %>
     @Transactional<% } %>
     public void testRegisterDuplicateEmail() throws Exception {
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         // First user
         ManagedUserVM firstUser = new ManagedUserVM();
         firstUser.setLogin("test-register-duplicate-email");
@@ -873,6 +930,12 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
         validUser.setLangKey(Constants.DEFAULT_LANGUAGE);
         validUser.setAuthorities(Collections.singleton(AuthoritiesConstants.ADMIN));
 
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         <%_ if (!reactive) { _%>
         restAccountMockMvc.perform(
             post("/api/register")
@@ -897,6 +960,12 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
     @Test<% if (databaseType === 'sql' && !reactive) { %>
     @Transactional<% } %>
     public void testActivateAccount()<% if (!reactive) { %> throws Exception<% } %> {
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         final String activationKey = "some activation key";
         <%= asEntity('User') %> user = new <%= asEntity('User') %>();
         <%_ if (databaseType === 'cassandra') { _%>
@@ -928,12 +997,11 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
 
     @Test<% if (databaseType === 'sql' && !reactive) { %>
     @Transactional<% } %>
-    <%_ if (!reactive) { _%>
     public void testActivateAccountWithWrongKey() <% if (!reactive) { %>throws Exception <% } %>{
+    <%_ if (!reactive) { _%>
         restAccountMockMvc.perform(get("/api/activate?key=wrongActivationKey"))
             .andExpect(status().isInternalServerError());
     <%_ } else { _%>
-    public void testActivateAccountWithWrongKey() {
         accountWebTestClient.get().uri("/api/activate?key=wrongActivationKey")
             .exchange()
             .expectStatus().isEqualTo(HttpStatus.INTERNAL_SERVER_ERROR);
@@ -955,9 +1023,14 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
         <%_ if (databaseType === 'sql' && reactive) { _%>
         user.setCreatedBy(Constants.SYSTEM_ACCOUNT);
         <%_ } _%>
-
         userRepository.save<% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
 
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         <%= asDto('User') %> userDTO = new <%= asDto('User') %>();
         userDTO.setLogin("not-used");
         userDTO.setFirstName("firstname");
@@ -1059,7 +1132,6 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
         <%_ if (databaseType === 'sql' && reactive) { _%>
         user.setCreatedBy(Constants.SYSTEM_ACCOUNT);
         <%_ } _%>
-
         userRepository.save<% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
 
         <%= asEntity('User') %> anotherUser = new <%= asEntity('User') %>();
@@ -1122,9 +1194,14 @@ public class AccountResourceIT <% if (databaseType === 'cassandra') { %>extends 
         <%_ if (databaseType === 'sql' && reactive) { _%>
         user.setCreatedBy(Constants.SYSTEM_ACCOUNT);
         <%_ } _%>
-
         userRepository.save<% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
 
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+
+        <%_ } _%>
         <%= asDto('User') %> userDTO = new <%= asDto('User') %>();
         userDTO.setLogin("not-used");
         userDTO.setFirstName("firstname");

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -82,6 +82,9 @@ import org.springframework.test.web.servlet.MockMvc;
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import reactor.core.publisher.Mono;
+<%_ } _%>
 
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 import javax.persistence.EntityManager;
@@ -100,14 +103,17 @@ import java.util.UUID;
 <%_ } _%>
 
 import static org.assertj.core.api.Assertions.assertThat;
+<%_ if (reactive && searchEngine === 'elasticsearch') { _%>
+import static org.mockito.Mockito.*;
+<%_ } _%>
 <%_ if (!reactive) { _%>
     <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'neo4j' || databaseType === 'couchbase') { _%>
 import static org.hamcrest.Matchers.hasItems;
     <%_ } _%>
 import static org.hamcrest.Matchers.hasItem;
-<%_ if (testsNeedCsrf) { _%>
+    <%_ if (testsNeedCsrf) { _%>
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
-<%_ } _%>
+    <%_ } _%>
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 <%_ } else if (testsNeedCsrf) { _%>
@@ -261,7 +267,7 @@ public class UserResourceIT <% if (databaseType === 'neo4j') { %>extends Abstrac
     public void initTest() {
         <%_ if (databaseType === 'sql' && reactive) { _%>
         userRepository.deleteAllUserAuthorities().block();
-        <%_ } _%> 
+        <%_ } _%>
         <%_ if (databaseType !== 'sql' || reactive) { _%>
         userRepository.deleteAll()<% if (reactive) { %>.block()<% } %>;
         user = createEntity();
@@ -282,6 +288,11 @@ public class UserResourceIT <% if (databaseType === 'neo4j') { %>extends Abstrac
     public void createUser() throws Exception {
         int databaseSizeBeforeCreate = userRepository.findAll()<% if (reactive) { %>
             .collectList().block()<% } %>.size();
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
+        <%_ } _%>
 
         // Create the User
         ManagedUserVM managedUserVM = new ManagedUserVM();
@@ -471,9 +482,6 @@ public class UserResourceIT <% if (databaseType === 'neo4j') { %>extends Abstrac
     public void getAllUsers()<% if (!reactive) { %> throws Exception<% } %> {
         // Initialize the database
         userRepository.<% if (databaseType === 'sql' && reactive && authenticationType === 'oauth2') { %>create<% } else { %>save<% } %><% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
-        <%_ if (searchEngine === 'elasticsearch') { _%>
-        mockUserSearchRepository.save(user);
-        <%_ } _%>
 
         // Get all the users
         <%_ if (!reactive) { _%>
@@ -584,8 +592,10 @@ public class UserResourceIT <% if (databaseType === 'neo4j') { %>extends Abstrac
     public void updateUser() throws Exception {
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
-        <%_ if (searchEngine === 'elasticsearch') { _%>
-        mockUserSearchRepository.save(user);
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
         <%_ } _%>
         int databaseSizeBeforeUpdate = userRepository.findAll()<% if (reactive) { %>
             .collectList().block()<% } %>.size();
@@ -648,8 +658,10 @@ public class UserResourceIT <% if (databaseType === 'neo4j') { %>extends Abstrac
     public void updateUserLogin() throws Exception {
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
-        <%_ if (searchEngine === 'elasticsearch') { _%>
-        mockUserSearchRepository.save(user);
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.save(any()))
+            .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
         <%_ } _%>
         int databaseSizeBeforeUpdate = userRepository.findAll()<% if (reactive) { %>
             .collectList().block()<% } %>.size();
@@ -855,8 +867,9 @@ public class UserResourceIT <% if (databaseType === 'neo4j') { %>extends Abstrac
     public void deleteUser()<% if (!reactive) { %> throws Exception<% } %> {
         // Initialize the database
         userRepository.save<% if (databaseType === 'sql' && !reactive) { %>AndFlush<% } %>(user)<% if (reactive) { %>.block()<% } %>;
-        <%_ if (searchEngine === 'elasticsearch') { _%>
-        mockUserSearchRepository.save(user);
+        <%_ if (searchEngine === 'elasticsearch' && reactive) { _%>
+        // Configure the mock search repository
+        when(mockUserSearchRepository.delete(any())).thenReturn(Mono.empty());
         <%_ } _%>
         int databaseSizeBeforeDelete = userRepository.findAll()<% if (reactive) { %>
             .collectList().block()<% } %>.size();

--- a/test-integration/samples/webflux-couchbase-es-oauth2/.yo-rc.json
+++ b/test-integration/samples/webflux-couchbase-es-oauth2/.yo-rc.json
@@ -2,7 +2,7 @@
     "generator-jhipster": {
         "applicationType": "monolith",
         "reactive": true,
-        "baseName": "sampleWebflux",
+        "baseName": "sampleWebfluxCouchbaseOauth2",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
         "authenticationType": "oauth2",

--- a/test-integration/samples/webflux-couchbase-es-oauth2/.yo-rc.json
+++ b/test-integration/samples/webflux-couchbase-es-oauth2/.yo-rc.json
@@ -12,7 +12,7 @@
         "databaseType": "couchbase",
         "devDatabaseType": "couchbase",
         "prodDatabaseType": "couchbase",
-        "searchEngine": false,
+        "searchEngine": "elasticsearch",
         "buildTool": "gradle",
         "enableTranslation": true,
         "nativeLanguage": "en",

--- a/test-integration/samples/webflux-couchbase-session/.yo-rc.json
+++ b/test-integration/samples/webflux-couchbase-session/.yo-rc.json
@@ -2,7 +2,7 @@
     "generator-jhipster": {
         "applicationType": "monolith",
         "reactive": true,
-        "baseName": "sampleWebflux",
+        "baseName": "sampleWebfluxCouchbaseSession",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
         "authenticationType": "session",

--- a/test-integration/samples/webflux-couchbase/.yo-rc.json
+++ b/test-integration/samples/webflux-couchbase/.yo-rc.json
@@ -2,7 +2,7 @@
     "generator-jhipster": {
         "applicationType": "monolith",
         "reactive": true,
-        "baseName": "sampleWebflux",
+        "baseName": "sampleWebfluxCouchbase",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
         "authenticationType": "jwt",

--- a/test-integration/samples/webflux-mongodb-es-session/.yo-rc.json
+++ b/test-integration/samples/webflux-mongodb-es-session/.yo-rc.json
@@ -12,7 +12,7 @@
         "databaseType": "mongodb",
         "devDatabaseType": "mongodb",
         "prodDatabaseType": "mongodb",
-        "searchEngine": false,
+        "searchEngine": "elasticsearch",
         "buildTool": "maven",
         "enableTranslation": true,
         "nativeLanguage": "en",

--- a/test-integration/samples/webflux-mongodb-es-session/.yo-rc.json
+++ b/test-integration/samples/webflux-mongodb-es-session/.yo-rc.json
@@ -2,7 +2,7 @@
     "generator-jhipster": {
         "applicationType": "monolith",
         "reactive": true,
-        "baseName": "sampleWebflux",
+        "baseName": "sampleWebfluxMongodbEsSession",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
         "authenticationType": "session",

--- a/test-integration/samples/webflux-mongodb-es-session/.yo-rc.json
+++ b/test-integration/samples/webflux-mongodb-es-session/.yo-rc.json
@@ -21,6 +21,6 @@
         "serverPort": "8080",
         "jhiPrefix": "jhi",
         "clientPackageManager": "yarn",
-        "clientFramework": "react"
+        "clientFramework": "angularX"
     }
 }

--- a/test-integration/samples/webflux-mongodb-oauth2/.yo-rc.json
+++ b/test-integration/samples/webflux-mongodb-oauth2/.yo-rc.json
@@ -2,7 +2,7 @@
     "generator-jhipster": {
         "applicationType": "monolith",
         "reactive": true,
-        "baseName": "sampleWebflux",
+        "baseName": "sampleWebfluxMongodbOauth2",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
         "authenticationType": "oauth2",

--- a/test-integration/samples/webflux-mongodb/.yo-rc.json
+++ b/test-integration/samples/webflux-mongodb/.yo-rc.json
@@ -2,7 +2,7 @@
     "generator-jhipster": {
         "applicationType": "monolith",
         "reactive": true,
-        "baseName": "sampleWebflux",
+        "baseName": "sampleWebfluxMongodb",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
         "authenticationType": "jwt",


### PR DESCRIPTION
Fixes #11536

- Use reactive web client provided by spring-data-elasticsearch rather than Jest
- Handle reactive search for User entity
- Handle reactive search for generated entities
- Changed `webflux-mongodb-session` sample to `webflux-mongodb-es-session` in order to have a webflux sample with elasticsearch


-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
