### PR TITLE
Attempt to Skip Azure Pipelines for Dependabot

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -22,7 +22,7 @@ trigger:
             - dependabot/*
 jobs:
     - job: Test
-      condition: not(contains(variables['Build.RequestedFor'], 'dependabot'))
+      condition: not(contains(variables['System.PullRequest.SourceBranch'], 'dependabot'))
       pool:
           vmImage: 'ubuntu-18.04'
       variables:


### PR DESCRIPTION
I've noticed that dependabot isn't still skipped for Azure pipelines. This is another attempt to fix this.

Related to https://github.com/jhipster/generator-jhipster/issues/11914

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
