### PR TITLE
Implement --skip-jhipster-dependencies option

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -196,6 +196,10 @@ module.exports = class extends BaseBlueprintGenerator {
             desc: 'Recreate the initial database changelog based on the current config',
             type: Boolean,
         });
+        this.option('skip-jhipster-dependencies', {
+            desc: "Don't write jhipster dependencies.",
+            type: Boolean,
+        });
 
         // Just constructing help, stop here
         if (this.options.help) {

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -1,20 +1,20 @@
 <%#
- Copyright 2013-2020 the original author or authors from the JHipster project.
+Copyright 2013-2020 the original author or authors from the JHipster project.
 
- This file is part of the JHipster project, see https://www.jhipster.tech/
- for more information.
+This file is part of the JHipster project, see https://www.jhipster.tech/
+for more information.
 
- Licensed under the Apache License, Version 2.0 (the "License");
- you may not use this file except in compliance with the License.
- You may obtain a copy of the License at
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
 
-      http://www.apache.org/licenses/LICENSE-2.0
+http://www.apache.org/licenses/LICENSE-2.0
 
- Unless required by applicable law or agreed to in writing, software
- distributed under the License is distributed on an "AS IS" BASIS,
- WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- See the License for the specific language governing permissions and
- limitations under the License.
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
 -%>
 {
   "name": "<%= dasherizedBaseName %>",
@@ -101,7 +101,12 @@
     "eslint-loader": "4.0.2",
     "file-loader": "6.0.0",
     "friendly-errors-webpack-plugin": "1.7.0",
+    <%_ if (!skipJhipsterDependencies) { _%>
     "generator-jhipster": "<%= packagejs.version %>",
+        <%_ otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+        <%_ });
+    } _%>
     "html-loader": "1.1.0",
     "html-webpack-plugin": "4.3.0",
     <%_ if (!skipCommitHook) { _%>
@@ -149,9 +154,6 @@
     <%_ } _%>
     "tslint": "6.1.2",
     "typescript": "3.9.5",
-    <%_ otherModules.forEach(module => { _%>
-    "<%= module.name %>": "<%= module.version %>",
-    <%_ }); _%>
     <%_ if (protractorTests || cypressTests) { _%>
     "webdriver-manager": "12.1.7",
     <%_ } _%>

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -111,7 +111,12 @@ limitations under the License.
     "file-loader": "6.0.0",
     "fork-ts-checker-webpack-plugin": "4.1.3",
     "friendly-errors-webpack-plugin": "1.7.0",
+    <%_ if (!skipJhipsterDependencies) { _%>
     "generator-jhipster": "<%= packagejs.version %>",
+        <%_ otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+        <%_ });
+    } _%>
     "html-webpack-plugin": "4.3.0",
     <%_ if (!skipCommitHook) { _%>
     "husky": "<%= HUSKY_VERSION %>",
@@ -153,9 +158,6 @@ limitations under the License.
     "stripcomment-loader": "0.1.0",
     "style-loader": "1.2.0",
     "swagger-ui-dist": "3.25.1",
-    <%_ otherModules.forEach(module => { _%>
-    "<%= module.name %>": "<%= module.version %>",
-    <%_ }); _%>
     "terser-webpack-plugin": "2.3.6",
     "thread-loader": "2.1.3",
     "to-string-loader": "1.1.6",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -85,7 +85,12 @@ limitations under the License.
     "file-loader": "6.0.0",
     "fork-ts-checker-webpack-plugin": "4.1.4",
     "friendly-errors-webpack-plugin": "1.7.0",
+<%_ if (!skipJhipsterDependencies) { _%>
     "generator-jhipster": "<%= packagejs.version %>",
+    <%_ otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+    <%_ });
+} _%>
     "html-webpack-plugin": "4.3.0",
     <%_ if (!skipCommitHook) { _%>
     "husky": "4.2.5",

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2100,6 +2100,9 @@ module.exports = class extends PrivateBase {
         this.configOptions.optionsParsed = true;
 
         // Load stored options
+        if (options.skipJhipsterDependencies !== undefined) {
+            this.jhipsterConfig.skipJhipsterDependencies = options.skipJhipsterDependencies;
+        }
         if (options.incrementalChangelog !== undefined) {
             this.jhipsterConfig.incrementalChangelog = options.incrementalChangelog;
         }
@@ -2218,6 +2221,7 @@ module.exports = class extends PrivateBase {
         dest.skipClient = config.skipClient;
         dest.prettierJava = config.prettierJava;
         dest.pages = config.pages;
+        dest.skipJhipsterDependencies = !!config.skipJhipsterDependencies;
 
         dest.testFrameworks = config.testFrameworks || [];
         dest.gatlingTests = dest.testFrameworks.includes('gatling');

--- a/generators/server/templates/package.json.ejs
+++ b/generators/server/templates/package.json.ejs
@@ -27,10 +27,12 @@
   ],
   "devDependencies": {
     "@openapitools/openapi-generator-cli": "1.0.13-4.3.1",
-    <%_ otherModules.forEach(module => { _%>
-    "<%= module.name %>": "<%= module.version %>",
-    <%_ }); _%>
+    <%_ if (!skipJhipsterDependencies) { _%>
     "generator-jhipster": "<%= jhipsterVersion %>",
+        <%_ otherModules.forEach(module => { _%>
+    "<%= module.name %>": "<%= module.version %>",
+        <%_ });
+    } _%>
     <%_ if (!skipCommitHook) { _%>
     "husky": "<%= HUSKY_VERSION %>",
     "lint-staged": "<%= LINT_STAGED_VERSION %>",

--- a/test/client.spec.js
+++ b/test/client.spec.js
@@ -5,10 +5,10 @@ const getFilesForOptions = require('./utils/utils').getFilesForOptions;
 const expectedFiles = require('./utils/expected-files');
 const angularFiles = require('../generators/client/files-angular').files;
 const reactFiles = require('../generators/client/files-react').files;
-const constants = require('../generators/generator-constants');
-
-const ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
-const REACT = constants.SUPPORTED_CLIENT_FRAMEWORKS.REACT;
+const { appDefaultConfig } = require('../generators/generator-defaults');
+const {
+    SUPPORTED_CLIENT_FRAMEWORKS: { ANGULAR, REACT, VUE },
+} = require('../generators/generator-constants');
 
 describe('JHipster client generator', () => {
     describe('generate client with React', () => {
@@ -79,6 +79,37 @@ describe('JHipster client generator', () => {
         });
         it('contains clientPackageManager with npm value', () => {
             assert.fileContent('.yo-rc.json', /"clientPackageManager": "npm"/);
+        });
+    });
+
+    describe.only('--skip-jhipster-dependencies', () => {
+        [ANGULAR, REACT, VUE].forEach(clientFramework => {
+            describe(`and ${clientFramework}`, () => {
+                let runResult;
+                before(() => {
+                    return helpers
+                        .create(require.resolve('../generators/app'))
+                        .withOptions({
+                            fromCli: true,
+                            skipInstall: true,
+                            defaultLocalConfig: { ...appDefaultConfig, clientFramework, skipServer: true },
+                            skipJhipsterDependencies: true,
+                        })
+                        .run()
+                        .then(result => {
+                            runResult = result;
+                        });
+                });
+
+                after(() => runResult.cleanup());
+
+                it('should add clientFramework to .yo-rc.json', () => {
+                    runResult.assertFileContent('.yo-rc.json', `"clientFramework": "${clientFramework}"`);
+                });
+                it('should not add generator-jhipster to package.json', () => {
+                    runResult.assertNoFileContent('package.json', 'generator-jhipster');
+                });
+            });
         });
     });
 });


### PR DESCRIPTION
When developing a blueprint or generator-jhipster, package.json always adds a released version of generator-jhipster*.
This option allows to use global generator-jhipster and blueprints without having to remove from package.json/npm uninstall.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
