### PR TITLE
Redis: use @DynamicPropertySource to set server url in tests

### DIFF
--- a/generators/server/templates/src/test/java/package/RedisTestContainerExtension.java.ejs
+++ b/generators/server/templates/src/test/java/package/RedisTestContainerExtension.java.ejs
@@ -21,21 +21,28 @@ package <%= packageName %>;
 
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RedisTestContainerExtension implements BeforeAllCallback {
+
     private static AtomicBoolean started = new AtomicBoolean(false);
+
+    private static GenericContainer redis;
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("jhipster.cache.redis.server", () -> "redis://" + redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379));
+    }
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
         if (!started.get()) {
-            GenericContainer redis =
-                new GenericContainer("<%= DOCKER_REDIS %>")
-                    .withExposedPorts(6379);
+            redis = new GenericContainer("<%= DOCKER_REDIS %>").withExposedPorts(6379);
             redis.start();
-            System.setProperty("redis.test.server", "redis://" + redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379));
             started.set(true);
         }
     }

--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -235,11 +235,6 @@ jhipster:
         logs: # Reports metrics in the logs
             enabled: true
             report-frequency: 60 # in seconds
-<%_ if (cacheProvider === 'redis') { _%>
-    cache:
-        redis:
-            server: ${redis.test.server}
-<%_ } _%>
 <%_ if (messageBroker === 'kafka') { _%>
 kafka:
     bootstrap-servers: localhost:9092


### PR DESCRIPTION
Attempt to fixes #11793

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
