### PR TITLE
Upgrade the liquibase dependency version 

### DIFF
--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -80,7 +80,7 @@ gradle_node_plugin_version=2.2.3
 <%_ } _%>
 apt_plugin_version=0.21
 <%_ if (databaseType === 'sql' && !reactive) { _%>
-liquibase_plugin_version=2.0.2
+liquibase_plugin_version=2.0.3
 <%_ } _%>
 sonarqube_plugin_version=2.8
 <%_ if (enableSwaggerCodegen) { _%>


### PR DESCRIPTION
It was failing with gradle 6.4.1 , 

Please refer here.
https://github.com/liquibase/liquibase-gradle-plugin/issues/70

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
