### PR TITLE
Improvements to dependabot client updates.

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,18 +11,21 @@ updates:
       schedule:
           interval: 'daily'
       open-pull-requests-limit: 5
+      versioning-strategy: increase
 
     - package-ecosystem: 'npm'
       directory: '/generators/client/templates/react/'
       schedule:
           interval: 'daily'
       open-pull-requests-limit: 5
+      versioning-strategy: increase
 
     - package-ecosystem: 'npm'
       directory: '/generators/client/templates/vue/'
       schedule:
           interval: 'daily'
       open-pull-requests-limit: 5
+      versioning-strategy: increase
 
     - package-ecosystem: 'github-actions'
       directory: '/'

--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -1,5 +1,10 @@
 {
+  "dependencies": {
+    "@angular/common": "10.1.1",
+    "bootstrap": "4.5.2"
+  },
   "devDependencies": {
+    "@angular/cli": "10.1.1",
     "webpack": "4.44.1"
   }
 }

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -26,23 +26,23 @@ limitations under the License.
     "node_modules"
   ],
   "dependencies": {
-    "@angular/common": "10.1.1",
-    "@angular/compiler": "10.1.1",
-    "@angular/core": "10.1.1",
-    "@angular/forms": "10.1.1",
-    "@angular/localize": "10.1.1",
-    "@angular/platform-browser": "10.1.1",
-    "@angular/platform-browser-dynamic": "10.1.1",
-    "@angular/router": "10.1.1",
+    "@angular/common": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
+    "@angular/compiler": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@angular/core": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@angular/forms": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@angular/localize": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@angular/platform-browser": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@angular/platform-browser-dynamic": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@angular/router": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
     "@fortawesome/angular-fontawesome": "0.7.0",
     "@fortawesome/fontawesome-svg-core": "1.2.30",
     "@fortawesome/free-solid-svg-icons": "5.14.0",
     "@ng-bootstrap/ng-bootstrap": "7.0.0",
     "@ngx-translate/core": "12.1.2",
     "@ngx-translate/http-loader": "5.0.0",
-    "bootstrap": "4.5.2",
+    "bootstrap": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     <%_ if (clientTheme !== 'none') { _%>
-    "bootswatch": "4.5.2",
+    "bootswatch": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#bootstrap",
     <%_ } _%>
     "moment": "2.27.0",
     "ng-jhipster": "0.15.0",
@@ -62,9 +62,9 @@ limitations under the License.
     "zone.js": "0.10.3"
   },
   "devDependencies": {
-    "@angular/cli": "10.1.0",
-    "@angular/compiler-cli": "10.1.1",
-    "@ngtools/webpack": "10.0.0",
+    "@angular/cli": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
+    "@angular/compiler-cli": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#@angular/common",
+    "@ngtools/webpack": "VERSION_MANAGED_BY_CLIENT_ANGULAR#devDependencies#@angular/cli",
     "@openapitools/openapi-generator-cli": "1.0.13-4.3.1",
     <%_ if (protractorTests) { _%>
     "@types/chai": "4.2.11",

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -191,12 +191,16 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
         const packageJsonTarget = this.fs.readJSON(packageJsonTargetFile);
         const replace = section => {
             if (packageJsonTarget[section]) {
-                Object.entries(packageJsonTarget[section]).forEach(([dependency, version]) => {
-                    if (version === keyToReplace) {
-                        if (!packageJsonSource[section][dependency]) {
-                            throw new Error(`Error setting ${dependency} version`);
+                Object.entries(packageJsonTarget[section]).forEach(([dependency, targetReference]) => {
+                    if (targetReference.startsWith(keyToReplace)) {
+                        const [referenceAtSource, sectionAtSource = section, dependencyAtSource = dependency] = targetReference.split('#');
+                        if (referenceAtSource !== keyToReplace) return;
+                        if (!packageJsonSource[sectionAtSource] || !packageJsonSource[sectionAtSource][dependencyAtSource]) {
+                            throw new Error(
+                                `Error setting ${dependencyAtSource} version, not found at ${sectionAtSource}.${dependencyAtSource}`
+                            );
                         }
-                        packageJsonTarget[section][dependency] = packageJsonSource[section][dependency];
+                        packageJsonTarget[section][dependency] = packageJsonSource[sectionAtSource][dependencyAtSource];
                     }
                 });
             }

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -191,10 +191,14 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
         const packageJsonTarget = this.fs.readJSON(packageJsonTargetFile);
         const replace = section => {
             if (packageJsonTarget[section]) {
-                Object.entries(packageJsonTarget[section]).forEach(([dependency, targetReference]) => {
-                    if (targetReference.startsWith(keyToReplace)) {
-                        const [referenceAtSource, sectionAtSource = section, dependencyAtSource = dependency] = targetReference.split('#');
-                        if (referenceAtSource !== keyToReplace) return;
+                Object.entries(packageJsonTarget[section]).forEach(([dependency, dependencyReference]) => {
+                    if (dependencyReference.startsWith(keyToReplace)) {
+                        const [
+                            keyToReplaceAtSource,
+                            sectionAtSource = section,
+                            dependencyAtSource = dependency,
+                        ] = dependencyReference.split('#');
+                        if (keyToReplaceAtSource !== keyToReplace) return;
                         if (!packageJsonSource[sectionAtSource] || !packageJsonSource[sectionAtSource][dependencyAtSource]) {
                             throw new Error(
                                 `Error setting ${dependencyAtSource} version, not found at ${sectionAtSource}.${dependencyAtSource}`


### PR DESCRIPTION
- Implement our own grouped update, dependabot does not support it (https://github.com/dependabot/dependabot-core/issues/1296) and this will create a lot of noise if we migrate to auto update.
- Change dependabot strategy, templates package.json are detected as a library, default strategy is widen for libraries.
With our current practices, we should use increase.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
