### PR TITLE
Support again hooks for linked modules

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1199,12 +1199,23 @@ module.exports = class extends PrivateBase {
      * @return {object} the composed generator
      */
     composeExternalModule(npmPackageName, subGen, options) {
-        const generatorName = jhipsterUtils.packageNameToNamespace(npmPackageName);
-        const generatorCallback = `${generatorName}:${subGen}`;
-        if (!this.env.get(generatorCallback)) {
-            throw new Error(`Generator ${generatorCallback} isn't registered.`);
+        try {
+            let generatorTocall = path.join(process.cwd(), 'node_modules', npmPackageName, 'generators', subGen);
+            if (!fs.existsSync(generatorTocall)) {
+                this.debug('using global module as local version could not be found in node_modules');
+                generatorTocall = path.join(npmPackageName, 'generators', subGen);
+            }
+            this.debug('Running yeoman compose with options: ', generatorTocall, options);
+            return this.composeWith(require.resolve(generatorTocall), options);
+        } catch (err) {
+            this.debug('ERROR:', err);
+            const generatorName = jhipsterUtils.packageNameToNamespace(npmPackageName);
+            const generatorCallback = `${generatorName}:${subGen}`;
+            if (!this.env.get(generatorCallback)) {
+                throw new Error(`Generator ${generatorCallback} isn't registered.`);
+            }
+            return this.composeWith(generatorCallback, options, true);
         }
-        return this.composeWith(generatorCallback, options, true);
     }
 
     /**


### PR DESCRIPTION
Fix #11747

Linked modules support in hooks was removed in JHipster version 6.8.0 by PR #11313 by this change: https://github.com/jhipster/generator-jhipster/commit/5ef266082822d3bb5030763f66b981d30bf1010a#diff-fddb513f7a2937b33eb1c1f6a71e64a7L1159-R1161

Some discussion about that removal can be found also in #10571 starting from https://github.com/jhipster/generator-jhipster/pull/10571#discussion_r332889618

I believe that it's important to support hooks for linked modules because:
* this simplifies module developers life
* this simplifies working with private modules

So this PR restores linked modules hooks support.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
