### PR TITLE
prevent potential log forging

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/AccountResource.java.ejs
@@ -445,7 +445,7 @@ public class AccountResource {
         } else {
             // Pretend the request has been successful to prevent checking which emails really exist
             // but log that an invalid attempt has been made
-            log.warn("Password reset requested for non existing mail '{}'", mail);
+            log.warn("Password reset requested for non existing mail");
         }
     <%_ } else { _%>
     public Mono<Void> requestPasswordReset(@RequestBody String mail) {
@@ -456,7 +456,7 @@ public class AccountResource {
                 } else {
                     // Pretend the request has been successful to prevent checking which emails really exist
                     // but log that an invalid attempt has been made
-                    log.warn("Password reset requested for non existing mail '{}'", mail);
+                    log.warn("Password reset requested for non existing mail");
                 }
             })
             .then();


### PR DESCRIPTION
Usually our UI prevents sending forged data, but in case someone uses the api directly we write a user provided text to our logs. This may be used to forge log statements.

As it is not relevant which non existing email was used (e.g. detect bruce force attacks or so) I just removed the mail from the log statement instead of escaping it as it is not worth the effort I would say.

* https://sonarcloud.io/project/issues?id=jhipster-sample-application&open=AXB4zsKh1I-_jbRftkUh&resolved=false&types=VULNERABILITY
* https://owasp.org/www-community/attacks/Log_Injection
* https://www.baeldung.com/jvm-log-forging

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
