### PR TITLE
[Samples] Fix inversion authentication type in .yo-rc

### DIFF
--- a/test-integration/samples/ms-react-gateway-consul-jwt/.yo-rc.json
+++ b/test-integration/samples/ms-react-gateway-consul-jwt/.yo-rc.json
@@ -4,7 +4,7 @@
         "baseName": "sampleGateway",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
-        "authenticationType": "oauth2",
+        "authenticationType": "jwt",
         "cacheProvider": "hazelcast",
         "enableHibernateCache": true,
         "websocket": false,

--- a/test-integration/samples/ms-react-gateway-consul-oauth2/.yo-rc.json
+++ b/test-integration/samples/ms-react-gateway-consul-oauth2/.yo-rc.json
@@ -4,7 +4,7 @@
         "baseName": "sampleGateway",
         "packageName": "io.github.jhipster.sample",
         "packageFolder": "io/github/jhipster/sample",
-        "authenticationType": "jwt",
+        "authenticationType": "oauth2",
         "cacheProvider": "hazelcast",
         "enableHibernateCache": true,
         "websocket": false,


### PR DESCRIPTION
Concern ms-react-gateway-consul and ms-react-gateway-consul-oauth2

<!--
PR description.
-->
There is an inversion between ms-react-gateway-consul and ms-react-gateway-consul-oauth2 authentication types
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
