### PR TITLE
Use autoincrement property in liquibase for PostgreSQL

### DIFF
--- a/generators/aws-containers/index.js
+++ b/generators/aws-containers/index.js
@@ -361,9 +361,9 @@ module.exports = class extends BaseGenerator {
                     app.dbType = appConfig.prodDatabaseType;
 
                     app.auroraEngine = appConfig.prodDatabaseType === postgresqlType ? 'aurora-postgresql' : 'aurora-mysql';
-                    app.auroraFamily = appConfig.prodDatabaseType === postgresqlType ? 'aurora-postgresql9.6' : 'aurora-mysql5.7';
+                    app.auroraFamily = appConfig.prodDatabaseType === postgresqlType ? 'aurora-postgresql10.4' : 'aurora-mysql5.7';
                     app.auroraClusterParameterGroupName =
-                        appConfig.prodDatabaseType === postgresqlType ? 'default.aurora-postgresql9.6' : 'default.aurora-mysql5.7';
+                        appConfig.prodDatabaseType === postgresqlType ? 'default.aurora-postgresql10.4' : 'default.aurora-mysql5.7';
                     app.auroraDbParam =
                         appConfig.prodDatabaseType === postgresqlType ? 'check_function_bodies: 0' : 'sql_mode: IGNORE_SPACE';
                 });

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -175,7 +175,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
 <%_ if (!embedded) { _%>
     @Id
     <%_ if (databaseType === 'sql' && isUsingMapsId === false) { _%>
-        <%_ if (prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb') { _%>
+        <%_ if (['mysql', 'mariadb', 'postgresql'].includes(prodDatabaseType)) { _%>
     @GeneratedValue(strategy = GenerationType.IDENTITY)
         <%_ }  else { _%>
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")

--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -26,7 +26,7 @@
 
     <% let autoIncrementValue = primaryKeyType !== 'String';
         let databasePKType = primaryKeyType !== 'String' ? 'bigint' : 'varchar(100)';
-        const isAutoIncrementDB = prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb';
+        const isAutoIncrementDB = ['mysql', 'mariadb', 'postgresql'].includes(prodDatabaseType);
     _%>
     <%_ if (isAutoIncrementDB) { _%>
     <property name="autoIncrement" value="<%- autoIncrementValue %>"/>

--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -649,7 +649,7 @@ module.exports = class extends BaseGenerator {
                 const name = this.gcpCloudSqlInstanceName;
                 // for mysql keep default options, set specific option for pg
                 const dbVersionFlag =
-                    this.prodDatabaseType === 'postgresql' ? ' --database-version="POSTGRES_9_6" --tier="db-g1-small"' : '';
+                    this.prodDatabaseType === 'postgresql' ? ' --database-version="POSTGRES_10" --tier="db-g1-small"' : '';
                 let gaeCloudSqlLocation = this.gaeLocation;
                 if (gaeCloudSqlLocation === 'us-central') {
                     gaeCloudSqlLocation = 'us-central1';

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -122,7 +122,7 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
 <%_ if (databaseType === 'sql') { _%>
     @Id
     <%_ if (!reactive) { _%>
-        <%_ if (authenticationType !== 'oauth2' && (prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb')) { _%>
+        <%_ if (authenticationType !== 'oauth2' && (['mysql', 'mariadb', 'postgresql'].includes(prodDatabaseType))) { _%>
     @GeneratedValue(strategy = GenerationType.IDENTITY)
         <%_ } else if (authenticationType !== 'oauth2') { _%>
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -24,7 +24,7 @@
     xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-<%= LIQUIBASE_DTD_VERSION %>.xsd
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
-    <% const isAutoIncrementDB = reactive || ['mysql', 'mariadb'].includes(prodDatabaseType);
+    <% const isAutoIncrementDB = reactive || ['mysql', 'mariadb', 'postgresql'].includes(prodDatabaseType);
        const isSequenceDB = !reactive && ['postgresql', 'oracle', 'mssql'].includes(prodDatabaseType);
     _%>
     <%_ if (isAutoIncrementDB) { _%>

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -25,7 +25,7 @@
                         http://www.liquibase.org/xml/ns/dbchangelog-ext http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-ext.xsd">
 
     <% const isAutoIncrementDB = reactive || ['mysql', 'mariadb', 'postgresql'].includes(prodDatabaseType);
-       const isSequenceDB = !reactive && ['postgresql', 'oracle', 'mssql'].includes(prodDatabaseType);
+       const isSequenceDB = !reactive && ['oracle', 'mssql'].includes(prodDatabaseType);
     _%>
     <%_ if (isAutoIncrementDB) { _%>
     <property name="autoIncrement" value="true"/>

--- a/generators/server/templates/src/test/java/package/repository/timezone/DateTimeWrapper.java.ejs
+++ b/generators/server/templates/src/test/java/package/repository/timezone/DateTimeWrapper.java.ejs
@@ -30,7 +30,7 @@ public class DateTimeWrapper implements Serializable {
     private static final long serialVersionUID = 1L;
 
     @Id
-    <%_ if (prodDatabaseType === 'mysql' || prodDatabaseType === 'mariadb') { _%>
+    <%_ if (['mysql', 'mariadb', 'postgresql'].includes(prodDatabaseType)) { _%>
     @GeneratedValue(strategy = GenerationType.IDENTITY)
     <%_ } else { _%>
     @GeneratedValue(strategy = GenerationType.SEQUENCE, generator = "sequenceGenerator")


### PR DESCRIPTION
Related with https://github.com/jhipster/generator-jhipster/issues/11736:
- Use liquibase property autoincrement for PostgreSQL that define 'GENERATED BY DEFAULT AS IDENTITY' (see https://github.com/liquibase/liquibase/pull/874 and https://github.com/liquibase/liquibase/pull/941)
- Define 'POSTGRES_10' by default for GAE
- Define 'aurora-postgresql10.4' by default for AWS

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
