### PR TITLE
support okta as oicd provider when deploying to heroku

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -366,7 +366,7 @@ module.exports = class extends BaseGenerator {
                 const regionParams = this.herokuRegion !== 'us' ? ` --region ${this.herokuRegion}` : '';
 
                 this.log(chalk.bold('\nCreating Heroku application and setting up node environment'));
-                const child = exec(`heroku create ${this.herokuAppName}${regionParams}`, (err, stdout, stderr) => {
+                const child = ChildProcess.exec(`heroku create ${this.herokuAppName}${regionParams}`, (err, stdout, stderr) => {
                     if (err) {
                         if (stderr.includes('is already taken')) {
                             const prompts = [
@@ -405,7 +405,7 @@ module.exports = class extends BaseGenerator {
                                         done();
                                     });
                                 } else {
-                                    exec(`heroku create ${regionParams}`, (err, stdout, stderr) => {
+                                    ChildProcess.exec(`heroku create ${regionParams}`, (err, stdout, stderr) => {
                                         if (err) {
                                             this.abort = true;
                                             this.log.error(err);
@@ -493,7 +493,7 @@ module.exports = class extends BaseGenerator {
                 }
 
                 if (this.useOkta) {
-                    exec(`heroku addons:create okta --app ${this.herokuAppName}`, (err, stdout, stderr) => {
+                    ChildProcess.exec(`heroku addons:create okta --app ${this.herokuAppName}`, (err, stdout, stderr) => {
                         addonCreateCallback('Okta', err, stdout, stderr);
                     });
                 }

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -330,12 +330,9 @@ module.exports = class extends BaseGenerator {
                 const done = this.async();
 
                 const regionParams = this.herokuRegion !== 'us' ? ` --region ${this.herokuRegion}` : '';
-                let buildPackParams = ' --buildpack heroku/jvm';
-                if (this.buildTool === 'gradle') {
-                    buildPackParams = ' --buildpack heroku/gradle';
-                }
+
                 this.log(chalk.bold('\nCreating Heroku application and setting up node environment'));
-                const child = exec(`heroku create ${this.herokuAppName}${regionParams}${buildPackParams}`, (err, stdout, stderr) => {
+                const child = exec(`heroku create ${this.herokuAppName}${regionParams}`, (err, stdout, stderr) => {
                     if (err) {
                         if (stderr.includes('is already taken')) {
                             const prompts = [
@@ -374,7 +371,7 @@ module.exports = class extends BaseGenerator {
                                         done();
                                     });
                                 } else {
-                                    exec(`heroku create ${regionParams}${buildPackParams}`, (err, stdout, stderr) => {
+                                    exec(`heroku create ${regionParams}`, (err, stdout, stderr) => {
                                         if (err) {
                                             this.abort = true;
                                             this.log.error(err);

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -732,29 +732,41 @@ module.exports = class extends BaseGenerator {
                             let curlAvailable = false;
                             let jqAvailable = false;
                             try {
-                                await execCmd("curl --help")
+                                await execCmd('curl --help');
                                 curlAvailable = true;
                             } catch (err) {
-                                this.log(chalk.red("cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance."));
-                                this.log(chalk.yellow("After you have installed curl execute ./provision-okta-addon.sh manually."));
+                                this.log(
+                                    chalk.red(
+                                        'cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance.'
+                                    )
+                                );
+                                this.log(chalk.yellow('After you have installed curl execute ./provision-okta-addon.sh manually.'));
                             }
                             try {
-                                await execCmd("jq --help");
+                                await execCmd('jq --help');
                                 jqAvailable = true;
                             } catch (err) {
-                                this.log(chalk.red("jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance."));
-                                this.log(chalk.yellow("After you have installed jq execute ./provision-okta-addon.sh manually."));
+                                this.log(
+                                    chalk.red(
+                                        'jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance.'
+                                    )
+                                );
+                                this.log(chalk.yellow('After you have installed jq execute ./provision-okta-addon.sh manually.'));
                             }
                             if (curlAvailable && jqAvailable) {
                                 this.log(
-                                    chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.')
+                                    chalk.green(
+                                        'Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.'
+                                    )
                                 );
                                 try {
                                     await execCmd('./provision-okta-addon.sh');
                                 } catch (err) {
                                     this.log(
-                                        chalk.red("Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.")
-                                    )
+                                        chalk.red(
+                                            'Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.'
+                                        )
+                                    );
                                 }
                             }
                         }
@@ -799,29 +811,41 @@ module.exports = class extends BaseGenerator {
                             let curlAvailable = false;
                             let jqAvailable = false;
                             try {
-                                await execCmd("curl --help")
+                                await execCmd('curl --help');
                                 curlAvailable = true;
                             } catch (err) {
-                                this.log(chalk.red("cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance."));
-                                this.log(chalk.yellow("After you have installed curl execute ./provision-okta-addon.sh manually."));
+                                this.log(
+                                    chalk.red(
+                                        'cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance.'
+                                    )
+                                );
+                                this.log(chalk.yellow('After you have installed curl execute ./provision-okta-addon.sh manually.'));
                             }
                             try {
-                                await execCmd("jq --help");
+                                await execCmd('jq --help');
                                 jqAvailable = true;
                             } catch (err) {
-                                this.log(chalk.red("jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance."));
-                                this.log(chalk.yellow("After you have installed jq execute ./provision-okta-addon.sh manually."));
+                                this.log(
+                                    chalk.red(
+                                        'jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance.'
+                                    )
+                                );
+                                this.log(chalk.yellow('After you have installed jq execute ./provision-okta-addon.sh manually.'));
                             }
                             if (curlAvailable && jqAvailable) {
                                 this.log(
-                                    chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.')
+                                    chalk.green(
+                                        'Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.'
+                                    )
                                 );
                                 try {
                                     await execCmd('./provision-okta-addon.sh');
                                 } catch (err) {
                                     this.log(
-                                        chalk.red("Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.")
-                                    )
+                                        chalk.red(
+                                            'Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.'
+                                        )
+                                    );
                                 }
                             }
                         }

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -671,20 +671,11 @@ module.exports = class extends BaseGenerator {
                 }
 
                 if (this.herokuDeployType === 'git') {
-                    const gitAddCmd = 'git add .';
-                    const gitCommitCmd = 'git commit -m "Deploy to Heroku" --allow-empty';
-
-                    let buildpack = 'heroku/java';
-                    let configVars = 'MAVEN_CUSTOM_OPTS="-Pprod,heroku -DskipTests" ';
-                    if (this.buildTool === 'gradle') {
-                        buildpack = 'heroku/gradle';
-                        configVars = 'GRADLE_TASK="stage -Pprod -PnodeInstall" ';
-                    }
-
-                    this.log(chalk.bold('\nUpdating Git repository'));
-                    this.log(chalk.cyan(gitAddCmd));
-
                     try {
+                        this.log(chalk.bold('\nUpdating Git repository'));
+                        const gitAddCmd = 'git add .';
+                        this.log(chalk.cyan(gitAddCmd));
+    
                         const gitAdd = execCmd(gitAddCmd);
                         gitAdd.child.stdout.on('data', data => {
                             this.log(data);
@@ -694,7 +685,8 @@ module.exports = class extends BaseGenerator {
                             this.log(data);
                         });
                         await gitAdd;
-
+                        
+                        const gitCommitCmd = 'git commit -m "Deploy to Heroku" --allow-empty';
                         this.log(chalk.cyan(gitCommitCmd));
 
                         const gitCommit = execCmd(gitCommitCmd);
@@ -706,6 +698,14 @@ module.exports = class extends BaseGenerator {
                             this.log(data);
                         });
                         await gitCommit;
+
+
+                        let buildpack = 'heroku/java';
+                        let configVars = 'MAVEN_CUSTOM_OPTS="-Pprod,heroku -DskipTests" ';
+                        if (this.buildTool === 'gradle') {
+                            buildpack = 'heroku/gradle';
+                            configVars = 'GRADLE_TASK="stage -Pprod -PnodeInstall" ';
+                        }
 
                         this.log(chalk.bold('\nConfiguring Heroku'));
                         await execCmd(`heroku config:set ${configVars}--app ${this.herokuAppName}`);
@@ -736,7 +736,6 @@ module.exports = class extends BaseGenerator {
                             await execCmd('./provision-okta-addon.sh');
                         }
                     } catch (err) {
-                        this.abort = true;
                         this.log.error(err);
                     }
                 } else {
@@ -784,7 +783,6 @@ module.exports = class extends BaseGenerator {
                             }
                         }
                     } catch (err) {
-                        this.abort = true;
                         this.log.error(err);
                     }
                 }

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -549,7 +549,7 @@ module.exports = class extends BaseGenerator {
                 if (this.buildTool === 'gradle') {
                     this.template('heroku.gradle.ejs', 'gradle/heroku.gradle');
                 }
-                this.template('provision-okta-addson.sh.ejs', 'provision-okta-addon.sh');
+                this.template('provision-okta-addon.sh.ejs', 'provision-okta-addon.sh');
 
                 this.conflicter.resolve(err => {
                     done();

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -675,7 +675,7 @@ module.exports = class extends BaseGenerator {
                         this.log(chalk.bold('\nUpdating Git repository'));
                         const gitAddCmd = 'git add .';
                         this.log(chalk.cyan(gitAddCmd));
-    
+
                         const gitAdd = execCmd(gitAddCmd);
                         gitAdd.child.stdout.on('data', data => {
                             this.log(data);
@@ -685,7 +685,7 @@ module.exports = class extends BaseGenerator {
                             this.log(data);
                         });
                         await gitAdd;
-                        
+
                         const gitCommitCmd = 'git commit -m "Deploy to Heroku" --allow-empty';
                         this.log(chalk.cyan(gitCommitCmd));
 
@@ -698,7 +698,6 @@ module.exports = class extends BaseGenerator {
                             this.log(data);
                         });
                         await gitCommit;
-
 
                         let buildpack = 'heroku/java';
                         let configVars = 'MAVEN_CUSTOM_OPTS="-Pprod,heroku -DskipTests" ';

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -224,15 +224,15 @@ module.exports = class extends BaseGenerator {
                         type: 'list',
                         name: 'useOkta',
                         message:
-                            'You are using oauth2. Do you want to use Okta as IAM or configure e.g. keycloak yourself? When you choose Okta the automatic setup of users and groups requires cURL and jq.',
+                            'You are using OAuth 2.0. Do you want to use Okta as your identity provider it yourself? When you choose Okta, the automated configuration of users and groups requires cURL and jq.',
                         choices: [
                             {
                                 value: true,
-                                name: 'Yes, provision the Okta addon',
+                                name: 'Yes, provision the Okta add-on',
                             },
                             {
                                 value: false,
-                                name: 'No, I want to configure the IAM manually',
+                                name: 'No, I want to configure my identity provider manually',
                             },
                         ],
                         default: 1,
@@ -265,7 +265,7 @@ module.exports = class extends BaseGenerator {
                                 return true;
                             }
 
-                            return 'Your password must be at least 8 characters long and contain a lowercase letter, and uppercase letter, a number and no parts of your username!';
+                            return 'Your password must be at least 8 characters long and contain a lowercase letter, an uppercase letter, a number, and no parts of your username!';
                         },
                     },
                 ];

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -549,6 +549,7 @@ module.exports = class extends BaseGenerator {
                 if (this.buildTool === 'gradle') {
                     this.template('heroku.gradle.ejs', 'gradle/heroku.gradle');
                 }
+                this.template('provision-okta-addson.sh.ejs', 'provision-okta-addon.sh');
 
                 this.conflicter.resolve(err => {
                     done();

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -87,6 +87,8 @@ module.exports = class extends BaseGenerator {
         this.herokuDeployType = configuration.get('herokuDeployType');
         this.herokuJavaVersion = configuration.get('herokuJavaVersion');
         this.useOkta = configuration.get('useOkta');
+        this.oktaAdminLogin = configuration.get('oktaAdminLogin')
+        this.oktaAdminPassword = configuration.get('oktaAdminPassword')
     }
 
     get prompting() {
@@ -236,10 +238,35 @@ module.exports = class extends BaseGenerator {
                         ],
                         default: 1,
                     },
+                    {
+                        type: 'input',
+                        name: 'oktaAdminLogin',
+                        message: 'Login (valid email) for the JHipster Admin user:',
+                        validate: input => {
+                            if (!input) {
+                                return 'You must enter a login for the JHipster admin'
+                            }
+                            return true;
+                        },  
+                    },
+                    {
+                        type: 'password',
+                        name: 'oktaAdminPassword',
+                        message: 'Initial password for the JHipster Admin user:',
+                        mask: true,
+                        validate: input => {
+                            if (!input) {
+                                return 'You must enter an initial password for the JHipster admin'
+                            }
+                            return true;
+                        },
+                    },
                 ];
 
                 this.prompt(prompts).then(props => {
                     this.useOkta = props.useOkta;
+                    this.oktaAdminLogin = props.oktaAdminLogin;
+                    this.oktaAdminPassword = props.oktaAdminPassword;
                     done();
                 });
             },
@@ -267,6 +294,8 @@ module.exports = class extends BaseGenerator {
                     herokuDeployType: this.herokuDeployType,
                     herokuJavaVersion: this.herokuJavaVersion,
                     useOkta: this.useOkta,
+                    oktaAdminLogin: this.oktaAdminLogin,
+                    oktaAdminPassword: this.oktaAdminPassword
                 });
             },
         };
@@ -584,6 +613,19 @@ module.exports = class extends BaseGenerator {
 
     get end() {
         return {
+            makeScriptExecutable() {
+                if (this.useOkta) {
+                    try {
+                        fs.chmodSync('provision-okta-addon.sh', '755');
+                    } catch (err) {
+                        this.log(
+                            `${chalk.yellow.bold(
+                                'WARNING!'
+                            )}Failed to make 'provision-okta-addon.sh' executable, you may need to run 'chmod +x provison-okta-addon.sh'`
+                        );
+                    }
+                }
+            },
             productionBuild() {
                 if (this.abort) return;
 

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -223,7 +223,7 @@ module.exports = class extends BaseGenerator {
                     {
                         type: 'list',
                         name: 'useOkta',
-                        message: 'You are using oauth2. Do you want to use Okta as IAM or configure e.g. keycloak yourself?',
+                        message: 'You are using oauth2. Do you want to use Okta as IAM or configure e.g. keycloak yourself? When you choose Okta the automatic setup of users and groups requires cURL and jq.',
                         choices: [
                             {
                                 value: true,

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -223,7 +223,8 @@ module.exports = class extends BaseGenerator {
                     {
                         type: 'list',
                         name: 'useOkta',
-                        message: 'You are using oauth2. Do you want to use Okta as IAM or configure e.g. keycloak yourself? When you choose Okta the automatic setup of users and groups requires cURL and jq.',
+                        message:
+                            'You are using oauth2. Do you want to use Okta as IAM or configure e.g. keycloak yourself? When you choose Okta the automatic setup of users and groups requires cURL and jq.',
                         choices: [
                             {
                                 value: true,

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -729,10 +729,34 @@ module.exports = class extends BaseGenerator {
                         this.log(chalk.yellow(`After application modification, redeploy it with\n\t${chalk.bold('jhipster heroku')}`));
 
                         if (this.useOkta) {
-                            this.log(
-                                chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster')
-                            );
-                            await execCmd('./provision-okta-addon.sh');
+                            let curlAvailable = false;
+                            let jqAvailable = false;
+                            try {
+                                await execCmd("curl --help")
+                                curlAvailable = true;
+                            } catch (err) {
+                                this.log(chalk.red("cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance."));
+                                this.log(chalk.yellow("After you have installed curl execute ./provision-okta-addon.sh manually."));
+                            }
+                            try {
+                                await execCmd("jq --help");
+                                jqAvailable = true;
+                            } catch (err) {
+                                this.log(chalk.red("jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance."));
+                                this.log(chalk.yellow("After you have installed jq execute ./provision-okta-addon.sh manually."));
+                            }
+                            if (curlAvailable && jqAvailable) {
+                                this.log(
+                                    chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.')
+                                );
+                                try {
+                                    await execCmd('./provision-okta-addon.sh');
+                                } catch (err) {
+                                    this.log(
+                                        chalk.red("Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.")
+                                    )
+                                }
+                            }
                         }
                     } catch (err) {
                         this.log.error(err);
@@ -772,13 +796,33 @@ module.exports = class extends BaseGenerator {
                         this.log(chalk.yellow(`After application modification, redeploy it with\n\t${chalk.bold('jhipster heroku')}`));
 
                         if (this.useOkta) {
-                            this.log(
-                                chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster')
-                            );
+                            let curlAvailable = false;
+                            let jqAvailable = false;
                             try {
-                                await execCmd('./provision-okta-addon.sh');
+                                await execCmd("curl --help")
+                                curlAvailable = true;
                             } catch (err) {
-                                this.log.warn(err);
+                                this.log(chalk.red("cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance."));
+                                this.log(chalk.yellow("After you have installed curl execute ./provision-okta-addon.sh manually."));
+                            }
+                            try {
+                                await execCmd("jq --help");
+                                jqAvailable = true;
+                            } catch (err) {
+                                this.log(chalk.red("jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance."));
+                                this.log(chalk.yellow("After you have installed jq execute ./provision-okta-addon.sh manually."));
+                            }
+                            if (curlAvailable && jqAvailable) {
+                                this.log(
+                                    chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.')
+                                );
+                                try {
+                                    await execCmd('./provision-okta-addon.sh');
+                                } catch (err) {
+                                    this.log(
+                                        chalk.red("Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.")
+                                    )
+                                }
                             }
                         }
                     } catch (err) {

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -150,7 +150,6 @@ module.exports = class extends BaseGenerator {
             askForHerokuDeployType() {
                 if (this.abort) return;
                 if (this.herokuDeployType) return;
-                const done = this.async();
                 const prompts = [
                     {
                         type: 'list',
@@ -170,16 +169,14 @@ module.exports = class extends BaseGenerator {
                     },
                 ];
 
-                this.prompt(prompts).then(props => {
+                return this.prompt(prompts).then(props => {
                     this.herokuDeployType = props.herokuDeployType;
-                    done();
                 });
             },
 
             askForHerokuJavaVersion() {
                 if (this.abort) return;
                 if (this.herokuJavaVersion) return;
-                const done = this.async();
                 const prompts = [
                     {
                         type: 'list',
@@ -211,16 +208,14 @@ module.exports = class extends BaseGenerator {
                     },
                 ];
 
-                this.prompt(prompts).then(props => {
+                return this.prompt(prompts).then(props => {
                     this.herokuJavaVersion = props.herokuJavaVersion;
-                    done();
                 });
             },
             askForOkta() {
                 if (this.abort) return;
                 if (this.authenticationType !== 'oauth2') return;
                 if (this.useOkta) return;
-                const done = this.async();
                 const prompts = [
                     {
                         type: 'list',
@@ -271,11 +266,10 @@ module.exports = class extends BaseGenerator {
                     },
                 ];
 
-                this.prompt(prompts).then(props => {
+                return this.prompt(prompts).then(props => {
                     this.useOkta = props.useOkta;
                     this.oktaAdminLogin = props.oktaAdminLogin;
                     this.oktaAdminPassword = props.oktaAdminPassword;
-                    done();
                 });
             },
         };

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -330,9 +330,12 @@ module.exports = class extends BaseGenerator {
                 const done = this.async();
 
                 const regionParams = this.herokuRegion !== 'us' ? ` --region ${this.herokuRegion}` : '';
-
+                let buildPackParams = ' --buildpack heroku/jvm';
+                if (this.buildTool === 'gradle') {
+                    buildPackParams = ' --buildpack heroku/gradle';
+                }
                 this.log(chalk.bold('\nCreating Heroku application and setting up node environment'));
-                const child = exec(`heroku create ${this.herokuAppName}${regionParams}`, (err, stdout, stderr) => {
+                const child = exec(`heroku create ${this.herokuAppName}${regionParams}${buildPackParams}`, (err, stdout, stderr) => {
                     if (err) {
                         if (stderr.includes('is already taken')) {
                             const prompts = [
@@ -371,7 +374,7 @@ module.exports = class extends BaseGenerator {
                                         done();
                                     });
                                 } else {
-                                    exec(`heroku create ${regionParams}`, (err, stdout, stderr) => {
+                                    exec(`heroku create ${regionParams}${buildPackParams}`, (err, stdout, stderr) => {
                                         if (err) {
                                             this.abort = true;
                                             this.log.error(err);

--- a/generators/heroku/templates/application-heroku.yml.ejs
+++ b/generators/heroku/templates/application-heroku.yml.ejs
@@ -74,3 +74,15 @@ spring:
             uri: ${BONSAI_URL}
   <%_ } _%>
 <%_ } _%>
+<%_ if (useOkta) { _%>
+    security:
+        oauth2:
+            client:
+                provider:
+                    oidc:
+                        issuer-uri: ${OKTA_OAUTH2_ISSUER}
+                registration:
+                    oidc:
+                        client-id: ${OKTA_OAUTH2_CLIENT_ID_WEB}
+                        client-secret: ${OKTA_OAUTH2_CLIENT_SECRET_WEB}
+<%_ } _%>

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -112,6 +112,7 @@ add_admin_user() {
     GROUP_ID=$(curl --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
         --header "Authorization: SSWS ${2}" | jq '.[0].id')
 
+    # Create user with provided initial password
     USER_ID=$(curl --location --request POST "${1}/api/v1/users?activate=true" \
         --header "Accept: application/json" \
         --header "Content-Type: application/json" \
@@ -130,6 +131,13 @@ add_admin_user() {
         }' | jq '.id')
 
     curl --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw ''
+
+    # directly expire the password such that the user is forced to select a new password
+    curl --location --request POST "${1}/api/v1/users/${USER_ID//\"/}/lifecycle/expire_password" \
+        --header "Content-Type: application/json" \
+        --header "Accept: application/json" \
         --header "Authorization: SSWS ${2}" \
         --data-raw ''
 }

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -1,0 +1,116 @@
+#! /usr/bin/env bash
+# abort on nonzero exitstatus
+set -o errexit
+# abort on unbound variable
+set -o nounset
+# don't hide errors within pipes
+set -o pipefail
+
+get_app_url() {
+    heroku info -j | jq '.app.web_url'
+}
+
+get_apps() {
+    curl -s --location --request GET "${1}/api/v1/apps" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" >apps.json
+
+    jq '.[0]' apps-sh.json >app1.json
+    jq '.[1]' apps-sh.json >app2.json
+}
+
+add_redirect_url() {
+    REDIRECT_URL="${1//\"/}login/oauth2/code/oidc"
+    jq '.settings.oauthClient.redirect_uris += ["'"${REDIRECT_URL}"'"]' app1.json >app1-mod.json
+    jq '.settings.oauthClient.redirect_uris += ["'"${REDIRECT_URL}"'"]' app2.json >app2-mod.json
+}
+
+update_apps() {
+    data=$(jq '.' app1-mod.json)
+    id=$(jq '.id' app1-mod.json)
+
+    curl -s --location --request PUT "${1}/api/v1/apps/${id//\"/}" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw "${data}"
+
+    data=$(jq '.' app2-mod.json)
+    id=$(jq '.id' app2-mod.json)
+
+    curl -s --location --request PUT "${1}/api/v1/apps/${id//\"/}" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw "${data}"
+}
+
+add_groups() {
+    curl --location --request POST "${1}/api/v1/groups" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw '{"profile":
+            {
+                "name": "ROLE_ADMIN",
+                "description": "JHipster Admin Role"
+            }
+        }'
+
+    curl --location --request POST "${1}/api/v1/groups" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw '{"profile":
+            {
+                "name": "ROLE_USER",
+                "description": "JHipster User Role"
+            }
+        }'
+}
+
+add_admin_to_group() {
+    ADMIN_EMAIL=$(heroku config:get OKTA_ADMIN_EMAIL)
+
+    GROUP_ID=$(curl --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
+        --header "Authorization: SSWS ${2}" | jq '.[0].id')
+
+    USER_ID=$(curl --location --request GET "${1}/api/v1/users?q=${ADMIN_EMAIL}" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" | jq '.[0].id')
+
+    curl --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw ''
+}
+
+main() {
+    OKTA_URL=$(heroku config:get OKTA_CLIENT_ORGURL)
+    OKTA_TOKEN=$(heroku config:get OKTA_CLIENT_TOKEN)
+
+    APP_URL=$(get_app_url)
+
+    # First add the correct redirect url to each application
+    get_apps "${OKTA_URL}" "${OKTA_TOKEN}"
+    add_redirect_url "${APP_URL}"
+    update_apps "${OKTA_URL}" "${OKTA_TOKEN}"
+
+    # Create ROLE_ADMIN and ROLE_USER groups
+    add_groups "${OKTA_URL}" "${OKTA_TOKEN}"
+
+    # Add the automatically provisioned HEROKU ADMIN to the ROLE_ADMIN group
+    add_admin_to_group "${OKTA_URL}" "${OKTA_TOKEN}"
+
+    # Add the groups claim, see https://www.jhipster.tech/security/#okta
+    # TODO
+
+    # Delete all temporary files created during this script
+    rm apps.json
+    rm app1.json
+    rm app2.json
+    rm app1-mod.json
+    rm app2-mod.json
+    rm heroku.json
+}
+
+main

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -50,7 +50,7 @@ update_apps() {
 }
 
 add_groups() {
-    curl --location --request POST "${1}/api/v1/groups" \
+    curl -s --location --request POST "${1}/api/v1/groups" \
         --header "Content-Type: application/json" \
         --header "Authorization: SSWS ${2}" \
         --data-raw '{"profile":
@@ -60,7 +60,7 @@ add_groups() {
             }
         }'
 
-    curl --location --request POST "${1}/api/v1/groups" \
+    curl -s --location --request POST "${1}/api/v1/groups" \
         --header "Content-Type: application/json" \
         --header "Authorization: SSWS ${2}" \
         --data-raw '{"profile":
@@ -74,21 +74,21 @@ add_groups() {
 add_admin_to_group() {
     ADMIN_EMAIL=$(heroku config:get OKTA_ADMIN_EMAIL)
 
-    GROUP_ID=$(curl --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
+    GROUP_ID=$(curl -s --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
         --header "Authorization: SSWS ${2}" | jq '.[0].id')
 
-    USER_ID=$(curl --location --request GET "${1}/api/v1/users?q=${ADMIN_EMAIL}" \
+    USER_ID=$(curl -s --location --request GET "${1}/api/v1/users?q=${ADMIN_EMAIL}" \
         --header "Accept: application/json" \
         --header "Content-Type: application/json" \
         --header "Authorization: SSWS ${2}" | jq '.[0].id')
 
-    curl --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
+    curl -s --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
         --header "Authorization: SSWS ${2}" \
         --data-raw ''
 }
 
 add_groups_claim() {
-    curl --location --request POST "${1}/api/v1/authorizationServers/default/claims" \
+    curl -s --location --request POST "${1}/api/v1/authorizationServers/default/claims" \
         --header "Accept: application/json" \
         --header "Content-Type: application/json" \
         --header "Authorization: SSWS ${2}" \
@@ -109,11 +109,11 @@ add_groups_claim() {
 
 add_admin_user() {
 
-    GROUP_ID=$(curl --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
+    GROUP_ID=$(curl -s --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
         --header "Authorization: SSWS ${2}" | jq '.[0].id')
 
     # Create user with provided initial password
-    USER_ID=$(curl --location --request POST "${1}/api/v1/users?activate=true" \
+    USER_ID=$(curl -s --location --request POST "${1}/api/v1/users?activate=true" \
         --header "Accept: application/json" \
         --header "Content-Type: application/json" \
         --header "Authorization: SSWS ${2}" \
@@ -130,16 +130,30 @@ add_admin_user() {
           }
         }' | jq '.id')
 
-    curl --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
+    curl -s --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
         --header "Authorization: SSWS ${2}" \
         --data-raw ''
 
     # directly expire the password such that the user is forced to select a new password
-    curl --location --request POST "${1}/api/v1/users/${USER_ID//\"/}/lifecycle/expire_password" \
+    curl -s --location --request POST "${1}/api/v1/users/${USER_ID//\"/}/lifecycle/expire_password" \
         --header "Content-Type: application/json" \
         --header "Accept: application/json" \
         --header "Authorization: SSWS ${2}" \
         --data-raw ''
+}
+
+already_done() {
+    LENGTH=$(curl -s --location --request GET "${1}/api/v1/users?q=<%= oktaAdminLogin  %>" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" | jq '. | length')
+    
+    if [ $LENGTH -gt 0 ]
+    then
+        echo "true"
+    else
+        echo "false"
+    fi
 }
 
 main() {
@@ -147,6 +161,14 @@ main() {
     OKTA_TOKEN=$(heroku config:get OKTA_CLIENT_TOKEN)
 
     APP_URL=$(get_app_url)
+
+    DONE=$(already_done ${OKTA_URL} ${OKTA_TOKEN})
+
+    if  [ ${DONE} == "true" ]
+    then
+        echo "User already created, doing nothing."
+        return 0
+    fi
 
     # First add the correct redirect url to each application
     get_apps "${OKTA_URL}" "${OKTA_TOKEN}"

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -156,7 +156,27 @@ already_done() {
     fi
 }
 
+check_required_dependencies() {
+    if hash curl 2>/dev/null;
+    then
+        echo -e "\U2714 cURL is available."
+    else
+        echo "\U1F6D1cURL is not available but required. See https://curl.haxx.se/download.html for installation guidance."
+        return 0;
+    fi
+
+    if hash jq 2>/dev/null;
+    then
+        echo -e "\U2611 jq is available.️"
+    else
+        echo -e "\U1F6D1jq is not available but required. See https://stedolan.github.io/jq/download/ for installation guidance."
+        return 0;
+    fi
+}
+
 main() {
+    check_required_dependencies
+
     OKTA_URL=$(heroku config:get OKTA_CLIENT_ORGURL)
     OKTA_TOKEN=$(heroku config:get OKTA_CLIENT_TOKEN)
 

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -16,19 +16,22 @@ get_apps() {
         --header "Content-Type: application/json" \
         --header "Authorization: SSWS ${2}" >apps.json
 
-    jq '.[0]' apps-sh.json >app1.json
-    jq '.[1]' apps-sh.json >app2.json
+    jq '.[0]' apps.json >app1.json
+    jq '.[1]' apps.json >app2.json
 }
 
 add_redirect_url() {
     REDIRECT_URL="${1//\"/}login/oauth2/code/oidc"
     jq '.settings.oauthClient.redirect_uris += ["'"${REDIRECT_URL}"'"]' app1.json >app1-mod.json
     jq '.settings.oauthClient.redirect_uris += ["'"${REDIRECT_URL}"'"]' app2.json >app2-mod.json
+
+    jq '.settings.oauthClient.post_logout_redirect_uris += ["'"${1//\"/}"'"]' app1-mod.json >app1.json
+    jq '.settings.oauthClient.post_logout_redirect_uris += ["'"${1//\"/}"'"]' app2-mod.json >app2.json
 }
 
 update_apps() {
-    data=$(jq '.' app1-mod.json)
-    id=$(jq '.id' app1-mod.json)
+    data=$(jq '.' app1.json)
+    id=$(jq '.id' app1.json)
 
     curl -s --location --request PUT "${1}/api/v1/apps/${id//\"/}" \
         --header "Accept: application/json" \
@@ -104,6 +107,33 @@ add_groups_claim() {
     }'
 }
 
+add_admin_user() {
+
+    GROUP_ID=$(curl --location --request GET "${1}/api/v1/groups?q=ROLE_ADMIN" \
+        --header "Authorization: SSWS ${2}" | jq '.[0].id')
+
+    USER_ID=$(curl --location --request POST "${1}/api/v1/users?activate=true" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw '
+        {
+          "profile": {
+            "firstName": "JHipster",
+            "lastName": "Admin",
+            "email": "<%= oktaAdminLogin  %>",
+            "login": "<%= oktaAdminLogin %>"
+          },
+          "credentials": {
+            "password" : { "value": "<%= oktaAdminPassword %>" }
+          }
+        }' | jq '.id')
+
+    curl --location --request PUT "${1}/api/v1/groups/${GROUP_ID//\"/}/users/${USER_ID//\"/}" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw ''
+}
+
 main() {
     OKTA_URL=$(heroku config:get OKTA_CLIENT_ORGURL)
     OKTA_TOKEN=$(heroku config:get OKTA_CLIENT_TOKEN)
@@ -124,13 +154,14 @@ main() {
     # Add the groups claim, see https://www.jhipster.tech/security/#okta
     add_groups_claim "${OKTA_URL}" "${OKTA_TOKEN}"
 
+    add_admin_user "${OKTA_URL}" "${OKTA_TOKEN}"
+
     # Delete all temporary files created during this script
     rm apps.json
     rm app1.json
     rm app2.json
     rm app1-mod.json
     rm app2-mod.json
-    rm heroku.json
 }
 
 main

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -84,6 +84,26 @@ add_admin_to_group() {
         --data-raw ''
 }
 
+add_groups_claim() {
+    curl --location --request POST "${1}/api/v1/authorizationServers/default/claims" \
+        --header "Accept: application/json" \
+        --header "Content-Type: application/json" \
+        --header "Authorization: SSWS ${2}" \
+        --data-raw '{
+        "name": "groups",
+        "status": "ACTIVE",
+        "claimType": "IDENTITY",
+        "valueType": "GROUPS",
+        "value": ".*",
+        "conditions": {
+            "scopes": []
+        },
+        "system": false,
+        "alwaysIncludeInToken": true,
+        "group_filter_type": "REGEX"
+    }'
+}
+
 main() {
     OKTA_URL=$(heroku config:get OKTA_CLIENT_ORGURL)
     OKTA_TOKEN=$(heroku config:get OKTA_CLIENT_TOKEN)
@@ -102,7 +122,7 @@ main() {
     add_admin_to_group "${OKTA_URL}" "${OKTA_TOKEN}"
 
     # Add the groups claim, see https://www.jhipster.tech/security/#okta
-    # TODO
+    add_groups_claim "${OKTA_URL}" "${OKTA_TOKEN}"
 
     # Delete all temporary files created during this script
     rm apps.json

--- a/generators/heroku/templates/provision-okta-addon.sh.ejs
+++ b/generators/heroku/templates/provision-okta-addon.sh.ejs
@@ -39,8 +39,8 @@ update_apps() {
         --header "Authorization: SSWS ${2}" \
         --data-raw "${data}"
 
-    data=$(jq '.' app2-mod.json)
-    id=$(jq '.id' app2-mod.json)
+    data=$(jq '.' app2.json)
+    id=$(jq '.id' app2.json)
 
     curl -s --location --request PUT "${1}/api/v1/apps/${id//\"/}" \
         --header "Accept: application/json" \

--- a/test/heroku.spec.js
+++ b/test/heroku.spec.js
@@ -53,6 +53,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuJHipsterRegistryApp: 'sushi',
                         herokuJHipsterRegistryUsername: 'admin',
                         herokuJHipsterRegistryPassword: 'changeme',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });
@@ -90,6 +92,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuRegion: 'us',
                         herokuDeployType: 'jar',
                         herokuForceName: 'No',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });
@@ -105,10 +109,11 @@ describe('JHipster Heroku Sub Generator', () => {
                 stub.withArgs(`heroku addons:create jawsdb:kitefin --as DATABASE --app ${herokuAppName}`).yields(false, '', '');
                 stub.withArgs('git add .').yields(false, '', '');
                 stub.withArgs('git commit -m "Deploy to Heroku" --allow-empty').yields(false, '', '');
-                stub.withArgs(
-                    `heroku config:set NPM_CONFIG_PRODUCTION="false" MAVEN_CUSTOM_OPTS="-Pprod,heroku -DskipTests" --app ${herokuAppName}`
-                ).yields(false, '', '');
-                stub.withArgs(`heroku buildpacks:add -i 1 heroku/nodejs --app ${herokuAppName}`).yields(false, '', '');
+                stub.withArgs(`heroku config:set MAVEN_CUSTOM_OPTS="-Pprod,heroku -DskipTests" --app ${herokuAppName}`).yields(
+                    false,
+                    '',
+                    ''
+                );
                 stub.withArgs(`heroku buildpacks:add heroku/java --app ${herokuAppName}`).yields(false, '', '');
                 stub.withArgs('git push heroku HEAD:master').yields(false, '', '');
                 helpers
@@ -120,6 +125,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuAppName,
                         herokuRegion: 'us',
                         herokuDeployType: 'git',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });
@@ -143,6 +150,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuAppName,
                         herokuRegion: 'us',
                         herokuDeployType: 'jar',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });
@@ -168,6 +177,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuAppName,
                         herokuRegion: 'eu',
                         herokuDeployType: 'jar',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });
@@ -190,6 +201,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuAppName,
                         herokuRegion: 'eu',
                         herokuDeployType: 'jar',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });
@@ -235,6 +248,8 @@ describe('JHipster Heroku Sub Generator', () => {
                         herokuAppName,
                         herokuRegion: 'us',
                         herokuDeployType: 'jar',
+                        herokuJavaVersion: '11',
+                        useOkta: false,
                     })
                     .on('end', done);
             });


### PR DESCRIPTION
I will update our heroku documentation soon to reflect the new features and also document what manual steps are required to setup accounts on the okta addon.

Furthermore this PR

* removes the node buildpack and let maven/gradle handle it (instead of doing npm install two times)
* set the jvm buildpack such that jar deployment works

closes #11698

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
