### PR TITLE
Prevented commit additions when no JDL dist file have changed

### DIFF
--- a/jdl/bundling/scripts/changed-generated-jdl-files-committer.js
+++ b/jdl/bundling/scripts/changed-generated-jdl-files-committer.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const path = require('path');
+const git = require('simple-git')();
+
+const generatedGrammarFilesFolder = path.join('jdl', 'parsing', 'generated');
+const generatedGrammarFile = 'generated-serialized-grammar.js';
+const generatedGrammarHTMLFile = 'grammar.html';
+const generatedJDLDistFilesFolder = path.join('jdl', 'bundling', 'dist');
+const generatedJDLDistFileName = 'jdl-core.min.js';
+
+module.exports = { commitChangedGeneratedJDLFiles };
+
+async function commitChangedGeneratedJDLFiles() {
+    const [jdlDistFilesHaveChanged, jdlGrammarFilesHaveChanged] = await Promise.all([
+        haveTheJDLDistFilesChanged(),
+        haveTheGeneratedJDLGrammarFilesChanged(),
+    ]);
+    const filesHaveChanged = jdlDistFilesHaveChanged || jdlGrammarFilesHaveChanged;
+    if (!filesHaveChanged) {
+        console.info('No JDL dist file changes.');
+        return;
+    }
+    console.info('The JDL dist files have changed, committing them.');
+    await addChangedJDLFiles();
+    await commitChangedJDLFiles();
+}
+
+async function haveTheJDLDistFilesChanged() {
+    const changes = await git.diff([path.join(generatedJDLDistFilesFolder, generatedJDLDistFileName)]);
+    return !!changes;
+}
+
+async function haveTheGeneratedJDLGrammarFilesChanged() {
+    const changes = await git.diff([
+        path.join(generatedGrammarFilesFolder, generatedGrammarFile),
+        path.join(generatedGrammarFilesFolder, generatedGrammarHTMLFile),
+    ]);
+    return !!changes;
+}
+
+async function addChangedJDLFiles() {
+    await git.add(path.join(generatedJDLDistFilesFolder, generatedJDLDistFileName));
+    await git.add(path.join(generatedGrammarFilesFolder, generatedGrammarFile));
+    await git.add(path.join(generatedGrammarFilesFolder, generatedGrammarHTMLFile));
+}
+
+async function commitChangedJDLFiles() {
+    await git.commit('Update JDL dist files');
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,29 @@
                 "kuler": "^2.0.0"
             }
         },
+        "@kwsites/file-exists": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/file-exists/-/file-exists-1.1.1.tgz",
+            "integrity": "sha512-m9/5YGR18lIwxSFDwfE3oA7bWuq9kdau6ugN4H2rJeyhFQZcG9AgSHkQtSD15a8WvTgfz9aikZMrKPHvbpqFiw==",
+            "requires": {
+                "debug": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
+        },
+        "@kwsites/promise-deferred": {
+            "version": "1.1.1",
+            "resolved": "https://registry.npmjs.org/@kwsites/promise-deferred/-/promise-deferred-1.1.1.tgz",
+            "integrity": "sha512-GaHYm+c0O9MjZRu0ongGBRbinu8gVAMd2UZjji6jVmqKtZluZnptXGWhz1E8j8D2HJ3f/yMxKAUC0b+57wncIw=="
+        },
         "@mrmlnc/readdir-enhanced": {
             "version": "2.2.1",
             "resolved": "https://registry.npmjs.org/@mrmlnc/readdir-enhanced/-/readdir-enhanced-2.2.1.tgz",
@@ -7873,6 +7896,26 @@
             "version": "3.0.2",
             "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.2.tgz",
             "integrity": "sha1-tf3AjxKH6hF4Yo5BXiUTK3NkbG0="
+        },
+        "simple-git": {
+            "version": "2.12.0",
+            "resolved": "https://registry.npmjs.org/simple-git/-/simple-git-2.12.0.tgz",
+            "integrity": "sha512-64YrHYqHskWDumxM4thMGCkAd7rek4FEnxcugnpKzJZH6vCkietblsp7TUNdt9qU0pHAnJAanAmjyyQLE46k/Q==",
+            "requires": {
+                "@kwsites/file-exists": "^1.1.1",
+                "@kwsites/promise-deferred": "^1.0.1",
+                "debug": "^4.1.1"
+            },
+            "dependencies": {
+                "debug": {
+                    "version": "4.1.1",
+                    "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+                    "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+                    "requires": {
+                        "ms": "^2.1.1"
+                    }
+                }
+            }
         },
         "simple-swizzle": {
             "version": "0.2.2",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
         "jsdoc": "jsdoc --configure jsdoc-conf.json",
         "prepare": "npm run jdl:diagrams && npm run jdl:bundle && npm run jdl:commit-dist",
         "jdl:bundle": "node jdl/bundling/scripts/bundle.js && webpack --config jdl/bundling/webpack.config.js",
-        "jdl:commit-dist": "git add jdl/bundling/dist && git add jdl/parsing/generated && git commit --allow-empty -m \"Update dist\"",
+        "jdl:commit-dist": "git add jdl/bundling/dist && git add jdl/parsing/generated && node scripts/commit-changed-generated-jdl-files.js",
         "jdl:diagrams": "node jdl/bundling/scripts/serialize-grammar.js && eslint jdl/parsing/generated"
     },
     "dependencies": {
@@ -84,6 +84,7 @@
         "randexp": "0.5.3",
         "semver": "7.3.2",
         "shelljs": "0.8.4",
+        "simple-git": "2.12.0",
         "sync-request": "6.1.0",
         "tabtab": "2.2.2",
         "test": "^0.6.0",

--- a/scripts/commit-changed-generated-jdl-files.js
+++ b/scripts/commit-changed-generated-jdl-files.js
@@ -1,0 +1,22 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const { commitChangedGeneratedJDLFiles } = require('../jdl/bundling/scripts/changed-generated-jdl-files-committer');
+
+commitChangedGeneratedJDLFiles();

--- a/test/jdl/bundling/scripts/commit-changed-generated-jdl-files.test.js
+++ b/test/jdl/bundling/scripts/commit-changed-generated-jdl-files.test.js
@@ -1,0 +1,155 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see http://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-unused-expressions */
+
+const path = require('path');
+const chai = require('chai');
+const proxyquire = require('proxyquire').noCallThru().noPreserveCache();
+
+const { expect } = chai;
+
+describe('ChangedGeneratedJDLFilesCommitter', () => {
+    describe('commitChangedGeneratedJDLFiles', () => {
+        context('when no file has changed', () => {
+            let commitCalled;
+            let diffCalled;
+
+            before(async () => {
+                commitCalled = false;
+                diffCalled = false;
+                const gitStub = {
+                    commit: () => {
+                        commitCalled = true;
+                    },
+                    diff: () => {
+                        diffCalled = true;
+                        return '';
+                    },
+                };
+                const changedGeneratedJDLFilesCommitter = proxyquire(
+                    '../../../../jdl/bundling/scripts/changed-generated-jdl-files-committer',
+                    {
+                        'simple-git': () => gitStub,
+                    }
+                );
+                await changedGeneratedJDLFilesCommitter.commitChangedGeneratedJDLFiles();
+            });
+
+            it('should check the diff', () => {
+                expect(diffCalled).to.be.true;
+            });
+            it('should not commit anything', () => {
+                expect(commitCalled).to.be.false;
+            });
+        });
+        context('when individual files have changed', () => {
+            [
+                path.join('jdl', 'bundling', 'dist', 'jdl-core.min.js'),
+                path.join('jdl', 'parsing', 'generated', 'grammar.html'),
+                path.join('jdl', 'parsing', 'generated', 'generated-serialized-grammar.js'),
+            ].forEach(file => {
+                context(`such as ${file}`, () => {
+                    let addCalled;
+                    let commitCalled;
+                    let diffCalled;
+
+                    before(async () => {
+                        addCalled = false;
+                        commitCalled = false;
+                        diffCalled = false;
+                        const gitStub = {
+                            add: fileName => {
+                                if (fileName === file) {
+                                    addCalled = true;
+                                }
+                            },
+                            commit: () => {
+                                commitCalled = true;
+                            },
+                            diff: fileNames => {
+                                if (fileNames.includes(file)) {
+                                    diffCalled = true;
+                                    return 'test';
+                                }
+                                return '';
+                            },
+                        };
+                        const changedGeneratedJDLFilesCommitter = proxyquire(
+                            '../../../../jdl/bundling/scripts/changed-generated-jdl-files-committer',
+                            {
+                                'simple-git': () => gitStub,
+                            }
+                        );
+                        await changedGeneratedJDLFilesCommitter.commitChangedGeneratedJDLFiles();
+                    });
+
+                    it('should check the diff', () => {
+                        expect(diffCalled).to.be.true;
+                    });
+                    it('should add the dist file', () => {
+                        expect(addCalled).to.be.true;
+                    });
+                    it('should commit it', () => {
+                        expect(commitCalled).to.be.true;
+                    });
+                });
+            });
+        });
+        context('when all the files have changed', () => {
+            let addCalled;
+            let commitCalled;
+            let diffCalled;
+
+            before(async () => {
+                addCalled = false;
+                commitCalled = false;
+                diffCalled = false;
+                const gitStub = {
+                    add: () => {
+                        addCalled = true;
+                    },
+                    commit: () => {
+                        commitCalled = true;
+                    },
+                    diff: () => {
+                        diffCalled = true;
+                        return 'test';
+                    },
+                };
+                const changedGeneratedJDLFilesCommitter = proxyquire(
+                    '../../../../jdl/bundling/scripts/changed-generated-jdl-files-committer',
+                    {
+                        'simple-git': () => gitStub,
+                    }
+                );
+                await changedGeneratedJDLFilesCommitter.commitChangedGeneratedJDLFiles();
+            });
+
+            it('should check the diff', () => {
+                expect(diffCalled).to.be.true;
+            });
+            it('should add the dist file', () => {
+                expect(addCalled).to.be.true;
+            });
+            it('should commit it', () => {
+                expect(commitCalled).to.be.true;
+            });
+        });
+    });
+});


### PR DESCRIPTION
Used the simple-git package to programmatically use git inside a script and
created a script that:
  - checked the dist file diffs
  - add the files
  - commit them

If no file has changed, then no commit is done for a NPM prepare step.
The prepare steps does:
```
Run both BEFORE the package is packed and published,
and on local npm install without any arguments.
This is run AFTER prepublish, but BEFORE prepublishOnly
```

Only does a commit if a JDL dist file has changed.

@pascalgrimaud this is the PR I was talking about :)

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
