### PR TITLE
fix react microservice user relation request

### DIFF
--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -203,8 +203,8 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
         , <%= rel.relationshipFieldNamePlural %>: mapIdList(values.<%= rel.relationshipFieldNamePlural %>)
         <%_ }) _%>
       }
-      <%_ if (uniqueRelationFields.has('users')) { _%>
-      entity.user = props.users.find(user => user.id === values.user.id);
+      <%_ if (uniqueRelationFields.has('users') && dto !== 'mapstruct') { _%>
+      entity.user = users.find(user => user.id.toString() === entity.user.id.toString());
       <%_ } _%>
 
       if (isNew) {

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -204,7 +204,7 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
         <%_ }) _%>
       }
       <%_ if (uniqueRelationFields.has('users') && dto !== 'mapstruct') { _%>
-      entity.user = users.find(user => user.id.toString() === entity.user.id.toString());
+      entity.user = users.find(user => user.id.toString() === values.user.id.toString());
       <%_ } _%>
 
       if (isNew) {
@@ -407,10 +407,9 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
               id="<%= entityFileName %>-<%= relationshipName %>"
               type="select"
               className="form-control"
-              name="<%= relationshipFieldName %><% if (relationshipFieldName !== 'user') { %>.id<% } %>"
+              name="<%= relationshipFieldName %>.id"
             >
               <option value="" key="0" />
-              <%_ if (relationshipFieldName !== 'user') { _%>
               {
                 <%= otherEntityNamePlural %> ? <%= otherEntityNamePlural %>.map(otherEntity =>
                   <option
@@ -420,17 +419,6 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
                   </option>
                 ) : null
               }
-              <%_ } else { _%>
-              {
-                <%= otherEntityNamePlural %> ? <%= otherEntityNamePlural %>.map((otherEntity, index) =>
-                  <option
-                    value={index}
-                    key={otherEntity.id}>
-                    {otherEntity.<%= otherEntityField %>}
-                  </option>
-                ) : null
-              }
-              <%_ } _%>
             </AvInput>
               <%_ } else { _%>
             <AvInput

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -204,7 +204,7 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
         <%_ }) _%>
       }
       <%_ if (uniqueRelationFields.has('users')) { _%>
-      entity.user = values.user;
+      entity.user = props.users.find(user => user.id === values.user.id);
       <%_ } _%>
 
       if (isNew) {

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -203,8 +203,10 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
         , <%= rel.relationshipFieldNamePlural %>: mapIdList(values.<%= rel.relationshipFieldNamePlural %>)
         <%_ }) _%>
       }
-      <%_ if (uniqueRelationFields.has('users') && dto !== 'mapstruct') { _%>
-      entity.user = users.find(user => user.id.toString() === values.user.id.toString());
+      <%_ if (uniqueRelationFields.has('users') && authenticationType === 'oauth2' && applicationType === 'gateway' && dto !== 'mapstruct') { _%>
+        <%_ relationships.filter(rel => rel.relationshipType === 'one-to-one' && rel.ownerSide === true && rel.otherEntityName === 'user').forEach(rel => { _%>
+      entity.<%= rel.relationshipFieldName %> = users.find(user => user.id.toString() === values.<%= rel.relationshipFieldName %>.id.toString());
+        <%_ }) _%>
       <%_ } _%>
 
       if (isNew) {


### PR DESCRIPTION
Send the entire user object (including `login`) instead of just the `id` field

In Angular, we pass the whole User object `"user": {"id": "1", "login": "system", "firstName": "System" .... }`

In React we only pass the ID `"user":{"id":"1"}`, which results in an invalid User since login is a required field. This is because the value returned from the select box only returns the id.

Fixed by finding the `user` in `props.`user with the matching `id`.

Fix #11792

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
