### PR TITLE
Add dependabot.yml file for automatic version upgrades [ci skip]

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+    - package-ecosystem: maven
+      directory: "/"
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 10
+    - package-ecosystem: npm
+      directory: "/"
+      schedule:
+          interval: weekly
+      open-pull-requests-limit: 10


### PR DESCRIPTION
This adds dependabot.yml file to leverage native support for dependabot through GitHub

Related to https://github.com/jhipster/generator-jhipster/issues/11914

-   Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
