### PR TITLE
fix unused CachingHttpHeadersFilter import in WebConfigurerTest

### DIFF
--- a/generators/server/templates/src/test/java/package/config/WebConfigurerTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/WebConfigurerTest.java.ejs
@@ -20,9 +20,6 @@ package <%= packageName %>.config;
 
 import io.github.jhipster.config.JHipsterConstants;
 import io.github.jhipster.config.JHipsterProperties;
-<%_ if (!skipClient) { _%>
-import io.github.jhipster.web.filter.CachingHttpHeadersFilter;
-<%_ } _%>
 <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
 import org.h2.server.web.WebServlet;
 <%_ } _%>


### PR DESCRIPTION
Fix [#12477](https://github.com/jhipster/generator-jhipster/issues/12477)