### PR TITLE
minor cleanup in configuration files

### DIFF
--- a/generators/server/templates/src/main/java/package/config/JacksonConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/JacksonConfiguration.java.ejs
@@ -60,7 +60,7 @@ public class JacksonConfiguration {
      * Module for serialization/deserialization of RFC7807 Problem.
      */
     @Bean
-    ProblemModule problemModule() {
+    public ProblemModule problemModule() {
         return new ProblemModule();
     }
 
@@ -68,7 +68,7 @@ public class JacksonConfiguration {
      * Module for serialization/deserialization of ConstraintViolationProblem.
      */
     @Bean
-    ConstraintViolationProblemModule constraintViolationProblemModule() {
+    public ConstraintViolationProblemModule constraintViolationProblemModule() {
         return new ConstraintViolationProblemModule();
     }
 }

--- a/generators/server/templates/src/main/java/package/config/LocaleConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/LocaleConfiguration.java.ejs
@@ -30,7 +30,7 @@ import org.springframework.web.servlet.i18n.LocaleChangeInterceptor;
 @Configuration
 public class LocaleConfiguration implements WebMvcConfigurer {
 
-    @Bean(name = "localeResolver")
+    @Bean
     public LocaleResolver localeResolver() {
         AngularCookieLocaleResolver cookieLocaleResolver = new AngularCookieLocaleResolver();
         cookieLocaleResolver.setCookieName("NG_TRANSLATE_LANG_KEY");


### PR DESCRIPTION
- add `public` modifier for bean definitions for consistency
- remove unnecessary bean qualifier `localeResolver` 

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
