### PR TITLE
GitLab Build Speedup: DIND only within Integration Tests

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -99,6 +99,7 @@ module.exports = class extends BaseGenerator {
                 }
                 this.clientFramework = configuration.get('clientFramework');
                 this.testFrameworks = configuration.get('testFrameworks');
+                this.cacheProvider = configuration.get('cacheProvider');
                 this.autoconfigureTravis = this.options['autoconfigure-travis'];
                 this.autoconfigureJenkins = this.options['autoconfigure-jenkins'];
                 this.autoconfigureGitlab = this.options['autoconfigure-gitlab'];

--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -18,18 +18,6 @@
 -%>
 <%_ if (insideDocker) { _%>
 image: jhipster/jhipster:v<%= jhipsterVersion %>
-
-    <%_ if (cacheProvider === 'redis' || ['cassandra', 'couchbase', 'neo4j'].includes(prodDatabaseType)) { _%>
-# DinD service is required for Testcontainers
-services:
-    - docker:dind
-
-variables:
-    # Instruct Testcontainers to use the daemon of DinD.
-    DOCKER_HOST: 'tcp://docker:2375'
-    # Improve performance with overlayfs.
-    DOCKER_DRIVER: overlay2
-    <%_ } _%>
 <%_ } _%>
 
 <%_ if (buildTool === 'gradle') { _%>
@@ -79,6 +67,20 @@ gradle-compile:
         expire_in: 1 day
 
 gradle-test:
+<%_ if (insideDocker) { _%>
+    <%_ if (cacheProvider === 'redis' || ['cassandra', 'couchbase', 'neo4j'].includes(prodDatabaseType)) { _%>
+    # DinD service is required for Testcontainers
+    services:
+        - docker:dind
+
+    variables:
+        # Instruct Testcontainers to use the daemon of DinD.
+        DOCKER_HOST: 'tcp://docker:2375'
+        # Improve performance with overlayfs.
+        DOCKER_DRIVER: overlay2
+    <%_ } _%>
+<%_ } _%>
+
     stage: test
     script:
         - ./gradlew test -PnodeInstall --no-daemon
@@ -196,6 +198,20 @@ maven-compile:
         expire_in: 1 day
 
 maven-test:
+<%_ if (insideDocker) { _%>
+    <%_ if (cacheProvider === 'redis' || ['cassandra', 'couchbase', 'neo4j'].includes(prodDatabaseType)) { _%>
+    # DinD service is required for Testcontainers
+    services:
+        - docker:dind
+
+    variables:
+        # Instruct Testcontainers to use the daemon of DinD.
+        DOCKER_HOST: 'tcp://docker:2375'
+        # Improve performance with overlayfs.
+        DOCKER_DRIVER: overlay2
+    <%_ } _%>
+<%_ } _%>
+
     stage: test
     script:
         - ./mvnw -ntp verify -P-webpack -Dmaven.repo.local=$MAVEN_USER_HOME


### PR DESCRIPTION
As per our discussion at https://github.com/jhipster/generator-jhipster/pull/11602#issuecomment-616359536 I am opening this PR to increase the speed of the GitLab pipeline. This refactors the code such that the dind service is initiated only within the integration tests. 

Related to https://github.com/jhipster/generator-jhipster/issues/11601

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
