### PR TITLE
Fix getEntityJson when calling outside entity(-*) generators.

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1296,7 +1296,7 @@ module.exports = class extends PrivateBase {
 
         try {
             let filename = path.join(JHIPSTER_CONFIG_DIR, `${_.upperFirst(file)}.json`);
-            if (this.context.microservicePath) {
+            if (this.context && this.context.microservicePath) {
                 filename = path.join(this.context.microservicePath, filename);
             }
             // TODO 7.0 filename = this.destinationPath(filename);


### PR DESCRIPTION
this.context doesn't exists outside entity(-*) generators

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
