### PR TITLE
Gcloud sql command: Replace --format option by double quotes

### DIFF
--- a/generators/gae/index.js
+++ b/generators/gae/index.js
@@ -451,7 +451,7 @@ module.exports = class extends BaseGenerator {
 
                 const cloudSqlInstances = [{ value: '', name: 'New Cloud SQL Instance' }];
                 shelljs.exec(
-                    `gcloud sql instances list  --format='value[separator=":"](project,region,name)' --project="${this.gcpProjectId}"`,
+                    `gcloud sql instances list  --format="value[separator=':'](project,region,name)" --project="${this.gcpProjectId}"`,
                     (code, stdout, err) => {
                         if (err && code !== 0) {
                             this.log.error(err);
@@ -548,7 +548,7 @@ module.exports = class extends BaseGenerator {
                 const cloudSqlDatabases = [{ value: '', name: 'New Database' }];
                 const name = this.gcpCloudSqlInstanceName.split(':')[2];
                 shelljs.exec(
-                    `gcloud sql databases list -i ${name} --format='value(name)' --project="${this.gcpProjectId}"`,
+                    `gcloud sql databases list -i ${name} --format="value(name)" --project="${this.gcpProjectId}"`,
                     { silent: true },
                     (code, stdout, err) => {
                         if (err && code !== 0) {
@@ -685,7 +685,7 @@ module.exports = class extends BaseGenerator {
 
                 const name = this.gcpCloudSqlInstanceName.split(':')[2];
                 shelljs.exec(
-                    `gcloud sql users list -i jhipster --format='value(name)' --project="${this.gcpProjectId}"`,
+                    `gcloud sql users list -i jhipster --format="value(name)" --project="${this.gcpProjectId}"`,
                     { silent: true },
                     (code, stdout, err) => {
                         if (_.includes(stdout, this.gcpCloudSqlUserName)) {


### PR DESCRIPTION
This replaces the --format argument of the gcloud SQL command with double quotes.

Fixes https://github.com/jhipster/generator-jhipster/issues/12334

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
