### PR TITLE
Fix addIcon needle function generating double comma

### DIFF
--- a/generators/client/needle-api/needle-client-angular.js
+++ b/generators/client/needle-api/needle-client-angular.js
@@ -125,16 +125,11 @@ module.exports = class extends needleClientBase {
         const iconImport = `fa${this.generator.upperFirstCamelCase(iconName)}`;
         if (!jhipsterUtils.checkRegexInFile(iconsPath, new RegExp(`\\b${iconImport}\\b`), this.generator)) {
             try {
-                let newIconContent = `\n  ${iconImport},\n  // jhipster-needle-add-icon-import`;
-                const iconNeedle = '\\r?\\n\\s*\\/\\/ jhipster-needle-add-icon-import';
-                if (!jhipsterUtils.checkRegexInFile(iconsPath, new RegExp(`,${iconNeedle}`), this.generator)) {
-                    newIconContent = `,${newIconContent}`;
-                }
                 jhipsterUtils.replaceContent(
                     {
                         file: iconsPath,
-                        pattern: new RegExp(iconNeedle, 'g'),
-                        content: newIconContent,
+                        pattern: /(\r?\n)(\s*)\/\/ jhipster-needle-add-icon-import/g,
+                        content: `\n  ${iconImport},\n  // jhipster-needle-add-icon-import`,
                     },
                     this.generator
                 );

--- a/generators/client/needle-api/needle-client-angular.js
+++ b/generators/client/needle-api/needle-client-angular.js
@@ -125,11 +125,16 @@ module.exports = class extends needleClientBase {
         const iconImport = `fa${this.generator.upperFirstCamelCase(iconName)}`;
         if (!jhipsterUtils.checkRegexInFile(iconsPath, new RegExp(`\\b${iconImport}\\b`), this.generator)) {
             try {
+                let newIconContent = `\n  ${iconImport},\n  // jhipster-needle-add-icon-import`;
+                const iconNeedle = '\\r?\\n\\s*\\/\\/ jhipster-needle-add-icon-import';
+                if (!jhipsterUtils.checkRegexInFile(iconsPath, new RegExp(`,${iconNeedle}`), this.generator)) {
+                    newIconContent = `,${newIconContent}`;
+                }
                 jhipsterUtils.replaceContent(
                     {
                         file: iconsPath,
-                        pattern: /(\r?\n)(\s*)\/\/ jhipster-needle-add-icon-import/g,
-                        content: `,\n  ${iconImport}\n  // jhipster-needle-add-icon-import`,
+                        pattern: new RegExp(iconNeedle, 'g'),
+                        content: newIconContent,
                     },
                     this.generator
                 );

--- a/generators/client/templates/angular/src/main/webapp/app/core/icons/font-awesome-icons.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/icons/font-awesome-icons.ts.ejs
@@ -32,8 +32,8 @@ import {
   faTrashAlt,
   faAsterisk,
   faTasks,
-  faHome,
   // jhipster-needle-add-icon-import
+  faHome,
 } from '@fortawesome/free-solid-svg-icons';
 
 export const fontAwesomeIcons = [
@@ -70,6 +70,6 @@ export const fontAwesomeIcons = [
   faCalendarAlt,
   faSearch,
   faTrashAlt,
-  faAsterisk,
   // jhipster-needle-add-icon-import
+  faAsterisk,
 ];

--- a/generators/client/templates/angular/src/main/webapp/app/core/icons/font-awesome-icons.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/icons/font-awesome-icons.ts.ejs
@@ -32,7 +32,7 @@ import {
   faTrashAlt,
   faAsterisk,
   faTasks,
-  faHome
+  faHome,
   // jhipster-needle-add-icon-import
 } from '@fortawesome/free-solid-svg-icons';
 
@@ -70,6 +70,6 @@ export const fontAwesomeIcons = [
   faCalendarAlt,
   faSearch,
   faTrashAlt,
-  faAsterisk
+  faAsterisk,
   // jhipster-needle-add-icon-import
 ];


### PR DESCRIPTION
#11665 switched `Prettier` to `v2` which by default adds trailing commas to many places.  
`addIcon` needle function assumed that there is no trailing comma.  
After this change `addIcon` works both with and without trailing comma in icons array.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
