### PR TITLE
expose docker compose containers only on local

### DIFF
--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-app:
@@ -91,8 +92,10 @@ services:
             - JAVA_OPTS=-Djgroups.tcp.address=NON_LOOPBACK -Djava.net.preferIPv4Stack=true
             <%_ } _%>
         <%_ if (applicationType === 'monolith' || applicationType === 'gateway') { _%>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - <%= serverPort %>:<%= serverPort %>
+            - 127.0.0.1:<%= serverPort %>:<%= serverPort %>
         <%_ } _%>
     <%_ if (prodDatabaseType === 'mysql') { _%>
     <%= baseName.toLowerCase() %>-mysql:

--- a/generators/server/templates/src/main/docker/cassandra-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/cassandra-cluster.yml.ejs
@@ -16,18 +16,21 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-cassandra:
         image: <%= DOCKER_CASSANDRA %>
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/cassandra/:/var/lib/cassandra/data
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 7000:7000
-            - 7001:7001
-            - 7199:7199
-            - 9042:9042
-            - 9160:9160
+            - 127.0.0.1:7000:7000
+            - 127.0.0.1:7001:7001
+            - 127.0.0.1:7199:7199
+            - 127.0.0.1:9042:9042
+            - 127.0.0.1:9160:9160
     <%= baseName.toLowerCase() %>-cassandra-node:
         image: <%= DOCKER_CASSANDRA %>
         environment:

--- a/generators/server/templates/src/main/docker/cassandra.yml.ejs
+++ b/generators/server/templates/src/main/docker/cassandra.yml.ejs
@@ -16,18 +16,21 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-cassandra:
         image: <%= DOCKER_CASSANDRA %>
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/cassandra/:/var/lib/cassandra/data
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 7000:7000
-            - 7001:7001
-            - 7199:7199
-            - 9042:9042
-            - 9160:9160
+            - 127.0.0.1:7000:7000
+            - 127.0.0.1:7001:7001
+            - 127.0.0.1:7199:7199
+            - 127.0.0.1:9042:9042
+            - 127.0.0.1:9160:9160
     <%= baseName.toLowerCase() %>-cassandra-migration:
         extends:
             file: cassandra-migration.yml

--- a/generators/server/templates/src/main/docker/consul.yml.ejs
+++ b/generators/server/templates/src/main/docker/consul.yml.ejs
@@ -16,14 +16,17 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     consul:
         image: <%= DOCKER_CONSUL %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 8300:8300
-            - 8500:8500
-            - 8600:8600
+            - 127.0.0.1:8300:8300
+            - 127.0.0.1:8500:8500
+            - 127.0.0.1:8600:8600
         command: consul agent -dev -ui -client 0.0.0.0
 
     consul-config-loader:

--- a/generators/server/templates/src/main/docker/couchbase-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/couchbase-cluster.yml.ejs
@@ -1,15 +1,36 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-couchbase:
         build:
             context: .
             dockerfile: couchbase/Couchbase.Dockerfile
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix        
         ports:
-            - 8091:8091
-            - 8092:8092
-            - 8093:8093
-            - 8094:8094
-            - 11210:11210
+            - 127.0.0.1:8091:8091
+            - 127.0.0.1:8092:8092
+            - 127.0.0.1:8093:8093
+            - 127.0.0.1:8094:8094
+            - 127.0.0.1:11210:11210
         environment:
             - TYPE=MASTER
             - BUCKET=<%= baseName %>

--- a/generators/server/templates/src/main/docker/couchbase.yml.ejs
+++ b/generators/server/templates/src/main/docker/couchbase.yml.ejs
@@ -1,15 +1,36 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-couchbase:
         build:
             context: .
             dockerfile: couchbase/Couchbase.Dockerfile
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 8091:8091
-            - 8092:8092
-            - 8093:8093
-            - 8094:8094
-            - 11210:11210
+            - 127.0.0.1:8091:8091
+            - 127.0.0.1:8092:8092
+            - 127.0.0.1:8093:8093
+            - 127.0.0.1:8094:8094
+            - 127.0.0.1:11210:11210
         environment:
             - BUCKET=<%= baseName %>
         # volumes:

--- a/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
+++ b/generators/server/templates/src/main/docker/elasticsearch.yml.ejs
@@ -16,15 +16,18 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-elasticsearch:
         image: <%= DOCKER_ELASTICSEARCH %>
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/elasticsearch/:/usr/share/elasticsearch/data/
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 9200:9200
-            - 9300:9300
+            - 127.0.0.1:9200:9200
+            - 127.0.0.1:9300:9300
         environment:
             - "ES_JAVA_OPTS=-Xms1024m -Xmx1024m"
             - "discovery.type=single-node"

--- a/generators/server/templates/src/main/docker/hazelcast-management-center.yml.ejs
+++ b/generators/server/templates/src/main/docker/hazelcast-management-center.yml.ejs
@@ -1,6 +1,27 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-hazelcast-management-center:
         image: <%= DOCKER_HAZELCAST_MANAGEMENT_CENTER %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 8180:8080
+            - 127.0.0.1:8180:8080

--- a/generators/server/templates/src/main/docker/jhipster-control-center.yml.ejs
+++ b/generators/server/templates/src/main/docker/jhipster-control-center.yml.ejs
@@ -37,6 +37,7 @@ limitations under the License.
 #       - SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_MYAPP_1_URI=http://host.docker.internal:8082
 # Or add a new application named MyNewApp
 #       - SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_MYNEWAPP_0_URI=http://host.docker.internal:8080
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 <%_ let discoveryProfile = serviceDiscoveryType ? serviceDiscoveryType : 'static'; _%>
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
@@ -69,5 +70,7 @@ services:
       <%_ } else { _%>
       - SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_<%= baseName.toUpperCase() %>_0_URI=http://host.docker.internal:<%= serverPort %>
       <%_ } _%>
+    # If you want to expose these ports outside your dev PC, 
+    # remove the "127.0.0.1:" prefix
     ports:
-      - 7419:7419
+      - 127.0.0.1:7419:7419

--- a/generators/server/templates/src/main/docker/jhipster-registry.yml.ejs
+++ b/generators/server/templates/src/main/docker/jhipster-registry.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     jhipster-registry:
@@ -42,5 +43,7 @@ services:
             - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_ID=jhipster-registry
             - SPRING_SECURITY_OAUTH2_CLIENT_REGISTRATION_OIDC_CLIENT_SECRET=jhipster-registry
             <%_ } _%>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 8761:8761
+            - 127.0.0.1:8761:8761

--- a/generators/server/templates/src/main/docker/kafka.yml.ejs
+++ b/generators/server/templates/src/main/docker/kafka.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     zookeeper:
@@ -25,8 +26,10 @@ services:
             ZOOKEEPER_TICK_TIME: 2000
     kafka:
         image: <%= DOCKER_KAFKA %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 9092:9092
+            - 127.0.0.1:9092:9092
         environment:
             KAFKA_BROKER_ID: 1
             KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181

--- a/generators/server/templates/src/main/docker/keycloak.yml.ejs
+++ b/generators/server/templates/src/main/docker/keycloak.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     keycloak:
@@ -27,7 +28,9 @@ services:
             - KEYCLOAK_USER=admin
             - KEYCLOAK_PASSWORD=admin
             - DB_VENDOR=h2
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix        
         ports:
-            - 9080:9080
-            - 9443:9443
-            - 10990:10990
+            - 127.0.0.1:9080:9080
+            - 127.0.0.1:9443:9443
+            - 127.0.0.1:10990:10990

--- a/generators/server/templates/src/main/docker/mariadb.yml.ejs
+++ b/generators/server/templates/src/main/docker/mariadb.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-mariadb:
@@ -26,6 +27,8 @@ services:
             - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=<%= baseName.toLowerCase() %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix    
         ports:
-            - 3306:3306
+            - 127.0.0.1:3306:3306
         command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8mb4 --explicit_defaults_for_timestamp

--- a/generators/server/templates/src/main/docker/memcached.yml.ejs
+++ b/generators/server/templates/src/main/docker/memcached.yml.ejs
@@ -16,9 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-memcached:
         image: <%= DOCKER_MEMCACHED %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - "11211:11211"
+            - 127.0.0.1:11211:11211

--- a/generators/server/templates/src/main/docker/mongodb-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/mongodb-cluster.yml.ejs
@@ -16,12 +16,15 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-mongodb:
         image: <%= DOCKER_MONGODB %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - "27017:27017"
+            - 127.0.0.1:27017:27017
         command: mongos --configdb csvr/<%= baseName.toLowerCase() %>-mongodb-config --bind_ip 0.0.0.0
     <%= baseName.toLowerCase() %>-mongodb-node:
         build:

--- a/generators/server/templates/src/main/docker/mongodb.yml.ejs
+++ b/generators/server/templates/src/main/docker/mongodb.yml.ejs
@@ -16,11 +16,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-mongodb:
         image: <%= DOCKER_MONGODB %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - "27017:27017"
+            - 127.0.0.1:27017:27017
         # volumes:
         #     - ~/volumes/jhipster/<%= baseName %>/mongodb/:/data/db/

--- a/generators/server/templates/src/main/docker/monitoring.yml.ejs
+++ b/generators/server/templates/src/main/docker/monitoring.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-prometheus:
@@ -24,8 +25,10 @@ services:
             - ./prometheus/:/etc/prometheus/
         command:
             - '--config.file=/etc/prometheus/prometheus.yml'
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 9090:9090
+            - 127.0.0.1:9090:9090
         # On MacOS, remove next line and replace localhost by host.docker.internal in prometheus/prometheus.yml and
         # grafana/provisioning/datasources/datasource.yml
         network_mode: "host" # to test locally running service
@@ -37,8 +40,10 @@ services:
             - GF_SECURITY_ADMIN_PASSWORD=admin
             - GF_USERS_ALLOW_SIGN_UP=false
             - GF_INSTALL_PLUGINS=grafana-piechart-panel
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 3000:3000
+            - 127.0.0.1:3000:3000
         # On MacOS, remove next line and replace localhost by host.docker.internal in prometheus/prometheus.yml and
         # grafana/provisioning/datasources/datasource.yml
         network_mode: "host" # to test locally running service

--- a/generators/server/templates/src/main/docker/mssql.yml.ejs
+++ b/generators/server/templates/src/main/docker/mssql.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-mssql:
@@ -29,6 +30,8 @@ services:
             - SA_PASSWORD=yourStrong(!)Password
             - MSSQL_DATABASE=<%= baseName %>
             - MSSQL_SLEEP=60
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 1433:1433
+            - 127.0.0.1:1433:1433
         command: /bin/bash -c '/opt/mssql/bin/sqlservr & echo "wait $$MSSQL_SLEEP sec for DB to start "; sleep $$MSSQL_SLEEP; /opt/mssql-tools/bin/sqlcmd -U sa -P $$SA_PASSWORD -d tempdb -q "EXIT(CREATE DATABASE $$MSSQL_DATABASE)"; wait;'

--- a/generators/server/templates/src/main/docker/mysql.yml.ejs
+++ b/generators/server/templates/src/main/docker/mysql.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-mysql:
@@ -26,6 +27,8 @@ services:
             - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=<%= baseName.toLowerCase() %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 3306:3306
+            - 127.0.0.1:3306:3306
         command: mysqld --lower_case_table_names=1 --skip-ssl --character_set_server=utf8mb4 --explicit_defaults_for_timestamp

--- a/generators/server/templates/src/main/docker/neo4j.yml.ejs
+++ b/generators/server/templates/src/main/docker/neo4j.yml.ejs
@@ -1,5 +1,5 @@
 <%#
- Copyright 2013-2019 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
  This file is part of the JHipster project, see https://www.jhipster.tech/
  for more information.
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-neo4j:
@@ -24,6 +25,8 @@ services:
         #     - ~/volumes/jhipster/<%= baseName %>/neo4j/:/data
         environment:
             - NEO4J_AUTH=none
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - "7474:7474"
-            - "7687:7687"
+            - "127.0.0.1:7474:7474"
+            - "127.0.0.1:7687:7687"

--- a/generators/server/templates/src/main/docker/postgresql.yml.ejs
+++ b/generators/server/templates/src/main/docker/postgresql.yml.ejs
@@ -16,6 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-postgresql:
@@ -26,5 +27,7 @@ services:
             - POSTGRES_USER=<%= baseName %>
             - POSTGRES_PASSWORD=
             - POSTGRES_HOST_AUTH_METHOD=trust
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 5432:5432
+            - 127.0.0.1:5432:5432

--- a/generators/server/templates/src/main/docker/redis-cluster.yml.ejs
+++ b/generators/server/templates/src/main/docker/redis-cluster.yml.ejs
@@ -12,6 +12,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-redis:

--- a/generators/server/templates/src/main/docker/redis.yml.ejs
+++ b/generators/server/templates/src/main/docker/redis.yml.ejs
@@ -12,9 +12,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-version: '2'
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
+version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-redis:
         image: <%= DOCKER_REDIS %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - "6379:6379"
+            - 127.0.0.1:6379:6379

--- a/generators/server/templates/src/main/docker/sonar.yml.ejs
+++ b/generators/server/templates/src/main/docker/sonar.yml.ejs
@@ -16,9 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     <%= baseName.toLowerCase() %>-sonar:
         image: <%= DOCKER_SONAR %>
+        # If you want to expose these ports outside your dev PC, 
+        # remove the "127.0.0.1:" prefix
         ports:
-            - 9001:9000
+            - 127.0.0.1:9001:9000

--- a/generators/server/templates/src/main/docker/swagger-editor.yml.ejs
+++ b/generators/server/templates/src/main/docker/swagger-editor.yml.ejs
@@ -16,9 +16,10 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+# This configuration is intended for development purpose, it's **your** responsibility to harden it for production
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
     swagger-editor:
         image: <%= DOCKER_SWAGGER_EDITOR %>
         ports:
-            - 7742:8080
+            - 127.0.0.1:7742:8080


### PR DESCRIPTION
As discussed in #12015 this exposes all docker compose containers only on `127.0.0.1` and adds some hint that the provided configuration is intended only for development purposes. 

Should we do the same for the configurations in the docker-compose subgenerator? 

closes #12015

[ci-skip] [skip-ci]

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
