### PR TITLE
Revert "Remove es2015 from Webpack Configuration"

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -34,7 +34,7 @@ module.exports = (options) => ({
     resolve: {
         extensions: ['.ts', '.js'],
         modules: ['node_modules'],
-        mainFields: ['browser', 'module', 'main'],
+        mainFields: [ 'es2015', 'browser', 'module', 'main'],
         alias: utils.mapTypescriptAliasToWebpackAlias()
     },
     stats: {


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#11580. 

**Note:** This should be ideally merged **after June 06th** when FireFox 77 is released as I've mentioned at https://github.com/jhipster/generator-jhipster/issues/11566#issuecomment-614134292. 

Related to https://github.com/jhipster/generator-jhipster/issues/11566