### PR TITLE
Remove reference to other entities in an embedded entity

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -280,11 +280,17 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         const relationshipValidate = relationships[idx].relationshipValidate;
         const relationshipRequired = relationships[idx].relationshipRequired;
         const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-        const ownerSide = relationships[idx].ownerSide;
+        const ownerSide = relationships[idx].ownerSide || false;
         const isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
         if (otherEntityRelationshipName) {
             mappedBy = otherEntityRelationshipName.charAt(0).toLowerCase() + otherEntityRelationshipName.slice(1)
         }
+
+        // An embedded entity should not reference entities that embeds it, unless the other entity is also embedded
+        if (embedded && !otherEntityIsEmbedded && ownerSide === false) {
+          continue;
+        }
+
         if (typeof relationships[idx].javadoc != 'undefined') { _%>
 <%- formatAsFieldJavadoc(relationships[idx].javadoc) %>
             <%_ if (!hasDto) { _%>
@@ -303,7 +309,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     @DBRef
         <%_ } _%>
     @Field("<%= relationshipFieldName %>")
-        <%_ if (databaseType === 'couchbase'&& !otherEntityIsEmbedded) { _%>
+        <%_ if (databaseType === 'couchbase' && !otherEntityIsEmbedded) { _%>
     private Set<String> <%= relationshipFieldName %>Ids = new HashSet<>();
 
     @N1qlJoin(on = "lks.<%= relationshipFieldName %>=meta(rks).id", fetchType = FetchType.IMMEDIATE)
@@ -474,6 +480,12 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         const otherEntityRelationshipNameCapitalized = relationships[idx].otherEntityRelationshipNameCapitalized;
         const otherEntityRelationshipNameCapitalizedPlural = relationships[idx].otherEntityRelationshipNameCapitalizedPlural;
         const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
+        const ownerSide = relationships[idx].ownerSide || false;
+
+        // An embedded entity should not reference entities that embeds it, unless the other entity is also embedded
+        if (embedded && !otherEntityIsEmbedded && ownerSide === false) {
+            continue;
+        }
     _%>
     <%_ if (relationshipType === 'one-to-many' || relationshipType === 'many-to-many') { _%>
 
@@ -494,6 +506,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
 
     public <%= asEntity(entityClass) %> add<%= relationshipNameCapitalized %>(<%= asEntity(otherEntityNameCapitalized) %> <%= otherEntityName %>) {
         this.<%= relationshipFieldNamePlural %>.add(<%= otherEntityName %>);
+        <%_ if (!otherEntityIsEmbedded || embedded && ownerSide === true) { _%>
             <%_ if (databaseType === 'couchbase' && !otherEntityIsEmbedded) { _%>
         this.<%= relationshipFieldName %>Ids.add(<%= otherEntityName %>.getId());
             <%_ } _%>
@@ -503,11 +516,13 @@ public class <%= asEntity(entityClass) %> implements Serializable {
                 // JHipster version < 3.6.0 didn't ask for this relationship name _%>
         <%= otherEntityName %>.get<%= otherEntityRelationshipNameCapitalizedPlural %>().add(this);
             <%_ } _%>
+        <%_ } _%>
         return this;
     }
 
     public <%= asEntity(entityClass) %> remove<%= relationshipNameCapitalized %>(<%= asEntity(otherEntityNameCapitalized) %> <%= otherEntityName %>) {
         this.<%= relationshipFieldNamePlural %>.remove(<%= otherEntityName %>);
+        <%_ if (!otherEntityIsEmbedded || embedded && ownerSide === true) { _%>
             <%_ if (databaseType === 'couchbase' && !otherEntityIsEmbedded) { _%>
         this.<%= relationshipFieldName %>Ids.remove(<%= otherEntityName %>.getId());
             <%_ } _%>
@@ -517,6 +532,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
                 // JHipster version < 3.6.0 didn't ask for this relationship name _%>
         <%= otherEntityName %>.get<%= otherEntityRelationshipNameCapitalizedPlural %>().remove(this);
             <%_ } _%>
+        <%_ } _%>
         return this;
     }
         <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -130,7 +130,7 @@ public class <%= asDto(entityClass) %> implements Serializable {
     private Set<<%= asDto(otherEntityNameCapitalized) %>> <%= relationshipFieldNamePlural %> = new HashSet<>();
     <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true && otherEntityIsEmbedded) { _%>
     private <%= asDto(otherEntityNameCapitalized) %> <%= relationshipFieldName %>;
-    <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+    <%_ } else if (!embedded && (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true))) { _%>
 
     private <%= otherEntityPrimaryKeyType %> <%= relationshipFieldName %>Id;
     <%_ if (otherEntityFieldCapitalized !== 'Id' && otherEntityFieldCapitalized !== '') { _%>
@@ -211,7 +211,7 @@ public class <%= asDto(entityClass) %> implements Serializable {
     public void set<%= relationshipNameCapitalized %>(<%= asDto(otherEntityNameCapitalized) %> <%= otherEntityName %>) {
         this.<%= relationshipFieldName %> = <%= otherEntityName %>;
     }
-    <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+    <%_ } else if (!embedded && (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true))) { _%>
 
     <%_ if (relationshipNameCapitalized.length > 1) { _%>
     public <%= otherEntityPrimaryKeyType %> get<%= relationshipNameCapitalized %>Id() {
@@ -290,7 +290,7 @@ public class <%= asDto(entityClass) %> implements Serializable {
             ", <%= relationshipFieldNamePlural %>='" + get<%= relationshipNameCapitalizedPlural %>() + "'" +
                 <%_ } else if (relationshipType === 'one-to-one' && ownerSide === true && otherEntityIsEmbedded) { _%>
             ", <%= relationshipFieldName %>='" + get<%= relationshipNameCapitalized %>() + "'" +
-                <%_ } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
+                <%_ } else if (!embedded && (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true))) { _%>
             ", <%= relationshipFieldName %>Id=<% if (otherEntityPrimaryKeyType === 'String') { %>'<% } %>" + get<%= relationshipNameCapitalized %>Id() <% if (otherEntityPrimaryKeyType === 'String') { %>+ "'" <% } %>+
                     <%_ if (otherEntityFieldCapitalized !== 'Id' && otherEntityFieldCapitalized !== '') { _%>
             ", <%= relationshipFieldName %><%= otherEntityFieldCapitalized %>='" + get<%= relationshipNameCapitalized %><%= otherEntityFieldCapitalized %>() + "'" +

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -61,14 +61,14 @@ import java.util.UUID;
 public interface <%= entityClass %>Mapper extends EntityMapper<<%= asDto(entityClass) %>, <%= asEntity(entityClass) %>> {
 
 <%_
+if (!embedded) {
 // entity -> DTO mapping
 var renMapAnotEnt = false; //Render Mapping Annotation during Entity to DTO conversion?
 for (idx in relationships) {
     const relationshipType = relationships[idx].relationshipType;
     const relationshipName = relationships[idx].relationshipName;
-    const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
-    const ownerSide = relationships[idx].ownerSide;
-    if ((relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) && !otherEntityIsEmbedded) {
+    const ownerSide = relationships[idx].ownerSide || false;
+    if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) {
         renMapAnotEnt = true;
 _%>
     @Mapping(source = "<%= relationshipName %>.id", target = "<%= relationships[idx].relationshipFieldName %>Id")
@@ -81,18 +81,20 @@ _%>
     <%= asDto(entityClass) %> toDto(<%= asEntity(entityClass) %> <%= asEntity(entityInstance) %>);
     <%_ } _%>
 
+<%_ } _%>
 <%_
+
+if (!embedded) {
 // DTO -> entity mapping
 var renMapAnotDto = false;  //Render Mapping Annotation during DTO to Entity conversion?
 // var hasOAuthUser = false; // if OAuthUser, use a String id in fromId() method
 for (idx in relationships) {
     const relationshipType = relationships[idx].relationshipType;
     const relationshipName = relationships[idx].relationshipName;
-    const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
     const relationshipNamePlural = relationships[idx].relationshipNamePlural;
     const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
     const ownerSide = relationships[idx].ownerSide;
-    if ((relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true) && !otherEntityIsEmbedded)) {
+    if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) {
         renMapAnotDto = true;
 _%>
     @Mapping(source = "<%= relationshipName %>Id", target = "<%= relationshipName %>")
@@ -133,4 +135,5 @@ _%>
         return new String(value);
     }
     <%_ } _%>
+<%_ } _%>
 }


### PR DESCRIPTION
Unless the other entity is also an embedded one: then the ownerside should be taken into account

This was one of my comment on the original PR: https://github.com/jhipster/generator-jhipster/pull/11239#issuecomment-627612064
And this also cause issues when using both ElasticSearch and MongoDB in Spring Boot 2.3

An illustration, with the following JDL:
```
entity DocumentBankAccount

@embedded
entity EmbeddedOperation

relationship OneToMany {
  DocumentBankAccount to EmbeddedOperation
}
```

### Before
```java
public class DocumentBankAccount implements Serializable {
    @Field("embeddedOperation")
    private Set<EmbeddedOperation> embeddedOperations = new HashSet<>();
}

public class EmbeddedOperation implements Serializable {
    @DBRef
    private DocumentBankAccount documentBankAccount;
}
```
### After
```java
public class DocumentBankAccount implements Serializable {
    @Field("embeddedOperation")
    private Set<EmbeddedOperation> embeddedOperations = new HashSet<>();
}

public class EmbeddedOperation implements Serializable {
}
```

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
