### PR TITLE
Remove unused dependency reflect-metadata in Angular

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -134,7 +134,6 @@
     <%_ if (protractorTests) { _%>
     "protractor": "5.4.4",
     <%_ } _%>
-    "reflect-metadata": "0.1.13",
     "rimraf": "3.0.2",
     "sass": "1.26.5",
     "sass-loader": "8.0.2",


### PR DESCRIPTION
#6338 removed `reflect-metadata` polyfill, but dependency in `package.json` was not removed, this PR removes redundant `reflect-metadata` dependency.

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
