### PR TITLE
Remove java8 support

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -20,7 +20,7 @@ const semver = require('semver');
 const packagejs = require('../package.json');
 
 // Version of Java
-const JAVA_VERSION = '1.8'; // Java version is forced to be 1.8. We keep the variable as it might be useful in the future.
+const JAVA_VERSION = '11'; // Java version is forced to be 11. We keep the variable as it might be useful in the future.
 
 // Version of Node, Yarn, NPM
 const NODE_VERSION = '12.16.1';

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -60,7 +60,7 @@ description = ""
 
 sourceCompatibility=<%= JAVA_VERSION %>
 targetCompatibility=<%= JAVA_VERSION %>
-assert System.properties["java.specification.version"] == "1.8" || "11" || "12" || "13" || "14"
+assert System.properties["java.specification.version"] == "1.8" || "1.9" || "10" || "11" || "12" || "13" || "14"
 
 apply from: "gradle/docker.gradle"
 apply from: "gradle/sonar.gradle"

--- a/test/templates/ci-cd/maven-ngx-yarn/pom.xml
+++ b/test/templates/ci-cd/maven-ngx-yarn/pom.xml
@@ -36,7 +36,7 @@
     <properties>
         <!-- Build properties -->
         <maven.version>3.0.0</maven.version>
-        <java.version>1.8</java.version>
+        <java.version>11</java.version>
         <scala.version>2.12.1</scala.version>
         <node.version>v8.11.2</node.version>
         <yarn.version>v1.6.0</yarn.version>
@@ -375,7 +375,7 @@
                         <requireJavaVersion>
                             <!-- Until JHipster supports JDK 9 -->
                             <message>You are running an incompatible version of Java. JHipster requires JDK ${java.version}</message>
-                            <version>[1.8,1.9)</version>
+                            <version>[1.8,15)</version>
                         </requireJavaVersion>
                     </rules>
                 </configuration>


### PR DESCRIPTION
<!--
PR description.
-->
According to v7 roadmap. Remove Java8 support. I suggest to set Java 11 as default version and allow from 1.9 to 14. 
---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
