### PR TITLE
Use sameAs function in confirm password in vue module

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/app/account/change-password/change-password.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/change-password/change-password.component.ts.ejs
@@ -1,4 +1,4 @@
-import { maxLength, minLength, required } from 'vuelidate/lib/validators';
+import { maxLength, minLength, required, sameAs } from 'vuelidate/lib/validators';
 import axios from 'axios';
 import { mapGetters } from 'vuex';
 import Component from 'vue-class-component';
@@ -15,9 +15,10 @@ const validations = {
       maxLength: maxLength(254)
     },
     confirmPassword: {
-      required,
-      minLength: minLength(4),
-      maxLength: maxLength(254)
+    // prettier-ignore
+    sameAsPassword: sameAs(vm => {
+      return vm.newPassword;
+      })
     }
   }
 };

--- a/generators/client/templates/vue/src/main/webapp/app/account/change-password/change-password.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/change-password/change-password.vue.ejs
@@ -59,17 +59,9 @@
                                v-bind:placeholder="$t('global.form[\'confirmpassword.placeholder\']')"
                                v-model="$v.resetPassword.confirmPassword.$model" minlength=4 maxlength=50 required>
                         <div v-if="$v.resetPassword.confirmPassword.$anyDirty && $v.resetPassword.confirmPassword.$invalid">
-                            <small class="form-text text-danger"
-                                   v-if="!$v.resetPassword.confirmPassword.required" v-text="$t('global.messages.validate.confirmpassword.required')">
-                                Your confirmation password is required.
-                            </small>
-                            <small class="form-text text-danger"
-                                   v-if="!$v.resetPassword.confirmPassword.minLength" v-text="$t('global.messages.validate.confirmpassword.minlength')">
-                                Your confirmation password is required to be at least 4 characters.
-                            </small>
-                            <small class="form-text text-danger"
-                                   v-if="!$v.resetPassword.confirmPassword.maxLength" v-text="$t('global.messages.validate.confirmpassword.maxlength')">
-                                Your confirmation password cannot be longer than 50 characters.
+                            <small class="form-text text-danger" v-if="!$v.resetAccount.confirmPassword.sameAsPassword"
+                                   v-text="$t('global.messages.error.dontmatch')">
+                                The password and its confirmation do not match!
                             </small>
                         </div>
                     </div>

--- a/generators/client/templates/vue/src/main/webapp/app/account/reset-password/finish/reset-password-finish.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/reset-password/finish/reset-password-finish.component.ts.ejs
@@ -1,5 +1,5 @@
 import axios from 'axios';
-import { maxLength, minLength, required } from 'vuelidate/lib/validators';
+import { maxLength, minLength, required, sameAs } from 'vuelidate/lib/validators';
 import { Inject, Vue, Component } from 'vue-property-decorator';
 import LoginService from '@/account/login.service';
 
@@ -11,9 +11,10 @@ const validations = {
       maxLength: maxLength(254)
     },
     confirmPassword: {
-      required,
-      minLength: minLength(4),
-      maxLength: maxLength(254)
+    // prettier-ignore
+    sameAsPassword: sameAs(vm => {
+      return vm.newPassword;
+      })
     }
   }
 };

--- a/generators/client/templates/vue/src/main/webapp/app/account/reset-password/finish/reset-password-finish.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/reset-password/finish/reset-password-finish.vue.ejs
@@ -56,17 +56,9 @@
                                v-bind:placeholder="$t('global.form[\'confirmpassword.placeholder\']')"
                                v-model="$v.resetAccount.confirmPassword.$model" minlength=4 maxlength=50 required>
                             <div v-if="$v.resetAccount.confirmPassword.$anyDirty && $v.resetAccount.confirmPassword.$invalid">
-                                <small class="form-text text-danger"
-                                   v-if="!$v.resetAccount.confirmPassword.required" v-text="$t('global.messages.validate.confirmpassword.required')">
-                                    Your confirmation password is required.
-                                </small>
-                                <small class="form-text text-danger"
-                                   v-if="!$v.resetAccount.confirmPassword.minLength" v-text="$t('global.messages.validate.confirmpassword.minlength')">
-                                    Your confirmation password is required to be at least 4 characters.
-                                </small>
-                                <small class="form-text text-danger"
-                                   v-if="!$v.resetAccount.confirmPassword.maxLength" v-text="$t('global.messages.validate.confirmpassword.maxlength')">
-                                    Your confirmation password cannot be longer than 50 characters.
+                                <small class="form-text text-danger" v-if="!$v.resetAccount.confirmPassword.sameAsPassword"
+                                       v-text="$t('global.messages.error.dontmatch')">
+                                    The password and its confirmation do not match!
                                 </small>
                             </div>
                         </div>


### PR DESCRIPTION
Please make sure the below checklist is followed for Pull Requests.

-   [x ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x ] Tests are added where necessary
-   [x ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed


changes in validations (Vuelidate): check if the passwords match in the views "change-password" and "reset-password-finish". With the use of the sameAs function it is not necessary to check the password length. The same can be applied in the registry but I leave that to you
