### PR TITLE
Use then-request Instead of sync-request

### DIFF
--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -93,7 +93,7 @@ function askActionType() {
             name: 'jhipsterEndpoint',
             message: 'Enter the URL of the running Jhipster instance',
             default: 'http://localhost:8080',
-            validate: async (input) => {
+            validate: async input => {
                 try {
                     const availableDocs = await fetchSwaggerResources(input);
 
@@ -133,7 +133,7 @@ function askActionType() {
             message: 'Where is your Swagger/OpenAPI spec (URL or path) ?',
             default: 'http://petstore.swagger.io/v2/swagger.json',
             store: true,
-            validate: async (input) => {
+            validate: async input => {
                 try {
                     if (/^((http|https):\/\/)/.test(input)) {
                         await request('GET', `${input}`, {
@@ -160,7 +160,7 @@ function askActionType() {
         this.props = props;
 
         if (props.jhipsterEndpoint !== undefined) {
-            return fetchSwaggerResources(props.jhipsterEndpoint).then(availableDocs => {
+            fetchSwaggerResources(props.jhipsterEndpoint).then(availableDocs => {
                 props.availableDocs = availableDocs;
             });
         }

--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -18,7 +18,7 @@
  */
 const path = require('path');
 const shelljs = require('shelljs');
-const request = require('sync-request');
+const request = require('then-request');
 
 module.exports = {
     askActionType,

--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -160,7 +160,7 @@ function askActionType() {
         this.props = props;
 
         if (props.jhipsterEndpoint !== undefined) {
-            fetchSwaggerResources(props.jhipsterEndpoint).then(availableDocs => {
+            return fetchSwaggerResources(props.jhipsterEndpoint).then(availableDocs => {
                 props.availableDocs = availableDocs;
             });
         }
@@ -169,6 +169,7 @@ function askActionType() {
         } else if (props.customEndpoint !== undefined) {
             props.inputSpec = props.customEndpoint;
         }
+        return undefined;
     });
 }
 

--- a/generators/openapi-client/prompts.js
+++ b/generators/openapi-client/prompts.js
@@ -26,11 +26,11 @@ module.exports = {
     askGenerationInfos,
 };
 
-function fetchSwaggerResources(input) {
+async function fetchSwaggerResources(input) {
     const availableDocs = [];
 
     const baseUrl = input.replace(/\/$/, '');
-    const swaggerResources = request('GET', `${baseUrl}/swagger-resources`, {
+    const swaggerResources = await request('GET', `${baseUrl}/swagger-resources`, {
         // This header is needed to use the custom /swagger-resources controller
         // and not the default one that has only the gateway's swagger resource
         headers: { Accept: 'application/json, text/javascript;' },
@@ -49,10 +49,8 @@ function fetchSwaggerResources(input) {
 
 function askActionType() {
     if (this.options.regen) {
-        return;
+        return undefined;
     }
-
-    const done = this.async();
 
     const hasExistingApis = Object.keys(this.openApiClients).length !== 0;
 
@@ -95,9 +93,9 @@ function askActionType() {
             name: 'jhipsterEndpoint',
             message: 'Enter the URL of the running Jhipster instance',
             default: 'http://localhost:8080',
-            validate: input => {
+            validate: async (input) => {
                 try {
-                    const availableDocs = fetchSwaggerResources(input);
+                    const availableDocs = await fetchSwaggerResources(input);
 
                     if (availableDocs.length === 0) {
                         return `No live doc found at ${input}`;
@@ -135,10 +133,10 @@ function askActionType() {
             message: 'Where is your Swagger/OpenAPI spec (URL or path) ?',
             default: 'http://petstore.swagger.io/v2/swagger.json',
             store: true,
-            validate: input => {
+            validate: async (input) => {
                 try {
                     if (/^((http|https):\/\/)/.test(input)) {
-                        request('GET', `${input}`, {
+                        await request('GET', `${input}`, {
                             // headers: { Accept: 'application/json, text/javascript;' }
                         });
                     } else if (!shelljs.test('-f', input)) {
@@ -152,15 +150,7 @@ function askActionType() {
         },
     ];
 
-    this.prompt(prompts).then(props => {
-        if (props.jhipsterEndpoint !== undefined) {
-            props.availableDocs = fetchSwaggerResources(props.jhipsterEndpoint);
-        } else if (props.jhipsterDirectory !== undefined) {
-            props.inputSpec = `${props.jhipsterDirectory}/src/main/resources/swagger/api.yml`;
-        } else if (props.customEndpoint !== undefined) {
-            props.inputSpec = props.customEndpoint;
-        }
-
+    return this.prompt(prompts).then(props => {
         if (newClient) {
             props.action = 'new';
         }
@@ -168,15 +158,24 @@ function askActionType() {
         props.generatorName = this.config.get('reactive') ? 'java' : 'spring';
 
         this.props = props;
-        done();
+
+        if (props.jhipsterEndpoint !== undefined) {
+            return fetchSwaggerResources(props.jhipsterEndpoint).then(availableDocs => {
+                props.availableDocs = availableDocs;
+            });
+        }
+        if (props.jhipsterDirectory !== undefined) {
+            props.inputSpec = `${props.jhipsterDirectory}/src/main/resources/swagger/api.yml`;
+        } else if (props.customEndpoint !== undefined) {
+            props.inputSpec = props.customEndpoint;
+        }
     });
 }
 
 function askExistingAvailableDocs() {
     if (this.options.regen) {
-        return;
+        return undefined;
     }
-    const done = this.async();
 
     const prompts = [
         {
@@ -188,21 +187,19 @@ function askExistingAvailableDocs() {
         },
     ];
 
-    this.prompt(prompts).then(props => {
+    return this.prompt(prompts).then(props => {
         if (props.availableDoc !== undefined) {
             this.props.inputSpec = props.availableDoc.url;
             this.props.cliName = props.availableDoc.name === 'default' ? 'apidocs' : props.availableDoc.name; // "default" cannot be used as it's a keyword in java
         }
-        done();
     });
 }
 
 function askGenerationInfos() {
     if (this.options.regen) {
-        return;
+        return undefined;
     }
 
-    const done = this.async();
     const prompts = [
         {
             when:
@@ -255,12 +252,11 @@ function askGenerationInfos() {
         },
     ];
 
-    this.prompt(prompts).then(props => {
+    return this.prompt(prompts).then(props => {
         if (props.cliName !== undefined) {
             this.props.cliName = props.cliName;
         }
         this.props.saveConfig = props.saveConfig;
         this.props.selected = props.selected;
-        done();
     });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -3609,11 +3609,6 @@
             "integrity": "sha1-6td0q+5y4gQJQzoGY2YCPdaIekE=",
             "dev": true
         },
-        "get-port": {
-            "version": "3.2.0",
-            "resolved": "https://registry.npmjs.org/get-port/-/get-port-3.2.0.tgz",
-            "integrity": "sha1-3Xzn3hh8Bsi/NTeWrHHgmfCYDrw="
-        },
         "get-stdin": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/get-stdin/-/get-stdin-6.0.0.tgz",
@@ -8750,24 +8745,6 @@
             "integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
             "requires": {
                 "has-flag": "^4.0.0"
-            }
-        },
-        "sync-request": {
-            "version": "6.1.0",
-            "resolved": "https://registry.npmjs.org/sync-request/-/sync-request-6.1.0.tgz",
-            "integrity": "sha512-8fjNkrNlNCrVc/av+Jn+xxqfCjYaBoHqCsDz6mt030UMxJGr+GSfCV1dQt2gRtlL63+VPidwDVLr7V2OcTSdRw==",
-            "requires": {
-                "http-response-object": "^3.0.1",
-                "sync-rpc": "^1.2.1",
-                "then-request": "^6.0.0"
-            }
-        },
-        "sync-rpc": {
-            "version": "1.3.6",
-            "resolved": "https://registry.npmjs.org/sync-rpc/-/sync-rpc-1.3.6.tgz",
-            "integrity": "sha512-J8jTXuZzRlvU7HemDgHi3pGnh/rkoqR/OZSjhTyyZrEkkYQbk7Z33AXp37mkPfPpfdOuj7Ex3H/TJM1z48uPQw==",
-            "requires": {
-                "get-port": "^3.1.0"
             }
         },
         "syntax-error": {

--- a/package.json
+++ b/package.json
@@ -86,7 +86,7 @@
         "semver": "7.3.2",
         "shelljs": "0.8.4",
         "simple-git": "2.20.1",
-        "sync-request": "6.1.0",
+        "then-request": "6.0.2",
         "tabtab": "2.2.2",
         "test": "^0.6.0",
         "through2": "4.0.2",


### PR DESCRIPTION
The library sync-request cannot be used in production applications (reference: https://www.npmjs.com/package/sync-request). In jhipster-online, sync-request is I think the root cause of generation being hanging. When I look at the processes always see a stuck process originating from this library. Therefore I would suggest replacing this with then-process instead.

Fixes https://github.com/jhipster/jhipster-online/issues/233

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
