### PR TITLE
remove DataAccessException handling when no using db

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -26,7 +26,9 @@ import org.springframework.beans.factory.annotation.Value;
 <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
 import org.springframework.dao.ConcurrencyFailureException;
 <%_ } _%>
+<%_ if (databaseType !== 'no') { _%>
 import org.springframework.dao.DataAccessException;
+<%_ } _%>
 import org.springframework.http.ResponseEntity;
 import org.springframework.http.converter.HttpMessageConversionException;
 <%_ if (reactive && databaseType === 'sql') { _%>
@@ -203,7 +205,7 @@ _%>
         return create(ex, problem, request);
     }
     <%_ } _%>
-    
+
     @Override
     public ProblemBuilder prepare(final Throwable throwable, final StatusType status, final URI type) {
 
@@ -221,7 +223,7 @@ _%>
                         .map(this::toProblem)
                         .orElse(null));
             }
-
+            <%_ if (databaseType !== 'no') { _%>
             if (throwable instanceof DataAccessException) {
                 return Problem.builder()
                     .withType(type)
@@ -233,7 +235,7 @@ _%>
                         .map(this::toProblem)
                         .orElse(null));
             }
-
+            <%_ } _%>
             if (containsPackageName(throwable.getMessage())) {
                 return Problem.builder()
                     .withType(type)


### PR DESCRIPTION
<!--
PR description.
-->
daily builds with no db are failing because that recent modification, I suppose we should not handle this kind of exception if the application does not have a database. 

https://github.com/hipster-labs/jhipster-daily-builds
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
