### PR TITLE
start neo4j docker compose to run e2e tests

### DIFF
--- a/test-integration/scripts/20-docker-compose.sh
+++ b/test-integration/scripts/20-docker-compose.sh
@@ -27,6 +27,9 @@ fi
 if [ -a src/main/docker/mongodb.yml ]; then
     docker-compose -f src/main/docker/mongodb.yml up -d
 fi
+if [ -a src/main/docker/neo4j.yml ]; then
+    docker-compose -f src/main/docker/neo4j.yml up -d
+fi
 if [ -a src/main/docker/couchbase.yml ]; then
     # this container can't be started otherwise, it will be conflict with tests
     # so here, only prepare the image


### PR DESCRIPTION
This should fix the remaining issue in daily builds regarding e2e tests as no database is available

[ci-skip]

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
