### PR TITLE
Remove Couchbase and Neo4j builds badges [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,8 +148,6 @@ Additional builds at [hipster-labs/jhipster-daily-builds](https://github.com/hip
 | [![Microservices OAuth2][github-ms-oauth2]][github-actions]            |
 | [![Microservices UAA][github-ms-uaa]][github-actions]                  |
 | [![Docker Image][github-docker-image]][github-actions]                 |
-| [![Neo4j][github-neo4j]][github-actions]                               |
-| [![Couchbase][github-couchbase]][github-actions]                       |
 | [![Official Windows][github-official-windows]][github-actions]         |
 
 ## Analysis of the sample JHipster project
@@ -174,8 +172,6 @@ Additional builds at [hipster-labs/jhipster-daily-builds](https://github.com/hip
 [github-ms-oauth2]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Microservices%20OAuth2/badge.svg
 [github-ms-uaa]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Microservices%20UAA/badge.svg
 [github-docker-image]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Docker%20Image/badge.svg
-[github-neo4j]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Neo4j/badge.svg
-[github-couchbase]: https://github.com/hipster-labs/jhipster-daily-builds/workflows/Couchbase/badge.svg
 [sonar-url]: https://sonarcloud.io/dashboard?id=jhipster-sample-application
 [sonar-quality-gate]: https://sonarcloud.io/api/project_badges/measure?project=jhipster-sample-application&metric=alert_status
 [sonar-coverage]: https://sonarcloud.io/api/project_badges/measure?project=jhipster-sample-application&metric=coverage


### PR DESCRIPTION
As these builds seem stables enough, include them directly in:
- angular nosql
- react nosql
- vue nosql

Related to https://github.com/hipster-labs/jhipster-daily-builds/commit/78831fe6848de8b68e88dd2acfc13609988b8a25

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
