### PR TITLE
prevent leakage of technical details trough problem message

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -18,13 +18,17 @@
 -%>
 package <%= packageName %>.web.rest.errors;
 
+import io.github.jhipster.config.JHipsterConstants;
 import io.github.jhipster.web.util.HeaderUtil;
 
+import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
 import org.springframework.dao.ConcurrencyFailureException;
 <%_ } _%>
+import org.springframework.dao.DataAccessException;
 import org.springframework.http.ResponseEntity;
+import org.springframework.http.converter.HttpMessageConversionException;
 <%_ if (reactive && databaseType === 'sql') { _%>
 import org.springframework.stereotype.Component;
 <%_ } _%>
@@ -41,10 +45,12 @@ import org.springframework.web.server.ServerWebExchange;
 <%_ if (!reactive) { _%>
 import org.springframework.web.context.request.NativeWebRequest;
 <%_ } _%>
+import org.springframework.core.env.Environment;
 import org.zalando.problem.DefaultProblem;
 import org.zalando.problem.Problem;
 import org.zalando.problem.ProblemBuilder;
 import org.zalando.problem.Status;
+import org.zalando.problem.StatusType;
 import org.zalando.problem.spring.web<% if (reactive) { %>flux<% } %>.advice.ProblemHandling;
 import org.zalando.problem.spring.web<% if (reactive) { %>flux<% } %>.advice.security.SecurityAdviceTrait;
 import org.zalando.problem.violations.ConstraintViolationProblem;
@@ -57,7 +63,11 @@ import javax.annotation.Nullable;
 <%_ if (!reactive) { _%>
 import javax.servlet.http.HttpServletRequest;
 <%_ } _%>
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 /**
@@ -88,6 +98,12 @@ _%>
 
     @Value("${jhipster.clientApp.name}")
     private String applicationName;
+
+    private final Environment env;
+
+    public ExceptionTranslator(Environment env) {
+        this.env = env;
+    }
 
     /**
      * Post-process the Problem payload to add the message key for the front-end if needed.
@@ -187,4 +203,64 @@ _%>
         return create(ex, problem, request);
     }
     <%_ } _%>
+
+    @Override
+    public ProblemBuilder prepare(final Throwable throwable, final StatusType status, final URI type) {
+        
+        Collection<String> activeProfiles = Arrays.asList(env.getActiveProfiles());
+
+        if (activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_PRODUCTION)) {
+            if (throwable instanceof HttpMessageConversionException) {
+                return Problem.builder()
+                    .withType(type)
+                    .withTitle(status.getReasonPhrase())
+                    .withStatus(status)
+                    .withDetail("Unable to convert http message")
+                    .withCause(Optional.ofNullable(throwable.getCause())
+                        .filter(cause -> isCausalChainsEnabled())
+                        .map(this::toProblem)
+                        .orElse(null));
+            }
+    
+            if (throwable instanceof DataAccessException) {
+                return Problem.builder()
+                    .withType(type)
+                    .withTitle(status.getReasonPhrase())
+                    .withStatus(status)
+                    .withDetail("Failure during data access")
+                    .withCause(Optional.ofNullable(throwable.getCause())
+                        .filter(cause -> isCausalChainsEnabled())
+                        .map(this::toProblem)
+                        .orElse(null));
+            }
+    
+            if (containsPackageName(throwable.getMessage())) {
+                return Problem.builder()
+                    .withType(type)
+                    .withTitle(status.getReasonPhrase())
+                    .withStatus(status)
+                    .withDetail("Unexpected runtime exception")
+                    .withCause(Optional.ofNullable(throwable.getCause())
+                        .filter(cause -> isCausalChainsEnabled())
+                        .map(this::toProblem)
+                        .orElse(null));
+            }
+        }
+
+        return Problem.builder()
+            .withType(type)
+            .withTitle(status.getReasonPhrase())
+            .withStatus(status)
+            .withDetail(throwable.getMessage())
+            .withCause(Optional.ofNullable(throwable.getCause())
+                .filter(cause -> isCausalChainsEnabled())
+                .map(this::toProblem)
+                .orElse(null));
+    }
+
+    private boolean containsPackageName(String message) {
+
+        // This list is for sure not complete
+        return StringUtils.containsAny(message, "org.", "java.", "net.", "javax.", "com.", "io.", "de.", "<%= packageName %>");
+    }
 }


### PR DESCRIPTION
This prevents leaking of technical details via the problem message which is by default filled with the message of the exception. Most often the message contain/reveal technical details which should not be leak via an api call to the caller.

closes #12051

**This targets v6.x branch on purpose. I think this should be backported as it impacts security.**

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed


