### PR TITLE
Print ejs stacktrace.

### DIFF
--- a/generators/utils.js
+++ b/generators/utils.js
@@ -255,7 +255,8 @@ function renderContent(source, generator, context, options, cb) {
         if (!err) {
             cb(res);
         } else {
-            generator.error(`Copying template ${source} failed. [${err}]`);
+            generator.warning(`Copying template ${source} failed. [${err}]`);
+            throw err;
         }
     });
 }


### PR DESCRIPTION
Current ejs error handling is just printing the error and throwing another error without printing the stack trace.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
