### PR TITLE
Integration test for webflux and R2DBC

### DIFF
--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -53,6 +53,7 @@ jobs:
                     - webflux-couchbase
                     - webflux-couchbase-session
                     - webflux-couchbase-es-oauth2
+                    - webflux-psql
                 include:
                     - app-type: webflux-mongodb
                       entity: mongodb
@@ -90,6 +91,11 @@ jobs:
                       war: 0
                       protractor: 1
                     - app-type: webflux-couchbase-es-oauth2
+                      entity: none
+                      profile: prod
+                      war: 0
+                      protractor: 1
+                    - app-type: webflux-psql
                       entity: none
                       profile: prod
                       war: 0

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -51,7 +51,6 @@ jobs:
                     - webflux-gateway-jwt
                     - webflux-gateway-oauth2
                     - webflux-couchbase
-                    - webflux-couchbase-session
                     - webflux-couchbase-es-oauth2
                     - webflux-psql
                 include:
@@ -81,11 +80,6 @@ jobs:
                       war: 0
                       protractor: 1
                     - app-type: webflux-couchbase
-                      entity: none
-                      profile: prod
-                      war: 0
-                      protractor: 1
-                    - app-type: webflux-couchbase-session
                       entity: none
                       profile: prod
                       war: 0

--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -25,6 +25,9 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.dao.ConcurrencyFailureException;
 <%_ } _%>
 import org.springframework.http.ResponseEntity;
+<%_ if (reactive && databaseType === 'sql') { _%>
+import org.springframework.stereotype.Component;
+<%_ } _%>
 import org.springframework.validation.BindingResult;
 <%_ if (!reactive) { _%>
 import org.springframework.web.bind.MethodArgumentNotValidException;

--- a/test-integration/samples/webflux-psql/.yo-rc.json
+++ b/test-integration/samples/webflux-psql/.yo-rc.json
@@ -1,0 +1,26 @@
+{
+    "generator-jhipster": {
+        "applicationType": "monolith",
+        "reactive": true,
+        "baseName": "sampleWebfluxPsql",
+        "packageName": "io.github.jhipster.sample",
+        "packageFolder": "io/github/jhipster/sample",
+        "authenticationType": "jwt",
+        "cacheProvider": "no",
+        "enableHibernateCache": false,
+        "websocket": false,
+        "databaseType": "sql",
+        "devDatabaseType": "h2Disk",
+        "prodDatabaseType": "postgresql",
+        "searchEngine": false,
+        "buildTool": "maven",
+        "enableTranslation": true,
+        "nativeLanguage": "en",
+        "languages": ["en", "fr"],
+        "testFrameworks": ["gatling", "protractor"],
+        "serverPort": "8080",
+        "jhiPrefix": "jhi",
+        "clientPackageManager": "npm",
+        "clientFramework": "angularX"
+    }
+}


### PR DESCRIPTION
I've also disabled `webflux-couchbase-session` since there are already 2 other webflux-couchbase integration tests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
