### PR TITLE
Add Missing Method in SecurityConfiguration.java.ejs

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -841,6 +841,18 @@ const serverFiles = {
         },
         {
             condition: generator =>
+                (!generator.reactive && generator.applicationType === 'gateway' && !generator.serviceDiscoveryType) ||
+                generator.authenticationType === 'uaa',
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/config/RestTemplateConfiguration.java',
+                    renameTo: generator => `${generator.javaDir}config/RestTemplateConfiguration.java`
+                }
+            ]
+        },
+        {
+            condition: generator =>
                 !(
                     generator.applicationType !== 'microservice' &&
                     !(

--- a/generators/server/templates/src/main/java/package/config/RestTemplateConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/RestTemplateConfiguration.java.ejs
@@ -1,0 +1,15 @@
+package <%= packageName %>.config;
+
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.annotation.Bean;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+@Component
+public class RestTemplateConfiguration {
+    @Bean
+    @Qualifier("restTemplate")
+    public RestTemplate restTemplate() {
+        return new RestTemplate();
+    }
+}

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -446,11 +446,5 @@ public class SecurityConfiguration extends ResourceServerConfigurerAdapter {
         customizer.customize(restTemplate);
         return restTemplate;
     }
-
-    @Bean
-    @Qualifier("vanillaRestTemplate")
-    public RestTemplate vanillaRestTemplate() {
-        return new RestTemplate();
-    }
 }
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -101,6 +101,10 @@ import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWrite
     <%_ if (applicationType !== 'microservice') { _%>
 import org.springframework.web.filter.CorsFilter;
     <%_ } _%>
+    <%_ if (!reactive && applicationType === 'gateway' && !serviceDiscoveryType) { _%>
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.web.client.RestTemplate;
+    <%_ } _%>
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 
 @EnableWebSecurity
@@ -359,6 +363,14 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return new AuthorizationHeaderFilter(headerUtil);
     }
         <%_ } _%>
+    <%_ } _%>
+    <%_ if (!reactive && applicationType === 'gateway' && !serviceDiscoveryType) { _%>
+
+    @Bean
+    @Qualifier("vanillaRestTemplate")
+    public RestTemplate vanillaRestTemplate() {
+        return new RestTemplate();
+    }
     <%_ } _%>
 }
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -101,10 +101,6 @@ import org.springframework.security.web.header.writers.ReferrerPolicyHeaderWrite
     <%_ if (applicationType !== 'microservice') { _%>
 import org.springframework.web.filter.CorsFilter;
     <%_ } _%>
-    <%_ if (!reactive && applicationType === 'gateway' && !serviceDiscoveryType) { _%>
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.web.client.RestTemplate;
-    <%_ } _%>
 import org.zalando.problem.spring.web.advice.security.SecurityProblemSupport;
 
 @EnableWebSecurity
@@ -363,14 +359,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         return new AuthorizationHeaderFilter(headerUtil);
     }
         <%_ } _%>
-    <%_ } _%>
-    <%_ if (!reactive && applicationType === 'gateway' && !serviceDiscoveryType) { _%>
-
-    @Bean
-    @Qualifier("vanillaRestTemplate")
-    public RestTemplate vanillaRestTemplate() {
-        return new RestTemplate();
-    }
     <%_ } _%>
 }
 <%_ } _%>

--- a/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/UaaSignatureVerifierClient.java.ejs
@@ -43,7 +43,7 @@ public class UaaSignatureVerifierClient implements OAuth2SignatureVerifierClient
     private final RestTemplate restTemplate;
     protected final OAuth2Properties oAuth2Properties;
 
-    public UaaSignatureVerifierClient(DiscoveryClient discoveryClient, @Qualifier("<%= !serviceDiscoveryType ? 'vanillaRestTemplate' : 'loadBalancedRestTemplate' %>") RestTemplate restTemplate,
+    public UaaSignatureVerifierClient(DiscoveryClient discoveryClient, @Qualifier("<%= !serviceDiscoveryType ? 'restTemplate' : 'loadBalancedRestTemplate' %>") RestTemplate restTemplate,
                                   OAuth2Properties oAuth2Properties) {
         this.restTemplate = restTemplate;
         this.oAuth2Properties = oAuth2Properties;

--- a/generators/server/templates/src/main/java/package/security/oauth2/UaaTokenEndpointClient.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/oauth2/UaaTokenEndpointClient.java.ejs
@@ -35,7 +35,7 @@ import java.nio.charset.StandardCharsets;
 @Component
 public class UaaTokenEndpointClient extends OAuth2TokenEndpointClientAdapter implements OAuth2TokenEndpointClient {
 
-    public UaaTokenEndpointClient(@Qualifier("<%= !serviceDiscoveryType ? 'vanillaRestTemplate' : 'loadBalancedRestTemplate' %>") RestTemplate restTemplate,
+    public UaaTokenEndpointClient(@Qualifier("<%= !serviceDiscoveryType ? 'restTemplate' : 'loadBalancedRestTemplate' %>") RestTemplate restTemplate,
                                   JHipsterProperties jHipsterProperties, OAuth2Properties oAuth2Properties) {
         super(restTemplate, jHipsterProperties, oAuth2Properties);
     }

--- a/generators/server/templates/src/main/java/package/web/filter/RouteDetectorFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/filter/RouteDetectorFilter.java.ejs
@@ -48,7 +48,7 @@ public class RouteDetectorFilter implements Filter {
     private final ZuulProperties zuulProperties;
     private final ZuulHandlerMapping zuulHandlerMapping;
 
-    public RouteDetectorFilter(@Qualifier("vanillaRestTemplate") RestTemplate restTemplate, ZuulProperties zuulProperties, ZuulHandlerMapping zuulHandlerMapping) {
+    public RouteDetectorFilter(@Qualifier("restTemplate") RestTemplate restTemplate, ZuulProperties zuulProperties, ZuulHandlerMapping zuulHandlerMapping) {
         this.restTemplate = restTemplate;
         this.zuulProperties = zuulProperties;
         this.zuulHandlerMapping = zuulHandlerMapping;


### PR DESCRIPTION
When a gateway application with no service discovery is generated we have a RouteDetectorFilter.java file which refers this method.

Fixes #11551

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
