### PR TITLE
do not use dynamic property source in junit callbacks

### DIFF
--- a/generators/server/templates/src/test/java/package/RedisTestContainerExtension.java.ejs
+++ b/generators/server/templates/src/test/java/package/RedisTestContainerExtension.java.ejs
@@ -16,13 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-
 package <%= packageName %>;
 
 import org.junit.jupiter.api.extension.BeforeAllCallback;
 import org.junit.jupiter.api.extension.ExtensionContext;
-import org.springframework.test.context.DynamicPropertyRegistry;
-import org.springframework.test.context.DynamicPropertySource;
 import org.testcontainers.containers.GenericContainer;
 
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -31,18 +28,16 @@ public class RedisTestContainerExtension implements BeforeAllCallback {
 
     private static AtomicBoolean started = new AtomicBoolean(false);
 
-    private static GenericContainer redis;
-
-    @DynamicPropertySource
-    static void redisProperties(DynamicPropertyRegistry registry) {
-        registry.add("jhipster.cache.redis.server", () -> "redis://" + redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379));
-    }
+    private static GenericContainer redis = new GenericContainer("<%= DOCKER_REDIS %>").withExposedPorts(6379);
 
     @Override
     public void beforeAll(ExtensionContext extensionContext) throws Exception {
         if (!started.get()) {
-            redis = new GenericContainer("<%= DOCKER_REDIS %>").withExposedPorts(6379);
             redis.start();
+            System.setProperty(
+                "jhipster.cache.redis.server",
+                "redis://" + redis.getContainerIpAddress() + ":" + redis.getMappedPort(6379)
+            );
             started.set(true);
         }
     }


### PR DESCRIPTION
Set system property instead of using dynamic property sources which seem to work only when used directly in a test class.

EDIT: targeting 6.x as we should most likely provide a fix as 6.x will be used for a few more month I guess.

closes #12012

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
