### PR TITLE
Update Generator Node Version to 12.16.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
         "inquirer": "6.3.1"
     },
     "engines": {
-        "node": ">=8.10.0",
-        "npm": ">=5.6.0"
+        "node": ">=12.16.1",
+        "npm": ">=6.13.4"
     },
     "license": "Apache-2.0",
     "collective": {


### PR DESCRIPTION
This updates the generator node version to 12.16.1 along with respective npm version.

Fixes: #11650

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
