### PR TITLE
support reactive neo4j within entity server generator

### DIFF
--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -207,7 +207,8 @@ const serverFiles = {
         },
         {
             condition: generator =>
-                (!generator.reactive || !['mongodb', 'cassandra', 'couchbase'].includes(generator.databaseType)) && !generator.embedded,
+                (!generator.reactive || !['mongodb', 'cassandra', 'couchbase', 'neo4j'].includes(generator.databaseType)) &&
+                !generator.embedded,
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {
@@ -218,7 +219,9 @@ const serverFiles = {
         },
         {
             condition: generator =>
-                generator.reactive && ['mongodb', 'cassandra', 'couchbase'].includes(generator.databaseType) && !generator.embedded,
+                generator.reactive &&
+                ['mongodb', 'cassandra', 'couchbase', 'neo4j'].includes(generator.databaseType) &&
+                !generator.embedded,
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {
@@ -333,8 +336,7 @@ const serverFiles = {
         },
         {
             condition: generator =>
-                generator.dto === 'mapstruct' &&
-                (generator.databaseType === 'sql' || generator.databaseType === 'mongodb' || generator.databaseType === 'couchbase'),
+                generator.dto === 'mapstruct' && ['sql', 'mongodb', 'couchbase', 'neo4j'].includes(generator.databaseType),
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -652,7 +652,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 storageData.databaseType = context.databaseType;
                 storageData.readOnly = context.readOnly;
                 this.copyFilteringFlag(context, storageData, context);
-                if (['sql', 'mongodb', 'couchbase'].includes(context.databaseType)) {
+                if (['sql', 'mongodb', 'couchbase', 'neo4j'].includes(context.databaseType)) {
                     storageData.pagination = context.pagination;
                 } else {
                     storageData.pagination = 'no';
@@ -711,7 +711,8 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     context.clientRootFolder ? `${context.clientRootFolder}-${context.entityStateName}` : context.entityStateName
                 );
                 context.jhiTablePrefix = this.getTableName(context.jhiPrefix);
-                context.reactiveRepositories = context.reactive && ['mongodb', 'cassandra', 'couchbase'].includes(context.databaseType);
+                context.reactiveRepositories =
+                    context.reactive && ['mongodb', 'cassandra', 'couchbase', 'neo4j'].includes(context.databaseType);
 
                 context.fieldsContainDate = false;
                 context.fieldsContainInstant = false;


### PR DESCRIPTION
This PR adds reactive neo4j support to the entity server generator.

See https://github.com/hipster-labs/jhipster-daily-builds/runs/628447494?check_suite_focus=true for the failing builds. 

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
