### PR TITLE
Ignore push CI when files matches only another client.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -23,13 +23,16 @@ on:
         branches-ignore:
             - 'dependabot/**'
             - 'skip_ci*'
+        paths-ignore:
+            - 'generators/*client/templates/react/**'
+            - 'generators/*client/templates/vue/**'
     pull_request:
         branches:
             - '*'
         paths-ignore:
             - 'package*.json'
-            - 'generators/client/templates/react/**'
-            - 'generators/client/templates/vue/**'
+            - 'generators/*client/templates/react/**'
+            - 'generators/*client/templates/vue/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -23,13 +23,16 @@ on:
         branches-ignore:
             - 'dependabot/**'
             - 'skip_ci*'
+        paths-ignore:
+            - 'generators/*client/templates/angular/**'
+            - 'generators/*client/templates/vue/**'
     pull_request:
         branches:
             - '*'
         paths-ignore:
             - 'package*.json'
-            - 'generators/client/templates/angular/**'
-            - 'generators/client/templates/vue/**'
+            - 'generators/*client/templates/angular/**'
+            - 'generators/*client/templates/vue/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -23,13 +23,16 @@ on:
         branches-ignore:
             - 'dependabot/**'
             - 'skip_ci*'
+        paths-ignore:
+            - 'generators/*client/templates/angular/**'
+            - 'generators/*client/templates/react/**'
     pull_request:
         branches:
             - '*'
         paths-ignore:
             - 'package*.json'
-            - 'generators/client/templates/angular/**'
-            - 'generators/client/templates/react/**'
+            - 'generators/*client/templates/angular/**'
+            - 'generators/*client/templates/react/**'
 env:
     JHI_RUN_APP: 1
     JHI_JDK: 11


### PR DESCRIPTION
Client dependabot is triggering too many build, let's don't trigger builds for another client.

Adjusts to https://github.com/jhipster/generator-jhipster/pull/12415
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
