### PR TITLE
Fix prettier-java rule to .prettierrc

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -10,3 +10,9 @@ arrowParens: avoid
 
 # jsx and tsx rules:
 jsxBracketSameLine: false
+
+# java rules:
+overrides:
+  - files: "*.java"
+    options:
+      tabWidth: 4


### PR DESCRIPTION
`jhipster --prettier-java` is generating source code `tabWidth: 2` but creating `.prettierrc` with `tabWidth: 4`.

At first prettier format, every java file will change due to updating tabWidth to 4.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
