### PR TITLE
Remove jwt decoder bean for OAuth2

### DIFF
--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -37,10 +37,6 @@ import <%= packageName %>.service.AuditEventService;
     <%_ } _%>
 import io.github.jhipster.web.filter.reactive.CookieCsrfFilter;
 <%_ } _%>
-<%_ if (authenticationType === 'oauth2') { _%>
-import org.springframework.beans.factory.annotation.Value;
-import io.github.jhipster.config.JHipsterProperties;
-<%_ } _%>
 <%_ if (skipUserManagement && authenticationType !== 'oauth2') { _%>
 import org.springframework.boot.autoconfigure.security.SecurityProperties;
 <%_ } _%>
@@ -152,17 +148,9 @@ public class SecurityConfiguration {
     private final AuditEventService auditEventService;
 
     <%_ } _%>
-    <%_ if (authenticationType === 'oauth2') { _%>
-
-    @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}")
-    private String issuerUri;
-
-    private final JHipsterProperties jHipsterProperties;
-
-    <%_ } _%>
     private final SecurityProblemSupport problemSupport;
 
-    public SecurityConfiguration(<% if (!skipUserManagement && authenticationType !== 'oauth2') { %>ReactiveUserDetailsService userDetailsService, <% } %><% if (authenticationType === 'jwt') { %>TokenProvider tokenProvider, <% } %><% if (authenticationType === 'session' && !skipUserManagement || authenticationType === 'oauth2') { %>AuditEventService auditEventService, <% } %><% if (authenticationType === 'oauth2') { %>JHipsterProperties jHipsterProperties, <% } %>SecurityProblemSupport problemSupport) {
+    public SecurityConfiguration(<% if (!skipUserManagement && authenticationType !== 'oauth2') { %>ReactiveUserDetailsService userDetailsService, <% } %><% if (authenticationType === 'jwt') { %>TokenProvider tokenProvider, <% } %><% if (authenticationType === 'session' && !skipUserManagement || authenticationType === 'oauth2') { %>AuditEventService auditEventService, <% } %>SecurityProblemSupport problemSupport) {
         <%_ if (!skipUserManagement && authenticationType !== 'oauth2') { _%>
         this.userDetailsService = userDetailsService;
         <%_ } _%>
@@ -171,9 +159,6 @@ public class SecurityConfiguration {
         <%_ } _%>
         <%_ if (authenticationType === 'session' && !skipUserManagement || authenticationType === 'oauth2') { _%>
         this.auditEventService = auditEventService;
-        <%_ } _%>
-        <%_ if (authenticationType === 'oauth2') { _%>
-        this.jHipsterProperties = jHipsterProperties;
         <%_ } _%>
         this.problemSupport = problemSupport;
     }
@@ -333,19 +318,6 @@ public class SecurityConfiguration {
                 return new DefaultOidcUser(mappedAuthorities, user.getIdToken(), user.getUserInfo());
             });
         };
-    }
-
-    @Bean
-    ReactiveJwtDecoder jwtDecoder() {
-        NimbusReactiveJwtDecoder jwtDecoder = (NimbusReactiveJwtDecoder) ReactiveJwtDecoders.fromOidcIssuerLocation(issuerUri);
-
-        OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
-        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
-        OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
-
-        jwtDecoder.setJwtValidator(withAudience);
-
-        return jwtDecoder;
     }
 
     private ServerAuthenticationSuccessHandler redirectServerAuthenticationSuccessHandler = new RedirectServerAuthenticationSuccessHandler();

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -326,7 +326,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         };
     }
         <%_ } _%>
-    
+
         <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
 
     @Bean

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -31,9 +31,6 @@ import io.github.jhipster.config.JHipsterProperties;
 import io.github.jhipster.security.*;
     <%_ } _%>
 
-    <%_ if (authenticationType === 'oauth2') { _%>
-import io.github.jhipster.config.JHipsterProperties;
-    <%_ } _%>
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Import;
     <%_ if (authenticationType === 'oauth2') { _%>
@@ -121,16 +118,9 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
     private final CorsFilter corsFilter;
     <%_ } _%>
-    <%_ if (authenticationType === 'oauth2') { _%>
-
-    @Value("${spring.security.oauth2.client.provider.oidc.issuer-uri}")
-    private String issuerUri;
-
-    private final JHipsterProperties jHipsterProperties;
-    <%_ } _%>
     private final SecurityProblemSupport problemSupport;
 
-    public SecurityConfiguration(<% if (authenticationType === 'session' && !skipUserManagement) { %>JHipsterProperties jHipsterProperties, RememberMeServices rememberMeServices, <% } if (authenticationType === 'jwt') { %>TokenProvider tokenProvider, <% } %><% if (applicationType !== 'microservice') { %>CorsFilter corsFilter, <% } %><% if (authenticationType === 'oauth2') { %>JHipsterProperties jHipsterProperties, <% } %>SecurityProblemSupport problemSupport) {
+    public SecurityConfiguration(<% if (authenticationType === 'session' && !skipUserManagement) { %>JHipsterProperties jHipsterProperties, RememberMeServices rememberMeServices, <% } if (authenticationType === 'jwt') { %>TokenProvider tokenProvider, <% } %><% if (applicationType !== 'microservice') { %>CorsFilter corsFilter, <% } %>SecurityProblemSupport problemSupport) {
     <%_ if (authenticationType === 'session' && !skipUserManagement) { _%>
         this.jHipsterProperties = jHipsterProperties;
         this.rememberMeServices = rememberMeServices;
@@ -142,9 +132,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         this.corsFilter = corsFilter;
     <%_ } _%>
         this.problemSupport = problemSupport;
-    <%_ if (authenticationType === 'oauth2') { _%>
-        this.jHipsterProperties = jHipsterProperties;
-    <%_ } _%>
     }
     <%_ if (authenticationType === 'session') { _%>
 
@@ -339,19 +326,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         };
     }
         <%_ } _%>
-
-    @Bean
-    JwtDecoder jwtDecoder() {
-        NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder) JwtDecoders.fromOidcIssuerLocation(issuerUri);
-
-        OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
-        OAuth2TokenValidator<Jwt> withIssuer = JwtValidators.createDefaultWithIssuer(issuerUri);
-        OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
-
-        jwtDecoder.setJwtValidator(withAudience);
-
-        return jwtDecoder;
-    }
+    
         <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
 
     @Bean


### PR DESCRIPTION
I'm wondering if this code is still required for OAuth2 auth since we use spring-security 5.1.2+  

@mraible you added this code for the migration to Spring Security 5.1 (#9416) so at this time it was needed. Can you confirm it is not necessary anymore or I miss something?

Link: https://github.com/spring-projects/spring-security/issues/6098

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
