### PR TITLE
Update webpack-merge to 5.0.9

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -157,7 +157,7 @@
     "webpack-bundle-analyzer": "3.8.0",
     "webpack-cli": "3.3.12",
     "webpack-dev-server": "3.11.0",
-    "webpack-merge": "4.2.2",
+    "webpack-merge": "5.0.9",
     "webpack-notifier": "1.8.0",
     "workbox-webpack-plugin": "5.1.3",
     "write-file-webpack-plugin": "4.5.1"

--- a/generators/client/templates/angular/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.dev.js.ejs
@@ -18,7 +18,7 @@
 -%>
 const webpack = require('webpack');
 const writeFilePlugin = require('write-file-webpack-plugin');
-const webpackMerge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const SimpleProgressWebpackPlugin = require('simple-progress-webpack-plugin');

--- a/generators/client/templates/angular/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.prod.js.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const OptimizeCSSAssetsPlugin = require("optimize-css-assets-webpack-plugin");
 const BundleAnalyzerPlugin = require('webpack-bundle-analyzer').BundleAnalyzerPlugin;

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -175,7 +175,7 @@ limitations under the License.
     "webpack": "4.43.0",
     "webpack-cli": "3.3.11",
     "webpack-dev-server": "3.10.3",
-    "webpack-merge": "4.2.2",
+    "webpack-merge": "5.0.9",
     "webpack-notifier": "1.8.0",
     "workbox-webpack-plugin": "5.1.3",
     "write-file-webpack-plugin": "4.5.1"

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -18,7 +18,7 @@
 -%>
 const webpack = require('webpack');
 const writeFilePlugin = require('write-file-webpack-plugin');
-const webpackMerge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const FriendlyErrorsWebpackPlugin = require('friendly-errors-webpack-plugin');
 const SimpleProgressWebpackPlugin = require('simple-progress-webpack-plugin');

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 const webpack = require('webpack');
-const webpackMerge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');

--- a/generators/client/templates/vue/config/dev.env.js.ejs
+++ b/generators/client/templates/vue/config/dev.env.js.ejs
@@ -1,11 +1,11 @@
 'use strict';
-const merge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const prodEnv = require('./prod.env');
 <%_ if (buildTool === undefined) { _%>
 const packageJson = require('./../package.json');
 <%_ } _%>
 
-module.exports = merge(prodEnv, {
+module.exports = webpackMerge(prodEnv, {
   NODE_ENV: '"development"',
   SERVER_API_URL: '\'\'',
   BUILD_TIMESTAMP: `'${new Date().getTime()}'`,

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -141,7 +141,7 @@ limitations under the License.
     "webpack-bundle-analyzer": "3.8.0",
     "webpack-cli": "3.3.11",
     "webpack-dev-server": "3.11.0",
-    "webpack-merge": "4.2.2"
+    "webpack-merge": "5.0.9"
   },
   "engines": {
     "node": ">= 10.17.0",

--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -2,7 +2,7 @@
 const utils = require('./vue.utils');
 const webpack = require('webpack');
 const config = require('../config');
-const merge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const path = require('path');
 const baseWebpackConfig = require('./webpack.common');
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin');
@@ -12,7 +12,7 @@ const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const HOST = process.env.HOST;
 const PORT = process.env.PORT && Number(process.env.PORT);
 
-module.exports = merge(baseWebpackConfig, {
+module.exports = webpackMerge(baseWebpackConfig, {
   mode: 'development',
   module: {
     rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap, usePostCSS: true })

--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -2,7 +2,7 @@
 const utils = require('./vue.utils');
 const webpack = require('webpack');
 const config = require('../config');
-const merge = require('webpack-merge');
+const webpackMerge = require('webpack-merge').merge;
 const baseWebpackConfig = require('./webpack.common');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
@@ -13,7 +13,7 @@ const jhiUtils = require('./utils.js');
 
 const env = require('../config/prod.env');
 
-const webpackConfig = merge(baseWebpackConfig, {
+const webpackConfig = webpackMerge(baseWebpackConfig, {
   mode: 'production',
   module: {
     rules: utils.styleLoaders({


### PR DESCRIPTION
Bumps the `webpack-merge` dependency from `4.2.2` to `5.0.9` for Angular, React and Vue.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
