### PR TITLE
Remove legacy this.conflicter uses.

### DIFF
--- a/generators/aws-containers/index.js
+++ b/generators/aws-containers/index.js
@@ -370,8 +370,6 @@ module.exports = class extends BaseGenerator {
             },
             springProjectChanges() {
                 if (this.abort) return;
-                const done = this.async();
-
                 this.appConfigs.forEach(config => {
                     const directory = `${this.directoryPath}${config.appFolder}`;
                     this.temp = {
@@ -382,23 +380,13 @@ module.exports = class extends BaseGenerator {
                     this.template(SPRING_FACTORIES_FILENAME, SPRING_FACTORIES_PATH(directory));
                     this.template(BOOTSTRAP_FILENAME, BOOTSTRAP_PATH(directory));
                 });
-
-                this.conflicter.resolve(() => {
-                    delete this.temp;
-                    done();
-                });
             },
             generateCloudFormationTemplate() {
                 if (this.abort) return;
-                const done = this.async();
-
                 this.template(BASE_TEMPLATE_FILENAME, BASE_TEMPLATE_PATH);
                 this.aws.apps.forEach(config =>
                     this.template(APP_TEMPLATE_FILENAME, APP_TEMPLATE_PATH(config.baseName), null, {}, { aws: this.aws, app: config })
                 );
-                this.conflicter.resolve(() => {
-                    done();
-                });
             },
         };
     }

--- a/generators/azure-app-service/index.js
+++ b/generators/azure-app-service/index.js
@@ -462,15 +462,11 @@ which is free for the first 30 days`);
 
             copyAzureAppServiceFiles() {
                 if (this.abort) return;
-                const done = this.async();
                 this.log(chalk.bold('\nCreating Azure App Service deployment files'));
                 this.template('application-azure.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}/config/application-azure.yml`);
                 if (this.azureAppServiceDeploymentType === 'github-action') {
                     this.template('github/workflows/azure-app-service.yml.ejs', '.github/workflows/azure-app-service.yml');
                 }
-                this.conflicter.resolve(err => {
-                    done();
-                });
             },
         };
     }

--- a/generators/azure-spring-cloud/index.js
+++ b/generators/azure-spring-cloud/index.js
@@ -291,27 +291,21 @@ ${chalk.red('az extension add --name spring-cloud')}`
 
             copyAzureSpringCloudFiles() {
                 if (this.abort) return;
-                const done = this.async();
                 this.log(chalk.bold('\nCreating Azure Spring Cloud deployment files'));
                 this.template('application-azure.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}/config/application-azure.yml`);
                 this.template('bootstrap-azure.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}/config/bootstrap-azure.yml`);
                 if (this.azureSpringCloudDeploymentType === 'github-action') {
                     this.template('github/workflows/azure-spring-cloud.yml.ejs', '.github/workflows/azure-spring-cloud.yml');
                 }
-                this.conflicter.resolve(err => {
-                    done();
-                });
             },
 
             addAzureSpringCloudMavenProfile() {
                 if (this.abort) return;
-                const done = this.async();
                 if (this.buildTool === 'maven') {
                     this.render('pom-profile.xml.ejs', profile => {
                         this.addMavenProfile('azure', `            ${profile.toString().trim()}`);
                     });
                 }
-                done();
             },
         };
     }

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -737,7 +737,6 @@ module.exports = class extends BaseGenerator {
             copyFiles() {
                 if (this.abort) return;
 
-                const done = this.async();
                 this.log(chalk.bold('\nCreating Google App Engine deployment files'));
 
                 this.template('app.yaml.ejs', `${constants.MAIN_DIR}/appengine/app.yaml`);
@@ -748,10 +747,6 @@ module.exports = class extends BaseGenerator {
                 if (this.buildTool === 'gradle') {
                     this.template('gae.gradle.ejs', 'gradle/gae.gradle');
                 }
-
-                this.conflicter.resolve(err => {
-                    done();
-                });
             },
 
             addDependencies() {

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -563,8 +563,7 @@ module.exports = class extends BaseBlueprintGenerator {
             },
 
             configureJHipsterRegistry() {
-                if (this.abort || this.herokuAppExists) return;
-                const done = this.async();
+                if (this.abort || this.herokuAppExists) return undefined;
 
                 if (this.serviceDiscoveryType === 'eureka') {
                     const prompts = [
@@ -587,7 +586,7 @@ module.exports = class extends BaseBlueprintGenerator {
                     ];
 
                     this.log('');
-                    this.prompt(prompts).then(props => {
+                    return this.prompt(prompts).then(props => {
                         // Encode username/password to avoid errors caused by spaces
                         props.herokuJHipsterRegistryUsername = encodeURIComponent(props.herokuJHipsterRegistryUsername);
                         props.herokuJHipsterRegistryPassword = encodeURIComponent(props.herokuJHipsterRegistryPassword);
@@ -598,24 +597,19 @@ module.exports = class extends BaseBlueprintGenerator {
                                 this.abort = true;
                                 this.log.error(err);
                             }
-                            done();
                         });
 
                         child.stdout.on('data', data => {
                             this.log(data.toString());
                         });
                     });
-                } else {
-                    this.conflicter.resolve(err => {
-                        done();
-                    });
                 }
+                return undefined;
             },
 
             copyHerokuFiles() {
                 if (this.abort) return;
 
-                const done = this.async();
                 this.log(chalk.bold('\nCreating Heroku deployment files'));
 
                 this.template('bootstrap-heroku.yml.ejs', `${constants.SERVER_MAIN_RES_DIR}/config/bootstrap-heroku.yml`);
@@ -631,10 +625,6 @@ module.exports = class extends BaseBlueprintGenerator {
                         this.log(`${chalk.yellow.bold('WARNING!')}Failed to add 'provision-okta-addon.sh' to .gitignore.'`);
                     });
                 }
-
-                this.conflicter.resolve(err => {
-                    done();
-                });
             },
 
             addHerokuDependencies() {


### PR DESCRIPTION
- Conflicter is called internally from yeoman-generator, shouldn't be used without a specific reason.
- Conflicter is moving from the generator to the environment.
- They are traced back to 4 or more years and don't seems to be necessary anymore.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
