### PR TITLE
Remove non-conforming & ignored link type

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/404.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/404.html.ejs
@@ -22,7 +22,7 @@
     <meta charset="utf-8">
     <title>Page Not Found</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="icon" href="favicon.ico" />
     <style>
 
         * {

--- a/generators/client/templates/angular/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/index.html.ejs
@@ -27,7 +27,7 @@
     <meta name="google" content="notranslate"><% } %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="icon" href="favicon.ico" />
     <link rel="manifest" href="manifest.webapp" />
     <link rel="stylesheet" href="content/css/loading.css">
     <!-- jhipster-needle-add-resources-to-root - JHipster will add new resources here -->

--- a/generators/client/templates/react/src/main/webapp/404.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/404.html.ejs
@@ -22,7 +22,7 @@
     <meta charset="utf-8">
     <title>Page Not Found</title>
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="icon" href="favicon.ico" />
     <style>
 
         * {

--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -27,7 +27,7 @@
     <meta name="google" content="notranslate"><% } %>
     <meta name="viewport" content="width=device-width, initial-scale=1, shrink-to-fit=no">
     <meta name="theme-color" content="#000000">
-    <link rel="shortcut icon" href="favicon.ico" />
+    <link rel="icon" href="favicon.ico" />
     <link rel="manifest" href="manifest.webapp" />
     <link rel="stylesheet" href="content/css/loading.css">
     <!-- jhipster-needle-add-resources-to-root - JHipster will add new resources here -->

--- a/generators/server/templates/src/main/resources/templates/error.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/error.html.ejs
@@ -3,7 +3,7 @@
       xsi:schemaLocation="http://www.thymeleaf.org" th:lang="${#locale.language}" lang="en">
 <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
-    <link rel="shortcut icon" href="${baseUrl}/favicon.ico" />
+    <link rel="icon" href="${baseUrl}/favicon.ico" />
     <title>Your request cannot be processed</title>
     <style>
         ::-moz-selection {

--- a/generators/server/templates/src/main/resources/templates/mail/activationEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/activationEmail.html.ejs
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.activation.title}">JHipster activation</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
+        <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.activation.greeting(${user.login})}">

--- a/generators/server/templates/src/main/resources/templates/mail/creationEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/creationEmail.html.ejs
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.activation.title}">JHipster creation</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
+        <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.activation.greeting(${user.login})}">

--- a/generators/server/templates/src/main/resources/templates/mail/passwordResetEmail.html.ejs
+++ b/generators/server/templates/src/main/resources/templates/mail/passwordResetEmail.html.ejs
@@ -3,7 +3,7 @@
     <head>
         <title th:text="#{email.reset.title}">JHipster password reset</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="shortcut icon" th:href="@{|${baseUrl}/favicon.ico|}" />
+        <link rel="icon" th:href="@{|${baseUrl}/favicon.ico|}" />
     </head>
     <body>
         <p th:text="#{email.reset.greeting(${user.login})}">


### PR DESCRIPTION
Remove 'shortcut' as the link type is non-conforming & ignored

Reference: https://developer.mozilla.org/en-US/docs/Web/HTML/Link_types

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
