### PR TITLE
update login regex to be more consistent with current released one

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -84,7 +84,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
             setupClientconsts() {
                 // Make constants available in templates
-                this.LOGIN_REGEX = constants.LOGIN_REGEX;
+                this.LOGIN_REGEX = constants.LOGIN_REGEX_JS;
                 this.ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
                 this.HUSKY_VERSION = constants.HUSKY_VERSION;
                 this.LINT_STAGED_VERSION = constants.LINT_STAGED_VERSION;

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -84,6 +84,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
             setupClientconsts() {
                 // Make constants available in templates
+                this.LOGIN_REGEX = constants.LOGIN_REGEX;
                 this.ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
                 this.HUSKY_VERSION = constants.HUSKY_VERSION;
                 this.LINT_STAGED_VERSION = constants.LINT_STAGED_VERSION;

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -42,7 +42,7 @@ export class RegisterComponent implements AfterViewInit {
     success = false;
 
     registerForm = this.fb.group({
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%- LOGIN_REGEX %>')]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern(/<%- LOGIN_REGEX %>/)]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(254), Validators.email]],
         password: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]],
         confirmPassword: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]]

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -42,7 +42,7 @@ export class RegisterComponent implements AfterViewInit {
     success = false;
 
     registerForm = this.fb.group({
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%= LOGIN_REGEX %>')]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%- LOGIN_REGEX %>')]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(254), Validators.email]],
         password: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]],
         confirmPassword: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]]

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -42,7 +42,7 @@ export class RegisterComponent implements AfterViewInit {
     success = false;
 
     registerForm = this.fb.group({
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('^[a-zA-Z0-9!#$&\'*+=?^_`{|}~.-]+@?[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$')]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern("^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$")]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(254), Validators.email]],
         password: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]],
         confirmPassword: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]]

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -42,7 +42,7 @@ export class RegisterComponent implements AfterViewInit {
     success = false;
 
     registerForm = this.fb.group({
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern(/<%- LOGIN_REGEX %>/)]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern("<%- LOGIN_REGEX %>")]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(254), Validators.email]],
         password: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]],
         confirmPassword: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]]

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.component.ts.ejs
@@ -42,7 +42,7 @@ export class RegisterComponent implements AfterViewInit {
     success = false;
 
     registerForm = this.fb.group({
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern("^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$")]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%= LOGIN_REGEX %>')]],
         email: ['', [Validators.required, Validators.minLength(5), Validators.maxLength(254), Validators.email]],
         password: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]],
         confirmPassword: ['', [Validators.required, Validators.minLength(4), Validators.maxLength(50)]]

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -40,7 +40,7 @@ export class UserManagementUpdateComponent implements OnInit {
 
     editForm = this.fb.group({
         id: [],
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('^[a-zA-Z0-9!#$&\'*+=?^_`{|}~.-]+@?[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$')]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern("^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$")]],
         firstName: ['', [Validators.maxLength(50)]],
         lastName: ['', [Validators.maxLength(50)]],
         email: ['', [Validators.minLength(5), Validators.maxLength(254), Validators.email]],

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -40,7 +40,7 @@ export class UserManagementUpdateComponent implements OnInit {
 
     editForm = this.fb.group({
         id: [],
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%- LOGIN_REGEX %>')]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern(/<%- LOGIN_REGEX %>/)]],
         firstName: ['', [Validators.maxLength(50)]],
         lastName: ['', [Validators.maxLength(50)]],
         email: ['', [Validators.minLength(5), Validators.maxLength(254), Validators.email]],

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -40,7 +40,7 @@ export class UserManagementUpdateComponent implements OnInit {
 
     editForm = this.fb.group({
         id: [],
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern(/<%- LOGIN_REGEX %>/)]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern("<%- LOGIN_REGEX %>")]],
         firstName: ['', [Validators.maxLength(50)]],
         lastName: ['', [Validators.maxLength(50)]],
         email: ['', [Validators.minLength(5), Validators.maxLength(254), Validators.email]],

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -40,7 +40,7 @@ export class UserManagementUpdateComponent implements OnInit {
 
     editForm = this.fb.group({
         id: [],
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern("^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$")]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%= LOGIN_REGEX %>')]],
         firstName: ['', [Validators.maxLength(50)]],
         lastName: ['', [Validators.maxLength(50)]],
         email: ['', [Validators.minLength(5), Validators.maxLength(254), Validators.email]],

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management-update.component.ts.ejs
@@ -40,7 +40,7 @@ export class UserManagementUpdateComponent implements OnInit {
 
     editForm = this.fb.group({
         id: [],
-        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%= LOGIN_REGEX %>')]],
+        login: ['', [Validators.required, Validators.minLength(1), Validators.maxLength(50), Validators.pattern('<%- LOGIN_REGEX %>')]],
         firstName: ['', [Validators.maxLength(50)]],
         lastName: ['', [Validators.maxLength(50)]],
         email: ['', [Validators.minLength(5), Validators.maxLength(254), Validators.email]],

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -71,7 +71,7 @@ export const RegisterPage = (props: IRegisterProps) => {
               placeholder={translate('global.form.username.placeholder')}
               validate={{
                 required: { value: true, errorMessage: translate('register.messages.validate.login.required') },
-                pattern: { value: "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$", errorMessage: translate('register.messages.validate.login.pattern') },
+                pattern: { value: '<%= LOGIN_REGEX %>', errorMessage: translate('register.messages.validate.login.pattern') },
                 minLength: { value: 1, errorMessage: translate('register.messages.validate.login.minlength') },
                 maxLength: { value: 50, errorMessage: translate('register.messages.validate.login.maxlength') }
               }}

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -71,7 +71,7 @@ export const RegisterPage = (props: IRegisterProps) => {
               placeholder={translate('global.form.username.placeholder')}
               validate={{
                 required: { value: true, errorMessage: translate('register.messages.validate.login.required') },
-                pattern: { value: '^[a-zA-Z0-9!#$&\'*+=?^_`{|}~.-]+@?[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$', errorMessage: translate('register.messages.validate.login.pattern') },
+                pattern: { value: "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$", errorMessage: translate('register.messages.validate.login.pattern') },
                 minLength: { value: 1, errorMessage: translate('register.messages.validate.login.minlength') },
                 maxLength: { value: 50, errorMessage: translate('register.messages.validate.login.maxlength') }
               }}

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -71,7 +71,7 @@ export const RegisterPage = (props: IRegisterProps) => {
               placeholder={translate('global.form.username.placeholder')}
               validate={{
                 required: { value: true, errorMessage: translate('register.messages.validate.login.required') },
-                pattern: { value: '<%- LOGIN_REGEX %>', errorMessage: translate('register.messages.validate.login.pattern') },
+                pattern: { value: /<%- LOGIN_REGEX %>/, errorMessage: translate('register.messages.validate.login.pattern') },
                 minLength: { value: 1, errorMessage: translate('register.messages.validate.login.minlength') },
                 maxLength: { value: 50, errorMessage: translate('register.messages.validate.login.maxlength') }
               }}

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -71,7 +71,7 @@ export const RegisterPage = (props: IRegisterProps) => {
               placeholder={translate('global.form.username.placeholder')}
               validate={{
                 required: { value: true, errorMessage: translate('register.messages.validate.login.required') },
-                pattern: { value: '<%= LOGIN_REGEX %>', errorMessage: translate('register.messages.validate.login.pattern') },
+                pattern: { value: '<%- LOGIN_REGEX %>', errorMessage: translate('register.messages.validate.login.pattern') },
                 minLength: { value: 1, errorMessage: translate('register.messages.validate.login.minlength') },
                 maxLength: { value: 50, errorMessage: translate('register.messages.validate.login.maxlength') }
               }}

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/register/register.tsx.ejs
@@ -71,7 +71,7 @@ export const RegisterPage = (props: IRegisterProps) => {
               placeholder={translate('global.form.username.placeholder')}
               validate={{
                 required: { value: true, errorMessage: translate('register.messages.validate.login.required') },
-                pattern: { value: /<%- LOGIN_REGEX %>/, errorMessage: translate('register.messages.validate.login.pattern') },
+                pattern: { value: "<%- LOGIN_REGEX %>", errorMessage: translate('register.messages.validate.login.pattern') },
                 minLength: { value: 1, errorMessage: translate('register.messages.validate.login.minlength') },
                 maxLength: { value: 50, errorMessage: translate('register.messages.validate.login.maxlength') }
               }}

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -98,7 +98,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
                   errorMessage: translate('register.messages.validate.login.required')
                 },
                 pattern: {
-                  value: '<%- LOGIN_REGEX %>',
+                  value: /<%- LOGIN_REGEX %>/,
                   errorMessage: translate('register.messages.validate.login.pattern')
                 },
                 minLength: {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -98,7 +98,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
                   errorMessage: translate('register.messages.validate.login.required')
                 },
                 pattern: {
-                  value: /<%- LOGIN_REGEX %>/,
+                  value: "<%- LOGIN_REGEX %>",
                   errorMessage: translate('register.messages.validate.login.pattern')
                 },
                 minLength: {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -98,7 +98,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
                   errorMessage: translate('register.messages.validate.login.required')
                 },
                 pattern: {
-                  value: '<%= LOGIN_REGEX %>',
+                  value: '<%- LOGIN_REGEX %>',
                   errorMessage: translate('register.messages.validate.login.pattern')
                 },
                 minLength: {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -98,7 +98,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
                   errorMessage: translate('register.messages.validate.login.required')
                 },
                 pattern: {
-                  value: "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$",
+                  value: '<%= LOGIN_REGEX %>',
                   errorMessage: translate('register.messages.validate.login.pattern')
                 },
                 minLength: {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-update.tsx.ejs
@@ -98,7 +98,7 @@ export const UserManagementUpdate = (props: IUserManagementUpdateProps) => {
                   errorMessage: translate('register.messages.validate.login.required')
                 },
                 pattern: {
-                  value: '^[a-zA-Z0-9!#$&\'*+=?^_`{|}~.-]+@?[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$',
+                  value: "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$",
                   errorMessage: translate('register.messages.validate.login.pattern')
                 },
                 minLength: {

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -108,9 +108,8 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 // all constants used throughout all generators
 
-
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
-// JS does not support atomic groups , so we mimic it with 
+// JS does not support atomic groups , so we mimic it with
 const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*))\\1$';
 
 const MAIN_DIR = 'src/main/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -108,7 +108,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 // all constants used throughout all generators
 
-const LOGIN_REGEX = '^[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
+const LOGIN_REGEX = '^[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -109,9 +109,9 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 // all constants used throughout all generators
 
 
-const LOGIN_REGEX = '^(?>[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
+const LOGIN_REGEX = '^(?>[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
 // JS does not support atomic groups , so we mimic it with 
-const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\\\1|(?=([a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\\\\1$';
+const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\\\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\\\\1$';
 
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -110,6 +110,9 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
+// JS does not support atomic groups, so we mimic it with 
+const LOGIN_REGEX_JS = '^(?=([a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\1|(?=([_.@A-Za-z0-9-]+))\1$';
+
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -110,7 +110,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
 // JS does not support atomic groups
-const LOGIN_REGEX_JS = '^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
+const LOGIN_REGEX_JS = '^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*$|^[_.@A-Za-z0-9-]+$';
 
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -109,8 +109,8 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 // all constants used throughout all generators
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
-// JS does not support atomic groups , so we mimic it with
-const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*))\\1$';
+// JS does not support atomic groups
+const LOGIN_REGEX_JS = '^[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
 
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -111,7 +111,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
 // JS does not support atomic groups , so we mimic it with 
-const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*))\1$';
+const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*))\\1$';
 
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -108,7 +108,8 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 // all constants used throughout all generators
 
-const LOGIN_REGEX = '^[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
+
+const LOGIN_REGEX = '^(?>[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -111,7 +111,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
 // JS does not support atomic groups , so we mimic it with 
-const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\\\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\\\\1$';
+const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\1|(?=([a-zA-Z0-9!$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*))\1$';
 
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -108,6 +108,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 // all constants used throughout all generators
 
+const LOGIN_REGEX = '^[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -111,7 +111,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
 // JS does not support atomic groups , so we mimic it with 
-const LOGIN_REGEX_JS = '^(?=([a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\1|(?=([_.@A-Za-z0-9-]+))\1$';
+const LOGIN_REGEX_JS = '^(?=([_.@A-Za-z0-9-]+))\\\\1|(?=([a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\\\\1$';
 
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -110,7 +110,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 
 const LOGIN_REGEX = '^(?>[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*)|(?>[_.@A-Za-z0-9-]+)$';
-// JS does not support atomic groups, so we mimic it with 
+// JS does not support atomic groups , so we mimic it with 
 const LOGIN_REGEX_JS = '^(?=([a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\\\.[a-zA-Z0-9-]+)*))\1|(?=([_.@A-Za-z0-9-]+))\1$';
 
 const MAIN_DIR = 'src/main/';
@@ -310,6 +310,7 @@ const constants = {
     TEST_DIR,
 
     LOGIN_REGEX,
+    LOGIN_REGEX_JS,
     // supported client frameworks
     SUPPORTED_CLIENT_FRAMEWORKS,
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -108,7 +108,7 @@ const HELM_MOGODB_REPLICASET = '^3.10.1';
 
 // all constants used throughout all generators
 
-const LOGIN_REGEX = '^[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
+const LOGIN_REGEX = '^[a-zA-Z0-9!#$&*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$';
 const MAIN_DIR = 'src/main/';
 const TEST_DIR = 'src/test/';
 
@@ -305,6 +305,7 @@ const constants = {
     MAIN_DIR,
     TEST_DIR,
 
+    LOGIN_REGEX,
     // supported client frameworks
     SUPPORTED_CLIENT_FRAMEWORKS,
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -82,6 +82,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 // Make constants available in templates
                 this.MAIN_DIR = constants.MAIN_DIR;
                 this.TEST_DIR = constants.TEST_DIR;
+                this.LOGIN_REGEX = constants.LOGIN_REGEX;
                 this.CLIENT_WEBPACK_DIR = constants.CLIENT_WEBPACK_DIR;
                 this.SERVER_MAIN_SRC_DIR = constants.SERVER_MAIN_SRC_DIR;
                 this.SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;

--- a/generators/server/templates/src/main/java/package/config/Constants.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/Constants.java.ejs
@@ -25,7 +25,7 @@ public final class Constants {
 
     <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
     // Regex for acceptable logins
-    public static final String LOGIN_REGEX = "<%= LOGIN_REGEX %>";
+    public static final String LOGIN_REGEX = "<%- LOGIN_REGEX %>";
 
     <%_ } _%>
     <%_ if (!skipUserManagement || authenticationType === 'oauth2' || ['sql','mongodb','couchbase'].includes(databaseType)) { _%>

--- a/generators/server/templates/src/main/java/package/config/Constants.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/Constants.java.ejs
@@ -25,7 +25,7 @@ public final class Constants {
 
     <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
     // Regex for acceptable logins
-    public static final String LOGIN_REGEX = "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$";
+    public static final String LOGIN_REGEX = "<%= LOGIN_REGEX %>";
 
     <%_ } _%>
     <%_ if (!skipUserManagement || authenticationType === 'oauth2' || ['sql','mongodb','couchbase'].includes(databaseType)) { _%>

--- a/generators/server/templates/src/main/java/package/config/Constants.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/Constants.java.ejs
@@ -25,7 +25,7 @@ public final class Constants {
 
     <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
     // Regex for acceptable logins
-    public static final String LOGIN_REGEX = "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@?[a-zA-Z0-9-]+(?:\\.[a-zA-Z0-9-]+)*$";
+    public static final String LOGIN_REGEX = "^[a-zA-Z0-9!#$&'*+=?^_`{|}~.-]+@[a-zA-Z0-9-]+(?:\.[a-zA-Z0-9-]+)*|[_.@A-Za-z0-9-]+$";
 
     <%_ } _%>
     <%_ if (!skipUserManagement || authenticationType === 'oauth2' || ['sql','mongodb','couchbase'].includes(databaseType)) { _%>


### PR DESCRIPTION
This makes the login regex more consistent with the current released version. In particular for example:

* Released version: `foo@bar@com` -> VALID :heavy_check_mark: 
* Current master: `foo@bar@com` -> INVALID :red_circle: 
* New regex: `foo@bar@com` -> VALID :heavy_check_mark: 

closes #11726

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
