### PR TITLE
Downgrade node version to 10.20.1 in both templates and generator

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -23,7 +23,7 @@ const packagejs = require('../package.json');
 const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
 
 // Version of Node, Yarn, NPM
-const NODE_VERSION = '12.16.1';
+const NODE_VERSION = '10.20.1';
 const YARN_VERSION = '1.22.4';
 const NPM_VERSION = '6.14.4';
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -23,7 +23,7 @@ const packagejs = require('../package.json');
 const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
 
 // Version of Node, Yarn, NPM
-const NODE_VERSION = '10.20.1';
+const NODE_VERSION = '12.16.1';
 const YARN_VERSION = '1.22.4';
 const NPM_VERSION = '6.14.4';
 

--- a/package.json
+++ b/package.json
@@ -105,8 +105,8 @@
         "inquirer": "6.3.1"
     },
     "engines": {
-        "node": ">=12.16.1",
-        "npm": ">=6.13.4"
+        "node": ">=10.20.1",
+        "npm": ">=6.14.4"
     },
     "license": "Apache-2.0",
     "collective": {


### PR DESCRIPTION
This sets the template and generator node engine version to >=10.20.1

Related to https://github.com/jhipster/generator-jhipster/pull/11656

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
