### PR TITLE
Fix unused FontAwesomeIcon import in account menu

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/menus/account.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/menus/account.tsx.ejs
@@ -20,8 +20,8 @@ import React from 'react';
 import MenuItem from 'app/shared/layout/menus/menu-item';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { DropdownItem } from 'reactstrap';
-<%_ } _%>
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+<%_ } _%>
 import { Translate, translate } from 'react-jhipster';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { getLoginUrl } from 'app/shared/util/url-utils';


### PR DESCRIPTION
Fix [#12473](https://github.com/jhipster/generator-jhipster/issues/12473)
