### PR TITLE
Fix cache header

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -932,6 +932,16 @@ const serverFiles = {
             ],
         },
         {
+            condition: generator => !generator.reactive,
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/config/StaticResourcesWebConfiguration.java',
+                    renameTo: generator => `${generator.javaDir}config/StaticResourcesWebConfiguration.java`,
+                },
+            ],
+        },
+        {
             condition: generator =>
                 !generator.skipUserManagement || ['sql', 'mongodb', 'couchbase', 'neo4j'].includes(generator.databaseType),
             path: SERVER_MAIN_SRC_DIR,
@@ -1420,6 +1430,10 @@ const serverFiles = {
             condition: generator => !generator.reactive,
             path: SERVER_TEST_SRC_DIR,
             templates: [
+                {
+                    file: 'package/config/StaticResourcesWebConfigurerTest.java',
+                    renameTo: generator => `${generator.testDir}config/StaticResourcesWebConfigurerTest.java`,
+                },
                 {
                     file: 'package/config/WebConfigurerTest.java',
                     renameTo: generator => `${generator.testDir}config/WebConfigurerTest.java`,

--- a/generators/server/templates/src/main/java/package/config/StaticResourcesWebConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/StaticResourcesWebConfiguration.java.ejs
@@ -1,0 +1,67 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%=packageName%>.config;
+
+import io.github.jhipster.config.JHipsterConstants;
+import io.github.jhipster.config.JHipsterProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.http.CacheControl;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+import java.util.concurrent.TimeUnit;
+
+@Configuration
+@Profile({JHipsterConstants.SPRING_PROFILE_PRODUCTION})
+public class StaticResourcesWebConfiguration implements WebMvcConfigurer {
+
+    protected static final String[] RESOURCE_LOCATIONS = new String[]{"/app/", "/content/", "/i18n/"};
+    protected static final String[] RESOURCE_PATHS = new String[]{"/app/*", "/content/*", "/i18n/*"};
+
+    private final JHipsterProperties jhipsterProperties;
+
+    public StaticResourcesWebConfiguration(JHipsterProperties jHipsterProperties) {
+        this.jhipsterProperties = jHipsterProperties;
+    }
+
+    @Override
+    public void addResourceHandlers(ResourceHandlerRegistry registry) {
+        ResourceHandlerRegistration resourceHandlerRegistration = appendResourceHandler(registry);
+        initializeResourceHandler(resourceHandlerRegistration);
+    }
+
+    protected ResourceHandlerRegistration appendResourceHandler(ResourceHandlerRegistry registry) {
+        return registry.addResourceHandler(RESOURCE_PATHS);
+    }
+
+    protected void initializeResourceHandler(ResourceHandlerRegistration resourceHandlerRegistration) {
+        resourceHandlerRegistration.addResourceLocations(RESOURCE_LOCATIONS).setCacheControl(getCacheControl());
+    }
+
+    protected CacheControl getCacheControl() {
+        return CacheControl.maxAge(getJHipsterHttpCacheProperty(), TimeUnit.DAYS).cachePublic();
+    }
+
+    private int getJHipsterHttpCacheProperty() {
+        return jhipsterProperties.getHttp().getCache().getTimeToLiveInDays();
+    }
+
+}

--- a/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
@@ -28,7 +28,7 @@ import io.github.jhipster.config.JHipsterProperties;
 <%_ if (['h2Disk', 'h2Memory'].includes(devDatabaseType) && !reactive) { _%>
 import io.github.jhipster.config.h2.H2ConfigurationHelper;
 <%_ } _%>
-<%_ if (!skipClient) { _%>
+<%_ if (!skipClient && reactive) { _%>
 import io.github.jhipster.web.filter.<% if (reactive) { %>reactive.<% } %>CachingHttpHeadersFilter;
 <%_ } _%>
 import org.slf4j.Logger;
@@ -122,12 +122,7 @@ public class WebConfigurer implements <% if (!reactive) { %>ServletContextInitia
         if (env.getActiveProfiles().length != 0) {
             log.info("Web application configuration, using profiles: {}", (Object[]) env.getActiveProfiles());
         }
-        <%_ if (!skipClient) { _%>
-        EnumSet<DispatcherType> disps = EnumSet.of(DispatcherType.REQUEST, DispatcherType.FORWARD, DispatcherType.ASYNC);
-        if (env.acceptsProfiles(Profiles.of(JHipsterConstants.SPRING_PROFILE_PRODUCTION))) {
-            initCachingHttpHeadersFilter(servletContext, disps);
-        }
-        <%_ } _%>
+
         <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
         if (env.acceptsProfiles(Profiles.of(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT))) {
             initH2Console(servletContext);
@@ -191,21 +186,6 @@ public class WebConfigurer implements <% if (!reactive) { %>ServletContextInitia
         return extractedPath.substring(0, extractionEndIndex);
     }
 
-    /**
-     * Initializes the caching HTTP Headers Filter.
-     */
-    private void initCachingHttpHeadersFilter(ServletContext servletContext,
-                                              EnumSet<DispatcherType> disps) {
-        log.debug("Registering Caching HTTP Headers Filter");
-        FilterRegistration.Dynamic cachingHttpHeadersFilter =
-            servletContext.addFilter("cachingHttpHeadersFilter",
-                new CachingHttpHeadersFilter(jHipsterProperties));
-
-        cachingHttpHeadersFilter.addMappingForUrlPatterns(disps, true, "/i18n/*");
-        cachingHttpHeadersFilter.addMappingForUrlPatterns(disps, true, "/content/*");
-        cachingHttpHeadersFilter.addMappingForUrlPatterns(disps, true, "/app/*");
-        cachingHttpHeadersFilter.setAsyncSupported(true);
-    }
         <%_ } _%>
     <%_ } _%>
 

--- a/generators/server/templates/src/test/java/package/config/StaticResourcesWebConfigurerTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/StaticResourcesWebConfigurerTest.java.ejs
@@ -1,0 +1,98 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>.config;
+
+import io.github.jhipster.config.JHipsterDefaults;
+import io.github.jhipster.config.JHipsterProperties;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.CacheControl;
+import org.springframework.mock.web.MockServletContext;
+import org.springframework.web.context.WebApplicationContext;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistration;
+import org.springframework.web.servlet.config.annotation.ResourceHandlerRegistry;
+
+import java.util.concurrent.TimeUnit;
+
+import static <%= packageName %>.config.StaticResourcesWebConfiguration.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.*;
+
+public class StaticResourcesWebConfigurerTest {
+    public static final int MAX_AGE_TEST = 5;
+    public StaticResourcesWebConfiguration staticResourcesWebConfiguration;
+    private ResourceHandlerRegistry resourceHandlerRegistry;
+    private MockServletContext servletContext;
+    private WebApplicationContext applicationContext;
+    private JHipsterProperties props;
+
+    @BeforeEach
+    void setUp() {
+        servletContext = spy(new MockServletContext());
+        applicationContext = mock(WebApplicationContext.class);
+        resourceHandlerRegistry = spy(new ResourceHandlerRegistry(applicationContext, servletContext));
+        props = new JHipsterProperties();
+        staticResourcesWebConfiguration = spy(new StaticResourcesWebConfiguration(props));
+    }
+
+    @Test
+    public void shouldAppendResourceHandlerAndInitiliazeIt() {
+
+        staticResourcesWebConfiguration.addResourceHandlers(resourceHandlerRegistry);
+
+        verify(resourceHandlerRegistry, times(1))
+            .addResourceHandler(RESOURCE_PATHS);
+        verify(staticResourcesWebConfiguration, times(1))
+            .initializeResourceHandler(any(ResourceHandlerRegistration.class));
+        for (String testingPath : RESOURCE_PATHS) {
+            assertThat(resourceHandlerRegistry.hasMappingForPattern(testingPath)).isTrue();
+        }
+    }
+
+    @Test
+    public void shouldInitializeResourceHandlerWithCacheControlAndLocations() {
+        CacheControl ccExpected = CacheControl.maxAge(5, TimeUnit.DAYS).cachePublic();
+        when(staticResourcesWebConfiguration.getCacheControl()).thenReturn(ccExpected);
+        ResourceHandlerRegistration resourceHandlerRegistration = spy(new ResourceHandlerRegistration(RESOURCE_PATHS));
+
+        staticResourcesWebConfiguration.initializeResourceHandler(resourceHandlerRegistration);
+
+        verify(staticResourcesWebConfiguration, times(1)).getCacheControl();
+        verify(resourceHandlerRegistration, times(1)).setCacheControl(ccExpected);
+        verify(resourceHandlerRegistration, times(1)).addResourceLocations(RESOURCE_LOCATIONS);
+    }
+
+
+    @Test
+    public void shoudCreateCacheControlBasedOnJhipsterDefaultProperties() {
+        CacheControl cacheExpected = CacheControl.maxAge(JHipsterDefaults.Http.Cache.timeToLiveInDays, TimeUnit.DAYS).cachePublic();
+        assertThat(staticResourcesWebConfiguration.getCacheControl())
+            .extracting(CacheControl::getHeaderValue)
+            .isEqualTo(cacheExpected.getHeaderValue());
+    }
+
+    @Test
+    public void shoudCreateCacheControlWithSpecificConfigurationInProperties() {
+        props.getHttp().getCache().setTimeToLiveInDays(MAX_AGE_TEST);
+        CacheControl cacheExpected = CacheControl.maxAge(MAX_AGE_TEST, TimeUnit.DAYS).cachePublic();
+        assertThat(staticResourcesWebConfiguration.getCacheControl())
+            .extracting(CacheControl::getHeaderValue)
+            .isEqualTo(cacheExpected.getHeaderValue());
+    }
+}

--- a/generators/server/templates/src/test/java/package/config/WebConfigurerTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/WebConfigurerTest.java.ejs
@@ -86,9 +86,7 @@ public class WebConfigurerTest {
         env.setActiveProfiles(JHipsterConstants.SPRING_PROFILE_PRODUCTION);
         webConfigurer.onStartup(servletContext);
 
-        <%_ if (!skipClient) { _%>
-        verify(servletContext).addFilter(eq("cachingHttpHeadersFilter"), any(CachingHttpHeadersFilter.class));
-        <%_ } _%>
+
         <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
         verify(servletContext, never()).addServlet(eq("H2Console"), any(WebServlet.class));
         <%_ } _%>
@@ -99,9 +97,7 @@ public class WebConfigurerTest {
         env.setActiveProfiles(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT);
         webConfigurer.onStartup(servletContext);
 
-        <%_ if (!skipClient) { _%>
-        verify(servletContext, never()).addFilter(eq("cachingHttpHeadersFilter"), any(CachingHttpHeadersFilter.class));
-        <%_ } _%>
+
         <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
         verify(servletContext).addServlet(eq("H2Console"), any(WebServlet.class));
         <%_ } _%>


### PR DESCRIPTION
Fix #11575 
Removing the usage of CachingHttpHeadersFilter for "/i18n/** ", "/content/** ", "/app/** " paths

I replace it by the usage of ResourceHandler  Configured in a specific WebConfigurer

Headers "Cache-Control","Pragma","Expires" put by CachingHttpHeadersFilter are overwriting by The ResourceHttpRequestHandler


-   Please make sure the below checklist is followed for Pull Requests.

-   [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
