### PR TITLE
change the hover and focus properties of dropdown-item in css and scss

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/content/css/global.css.ejs
+++ b/generators/client/templates/vue/src/main/webapp/content/css/global.css.ejs
@@ -44,9 +44,14 @@ a {
 
 a:hover {
     color: #533f03;
-    font-weight: bold;
     /* make sure browsers use the pointer cursor for anchors, even with no href */
     cursor: pointer;
+}
+.dropdown-item:hover,
+.dropdown-item:focus {
+  color: white;
+  text-decoration: none;
+  background-color: #373a3c;
 }
 
 /* ==========================================================================

--- a/generators/client/templates/vue/src/main/webapp/content/scss/global.scss.ejs
+++ b/generators/client/templates/vue/src/main/webapp/content/scss/global.scss.ejs
@@ -48,9 +48,14 @@ a {
 
 a:hover {
     color: #533f03;
-    font-weight: bold;
     /* make sure browsers use the pointer cursor for anchors, even with no href */
     cursor: pointer;
+}
+.dropdown-item:hover,
+.dropdown-item:focus {
+  color: white;
+  text-decoration: none;
+  background-color: #373a3c;
 }
 
 /* ==========================================================================


### PR DESCRIPTION
Fixed #12453 : removed bold property in a:hover + add new css properties for dropdown-item:hover and dropdown-item:focus.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
