### PR TITLE
set default license to unlicensed in order to meet third party standard

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -352,7 +352,7 @@ jhipster:
         contact-name:
         contact-url:
         contact-email:
-        license:
+        license: unlicensed
         license-url:
     <%_ if (authenticationType === 'oauth2') { _%>
     security:


### PR DESCRIPTION
A default value for the license should be set as it is required by multiple other applications. So it would ease my daily duties as a developer.
On the other hand there is automatically a license depending on the country where the new application gets generated. In order to avoid confusion here, a default value can help.

- This is what we do in the package.json (the keyword used is "UNLICENSED" which means this is a private project) -> we need the same thing here to be consistent

- This license name is required by some third-parties