### PR TITLE
Extend wait time for application start when MSSQL is selected

### DIFF
--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -78,6 +78,8 @@ services:
                 <%_ } _%>
             <%_ } else if (prodDatabaseType === 'mariadb') { _%>
             - JHIPSTER_SLEEP=120 # gives time for mariadb server to start
+            <%_ } else if (prodDatabaseType === 'mssql') { _%>
+            - JHIPSTER_SLEEP=60 # gives time for mssql server to start
             <%_ } else { _%>
             - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
             <%_ } _%>


### PR DESCRIPTION
extend wait time to 60 for application when using mssql

Fix #12380

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related Github issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
