### PR TITLE
Remove redundant genDir from angularCompilerOptions

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -350,7 +350,6 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.pkType = this.getPkType(this.databaseType);
                 this.apiUaaPath = `${this.authenticationType === 'uaa' ? `services/${this.uaaBaseName.toLowerCase()}/` : ''}`;
                 this.DIST_DIR = this.getResourceBuildDirectoryForBuildTool(this.configOptions.buildTool) + constants.CLIENT_DIST_DIR;
-                this.AOT_DIR = `${this.getResourceBuildDirectoryForBuildTool(this.configOptions.buildTool)}aot`;
             },
 
             composeLanguages() {

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -172,7 +172,7 @@
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "<%= clientPackageManager %> run lint <%= optionsForwarder %>--fix",
     "ngc": "ngc -p tsconfig.app.json",
-    "cleanup": "rimraf <%= DIST_DIR %> <%= AOT_DIR %>",
+    "cleanup": "rimraf <%= DIST_DIR %>",
     "clean-www": "rimraf <%= DIST_DIR %>app/{src,<%= BUILD_DIR %>}",
     <%_ if (protractorTests) { _%>
     "e2e": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -39,7 +39,6 @@
       "importHelpers": true
     },
     "angularCompilerOptions": {
-      "genDir": "<%= AOT_DIR %>",
       "fullTemplateTypeCheck": true,
       "strictTemplates": true,
       "preserveWhitespaces": true


### PR DESCRIPTION
`genDir` is unused since Angular v5: https://blog.angular.io/version-5-0-0-of-angular-now-available-37e414935ced and this is no more listed in https://angular.io/guide/angular-compiler-options

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
