### PR TITLE
support different java versions when deploying to heroku

### DIFF
--- a/generators/heroku/USAGE
+++ b/generators/heroku/USAGE
@@ -7,5 +7,6 @@ Example:
 
     This will create:
         Procfile
+        system.properties
         application-heroku.yml
         gradle/heroku.gradle

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -80,6 +80,7 @@ module.exports = class extends BaseGenerator {
         this.herokuAppName = configuration.get('herokuAppName');
         this.dynoSize = 'Free';
         this.herokuDeployType = configuration.get('herokuDeployType');
+        this.herokuJavaVersion = configuration.get('herokuJavaVersion');
     }
 
     get prompting() {
@@ -163,6 +164,47 @@ module.exports = class extends BaseGenerator {
 
                 this.prompt(prompts).then(props => {
                     this.herokuDeployType = props.herokuDeployType;
+                    done();
+                });
+            },
+
+            askForHerokuJavaVersion() {
+                if (this.abort) return;
+                if (this.herokuJavaVersion) return;
+                const done = this.async();
+                const prompts = [
+                    {
+                        type: 'list',
+                        name: 'herokuJavaVersion',
+                        message: 'Which Java version would you like to use to build and run your app ?',
+                        choices: [
+                            {
+                                value: '1.8',
+                                name: '1.8',
+                            },
+                            {
+                                value: '11',
+                                name: '11',
+                            },
+                            {
+                                value: '12',
+                                name: '12',
+                            },
+                            {
+                                value: '13',
+                                name: '13',
+                            },
+                            {
+                                value: '14',
+                                name: '14',
+                            },
+                        ],
+                        default: 1,
+                    },
+                ];
+
+                this.prompt(prompts).then(props => {
+                    this.herokuJavaVersion = props.herokuJavaVersion;
                     done();
                 });
             },
@@ -460,6 +502,7 @@ module.exports = class extends BaseGenerator {
                 this.template('bootstrap-heroku.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}/config/bootstrap-heroku.yml`);
                 this.template('application-heroku.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}/config/application-heroku.yml`);
                 this.template('Procfile.ejs', 'Procfile');
+                this.template('system.properties.ejs', 'system.properties');
                 if (this.buildTool === 'gradle') {
                     this.template('heroku.gradle.ejs', 'gradle/heroku.gradle');
                 }

--- a/generators/heroku/templates/system.properties.ejs
+++ b/generators/heroku/templates/system.properties.ejs
@@ -1,0 +1,1 @@
+java.runtime.version=<%= herokuJavaVersion %> 


### PR DESCRIPTION
This PR adds a new prompt, which asks which java version to use for building and running the application.

See https://devcenter.heroku.com/articles/java-support#specifying-a-java-version for details

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
