### PR TITLE
fix audit event repository test to not check data attributes for neo4j

### DIFF
--- a/generators/server/templates/src/test/java/package/repository/CustomAuditEventRepositoryIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/repository/CustomAuditEventRepositoryIT.java.ejs
@@ -133,8 +133,10 @@ public class CustomAuditEventRepositoryIT {
         PersistentAuditEvent persistentAuditEvent = persistentAuditEvents.get(0);
         assertThat(persistentAuditEvent.getPrincipal()).isEqualTo(event.getPrincipal());
         assertThat(persistentAuditEvent.getAuditEventType()).isEqualTo(event.getType());
+        <%_ if (databaseType !== 'neo4j') { _%>
         assertThat(persistentAuditEvent.getData()).containsKey("test-key");
         assertThat(persistentAuditEvent.getData().get("test-key")).isEqualTo("test-value");
+        <%_ } _%>
         assertThat(persistentAuditEvent.getAuditEventDate().truncatedTo(ChronoUnit.MILLIS))
             .isEqualTo(event.getTimestamp().truncatedTo(ChronoUnit.MILLIS));
     }
@@ -154,10 +156,12 @@ public class CustomAuditEventRepositoryIT {
         PersistentAuditEvent persistentAuditEvent = persistentAuditEvents.get(0);
         assertThat(persistentAuditEvent.getPrincipal()).isEqualTo(event.getPrincipal());
         assertThat(persistentAuditEvent.getAuditEventType()).isEqualTo(event.getType());
+        <%_ if (databaseType !== 'neo4j') { _%>
         assertThat(persistentAuditEvent.getData()).containsKey("test-key");
         String actualData = persistentAuditEvent.getData().get("test-key");
         assertThat(actualData.length()).isEqualTo(EVENT_DATA_COLUMN_MAX_LENGTH);
         assertThat(actualData).isSubstringOf(largeData);
+        <%_ } _%>
         assertThat(persistentAuditEvent.getAuditEventDate().truncatedTo(ChronoUnit.MILLIS))
             .isEqualTo(event.getTimestamp().truncatedTo(ChronoUnit.MILLIS));
     }
@@ -176,9 +180,11 @@ public class CustomAuditEventRepositoryIT {
         customAuditEventRepository.add(event);
         List<PersistentAuditEvent> persistentAuditEvents = persistenceAuditEventRepository.findAll();
         assertThat(persistentAuditEvents).hasSize(1);
+        <%_ if (databaseType !== 'neo4j') { _%>
         PersistentAuditEvent persistentAuditEvent = persistentAuditEvents.get(0);
         assertThat(persistentAuditEvent.getData().get("remoteAddress")).isEqualTo("1.2.3.4");
         assertThat(persistentAuditEvent.getData().get("sessionId")).isEqualTo("test-session-id");
+        <%_ } _%>
     }
     <%_ } _%>
 
@@ -190,8 +196,10 @@ public class CustomAuditEventRepositoryIT {
         customAuditEventRepository.add(event);
         List<PersistentAuditEvent> persistentAuditEvents = persistenceAuditEventRepository.findAll();
         assertThat(persistentAuditEvents).hasSize(1);
+        <%_ if (databaseType !== 'neo4j') { _%>
         PersistentAuditEvent persistentAuditEvent = persistentAuditEvents.get(0);
         assertThat(persistentAuditEvent.getData().get("test-key")).isEqualTo("null");
+        <%_ } _%>
     }
 
     @Test


### PR DESCRIPTION
As we don't support the data map property with neo4j we should not do assertions on it.

https://github.com/hipster-labs/jhipster-daily-builds/runs/619102137?check_suite_focus=true

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
