### PR TITLE
update gradle plugins

### DIFF
--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -74,23 +74,20 @@ jaxb_runtime_version=2.3.3
 
 # gradle plugin version
 jib_plugin_version=<%= JIB_VERSION %>
-git_properties_plugin_version=2.2.2
+git_properties_plugin_version=2.2.3
 <%_ if (!skipClient) { _%>
 gradle_node_plugin_version=2.2.4
 <%_ } _%>
 apt_plugin_version=0.21
 <%_ if (databaseType === 'sql' && !reactive) { _%>
-liquibase_plugin_version=2.0.3
+liquibase_plugin_version=2.0.4
 <%_ } _%>
-sonarqube_plugin_version=2.8
+sonarqube_plugin_version=3.0
 <%_ if (enableSwaggerCodegen) { _%>
 openapi_plugin_version=4.3.1
 <%_ } _%>
-spring_no_http_plugin_version=0.0.4.RELEASE
+spring_no_http_plugin_version=0.0.5.RELEASE
 checkstyle_version=8.32
-<%_ if (reactive && (applicationType === 'gateway' || applicationType === 'monolith')) { _%>
-springfox_version=3.0.0-SNAPSHOT
-<%_ } _%>
 
 # jhipster-needle-gradle-property - JHipster will add additional properties here
 


### PR DESCRIPTION
This PR updates some gradle plugins to their latest releases:

* https://github.com/liquibase/liquibase-gradle-plugin/blob/master/CHANGELOG.md
* https://github.com/n0mer/gradle-git-properties/releases
* https://jira.sonarsource.com/secure/ReleaseNote.jspa?projectId=10974&version=15726
* https://github.com/spring-io/nohttp

Furthermore the no obsolete property for springfox version has been removed.
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
