### PR TITLE
Compose mocking and load entire app config from options.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -25,6 +25,7 @@ const prompts = require('./prompts');
 const packagejs = require('../../package.json');
 const statistics = require('../statistics');
 const { appDefaultConfig } = require('../generator-defaults');
+const { JHIPSTER_CONFIG_DIR } = require('../generator-constants');
 
 let useBlueprints;
 
@@ -203,6 +204,21 @@ module.exports = class extends BaseBlueprintGenerator {
         // Just constructing help, stop here
         if (this.options.help) {
             return;
+        }
+
+        // Write new definitions to memfs
+        if (this.options.applicationWithEntities) {
+            this.config.set({
+                ...this.config.getAll(),
+                ...this.options.applicationWithEntities.config,
+            });
+            const entities = this.options.applicationWithEntities.entities.map(entity => {
+                const entityName = _.upperFirst(entity.name);
+                const file = this.destinationPath(JHIPSTER_CONFIG_DIR, `${entityName}.json`);
+                this.fs.writeJSON(file, { ...this.fs.readJSON(file), ...entity });
+                return entityName;
+            });
+            this.jhipsterConfig.entities = [...new Set((this.jhipsterConfig.entities || []).concat(entities))];
         }
 
         this.loadOptions();

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -333,36 +333,31 @@ module.exports = class extends BaseBlueprintGenerator {
              */
             composing() {
                 const options = this.options;
-                const configOptions = this.configOptions;
                 if (!this.skipServer && !this.configOptions.skipComposeServer) {
                     this.configOptions.skipComposeServer = true;
-                    this.composeWith(require.resolve('../server'), {
+                    this.composeWithJHipster('server', {
                         ...options,
-                        configOptions,
                         debug: this.isDebugEnabled,
                     });
                 }
                 if (!this.skipClient && !this.configOptions.skipComposeClient) {
                     this.configOptions.skipComposeClient = true;
-                    this.composeWith(require.resolve('../client'), {
+                    this.composeWithJHipster('client', {
                         ...options,
-                        configOptions,
                         debug: this.isDebugEnabled,
                     });
                 }
                 if (!this.configOptions.skipComposeCommon) {
                     this.configOptions.skipComposeCommon = true;
-                    this.composeWith(require.resolve('../common'), {
+                    this.composeWithJHipster('common', {
                         ...options,
-                        configOptions,
                         debug: this.isDebugEnabled,
                     });
                 }
                 if (!this.configOptions.skipI18n && !this.configOptions.skipComposeLanguages) {
                     this.configOptions.skipComposeLanguages = true;
-                    this.composeWith(require.resolve('../languages'), {
+                    this.composeWithJHipster('languages', {
                         ...options,
-                        configOptions,
                         skipPrompts: this.options.withEntities || this.existingProject || this.options.defaults,
                         debug: this.isDebugEnabled,
                     });
@@ -417,11 +412,9 @@ module.exports = class extends BaseBlueprintGenerator {
                 if (this.withEntities && !this.configOptions.skipComposeEntity) {
                     this.configOptions.skipComposeEntity = true;
                     const options = this.options;
-                    const configOptions = this.configOptions;
                     this.getExistingEntities().forEach(entity => {
-                        this.composeWith(require.resolve('../entity'), {
+                        this.composeWithJHipster('entity', {
                             ...options,
-                            configOptions,
                             regenerate: true,
                             skipInstall: true,
                             debug: this.isDebugEnabled,
@@ -434,10 +427,8 @@ module.exports = class extends BaseBlueprintGenerator {
             regeneratePages() {
                 if (!this.configOptions.skipComposePage) {
                     this.configOptions.skipComposePage = true;
-                    const configOptions = this.configOptions;
                     this.jhipsterConfig.pages.forEach(page => {
-                        this.composeWith(require.resolve('../page'), {
-                            configOptions,
+                        this.composeWithJHipster('page', {
                             skipInstall: true,
                             debug: this.isDebugEnabled,
                             arguments: [page.name],

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -153,9 +153,8 @@ module.exports = class extends BaseBlueprintGenerator {
                 if (this.configOptions.skipComposeLanguages || this.jhipsterConfig.enableTranslation === false) return;
 
                 this.configOptions.skipComposeLanguages = true;
-                this.composeWith(require.resolve('../languages'), {
+                this.composeWithJHipster('languages', {
                     ...this.options,
-                    configOptions: this.configOptions,
                     debug: this.isDebugEnabled,
                 });
             },

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -527,11 +527,9 @@ class EntityGenerator extends BaseBlueprintGenerator {
             composeServer() {
                 const context = this.context;
                 if (context.skipServer) return;
-                const configOptions = this.configOptions;
 
-                this.composeWith(require.resolve('../entity-server'), {
+                this.composeWithJHipster('entity-server', {
                     context,
-                    configOptions,
                     force: context.options.force,
                     debug: context.isDebugEnabled,
                 });
@@ -540,11 +538,9 @@ class EntityGenerator extends BaseBlueprintGenerator {
             composeClient() {
                 const context = this.context;
                 if (context.skipClient) return;
-                const configOptions = this.configOptions;
 
-                this.composeWith(require.resolve('../entity-client'), {
+                this.composeWithJHipster('entity-client', {
                     context,
-                    configOptions,
                     skipInstall: context.options.skipInstall,
                     force: context.options.force,
                     debug: context.isDebugEnabled,
@@ -554,10 +550,8 @@ class EntityGenerator extends BaseBlueprintGenerator {
             composeI18n() {
                 const context = this.context;
                 if (context.skipClient) return;
-                const configOptions = this.configOptions;
-                this.composeWith(require.resolve('../entity-i18n'), {
+                this.composeWithJHipster('entity-i18n', {
                     context,
-                    configOptions,
                     skipInstall: context.options.skipInstall,
                     force: context.options.force,
                     debug: context.isDebugEnabled,

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1270,6 +1270,30 @@ module.exports = class extends PrivateBase {
     }
 
     /**
+     * Compose with a jhipster generator using default jhipster config.
+     * @param {string} generator - jhipster generator.
+     * @param {object} options - options to pass
+     * @return {object} the composed generator
+     */
+    composeWithJHipster(generator, options = {}) {
+        if (this.env.get(`jhipster:${generator}`)) {
+            generator = `jhipster:${generator}`;
+        } else {
+            // Keep test compatibily were jhipster lookup does not run.
+            generator = require.resolve(`./${generator}`);
+        }
+
+        return this.composeWith(
+            generator,
+            {
+                configOptions: this.configOptions,
+                ...options,
+            },
+            true
+        );
+    }
+
+    /**
      * Compose an external generator with Yeoman.
      * @param {string} npmPackageName - package name
      * @param {string} subGen - sub generator name

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -1325,35 +1325,44 @@ module.exports = class extends PrivateBase {
      * get sorted list of entities according to changelog date (i.e. the order in which they were added)
      */
     getExistingEntities() {
-        const entities = [];
-
         function isBefore(e1, e2) {
             return e1.definition.changelogDate - e2.definition.changelogDate;
         }
 
-        // TODO 7.0 this.destinationPath(JHIPSTER_CONFIG_DIR);
-        if (!shelljs.test('-d', JHIPSTER_CONFIG_DIR)) {
-            return entities;
+        const configDir = this.destinationPath(JHIPSTER_CONFIG_DIR);
+        if (!fs.existsSync(configDir)) {
+            fs.mkdirSync(configDir);
         }
+        const dir = fs.opendirSync(configDir);
+        const entityNames = [];
+        let dirent = dir.readSync();
+        while (dirent !== null) {
+            const extname = path.extname(dirent.name);
+            if (dirent.isFile() && extname === '.json') {
+                entityNames.push(path.basename(dirent.name, extname));
+            }
+            dirent = dir.readSync();
+        }
+        dir.closeSync();
 
-        // TODO 7.0 this.destinationPath(JHIPSTER_CONFIG_DIR);
-        return shelljs
-            .ls(path.join(JHIPSTER_CONFIG_DIR, '*.json'))
-            .reduce((acc, file) => {
+        return [...new Set((this.jhipsterConfig.entities || []).concat(entityNames))]
+            .map(entityName => {
+                const file = this.destinationPath(configDir, `${entityName}.json`);
                 try {
                     const definition = this.fs.readJSON(file);
                     if (this.options.namespace !== 'jhipster:info') {
                         // Execute a write operation to set the file as modified on mem-fs to trigger prettier.
                         this.fs.append(file, '', { trimEnd: false, separator: '' });
-                        acc.push({ name: path.basename(file, '.json'), definition });
                     }
+                    return { name: path.basename(file, '.json'), definition };
                 } catch (error) {
                     // not an entity file / malformed?
                     this.warning(`Unable to parse entity file ${file}`);
                     this.debug('Error:', error);
+                    return undefined;
                 }
-                return acc;
-            }, entities)
+            })
+            .filter(entity => entity)
             .sort(isBefore);
     }
 

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -224,9 +224,8 @@ module.exports = class extends BaseBlueprintGenerator {
                 if (this.configOptions.skipComposeLanguages || this.jhipsterConfig.enableTranslation === false) return;
 
                 this.configOptions.skipComposeLanguages = true;
-                this.composeWith(require.resolve('../languages'), {
+                this.composeWithJHipster('languages', {
                     ...this.options,
-                    configOptions: this.configOptions,
                     debug: this.isDebugEnabled,
                 });
             },

--- a/test/app/application-with-entities.js
+++ b/test/app/application-with-entities.js
@@ -1,0 +1,244 @@
+const fse = require('fs-extra');
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const { JHIPSTER_CONFIG_DIR } = require('../../generators/generator-constants');
+
+const mockedComposedGenerators = ['jhipster:common', 'jhipster:server', 'jhipster:client', 'jhipster:languages', 'jhipster:entity'];
+
+describe('jhipster:app applicationWithEntities feature', () => {
+    describe('with default options', () => {
+        let runResult;
+        before(() => {
+            return helpers
+                .create(require.resolve('../../generators/app'))
+                .withOptions({
+                    applicationWithEntities: {
+                        config: {
+                            baseName: 'jhipster',
+                        },
+                        entities: [],
+                    },
+                    fromCli: true,
+                    skipInstall: true,
+                    defaults: true,
+                })
+                .withMockedGenerators(mockedComposedGenerators)
+                .run()
+                .then(result => {
+                    runResult = result;
+                });
+        });
+
+        after(() => runResult.cleanup());
+
+        it('writes .yo-rc.json with config', () => {
+            assert.fileContent('.yo-rc.json', /"baseName": "jhipster"/);
+            runResult.assertFile('.yo-rc.json');
+        });
+    });
+
+    describe('with --with-entities', () => {
+        describe('and single entity', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/app'))
+                    .withOptions({
+                        applicationWithEntities: {
+                            config: {
+                                baseName: 'jhipster',
+                            },
+                            entities: [{ name: 'Foo' }],
+                        },
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('writes .yo-rc.json', () => {
+                runResult.assertFile('.yo-rc.json');
+                runResult.assertFileContent('.yo-rc.json', /"baseName": "jhipster"/);
+            });
+            it('writes entity config file', () => {
+                runResult.assertFile('.jhipster/Foo.json');
+                runResult.assertFileContent('.jhipster/Foo.json', /"name": "Foo"/);
+            });
+            it('calls entity generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert(EntityGenerator.calledOnce);
+                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
+            });
+        });
+
+        describe('and 2 entities', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/app'))
+                    .withOptions({
+                        applicationWithEntities: {
+                            config: {
+                                baseName: 'jhipster',
+                            },
+                            entities: [{ name: 'Foo' }, { name: 'Bar' }],
+                        },
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('writes .yo-rc.json', () => {
+                runResult.assertFile('.yo-rc.json');
+                runResult.assertFileContent('.yo-rc.json', /"baseName": "jhipster"/);
+            });
+            it('writes entity config file', () => {
+                runResult.assertFile('.jhipster/Foo.json');
+                runResult.assertFileContent('.jhipster/Foo.json', /"name": "Foo"/);
+                runResult.assertFile('.jhipster/Bar.json');
+                runResult.assertFileContent('.jhipster/Bar.json', /"name": "Bar"/);
+            });
+            it('calls entity generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert(EntityGenerator.callCount === 2);
+                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
+                assert.equal(EntityGenerator.getCall(1).args[0], 'Bar');
+            });
+        });
+
+        describe('and 1 entity and 1 entity file', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/app'))
+                    .withOptions({
+                        applicationWithEntities: {
+                            config: {
+                                baseName: 'jhipster',
+                            },
+                            entities: [{ name: 'Foo', changelogDate: 1 }],
+                        },
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .doInDir(dir => {
+                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
+                        fse.ensureDirSync(entitiesPath);
+                        const entityPath = path.join(entitiesPath, 'Bar.json');
+                        fse.writeFileSync(entityPath, '{"changelogDate": 2}');
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('composes with mocked common generator', () => {
+                const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+                assert(CommonGenerator.calledOnce);
+            });
+            it('compose with mocked server generator', () => {
+                const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+                assert(ServerGenerator.calledOnce);
+            });
+            it('composes with mocked client generator', () => {
+                const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+                assert(ClientGenerator.calledOnce);
+            });
+            it('composes with mocked languages generator', () => {
+                const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+                assert(LanguagesGenerator.calledOnce);
+            });
+            it('composes with mocked entity generator ordered by changelogDate', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert.equal(EntityGenerator.callCount, 2);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo']);
+                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Bar']);
+            });
+        });
+
+        describe('and more than 1 entity and than 1 entity files', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/app'))
+                    .withOptions({
+                        applicationWithEntities: {
+                            config: {
+                                baseName: 'jhipster',
+                            },
+                            entities: [
+                                { name: 'Four', changelogDate: 0 },
+                                { name: 'Two', changelogDate: 2 },
+                            ],
+                        },
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .doInDir(dir => {
+                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
+                        fse.ensureDirSync(entitiesPath);
+                        fse.writeFileSync(path.join(entitiesPath, 'One.json'), '{"changelogDate": 3}');
+                        fse.writeFileSync(path.join(entitiesPath, 'Three.json'), '{"changelogDate": 1}');
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('composes with mocked common generator', () => {
+                const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+                assert(CommonGenerator.calledOnce);
+            });
+            it('compose with mocked server generator', () => {
+                const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+                assert(ServerGenerator.calledOnce);
+            });
+            it('composes with mocked client generator', () => {
+                const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+                assert(ClientGenerator.calledOnce);
+            });
+            it('composes with mocked languages generator', () => {
+                const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+                assert(LanguagesGenerator.calledOnce);
+            });
+            it('composes with mocked entity generator ordered by changelogDate', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert.equal(EntityGenerator.callCount, 4);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Four']);
+                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Three']);
+                assert.deepStrictEqual(EntityGenerator.getCall(2).args[0], ['Two']);
+                assert.deepStrictEqual(EntityGenerator.getCall(3).args[0], ['One']);
+            });
+        });
+    });
+});

--- a/test/app/composing.js
+++ b/test/app/composing.js
@@ -1,0 +1,230 @@
+const fse = require('fs-extra');
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const { JHIPSTER_CONFIG_DIR } = require('../../generators/generator-constants');
+
+const mockedComposedGenerators = ['jhipster:common', 'jhipster:server', 'jhipster:client', 'jhipster:languages', 'jhipster:entity'];
+
+describe('jhipster:app composing with others generators', () => {
+    describe('with default options', () => {
+        let runResult;
+        before(() => {
+            return helpers
+                .create(require.resolve('../../generators/app'))
+                .withOptions({
+                    baseName: 'jhipster',
+                    fromCli: true,
+                    skipInstall: true,
+                    defaults: true,
+                })
+                .withMockedGenerators(mockedComposedGenerators)
+                .run()
+                .then(result => {
+                    runResult = result;
+                });
+        });
+
+        after(() => runResult.cleanup());
+
+        it('composes with mocked common generator', () => {
+            const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+            assert(CommonGenerator.calledOnce);
+        });
+        it('composes with mocked server generator', () => {
+            const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+            assert(ServerGenerator.calledOnce);
+        });
+        it('composes with mocked client generator', () => {
+            const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+            assert(ClientGenerator.calledOnce);
+        });
+        it('composes with mocked languages generator', () => {
+            const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+            assert(LanguagesGenerator.calledOnce);
+        });
+    });
+
+    describe('with --skip-client', () => {
+        let runResult;
+        before(() => {
+            return helpers
+                .create(require.resolve('../../generators/app'))
+                .withOptions({
+                    baseName: 'jhipster',
+                    fromCli: true,
+                    skipInstall: true,
+                    defaults: true,
+                    skipClient: true,
+                })
+                .withMockedGenerators(mockedComposedGenerators)
+                .run()
+                .then(result => {
+                    runResult = result;
+                });
+        });
+
+        after(() => runResult.cleanup());
+
+        it('composes with mocked common generator', () => {
+            const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+            assert(CommonGenerator.calledOnce);
+        });
+        it('composes with mocked server generator', () => {
+            const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+            assert(ServerGenerator.calledOnce);
+        });
+        it('does not compose with mocked client generator', () => {
+            const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+            assert(ClientGenerator.callCount === 0);
+        });
+        it('composes with mocked languages generator', () => {
+            const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+            assert(LanguagesGenerator.calledOnce);
+        });
+    });
+
+    describe('with --skip-server', () => {
+        let runResult;
+        before(() => {
+            return helpers
+                .create(require.resolve('../../generators/app'))
+                .withOptions({
+                    baseName: 'jhipster',
+                    fromCli: true,
+                    skipInstall: true,
+                    defaults: true,
+                    skipServer: true,
+                })
+                .withMockedGenerators(mockedComposedGenerators)
+                .run()
+                .then(result => {
+                    runResult = result;
+                });
+        });
+
+        after(() => runResult.cleanup());
+
+        it('composes with mocked common generator', () => {
+            const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+            assert(CommonGenerator.calledOnce);
+        });
+        it('does not compose with mocked server generator', () => {
+            const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+            assert(ServerGenerator.callCount === 0);
+        });
+        it('composes with mocked client generator', () => {
+            const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+            assert(ClientGenerator.calledOnce);
+        });
+        it('composes with mocked languages generator', () => {
+            const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+            assert(LanguagesGenerator.calledOnce);
+        });
+    });
+
+    describe('with --with-entities', () => {
+        describe('and 1 entity file', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/app'))
+                    .withOptions({
+                        baseName: 'jhipster',
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .doInDir(dir => {
+                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
+                        fse.ensureDirSync(entitiesPath);
+                        const entityPath = path.join(entitiesPath, 'Foo.json');
+                        fse.writeFileSync(entityPath, '{}');
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('composes with mocked common generator', () => {
+                const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+                assert(CommonGenerator.calledOnce);
+            });
+            it('compose with mocked server generator', () => {
+                const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+                assert(ServerGenerator.calledOnce);
+            });
+            it('composes with mocked client generator', () => {
+                const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+                assert(ClientGenerator.calledOnce);
+            });
+            it('composes with mocked languages generator', () => {
+                const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+                assert(LanguagesGenerator.calledOnce);
+            });
+            it('composes with mocked entity generator once', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert(EntityGenerator.calledOnce);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo']);
+            });
+        });
+
+        describe('and more than 1 entity file', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/app'))
+                    .withOptions({
+                        baseName: 'jhipster',
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .doInDir(dir => {
+                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
+                        fse.ensureDirSync(entitiesPath);
+                        fse.writeFileSync(path.join(entitiesPath, 'One.json'), '{"changelogDate": 3}');
+                        fse.writeFileSync(path.join(entitiesPath, 'Two.json'), '{"changelogDate": 2}');
+                        fse.writeFileSync(path.join(entitiesPath, 'Three.json'), '{"changelogDate": 1}');
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('composes with mocked common generator', () => {
+                const CommonGenerator = runResult.mockedGenerators['jhipster:common'];
+                assert(CommonGenerator.calledOnce);
+            });
+            it('compose with mocked server generator', () => {
+                const ServerGenerator = runResult.mockedGenerators['jhipster:server'];
+                assert(ServerGenerator.calledOnce);
+            });
+            it('composes with mocked client generator', () => {
+                const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
+                assert(ClientGenerator.calledOnce);
+            });
+            it('composes with mocked languages generator', () => {
+                const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
+                assert(LanguagesGenerator.calledOnce);
+            });
+            it('composes with mocked entity generator ordered by changelogDate', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert.equal(EntityGenerator.callCount, 3);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Three']);
+                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Two']);
+                assert.deepStrictEqual(EntityGenerator.getCall(2).args[0], ['One']);
+            });
+        });
+    });
+});


### PR DESCRIPTION
- Implement composeWithJHipster to allow mocking generators.
- Load config and entities from applicationWithEntities option.

Related to https://github.com/jhipster/generator-jhipster/issues/12178
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
