### PR TITLE
Fix jhipster cli not passing fromCli option.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -159,6 +159,7 @@ Object.entries(allCommands).forEach(([key, opts]) => {
                 ...addKebabCase(program.opts()),
                 ...addKebabCase(cmdOptions),
                 ...addKebabCase(customOptions),
+                ...addKebabCase({ fromCli: true }),
             };
 
             if (opts.cliOnly) {

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -148,7 +148,7 @@ Object.entries(allCommands).forEach(([key, opts]) => {
                 return;
             }
 
-            const customOptions = {};
+            const customOptions = { fromCli: true };
             if (key === 'jdl' && process.argv[2] === 'import-jdl') {
                 customOptions.skipSampleRepository = true;
             }
@@ -159,7 +159,6 @@ Object.entries(allCommands).forEach(([key, opts]) => {
                 ...addKebabCase(program.opts()),
                 ...addKebabCase(cmdOptions),
                 ...addKebabCase(customOptions),
-                ...addKebabCase({ fromCli: true }),
             };
 
             if (opts.cliOnly) {

--- a/cli/utils.js
+++ b/cli/utils.js
@@ -182,7 +182,7 @@ const addKebabCase = (options = {}) => {
 const getCommandOptions = (pkg, argv = []) => {
     const options = meow({ help: false, pkg, argv });
     const flags = options ? options.flags : undefined;
-    return addKebabCase({ fromCli: true, ...flags });
+    return addKebabCase({ ...flags });
 };
 
 const doneFactory = successMsg => {

--- a/test/cli/cli-utils.spec.js
+++ b/test/cli/cli-utils.spec.js
@@ -144,7 +144,7 @@ describe('jhipster cli utils test', () => {
     describe('getCommandOptions', () => {
         describe('when called with empty argv', () => {
             it('returns the default object', () => {
-                expect(cliUtil.getCommandOptions(packageJson, [])).to.eql({ 'from-cli': true, fromCli: true });
+                expect(cliUtil.getCommandOptions(packageJson, [])).to.eql({});
             });
         });
         describe('when called with argv flags', () => {
@@ -154,8 +154,6 @@ describe('jhipster cli utils test', () => {
                     force: true,
                     'skip-install': true,
                     skipInstall: true,
-                    'from-cli': true,
-                    fromCli: true,
                 });
             });
         });
@@ -167,8 +165,6 @@ describe('jhipster cli utils test', () => {
                     'skip-install': true,
                     skipInstall: true,
                     foo: 'bar',
-                    'from-cli': true,
-                    fromCli: true,
                 });
             });
         });
@@ -180,8 +176,6 @@ describe('jhipster cli utils test', () => {
                     'skip-install': true,
                     skipInstall: true,
                     foo: 'bar,who',
-                    'from-cli': true,
-                    fromCli: true,
                 });
             });
         });

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -90,15 +90,37 @@ describe('jhipster cli test', () => {
             Environment.prototype.create.restore();
         });
 
+        const commonTests = () => {
+            it('should pass a truthy fromCli', done => {
+                callback = (_command, options) => {
+                    expect(options.fromCli).to.be.true;
+                    expect(options['from-cli']).to.be.true;
+                    done();
+                };
+                proxyquire('../../cli/cli', { './commands': commands });
+            });
+            it('should pass a defined command', done => {
+                callback = (command, _options) => {
+                    expect(command).to.not.be.undefined;
+                    done();
+                };
+                proxyquire('../../cli/cli', { './commands': commands });
+            });
+        };
+
         describe('without argument', () => {
             beforeEach(() => {
                 process.argv = ['jhipster', 'jhipster', 'mocked', '--foo', '--foo-bar'];
             });
+
+            commonTests();
+
             it('should forward options', done => {
                 callback = (command, options) => {
-                    expect(command).to.not.be.undefined;
                     expect(command).to.be.equal('jhipster:mocked');
-                    expect(options).to.eql({ foo: true, 'from-cli': true, fromCli: true, fooBar: true, 'foo-bar': true });
+                    expect(options.foo).to.be.true;
+                    expect(options.fooBar).to.be.true;
+                    expect(options['foo-bar']).to.be.true;
                     done();
                 };
                 proxyquire('../../cli/cli', { './commands': commands });
@@ -110,10 +132,15 @@ describe('jhipster cli test', () => {
                 commands.mocked.argument = ['name'];
                 process.argv = ['jhipster', 'jhipster', 'mocked', 'Foo', '--foo', '--foo-bar'];
             });
+
+            commonTests();
+
             it('should forward argument and options', done => {
                 callback = (command, options) => {
                     expect(command).to.be.equal('jhipster:mocked Foo');
-                    expect(options).to.eql({ foo: true, 'from-cli': true, fromCli: true, fooBar: true, 'foo-bar': true });
+                    expect(options.foo).to.be.true;
+                    expect(options.fooBar).to.be.true;
+                    expect(options['foo-bar']).to.be.true;
                     done();
                 };
                 proxyquire('../../cli/cli', { './commands': commands });
@@ -125,10 +152,15 @@ describe('jhipster cli test', () => {
                 commands.mocked.argument = ['name...'];
                 process.argv = ['jhipster', 'jhipster', 'mocked', 'Foo', 'Bar', '--foo', '--foo-bar'];
             });
+
+            commonTests();
+
             it('should forward argument and options', done => {
                 callback = (command, options) => {
                     expect(command).to.be.equal('jhipster:mocked Foo Bar');
-                    expect(options).to.eql({ foo: true, 'from-cli': true, fromCli: true, fooBar: true, 'foo-bar': true });
+                    expect(options.foo).to.be.true;
+                    expect(options.fooBar).to.be.true;
+                    expect(options['foo-bar']).to.be.true;
                     done();
                 };
                 proxyquire('../../cli/cli', { './commands': commands });
@@ -149,6 +181,24 @@ describe('jhipster cli test', () => {
             commands.mocked = { cb: () => {} };
         });
 
+        const commonTests = () => {
+            it('should pass a truthy fromCli', done => {
+                const cb = (_args, options, _env) => {
+                    expect(options.fromCli).to.be.true;
+                    expect(options['from-cli']).to.be.true;
+                    done();
+                };
+                proxyquire('../../cli/cli', { './commands': commands, './mocked': cb });
+            });
+            it('should pass a defined environment', done => {
+                const cb = (_args, _options, env) => {
+                    expect(env).to.not.be.undefined;
+                    done();
+                };
+                proxyquire('../../cli/cli', { './commands': commands, './mocked': cb });
+            });
+        };
+
         describe('with argument', () => {
             beforeEach(() => {
                 commands.mocked.desc = 'Mocked command';
@@ -156,11 +206,15 @@ describe('jhipster cli test', () => {
                 commands.mocked.cliOnly = true;
                 process.argv = ['jhipster', 'jhipster', 'mocked', 'Foo', '--foo', '--foo-bar'];
             });
+
+            commonTests();
+
             it('should forward argument and options', done => {
-                const cb = (args, options, env) => {
-                    expect(env).to.not.be.undefined;
+                const cb = (args, options) => {
                     expect(args).to.eql(['Foo']);
-                    expect(options).to.eql({ foo: true, 'from-cli': true, fromCli: true, fooBar: true, 'foo-bar': true });
+                    expect(options.foo).to.be.true;
+                    expect(options.fooBar).to.be.true;
+                    expect(options['foo-bar']).to.be.true;
                     done();
                 };
                 proxyquire('../../cli/cli', { './commands': commands, './mocked': cb });
@@ -174,11 +228,15 @@ describe('jhipster cli test', () => {
                 commands.mocked.cliOnly = true;
                 process.argv = ['jhipster', 'jhipster', 'mocked', 'Foo', 'Bar', '--foo', '--foo-bar'];
             });
+
+            commonTests();
+
             it('should forward argument and options', done => {
                 const cb = (args, options, env) => {
-                    expect(env).to.not.be.undefined;
                     expect(args).to.eql(['Foo', 'Bar']);
-                    expect(options).to.eql({ foo: true, 'from-cli': true, fromCli: true, fooBar: true, 'foo-bar': true });
+                    expect(options.foo).to.be.true;
+                    expect(options.fooBar).to.be.true;
+                    expect(options['foo-bar']).to.be.true;
                     done();
                 };
                 proxyquire('../../cli/cli', { './commands': commands, './mocked': cb });
@@ -191,11 +249,15 @@ describe('jhipster cli test', () => {
                 commands.mocked.cliOnly = true;
                 process.argv = ['jhipster', 'jhipster', 'mocked', '--foo', '--foo-bar'];
             });
+
+            commonTests();
+
             it('should forward argument and options', done => {
                 const cb = (args, options, env) => {
-                    expect(env).to.not.be.undefined;
                     expect(args).to.eql([]);
-                    expect(options).to.eql({ foo: true, 'from-cli': true, fromCli: true, fooBar: true, 'foo-bar': true });
+                    expect(options.foo).to.be.true;
+                    expect(options.fooBar).to.be.true;
+                    expect(options['foo-bar']).to.be.true;
                     done();
                 };
                 proxyquire('../../cli/cli', { './commands': commands, './mocked': cb });


### PR DESCRIPTION
-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
