### PR TITLE
Adds Docker in Docker Service to .gitlab-ci.yml.ejs

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -19,7 +19,7 @@
 <%_ if (insideDocker) { _%>
 image: jhipster/jhipster:v<%= jhipsterVersion %>
 
-    <%_ if (cacheProvider === 'redis' || prodDatabaseType === 'cassandra' || prodDatabaseType === 'couchbase' || prodDatabaseType === 'neo4j') { _%>
+    <%_ if (cacheProvider === 'redis' || ['cassandra', 'couchbase', 'neo4j'].includes(prodDatabaseType)) { _%>
 # DinD service is required for Testcontainers
 services:
     - docker:dind

--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -18,6 +18,18 @@
 -%>
 <%_ if (insideDocker) { _%>
 image: jhipster/jhipster:v<%= jhipsterVersion %>
+
+    <%_ if (cacheProvider === 'redis' || prodDatabaseType === 'cassandra' || prodDatabaseType === 'couchbase' || prodDatabaseType === 'neo4j') { _%>
+# DinD service is required for Testcontainers
+services:
+    - docker:dind
+
+variables:
+    # Instruct Testcontainers to use the daemon of DinD.
+    DOCKER_HOST: 'tcp://docker:2375'
+    # Improve performance with overlayfs.
+    DOCKER_DRIVER: overlay2
+    <%_ } _%>
 <%_ } _%>
 
 <%_ if (buildTool === 'gradle') { _%>


### PR DESCRIPTION
This adds docker in docker service to our .gitlab-ci.yml so that the generated gitlab configuration can run tests on GitLab ci.

Reference: https://www.testcontainers.org/supported_docker_environment/continuous_integration/gitlab_ci/

Fixes #11601

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
