### PR TITLE
Fix duration displayed in current locale

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/DurationFormat.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/DurationFormat.tsx.ejs
@@ -17,5 +17,5 @@ export const DurationFormat = ({ value, blankOnInvalid, locale }: IDurationForma
     locale = TranslatorContext.context.locale;
   }
 
-  return <span title={value}>{moment.duration(value).humanize()}</span>;
+  return <span title={value}>{moment.duration(value).locale(locale).humanize()}</span>;
 };


### PR DESCRIPTION
<!--
PR description.
-->
Fix #12472 duration should be displayed on the app language.

When a locale is given as an input, this locale should be used to display the duration in a textual way. Otherwise, the locale used by the application should be used.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
