### PR TITLE
[SpringBoot 2.3] Change kubernetes probes and define graceful shutdown

### DIFF
--- a/generators/kubernetes-knative/templates/service.yml.ejs
+++ b/generators/kubernetes-knative/templates/service.yml.ejs
@@ -167,6 +167,8 @@ spec:
             <%_ } _%>
             - name: JAVA_OPTS
               value: " -Xmx256m -Xms256m"
+            - name: SERVER_SHUTDOWN
+              value: graceful
             resources:
               requests:
                 memory: "512Mi"
@@ -178,14 +180,14 @@ spec:
             - containerPort: <%= app.serverPort %>
             readinessProbe:
               httpGet:
-                path: <%= app.applicationType === 'microservice' && !app.serviceDiscoveryType ? `/services/${app.baseName.toLowerCase()}` : '' %>/management/health
+                path: <%= app.applicationType === 'microservice' && !app.serviceDiscoveryType ? `/services/${app.baseName.toLowerCase()}` : '' %>/management/health/readiness
               initialDelaySeconds: 20
               periodSeconds: 15
               failureThreshold: 6
               timeoutSeconds: 5
             livenessProbe:
               httpGet:
-                path: <%= app.applicationType === 'microservice' && !app.serviceDiscoveryType ? `/services/${app.baseName.toLowerCase()}` : '' %>/management/info
+                path: <%= app.applicationType === 'microservice' && !app.serviceDiscoveryType ? `/services/${app.baseName.toLowerCase()}` : '' %>/management/health/liveness
               initialDelaySeconds: 120
               timeoutSeconds: 5
   traffic:

--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -204,6 +204,8 @@ spec:
         <%_ } _%>
         - name: JAVA_OPTS
           value: " -Xmx256m -Xms256m"
+        - name: SERVER_SHUTDOWN
+          value: graceful
         resources:
           requests:
             memory: "512Mi"
@@ -216,13 +218,13 @@ spec:
           containerPort: <%= app.serverPort %>
         readinessProbe:
           httpGet:
-            path: /management/health
+            path: /management/health/readiness
             port: http
           initialDelaySeconds: 20
           periodSeconds: 15
           failureThreshold: 6
         livenessProbe:
           httpGet:
-            path: /management/health
+            path: /management/health/liveness
             port: http
           initialDelaySeconds: 120


### PR DESCRIPTION
- Changed Kubernetes probes: https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/production-ready-features.html#production-ready-kubernetes-probes
- define graceful shutdown: https://docs.spring.io/spring-boot/docs/2.3.0.RELEASE/reference/html/spring-boot-features.html#boot-features-graceful-shutdown

Fix https://github.com/jhipster/generator-jhipster/issues/10770

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
