### PR TITLE
fix: fix prettier-plugin-java version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3688,12 +3688,19 @@
             }
         },
         "java-parser": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-0.8.0.tgz",
-            "integrity": "sha512-8MOu9EDjWlAcBnxjVI8jblcOX/zJt9XVLaMLrXYvmJYk3gvRqTUKsEp/PxaooJQc6wh+nPEyqEbhCy3BWIgi0g==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/java-parser/-/java-parser-0.8.1.tgz",
+            "integrity": "sha512-jexK+CFoLuXaklg+tYqW2MmazpKjkLP+o8hROAIHZAGoeQGLPizMuXwuzJENClcaw7sdT1VjuHB9C/56y+mafA==",
             "requires": {
                 "chevrotain": "6.5.0",
-                "lodash": "4.17.15"
+                "lodash": "4.17.20"
+            },
+            "dependencies": {
+                "lodash": {
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+                }
             }
         },
         "jhipster-core": {
@@ -5580,19 +5587,24 @@
             }
         },
         "prettier-plugin-java": {
-            "version": "0.8.0",
-            "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-0.8.0.tgz",
-            "integrity": "sha512-+4qdhUfFQIj4bLGSDrAGmUZKXQRjJYpQFbmRh04atEZe7QEZUF6NHVyRjJ73Cgwhc5NaiyIpFhtcXgLf9J9V6A==",
+            "version": "0.8.1",
+            "resolved": "https://registry.npmjs.org/prettier-plugin-java/-/prettier-plugin-java-0.8.1.tgz",
+            "integrity": "sha512-yz0MMCSq93Gac7JXLOIzfeE1lJ664ZLvJudNCkL5lpHS9Svwjr7By3ZjuEsBJ2FHhbuliPFSH9gFIgzdLx9TCg==",
             "requires": {
-                "java-parser": "^0.8.0",
-                "lodash": "4.17.15",
-                "prettier": "2.0.4"
+                "java-parser": "^0.8.1",
+                "lodash": "4.17.20",
+                "prettier": "2.1.1"
             },
             "dependencies": {
+                "lodash": {
+                    "version": "4.17.20",
+                    "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
+                    "integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+                },
                 "prettier": {
-                    "version": "2.0.4",
-                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.0.4.tgz",
-                    "integrity": "sha512-SVJIQ51spzFDvh4fIbCLvciiDMCrRhlN3mbZvv/+ycjvmF5E73bKdGfU8QDLNmjYJf+lsGnDBC4UUnvTe5OO0w=="
+                    "version": "2.1.1",
+                    "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.1.1.tgz",
+                    "integrity": "sha512-9bY+5ZWCfqj3ghYBLxApy2zf6m+NJo5GzmLTpr9FsApsfjriNnS2dahWReHMi7qNPhhHl9SYHJs2cHZLgexNIw=="
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "parse-gitignore": "1.0.1",
         "pluralize": "8.0.0",
         "prettier": "2.0.5",
-        "prettier-plugin-java": "0.8.0",
+        "prettier-plugin-java": "0.8.1",
         "progress": "2.0.3",
         "randexp": "0.5.3",
         "semver": "7.3.2",


### PR DESCRIPTION
<!--
PR description.
-->

Fix version of prettier-plugin-java for v6

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
