### PR TITLE
Set the default TLS port as 443

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-tls.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-tls.yml.ejs
@@ -8,6 +8,7 @@
 # at chrome://flags/#allow-insecure-localhost
 # ===================================================================
 server:
+    port: 443
     ssl:
         key-store: classpath:config/tls/keystore.p12
         key-store-password: password


### PR DESCRIPTION
Otherwise it will use our default of 8080

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
