### PR TITLE
Add support to i18n variant

### DIFF
--- a/generators/entity-i18n/templates/i18n/entity_pt-br.json.ejs
+++ b/generators/entity-i18n/templates/i18n/entity_pt-br.json.ejs
@@ -18,6 +18,8 @@
 -%><%
 let helpBlocks = 0; %>
 {
+    <% // Male (default) variant
+    if (entityI18nVariant !== 'female') { %>
     "<%= angularAppName %>": {
         "<%= entityTranslationKey %>" : {
             "home": {
@@ -47,12 +49,52 @@ let helpBlocks = 0; %>
             } %>
             }<% } %>
         }
-    }<% if (microserviceAppName) { %>,
+    }<%     if (microserviceAppName) { %>,
     "<%= microserviceAppName %>": {
         "<%= entityTranslationKey %>" : {
             "created": "Um novo <%= entityClassHumanized %> foi criado com o identificador {{ param }}",
             "updated": "Um <%= entityClassHumanized %> foi atualizado com o identificador {{ param }}",
             "deleted": "Um <%= entityClassHumanized %> foi excluído com o identificador {{ param }}"
         }
-    }<% } %>
+    }<%     } %>
+    <% } else {
+      // Female variant %>
+    "<%= angularAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "home": {
+                "title": "<%= entityClassPluralHumanized %>",
+                "createLabel": "Criar nova <%= entityClassHumanized %>",
+                "createOrEditLabel": "Criar ou editar <%= entityClassHumanized %>"<% if (searchEngine !== false) { %>,
+                "search": "Pesquisar por <%= entityClassHumanized %>"<% } %>,
+                "notFound": "Nenhuma <%= entityClassHumanized %> encontrada"
+            },<% if (!microserviceAppName) { %>
+            "created": "Uma nova <%= entityClassHumanized %> foi criada com o identificador {{ param }}",
+            "updated": "Uma <%= entityClassHumanized %> foi atualizada com o identificador {{ param }}",
+            "deleted": "Uma <%= entityClassHumanized %> foi excluída com o identificador {{ param }}",<% } %>
+            "delete": {
+                "question": "Tem certeza de que deseja excluir <%= entityClassHumanized %> {{ id }}?"
+            },
+            "detail": {
+                "title": "<%= entityClassHumanized %>"
+            }<% for (idx in fields) {
+            if (typeof fields[idx].javadoc !== 'undefined') ++helpBlocks; %>,
+            "<%= fields[idx].fieldName %>": "<%= fields[idx].fieldNameHumanized %>"<% } %><% for (idx in relationships) { %>,
+            "<%= relationships[idx].relationshipName %>": "<%= relationships[idx].relationshipNameHumanized %>"<% } if (helpBlocks > 0) { %>,
+            "help": {<% for (idx in fields) {
+                if (fields[idx].javadoc) {
+                    --helpBlocks; %>
+                "<%= fields[idx].fieldName %>": "<%= fields[idx].javadoc %>"<% if (helpBlocks > 0) { %>,<% }
+                }
+            } %>
+            }<% } %>
+        }
+    }<%     if (microserviceAppName) { %>,
+    "<%= microserviceAppName %>": {
+        "<%= entityTranslationKey %>" : {
+            "created": "Uma nova <%= entityClassHumanized %> foi criada com o identificador {{ param }}",
+            "updated": "Uma <%= entityClassHumanized %> foi atualizada com o identificador {{ param }}",
+            "deleted": "Uma <%= entityClassHumanized %> foi excluída com o identificador {{ param }}"
+        }
+    }<%     } %>
+    <% } %>
 }

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -688,9 +688,13 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 const entityNamePluralizedAndSpinalCased = _.kebabCase(pluralize(entityName));
 
                 context.entityClass = context.entityNameCapitalized;
-                context.entityClassHumanized = _.startCase(context.entityNameCapitalized);
                 context.entityClassPlural = pluralize(context.entityClass);
-                context.entityClassPluralHumanized = _.startCase(context.entityClassPlural);
+
+                const fileData = this.data || this.context.fileData;
+                // Used for i18n
+                context.entityClassHumanized = fileData.entityClassHumanized || _.startCase(context.entityNameCapitalized);
+                context.entityClassPluralHumanized = fileData.entityClassPluralHumanized || _.startCase(context.entityClassPlural);
+
                 context.entityInstance = _.lowerFirst(entityName);
                 context.entityInstancePlural = pluralize(context.entityInstance);
                 context.entityApiUrl = entityNamePluralizedAndSpinalCased;

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -748,6 +748,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
 
                 // Load in-memory data for fields
                 context.fields.forEach(field => {
+                    const fieldOptions = field.options || {};
                     // Migration from JodaTime to Java Time
                     if (field.fieldType === 'DateTime' || field.fieldType === 'Date') {
                         field.fieldType = 'Instant';
@@ -807,7 +808,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     }
 
                     if (_.isUndefined(field.fieldNameHumanized)) {
-                        field.fieldNameHumanized = _.startCase(field.fieldName);
+                        field.fieldNameHumanized = fieldOptions.fieldNameHumanized || _.startCase(field.fieldName);
                     }
 
                     if (_.isUndefined(field.fieldInJavaBeanMethod)) {
@@ -881,6 +882,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 let hasUserField = false;
                 // Load in-memory data for relationships
                 context.relationships.forEach(relationship => {
+                    const relationshipOptions = relationship.options || {};
                     const otherEntityName = relationship.otherEntityName;
                     const otherEntityData = this.getEntityJson(otherEntityName);
                     if (otherEntityData) {
@@ -969,7 +971,8 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     }
 
                     if (_.isUndefined(relationship.relationshipNameHumanized)) {
-                        relationship.relationshipNameHumanized = _.startCase(relationship.relationshipName);
+                        relationship.relationshipNameHumanized =
+                            relationshipOptions.relationshipNameHumanized || _.startCase(relationship.relationshipName);
                     }
 
                     if (_.isUndefined(relationship.relationshipNamePlural)) {

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -694,6 +694,8 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 // Used for i18n
                 context.entityClassHumanized = fileData.entityClassHumanized || _.startCase(context.entityNameCapitalized);
                 context.entityClassPluralHumanized = fileData.entityClassPluralHumanized || _.startCase(context.entityClassPlural);
+                // Implement i18n variant ex: 'male', 'female' when applied
+                context.entityI18nVariant = fileData.entityI18nVariant || 'default';
 
                 context.entityInstance = _.lowerFirst(entityName);
                 context.entityInstancePlural = pluralize(context.entityInstance);


### PR DESCRIPTION
Allows i18n to be generated based on the entityI18nVariant like:

Portuguese example:
```
@entityI18nVariant(female)
entity Empresa {
}

entity Usuario {
}
```

Should generate string:
`Um Usuario` for Usuario entity and `Uma Empresa` for Empresa entity.

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
