### PR TITLE
Try to load config from mem-fs so it can load current working version.

### DIFF
--- a/generators/utils.js
+++ b/generators/utils.js
@@ -594,7 +594,12 @@ function getAllJhipsterConfig(generator, force, basePath = '') {
     let configuration = generator && generator.config ? generator.config.getAll() || {} : {};
     const filePath = path.join(basePath || '', '.yo-rc.json');
     if ((force || !configuration.baseName) && jhiCore.FileUtils.doesFileExist(filePath)) {
-        const yoRc = loadYoRc(filePath);
+        let yoRc;
+        if (generator && generator.fs) {
+            yoRc = generator.fs.readJSON(filePath);
+        } else {
+            yoRc = loadYoRc(filePath);
+        }
         configuration = yoRc['generator-jhipster'];
         // merge the blueprint configs if available
         configuration.blueprints = loadBlueprintsFromConfiguration(configuration);


### PR DESCRIPTION
Fixes config synchronization with getAllJhipsterConfig.
When saving config with `this.config.set(‘foo’, ‘bar’);`
getAllJhipsterConfig will not read the updated config until next jhipster execution.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
