### PR TITLE
Change this.error() to throw error

### DIFF
--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -136,7 +136,7 @@ function askForUpdate() {
     this.prompt(prompts).then(props => {
         context.updateEntity = props.updateEntity;
         if (context.updateEntity === 'none') {
-            this.env.error(chalk.green('Aborting entity update, no changes were made.'));
+            this.error(chalk.green('Aborting entity update, no changes were made.'));
         }
         done();
     });

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -104,7 +104,7 @@ module.exports = class extends BaseGenerator {
                     // Verify if the blueprints has been registered.
                     const missing = namespaces.filter(namespace => !this.env.isPackageRegistered(namespace));
                     if (missing && missing.length > 0) {
-                        this.env.error(`Some blueprints were not found ${missing}, you should install them manually`);
+                        this.error(`Some blueprints were not found ${missing}, you should install them manually`);
                     }
                 }
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1547,8 +1547,7 @@ module.exports = class extends PrivateBase {
         if (this._debug && this._debug.enabled) {
             this._debug(`${chalk.red.bold('ERROR!')} ${msg}`);
         }
-        // Terminate current environment.
-        this.env.error(`${msg}`);
+        throw new Error(`${msg}`);
     }
 
     /**


### PR DESCRIPTION
This shouldn't have any behaviour changes.

Current implementation: 
```
this.env.error(`${msg}`);
```
Only generates a new error and emit the event on the environment.
https://github.com/yeoman/environment/blob/d8c706f3f2760d03b033d4c2ae393a894ce74389/lib/environment.js#L242-L250

According to https://nodejs.org/api/events.html#events_error_events.
There are 2 behaviours:
1 - When there isn't any error listener, the error is thrown.
2 - When there is an error listener, the event is emitted and the execution follows.

JHipster creates a new environment and doesn't register any error listeners.
So the behaviour is always 1.

If for some reason an error listener is registered, the execution will continue and unless a process.exit(1) is called. The error will be ignored.
See yo:
https://github.com/yeoman/yo/blob/a0e8c515986a6b12b9f5b6e85b0a129045dfcdba/lib/cli.js#L121-L125

Since process.exit is not recommended by node.js https://nodejs.org/api/process.html#process_process_exit_code,
this PR change to always use behaviour 1.

## Reproducing:

Add `env.on('error', error => {console.log(error);});` before
https://github.com/jhipster/generator-jhipster/blob/590c208e89bca3a4c4a4fde24357ce022c58e830/cli/utils.js#L227

And run `jhipster entity $`, the stacktrace will be printed, but the process will continue.

##
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
