### PR TITLE
skip importing entity into its own model

### DIFF
--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -26,7 +26,9 @@ const enumImports = generateEntityClientEnumImports(fields);
 import { Moment } from 'moment';
 <%_ } _%>
 <%_ typeImports.forEach( (importedPath, importedType) => { _%>
+    <%_ if (importedType !== `I${entityReactName}`) { _%>
 import { <%- importedType %> } from '<%- importedPath %>';
+    <%_ } _%>
 <%_ }); _%>
 <%_ enumImports.forEach( (importedPath, importedType) => { _%>
 import { <%- importedType %> } from '<%- importedPath %>';


### PR DESCRIPTION
This prevents a conflict between import and local declarations.  For example, `person.model.ts` should not try to import `IPerson` from itself when it is declared in that file.

Already done for Angular [here](https://github.com/jhipster/generator-jhipster/blob/99eaa8ae078dd806a229890b16dbb6c1654547e3/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs#L29)

Fix #11549

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
