### PR TITLE
Improve generator error handlers.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -65,11 +65,7 @@ const runYoCommand = (cmd, args, options, opts) => {
     const command = getCommand(cmd, args, opts);
     logger.info(chalk.yellow(`Executing ${command}`));
     logger.info(chalk.yellow(`Options: ${toString(options)}`));
-    try {
-        env.run(command, options, done);
-    } catch (e) {
-        logger.error(e.message, e);
-    }
+    env.run(command, options).then(done, done);
 };
 
 program

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -206,17 +206,16 @@ const generateEntityFiles = (generator, entity, inFolder, env, shouldTriggerInst
         }
         return Promise.all(baseNames.map(callGenerator));
     }
+    /* Create done with empty success message */
+    const done = doneFactory();
     /* Traditional entity only generation */
-    return env.run(
-        command,
-        {
+    return env
+        .run(command, {
             ...options,
             force: options.force || !options.interactive,
             'skip-install': !shouldTriggerInstall
-        },
-        /* Create done with empty success message */
-        doneFactory()
-    );
+        })
+        .then(done, done);
 };
 
 /**

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -206,8 +206,6 @@ const generateEntityFiles = (generator, entity, inFolder, env, shouldTriggerInst
         }
         return Promise.all(baseNames.map(callGenerator));
     }
-    /* Create done with empty success message */
-    const done = doneFactory();
     /* Traditional entity only generation */
     return env
         .run(command, {
@@ -215,7 +213,7 @@ const generateEntityFiles = (generator, entity, inFolder, env, shouldTriggerInst
             force: options.force || !options.interactive,
             'skip-install': !shouldTriggerInstall
         })
-        .then(done, done);
+        .catch(doneFactory()); // Create done with empty success message
 };
 
 /**

--- a/cli/run-yeoman-process.js
+++ b/cli/run-yeoman-process.js
@@ -22,11 +22,11 @@ const packageJson = require('../package.json');
 const { logger, createYeomanEnv, toString, getCommandOptions, doneFactory } = require('./utils');
 
 const env = createYeomanEnv();
-/* Create done with empty success message */
-const done = doneFactory();
 
 const command = process.argv[2];
 const options = getCommandOptions(packageJson, process.argv.slice(3));
 logger.info(chalk.yellow(`Executing ${command} on ${process.cwd()}`));
 logger.info(chalk.yellow(`Options: ${toString(options)}`));
-env.run(command, options).then(done, done);
+
+/* Create done with empty success message */
+env.run(command, options).catch(doneFactory());

--- a/cli/run-yeoman-process.js
+++ b/cli/run-yeoman-process.js
@@ -22,14 +22,11 @@ const packageJson = require('../package.json');
 const { logger, createYeomanEnv, toString, getCommandOptions, doneFactory } = require('./utils');
 
 const env = createYeomanEnv();
+/* Create done with empty success message */
+const done = doneFactory();
 
 const command = process.argv[2];
 const options = getCommandOptions(packageJson, process.argv.slice(3));
 logger.info(chalk.yellow(`Executing ${command} on ${process.cwd()}`));
 logger.info(chalk.yellow(`Options: ${toString(options)}`));
-try {
-    env.run(command, options, doneFactory());
-} catch (e) {
-    logger.error(e.message, e);
-    process.exitCode = 1;
-}
+env.run(command, options).then(done, done);

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -219,7 +219,7 @@ const printSuccess = () => {
 };
 
 const createYeomanEnv = packagePatterns => {
-    const env = yeoman.createEnv(undefined, { newErrorHandler: true });
+    const env = yeoman.createEnv();
     // Register jhipster generators.
     env.lookup({ packagePaths: [path.join(__dirname, '..')] });
     if (packagePatterns) {

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -199,9 +199,11 @@ const getCommandOptions = (pkg, argv) => {
 };
 
 const doneFactory = successMsg => {
-    return errorMsg => {
-        if (errorMsg) {
-            logger.error(`ERROR! ${errorMsg}`);
+    return errorOrMsg => {
+        if (errorOrMsg instanceof Error) {
+            logger.error(`ERROR! ${errorOrMsg.message}`, errorOrMsg);
+        } else if (errorOrMsg) {
+            logger.error(`ERROR! ${errorOrMsg}`);
         } else if (successMsg) {
             logger.info(chalk.green.bold(successMsg));
         }
@@ -217,7 +219,7 @@ const printSuccess = () => {
 };
 
 const createYeomanEnv = packagePatterns => {
-    const env = yeoman.createEnv();
+    const env = yeoman.createEnv(undefined, { newErrorHandler: true });
     // Register jhipster generators.
     env.lookup({ packagePaths: [path.join(__dirname, '..')] });
     if (packagePatterns) {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1201,6 +1201,9 @@ module.exports = class extends PrivateBase {
     composeExternalModule(npmPackageName, subGen, options) {
         const generatorName = jhipsterUtils.packageNameToNamespace(npmPackageName);
         const generatorCallback = `${generatorName}:${subGen}`;
+        if (!this.env.get(generatorCallback)) {
+            throw new Error(`Generator ${generatorCallback} isn't registered.`);
+        }
         return this.composeWith(generatorCallback, options, true);
     }
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1550,8 +1550,7 @@ module.exports = class extends PrivateBase {
         if (this._debug && this._debug.enabled) {
             this._debug(`${chalk.red.bold('ERROR!')} ${msg}`);
         }
-        // Terminate current environment.
-        this.env.error(`${msg}`);
+        throw new Error(`${msg}`);
     }
 
     /**

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -14,11 +14,11 @@ let subGenCallParams = {
 };
 
 const env = {
-    run(command, options, done) {
+    run(command, options) {
         subGenCallParams.count++;
         subGenCallParams.commands.push(command);
         subGenCallParams.options.push(options);
-        done();
+        return Promise.resolve();
     }
 };
 


### PR DESCRIPTION
Yeoman generator emits an error event on generator inside a scheduled function, when the event doesn't have any listener the error is thrown (https://nodejs.org/api/events.html#events_error_events) and makes the process crash.

generator-jhipster is not listening any error event and relying on the process crash.

When running an updated yeoman-generator with an updated yeoman-environment, error listeners are registered and the process crash doesn't happens.
All generators errors are forwarded to the environment.

This PR takes advantage of this new error handler.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
