### PR TITLE
Implement blueprint auto installation.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -30,8 +30,7 @@ const {
     getCommandOptions,
     getArgs,
     done,
-    loadBlueprints,
-    loadBlueprintsFromYoRc,
+    loadAllBlueprintsWithVersion,
     getBlueprintPackagePaths,
     loadBlueprintCommands,
     loadSharedOptions,
@@ -44,12 +43,12 @@ const program = new commander.Command();
 const version = packageJson.version;
 const JHIPSTER_NS = CLI_NAME;
 
-const argBlueprints = loadBlueprints();
-const configBlueprints = loadBlueprintsFromYoRc().map(bp => bp.name);
-const allBlueprints = [...new Set([...argBlueprints, ...configBlueprints])];
+const blueprintsWithVersion = loadAllBlueprintsWithVersion();
+const allBlueprints = Object.keys(blueprintsWithVersion);
 
 const env = createYeomanEnv(allBlueprints);
-const sharedOptions = loadSharedOptions(getBlueprintPackagePaths(env, allBlueprints)) || {};
+const blueprintsPackagePath = getBlueprintPackagePaths(env, blueprintsWithVersion);
+const sharedOptions = loadSharedOptions(blueprintsPackagePath) || {};
 // Env will forward sharedOptions to every generator
 Object.assign(env.sharedOptions, sharedOptions);
 
@@ -75,7 +74,7 @@ const runYoCommand = (cmd, args, options, opts) => {
 
 program.version(version).usage('[command] [options]').allowUnknownOption();
 
-const blueprintCommands = loadBlueprintCommands(getBlueprintPackagePaths(env, argBlueprints));
+const blueprintCommands = loadBlueprintCommands(blueprintsPackagePath);
 const allCommands = { ...SUB_GENERATORS, ...blueprintCommands };
 
 /* create commands */

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -21,6 +21,7 @@ const path = require('path');
 const _ = require('lodash');
 const Generator = require('yeoman-generator');
 const chalk = require('chalk');
+const fs = require('fs');
 const shelljs = require('shelljs');
 const semver = require('semver');
 const exec = require('child_process').exec;
@@ -865,8 +866,7 @@ module.exports = class extends Generator {
             this.warning(msg);
             return undefined;
         }
-        // eslint-disable-next-line global-require,import/no-dynamic-require
-        return require(path.join(blueprintPackagePath, 'package.json'));
+        return JSON.parse(fs.readFileSync(path.join(blueprintPackagePath, 'package.json')));
     }
 
     /**

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1201,6 +1201,9 @@ module.exports = class extends PrivateBase {
     composeExternalModule(npmPackageName, subGen, options) {
         const generatorName = jhipsterUtils.packageNameToNamespace(npmPackageName);
         const generatorCallback = `${generatorName}:${subGen}`;
+        if (!this.env.get(generatorCallback)) {
+            throw new Error(`Generator ${generatorCallback} isn't registered.`);
+        }
         return this.composeWith(generatorCallback, options, true);
     }
 

--- a/test/cli/cli-utils.spec.js
+++ b/test/cli/cli-utils.spec.js
@@ -209,7 +209,7 @@ describe('jhipster cli utils test', () => {
                 revertTempDir(oldCwd);
             });
 
-            it('returns an empty object', () => {
+            it('returns blueprints with no version', () => {
                 expect(returned).to.deep.equal({
                     'generator-jhipster-vuejs': undefined,
                     'generator-jhipster-dotnet': undefined,

--- a/test/cli/cli-utils.spec.js
+++ b/test/cli/cli-utils.spec.js
@@ -180,8 +180,8 @@ describe('jhipster cli utils test', () => {
             let oldCwd;
 
             before(() => {
-                assert(!fs.existsSync('.yo-rc.json'));
                 oldCwd = testInTempDir(() => {}, true);
+                assert(!fs.existsSync('.yo-rc.json'));
             });
             after(() => {
                 revertTempDir(oldCwd);
@@ -198,10 +198,10 @@ describe('jhipster cli utils test', () => {
             let returned;
 
             before(() => {
+                oldCwd = testInTempDir(() => {}, true);
                 oldArgv = process.argv;
                 process.argv = ['--blueprints', 'vuejs,dotnet'];
                 assert(!fs.existsSync('.yo-rc.json'));
-                oldCwd = testInTempDir(() => {}, true);
                 returned = cliUtil.loadAllBlueprintsWithVersion();
             });
             after(() => {
@@ -277,11 +277,11 @@ describe('jhipster cli utils test', () => {
             let returned;
 
             before(() => {
-                oldArgv = process.argv;
-                process.argv = ['--blueprints', 'vuejs,dotnet'];
-                assert(!fs.existsSync('.yo-rc.json'));
                 oldCwd = testInTempDir(() => {}, true);
+                oldArgv = process.argv;
 
+                assert(!fs.existsSync('.yo-rc.json'));
+                process.argv = ['--blueprints', 'vuejs,dotnet'];
                 const yoRcContent = {
                     'generator-jhipster': {
                         blueprints: [


### PR DESCRIPTION
Implement blueprint auto install when it is passed as a parameter ex:
```
jhipster --blueprints vuejs
```
Or the blueprint already is registered at .yo-rc.json

Prompt to install blueprints cannot be added since it will conflict with blueprints with app generators (the generator has already started)
Closes https://github.com/jhipster/generator-jhipster/issues/11480


-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
