### PR TITLE
Add CircleCI auto configuration for jhipster-online

### DIFF
--- a/generators/ci-cd/index.js
+++ b/generators/ci-cd/index.js
@@ -70,6 +70,13 @@ module.exports = class extends BaseGenerator {
             description: 'Automatically configure GitHub Actions',
         });
 
+        // Automatically configure CircleCI
+        this.argument('autoconfigure-circle', {
+            type: Boolean,
+            defaults: false,
+            description: 'Automatically configure CircleCI',
+        });
+
         this.registerPrettierTransform();
     }
 
@@ -106,6 +113,7 @@ module.exports = class extends BaseGenerator {
                 this.autoconfigureGitlab = this.options['autoconfigure-gitlab'];
                 this.autoconfigureAzure = this.options['autoconfigure-azure'];
                 this.autoconfigureGithub = this.options['autoconfigure-github'];
+                this.autoconfigureCircleCI = this.options['autoconfigure-circle'];
                 this.abort = false;
             },
             initConstants() {

--- a/generators/ci-cd/prompts.js
+++ b/generators/ci-cd/prompts.js
@@ -58,6 +58,12 @@ function askPipeline() {
         return;
     }
 
+    if (this.autoconfigureCircleCI) {
+        this.log('Auto-configuring CircleCI');
+        this.pipeline = 'circle';
+        return;
+    }
+
     const done = this.async();
     const prompts = [
         {
@@ -110,6 +116,12 @@ function askIntegrations() {
     if (this.autoconfigureGithub) {
         this.log('Auto-configuring GitHub Actions');
         this.pipeline = 'github';
+        return;
+    }
+
+    if (this.autoconfigureCircleCI) {
+        this.log('Auto-configuring CircleCI');
+        this.pipeline = 'circle';
         return;
     }
 


### PR DESCRIPTION
This adds CircleCI configuration needed for jhipster-online to work.

Related to https://github.com/jhipster/jhipster-online/issues/163

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
