### PR TITLE
Fix OpenApiConfiguration to not use google.guava.predicates - which i…

### DIFF
--- a/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
@@ -18,7 +18,6 @@ limitations under the License.
 -%>
 package <%= packageName %>.config;
 
-import com.google.common.base.Predicates;
 import io.github.jhipster.config.JHipsterConstants;
 import io.github.jhipster.config.JHipsterProperties;
 import io.github.jhipster.config.apidoc.customizer.SwaggerCustomizer;
@@ -47,7 +46,7 @@ public class OpenApiConfiguration {
     @Bean
     public SwaggerCustomizer noApiFirstCustomizer() {
         return docket -> docket.select()
-            .apis(Predicates.not(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api")));
+            .apis(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api").negate());
     }
 
     @Bean


### PR DESCRIPTION
…s not referred by directly anymore

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
