### PR TITLE
use git hash or build information to prefix cache keys

### DIFF
--- a/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/CacheConfiguration.java.ejs
@@ -51,9 +51,7 @@ import com.hazelcast.core.Hazelcast;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-    <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
-import org.springframework.beans.factory.annotation.Autowired;
-    <%_ } _%>
+
 <%_ } _%>
 <%_ if (cacheProvider === 'ehcache' || cacheProvider === 'caffeine') { _%>
 import org.springframework.boot.autoconfigure.cache.JCacheManagerCustomizer;
@@ -67,6 +65,7 @@ import org.springframework.boot.autoconfigure.web.ServerProperties;
     <%_ } _%>
 
 import org.springframework.cache.CacheManager;
+
 <%_ } _%>
 <%_ if (cacheProvider === 'memcached') { _%>
     <%_ if (!skipUserManagement || (authenticationType === 'oauth2' && databaseType !== 'no')) { _%>
@@ -78,6 +77,13 @@ import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.cache.CacheManager;
+<%_ } _%>
+<%_ if (cacheProvider !== 'no') { _%>
+import org.springframework.boot.info.BuildProperties;
+import org.springframework.boot.info.GitProperties;
+import org.springframework.cache.interceptor.KeyGenerator;
+import org.springframework.beans.factory.annotation.Autowired;
+import io.github.jhipster.config.cache.PrefixedKeyGenerator;
 <%_ } _%>
 import org.springframework.cache.annotation.EnableCaching;
 <%_ if (cacheProvider !== 'memcached') { _%>
@@ -115,7 +121,6 @@ import org.infinispan.transaction.TransactionMode;
 import org.springframework.boot.autoconfigure.orm.jpa.HibernatePropertiesCustomizer;
 import java.util.stream.Stream;
     <%_ if (serviceDiscoveryType === 'eureka' || serviceDiscoveryType === 'consul') { _%>
-import org.springframework.beans.factory.annotation.Autowired;
 import org.infinispan.remoting.transport.jgroups.JGroupsTransport;
 import org.jgroups.Channel;
 import org.jgroups.JChannel;
@@ -167,8 +172,11 @@ import io.github.jhipster.config.JHipsterProperties;
 @Configuration
 @EnableCaching
 public class CacheConfiguration {
+    <%_ if (cacheProvider !== 'no') { _%>
+    private GitProperties gitProperties;
+    private BuildProperties buildProperties;
+    <%_ } _%>
     <%_ if (cacheProvider === 'ehcache' || cacheProvider === 'caffeine') { _%>
-
     private final javax.cache.configuration.Configuration<Object, Object> jcacheConfiguration;
 
     public CacheConfiguration(JHipsterProperties jHipsterProperties) {
@@ -763,5 +771,21 @@ public class CacheConfiguration {
         }
     }
 
+    <%_ } _%>
+    <%_ if (cacheProvider !== 'no') { _%>
+    @Autowired(required = false)
+    public void setGitProperties(GitProperties gitProperties) {
+        this.gitProperties = gitProperties;
+    }
+
+    @Autowired(required = false)
+    public void setBuildProperties(BuildProperties buildProperties) {
+        this.buildProperties = buildProperties;
+    }
+
+    @Bean
+    public KeyGenerator keyGenerator() {
+        return new PrefixedKeyGenerator(this.gitProperties, this.buildProperties);
+    }
     <%_ } _%>
 }


### PR DESCRIPTION
Finally I found some time to integrate the custom prefixed cash key implementation. For details how keys for spring cache abstractions are generated look at the implementation in the jhipster lib.

https://github.com/jhipster/jhipster/pull/618

closes #9822

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
