### PR TITLE
Fix liveness and readiness health endpoint access

### DIFF
--- a/generators/server/templates/src/main/java/package/config/OAuth2SsoConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/OAuth2SsoConfiguration.java.ejs
@@ -74,6 +74,7 @@ public class OAuth2SsoConfiguration extends WebSecurityConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/health/**").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .anyRequest().permitAll();
     }

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -270,6 +270,7 @@ public class SecurityConfiguration {
             .pathMatchers("/services/**", "/swagger-resources/**").authenticated()
             <%_ } _%>
             .pathMatchers("/management/health").permitAll()
+            .antMatchers("/management/health/**").permitAll()
             .pathMatchers("/management/info").permitAll()
             .pathMatchers("/management/prometheus").permitAll()
             .pathMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN);

--- a/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/ReactiveSecurityConfiguration.java.ejs
@@ -270,7 +270,7 @@ public class SecurityConfiguration {
             .pathMatchers("/services/**", "/swagger-resources/**").authenticated()
             <%_ } _%>
             .pathMatchers("/management/health").permitAll()
-            .antMatchers("/management/health/**").permitAll()
+            .pathMatchers("/management/health/**").permitAll()
             .pathMatchers("/management/info").permitAll()
             .pathMatchers("/management/prometheus").permitAll()
             .pathMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN);

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -277,6 +277,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
             .antMatchers("/websocket/**").permitAll()
     <%_ } _%>
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/health/**").permitAll()
             .antMatchers("/management/info").permitAll()
             .antMatchers("/management/prometheus").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)<%_ if (authenticationType === 'session') { %>;<% } %>
@@ -426,6 +427,7 @@ public class SecurityConfiguration extends ResourceServerConfigurerAdapter {
             .authorizeRequests()
             .antMatchers("/api/**").authenticated()
             .antMatchers("/management/health").permitAll()
+            .antMatchers("/management/health/**").permitAll()
             .antMatchers("/management/info").permitAll()
             .antMatchers("/management/prometheus").permitAll()
             .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN);

--- a/generators/server/templates/src/main/java/package/config/UaaConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/UaaConfiguration.java.ejs
@@ -110,6 +110,7 @@ public class UaaConfiguration extends AuthorizationServerConfigurerAdapter imple
                 .antMatchers("/websocket/tracker").hasAuthority(AuthoritiesConstants.ADMIN)
                 .antMatchers("/websocket/**").permitAll()<% } %>
                 .antMatchers("/management/health").permitAll()
+                .antMatchers("/management/health/**").permitAll()
                 .antMatchers("/management/**").hasAuthority(AuthoritiesConstants.ADMIN)
                 .antMatchers("/v2/api-docs/**").permitAll()
                 .antMatchers("/v3/api-docs/**").permitAll()

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -125,6 +125,13 @@ management:
         git:
             mode: full
     health:
+        group:
+            liveness:
+                include: livenessState
+            readiness:
+                include: readinessState<% if (databaseType === 'sql'>,datasource<% } %>
+        probes:
+            enabled: true
         mail:
             enabled: false # When using the MailService, configure an SMTP server and set this to true
     metrics:

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -129,7 +129,7 @@ management:
             liveness:
                 include: livenessState
             readiness:
-                include: readinessState<% if (databaseType === 'sql'>,datasource<% } %>
+                include: readinessState<% if (databaseType === 'sql') { %>,datasource<% } %>
         probes:
             enabled: true
         mail:

--- a/test-integration/scripts/24-tests-e2e.sh
+++ b/test-integration/scripts/24-tests-e2e.sh
@@ -20,33 +20,7 @@ fi
 #-------------------------------------------------------------------------------
 # Functions
 #-------------------------------------------------------------------------------
-launchCurlOrE2e() {
-    retryCount=1
-    maxRetry=10
-    httpUrl="http://localhost:8080"
-    if [[ "$JHI_APP" == *"micro"* ]]; then
-        httpUrl="http://localhost:8081/management/health"
-    fi
-
-    rep=$(curl -v "$httpUrl")
-    status=$?
-    while [ "$status" -ne 0 ] && [ "$retryCount" -le "$maxRetry" ]; do
-        echo "*** [$(date)] Application not reachable yet. Sleep and retry - retryCount =" $retryCount "/" $maxRetry
-        retryCount=$((retryCount+1))
-        sleep 10
-        rep=$(curl -v "$httpUrl")
-        status=$?
-    done
-
-    if [ "$status" -ne 0 ]; then
-        echo "*** [$(date)] Not connected after" $retryCount " retries."
-        return 1
-    fi
-
-    if [ "$JHI_E2E" != 1 ]; then
-        return 0
-    fi
-
+launchE2eTests() {
     retryCount=0
     maxRetry=1
     until [ "$retryCount" -ge "$maxRetry" ]
@@ -62,7 +36,35 @@ launchCurlOrE2e() {
         sleep 15
     done
     return $result
+    return $?
+}
 
+launchCurlTests() {
+    endpointsToTest=("$@")
+    retryCount=1
+    maxRetry=10
+    httpUrl="http://localhost:8080"
+
+    if [[ "$JHI_APP" == *"micro"* ]]; then
+        httpUrl="http://localhost:8081"
+    fi
+
+    for endpoint in "${endpointsToTest[@]}"; do
+        curl -fv "$httpUrl$endpoint"
+        status=$?
+        while [ "$status" -ne 0 ] && [ "$retryCount" -le "$maxRetry" ]; do
+            echo "*** [$(date)] Application not reachable yet. Sleep and retry - retryCount =" $retryCount "/" $maxRetry
+            retryCount=$((retryCount+1))
+            sleep 10
+            curl -fv "$httpUrl$endpoint"
+            status=$?
+        done
+
+        if [ "$status" -ne 0 ]; then
+            echo "*** [$(date)] Not connected after" $retryCount " retries."
+            return 1
+        fi
+    done
     return $?
 }
 #-------------------------------------------------------------------------------
@@ -106,7 +108,20 @@ if [ "$JHI_RUN_APP" == 1 ]; then
     fi
     sleep 40
 
-    launchCurlOrE2e
+    # Curl some test endpoints
+    endpointsToTest=(
+        '/'
+        '/management/health'
+        '/management/health/liveness'
+        '/management/health/readiness'
+    )
+    launchCurlTests "${endpointsToTest[@]}"
+
+    # Run E2E tests
+    if [ "$JHI_E2E" == 1 ]; then
+        launchE2eTests
+    fi
+
     resultRunApp=$?
     kill $(cat .pidRunApp)
 


### PR DESCRIPTION
- Fix an issue where liveness and readiness endpoints were not public which failed Kubernetes deployments.
- Improve `curl` tests to check more sample endpoints

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
