### PR TITLE
fix swagger globptions ignore [v6.x_maintenance]

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.common.js.ejs
@@ -103,7 +103,7 @@ module.exports = (options) => ({
         new CopyWebpackPlugin({
             patterns: [
                 <%_ if (!reactive && (applicationType === 'gateway' || applicationType === 'monolith')) { _%>
-                { from: './node_modules/swagger-ui-dist/*.{js,css,html,png}', to: 'swagger-ui', flatten: true, globOptions: { ignore: ['index.html'] }},
+                { from: './node_modules/swagger-ui-dist/*.{js,css,html,png}', to: 'swagger-ui', flatten: true, globOptions: { ignore: ['**/index.html'] }},
                 { from: './node_modules/axios/dist/axios.min.js', to: 'swagger-ui' },
                 { from: './<%= MAIN_SRC_DIR %>swagger-ui/', to: 'swagger-ui' },
                 <%_ } _%>


### PR DESCRIPTION
This correctly overrides the swagger index.html to use the generated app's swagger /v2/api-docs endpoint instead of the default swagger petstore endpoint

Fix #12025

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
