### PR TITLE
Use absolute path for h2disk jdbc path

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -199,7 +199,7 @@ spring:
             <%_ } else if (devDatabaseType === 'oracle') { _%>
         url: <%- getJDBCUrl(devDatabaseType, { databaseName: 'xe', hostname: 'localhost' }) %>
             <%_ } else if (devDatabaseType === 'h2Disk') { _%>
-        url: <%- getJDBCUrl(devDatabaseType, { databaseName: lowercaseBaseName, localDirectory: `${BUILD_DIR}h2db/db` }) %>
+        url: <%- getJDBCUrl(devDatabaseType, { databaseName: lowercaseBaseName, localDirectory: `./${BUILD_DIR}h2db/db` }) %>
             <%_ } else if (devDatabaseType === 'h2Memory') { _%>
         url: <%- getJDBCUrl(devDatabaseType, { databaseName: lowercaseBaseName }) %>
             <%_ } _%>


### PR DESCRIPTION
Avoid the liquibase exception:

```
Liquibase could not start correctly, your database is NOT ready: A file path that is implicitly relative to the current working directory is not allowed in the database URL "jdbc:h2:file:target/h2db/db/h2db;DB_CLOSE_DELAY=-1".
Use an absolute path, ~/name, ./name, or the baseDir setting instead. [90011-200]
```

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.