### PR TITLE
neo4j: fix dependency error

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -409,6 +409,9 @@ dependencies {
     <%_ if (databaseType === 'neo4j') { _%>
     implementation "org.neo4j.springframework.data:spring-data-neo4j-rx-spring-boot-starter"
     implementation "eu.michael-simons.neo4j:neo4j-migrations-spring-boot-starter"
+    // This is done here explicitly as dependency resolution seems to have changed recently such that the validation starter
+    // and therefore hibernate validators is not included anymore
+    implementation "org.springframework.boot:spring-boot-starter-validation"
     testImplementation "org.testcontainers:neo4j"
     testImplementation 'org.testcontainers:junit-jupiter'
     <%_ } _%>


### PR DESCRIPTION
Somehow dependency resolution has changed a little bit in recent gradle version. Therefore boot starter validation is not included anymore and therefore hibernate validators not too. See https://github.com/hipster-labs/jhipster-daily-builds/runs/729654703?check_suite_focus=true 

This fixes this compile error. As we seem not to have this problem in general I added the missing dependency just to the neo4j part in gradle.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
