### PR TITLE
support neo4j via graphene addon

### DIFF
--- a/generators/heroku/USAGE
+++ b/generators/heroku/USAGE
@@ -7,5 +7,5 @@ Example:
 
     This will create:
         Procfile
-        src/main/java/your_package_name/config/HerokuDatabaseConfiguration.java
+        application-heroku.yml
         gradle/heroku.gradle

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -75,6 +75,7 @@ module.exports = class extends BaseGenerator {
         this.angularAppName = this.getAngularAppName();
         this.buildTool = configuration.get('buildTool');
         this.applicationType = configuration.get('applicationType');
+        this.reactive = configuration.get('reactive') || false;
         this.serviceDiscoveryType = configuration.get('serviceDiscoveryType');
         this.herokuAppName = configuration.get('herokuAppName');
         this.dynoSize = 'Free';
@@ -369,6 +370,15 @@ module.exports = class extends BaseGenerator {
                     );
                 }
 
+                if (this.prodDatabaseType === 'neo4j' && this.reactive) {
+                    this.log(
+                        chalk.red(
+                            'The reactive Neo4j driver requires Neo4j >= 4. The Graphene addon does not support this database version (yet).'
+                        )
+                    );
+                    done();
+                }
+
                 let dbAddOn = '';
                 if (this.prodDatabaseType === 'postgresql') {
                     dbAddOn = 'heroku-postgresql --as DATABASE';
@@ -378,6 +388,8 @@ module.exports = class extends BaseGenerator {
                     dbAddOn = 'jawsdb-maria:kitefin --as DATABASE';
                 } else if (this.prodDatabaseType === 'mongodb') {
                     dbAddOn = 'mongolab:sandbox --as MONGODB';
+                } else if (this.prodDatabaseType === 'neo4j') {
+                    dbAddOn = 'graphenedb:dev-free --as GRAPHENEDB';
                 } else {
                     done();
                     return;

--- a/generators/heroku/templates/application-heroku.yml.ejs
+++ b/generators/heroku/templates/application-heroku.yml.ejs
@@ -41,6 +41,18 @@ eureka:
             defaultZone: ${JHIPSTER_REGISTRY_URL}/eureka/
 <%_ } _%>
 
+<%_ if (prodDatabaseType === 'neo4j') { _%> 
+org:
+    neo4j:
+      driver:
+        uri: ${GRAPHENEDB_BOLT_URL}
+        authentication:
+            username: ${GRAPHENEDB_BOLT_USER}
+            password: ${GRAPHENEDB_BOLT_PASSWORD}
+        config:
+            encrypted: true
+<%_ } _%>
+
 spring:
 <%_ if (prodDatabaseType === 'postgresql' || prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb') { _%>
     datasource:


### PR DESCRIPTION
The dev plan is quite slow, but the app starts. Right now only neo 3.5 is supported, therefore we don't allow to deploy a reactive/webflux application in that case.

For details https://elements.heroku.com/addons/graphenedb 

closes #11693

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
