### PR TITLE
Improvements to relationship handling.

### DIFF
--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -82,7 +82,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.relationships
                     .filter(relationship => relationship.relationshipOtherSideIgnore === undefined)
                     .forEach(relationship => {
-                        relationship.ignoreOtherSideProperty = !relationship.embedded && relationship.otherSideReferenceExists;
+                        relationship.ignoreOtherSideProperty = !relationship.embedded && !!relationship.otherEntity;
                     });
                 this.relationshipsContainOtherSideIgnore = this.relationships.some(relationship => relationship.ignoreOtherSideProperty);
             },

--- a/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/get_all_template.ejs
@@ -50,25 +50,25 @@ _%>
     }
 <%_ } else { _%>
     <%_ if (pagination === 'no') { _%>
-    public <% if (reactive) { %>Mono<<% } %>List<<%= instanceType %>><% if (reactive) { %>><% } %> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (fieldsContainOwnerManyToMany) { %>@RequestParam(required = false, defaultValue = "false") boolean eagerload<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+    public <% if (reactive) { %>Mono<<% } %>List<<%= instanceType %>><% if (reactive) { %>><% } %> getAll<%= entityClassPlural %>(<% if (fieldsContainNoOwnerOneToOne) { %>@RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany && fieldsContainNoOwnerOneToOne) { %>,<% } %><% if (relationshipsContainEagerLoad) { %>@RequestParam(required = false, defaultValue = "false") boolean eagerload<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get all <%= entityClassPlural %>");
         <%_ if (viaService) { _%>
         return <%= entityInstance %>Service.findAll()<% if (reactive) { %>.collectList()<% } %>;
         <%_ } else if (dto === 'mapstruct') { _%>
-        <%= reactive ? 'Flux' : 'List' %><<%= asEntity(entityClass) %>> <%= entityInstancePlural %> = <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>();
+        <%= reactive ? 'Flux' : 'List' %><<%= asEntity(entityClass) %>> <%= entityInstancePlural %> = <%= entityInstance %>Repository.<% if (relationshipsContainEagerLoad) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>();
             <%_ if (!reactive) { _%>
         return <%= entityListToDtoListReference %>(<%= entityInstancePlural %>);
             <%_ } else { _%>
         return <%= entityInstancePlural %>.map(<%= entityToDtoReference %>).collectList();
             <%_ } _%>
         <%_ } else { _%>
-        return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (reactive) { %>.collectList()<% } %>;
+        return <%= entityInstance %>Repository.<% if (relationshipsContainEagerLoad) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (reactive) { %>.collectList()<% } %>;
         <%_ } _%>
     <%_ } else { _%>
-    public <% if (reactive) { %>Mono<ResponseEntity<List<<%= instanceType %>>>><% } else { %>ResponseEntity<List<<%= instanceType %>>><% } %> getAll<%= entityClassPlural %>(Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %><% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %><% if (fieldsContainOwnerManyToMany) { %>, @RequestParam(required = false, defaultValue = "false") boolean eagerload<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
+    public <% if (reactive) { %>Mono<ResponseEntity<List<<%= instanceType %>>>><% } else { %>ResponseEntity<List<<%= instanceType %>>><% } %> getAll<%= entityClassPlural %>(Pageable pageable<% if (reactive) { %>, ServerHttpRequest request<% } %><% if (fieldsContainNoOwnerOneToOne) { %>, @RequestParam(required = false) String filter<% } %><% if (relationshipsContainEagerLoad) { %>, @RequestParam(required = false, defaultValue = "false") boolean eagerload<% } %>) {<%- include('get_all_stream_template', {viaService: viaService}); -%>
         log.debug("REST request to get a page of <%= entityClassPlural %>");
         <%_ if (!reactive) { _%>
-            <%_ if (fieldsContainOwnerManyToMany) { _%>
+            <%_ if (relationshipsContainEagerLoad) { _%>
         Page<<%= instanceType %>> page;
         if (eagerload) {
             page = <%= entityInstance %><%= viaService ? 'Service' : 'Repository' %>.findAllWithEagerRelationships(pageable)<%= reactiveEntityToDto %>;

--- a/generators/entity-server/templates/src/main/java/package/common/get_template.ejs
+++ b/generators/entity-server/templates/src/main/java/package/common/get_template.ejs
@@ -24,7 +24,7 @@
     const returnPrefix = returnDirectly ? 'return' : `${instanceType} ${instanceName} =`;
 %>
 <%_ if (!viaService) { _%>
-        <%- returnPrefix %> <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany === true) { %>findOneWithEagerRelationships(id)<% } else { %>findById(id)<% } %><% if (dto !== 'mapstruct') { %>;<% } else { %>
+        <%- returnPrefix %> <%= entityInstance %>Repository.<% if (relationshipsContainEagerLoad) { %>findOneWithEagerRelationships(id)<% } else { %>findById(id)<% } %><% if (dto !== 'mapstruct') { %>;<% } else { %>
             .map(<%= entityToDtoReference %>);<% } %>
 <%_ } else { _%>
         <%- returnPrefix %> <%= entityInstance %>Service.findOne(id);

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -38,9 +38,7 @@ import org.springframework.data.annotation.Id;
 import org.springframework.data.cassandra.core.mapping.Column;
     <%_ } _%>
 import org.springframework.data.cassandra.core.mapping.Table;
-<%_ } if (importJsonIgnore === true) { _%>
-import com.fasterxml.jackson.annotation.JsonIgnore;
-<%_ } if (importJsonIgnoreProperties === true) { _%>
+<%_ } if (relationshipsContainOtherSideIgnore === true) { _%>
 import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
 <%_ } if (!hasDto && typeof javadoc != 'undefined') { _%>
 import io.swagger.annotations.ApiModel;
@@ -112,7 +110,7 @@ import java.time.LocalDate;
 import java.time.ZonedDateTime;
 <%_ } if (fieldsContainDuration === true) { _%>
 import java.time.Duration;
-<%_ } if (importSet === true) { _%>
+<%_ } if (entityContainsCollectionField) { _%>
 import java.util.HashSet;
 import java.util.Set;
 <%_ } if (databaseType === 'couchbase' && hasRelationship) { _%>
@@ -277,45 +275,45 @@ public class <%= asEntity(entityClass) %> implements Serializable {
       <%_ } _%>
     private String <%= fieldName %>ContentType;
 
-    <%_ }
+<%_ }
+}
+
+relationships.forEach((relationship, idx) => {
+    const otherEntityRelationshipName = relationships[idx].otherEntityRelationshipName;
+    const otherEntityRelationshipNamePlural = relationships[idx].otherEntityRelationshipNamePlural;
+    const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
+    const relationshipName = relationships[idx].relationshipName;
+    const relationshipFieldName = relationships[idx].relationshipFieldName;
+    const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+    const joinTableName = getJoinTableName(entityTableName, relationshipName, prodDatabaseType);
+    const relationshipType = relationships[idx].relationshipType;
+    const relationshipValidate = relationships[idx].relationshipValidate;
+    const relationshipRequired = relationships[idx].relationshipRequired;
+    const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
+    const ownerSide = relationships[idx].ownerSide || false;
+    const isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
+    if (otherEntityRelationshipName) {
+        mappedBy = otherEntityRelationshipName.charAt(0).toLowerCase() + otherEntityRelationshipName.slice(1)
     }
 
-    for (idx in relationships) {
-        const otherEntityRelationshipName = relationships[idx].otherEntityRelationshipName;
-        const otherEntityRelationshipNamePlural = relationships[idx].otherEntityRelationshipNamePlural;
-        const otherEntityIsEmbedded = relationships[idx].otherEntityIsEmbedded;
-        const relationshipName = relationships[idx].relationshipName;
-        const relationshipFieldName = relationships[idx].relationshipFieldName;
-        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-        const joinTableName = getJoinTableName(entityTableName, relationshipName, prodDatabaseType);
-        const relationshipType = relationships[idx].relationshipType;
-        const relationshipValidate = relationships[idx].relationshipValidate;
-        const relationshipRequired = relationships[idx].relationshipRequired;
-        const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-        const ownerSide = relationships[idx].ownerSide || false;
-        const isUsingMapsId = relationships[idx].useJPADerivedIdentifier;
-        if (otherEntityRelationshipName) {
-            mappedBy = otherEntityRelationshipName.charAt(0).toLowerCase() + otherEntityRelationshipName.slice(1)
-        }
+    // An embedded entity should not reference entities that embeds it, unless the other entity is also embedded
+    if (embedded && !otherEntityIsEmbedded && ownerSide === false) {
+      return;
+    }
 
-        // An embedded entity should not reference entities that embeds it, unless the other entity is also embedded
-        if (embedded && !otherEntityIsEmbedded && ownerSide === false) {
-          continue;
-        }
-
-        if (typeof relationships[idx].javadoc != 'undefined') { _%>
+    if (typeof relationships[idx].javadoc != 'undefined') { _%>
 <%- formatAsFieldJavadoc(relationships[idx].javadoc) %>
-            <%_ if (!hasDto) { _%>
+    <%_ if (!hasDto) { _%>
     @ApiModelProperty(value = "<%- formatAsApiDescription(relationships[idx].javadoc) %>")
-            <%_ } _%>
-    <%_ }
-        if (relationshipType === 'one-to-many') {
-            if (databaseType === 'sql' && !reactive) {
+    <%_ } _%>
+<%_ }
+    if (relationshipType === 'one-to-many') {
+        if (databaseType === 'sql' && !reactive) {
     _%>
     @OneToMany(mappedBy = "<%= otherEntityRelationshipName %>")
-            <%_ if (enableHibernateCache) { _%>
+        <%_ if (enableHibernateCache) { _%>
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-            <%_ }
+        <%_ }
         } else if (databaseType === 'mongodb' || databaseType === 'couchbase') {
             if (databaseType === 'mongodb' && !otherEntityIsEmbedded) { _%>
     @DBRef
@@ -331,14 +329,17 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     <%_ } else if (databaseType === 'sql' && reactive) { _%>
     @Transient
     <%_ } _%>
+    <%_ if (relationship.ignoreOtherSideProperty) { _%>
+    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipName %>", allowSetters = true)
+    <%_ } _%>
     private Set<<%= asEntity(otherEntityNameCapitalized) %>> <%= relationshipFieldNamePlural %> = new HashSet<>();
 
-    <%_ } else if (relationshipType === 'many-to-one') {
-            if (databaseType === 'sql' && !reactive) {
+<%_ } else if (relationshipType === 'many-to-one') {
+        if (databaseType === 'sql' && !reactive) {
     _%>
     @ManyToOne<% if (relationshipRequired) { %>(optional = false)<% } %>
         <%_ if (relationshipValidate) { _%>
-    <%- include('relationship_validators'); -%>
+    <%- include('relationship_validators', { relationships, idx }); -%>
         <%_ }
     } else if ((databaseType === 'mongodb' || databaseType === 'couchbase') && !otherEntityIsEmbedded) {
         if (databaseType === 'mongodb') { _%>
@@ -353,7 +354,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     } else if (databaseType === 'neo4j') { _%>
     @Relationship("<%= relationshipFieldName %>")
     <%_ } _%>
-    <%_ if (otherEntityRelationshipNamePlural !== undefined && otherEntityRelationshipNamePlural !== '') { _%>
+    <%_ if (relationship.ignoreOtherSideProperty) { _%>
     @JsonIgnoreProperties(value = "<%= otherEntityRelationshipNamePlural %>", allowSetters = true)
     <%_ } _%>
     <%_ if (databaseType === 'sql' && reactive) { _%>
@@ -366,14 +367,14 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     private Long <%= relationshipFieldName %>Id;
     <%_ } _%>
 
-    <%_ } else if (relationshipType === 'many-to-many') {
+<%_ } else if (relationshipType === 'many-to-many') {
         if (databaseType === 'sql' && !reactive) { _%>
     @ManyToMany<% if (ownerSide === false) { %>(mappedBy = "<%= otherEntityRelationshipNamePlural %>")<% } %>
         <%_ if (enableHibernateCache) {_%>
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
         <%_ } if (ownerSide === true) {
             if (relationshipValidate) { _%>
-    <%- include('relationship_validators'); -%>
+    <%- include('relationship_validators', { relationships, idx }); -%>
         <%_ } _%>
     @JoinTable(name = "<%= joinTableName %>",
                joinColumns = @JoinColumn(name = "<%= getColumnName(name) %>_id", referencedColumnName = "id"),
@@ -389,20 +390,24 @@ public class <%= asEntity(entityClass) %> implements Serializable {
 
     @N1qlJoin(on = "lks.<%= relationshipFieldNamePlural %>=meta(rks).id", fetchType = FetchType.IMMEDIATE)
         <%_ }
-         } if (ownerSide === false) { _%>
-    @JsonIgnore
+        }
+        if (relationship.ignoreOtherSideProperty) { _%>
+    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipNamePlural %>", allowSetters = true)
     <%_ } _%>
     <%_ if (databaseType === 'sql' && reactive) { _%>
     @Transient
     <%_ } _%>
     private Set<<%= asEntity(otherEntityNameCapitalized) %>> <%= relationshipFieldNamePlural %> = new HashSet<>();
 
-    <%_ } else {
+<%_ } else {
         if (databaseType === 'sql' && !reactive) {
+            if (relationship.ignoreOtherSideProperty) { _%>
+    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipName %>", allowSetters = true)
+        <%_ }
             if (ownerSide) { _%>
     @OneToOne<% if (relationshipRequired) { %>(optional = false)<% } %>
             <%_ if (relationshipValidate) { _%>
-    <%- include('relationship_validators'); -%>
+    <%- include('relationship_validators', { relationships, idx }); -%>
             <%_ } _%>
             <%_ if (isUsingMapsId === true) { %>
     @MapsId
@@ -412,7 +417,6 @@ public class <%= asEntity(entityClass) %> implements Serializable {
             <%_ } _%>
         <%_ } else { _%>
     @OneToOne(mappedBy = "<%= otherEntityRelationshipName %>")
-    @JsonIgnore
         <%_ }
         } else if ((databaseType === 'mongodb' || databaseType === 'couchbase') && !otherEntityIsEmbedded) {
             if (databaseType === 'mongodb') { _%>
@@ -424,9 +428,6 @@ public class <%= asEntity(entityClass) %> implements Serializable {
 
     @N1qlJoin(on = "lks.<%= relationshipFieldName %>=meta(rks).id", fetchType = FetchType.IMMEDIATE)
         <%_ }
-            if (ownerSide === false) { _%>
-    @com.fasterxml.jackson.annotation.JsonBackReference
-    <%_     }
         } else if (databaseType === 'sql' && reactive) { _%>
           <%_ if (ownerSide === true && isUsingMapsId !== true) { _%>
     private Long <%= relationshipFieldName %>Id;
@@ -436,10 +437,11 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     <%_ } _%>
     private <%= asEntity(otherEntityNameCapitalized) %> <%= relationshipFieldName %>;
 
-    <%_ }
-    } _%>
+<%_ }
+}); _%>
     // jhipster-needle-entity-add-field - JHipster will add fields here
-    <%_ if (!embedded) { _%>
+<%_
+if (!embedded) { _%>
     public <% if (databaseType === 'sql') { %><%= primaryKeyType %><% } %><% if (databaseType === 'mongodb' || databaseType === 'couchbase' || databaseType === 'neo4j') { %>String<% } %><% if (databaseType === 'cassandra') { %>UUID<% } %> getId() {
         return id;
     }
@@ -448,13 +450,13 @@ public class <%= asEntity(entityClass) %> implements Serializable {
         this.id = id;
     }
 
-        <%_ if (fluentMethods) { _%>
+<%_ if (fluentMethods) { _%>
     public <%= asEntity(entityClass) %> id(<% if (databaseType === 'sql') { %><%= primaryKeyType %><% } %><% if (databaseType === 'mongodb' || databaseType === 'neo4j' || databaseType === 'couchbase') { %>String<% } %><% if (databaseType === 'cassandra') { %>UUID<% } %> id) {
         this.id = id;
         return this;
     }
-        <%_ } _%>
-    <%_ } _%>
+<%_ }
+} _%>
 <%_ for (idx in fields) {
         const fieldType = fields[idx].fieldType;
         const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
@@ -564,7 +566,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
                 if (databaseType !== 'neo4j') { _%>
         <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(this);
                 <%_ } _%>
-            <%_ } else if (otherEntityRelationshipNameCapitalizedPlural !== '' && asEntity(otherEntityNameCapitalized)!=='User' && relationshipType === 'many-to-many') {
+            <%_ } else if (otherEntityRelationshipNameCapitalizedPlural && asEntity(otherEntityNameCapitalized)!=='User' && relationshipType === 'many-to-many') {
                 // JHipster version < 3.6.0 didn't ask for this relationship name _%>
         <%= otherEntityName %>.get<%= otherEntityRelationshipNameCapitalizedPlural %>().add(this);
             <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -330,7 +330,11 @@ relationships.forEach((relationship, idx) => {
     @Transient
     <%_ } _%>
     <%_ if (relationship.ignoreOtherSideProperty) { _%>
-    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipName %>", allowSetters = true)
+    @JsonIgnoreProperties(value = {
+        <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
+        "<%= otherRelationship.relationshipReferenceField %>",
+        <%_ }); _%>
+    }, allowSetters = true)
     <%_ } _%>
     private Set<<%= asEntity(otherEntityNameCapitalized) %>> <%= relationshipFieldNamePlural %> = new HashSet<>();
 
@@ -355,7 +359,11 @@ relationships.forEach((relationship, idx) => {
     @Relationship("<%= relationshipFieldName %>")
     <%_ } _%>
     <%_ if (relationship.ignoreOtherSideProperty) { _%>
-    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipNamePlural %>", allowSetters = true)
+    @JsonIgnoreProperties(value = {
+        <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
+        "<%= otherRelationship.relationshipReferenceField %>",
+        <%_ }); _%>
+    }, allowSetters = true)
     <%_ } _%>
     <%_ if (databaseType === 'sql' && reactive) { _%>
     @Transient
@@ -392,7 +400,11 @@ relationships.forEach((relationship, idx) => {
         <%_ }
         }
         if (relationship.ignoreOtherSideProperty) { _%>
-    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipNamePlural %>", allowSetters = true)
+    @JsonIgnoreProperties(value = {
+        <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
+        "<%= otherRelationship.relationshipReferenceField %>",
+        <%_ }); _%>
+    }, allowSetters = true)
     <%_ } _%>
     <%_ if (databaseType === 'sql' && reactive) { _%>
     @Transient
@@ -402,7 +414,11 @@ relationships.forEach((relationship, idx) => {
 <%_ } else {
         if (databaseType === 'sql' && !reactive) {
             if (relationship.ignoreOtherSideProperty) { _%>
-    @JsonIgnoreProperties(value = "<%= otherEntityRelationshipName %>", allowSetters = true)
+    @JsonIgnoreProperties(value = {
+        <%_ relationship.otherEntity.relationships.forEach(otherRelationship => { _%>
+        "<%= otherRelationship.relationshipReferenceField %>",
+        <%_ }); _%>
+    }, allowSetters = true)
         <%_ }
             if (ownerSide) { _%>
     @OneToOne<% if (relationshipRequired) { %>(optional = false)<% } %>

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepository.java.ejs
@@ -33,7 +33,7 @@ import org.springframework.data.couchbase.repository.ReactiveCouchbaseSortingRep
 import org.neo4j.springframework.data.repository.ReactiveNeo4jRepository;
 import org.neo4j.springframework.data.repository.query.Query;
 <%_ } _%>
-<%_ if (pagination !== 'no' || fieldsContainOwnerManyToMany === true || databaseType ==='sql') { _%>
+<%_ if (pagination !== 'no' || relationshipsContainEagerLoad || databaseType ==='sql') { _%>
 import org.springframework.data.domain.Pageable;
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>
@@ -42,16 +42,16 @@ import org.springframework.data.r2dbc.repository.R2dbcRepository;
 import org.springframework.data.relational.core.query.Criteria;
 <%_ } _%>
 <%_ if (databaseType === 'mongodb') { _%>
-    <%_ if (fieldsContainOwnerManyToMany === true) { _%>
+    <%_ if (relationshipsContainEagerLoad) { _%>
 import org.springframework.data.mongodb.repository.Query;
     <%_ } _%>
 import org.springframework.data.mongodb.repository.ReactiveMongoRepository;
 <%_ } _%>
 import org.springframework.stereotype.Repository;
-<%_ if (['couchbase', 'sql'].includes(databaseType) || pagination !== 'no' || fieldsContainOwnerManyToMany === true) { _%>
+<%_ if (['couchbase', 'sql'].includes(databaseType) || pagination !== 'no' || relationshipsContainEagerLoad) { _%>
 import reactor.core.publisher.Flux;
 <%_ } _%>
-<%_ if (fieldsContainOwnerManyToMany === true || databaseType === 'sql') { _%>
+<%_ if (relationshipsContainEagerLoad || databaseType === 'sql') { _%>
 import reactor.core.publisher.Mono;
 <%_ } _%>
 <%_ if (databaseType === 'cassandra') { _%>
@@ -70,7 +70,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
 
     Flux<<%= asEntity(entityClass) %>> findAllBy(Pageable pageable);
     <%_ } _%>
-    <%_ if (fieldsContainOwnerManyToMany === true) { _%>
+    <%_ if (relationshipsContainEagerLoad) { _%>
         <%_ if (['couchbase', 'mongodb'].includes(databaseType)) { _%>
 
     @Query("<%= (databaseType === 'mongodb') ? '{}' : '#{#n1ql.selectEntity} WHERE #{#n1ql.filter}' %>")

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -20,13 +20,13 @@ package <%= packageName %>.repository;
 
 import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
 
-<%_ if (fieldsContainOwnerManyToMany) { _%>
+<%_ if (relationshipsContainEagerLoad) { _%>
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.data.jpa.repository.*;
-    <%_ if (fieldsContainOwnerManyToMany) { _%>
+    <%_ if (relationshipsContainEagerLoad) { _%>
 import org.springframework.data.repository.query.Param;
     <%_ } _%>
 <%_ } _%>
@@ -42,7 +42,7 @@ import java.util.List;
 <%_ if (searchEngine === 'couchbase') { _%>
 import <%= packageName %>.repository.search.SearchCouchbaseRepository;
 <%_ } _%>
-<%_ if (databaseType === 'couchbase' && fieldsContainOwnerManyToMany === true) { _%>
+<%_ if (databaseType === 'couchbase' && relationshipsContainEagerLoad === true) { _%>
 import org.springframework.data.couchbase.core.query.Query;
 <%_ } _%>
 <%_ if (databaseType === 'cassandra') { _%>
@@ -58,13 +58,10 @@ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'ne
         }
     }
 _%>
-    <%_ if (importList || fieldsContainOwnerManyToMany) { _%>
-
-    <%_ } _%>
     <%_ if (importList) { _%>
 import java.util.List;
     <%_ } _%>
-    <%_ if (fieldsContainOwnerManyToMany) { _%>
+    <%_ if (relationshipsContainEagerLoad) { _%>
 import java.util.Optional;
     <%_ } _%>
 <%_ } _%>
@@ -76,7 +73,7 @@ import java.util.UUID;
 /**
  * Spring Data <%= officialDatabaseType %> repository for the <%= asEntity(entityClass) %> entity.
  */
-<%_ if (!fieldsContainOwnerManyToMany) { _%>
+<%_ if (!relationshipsContainEagerLoad) { _%>
 @SuppressWarnings("unused")
 <%_ } _%>
 @Repository
@@ -87,20 +84,26 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     @Query("select <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %> where <%= entityInstance %>.<%= relationships[idx].relationshipFieldName %>.login = ?#{principal.<% if (authenticationType === 'oauth2') { %>preferredUsername<% } else { %>username<% } %>}")
     List<<%= asEntity(entityClass) %>> findBy<%= relationships[idx].relationshipNameCapitalized %>IsCurrentUser();
     <%_ } } _%>
-    <%_ if (fieldsContainOwnerManyToMany === true) {
+    <%_ if (relationshipsContainEagerLoad) {
         if (databaseType === 'sql') { _%>
 
-    @Query(value = "select distinct <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %><% for (idx in relationships) {
-    if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% } } %>",
+    @Query(value = "select distinct <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %><%
+    for (idx in relationships) {
+        if (relationships[idx].relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% }
+    } %>",
         countQuery = "select count(distinct <%= entityInstance %>) from <%= asEntity(entityClass) %> <%= entityInstance %>")
     Page<<%= asEntity(entityClass) %>> findAllWithEagerRelationships(Pageable pageable);
 
-    @Query("select distinct <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %><% for (idx in relationships) {
-    if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% } } %>")
+    @Query("select distinct <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %><%
+    for (idx in relationships) {
+        if (relationships[idx].relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% }
+    } %>")
     List<<%= asEntity(entityClass) %>> findAllWithEagerRelationships();
 
-    @Query("select <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %><% for (idx in relationships) {
-    if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% } } %> where <%= entityInstance %>.id =:id")
+    @Query("select <%= entityInstance %> from <%= asEntity(entityClass) %> <%= entityInstance %><%
+    for (idx in relationships) {
+        if (relationships[idx].relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% }
+    } %> where <%= entityInstance %>.id =:id")
     Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(@Param("id") <%= primaryKeyType %> id);
     <%_
         } else if (databaseType === 'mongodb' || databaseType === 'couchbase')  { _%>

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -30,7 +30,7 @@ import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
 <%_ } else { _%>
 import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
 <%_ } _%>
-<%_ if (pagination !== 'no' || fieldsContainOwnerManyToMany === true) { _%>
+<%_ if (pagination !== 'no' || relationshipsContainEagerLoad) { _%>
 
     <%_ if (!reactive) { _%>
 import org.springframework.data.domain.Page;
@@ -81,7 +81,7 @@ public interface <%= entityClass %>Service {
     <%= listOrFlux %><<%= instanceType %>> findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull();
 <%_ } } _%>
 
-    <%_ if (fieldsContainOwnerManyToMany === true) { _%>
+    <%_ if (relationshipsContainEagerLoad) { _%>
     /**
      * Get all the <%= entityInstancePlural %> with eager load of many-to-many relationships.
      *

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -51,7 +51,7 @@ import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-<%_ if (pagination !== 'no' || fieldsContainOwnerManyToMany === true) { _%>
+<%_ if (pagination !== 'no' || relationshipsContainEagerLoad) { _%>
     <%_ if (!reactive) { _%>
 import org.springframework.data.domain.Page;
     <%_ } _%>
@@ -136,7 +136,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     public <% if (pagination !== 'no') { %><%= pageOrFlux %><<%= instanceType %><% } else { %><%= listOrFlux %><<%= instanceType %><% } %>> findAll(<% if (pagination !== 'no') { %>Pageable pageable<% } %>) {
         log.debug("Request to get all <%= entityClassPlural %>");
         <%_ if (pagination === 'no') { _%>
-        return <%= entityInstance %>Repository.<% if (fieldsContainOwnerManyToMany === true) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto === 'mapstruct') { %><% if (!reactive) { %>.stream()<% } %>
+        return <%= entityInstance %>Repository.<% if (relationshipsContainEagerLoad) { %>findAllWithEagerRelationships<% } else { %>findAll<% } %>()<% if (dto === 'mapstruct') { %><% if (!reactive) { %>.stream()<% } %>
             .map(<%= entityToDtoReference %>)<% if (!reactive) { %>
             .collect(Collectors.toCollection(LinkedList::new))<% } } %>;
         <%_ } else { _%>
@@ -145,7 +145,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
         <%_ } _%>
     }
 
-    <%_ if (fieldsContainOwnerManyToMany === true) { _%>
+    <%_ if (relationshipsContainEagerLoad) { _%>
 
     <%_ if (service !== 'serviceImpl') { _%>
     /**

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -260,7 +260,7 @@ public class <%= entityClass %>Resource {
      * @param request a {@link ServerHttpRequest} request.
         <%_ } _%>
     <%_ } _%>
-    <%_ if (!jpaMetamodelFiltering && fieldsContainOwnerManyToMany) { _%>
+    <%_ if (!jpaMetamodelFiltering && relationshipsContainEagerLoad) { _%>
      * @param eagerload flag to eager load entities from relationships (This is applicable for many-to-many).
      <%_ } _%>
      <%_ if (jpaMetamodelFiltering) { _%>

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -130,7 +130,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
         }
 
         const name = _.upperFirst(this.options.name).replace('.json', '');
-        this.entityStorage = this.getEntityConfig(name);
+        this.entityStorage = this.getEntityConfig(name, true);
         this.entityConfig = this.entityStorage.createProxy();
 
         const entityExisted = this.options.entityExisted !== undefined ? this.options.entityExisted : this.entityStorage.existed;
@@ -467,6 +467,10 @@ class EntityGenerator extends BaseBlueprintGenerator {
                     prepareFieldForTemplates(entity, field, this);
                 });
             },
+            shareEntity() {
+                this.configOptions.sharedEntities = this.configOptions.sharedEntities || {};
+                this.configOptions.sharedEntities[this.context.name] = this.context;
+            },
         };
     }
 
@@ -482,6 +486,9 @@ class EntityGenerator extends BaseBlueprintGenerator {
 
             prepareRelationshipsForTemplates() {
                 this.context.relationships.forEach(relationship => {
+                    const otherEntityName = this._.upperFirst(relationship.otherEntityName);
+                    relationship.otherEntity = this.configOptions.sharedEntities[otherEntityName];
+
                     prepareRelationshipForTemplates(this.context, relationship, this);
                     this._.defaults(relationship, {
                         // otherEntityField should be id if not specified

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1044,15 +1044,11 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
                 fieldName = relationship.relationshipFieldName;
             } else {
                 const relationshipFieldName = relationship.relationshipFieldName;
-                const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
                 const relationshipType = relationship.relationshipType;
                 const otherEntityFieldCapitalized = relationship.otherEntityFieldCapitalized;
                 const ownerSide = relationship.ownerSide;
 
-                if (relationshipType === 'many-to-many' && ownerSide === true) {
-                    fieldType = `I${otherEntityFieldCapitalized}[]`;
-                    fieldName = relationshipFieldNamePlural;
-                } else if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) {
+                if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) {
                     if (otherEntityFieldCapitalized !== 'Id' && otherEntityFieldCapitalized !== '') {
                         fieldType = 'string';
                         fieldName = `${relationshipFieldName}${otherEntityFieldCapitalized}`;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2421,9 +2421,12 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
     /**
      * Get all the generator configuration from the .yo-rc.json file
      * @param {string} entityName - Name of the entity to load.
+     * @param {boolean} create - Create storage if doesn't exists.
      */
-    getEntityConfig(entityName) {
-        return this.createStorage(this.destinationPath(JHIPSTER_CONFIG_DIR, `${_.upperFirst(entityName)}.json`));
+    getEntityConfig(entityName, create = false) {
+        const entityPath = this.destinationPath(JHIPSTER_CONFIG_DIR, `${_.upperFirst(entityName)}.json`);
+        if (!create && !this.fs.exists(entityPath)) return undefined;
+        return this.createStorage(entityPath);
     }
 
     /**

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -135,6 +135,15 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
     }
 
     /**
+     * Verify if the entity is a built-in Entity.
+     * @param {String} entityName - Entity name to verify.
+     * @return {boolean} true if the entity is built-in.
+     */
+    isBuiltInEntity(entityName) {
+        return this.isBuiltInUser(entityName) || this.isBuiltInAuthority(entityName);
+    }
+
+    /**
      * Verify if the application is using built-in User.
      * @return {boolean} true if the User is built-in.
      */
@@ -152,10 +161,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @return {boolean} true if the entity is User.
      */
     isUserEntity(entityName) {
-        if (_.upperFirst(entityName) === 'User') {
-            return true;
-        }
-        return false;
+        return _.upperFirst(entityName) === 'User';
     }
 
     /**
@@ -186,10 +192,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @return {boolean} true if the entity is Authority.
      */
     isAuthorityEntity(entityName) {
-        if (_.upperFirst(entityName) === 'Authority') {
-            return true;
-        }
-        return false;
+        return _.upperFirst(entityName) === 'Authority';
     }
 
     /**

--- a/test/app/database-changelog.spec.js
+++ b/test/app/database-changelog.spec.js
@@ -13,10 +13,7 @@ describe('jhipster:app database changelogs', () => {
                     .create(require.resolve('../../generators/app'))
                     .doInDir(dir => {
                         fse.copySync(path.join(__dirname, '../templates/compose/05-cassandra'), dir);
-                        fse.copySync(
-                            path.join(__dirname, '../templates/export-jdl/.jhipster/Country.json'),
-                            path.join(dir, '.jhipster/Foo.json')
-                        );
+                        fse.copySync(path.join(__dirname, '../templates/.jhipster/Simple.json'), path.join(dir, '.jhipster/Foo.json'));
                     })
                     .withOptions({ withEntities: true, force: true, skipClient: true })
                     .run()

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -741,11 +741,8 @@ describe('JHipster generator for entity', () => {
                     helpers
                         .run(require.resolve('../generators/entity'))
                         .inTmpDir(dir => {
-                            fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                            fse.copySync(
-                                path.join(__dirname, '../test/templates/export-jdl/.jhipster/Country.json'),
-                                path.join(dir, '.jhipster/Foo.json')
-                            );
+                            fse.copySync(path.join(__dirname, './templates/default-ng2'), dir);
+                            fse.copySync(path.join(__dirname, 'templates/.jhipster/Simple.json'), path.join(dir, '.jhipster/Foo.json'));
                         })
                         .withArguments(['Foo'])
                         .withOptions({ regenerate: true, force: true })
@@ -770,10 +767,7 @@ describe('JHipster generator for entity', () => {
                         .run(require.resolve('../generators/entity'))
                         .inTmpDir(dir => {
                             fse.copySync(path.join(__dirname, '../test/templates/default-ng2'), dir);
-                            fse.copySync(
-                                path.join(__dirname, '../test/templates/export-jdl/.jhipster/Country.json'),
-                                path.join(dir, '.jhipster/Foo.json')
-                            );
+                            fse.copySync(path.join(__dirname, 'templates/.jhipster/Simple.json'), path.join(dir, '.jhipster/Foo.json'));
                         })
                         .withArguments(['Foo'])
                         .withOptions({ regenerate: true, force: true, skipDbChangelog: true })
@@ -799,10 +793,7 @@ describe('JHipster generator for entity', () => {
                         .run(require.resolve('../generators/entity'))
                         .inTmpDir(dir => {
                             fse.copySync(path.join(__dirname, '../test/templates/compose/05-cassandra'), dir);
-                            fse.copySync(
-                                path.join(__dirname, '../test/templates/export-jdl/.jhipster/Country.json'),
-                                path.join(dir, '.jhipster/Foo.json')
-                            );
+                            fse.copySync(path.join(__dirname, 'templates/.jhipster/Simple.json'), path.join(dir, '.jhipster/Foo.json'));
                         })
                         .withArguments(['Foo'])
                         .withOptions({ regenerate: true, force: true, skipDbChangelog: true })
@@ -827,7 +818,7 @@ describe('JHipster generator for entity', () => {
                         .inTmpDir(dir => {
                             fse.copySync(path.join(__dirname, '../test/templates/default-microservice'), dir);
                             fse.copySync(
-                                path.join(__dirname, '../test/templates/export-jdl/.jhipster/Employee.json'),
+                                path.join(__dirname, 'templates/.jhipster/DtoServicePagination.json'),
                                 path.join(dir, '.jhipster/Foo.json')
                             );
                         })

--- a/test/entity/database-changelog.spec.js
+++ b/test/entity/database-changelog.spec.js
@@ -13,10 +13,7 @@ describe('jhipster:entity database changelogs', () => {
                     .create(require.resolve('../../generators/entity'))
                     .doInDir(dir => {
                         fse.copySync(path.join(__dirname, '../templates/compose/05-cassandra'), dir);
-                        fse.copySync(
-                            path.join(__dirname, '../templates/export-jdl/.jhipster/Country.json'),
-                            path.join(dir, '.jhipster/Foo.json')
-                        );
+                        fse.copySync(path.join(__dirname, '../templates/.jhipster/Simple.json'), path.join(dir, '.jhipster/Foo.json'));
                     })
                     .withArguments(['Foo'])
                     .withOptions({ regenerate: true, force: true })

--- a/test/templates/.jhipster/DtoServicePagination.json
+++ b/test/templates/.jhipster/DtoServicePagination.json
@@ -1,0 +1,57 @@
+{
+    "relationships": [],
+    "fields": [
+        {
+            "fieldName": "employeeId",
+            "fieldType": "Long"
+        },
+        {
+            "fieldName": "employeeUuid",
+            "fieldType": "UUID"
+        },
+        {
+            "fieldName": "firstName",
+            "javadoc": "The firstname attribute.",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "lastName",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "email",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "phoneNumber",
+            "fieldType": "String"
+        },
+        {
+            "fieldName": "hireDate",
+            "fieldType": "ZonedDateTime"
+        },
+        {
+            "fieldName": "salary",
+            "fieldType": "Long",
+            "fieldValidateRules": [
+                "min", "max"
+            ],
+            "fieldValidateRulesMin": 10000,
+            "fieldValidateRulesMax": 1000000
+        },
+        {
+            "fieldName": "commissionPct",
+            "fieldType": "Long"
+        }
+    ],
+    "changelogDate": "20160926083805",
+    "javadoc": "The Employee entity.",
+    "entityTableName": "emp",
+    "dto": "mapstruct",
+    "pagination": "infinite-scroll",
+    "service": "serviceClass",
+    "fluentMethods": false,
+    "searchEngine": "elasticsearch",
+    "angularJSSuffix": "myentities",
+    "microserviceName": "mymicroservice"
+}

--- a/test/templates/.jhipster/Simple.json
+++ b/test/templates/.jhipster/Simple.json
@@ -1,0 +1,20 @@
+{
+    "fluentMethods": true,
+    "relationships": [],
+    "fields": [
+        {
+            "fieldName": "simpleId",
+            "fieldType": "Long",
+            "javadoc": "The simple Id"
+        },
+        {
+            "fieldName": "simpleName",
+            "fieldType": "String"
+        }
+    ],
+    "changelogDate": "20160926101210",
+    "entityTableName": "simple",
+    "dto": "no",
+    "pagination": "no",
+    "service": "no"
+}

--- a/utils/index.js
+++ b/utils/index.js
@@ -18,5 +18,5 @@
  */
 
 module.exports = {
-    stringify: data => JSON.stringify(data, null, 4),
+    stringify: data => JSON.stringify(data, (key, value) => (key === 'otherEntity' && value ? `[${value.name} entity]` : value), 4),
 };

--- a/utils/relationship.js
+++ b/utils/relationship.js
@@ -28,6 +28,8 @@ function prepareRelationshipForTemplates(entityWithConfig, relationship, generat
     const otherEntityName = relationship.otherEntityName;
     const jhiTablePrefix = entityWithConfig.jhiTablePrefix || generator.getTableName(entityWithConfig.jhiPrefix);
 
+    relationship.otherSideReferenceExists = false;
+
     const otherEntityData = generator.getEntityConfig(otherEntityName).getAll();
     if (!otherEntityData && !this.isBuiltInEntity(otherEntityName)) {
         throw new Error(`Error at entity ${entityName}: could not find the entity of the relationship ${stringify(relationship)}`);
@@ -76,6 +78,7 @@ function prepareRelationshipForTemplates(entityWithConfig, relationship, generat
             });
         }
         if (otherRelationship) {
+            relationship.otherSideReferenceExists = true;
             if (
                 !(relationship.relationshipType === 'one-to-one' && otherRelationship.relationshipType === 'one-to-one') &&
                 !(relationship.relationshipType === 'many-to-one' && otherRelationship.relationshipType === 'one-to-many') &&


### PR DESCRIPTION
- Creates a shared object containing every prepared entity, so relationships can easily get updated data from the other entity.
- Relationships: make `otherEntity` available to templates. (and workaround cyclic json at stringify).
- Relationships: start loading fields from `otherEntity` for consistency, instead of creating based only on relationship data.
- Relationships: really throw error if other side entity is not found and is not a built-in entity.
- Relationships: replace `@JsonIgnore` in favor of `@JsonIgnoreProperty` with every relationship ignored.
- Relationships: pre calculate what relationships must be eager loaded.
- Indentation fixes.
- Removes unreachable code.

Related to https://github.com/jhipster/generator-jhipster/issues/12562.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
