### PR TITLE
Register prettier-java plugin.

### DIFF
--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -18,6 +18,7 @@
  */
 const through = require('through2');
 const prettier = require('prettier');
+const prettierJava = require('prettier-plugin-java');
 
 const prettierOptions = {
     printWidth: 140,
@@ -27,7 +28,8 @@ const prettierOptions = {
     // js and ts rules:
     arrowParens: 'avoid',
     // jsx and tsx rules:
-    jsxBracketSameLine: false
+    jsxBracketSameLine: false,
+    plugins: [prettierJava]
 };
 
 const prettierTransform = function(defaultOptions) {
@@ -36,9 +38,7 @@ const prettierTransform = function(defaultOptions) {
         prettier.resolveConfig(file.relative).then(options => {
             if (file.state !== 'deleted') {
                 const str = file.contents.toString('utf8');
-                if (!options || Object.keys(options).length === 0) {
-                    options = defaultOptions;
-                }
+                options = { ...defaultOptions, ...options };
                 // for better errors
                 options.filepath = file.relative;
                 const data = prettier.format(str, options);
@@ -50,6 +50,11 @@ const prettierTransform = function(defaultOptions) {
     return through.obj(transform);
 };
 
+/**
+ * @deprecated
+ * Not used.
+ * Remove for jhipster 7.
+ */
 const prettierFormat = function(str, options = {}) {
     return prettier.format(str, { ...prettierOptions, ...options });
 };


### PR DESCRIPTION
Prettier lookup for plugins at same level node_modules repository.
Workaround prettier-java failing with npm changing it's location.

Fixes https://github.com/jhipster/generator-jhipster/issues/11533

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
