### PR TITLE
Make reactive variable available to ci/cd templates

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -93,6 +93,7 @@ module.exports = class extends BaseGenerator {
                 this.skipServer = configuration.get('skipServer');
                 this.clientPackageManager = configuration.get('clientPackageManager');
                 this.buildTool = configuration.get('buildTool');
+                this.reactive = configuration.get('reactive');
                 this.herokuAppName = configuration.get('herokuAppName');
                 if (this.herokuAppName === undefined) {
                     this.herokuAppName = _.kebabCase(this.baseName);


### PR DESCRIPTION
I just noticed we are missing the reactive variable inside the ci/cd templates.

[ci-skip]

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
