### PR TITLE
Add prettier check workflow

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,7 +1,7 @@
 version: 2
 updates:
     - package-ecosystem: npm
-      directory: "/"
+      directory: '/'
       schedule:
           interval: weekly
       open-pull-requests-limit: 10

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -29,12 +29,6 @@ jobs:
     generator-jhipster:
         name: npm test
         runs-on: ${{ matrix.os }}
-        if: >-
-            !contains(github.event.head_commit.message, '[ci skip]') &&
-            !contains(github.event.head_commit.message, '[skip ci]') &&
-            !contains(github.event.pull_request.title, '[skip ci]') &&
-            !contains(github.event.pull_request.title, '[ci skip]') &&
-            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))
         timeout-minutes: 20
         strategy:
             fail-fast: false
@@ -54,4 +48,11 @@ jobs:
               run: $JHI_SCRIPTS/04-git-config.sh
               shell: bash
             - run: npm ci
+            - run: npm run prettier:check
             - run: npm test
+              if: >-
+                  !contains(github.event.head_commit.message, '[ci skip]') &&
+                  !contains(github.event.head_commit.message, '[skip ci]') &&
+                  !contains(github.event.pull_request.title, '[skip ci]') &&
+                  !contains(github.event.pull_request.title, '[ci skip]') &&
+                  (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci'))

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,7 @@
 trigger:
     branches:
         exclude:
-        - dependabot/*
+            - dependabot/*
 jobs:
     - job: Test
       condition: not(contains(variables['Build.RequestedFor'], 'dependabot'))

--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     },
     "scripts": {
         "prettier:format": "prettier --write \"{,**/}*.{js,json,md,yml,java}\"",
+        "prettier:check": "prettier --check \"{,**/}*.{js,json,md,yml,java}\"",
         "completion": "tabtab install --name jhipster --auto",
         "lint": "npm run eslint && npm run ejs-lint",
         "lint-fix": "npm run prettier:format && npm run eslint -- --fix",


### PR DESCRIPTION
This PR add a prettier:check script and a github workflow to check.
`skip-ci` is not be applied to this workflow since README.md and others text files should be formatted too.

An alternative is to run prettier:check at pretest script.

---

-   Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
