### PR TITLE
Unify prettier extensions handling.

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -167,7 +167,7 @@
     "yarn": ">=1.19.0"<% } %>
   },
   "scripts": {
-    "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,css,scss,yml<%= !skipServer && prettierJava ? ',java' : '' %>}\"",
+    "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
     "lint": "eslint . --ext .js,.ts",
     "lint:fix": "<%= clientPackageManager %> run lint <%= optionsForwarder %>--fix",
     "ngc": "ngc -p tsconfig.app.json",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -191,7 +191,7 @@ limitations under the License.
     "yarn": ">=1.19.0"<% } %>
   },
   "scripts": {
-    "prettier:format": "prettier --write \"{,src/**/}*.{md,json,ts,tsx,css,scss,yml<%= !skipServer && prettierJava ? ',java' : '' %>}\"",
+    "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
     "lint:fix": "<%= clientPackageManager %> run lint <%= optionsForwarder %>--fix",
     "cleanup": "rimraf <%= DIST_DIR %>",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -147,16 +147,8 @@ limitations under the License.
     "node": ">= 10.17.0",
     "npm": ">= 6.13.4"
   },
-  <%_ if (!skipCommitHook) { _%>
-  "lint-staged": {
-    "{,src/**/,webpack/}*.{md,json,js,ts,css,scss}": [
-      "prettier --write",
-      "git add"
-    ]
-  },
-  <%_ } _%>
   "scripts": {
-    "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{md,json,js,ts,tsx,css,scss<%= !skipServer && prettierJava ? ',java' : '' %>}\"",
+    "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
     "lint": "tslint --project tsconfig.json -e 'node_modules/**'",
     "lint:fix": "<%= clientPackageManager %> run lint <%= optionsForwarder %>--fix",
     "cleanup": "rimraf <%= DIST_DIR %>",

--- a/generators/common/templates/.lintstagedrc.js.ejs
+++ b/generators/common/templates/.lintstagedrc.js.ejs
@@ -16,15 +16,6 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<%_
-  let handledExtensions = ['json', 'md', 'yml'];
-  if (!skipServer && prettierJava) {
-    handledExtensions.push('java');
-  }
-  if (!skipClient) {
-    handledExtensions.push('ts', 'css', 'scss');
-  }
-_%>
 module.exports = {
-  '{,src/**/}*.{<%= handledExtensions.join(',') %>}': ['prettier --write', 'git add']
+  '{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}': ['prettier --write', 'git add']
 };

--- a/generators/common/templates/.lintstagedrc.js.ejs
+++ b/generators/common/templates/.lintstagedrc.js.ejs
@@ -17,5 +17,5 @@
  limitations under the License.
 -%>
 module.exports = {
-  '{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}': ['prettier --write', 'git add']
+  '{,src/**/<%= !skipClient ? ',webpack/' : '' %>}*.{<%= getPrettierExtensions() %>}': ['prettier --write', 'git add']
 };

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1479,11 +1479,11 @@ module.exports = class extends Generator {
      * @param {any} generator
      */
     registerPrettierTransform(generator = this) {
-        // Prettier is clever, it uses correct rules and correct parser according to file extension.
-        let filterPatternForPrettier = '{,**/,.jhipster/**/}*.{md,json,ts,tsx,scss,css,yml}';
-        if (!this.skipServer && this.prettierJava) {
-            filterPatternForPrettier = '{,**/,.jhipster/**/}*.{md,json,ts,tsx,scss,css,yml,java}';
+        if (this.options.help) {
+            return;
         }
+        // Prettier is clever, it uses correct rules and correct parser according to file extension.
+        const filterPatternForPrettier = `{,.,**/,.jhipster/**/}*.{${this.getPrettierExtensions()}}`;
         const prettierFilter = filter(['.yo-rc.json', filterPatternForPrettier], { restore: true });
         // this pipe will pass through (restore) anything that doesn't match typescriptFilter
         generator.registerTransformStream([prettierFilter, prettierTransform(prettierOptions), prettierFilter.restore]);

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -127,6 +127,17 @@ module.exports = class extends PrivateBase {
         return outputPathCustomizer.call(this, outputPath);
     }
 
+    getPrettierExtensions() {
+        let prettierExtensions = 'md,json,yml';
+        if (!this.skipClient && !this.jhipsterConfig.skipClient) {
+            prettierExtensions = `${prettierExtensions},js,ts,tsx,css,scss`;
+        }
+        if (!this.skipServer && !this.jhipsterConfig.skipServer && (this.jhipsterConfig.prettierJava || this.prettierJava)) {
+            prettierExtensions = `${prettierExtensions},java`;
+        }
+        return prettierExtensions;
+    }
+
     /**
      * Add a new icon to icon imports.
      *

--- a/generators/server/templates/package.json.ejs
+++ b/generators/server/templates/package.json.ejs
@@ -42,6 +42,6 @@
     "node": ">=<%= NODE_VERSION %>"
   },
   "scripts": {
-    "prettier:format": "prettier --write \"{,src/**/}*.{md,json,yml<%= prettierJava ? ',java' : '' %>}\""
+    "prettier:format": "prettier --write \"{,src/**/}*.{<%= getPrettierExtensions() %>}\""
   }
 }

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -1485,6 +1485,9 @@ describe('JHipster generator', () => {
         it('generates a README with no undefined value', () => {
             assert.noFileContent('README.md', /undefined/);
         });
+        it('generates a .prettierrc with no reference to java extension', () => {
+            assert.noFileContent('.prettierrc', ',java');
+        });
     });
 
     context('App with skip client', () => {
@@ -1542,6 +1545,16 @@ describe('JHipster generator', () => {
                 assert.noFileContent('pom.xml', 'node.version');
                 assert.noFileContent('pom.xml', 'npm.version');
                 assert.noFileContent('pom.xml', 'frontend-maven-plugin');
+            });
+            it('generates a .prettierrc with no reference to webpack', () => {
+                assert.noFileContent('.prettierrc', 'webpack');
+            });
+            it('generates a .prettierrc with no reference to client extensions', () => {
+                assert.noFileContent('.prettierrc', ',js');
+                assert.noFileContent('.prettierrc', ',ts');
+                assert.noFileContent('.prettierrc', ',tsx');
+                assert.noFileContent('.prettierrc', ',css');
+                assert.noFileContent('.prettierrc', ',scss');
             });
         });
 


### PR DESCRIPTION
@pascalgrimaud vue prettier transform is missing `js` extension.
Related to https://github.com/jhipster/generator-jhipster/issues/12109

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
