### PR TITLE
Filter builds according to modified generators

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -22,9 +22,17 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
+        paths:
+            - '!generators/client/**react.js'
+            - '!generators/client/**vue.js'
+            - 'generators/client/templates/angular/**'
     pull_request:
         branches:
             - '*'
+        paths:
+            - '!generators/client/**react.js'
+            - '!generators/client/**vue.js'
+            - 'generators/client/templates/angular/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11

--- a/.github/workflows/default-app.yml
+++ b/.github/workflows/default-app.yml
@@ -22,9 +22,13 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
+        paths-ignore:
+            - 'generators/client/**'
     pull_request:
         branches:
             - '*'
+        paths-ignore:
+            - 'generators/client/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11

--- a/.github/workflows/default-app.yml
+++ b/.github/workflows/default-app.yml
@@ -1,0 +1,144 @@
+#
+# Copyright 2013-2020 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Default-app
+on:
+    push:
+        branches-ignore:
+            - 'dependabot/**'
+    pull_request:
+        branches:
+            - '*'
+env:
+    JHI_RUN_APP: 1
+    JHI_JDK: 11
+    JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
+    JHI_LIB_BRANCH: master
+    JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
+    JHI_GEN_BRANCH: master
+    SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
+    SPRING_JPA_SHOW_SQL: false
+    JHI_DISABLE_WEBPACK_LOGS: true
+    JHI_E2E_HEADLESS: true
+    JHI_SCRIPTS: ./test-integration/scripts
+    NG_CLI_ANALYTICS: 'false'
+    JHI_GITHUB_CI: true
+    FORCE_COLOR: 1
+jobs:
+    applications:
+        name: ${{ matrix.app-type }}
+        runs-on: ${{ matrix.os }}
+        if: >-
+            !contains(github.event.head_commit.message, '[ci skip]') &&
+            !contains(github.event.head_commit.message, '[skip ci]') &&
+            !contains(github.event.pull_request.title, '[skip ci]') &&
+            !contains(github.event.pull_request.title, '[ci skip]') &&
+            (github.event.pull_request.draft == false || !contains(github.event.pull_request.labels.*.name, 'pr: skip-ci')) &&
+            !contains(github.event.pull_request.user.login, 'dependabot')
+        timeout-minutes: 40
+        strategy:
+            fail-fast: false
+            matrix:
+                node_version: [12.16.1]
+                os: [ubuntu-latest]
+                app-type:
+                    - ngx-default
+                    - react-default
+                    - vue-default
+                include:
+                    - app-type: ngx-default
+                      entity: sql
+                      profile: prod
+                      war: 0
+                      protractor: 1
+                      testcontainers: 1
+                    -   app-type: react-default
+                        entity: sql
+                        profile: prod
+                        war: 0
+                        protractor: 1
+                        testcontainers: 0
+                    -   app-type: vue-default
+                        entity: sqlfull
+                        profile: prod
+                        war: 0
+                        protractor: 1
+        env:
+            JHI_ENTITY: ${{ matrix.entity }}
+            JHI_APP: ${{ matrix.app-type }}
+            JHI_PROFILE: ${{ matrix.profile }}
+            JHI_WAR: ${{ matrix.war }}
+            JHI_PROTRACTOR: ${{ matrix.protractor }}
+            JHI_TESTCONTAINERS: ${{ matrix.testcontainers }}
+        steps:
+            #----------------------------------------------------------------------
+            # Install all tools and check configuration
+            #----------------------------------------------------------------------
+            - uses: actions/checkout@v2
+            - uses: actions/setup-node@v2.1.1
+              with:
+                  node-version: ${{ matrix.node_version }}
+            - uses: actions/setup-java@v1
+              with:
+                  java-version: '11.x'
+            - name: Get chrome/chromedriver version
+              id: chromedriver-version
+              run: |
+                  CHROME_VERSION=$(google-chrome --version | cut -f 3 -d ' ' | cut -d '.' -f 1) \
+                  && CHROMEDRIVER_VERSION=$(curl --location --fail --retry 3 http://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_VERSION}) \
+                  && echo "::set-output name=version::$CHROMEDRIVER_VERSION"
+            - name: 'TOOLS: configure tools installed by the system'
+              run: $JHI_SCRIPTS/03-system.sh
+            - name: 'TOOLS: configure git'
+              run: $JHI_SCRIPTS/04-git-config.sh
+            #----------------------------------------------------------------------
+            # Install JHipster and generate project+entities
+            #----------------------------------------------------------------------
+            - name: 'GENERATION: install JHipster'
+              run: $JHI_SCRIPTS/10-install-jhipster.sh
+            - name: 'GENERATION: entities'
+              run: $JHI_SCRIPTS/11-generate-entities.sh
+            - name: 'GENERATION: project'
+              run: $JHI_SCRIPTS/12-generate-project.sh
+            - name: 'GENERATION: replace version in generated project'
+              run: $JHI_SCRIPTS/13-replace-version-generated-project.sh
+            - name: 'GENERATION: jhipster info'
+              run: $JHI_SCRIPTS/14-jhipster-info.sh
+            #----------------------------------------------------------------------
+            # Launch tests
+            #----------------------------------------------------------------------
+            - name: 'TESTS: Start docker-compose containers'
+              run: $JHI_SCRIPTS/20-docker-compose.sh
+            - name: 'TESTS: backend'
+              run: $JHI_SCRIPTS/21-tests-backend.sh
+            - name: 'TESTS: frontend'
+              run: $JHI_SCRIPTS/22-tests-frontend.sh
+            - name: 'TESTS: packaging'
+              run: $JHI_SCRIPTS/23-package.sh
+            - name: 'Synchronize chromedriver version'
+              if: ${{ matrix.protractor == 1 }}
+              run: npm run e2e:update-webdriver --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
+              working-directory: /home/runner/app
+            - name: 'TESTS: End-to-End'
+              run: $JHI_SCRIPTS/24-tests-e2e.sh
+            - name: 'TESTS: Sonar analysis'
+              run: $JHI_SCRIPTS/25-sonar-analyze.sh
+              env:
+                  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+                  SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/.github/workflows/default-app.yml
+++ b/.github/workflows/default-app.yml
@@ -68,17 +68,17 @@ jobs:
                       war: 0
                       protractor: 1
                       testcontainers: 1
-                    -   app-type: react-default
-                        entity: sql
-                        profile: prod
-                        war: 0
-                        protractor: 1
-                        testcontainers: 0
-                    -   app-type: vue-default
-                        entity: sqlfull
-                        profile: prod
-                        war: 0
-                        protractor: 1
+                    - app-type: react-default
+                      entity: sql
+                      profile: prod
+                      war: 0
+                      protractor: 1
+                      testcontainers: 0
+                    - app-type: vue-default
+                      entity: sqlfull
+                      profile: prod
+                      war: 0
+                      protractor: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -22,10 +22,13 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
+        paths:
+            - 'generators/server/gradle/wrapper/**'
     pull_request:
         branches:
             - '*'
-
+        paths:
+            - 'generators/server/gradle/wrapper/**'
 jobs:
     validation:
         name: 'Validation'

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -22,9 +22,17 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
+        paths:
+            - '!generators/client/**angular.js'
+            - '!generators/client/**vue.js'
+            - 'generators/client/templates/react/**'
     pull_request:
         branches:
             - '*'
+        paths:
+            - '!generators/client/**angular.js'
+            - '!generators/client/**vue.js'
+            - 'generators/client/templates/react/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -22,9 +22,17 @@ on:
     push:
         branches-ignore:
             - 'dependabot/**'
+        paths:
+            - '!generators/client/**angular.js'
+            - '!generators/client/**react.js'
+            - 'generators/client/templates/vue/**'
     pull_request:
         branches:
             - '*'
+        paths:
+            - '!generators/client/**angular.js'
+            - '!generators/client/**react.js'
+            - 'generators/client/templates/vue/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11


### PR DESCRIPTION
<!--
PR description.
-->
We have some issues with Github action workflows at the moment, many of them are stuck in a queue. This is a Github bug, but I suggest to reduce the number of ran builds according to `paths` or `paths-ignore` properties to improve our CI.

WDYT @jhipster/developers ?

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
