### PR TITLE
Jhipster Sample fix vulnerabilities : Change Key squid:s4684 to java:s4684

### DIFF
--- a/generators/common/templates/sonar-project.properties.ejs
+++ b/generators/common/templates/sonar-project.properties.ejs
@@ -37,9 +37,9 @@ sonar.issue.ignore.multicriteria.UndocumentedApi.ruleKey=squid:UndocumentedApi
 sonar.issue.ignore.multicriteria.S4502.resourceKey=<%= MAIN_DIR %>java/**/*
 sonar.issue.ignore.multicriteria.S4502.ruleKey=squid:S4502
 <%_ } _%>
-# Rule https://sonarcloud.io/coding_rules?open=squid%3AS4684&rule_key=squid%3AS4684
+# Rule https://sonarcloud.io/coding_rules?open=java%3AS4684&rule_key=java%3AS4684
 sonar.issue.ignore.multicriteria.S4684.resourceKey=<%= MAIN_DIR %>java/**/*
-sonar.issue.ignore.multicriteria.S4684.ruleKey=squid:S4684
+sonar.issue.ignore.multicriteria.S4684.ruleKey=java:S4684
 <%_ } _%>
 <%_ if (!skipClient) { _%>
 # Rule https://sonarcloud.io/coding_rules?open=Web%3ABoldAndItalicTagsCheck&rule_key=Web%3ABoldAndItalicTagsCheck is ignored. Even if we agree that using the "i" tag is an awful practice, this is what is recommended by http://fontawesome.io/examples/


### PR DESCRIPTION
Fix vulnerabilities for sonar jhipster sample 
[Persistent entities should not be used as arguments of "@RequestMapping" methods
](https://sonarcloud.io/organizations/jhipster/rules?open=java%3AS4684&rule_key=java%3AS4684)


-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
