### PR TITLE
Temporarily disable BlockHound to fix unstable webflux CI tests

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -563,8 +563,9 @@ dependencies {
     testImplementation "org.springframework.security:spring-security-test"
     testImplementation "org.springframework.boot:spring-boot-test"
     <%_ if (reactive) { _%>
-    testImplementation "io.projectreactor.tools:blockhound-junit-platform:${blockhound_junit_platform_version}"
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher:${junit_platform_launcher_version}'
+    // Temporarily disabled see https://github.com/jhipster/generator-jhipster/issues/11599
+    // testImplementation "io.projectreactor.tools:blockhound-junit-platform:${blockhound_junit_platform_version}"
+    // testRuntimeOnly 'org.junit.platform:junit-platform-launcher:${junit_platform_launcher_version}'
     // See https://github.com/netty/netty/pull/10020 . Remove when Spring Boot has caught up
     implementation 'io.netty:netty-common:${netty_common_version}'
     <%_ } _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -708,12 +708,14 @@
             <scope>test</scope>
         </dependency>
 <%_ if (reactive) { _%>
+        <!-- # Temporarily disabled see https://github.com/jhipster/generator-jhipster/issues/11599
         <dependency>
             <groupId>io.projectreactor.tools</groupId>
             <artifactId>blockhound-junit-platform</artifactId>
             <version>${blockhound-junit-platform.version}</version>
             <scope>test</scope>
         </dependency>
+        -->
         <!-- See https://github.com/netty/netty/pull/10020 . Remove when Spring Boot has caught up -->
         <dependency>
             <groupId>io.netty</groupId>


### PR DESCRIPTION
Our CI tests have been very unreliable since we've enabled BlockHound on webflux apps.
I propose to disable BlockHound temporarily and I've open https://github.com/jhipster/generator-jhipster/issues/11599 so we don't forget to re-enable it once blocking issues has been resolved.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
