### PR TITLE
Fix jhipster regeneration showing prompt without --with-entities and

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -396,7 +396,7 @@ module.exports = class extends BaseBlueprintGenerator {
                     this.composeWith(require.resolve('../languages'), {
                         ...options,
                         configOptions,
-                        skipPrompts: this.options.withEntities || this.options.defaults,
+                        skipPrompts: this.options.withEntities || this.options.existingProject || this.options.defaults,
                         debug: this.isDebugEnabled,
                     });
                 }

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -146,6 +146,10 @@ module.exports = class extends BaseBlueprintGenerator {
             },
             updateLanguages() {
                 if (this.jhipsterConfig.enableTranslation) {
+                    if (this.languagesToApply && !this.jhipsterConfig.languages.includes(this.jhipsterConfig.nativeLanguage)) {
+                        // First time we are generating the native language
+                        this.languagesToApply.unshift(this.jhipsterConfig.nativeLanguage);
+                    }
                     // Concatenate the native language, current languages, and the new languages.
                     this.jhipsterConfig.languages = _.union(
                         [this.jhipsterConfig.nativeLanguage],

--- a/generators/languages/index.js
+++ b/generators/languages/index.js
@@ -113,8 +113,6 @@ module.exports = class extends BaseBlueprintGenerator {
                     } else {
                         this.log(chalk.bold(`\nInstalling languages: ${this.languagesToApply.join(', ')}`));
                     }
-                } else {
-                    this.log(chalk.bold('\nLanguages configuration is starting'));
                 }
             },
         };

--- a/test/languages.spec.js
+++ b/test/languages.spec.js
@@ -75,7 +75,7 @@ describe('JHipster generator languages', () => {
             });
         });
     });
-    context.only('Creates default i18n files for more then one language', () => {
+    context('Creates default i18n files for the native language', () => {
         describe('with prompts', () => {
             before(done => {
                 helpers
@@ -83,7 +83,82 @@ describe('JHipster generator languages', () => {
                     .withOptions({ skipInstall: true })
                     .withPrompts({
                         enableTranslation: true,
-                        nativeLanguage: 'en',
+                        nativeLanguage: 'fr',
+                        languages: [],
+                    })
+                    .on('end', done);
+            });
+            containsLanguageFiles('fr');
+        });
+        describe('with options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/languages'))
+                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'fr' })
+                    .withOptions({ skipInstall: true, languages: [] })
+                    .on('end', done);
+            });
+            containsLanguageFiles('fr');
+        });
+        describe('regenerating', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/languages'))
+                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'fr', languages: [] })
+                    .withOptions({ skipInstall: true })
+                    .on('end', done);
+            });
+            containsLanguageFiles('fr');
+        });
+    });
+    context('Creates default i18n files for the native language and an additional language', () => {
+        describe('with prompts', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/languages'))
+                    .withOptions({ skipInstall: true })
+                    .withPrompts({
+                        enableTranslation: true,
+                        nativeLanguage: 'fr',
+                        languages: ['en'],
+                    })
+                    .on('end', done);
+            });
+            containsLanguageFiles('fr');
+            containsLanguageFiles('en');
+        });
+        describe('with options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/languages'))
+                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'fr' })
+                    .withOptions({ skipInstall: true, languages: ['en'] })
+                    .on('end', done);
+            });
+            containsLanguageFiles('fr');
+            containsLanguageFiles('en');
+        });
+        describe('regenerating', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/languages'))
+                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'fr', languages: ['en'] })
+                    .withOptions({ skipInstall: true })
+                    .on('end', done);
+            });
+            containsLanguageFiles('fr');
+            containsLanguageFiles('en');
+        });
+    });
+    context('Creates default i18n files for more than one language', () => {
+        describe('with prompts', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/languages'))
+                    .withOptions({ skipInstall: true })
+                    .withPrompts({
+                        enableTranslation: true,
+                        nativeLanguage: 'fr',
                         languages: ['fr', 'de'],
                     })
                     .on('end', done);
@@ -95,22 +170,10 @@ describe('JHipster generator languages', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/languages'))
-                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'en' })
+                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'fr' })
                     .withOptions({ skipInstall: true, languages: ['fr', 'de'] })
                     .on('end', done);
             });
-            containsLanguageFiles('fr');
-            containsLanguageFiles('de');
-        });
-        describe('regenerating writes files for native language', () => {
-            before(done => {
-                helpers
-                    .run(require.resolve('../generators/languages'))
-                    .withLocalConfig({ enableTranslation: true, nativeLanguage: 'en', languages: ['fr', 'de'] })
-                    .withOptions({ skipInstall: true })
-                    .on('end', done);
-            });
-            containsLanguageFiles('en');
             containsLanguageFiles('fr');
             containsLanguageFiles('de');
         });


### PR DESCRIPTION
generate the native language the first time.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
