### PR TITLE
Adds Testcontainers as a Test Dependency for Gradle + Redis Configuration

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -596,6 +596,9 @@ dependencies {
     <%_ if (messageBroker === 'kafka') { _%>
     testImplementation "org.testcontainers:kafka"
     <%_ } _%>
+    <%_ if (cacheProvider === 'redis') { %>
+    testImplementation "org.testcontainers:testcontainers"
+    <%_ } _%>
     //jhipster-needle-gradle-dependency - JHipster will add additional dependencies here
 }
 


### PR DESCRIPTION
This adds Testcontainers as a test dependency for Gradle + Redis configuration. I've added the `database-common` artifact just as we do in `Cassandra`. 

@bsideup: Hey, if you don't mind me asking a quick question; I am wondering what is the difference between; `org.testcontainers:database-commons` vs `org.testcontainers:testcontainers` dependencies?  

Fixes https://github.com/jhipster/generator-jhipster/issues/11615

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
