### PR TITLE
Fix vue.js constants usage for outputPathCustomizer

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const mkdirp = require('mkdirp');
 const constants = require('../generator-constants');
 
 /* Constants use throughout */

--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -494,7 +494,6 @@ module.exports = {
 };
 
 function writeFiles() {
-    mkdirp(this.CLIENT_MAIN_SRC_DIR);
     // write angular 2.x and above files
     this.writeFilesToDisk(files, this, false, this.fetchFromInstalledJHipster('client/templates/angular'));
 }

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -399,7 +399,6 @@ module.exports = {
 };
 
 function writeFiles() {
-    mkdirp(this.CLIENT_MAIN_SRC_DIR);
     // write React files
     this.writeFilesToDisk(files, this, false, this.fetchFromInstalledJHipster('client/templates/react'));
 }

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const mkdirp = require('mkdirp');
 const constants = require('../generator-constants');
 
 /* Constants use throughout */

--- a/generators/client/files-vue.js
+++ b/generators/client/files-vue.js
@@ -370,7 +370,6 @@ const vueFiles = {
 };
 
 function writeFiles() {
-    mkdirp(this.CLIENT_MAIN_SRC_DIR);
     // write Vue files
     this.writeFilesToDisk(vueFiles, this, false, this.fetchFromInstalledJHipster('client/templates/vue'));
 

--- a/generators/client/files-vue.js
+++ b/generators/client/files-vue.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const mkdirp = require('mkdirp');
 const constants = require('../generator-constants');
 const utils = require('../utils');
 

--- a/generators/client/files-vue.js
+++ b/generators/client/files-vue.js
@@ -370,7 +370,7 @@ const vueFiles = {
 };
 
 function writeFiles() {
-    mkdirp(MAIN_SRC_DIR);
+    mkdirp(this.CLIENT_MAIN_SRC_DIR);
     // write Vue files
     this.writeFilesToDisk(vueFiles, this, false, this.fetchFromInstalledJHipster('client/templates/vue'));
 

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -707,7 +707,7 @@ function isGitInstalled(callback) {
  */
 function vueReplaceTranslation(generator, files) {
     for (let i = 0; i < files.length; i++) {
-        const filePath = `${constants.CLIENT_MAIN_SRC_DIR}${files[i]}`;
+        const filePath = `${generator.CLIENT_MAIN_SRC_DIR}${files[i]}`;
         // Match the below attributes and the $t() method
         const regexp = ['v-text', 'v-bind:placeholder', 'v-html', 'v-bind:title', 'v-bind:label', 'v-bind:value', 'v-bind:html']
             .map(s => `${s}="\\$t\\(.*?\\)"`)

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -726,7 +726,7 @@ function vueReplaceTranslation(generator, files) {
 function vueAddPageToRouterImport(generator, pageName, pageFolderName, pageFilename = pageFolderName) {
     this.rewriteFile(
         {
-            file: `${constants.CLIENT_MAIN_SRC_DIR}/app/router/pages.ts`,
+            file: `${generator.CLIENT_MAIN_SRC_DIR}/app/router/pages.ts`,
             needle: 'jhipster-needle-add-entity-to-router-import',
             splicable: [
                 generator.stripMargin(
@@ -743,7 +743,7 @@ function vueAddPageToRouterImport(generator, pageName, pageFolderName, pageFilen
 function vueAddPageToRouter(generator, pageName, pageFilename) {
     this.rewriteFile(
         {
-            file: `${constants.CLIENT_MAIN_SRC_DIR}/app/router/pages.ts`,
+            file: `${generator.CLIENT_MAIN_SRC_DIR}/app/router/pages.ts`,
             needle: 'jhipster-needle-add-entity-to-router',
             splicable: [
                 generator.stripMargin(
@@ -764,7 +764,7 @@ function vueAddPageToRouter(generator, pageName, pageFilename) {
 function vueAddPageServiceToMainImport(generator, pageName, pageFolderName, pageFilename = pageFolderName) {
     this.rewriteFile(
         {
-            file: `${constants.CLIENT_MAIN_SRC_DIR}/app/main.ts`,
+            file: `${generator.CLIENT_MAIN_SRC_DIR}/app/main.ts`,
             needle: 'jhipster-needle-add-entity-service-to-main-import',
             splicable: [
                 generator.stripMargin(
@@ -780,7 +780,7 @@ function vueAddPageServiceToMainImport(generator, pageName, pageFolderName, page
 function vueAddPageServiceToMain(generator, pageName, pageInstance) {
     this.rewriteFile(
         {
-            file: `${constants.CLIENT_MAIN_SRC_DIR}/app/main.ts`,
+            file: `${generator.CLIENT_MAIN_SRC_DIR}/app/main.ts`,
             needle: 'jhipster-needle-add-entity-service-to-main',
             splicable: [
                 generator.stripMargin(

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -796,7 +796,7 @@ function vueAddPageServiceToMain(generator, pageName, pageInstance) {
 function vueAddPageProtractorConf(generator) {
     this.rewriteFile(
         {
-            file: `${constants.CLIENT_TEST_SRC_DIR}/protractor.conf.js`,
+            file: `${generator.CLIENT_TEST_SRC_DIR}/protractor.conf.js`,
             needle: 'jhipster-needle-add-protractor-tests',
             splicable: [generator.stripMargin("'./e2e/pages/**/*.spec.ts',")],
         },


### PR DESCRIPTION
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->

fix #12346 
