### PR TITLE
@EnableDiscoveryClient is no longer required

### DIFF
--- a/generators/server/templates/src/main/java/package/Application.java.ejs
+++ b/generators/server/templates/src/main/java/package/Application.java.ejs
@@ -35,9 +35,6 @@ import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.liquibase.LiquibaseProperties;
 <%_ } _%>
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
-<%_ if (serviceDiscoveryType) { _%>
-import org.springframework.cloud.client.discovery.EnableDiscoveryClient;
-<%_ } _%>
 <%_ if (applicationType === 'gateway' && !reactive) { _%>
 import org.springframework.cloud.netflix.zuul.EnableZuulProxy;
 <%_ } _%>
@@ -60,9 +57,6 @@ import java.util.Collection;
 <%_ } _%>
 @SpringBootApplication
 @EnableConfigurationProperties({<% if (databaseType === 'sql') { %>LiquibaseProperties.class, <% } %>ApplicationProperties.class})
-<%_ if (serviceDiscoveryType) { _%>
-@EnableDiscoveryClient
-<%_ } _%>
 <%_ if (applicationType === 'gateway' && !reactive) { _%>
 @EnableZuulProxy
 <%_ } _%>


### PR DESCRIPTION
See: https://cloud.spring.io/spring-cloud-commons/multi/multi__spring_cloud_commons_common_abstractions.html#_enablediscoveryclient

"@EnableDiscoveryClient is no longer required. You can put a DiscoveryClient implementation on the classpath to cause the Spring Boot application to register with the service discovery server."

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
