### PR TITLE
remove extra lines in readme code blocks

### DIFF
--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -87,12 +87,12 @@ Run the following commands in two separate terminals to create a blissful develo
 auto-refreshes when files change on your hard drive.
 
 ```
-<% if (buildTool === 'maven') { %>
+<%_ if (buildTool === 'maven') { _%>
 ./mvnw
-<% } %>
-<% if (buildTool === 'gradle') { %>
+<%_ } _%>
+<%_ if (buildTool === 'gradle') { _%>
 ./gradlew -x webpack
-<% } %>
+<%_ } _%>
 <%= clientPackageManager %> start
 ```
 
@@ -266,12 +266,12 @@ Refer to [Doing API-First development][] for more details.
 To build the final jar and optimize the <%= baseName %> application for production, run:
 
 ```
-<% if (buildTool === 'maven') { %>
+<%_ if (buildTool === 'maven') { _%>
 ./mvnw -Pprod clean verify
-<% } %>
-<% if (buildTool === 'gradle') { %>
+<%_ } _%>
+<%_ if (buildTool === 'gradle') { _%>
 ./gradlew -Pprod clean bootJar
-<% } %>
+<%_ } _%>
 ```
 
 <%_ if (!skipClient) { _%>
@@ -280,12 +280,12 @@ This will concatenate and minify the client CSS and JavaScript files. It will al
 To ensure everything worked, run:
 
 ```
-<% if (buildTool === 'maven') { %>
+<%_ if (buildTool === 'maven') { _%>
 java -jar target/*.jar
-<% } %>
-<% if (buildTool === 'gradle') { %>
+<%_ } _%>
+<%_ if (buildTool === 'gradle') { _%>
 java -jar build/libs/*.jar
-<% } %>
+<%_ } _%>
 ```
 
 <% if (!skipClient) { %>Then navigate to [http://localhost:<%= serverPort %>](http://localhost:<%= serverPort %>) in your browser.
@@ -297,12 +297,12 @@ Refer to [Using JHipster in production][] for more details.
 To package your application as a war in order to deploy it to an application server, run:
 
 ```
-<% if (buildTool === 'maven') { %>
+<%_ if (buildTool === 'maven') { _%>
 ./mvnw -Pprod,war clean verify
-<% } %>
-<% if (buildTool === 'gradle') { %>
+<%_ } _%>
+<%_ if (buildTool === 'gradle') { _%>
 ./gradlew -Pprod -Pwar clean bootWar
-<% } %>
+<%_ } _%>
 ```
 
 ## Testing


### PR DESCRIPTION
Removes extra blank lines in the README code blocks.  For example:
```

./mvnw


npm start
```
Should be:
```
./mvnw
npm start
```

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
