### PR TITLE
BugFix: Fixes logout link for protractor tests in React client

### DIFF
--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/navbar-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/navbar-page.ts.ejs
@@ -71,7 +71,7 @@ export default class NavBarPage extends BasePage {
 
   async clickOnAccountMenuItem(item: string) {
     await this.accountMenu.click();
-    await this.selector.$(`.dropdown-item[href="/account/${item}"`).click();
+    await this.selector.$(`.dropdown-item[href="/account/${item}"]`).click();
   }
 
   async clickOnAdminMenuItem(item: string) {
@@ -100,6 +100,6 @@ export default class NavBarPage extends BasePage {
 
   async autoSignOut() {
     await this.accountMenu.click();
-    await this.selector.$(`.dropdown-item[href="/logout"`).click();
+    await this.selector.$(`.dropdown-item[href="/logout"]`).click();
   }
 }


### PR DESCRIPTION
While testing OAuth2 integration with the Micronaut Generator and the end-to-end Protractor tests in the React client, I discovered that the tests were failing due to the application not properly logging out after a test.

Adding the closing `]` to the logout selector seems to have fixed the issue.