### PR TITLE
document command necessary before running `jhipster import-jdl`

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,7 +228,7 @@ This will do a symbolic link from the global `node_modules` version to point to 
 For testing, you will want to generate an application, and there is a specific issue here: for each application, JHipster installs a local version of itself. This is made to enable several applications to each use a specific JHipster version (application A uses JHipster 3.1.0, and application B uses JHipster 3.2.0).
 
 To overcome this you need to run `npm link generator-jhipster` on the generated project folder as well, so that the local version has a symbolic link to the development version of JHipster.
-Also add the option `--skip-jhipster-dependencies` to generate the application ignoring the JHipster dependencies (otherwise a released version with be installed each time npm install/ci is called). You can later on re-add the dependency with the command `jhipster --no-skip-jhipster-dependencies`.
+Also add the option `--skip-jhipster-dependencies` to generate the application ignoring the JHipster dependencies (otherwise a released version will be installed each time npm install/ci is called). You can later on re-add the dependency with the command `jhipster --no-skip-jhipster-dependencies`.
 
 To put it in a nutshell, you need to:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,12 +227,13 @@ This will do a symbolic link from the global `node_modules` version to point to 
 
 For testing, you will want to generate an application, and there is a specific issue here: for each application, JHipster installs a local version of itself. This is made to enable several applications to each use a specific JHipster version (application A uses JHipster 3.1.0, and application B uses JHipster 3.2.0).
 
-To overcome this you need to run `npm link generator-jhipster` on the generated project folder as well, so that the local version has a symbolic link to the development version of JHipster.
+To overcome this you need to run `npm link generator-jhipster` on the generated project folder as well, so that the local version has a symbolic link to the development version of JHipster.  
+You also need to run this command before you generate entities with JHipster.
 
 To put it in a nutshell, you need to:
 
 1.  run `npm link` on the `generator-jhipster` project
-2.  run `npm link generator-jhipster` on the generated application folder (you need to do this for each application you create)
+2.  run `npm link generator-jhipster` on the generated application folder (you need to do this for each application you create and before generating entities as well)
 
 Now, running the 'jhipster' command should run your locally installed JHipster version directly from sources. Check that the symbolic link is correct with the following command:
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,13 +227,14 @@ This will do a symbolic link from the global `node_modules` version to point to 
 
 For testing, you will want to generate an application, and there is a specific issue here: for each application, JHipster installs a local version of itself. This is made to enable several applications to each use a specific JHipster version (application A uses JHipster 3.1.0, and application B uses JHipster 3.2.0).
 
-To overcome this you need to run `npm link generator-jhipster` on the generated project folder as well, so that the local version has a symbolic link to the development version of JHipster.  
-You also need to run this command before you generate entities with JHipster.
+To overcome this you need to run `npm link generator-jhipster` on the generated project folder as well, so that the local version has a symbolic link to the development version of JHipster.
+Also add the option `--skip-jhipster-dependencies` to generate the application ignoring the JHipster dependencies (otherwise a released version with be installed each time npm install/ci is called). You can later on re-add the dependency with the command `jhipster --no-skip-jhipster-dependencies`.
 
 To put it in a nutshell, you need to:
 
 1.  run `npm link` on the `generator-jhipster` project
-2.  run `npm link generator-jhipster` on the generated application folder (you need to do this for each application you create and before generating entities as well)
+2.  run `npm link generator-jhipster` on the generated application folder (you need to do this for each application you create)
+3.  run `jhipster --skip-jhipster-dependencies` on the generated application folder
 
 Now, running the 'jhipster' command should run your locally installed JHipster version directly from sources. Check that the symbolic link is correct with the following command:
 


### PR DESCRIPTION
<!--
PR description.
-->
fix https://github.com/jhipster/generator-jhipster/issues/12553

Adding documentation on command to run before generation of entities

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
