### PR TITLE
Fix toString() formatting in Java

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -575,6 +575,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         return 31;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "<%= asEntity(entityClass) %>{" +

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
@@ -162,6 +162,7 @@ public class <%= entityClass %>Criteria implements Serializable, Criteria {
         );
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "<%= entityClass %>Criteria{" +

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -262,6 +262,7 @@ public class <%= asDto(entityClass) %> implements Serializable {
         return 31;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "<%= asDto(entityClass) %>{" +

--- a/generators/server/templates/src/main/java/package/domain/Authority.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/Authority.java.ejs
@@ -110,6 +110,7 @@ public class Authority implements Serializable<% if (databaseType === 'sql' && r
         return Objects.hashCode(name);
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "Authority{" +

--- a/generators/server/templates/src/main/java/package/domain/PersistentAuditEvent.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/PersistentAuditEvent.java.ejs
@@ -219,6 +219,7 @@ public class PersistentAuditEvent implements Serializable {
         return 31;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "PersistentAuditEvent{" +

--- a/generators/server/templates/src/main/java/package/domain/PersistentToken.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/PersistentToken.java.ejs
@@ -249,6 +249,7 @@ public class PersistentToken implements Serializable {
         return Objects.hashCode(series);
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "PersistentToken{" +

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -336,9 +336,9 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
         joinColumns = {@JoinColumn(name = "user_id", referencedColumnName = "id")},
         inverseJoinColumns = {@JoinColumn(name = "authority_name", referencedColumnName = "name")})
         <%_ if (enableHibernateCache) { if (cacheProvider === 'infinispan') { _%>
-    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE) 
+    @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
             <%_ } else { _%>
-    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE) 
+    @Cache(usage = CacheConcurrencyStrategy.NONSTRICT_READ_WRITE)
         <%_ } } _%>
     @BatchSize(size = 20)
     <%_ } _%>
@@ -495,6 +495,7 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
         return 31;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "<%= asEntity('User') %>{" +

--- a/generators/server/templates/src/main/java/package/service/dto/UserDTO.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/dto/UserDTO.java.ejs
@@ -218,6 +218,7 @@ public class <%= asDto('User') %> {
         this.authorities = authorities;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "<%= asDto('User') %>{" +

--- a/generators/server/templates/src/main/java/package/web/rest/vm/LoginVM.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/vm/LoginVM.java.ejs
@@ -60,6 +60,7 @@ public class LoginVM {
         this.rememberMe = rememberMe;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "LoginVM{" +

--- a/generators/server/templates/src/main/java/package/web/rest/vm/ManagedUserVM.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/vm/ManagedUserVM.java.ejs
@@ -51,6 +51,7 @@ public class ManagedUserVM extends <%= asDto('User') %> {
     }
     <%_ } _%>
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "ManagedUserVM{" + super.toString() + "} ";

--- a/generators/server/templates/src/main/java/package/web/websocket/dto/ActivityDTO.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/websocket/dto/ActivityDTO.java.ejs
@@ -75,6 +75,7 @@ public class ActivityDTO {
         this.time = time;
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "ActivityDTO{" +

--- a/generators/server/templates/src/test/java/package/repository/timezone/DateTimeWrapper.java.ejs
+++ b/generators/server/templates/src/test/java/package/repository/timezone/DateTimeWrapper.java.ejs
@@ -141,6 +141,7 @@ public class DateTimeWrapper implements Serializable {
         return Objects.hashCode(getId());
     }
 
+    // prettier-ignore
     @Override
     public String toString() {
         return "TimeZoneTest{" +


### PR DESCRIPTION
Follow up to #11371

In https://github.com/jhipster/generator-jhipster/pull/11371#issuecomment-590238517 was proposed couple of solutions to Java `toString()` formatting.

https://github.com/jhipster/generator-jhipster/pull/11371#pullrequestreview-368593394 decided ATM not to handle Java `toString()` problem.

This PR proposes `// prettier-ignore` to solve `toString()` formatting.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
