### PR TITLE
enable console exporter only for elk

### DIFF
--- a/generators/docker-compose/files.js
+++ b/generators/docker-compose/files.js
@@ -60,6 +60,16 @@ function writeFiles() {
             }
         },
 
+        writeGatewayConfig() {
+            if (this.serviceDiscoveryType) {
+                this.appConfigs.forEach(appConfig => {
+                    if (appConfig.applicationType === 'gateway') {
+                        this.template('central-server-config/gateway.yml.ejs', `central-server-config/${appConfig.baseName}.yml`);
+                    }
+                });
+            }
+        },
+
         writeElkFiles() {
             if (this.monitoring !== 'elk') return;
 

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -110,6 +110,13 @@ module.exports = class extends BaseDockerGenerator {
                         yamlConfig.environment.push('JHIPSTER_LOGGING_LOGSTASH_HOST=jhipster-logstash');
                         yamlConfig.environment.push('JHIPSTER_METRICS_LOGS_ENABLED=true');
                         yamlConfig.environment.push('JHIPSTER_METRICS_LOGS_REPORT_FREQUENCY=60');
+                        yamlConfig.environment.push('MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=false');
+                    }
+
+                    if (appConfig.applicationType === 'monolith' && this.monitoring === 'prometheus') {
+                        yamlConfig.environment.push('JHIPSTER_LOGGING_LOGSTASH_ENABLED=false');
+                        yamlConfig.environment.push('JHIPSTER_METRICS_LOGS_ENABLED=false');
+                        yamlConfig.environment.push('MANAGEMENT_METRICS_EXPORT_PROMETHEUS_ENABLED=true');
                     }
 
                     if (this.serviceDiscoveryType === 'eureka') {

--- a/generators/docker-compose/templates/central-server-config/application.yml.ejs
+++ b/generators/docker-compose/templates/central-server-config/application.yml.ejs
@@ -20,7 +20,7 @@
 configserver:
     name: Docker JHipster Registry
     status: Connected to <% if (serviceDiscoveryType === 'eureka') { %>the JHipster Registry<% } %><% if (serviceDiscoveryType === 'consul') { %>Consul<% } %> running in Docker
-
+   
 jhipster:
     security:
         authentication:
@@ -35,8 +35,28 @@ jhipster:
         logs: # report metrics in the logs
             enabled: true
             report-frequency: 60 # in seconds
-<%_ } _%>
 
+management:
+    metrics:
+        export:
+            prometheus:
+                enabled: false
+<%_ } _%>
+<%_ if (monitoring === 'prometheus') { _%>
+    logging:
+        logstash: # do not forward logs to ELK
+            enabled: false
+            host: jhipster-logstash
+    metrics:
+        logs: # do not report metrics in the logs
+            enabled: false
+
+management:
+    metrics:
+        export:
+            prometheus:
+                enabled: true
+<%_ } _%>  
 <%_ if (consoleOptions && consoleOptions.includes('zipkin') || !skipClient && gatewayType === 'traefik' && authenticationType === 'oauth2') { _%>
 spring:
     <%_ if (consoleOptions && consoleOptions.includes('zipkin')) { _%>

--- a/generators/docker-compose/templates/central-server-config/gateway.yml.ejs
+++ b/generators/docker-compose/templates/central-server-config/gateway.yml.ejs
@@ -1,0 +1,4 @@
+jhipster:
+  metrics:
+    logs: # do report metrics in the logs for gateway applications
+      enabled: false

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -41,6 +41,9 @@ services:
             - SPRING_DATA_MONGODB_URI=mongodb://<%= baseName.toLowerCase() %>-mongodb:27017<% if (reactive) { %>/?waitQueueMultiple=1000<% } %>
             - SPRING_DATA_MONGODB_DATABASE=<%= baseName %>
             <%_ } _%>
+            <%_ if (prodDatabaseType === 'neo4j') { _%>
+            - ORG_NEO4J_DRIVER_URI=bolt://<%= baseName.toLowerCase() %>-neo4j:7687
+            <%_ } _%>
             <%_ if (prodDatabaseType === 'couchbase') { _%>
             - SPRING_COUCHBASE_BOOTSTRAP_HOSTS=<%= baseName.toLowerCase() %>-couchbase
             - SPRING_COUCHBASE_BUCKET_NAME=<%= baseName %>

--- a/generators/server/templates/src/test/java/package/AbstractNeo4jIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/AbstractNeo4jIT.java.ejs
@@ -20,12 +20,9 @@ package <%= packageName %>;
 
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.Neo4jContainer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
-
 
 public class AbstractNeo4jIT implements BeforeAllCallback {
 
@@ -33,15 +30,13 @@ public class AbstractNeo4jIT implements BeforeAllCallback {
 
     private static Neo4jContainer neo4jContainer = new Neo4jContainer("<%= DOCKER_NEO4J %>").withoutAuthentication();
 
-    @DynamicPropertySource
-    static void neo4jProperties(DynamicPropertyRegistry registry) {
-        registry.add("org.neo4j.driver.uri", () -> neo4jContainer.getBoltUrl());
-    }
-
-    @Override
-    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+    public void beforeAll(ExtensionContext extensionContext) {
         if (!started.get()) {
             neo4jContainer.start();
+            System.setProperty(
+                "org.neo4j.driver.uri",
+                neo4jContainer.getBoltUrl()
+            );
             started.set(true);
         }
     }


### PR DESCRIPTION
This pr makes sure prometheus export is disabled when using elk for monitoring (and vice versa).

@mraible I think we are missing neo4j support in this sub generator. I will add it inside this PR if everyone agrees, such that your demo will eventually work.

update #11819

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
