### PR TITLE
bugfix: swagger-ui doesn't load when client and backend located on di…

### DIFF
--- a/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
@@ -196,6 +196,7 @@ public class WebConfigurer implements <% if (!reactive) { %>ServletContextInitia
             source.registerCorsConfiguration("/management/**", config);
             source.registerCorsConfiguration("/v2/api-docs", config);
             source.registerCorsConfiguration("/v3/api-docs", config);
+            source.registerCorsConfiguration("/swagger-resources", config);
             <%_ if (applicationType === 'gateway' && authenticationType === 'uaa') { _%>
             source.registerCorsConfiguration("/auth/**", config);
             <%_ } _%>


### PR DESCRIPTION
bugfix: swagger-ui doesn't load when client and backend located on different domains. request for /swagger-resources is blocked due to missing CORS headers
This MR supersedes https://github.com/jhipster/generator-jhipster/pull/11267, due to merge issues