### PR TITLE
add testcontainers for reactive sql option

### DIFF
--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -67,6 +67,9 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 <%_ if (authenticationType === 'uaa') { _%>
 import <%= packageName %>.config.SecurityBeanOverrideConfiguration;
@@ -110,13 +113,10 @@ import <%= packageName %>.service.<%= entityClass %>QueryService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (searchEngine === 'elasticsearch' || fieldsContainOwnerManyToMany || cacheProvider === 'redis') { _%>
+<%_ if ((searchEngine === 'elasticsearch' || fieldsContainOwnerManyToMany || cacheProvider === 'redis') || databaseType === 'neo4j' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.mockito.Mock;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.junit.jupiter.MockitoExtension;
-<%_ } _%>
-<%_ if (databaseType === 'neo4j') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
 <%_ if (!reactive) { _%>
@@ -218,6 +218,9 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 <%_ } _%>
 <%_ if (databaseType === 'neo4j') { _%>
 @ExtendWith(AbstractNeo4jIT.class)
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
 <%_ if (!reactive) { _%>
 @AutoConfigureMockMvc

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1410,6 +1410,16 @@ const serverFiles = {
             templates: [{ file: 'testcontainers/mariadb/my.cnf', method: 'copy', noEjs: true }],
         },
         {
+            condition: generator => ['mysql', 'postgresql', 'mssql'].includes(generator.prodDatabaseType) && generator.reactive,
+            path: SERVER_TEST_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/ReactiveSqlTestContainerExtension.java',
+                    renameTo: generator => `${generator.testDir}ReactiveSqlTestContainerExtension.java`
+                }
+            ],
+        },
+        {
             // TODO : add these tests to reactive
             condition: generator => !generator.reactive,
             path: SERVER_TEST_SRC_DIR,

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1415,8 +1415,8 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/ReactiveSqlTestContainerExtension.java',
-                    renameTo: generator => `${generator.testDir}ReactiveSqlTestContainerExtension.java`
-                }
+                    renameTo: generator => `${generator.testDir}ReactiveSqlTestContainerExtension.java`,
+                },
             ],
         },
         {

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -146,7 +146,7 @@ task integrationTest(type: Test) {
         events 'FAILED', 'SKIPPED'
     }
 
-<%_ if (databaseType === 'sql' && !reactive) { _%>
+<%_ if (databaseType === 'sql') { _%>
     if (project.hasProperty('testcontainers')) {
         environment 'spring.profiles.active', 'testcontainers'
     }
@@ -407,16 +407,16 @@ dependencies {
     testImplementation "org.testcontainers:neo4j"
     testImplementation 'org.testcontainers:junit-jupiter'
     <%_ } _%>
-    <%_ if (prodDatabaseType === 'mysql' && !reactive) { _%>
+    <%_ if (prodDatabaseType === 'mysql') { _%>
     testImplementation "org.testcontainers:mysql"
     <%_ } _%>
     <%_ if (prodDatabaseType === 'mariadb' && !reactive) { _%>
     testImplementation "org.testcontainers:mariadb"
     <%_ } _%>
-    <%_ if (prodDatabaseType === 'postgresql' && !reactive) { _%>
+    <%_ if (prodDatabaseType === 'postgresql') { _%>
     testImplementation "org.testcontainers:postgresql"
     <%_ } _%>
-    <%_ if (prodDatabaseType === 'mssql' && !reactive) { _%>
+    <%_ if (prodDatabaseType === 'mssql') { _%>
     testImplementation "org.testcontainers:mssqlserver"
     <%_ } _%>
     <%_ if (prodDatabaseType === 'oracle' && !reactive) { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -414,6 +414,19 @@
             <scope>test</scope>
         </dependency>
 <%_ } _%>
+<%_ if (databaseType === 'sql' && reactive) { _%>
+        <dependency>
+            <groupId>org.testcontainers</groupId>
+    <%_ if (prodDatabaseType === 'mysql') { _%>
+            <artifactId>mysql</artifactId>
+    <%_ } else if (prodDatabaseType === 'postgresql') { _%>
+            <artifactId>postgresql</artifactId>
+    <%_ } else if (prodDatabaseType === 'mssql') { _%>
+            <artifactId>mssqlserver</artifactId>
+    <%_ } _%>
+            <scope>test</scope>
+        </dependency>
+<%_ } _%>
 <%_ if (['ehcache', 'caffeine', 'hazelcast', 'infinispan', 'memcached'].includes(cacheProvider)) { _%>
         <dependency>
             <groupId>javax.cache</groupId>

--- a/generators/server/templates/src/test/java/package/ReactiveSqlTestContainerExtension.java.ejs
+++ b/generators/server/templates/src/test/java/package/ReactiveSqlTestContainerExtension.java.ejs
@@ -1,0 +1,73 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= packageName %>;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.extension.BeforeAllCallback;
+import org.junit.jupiter.api.extension.ExtensionContext;
+<%_ if (prodDatabaseType === 'mysql') { _%>
+import org.testcontainers.containers.MySQLContainer;
+<%_ } else if (prodDatabaseType === 'postgresql') { _%>
+import org.testcontainers.containers.PostgreSQLContainer;
+<%_ } else if (prodDatabaseType === 'mssql') { _%>
+import org.testcontainers.containers.MSSQLServerContainer;      
+<%_ } _%>
+import java.util.Collections;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+public class ReactiveSqlTestContainerExtension implements BeforeAllCallback {
+
+    private static AtomicBoolean started = new AtomicBoolean(false);
+    
+    <%_ if (prodDatabaseType === 'mysql') { _%>
+    private static MySQLContainer container = (MySQLContainer) new MySQLContainer("<%= DOCKER_MYSQL %>")
+            .withDatabaseName("<%= baseName %>")
+            .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"));
+    <%_ } else if (prodDatabaseType === 'postgresql') { _%>
+    private static PostgreSQLContainer container = (PostgreSQLContainer) new PostgreSQLContainer("<%= DOCKER_POSTGRESQL %>")
+            .withDatabaseName("<%= baseName %>")
+            .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"));
+    <%_ } else if (prodDatabaseType === 'mssql') { _%>
+    private static MSSQLServerContainer container =  (MSSQLServerContainer) new MSSQLServerContainer<>("<%= DOCKER_MSSQL %>")
+            .withDatabaseName("<%= baseName %>")
+            .withTmpFs(Collections.singletonMap("/testtmpfs", "rw"));
+    <%_ } _%>
+    
+    @Override
+    public void beforeAll(ExtensionContext extensionContext) throws Exception {
+    if (!started.get() && useTestcontainers()) {
+            container.start();
+            System.setProperty("spring.r2dbc.url", container.getJdbcUrl().replace("jdbc", "r2dbc"));
+            System.setProperty("spring.r2dbc.username", container.getUsername());
+            System.setProperty("spring.r2dbc.password", container.getPassword());
+            System.setProperty("spring.liquibase.url", container.getJdbcUrl());
+            System.setProperty("spring.liquibase.user", container.getUsername());
+            System.setProperty("spring.liquibase.password", container.getPassword());
+            started.set(true);
+        }
+    }
+
+    private boolean useTestcontainers() {
+
+        String systemProperties = StringUtils.defaultIfBlank(System.getProperty("spring.profiles.active"), "");
+        String environmentVariables = StringUtils.defaultIfBlank(System.getenv("SPRING_PROFILES_ACTIVE"), "");
+
+        return systemProperties.contains("testcontainers") || environmentVariables.contains("testcontainers");
+    }
+}

--- a/generators/server/templates/src/test/java/package/security/DomainUserDetailsServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/DomainUserDetailsServiceIT.java.ejs
@@ -27,6 +27,9 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 <%_ if (databaseType === 'sql' && reactive) { _%>
 import <%= packageName %>.config.Constants;
@@ -37,10 +40,7 @@ import <%= packageName %>.repository.UserRepository;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (cacheProvider === 'redis') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
-<%_ } _%>
-<%_ if (databaseType === 'neo4j') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
@@ -76,6 +76,9 @@ import static org.assertj.core.api.Assertions.assertThatExceptionOfType;
 <%_ } _%>
 <%_ if (databaseType === 'neo4j') { _%>
 @ExtendWith(AbstractNeo4jIT.class)
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 @Transactional

--- a/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/MailServiceIT.java.ejs
@@ -27,15 +27,15 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 import <%= packageName %>.domain.<%= asEntity('User') %>;
 import io.github.jhipster.config.JHipsterProperties;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (cacheProvider === 'redis') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
-<%_ } _%>
-<%_ if (databaseType === 'neo4j') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.mockito.ArgumentCaptor;
@@ -77,6 +77,9 @@ import static org.mockito.Mockito.*;
 <%_ } _%>
 <%_ if (databaseType === 'neo4j') { _%>
 @ExtendWith(AbstractNeo4jIT.class)
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
 class MailServiceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 

--- a/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/service/UserServiceIT.java.ejs
@@ -27,6 +27,9 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 import <%= packageName %>.config.Constants;
 <%_ if (authenticationType === 'oauth2') { _%>
@@ -61,10 +64,7 @@ import org.apache.commons.lang3.RandomStringUtils;
 <%_ } _%>
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (cacheProvider === 'redis') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
-<%_ } _%>
-<%_ if (databaseType === 'neo4j') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
@@ -157,6 +157,9 @@ import static org.mockito.Mockito.when;
 <%_ } _%>
 <%_ if (databaseType === 'neo4j') { _%>
 @ExtendWith(AbstractNeo4jIT.class)
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 @Transactional

--- a/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/AccountResourceIT.java.ejs
@@ -28,6 +28,9 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 import <%= packageName %>.config.TestSecurityConfiguration;
 import <%= packageName %>.security.AuthoritiesConstants;
@@ -35,7 +38,7 @@ import <%= packageName %>.service.UserService;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
@@ -88,6 +91,9 @@ import static org.springframework.security.test.web.reactive.server.SecurityMock
 /**
  * Integration tests for the {@link AccountResource} REST controller.
  */
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
+<%_ } _%>  
 <%_ if (!reactive) { _%>
 @AutoConfigureMockMvc
 <%_ } else { _%>
@@ -194,8 +200,11 @@ import <%= packageName %>.repository.search.UserSearchRepository;
 import <%= packageName %>.security.AuthoritiesConstants;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
 <%_ if (!reactive) { _%>
@@ -224,6 +233,9 @@ import static <%= packageName %>.web.rest.AccountResourceIT.TEST_USER_LOGIN;
 /**
  * Integration tests for the {@link AccountResource} REST controller.
  */
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
+<%_ } _%>  
 <%_ if (!reactive) { _%>
 @AutoConfigureMockMvc
 <%_ } else { _%>
@@ -285,6 +297,9 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 import <%= packageName %>.config.Constants;
 <%_ if (authenticationType === 'session' && !reactive) { _%>
@@ -308,7 +323,7 @@ import <%= packageName %>.service.dto.<%= asDto('User') %>;
 import <%= packageName %>.web.rest.vm.KeyAndPasswordVM;
 import <%= packageName %>.web.rest.vm.ManagedUserVM;
 import org.apache.commons.lang3.RandomStringUtils;
-<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.junit.jupiter.api.BeforeEach;
@@ -370,6 +385,9 @@ import static org.springframework.security.test.web.reactive.server.SecurityMock
 /**
  * Integration tests for the {@link AccountResource} REST controller.
  */
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
+<%_ } _%>  
 <%_ if (!reactive) { _%>
 @AutoConfigureMockMvc
 <%_ } else { _%>

--- a/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/LogoutResourceIT.java.ejs
@@ -25,13 +25,13 @@ import <%= packageName %>.RedisTestContainerExtension;
 <%_ if (databaseType === 'neo4j') { _%>
 import <%= packageName %>.AbstractNeo4jIT;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.config.TestSecurityConfiguration;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (cacheProvider === 'redis') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
-<%_ } _%>
-<%_ if (databaseType === 'neo4j') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
@@ -75,6 +75,9 @@ import static org.springframework.security.test.web.reactive.server.SecurityMock
 <%_ } _%>
 <%_ if (databaseType === 'neo4j') { _%>
 @ExtendWith(AbstractNeo4jIT.class)
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
 public class LogoutResourceIT {
 

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -27,6 +27,9 @@ import <%= packageName %>.AbstractNeo4jIT;
 <%_ if (cacheProvider === 'redis') { _%>
 import <%= packageName %>.RedisTestContainerExtension;
 <%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+import <%= packageName %>.ReactiveSqlTestContainerExtension;
+<%_ } _%>
 import <%= packageName %>.<%= mainClass %>;
 <%_ if (databaseType === 'sql' && reactive) { _%>
 import <%= packageName %>.config.Constants;
@@ -51,10 +54,7 @@ import <%= packageName %>.web.rest.vm.ManagedUserVM;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
-<%_ if (cacheProvider === 'redis') { _%>
-import org.junit.jupiter.api.extension.ExtendWith;
-<%_ } _%>
-<%_ if (databaseType === 'neo4j') { _%>
+<%_ if (databaseType === 'neo4j' || cacheProvider === 'redis' || (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType))) { _%>
 import org.junit.jupiter.api.extension.ExtendWith;
 <%_ } _%>
 import org.springframework.beans.factory.annotation.Autowired;
@@ -142,6 +142,9 @@ import static org.springframework.security.test.web.reactive.server.SecurityMock
 <%_ } _%>
 <%_ if (databaseType === 'neo4j') { _%>
 @ExtendWith(AbstractNeo4jIT.class)
+<%_ } _%>
+<%_ if (reactive && ['mysql', 'postgresql', 'mssql'].includes(prodDatabaseType)) { _%>
+@ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
 class UserResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 


### PR DESCRIPTION
This adds testcontainers to reactive sql option (for supported databases). As already stated in the issue #11689 we can't change the datasource to the testcontainers r2dbc url like we do for jdbc as liquibase does not support r2dbc urls (yet). 
Therefore there is now a custom junit extension, which starts a singleton container and sets the required properties, only when started with the testcontainers profile.

closes #11689

EDIT: I forgot to trigger webflux build :facepalm: 

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
