### PR TITLE
Fix Mistakes in Logic Concerning dependabot CI Exclusions

### DIFF
--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -18,13 +18,24 @@
 #
 
 name: 'Validate Gradle Wrapper'
-on: [push, pull_request]
+on:
+    push:
+        branches-ignore:
+            - 'dependabot/**'
+    pull_request:
+        branches:
+            - '*'
 
 jobs:
     validation:
         name: 'Validation'
         runs-on: ubuntu-latest
-        if: "!contains(github.event.head_commit.message, '[ci skip]') && !contains(github.event.head_commit.message, '[skip ci]') && !contains(github.event.pull_request.title, '[skip ci]') && !contains(github.event.pull_request.title, '[ci skip]')"
+        if: >-
+            !contains(github.event.head_commit.message, '[ci skip]') &&
+            !contains(github.event.head_commit.message, '[skip ci]') &&
+            !contains(github.event.pull_request.title, '[skip ci]') &&
+            !contains(github.event.pull_request.title, '[ci skip]') &&
+            !contains(github.event.pull_request.user.login, 'dependabot')
         steps:
             - uses: actions/checkout@v2
             - uses: gradle/wrapper-validation-action@v1

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,6 +22,7 @@ trigger:
         - dependabot/*
 jobs:
     - job: Test
+      condition: not(contains(variables['Build.RequestedFor'], 'dependabot'))
       pool:
           vmImage: 'ubuntu-18.04'
       variables:


### PR DESCRIPTION
This fixes some mistakes in the dependabot logic. Currently dependabot only skips for pull request CI. We also need to skip pushes. Also with this change the azure builds are skipped for dependabot.

Related to https://github.com/jhipster/generator-jhipster/issues/11962

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
