### PR TITLE
Remove getAllJhipsterConfig.

### DIFF
--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 const chalk = require('chalk');
+const fs = require('fs');
 const _ = require('lodash');
 const path = require('path');
 const jhiCore = require('jhipster-core');
@@ -25,7 +26,7 @@ const pluralize = require('pluralize');
 const { fork } = require('child_process');
 
 const { CLI_NAME, GENERATOR_NAME, logger, toString, printSuccess, doneFactory, getOptionAsArgs } = require('./utils');
-const jhipsterUtils = require('../generators/utils');
+const { getDBTypeFromDBValue, loadYoRc } = require('../generators/utils');
 
 const packagejs = require('../package.json');
 const statistics = require('../generators/statistics');
@@ -242,16 +243,20 @@ class JDLProcessor {
     }
 
     getConfig() {
-        if (jhiCore.FileUtils.doesFileExist('.yo-rc.json')) {
+        if (fs.existsSync('.yo-rc.json')) {
+            const yoRC = loadYoRc('.yo-rc.json');
+            const configuration = yoRC['generator-jhipster'];
+            if (!configuration) {
+                return;
+            }
             logger.info('Found .yo-rc.json on path. This is an existing app');
-            const configuration = jhipsterUtils.getAllJhipsterConfig(null, true);
             if (_.isUndefined(this.options.interactive)) {
                 logger.debug('Setting interactive true for existing apps');
                 this.options.interactive = true;
             }
             this.applicationType = configuration.applicationType;
             this.baseName = configuration.baseName;
-            this.databaseType = configuration.databaseType || jhipsterUtils.getDBTypeFromDBValue(this.options.db);
+            this.databaseType = configuration.databaseType || getDBTypeFromDBValue(this.options.db);
             this.prodDatabaseType = configuration.prodDatabaseType || this.options.db;
             this.devDatabaseType = configuration.devDatabaseType || this.options.db;
             this.skipClient = configuration.skipClient;

--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -83,7 +83,7 @@ module.exports = class extends BaseGenerator {
             },
             getConfig() {
                 this.jhipsterVersion = packagejs.version;
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.baseName = configuration.get('baseName');
                 this.dasherizedBaseName = _.kebabCase(this.baseName);
                 this.applicationType = configuration.get('applicationType');

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -92,7 +92,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.PRETTIER_JAVA_VERSION = constants.PRETTIER_JAVA_VERSION;
                 this.NODE_VERSION = constants.NODE_VERSION;
 
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.serverPort = configuration.get('serverPort') || this.configOptions.serverPort || 8080;
                 this.applicationType = configuration.get('applicationType') || this.configOptions.applicationType;
                 if (!this.applicationType) {

--- a/generators/cloudfoundry/index.js
+++ b/generators/cloudfoundry/index.js
@@ -36,7 +36,7 @@ module.exports = class extends BaseGenerator {
 
     initializing() {
         this.log(chalk.bold('CloudFoundry configuration is starting'));
-        const configuration = this.getAllJhipsterConfig(this, true);
+        const configuration = this.config;
         this.env.options.appPath = configuration.get('appPath') || constants.CLIENT_MAIN_SRC_DIR;
         this.baseName = configuration.get('baseName');
         this.buildTool = configuration.get('buildTool');

--- a/generators/docker-base.js
+++ b/generators/docker-base.js
@@ -19,7 +19,7 @@
 const shelljs = require('shelljs');
 const chalk = require('chalk');
 const dockerUtils = require('./docker-utils');
-const { getBase64Secret, getAllJhipsterConfig } = require('./utils');
+const { getBase64Secret } = require('./utils');
 
 module.exports = {
     checkDocker: dockerUtils.checkDocker,
@@ -105,7 +105,7 @@ function loadConfigs() {
     this.appsFolders.forEach(appFolder => {
         const path = this.destinationPath(`${this.directoryPath + appFolder}`);
         if (this.fs.exists(`${path}/.yo-rc.json`)) {
-            const config = getAllJhipsterConfig(this, true, path);
+            const config = this.getJhipsterConfig(`${path}/.yo-rc.json`).createProxy();
 
             if (config.applicationType === 'monolith') {
                 this.monolithicNb++;

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -144,7 +144,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
 
             getConfig() {
                 const context = this.context;
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 context.useConfigurationFile = false;
                 context.options = this.options;
                 context.baseName = configuration.get('baseName');

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -82,7 +82,7 @@ module.exports = class extends BaseGenerator {
             },
 
             loadConfig() {
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.env.options.appPath = configuration.get('appPath') || constants.CLIENT_MAIN_SRC_DIR;
                 this.baseName = configuration.get('baseName');
                 this.mainClass = this.getMainClassName();

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2178,15 +2178,16 @@ module.exports = class extends PrivateBase {
     /**
      * Get all the generator configuration from the .yo-rc.json file
      * @param {Generator} generator the generator instance to use
-     * @param {boolean} force force getting direct from file
      */
-    getAllJhipsterConfig(generator = this, force) {
-        const configRootPath =
-            generator.configRootPath ||
-            (generator.options && generator.options.configRootPath) ||
-            (generator.configOptions && generator.configOptions.configRootPath) ||
-            '';
-        return jhipsterUtils.getAllJhipsterConfig(generator, force, configRootPath);
+    getJhipsterConfig(yoRcPath) {
+        if (yoRcPath === undefined) {
+            const configRootPath =
+                this.configRootPath ||
+                (this.options && this.options.configRootPath) ||
+                (this.configOptions && this.configOptions.configRootPath);
+            yoRcPath = path.join(configRootPath || this.destinationPath(), '.yo-rc.json');
+        }
+        return this.createStorage(yoRcPath, 'generator-jhipster');
     }
 
     /**

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -74,7 +74,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
             initializing() {
                 this.log(chalk.bold('Heroku configuration is starting'));
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.env.options.appPath = configuration.get('appPath') || constants.CLIENT_MAIN_SRC_DIR;
                 this.baseName = configuration.get('baseName');
                 this.packageName = configuration.get('packageName');

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -94,7 +94,7 @@ module.exports = class extends BaseBlueprintGenerator {
             },
 
             setupConsts() {
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 if (this.languages) {
                     if (this.skipClient) {
                         this.log(chalk.bold(`\nInstalling languages: ${this.languages.join(', ')} for server`));

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -142,7 +142,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.JACKSON_DATABIND_NULLABLE_VERSION = constants.JACKSON_DATABIND_NULLABLE_VERSION;
 
                 this.packagejs = packagejs;
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.applicationType = configuration.get('applicationType') || this.configOptions.applicationType;
                 if (!this.applicationType) {
                     this.applicationType = 'monolith';

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -60,7 +60,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
             initializing() {
                 this.log(`The spring-controller ${this.name} is being created.`);
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.baseName = configuration.get('baseName');
                 this.packageName = configuration.get('packageName');
                 this.packageFolder = configuration.get('packageFolder');

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -56,7 +56,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
             initializing() {
                 this.log(`The service ${this.name} is being created.`);
-                const configuration = this.getAllJhipsterConfig(this, true);
+                const configuration = this.config;
                 this.baseName = configuration.get('baseName');
                 this.packageName = configuration.get('packageName');
                 this.packageFolder = configuration.get('packageFolder');

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -59,7 +59,6 @@ module.exports = {
     getEnumInfo,
     copyObjectProps,
     decodeBase64,
-    getAllJhipsterConfig,
     getDBTypeFromDBValue,
     getBase64Secret,
     getRandomHex,
@@ -582,44 +581,6 @@ function loadYoRc(filePath = '.yo-rc.json') {
         return undefined;
     }
     return JSON.parse(fs.readFileSync(filePath, { encoding: 'utf-8' }));
-}
-
-/**
- * Get all the generator configuration from the .yo-rc.json file
- * @param {Generator} generator the generator instance to use
- * @param {boolean} force force getting direct from file
- * @param {String} base path where the .yo-rc.json file is located. Default is cwd.
- */
-function getAllJhipsterConfig(generator, force, basePath = '') {
-    let configuration = generator && generator.config ? generator.config.getAll() || {} : {};
-    const filePath = path.join(basePath || '', '.yo-rc.json');
-    if ((force || !configuration.baseName) && jhiCore.FileUtils.doesFileExist(filePath)) {
-        let yoRc;
-        if (generator && generator.fs) {
-            yoRc = generator.fs.readJSON(filePath);
-        } else {
-            yoRc = loadYoRc(filePath);
-        }
-        configuration = yoRc['generator-jhipster'];
-        // merge the blueprint configs if available
-        configuration.blueprints = loadBlueprintsFromConfiguration(configuration);
-        const blueprintConfigs = configuration.blueprints.map(bp => yoRc[bp.name]).filter(el => el !== null && el !== undefined);
-        if (blueprintConfigs.length > 0) {
-            const mergedConfigs = Object.assign(...blueprintConfigs);
-            configuration = { ...configuration, ...mergedConfigs };
-        }
-    }
-    if (!configuration.get || typeof configuration.get !== 'function') {
-        configuration = {
-            ...configuration,
-            getAll: () => configuration,
-            get: key => configuration[key],
-            set: (key, value) => {
-                configuration[key] = value;
-            },
-        };
-    }
-    return configuration;
 }
 
 /**

--- a/test/templates/ngx-blueprint/.yo-rc.json
+++ b/test/templates/ngx-blueprint/.yo-rc.json
@@ -1,5 +1,5 @@
 {
-    "generator-jhipster-myblueprint": {
+    "generator-jhipster": {
         "promptValues": {
             "packageName": "com.mycompany.myapp"
         },
@@ -22,14 +22,6 @@
         "enableSwaggerCodegen": false,
         "jwtSecretKey": "147e04cf224f52908a60d7a2902e19e0648d0a8c52503b4624f1708478dd29ba2885a9bb823c85873a76b27964a90e22f1e8",
         "clientFramework": "angularX",
-        "clientPackageManager": "npm"
-    },
-    "generator-jhipster": {
-        "promptValues": {
-            "nativeLanguage": "en"
-        },
-        "applicationType": "monolith",
-        "baseName": "myblueprint",
         "testFrameworks": [
             "gatling",
             "protractor"

--- a/test/utils.spec.js
+++ b/test/utils.spec.js
@@ -1,5 +1,4 @@
 const assert = require('yeoman-assert');
-const helpers = require('yeoman-test');
 const sinon = require('sinon');
 const utils = require('../generators/utils');
 
@@ -250,76 +249,6 @@ describe('JHipster Utils', () => {
         it("doesn't  do anything for scoped package", () => {
             const generatorName = utils.normalizeBlueprintName('@corp/foo');
             assert.textEqual(generatorName, '@corp/foo');
-        });
-    });
-    describe('::getAllJhipsterConfig', () => {
-        describe('without blueprint', () => {
-            const cwd = process.cwd();
-            const configRootDir = './test/templates/default';
-            const expectedConfig = {
-                applicationType: 'monolith',
-                baseName: 'sampleMysql',
-                packageName: 'com.mycompany.myapp',
-                packageFolder: 'com/mycompany/myapp',
-                authenticationType: 'session',
-                cacheProvider: 'ehcache',
-                websocket: 'no',
-                databaseType: 'sql',
-                devDatabaseType: 'h2Disk',
-                prodDatabaseType: 'mysql',
-                searchEngine: 'no',
-                buildTool: 'maven',
-                enableTranslation: true,
-                nativeLanguage: 'en',
-                languages: ['en', 'fr'],
-                rememberMeKey: '2bb60a80889aa6e6767e9ccd8714982681152aa5',
-                testFrameworks: ['gatling'],
-            };
-
-            it('load config from alternate directory', () => {
-                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
-                assert.objectContent(loadedConfig, expectedConfig);
-            });
-            it('load config from current working directory', () => {
-                process.chdir(configRootDir);
-                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true);
-                assert.objectContent(loadedConfig, expectedConfig);
-            });
-            after(() => {
-                process.chdir(cwd);
-            });
-        });
-        describe('with blueprint', () => {
-            const configRootDir = './test/templates/ngx-blueprint';
-
-            it('merges config from main generator and blueprint', () => {
-                const expectedConfig = {
-                    applicationType: 'monolith',
-                    baseName: 'myblueprint',
-                    packageName: 'com.mycompany.myapp',
-                    packageFolder: 'com/mycompany/myapp',
-                    authenticationType: 'jwt',
-                    cacheProvider: 'ehcache',
-                    websocket: false,
-                    databaseType: 'sql',
-                    devDatabaseType: 'h2Disk',
-                    prodDatabaseType: 'mysql',
-                    searchEngine: false,
-                    buildTool: 'maven',
-                    enableTranslation: true,
-                    nativeLanguage: 'en',
-                    languages: ['en', 'fr'],
-                    testFrameworks: ['gatling', 'protractor'],
-                    jhiPrefix: 'jhi',
-                };
-                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
-                assert.objectContent(loadedConfig, expectedConfig);
-            });
-            it('correctly handles deprecated blueprint information', () => {
-                const expectedBlueprints = [{ name: 'generator-jhipster-myblueprint', version: '0.2' }];
-                const loadedConfig = utils.getAllJhipsterConfig(helpers.createDummyGenerator(), true, configRootDir);
-                assert.deepStrictEqual(loadedConfig.get('blueprints'), expectedBlueprints);
-            });
         });
     });
     describe('::stringHashCode', () => {

--- a/utils/jhipster6-mixin.js
+++ b/utils/jhipster6-mixin.js
@@ -1,0 +1,39 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const jhipster6Compatibility = {};
+
+/**
+ * Provides a replacement for jhipster 6 getAllJhipsterConfig.
+ * - Removed force parameter.
+ * - Set will write to config file.
+ */
+jhipster6Compatibility.getAllJhipsterConfig = function (generator = this) {
+    const proxy = generator.getJhipsterConfig().createProxy();
+    return {
+        ...proxy,
+        getAll: () => proxy,
+        get: key => proxy[key],
+        set: (key, value) => {
+            proxy[key] = value;
+        },
+    };
+};
+
+module.exports = jhipster6Compatibility;


### PR DESCRIPTION
Fixes #12023 

Remove getAllJhipsterConfig and implement getJhipsterConfig alternative.

- getAllJhipsterConfig was implemented as a workaround to blueprint/modules saving config to .yo-rc.json with another namespace.
- Merge implemented by getAllJhipsterConfig is not deterministic (depends on the order blueprints are loaded).
- Fixed by making blueprints always write to 'generator-jhipster' namespace
- `generator/utils` does not have stability guarantee.

Modules can get a Storage instance by: 
- `const jhipsterConfig = this._getStorage('generator-jhipster');` extending plain yeoman-generator.
-  or `const jhipsterConfig = this.getJhipsterConfig();` extending generator-base.

This requires to use `jhipsterConfig.get/set` methods.

If you prefer to use the object directly :
```
const proxyConfig = jhipsterConfig.createProxy();
proxyConfig.customConfig = 'configValue';
const customConfig = proxyConfig.customConfig;
```
 
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
