### PR TITLE
Remove side effect of mock dateTimeProvider

### DIFF
--- a/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
@@ -70,7 +70,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 <%_ if (databaseType === 'sql' && !reactive && authenticationType !== 'oauth2') { _%>
-import org.springframework.boot.test.mock.mockito.MockBean
+import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.data.auditing.DateTimeProvider;
 <%_ } _%>

--- a/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
@@ -67,12 +67,10 @@ import org.junit.jupiter.api.extension.ExtendWith;
 <%_ if (databaseType === 'neo4j') { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
-<%_ if (databaseType === 'sql' && !reactive && authenticationType !== 'oauth2') { _%>
-import org.mockito.Mock;
-<%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 <%_ if (databaseType === 'sql' && !reactive && authenticationType !== 'oauth2') { _%>
+import org.springframework.boot.test.mock.mockito.MockBean
 import org.springframework.data.auditing.AuditingHandler;
 import org.springframework.data.auditing.DateTimeProvider;
 <%_ } _%>
@@ -206,7 +204,7 @@ public class UserServiceIT <% if (databaseType === 'cassandra') { %>extends Abst
     @Autowired
     private AuditingHandler auditingHandler;
 
-    @Mock
+    @MockBean
     private DateTimeProvider dateTimeProvider;
     <%_ } _%>
     <%_ if (databaseType !== 'no') { _%>


### PR DESCRIPTION
Using mock for dateTimeProvider may affect users test that use dateTimeProvider. To avoid side affect we need to use @MockBean

[issue](https://github.com/jhipster/generator-jhipster/issues/12042)
[pr jhipster-kotlin](https://github.com/jhipster/jhipster-kotlin/pull/247)