### PR TITLE
Change cli options from info to debug.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -48,7 +48,7 @@ const runYoCommand = (cmd, args, options, opts) => {
     logger.debug(`opts: ${toString(opts)}`);
     const command = getCommand(cmd, args, opts);
     logger.info(chalk.yellow(`Executing ${command}`));
-    logger.info(chalk.yellow(`Options: ${toString(options)}`));
+    logger.debug(chalk.yellow(`Options: ${toString(options)}`));
     try {
         env.run(command, options, done);
     } catch (e) {


### PR DESCRIPTION
With options been registered to commander, it improves help, but it sets
every default value making options debug very loud.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
