### PR TITLE
Fix tzdata when building Docker image [skip ci]

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,11 +1,13 @@
 FROM ubuntu:20.04
-
 RUN \
   # configure the "jhipster" user
   groupadd jhipster && \
   useradd jhipster -s /bin/bash -m -g jhipster -G sudo && \
   echo 'jhipster:jhipster' |chpasswd && \
   mkdir /home/jhipster/app && \
+  export DEBIAN_FRONTEND=noninteractive && \
+  export TZ=Europe\Paris && \
+  ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
   apt-get update && \
   # install utilities
   apt-get install -y \
@@ -22,9 +24,6 @@ RUN \
     build-essential \
     software-properties-common \
     sudo && \
-  # install tzdata
-  export DEBIAN_FRONTEND=noninteractive && \
-  apt-get install -y tzdata && \
   # install OpenJDK 11
   add-apt-repository ppa:openjdk-r/ppa && \
   apt-get update && \


### PR DESCRIPTION
<!--
PR description.
-->

Related to https://github.com/jhipster/generator-jhipster/issues/10819
But with Ubuntu 20.04, it will still work

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
