### PR TITLE
Datetime column type doesn't store sub-second informations on MySQL and MariaDB

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -76,9 +76,9 @@
                 } else if (fieldType === 'LocalDate') {
                     columnType="date";
                 } else if (fieldType === 'Instant') {
-                    columnType="datetime";
+                    columnType="${datetimeType}";
                 } else if (fieldType === 'ZonedDateTime') {
-                    columnType="datetime";
+                    columnType="${datetimeType}";
                 } else if (fieldType === 'Duration') {
                     columnType="bigint";
                 } else if (fieldType === 'UUID') {
@@ -142,7 +142,7 @@
         </createTable>
         <%_ for (const idx in fields) {
             if (fields[idx].fieldType === 'ZonedDateTime' || fields[idx].fieldType === 'Instant') { _%>
-        <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%= fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="datetime"/>
+        <dropDefaultValue tableName="<%= entityTableName %>" columnName="<%= fields[idx].fieldNameAsDatabaseColumn %>" columnDataType="${datetimeType}"/>
         <%_ }
         } _%>
     </changeSet>

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -156,7 +156,7 @@
             <column name="activated" type="boolean"/>
             <column name="created_date" type="timestamp"/>
         </<% if (prodDatabaseType === 'mssql') { %>ext:<% } %>loadData>
-        <dropDefaultValue tableName="<%= jhiTablePrefix %>_user" columnName="created_date" columnDataType="datetime"/>
+        <dropDefaultValue tableName="<%= jhiTablePrefix %>_user" columnName="created_date" columnDataType="${datetimeType}"/>
         <<% if (prodDatabaseType === 'mssql') { %>ext:<% } %>loadData
                   file="config/liquibase/data/authority.csv"
                   separator=";"

--- a/generators/server/templates/src/main/resources/config/liquibase/master.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/master.xml.ejs
@@ -32,6 +32,9 @@
     <property name="uuidType" value="uuid" dbms="h2, <%= prodDatabaseType %>"/>
     <%_ } _%>
 
+    <property name="datetimeType" value="datetime(6)" dbms="mysql, mariadb"/>
+    <property name="datetimeType" value="datetime" dbms="oracle, mssql, postgresql, h2"/>
+
     <include file="config/liquibase/changelog/00000000000000_initial_schema.xml" relativeToChangelogFile="false"/>
     <!-- jhipster-needle-liquibase-add-changelog - JHipster will add liquibase changelogs here -->
     <!-- jhipster-needle-liquibase-add-constraints-changelog - JHipster will add liquibase constraints changelogs here -->


### PR DESCRIPTION
Datetime column type doesn't store sub-second informations on MySQL and MariaDB by default, here the precision defaults to 0.
As opposed to PostgreSQL and H2, where it assumes that 6 digit should be stored.

* https://mariadb.com/kb/en/microseconds-in-mariadb/
* https://dev.mysql.com/doc/refman/8.0/en/fractional-seconds.html
* https://www.postgresql.org/docs/current/datatype-datetime.html
* http://h2database.com/html/datatypes.html


---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
