### PR TITLE
Revert "Fix OpenApiConfiguration to not use google.guava.predicates - which i…"

### DIFF
--- a/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/OpenApiConfiguration.java.ejs
@@ -18,6 +18,7 @@ limitations under the License.
 -%>
 package <%= packageName %>.config;
 
+import com.google.common.base.Predicates;
 import io.github.jhipster.config.JHipsterConstants;
 import io.github.jhipster.config.JHipsterProperties;
 import io.github.jhipster.config.apidoc.customizer.SwaggerCustomizer;
@@ -46,7 +47,7 @@ public class OpenApiConfiguration {
     @Bean
     public SwaggerCustomizer noApiFirstCustomizer() {
         return docket -> docket.select()
-            .apis(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api").negate());
+            .apis(Predicates.not(RequestHandlerSelectors.basePackage("<%= packageName %>.web.api")));
     }
 
     @Bean


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#11646

SpringFox 2.9.x has a mixture of java predicates and guava predicates. 