### PR TITLE
Create jhipsterConfig for synchronised config and move configOptions to generator-base.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -32,7 +32,6 @@ module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.configOptions = opts.configOptions || {};
         // This adds support for a `--from-cli` flag
         this.option('from-cli', {
             desc: 'Indicates the command is run from JHipster CLI',

--- a/generators/aws-containers/index.js
+++ b/generators/aws-containers/index.js
@@ -65,7 +65,6 @@ module.exports = class extends BaseGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.configOptions = this.options.configOptions || {};
         // This adds support for a `--from-cli` flag
         this.option('from-cli', {
             desc: 'Indicates the command is run from JHipster CLI',

--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -28,7 +28,6 @@ module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.configOptions = this.options.configOptions || {};
         // This adds support for a `--from-cli` flag
         this.option('from-cli', {
             desc: 'Indicates the command is run from JHipster CLI',

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -29,7 +29,6 @@ module.exports = class extends BaseBlueprintGenerator {
         super(args, opts);
         utils.copyObjectProps(this, opts.context);
         this.jhipsterContext = opts.jhipsterContext || opts.context;
-        this.configOptions = opts.configOptions || {};
 
         useBlueprints =
             !this.fromBlueprint &&

--- a/generators/entity-i18n/index.js
+++ b/generators/entity-i18n/index.js
@@ -29,7 +29,6 @@ module.exports = class extends BaseBlueprintGenerator {
         super(args, opts);
         utils.copyObjectProps(this, opts.context);
         this.jhipsterContext = opts.jhipsterContext || opts.context;
-        this.configOptions = opts.configOptions || {};
 
         useBlueprints =
             !this.fromBlueprint && this.instantiateBlueprints('entity-i18n', { context: opts.context, debug: opts.context.isDebugEnabled });

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -30,7 +30,6 @@ module.exports = class extends BaseBlueprintGenerator {
         super(args, opts);
         utils.copyObjectProps(this, opts.context);
         this.jhipsterContext = opts.jhipsterContext || opts.context;
-        this.configOptions = opts.configOptions || {};
 
         this.testsNeedCsrf = ['uaa', 'oauth2', 'session'].includes(this.jhipsterContext.authenticationType);
 

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -35,8 +35,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.configOptions = this.options.configOptions || {};
-
         // This makes `name` a required argument.
         this.argument('name', {
             type: String,

--- a/generators/generator-base-blueprint.js
+++ b/generators/generator-base-blueprint.js
@@ -28,12 +28,11 @@ module.exports = class extends BaseGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.jhipsterConfig = this._getStorage('generator-jhipster');
         this.fromBlueprint = this.rootGeneratorName() !== 'generator-jhipster';
 
         if (this.fromBlueprint) {
             this.blueprintConfig = this.config;
-            this.config = this.jhipsterConfig;
+            this.config = this._getStorage('generator-jhipster');
         }
     }
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -56,6 +56,9 @@ module.exports = class extends PrivateBase {
 
         // JHipster config using proxy mode (like a plain object)
         this.jhipsterConfig = this._getStorage('generator-jhipster').createProxy();
+
+        // JHipster runtime config that should not be stored to .yo-rc.json.
+        this.configOptions = this.options.configOptions || {};
     }
 
     /**
@@ -1239,7 +1242,7 @@ module.exports = class extends PrivateBase {
      * @param {any} options - options to pass
      * @return {object} the composed generator
      */
-    composeExternalModule(npmPackageName, subGen, options) {
+    composeExternalModule(npmPackageName, subGen, options = {}) {
         const generatorName = jhipsterUtils.packageNameToNamespace(npmPackageName);
         const generatorCallback = `${generatorName}:${subGen}`;
         if (!this.env.isPackageRegistered(generatorName)) {
@@ -1248,6 +1251,7 @@ module.exports = class extends PrivateBase {
         if (!this.env.get(generatorCallback)) {
             throw new Error(`Generator ${generatorCallback} isn't registered.`);
         }
+        options.configOptions = options.configOptions || this.configOptions;
         return this.composeWith(generatorCallback, options, true);
     }
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -51,6 +51,13 @@ const REACT = constants.SUPPORTED_CLIENT_FRAMEWORKS.REACT;
  * The method signatures in public API should not be changed without a major version change
  */
 module.exports = class extends PrivateBase {
+    constructor(args, opts) {
+        super(args, opts);
+
+        // JHipster config using proxy mode (like a plain object)
+        this.jhipsterConfig = this._getStorage('generator-jhipster').createProxy();
+    }
+
     /**
      * expose custom CLIENT_MAIN_SRC_DIR to templates and needles
      */

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -36,7 +36,7 @@ let useBlueprints;
 module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
-        this.configOptions = this.options.configOptions || {};
+
         // This adds support for a `--from-cli` flag
         this.option('from-cli', {
             desc: 'Indicates the command is run from JHipster CLI',

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -33,7 +33,6 @@ module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.configOptions = this.options.configOptions || {};
         // This adds support for a `--from-cli` flag
         this.option('from-cli', {
             desc: 'Indicates the command is run from JHipster CLI',

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -34,7 +34,6 @@ module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
 
-        this.configOptions = this.options.configOptions || {};
         // This adds support for a `--from-cli` flag
         this.option('from-cli', {
             desc: 'Indicates the command is run from JHipster CLI',

--- a/generators/spring-controller/index.js
+++ b/generators/spring-controller/index.js
@@ -32,7 +32,7 @@ let useBlueprints;
 module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
-        this.configOptions = this.options.configOptions || {};
+
         this.argument('name', { type: String, required: true });
         this.name = this.options.name;
         // This adds support for a `--from-cli` flag

--- a/generators/spring-service/index.js
+++ b/generators/spring-service/index.js
@@ -28,7 +28,7 @@ let useBlueprints;
 module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
-        this.configOptions = this.options.configOptions || {};
+
         this.argument('name', { type: String, required: true });
         this.name = this.options.name;
         // This adds support for a `--from-cli` flag


### PR DESCRIPTION
- Create jhipsterConfig for easily read/write synchronised configuration.
- Move configOptions initialisation to generator-base since almost every generator implements it.


Breaking change:  `jhipsterConfig` already existed at generator-base-blueprint, but its not documented and probably no blueprint uses it.
Replacement:
Change `const config = this.jhipsterConfig.get('config');` to `const config = this.jhipsterConfig.config;`
Or create getter/setter:
```
const jhipsterConfig = this.jhipsterConfig;
this.jhipsterConfig = {};
this.jhipsterConfig.get = config -> jhipsterConfig[config];
this.jhipsterConfig.set = (config, value) -> jhipsterConfig[config] = value;
```

Related to #10528 
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
