### PR TITLE
Add reminder to update jhipster-online

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,6 +8,7 @@ Please make sure the below checklist is followed for Pull Requests.
 
 -   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
 -   [ ] Tests are added where necessary
+-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
 -   [ ] Documentation is added/updated where necessary
 -   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
 


### PR DESCRIPTION
This adds a small reminder to update jhipster-online when submitting a pull request.

https://github.com/jhipster/jhipster-online/pull/229#issuecomment-687653077

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
