### PR TITLE
Implement --skip-jhipster-dependencies option.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -199,6 +199,12 @@ module.exports = class extends BaseBlueprintGenerator {
             defaults: false,
         });
 
+        this.option('skip-jhipster-dependencies', {
+            desc: 'Generate package.json without generator-jhipster[-*] dependencies',
+            type: Boolean,
+            defaults: false,
+        });
+
         this.skipClient = this.configOptions.skipClient = this.options['skip-client'] || this.config.get('skipClient');
         this.skipServer = this.configOptions.skipServer = this.options['skip-server'] || this.config.get('skipServer');
         this.skipUserManagement = this.configOptions.skipUserManagement =
@@ -247,6 +253,10 @@ module.exports = class extends BaseBlueprintGenerator {
         this.experimental = this.configOptions.experimental = this.options.experimental;
         this.registerPrettierTransform();
         this.setupAppOptions(this);
+
+        if (this.options.skipJhipsterDependencies) {
+            this.config.set('skipJhipsterDependencies', this.options.skipJhipsterDependencies);
+        }
     }
 
     _initializing() {

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -287,6 +287,7 @@ module.exports = class extends BaseBlueprintGenerator {
     _default() {
         return {
             getSharedConfigOptions() {
+                this.skipJhipsterDependencies = this.config.get('skipJhipsterDependencies');
                 if (this.configOptions.cacheProvider) {
                     this.cacheProvider = this.configOptions.cacheProvider;
                 }

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -103,7 +103,12 @@
     "eslint-loader": "4.0.2",
     "file-loader": "6.0.0",
     "friendly-errors-webpack-plugin": "1.7.0",
+    <%_ if (!skipJhipsterDependencies) { %>
     "generator-jhipster": "<%= packagejs.version %>",
+    <%_     otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+    <%_     }); _%>
+    <%_ } _%>
     "html-loader": "1.1.0",
     "html-webpack-plugin": "3.2.0",
     <%_ if (!skipCommitHook) { _%>
@@ -149,9 +154,6 @@
     <%_ } _%>
     "tslint": "6.1.2",
     "typescript": "3.8.3",
-    <%_ otherModules.forEach(module => { _%>
-    "<%= module.name %>": "<%= module.version %>",
-    <%_ }); _%>
     <%_ if (protractorTests) { _%>
     "webdriver-manager": "12.1.7",
     <%_ } _%>

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -115,7 +115,12 @@ limitations under the License.
     "file-loader": "6.0.0",
     "fork-ts-checker-webpack-plugin": "4.1.3",
     "friendly-errors-webpack-plugin": "1.7.0",
+    <%_ if (!skipJhipsterDependencies) { %>
     "generator-jhipster": "<%= packagejs.version %>",
+    <%_     otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+    <%_     }); _%>
+    <%_ } _%>
     "html-webpack-plugin": "3.2.0",
     <%_ if (!skipCommitHook) { _%>
     "husky": "<%= HUSKY_VERSION %>",
@@ -157,9 +162,6 @@ limitations under the License.
     "stripcomment-loader": "0.1.0",
     "style-loader": "1.2.0",
     "swagger-ui-dist": "3.25.1",
-    <%_ otherModules.forEach(module => { _%>
-    "<%= module.name %>": "<%= module.version %>",
-    <%_ }); _%>
     "terser-webpack-plugin": "2.3.6",
     "thread-loader": "2.1.3",
     "to-string-loader": "1.1.6",

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -469,6 +469,7 @@ module.exports = class extends BaseBlueprintGenerator {
     _default() {
         return {
             getSharedConfigOptions() {
+                this.skipJhipsterDependencies = this.config.get('skipJhipsterDependencies');
                 if (this.configOptions.enableTranslation !== undefined) {
                     this.enableTranslation = this.configOptions.enableTranslation;
                 }

--- a/generators/server/templates/package.json.ejs
+++ b/generators/server/templates/package.json.ejs
@@ -26,10 +26,12 @@
     "node_modules"
   ],
   "devDependencies": {
-    <%_ otherModules.forEach(module => { _%>
+    <%_ if (!skipJhipsterDependencies) { %>
+    "generator-jhipster": "<%= packagejs.version %>",
+    <%_     otherModules.forEach(module => { _%>
     "<%= module.name %>": "<%= module.version %>",
-    <%_ }); _%>
-    "generator-jhipster": "<%= jhipsterVersion %>",
+    <%_     }); _%>
+    <%_ } _%>
     <%_ if (!skipCommitHook) { _%>
     "husky": "<%= HUSKY_VERSION %>",
     "lint-staged": "<%= LINT_STAGED_VERSION %>",


### PR DESCRIPTION
When running a linked version of generator-jhipster, it keeps been overridden with the released version.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
