### PR TITLE
[webflux] Fix r2dbc URL for H2 in memory database

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1367,7 +1367,7 @@ module.exports = class extends Generator {
             dbcUrl = `${protocol}:h2:file:${options.localDirectory}/${options.databaseName}`;
             extraOptions = ';DB_CLOSE_DELAY=-1';
         } else if (databaseType === 'h2Memory') {
-            dbcUrl = `${protocol}:h2:mem:${options.databaseName}`;
+            dbcUrl = `${protocol}:h2:mem:${protocol === 'r2dbc' ? '///' : ''}${options.databaseName}`;
             extraOptions = ';DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE';
         } else {
             throw new Error(`${databaseType} databaseType is not supported`);

--- a/test/generator-base-private.spec.js
+++ b/test/generator-base-private.spec.js
@@ -346,16 +346,16 @@ export * from './entityFolderName/entityFileName.state';`;
             });
         });
         describe('when called for h2Memory', () => {
-            it('return r2dbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE', () => {
+            it('return r2dbc:h2:mem:///test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE', () => {
                 expect(BaseGenerator.getR2DBCUrl('h2Memory', { databaseName: 'test' })).to.equal(
-                    'r2dbc:h2:mem:test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE'
+                    'r2dbc:h2:mem:///test;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE'
                 );
             });
         });
         describe('when called for h2Memory with skipExtraOptions enabled', () => {
-            it('return r2dbc:h2:mem:test', () => {
+            it('return r2dbc:h2:mem:///test', () => {
                 expect(BaseGenerator.getR2DBCUrl('h2Memory', { databaseName: 'test', skipExtraOptions: true })).to.equal(
-                    'r2dbc:h2:mem:test'
+                    'r2dbc:h2:mem:///test'
                 );
             });
         });


### PR DESCRIPTION
This is a cherry-pick from @murdos from spring-boot 2.3 branch.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
