### PR TITLE
Adjust dependabot.yml to skip ci and remove maven config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,12 +1,9 @@
 version: 2
 updates:
-    - package-ecosystem: maven
-      directory: "/"
-      schedule:
-          interval: weekly
-      open-pull-requests-limit: 10
     - package-ecosystem: npm
       directory: "/"
       schedule:
           interval: weekly
+      labels:
+          - "theme: dependabot-dependencies"
       open-pull-requests-limit: 10

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -43,7 +43,8 @@ jobs:
             !contains(github.event.head_commit.message, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[ci skip]') &&
-            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))
+            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
+            !contains(github.event.pull_request.labels.*.name, 'theme: dependabot-dependencies')
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -43,7 +43,8 @@ jobs:
             !contains(github.event.head_commit.message, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[ci skip]') &&
-            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))
+            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
+            !contains(github.event.pull_request.labels.*.name, 'theme: dependabot-dependencies')
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -43,7 +43,8 @@ jobs:
             !contains(github.event.head_commit.message, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[ci skip]') &&
-            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))
+            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
+            !contains(github.event.pull_request.labels.*.name, 'theme: dependabot-dependencies')
         timeout-minutes: 40
         strategy:
             fail-fast: false


### PR DESCRIPTION
This removes the unnecessary maven configuration from dependabot.yml and adds a label so that GitHub CI is skipped.

Fixes https://github.com/jhipster/generator-jhipster/issues/11962

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
