### PR TITLE
Change Logic Concerning dependabot CI Skipping

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,6 +4,4 @@ updates:
       directory: "/"
       schedule:
           interval: weekly
-      labels:
-          - "theme: dependabot-dependencies"
       open-pull-requests-limit: 10

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -44,7 +44,7 @@ jobs:
             !contains(github.event.pull_request.title, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[ci skip]') &&
             (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
-            !contains(github.event.pull_request.labels.*.name, 'theme: dependabot-dependencies')
+            !contains(github.event.pull_request.user.login, 'dependabot')
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -44,7 +44,7 @@ jobs:
             !contains(github.event.pull_request.title, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[ci skip]') &&
             (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
-            !contains(github.event.pull_request.labels.*.name, 'theme: dependabot-dependencies')
+            !contains(github.event.pull_request.user.login, 'dependabot')
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -44,7 +44,7 @@ jobs:
             !contains(github.event.pull_request.title, '[skip ci]') &&
             !contains(github.event.pull_request.title, '[ci skip]') &&
             (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
-            !contains(github.event.pull_request.labels.*.name, 'theme: dependabot-dependencies')
+            !contains(github.event.pull_request.user.login, 'dependabot')
         timeout-minutes: 40
         strategy:
             fail-fast: false

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -16,7 +16,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-trigger:
+pr:
     branches:
         exclude:
         - dependabot/*


### PR DESCRIPTION
This changes the logic in dependabot pull request CI skipping. Current logic was created with the hope dependabot creates a label on the PR creation. But unfortunately dependabot adds the label after the PR is created by which time the CI has already been triggered.

Related to https://github.com/jhipster/generator-jhipster/issues/11962

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
