### PR TITLE
Revert lint-stage library back to 8.2.1

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -116,7 +116,7 @@
     "jest-sonar-reporter": "2.0.0",
     <%_ if (!skipCommitHook) { _%>
     <%# Not using the latest version because of https://github.com/jhipster/generator-jhipster/issues/10312 -%>
-    "lint-staged": "10.1.7",
+    "lint-staged": "8.2.1",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.21",


### PR DESCRIPTION
This is due to https://github.com/jhipster/generator-jhipster/issues/10312 as pointed out by @murdos in https://github.com/jhipster/generator-jhipster/pull/11655#discussion_r416858719

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
