### PR TITLE
Fix Mistake in Adding DIND Support for GitLab CI with Gradle

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -67,6 +67,18 @@ gradle-compile:
         expire_in: 1 day
 
 gradle-test:
+    stage: test
+    script:
+        - ./gradlew test -PnodeInstall --no-daemon
+    artifacts:
+        reports:
+            junit: build/test-results/test/TEST-*.xml
+        paths:
+            - build/test-results/
+            - build/jacoco/
+        expire_in: 1 day
+
+gradle-integration-test:
 <%_ if (insideDocker) { _%>
     <%_ if (cacheProvider === 'redis' || ['cassandra', 'couchbase', 'neo4j'].includes(prodDatabaseType)) { _%>
     # DinD service is required for Testcontainers
@@ -81,18 +93,6 @@ gradle-test:
     <%_ } _%>
 <%_ } _%>
 
-    stage: test
-    script:
-        - ./gradlew test -PnodeInstall --no-daemon
-    artifacts:
-        reports:
-            junit: build/test-results/test/TEST-*.xml
-        paths:
-            - build/test-results/
-            - build/jacoco/
-        expire_in: 1 day
-
-gradle-integration-test:
     stage: test
     script:
         - ./gradlew integrationTest -PnodeInstall --no-daemon


### PR DESCRIPTION
This is related to https://github.com/jhipster/generator-jhipster/pull/11603. We've added the DIND initialization in the wrong place. We have to add it within the integration tests as pointed out by @ecostanzi at https://github.com/jhipster/generator-jhipster/pull/11584#discussion_r412358519

Related to #11603, #11602 and #11601

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
