### PR TITLE
Adds the Windows Daily Builds Badge to README.md [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -167,12 +167,14 @@ Additional builds at [hipster-labs/jhipster-daily-builds](https://github.com/hip
 | [![Docker Image][github-docker-image]][github-actions]                         |
 | [![Neo4j][github-neo4j]][github-actions]                                       |
 | [![Couchbase][github-couchbase]][github-actions]                               |
+| [![Official Windows][github-official-windows]][github-actions]                 |
 
 ## Analysis of the sample JHipster project
 
 [![sonar-quality-gate][sonar-quality-gate]][sonar-url] [![sonar-coverage][sonar-coverage]][sonar-url] [![sonar-bugs][sonar-bugs]][sonar-url] [![sonar-vulnerabilities][sonar-vulnerabilities]][sonar-url]
 
 [github-actions]: https://github.com/hipster-labs/jhipster-daily-builds/actions
+[github-official-windows]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Official%20Windows/badge.svg
 [github-angular-maven]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Angular%20Maven/badge.svg
 [github-angular-maven-nosql]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Angular%20Maven%20NoSQL/badge.svg
 [github-angular-gradle]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Angular%20Gradle/badge.svg


### PR DESCRIPTION
This adds the Windows Daily Builds badge to readme now that the build is working.

Related to https://github.com/hipster-labs/jhipster-daily-builds/issues/48

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
