### PR TITLE
Save dateFormatForLiquibase.

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -580,7 +580,9 @@ module.exports = class extends Generator {
         if (this.options.creationTimestamp) {
             creationTimestamp = Date.parse(this.options.creationTimestamp);
             if (!creationTimestamp) {
-                this.warning(`Error parsing creationTimestamp ${this.options.creationTimestamp}`);
+                this.warning(`Error parsing creationTimestamp ${this.options.creationTimestamp}.`);
+            } else if (creationTimestamp > new Date().getTime()) {
+                this.error(`Creation timestamp should not be in the future: ${this.options.creationTimestamp}.`);
             }
         }
         return creationTimestamp;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -891,21 +891,46 @@ module.exports = class extends PrivateBase {
 
     /**
      * Generate a date to be used by Liquibase changelogs.
+     *
+     * @param {Boolean} [reproducible=true] - Set true if the changelog date can be reproducible.
+     *                                 Set false to create a changelog date incrementing the last one.
+     * @return {String} Changelog date.
      */
-    dateFormatForLiquibase() {
+    dateFormatForLiquibase(reproducible = true) {
         let now = new Date();
+        // Miliseconds is ignored for changelogDate.
+        now.setMilliseconds(0);
         // Run reproducible timestamp when regenerating the project with with-entities option.
-        if (this.options.withEntities || this.options.creationTimestamp) {
-            if (this.configOptions.lastLiquibaseTimestamp) {
+        if (reproducible && (this.options.withEntities || this.options.creationTimestamp)) {
+            if (this.configOptions.reproducibleLiquibaseTimestamp) {
                 // Counter already started.
-                now = this.configOptions.lastLiquibaseTimestamp;
+                now = this.configOptions.reproducibleLiquibaseTimestamp;
             } else {
                 // Create a new counter
                 const creationTimestamp = this.parseCreationTimestamp() || this.config.get('creationTimestamp');
                 now = creationTimestamp ? new Date(creationTimestamp) : now;
+                now.setMilliseconds(0);
             }
             now.setMinutes(now.getMinutes() + 1);
-            this.configOptions.lastLiquibaseTimestamp = now;
+            this.configOptions.reproducibleLiquibaseTimestamp = now;
+
+            // Reproducible build can create future timestamp, save it.
+            const lastLiquibaseTimestamp = this.config.get('lastLiquibaseTimestamp');
+            if (!lastLiquibaseTimestamp || now.getTime() > lastLiquibaseTimestamp) {
+                this.config.set('lastLiquibaseTimestamp', now.getTime());
+            }
+        } else {
+            // Get and store lastLiquibaseTimestamp, a future timestamp can be used
+            let lastLiquibaseTimestamp = this.config.get('lastLiquibaseTimestamp');
+            if (lastLiquibaseTimestamp) {
+                lastLiquibaseTimestamp = new Date(lastLiquibaseTimestamp);
+                if (lastLiquibaseTimestamp > now) {
+                    now = lastLiquibaseTimestamp;
+                    now.setSeconds(now.getSeconds() + 1);
+                    now.setMilliseconds(0);
+                }
+            }
+            this.config.set('lastLiquibaseTimestamp', now.getTime());
         }
 
         const nowUTC = new Date(

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -950,4 +950,27 @@ describe('JHipster generator for entity', () => {
             });
         });
     });
+    describe('regeneration from app generator', () => {
+        describe('with creation timestamp', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/app'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
+                        const jhipsterFolder = path.join(dir, '.jhipster');
+                        fse.ensureDirSync(jhipsterFolder);
+                        fse.writeJsonSync(path.join(jhipsterFolder, 'Foo.json'), {});
+                    })
+                    .withOptions({ creationTimestamp: '2016-01-20', withEntities: true })
+                    .on('end', done);
+            });
+
+            it('creates expected default files', () => {
+                assert.file(expectedFiles.server);
+                assert.file(expectedFiles.serverLiquibase);
+                assert.file(expectedFiles.clientNg2);
+                assert.file(expectedFiles.gatling);
+            });
+        });
+    });
 });

--- a/test/generator-base.spec.js
+++ b/test/generator-base.spec.js
@@ -1,6 +1,12 @@
+/* eslint-disable no-unused-expressions */
 const expect = require('chai').expect;
+const assert = require('yeoman-assert');
 const expectedFiles = require('./utils/expected-files');
-const BaseGenerator = require('../generators/generator-base').prototype;
+const Base = require('../generators/generator-base');
+const { testInTempDir, revertTempDir } = require('./utils/utils');
+const { parseLiquibaseChangelogDate } = require('../utils/liquibase');
+
+const BaseGenerator = Base.prototype;
 
 BaseGenerator.log = msg => {
     // eslint-disable-next-line no-console
@@ -343,6 +349,136 @@ describe('Generator Base', () => {
                     { name: 'ENGLAND', value: 'england' },
                     { name: 'ICELAND', value: 'iceland' },
                 ]);
+            });
+        });
+    });
+    describe('dateFormatForLiquibase', () => {
+        let base;
+        let oldCwd;
+        before(() => {
+            oldCwd = testInTempDir(() => {}, true);
+            base = new Base();
+            base.configOptions = base.configOptions || {};
+        });
+        after(() => {
+            revertTempDir(oldCwd);
+        });
+        afterEach(() => {
+            base.config.delete('lastLiquibaseTimestamp');
+            base.config.delete('creationTimestamp');
+            delete base.options.withEntities;
+            delete base.options.creationTimestamp;
+            delete base.configOptions.reproducibleLiquibaseTimestamp;
+        });
+        describe('when there is no configured lastLiquibaseTimestamp', () => {
+            let firstChangelogDate;
+            beforeEach(() => {
+                assert.noFile('.yo-rc.json');
+                firstChangelogDate = base.dateFormatForLiquibase();
+            });
+            it('should return a valid changelog date', () => {
+                expect(/^\d{14}$/.test(firstChangelogDate)).to.be.true;
+            });
+            it('should save lastLiquibaseTimestamp', () => {
+                expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(parseLiquibaseChangelogDate(firstChangelogDate).getTime());
+            });
+        });
+        describe('when a past lastLiquibaseTimestamp is configured', () => {
+            let firstChangelogDate;
+            beforeEach(() => {
+                const lastLiquibaseTimestamp = new Date(2000, 1, 1);
+                base.config.set('lastLiquibaseTimestamp', lastLiquibaseTimestamp.getTime());
+                expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(lastLiquibaseTimestamp.getTime());
+                firstChangelogDate = base.dateFormatForLiquibase();
+            });
+            it('should return a valid changelog date', () => {
+                expect(/^\d{14}$/.test(firstChangelogDate)).to.be.true;
+            });
+            it('should not return a past changelog date', () => {
+                expect(firstChangelogDate.startsWith('2000')).to.be.false;
+            });
+            it('should save lastLiquibaseTimestamp', () => {
+                expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(parseLiquibaseChangelogDate(firstChangelogDate).getTime());
+            });
+        });
+        describe('when a future lastLiquibaseTimestamp is configured', () => {
+            let firstChangelogDate;
+            let secondChangelogDate;
+            beforeEach(() => {
+                const lastLiquibaseTimestamp = new Date(Date.parse('2030-01-01'));
+                base.config.set('lastLiquibaseTimestamp', lastLiquibaseTimestamp.getTime());
+                expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(lastLiquibaseTimestamp.getTime());
+                firstChangelogDate = base.dateFormatForLiquibase();
+                secondChangelogDate = base.dateFormatForLiquibase();
+            });
+            it('should return a valid changelog date', () => {
+                expect(/^\d{14}$/.test(firstChangelogDate)).to.be.true;
+            });
+            it('should return a future changelog date', () => {
+                expect(firstChangelogDate.startsWith('2030')).to.be.true;
+            });
+            it('should return a reproducible changelog date', () => {
+                expect(firstChangelogDate).to.be.equal('20300101000001');
+                expect(secondChangelogDate).to.be.equal('20300101000002');
+            });
+            it('should save lastLiquibaseTimestamp', () => {
+                expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(parseLiquibaseChangelogDate('20300101000002').getTime());
+            });
+        });
+        describe('with withEntities option', () => {
+            beforeEach(() => {
+                base.options.withEntities = true;
+            });
+            describe('with reproducible=false argument', () => {
+                let firstChangelogDate;
+                let secondChangelogDate;
+                beforeEach(() => {
+                    base.options.creationTimestamp = '2000-01-01';
+                    const lastLiquibaseTimestamp = new Date(Date.parse('2030-01-01'));
+                    base.config.set('lastLiquibaseTimestamp', lastLiquibaseTimestamp.getTime());
+                    firstChangelogDate = base.dateFormatForLiquibase(false);
+                    secondChangelogDate = base.dateFormatForLiquibase(false);
+                });
+                it('should return a valid changelog date', () => {
+                    expect(/^\d{14}$/.test(firstChangelogDate)).to.be.true;
+                });
+                it('should return a reproducible changelog date incremental to lastLiquibaseTimestamp', () => {
+                    expect(firstChangelogDate).to.be.equal('20300101000001');
+                    expect(secondChangelogDate).to.be.equal('20300101000002');
+                });
+                it('should save lastLiquibaseTimestamp', () => {
+                    expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(parseLiquibaseChangelogDate('20300101000002').getTime());
+                });
+            });
+            describe('with a past creationTimestamp option', () => {
+                let firstChangelogDate;
+                let secondChangelogDate;
+                beforeEach(() => {
+                    base.options.creationTimestamp = '2000-01-01';
+                    firstChangelogDate = base.dateFormatForLiquibase();
+                    secondChangelogDate = base.dateFormatForLiquibase();
+                });
+                it('should return a valid changelog date', () => {
+                    expect(/^\d{14}$/.test(firstChangelogDate)).to.be.true;
+                });
+                it('should return a past changelog date', () => {
+                    expect(firstChangelogDate.startsWith('2000')).to.be.true;
+                });
+                it('should return a reproducible changelog date', () => {
+                    expect(firstChangelogDate).to.be.equal('20000101000100');
+                    expect(secondChangelogDate).to.be.equal('20000101000200');
+                });
+                it('should save lastLiquibaseTimestamp', () => {
+                    expect(base.config.get('lastLiquibaseTimestamp')).to.be.equal(parseLiquibaseChangelogDate('20000101000200').getTime());
+                });
+            });
+            describe('with a future creationTimestamp option', () => {
+                beforeEach(() => {
+                    base.options.creationTimestamp = '2030-01-01';
+                });
+                it('should return a valid changelog date', () => {
+                    expect(() => base.dateFormatForLiquibase()).to.throw(/^Creation timestamp should not be in the future: 2030-01-01\.$/);
+                });
             });
         });
     });


### PR DESCRIPTION
Reproducible builds can set changelogDate to future date, so save it to keep changelogs linear.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
