### PR TITLE
Implement domain support at entity-server.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -398,6 +398,30 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
         return this._loading();
     }
 
+    _preparing() {
+        return {
+            createBuiltInEntitiesStubs() {
+                this.configOptions.sharedEntities = this.configOptions.sharedEntities || {};
+                if (this.jhipsterConfig.skipUserManagement && this.jhipsterConfig.authenticationType !== 'oauth2') return;
+                // Create entity definition for built-in entity to make easier to deal with relationships.
+                this.configOptions.sharedEntities.User = {
+                    entityClassPath: `${this.jhipsterConfig.packageName}.domain.${this.asEntity('User')}`,
+                    entityControllerClassPath: `${this.jhipsterConfig.packageName}.web.rest.UserResource`,
+                    relationships: [],
+                };
+                this.configOptions.sharedEntities.Authority = {
+                    entityClassPath: `${this.jhipsterConfig.packageName}.domain.${this.asEntity('Authority')}`,
+                    entityControllerClassPath: `${this.jhipsterConfig.packageName}.web.rest.AuthorityResource`,
+                    relationships: [],
+                };
+            },
+        };
+    }
+
+    get preparing() {
+        return this._preparing();
+    }
+
     _default() {
         return {
             ...super._missingPreDefault(),

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -63,7 +63,7 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/domain/Entity.java',
-                    renameTo: generator => `${generator.packageFolder}/domain/${generator.asEntity(generator.entityClass)}.java`,
+                    renameTo: generator => `${generator.entityBaseName}.java`,
                 },
             ],
         },
@@ -73,7 +73,7 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/web/rest/EntityResource.java',
-                    renameTo: generator => `${generator.packageFolder}/web/rest/${generator.entityClass}Resource.java`,
+                    renameTo: generator => `${generator.entityControllerBaseName}.java`,
                 },
             ],
         },
@@ -83,11 +83,11 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/service/dto/EntityCriteria.java',
-                    renameTo: generator => `${generator.packageFolder}/service/dto/${generator.entityClass}Criteria.java`,
+                    renameTo: generator => `${generator.domainServiceFolder}/dto/${generator.entityClass}Criteria.java`,
                 },
                 {
                     file: 'package/service/EntityQueryService.java',
-                    renameTo: generator => `${generator.packageFolder}/service/${generator.entityClass}QueryService.java`,
+                    renameTo: generator => `${generator.domainServiceFolder}/${generator.entityClass}QueryService.java`,
                 },
             ],
         },
@@ -97,7 +97,7 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/repository/search/EntitySearchRepository.java',
-                    renameTo: generator => `${generator.packageFolder}/repository/search/${generator.entityClass}SearchRepository.java`,
+                    renameTo: generator => `${generator.domainRepositoryFolder}/search/${generator.entityClass}SearchRepository.java`,
                 },
             ],
         },
@@ -107,7 +107,7 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/repository/EntityRepository.java',
-                    renameTo: generator => `${generator.packageFolder}/repository/${generator.entityClass}Repository.java`,
+                    renameTo: generator => `${generator.entityRepositoryBaseName}.java`,
                 },
             ],
         },
@@ -117,7 +117,7 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/repository/EntityReactiveRepository.java',
-                    renameTo: generator => `${generator.packageFolder}/repository/${generator.entityClass}Repository.java`,
+                    renameTo: generator => `${generator.entityRepositoryBaseName}.java`,
                 },
             ],
         },
@@ -127,11 +127,11 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/repository/EntityReactiveRepositoryInternalImpl.java',
-                    renameTo: generator => `${generator.packageFolder}/repository/${generator.entityClass}RepositoryInternalImpl.java`,
+                    renameTo: generator => `${generator.entityRepositoryBaseName}InternalImpl.java`,
                 },
                 {
                     file: 'package/repository/rowmapper/EntityRowMapper.java',
-                    renameTo: generator => `${generator.packageFolder}/repository/rowmapper/${generator.entityClass}RowMapper.java`,
+                    renameTo: generator => `${generator.domainRepositoryFolder}/rowmapper/${generator.entityClass}RowMapper.java`,
                 },
             ],
         },
@@ -141,11 +141,11 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/service/EntityService.java',
-                    renameTo: generator => `${generator.packageFolder}/service/${generator.entityClass}Service.java`,
+                    renameTo: generator => `${generator.entityServiceBaseName}.java`,
                 },
                 {
                     file: 'package/service/impl/EntityServiceImpl.java',
-                    renameTo: generator => `${generator.packageFolder}/service/impl/${generator.entityClass}ServiceImpl.java`,
+                    renameTo: generator => `${generator.entityServiceImplBaseName}.java`,
                 },
             ],
         },
@@ -155,25 +155,7 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/service/impl/EntityServiceImpl.java',
-                    renameTo: generator => `${generator.packageFolder}/service/${generator.entityClass}Service.java`,
-                },
-            ],
-        },
-        {
-            condition: generator => generator.dto === 'mapstruct',
-            path: SERVER_MAIN_SRC_DIR,
-            templates: [
-                {
-                    file: 'package/service/dto/EntityDTO.java',
-                    renameTo: generator => `${generator.packageFolder}/service/dto/${generator.asDto(generator.entityClass)}.java`,
-                },
-                {
-                    file: 'package/service/mapper/BaseEntityMapper.java',
-                    renameTo: generator => `${generator.packageFolder}/service/mapper/EntityMapper.java`,
-                },
-                {
-                    file: 'package/service/mapper/EntityMapper.java',
-                    renameTo: generator => `${generator.packageFolder}/service/mapper/${generator.entityClass}Mapper.java`,
+                    renameTo: generator => `${generator.entityServiceBaseName}.java`,
                 },
             ],
         },
@@ -193,7 +175,7 @@ const serverFiles = {
                             SERVER_TEST_SRC_DIR,
                         },
                     },
-                    renameTo: generator => `${generator.packageFolder}/web/rest/${generator.entityClass}ResourceIT.java`,
+                    renameTo: generator => `${generator.entityControllerBaseName}IT.java`,
                 },
             ],
         },
@@ -204,7 +186,7 @@ const serverFiles = {
                 {
                     file: 'package/repository/search/EntitySearchRepositoryMockConfiguration.java',
                     renameTo: generator =>
-                        `${generator.packageFolder}/repository/search/${generator.entityClass}SearchRepositoryMockConfiguration.java`,
+                        `${generator.domainRepositoryFolder}/search/${generator.entityClass}SearchRepositoryMockConfiguration.java`,
                 },
             ],
         },
@@ -224,28 +206,48 @@ const serverFiles = {
             templates: [
                 {
                     file: 'package/domain/EntityTest.java',
-                    renameTo: generator => `${generator.packageFolder}/domain/${generator.entityClass}Test.java`,
+                    renameTo: generator => `${generator.entityBaseName}Test.java`,
+                },
+            ],
+        },
+    ],
+};
+
+const dtoFiles = {
+    dto: [
+        {
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/service/dto/EntityDTO.java',
+                    renameTo: generator => `${generator.entityServiceDtoBaseName}.java`,
+                },
+                {
+                    file: 'package/service/mapper/BaseEntityMapper.java',
+                    renameTo: generator => `${generator.domainServiceFolder}/mapper/EntityMapper.java`,
+                },
+                {
+                    file: 'package/service/mapper/EntityMapper.java',
+                    renameTo: generator => `${generator.domainServiceFolder}/mapper/${generator.entityClass}Mapper.java`,
                 },
             ],
         },
         {
-            condition: generator => generator.dto === 'mapstruct',
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
                     file: 'package/service/dto/EntityDTOTest.java',
-                    renameTo: generator => `${generator.packageFolder}/service/dto/${generator.asDto(generator.entityClass)}Test.java`,
+                    renameTo: generator => `${generator.entityServiceDtoBaseName}Test.java`,
                 },
             ],
         },
         {
-            condition: generator =>
-                generator.dto === 'mapstruct' && ['sql', 'mongodb', 'couchbase', 'neo4j'].includes(generator.databaseType),
+            condition: generator => ['sql', 'mongodb', 'couchbase', 'neo4j'].includes(generator.databaseType),
             path: SERVER_TEST_SRC_DIR,
             templates: [
                 {
                     file: 'package/service/mapper/EntityMapperTest.java',
-                    renameTo: generator => `${generator.packageFolder}/service/mapper/${generator.entityClass}MapperTest.java`,
+                    renameTo: generator => `${generator.domainServiceFolder}/mapper/${generator.entityClass}MapperTest.java`,
                 },
             ],
         },
@@ -255,6 +257,7 @@ const serverFiles = {
 module.exports = {
     writeFiles,
     serverFiles,
+    dtoFiles,
 };
 
 function writeFiles() {
@@ -272,15 +275,24 @@ function writeFiles() {
             // write server side files
             this.writeFilesToDisk(serverFiles, this, false, this.fetchFromInstalledJHipster('entity-server/templates'));
 
+            // write dto files for the domain service
+            if (this.dto === 'mapstruct') {
+                this.writeFilesToDisk(dtoFiles, this, false, this.fetchFromInstalledJHipster('entity-server/templates'));
+            }
+
             if (this.databaseType === 'sql') {
                 if (['ehcache', 'caffeine', 'infinispan', 'redis'].includes(this.cacheProvider) && this.enableHibernateCache) {
-                    this.addEntityToCache(
-                        this.asEntity(this.entityClass),
-                        this.relationships,
-                        this.packageName,
-                        this.packageFolder,
-                        this.cacheProvider
-                    );
+                    const entityClassNameGetter = `${this.entityClassPath}.class.getName()`;
+                    this.addEntryToCache(entityClassNameGetter, this.packageFolder, this.cacheProvider);
+                    this.relationships.forEach(relationship => {
+                        if (relationship.relationshipType === 'one-to-many' || relationship.relationshipType === 'many-to-many') {
+                            this.addEntryToCache(
+                                `${entityClassNameGetter} + ".${relationship.relationshipFieldNamePlural}"`,
+                                this.packageFolder,
+                                this.cacheProvider
+                            );
+                        }
+                    });
                 }
             }
         },
@@ -303,10 +315,13 @@ function writeFiles() {
                     )}/${SERVER_MAIN_SRC_DIR}package/domain/enumeration/Enum.java.ejs`;
                     this.template(
                         pathToTemplateFile,
-                        `${SERVER_MAIN_SRC_DIR}${this.packageFolder}/domain/enumeration/${fieldType}.java`,
+                        `${SERVER_MAIN_SRC_DIR}${this.domainModelFolder}/enumeration/${fieldType}.java`,
                         this,
                         {},
-                        enumInfo
+                        {
+                            ...enumInfo,
+                            domainModelPackageName: this.domainModelPackageName,
+                        }
                     );
                 }
             });

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -254,10 +254,25 @@ const dtoFiles = {
     ],
 };
 
+const domainFiles = {
+    domainConfig: [
+        {
+            path: SERVER_MAIN_SRC_DIR,
+            templates: [
+                {
+                    file: 'package/config/DomainConfiguration.java',
+                    renameTo: generator => `${generator.domainRepositoryFolder}/${generator.domainName}DomainConfiguration.java`,
+                },
+            ],
+        },
+    ],
+};
+
 module.exports = {
     writeFiles,
     serverFiles,
     dtoFiles,
+    domainFiles,
 };
 
 function writeFiles() {
@@ -278,6 +293,10 @@ function writeFiles() {
             // write dto files for the domain service
             if (this.dto === 'mapstruct') {
                 this.writeFilesToDisk(dtoFiles, this, false, this.fetchFromInstalledJHipster('entity-server/templates'));
+            }
+            // write domain files.
+            if (this.domainName) {
+                this.writeFilesToDisk(domainFiles, this, false, this.fetchFromInstalledJHipster('entity-server/templates'));
             }
 
             if (this.databaseType === 'sql') {

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -67,14 +67,19 @@ module.exports = class extends BaseBlueprintGenerator {
                 } else {
                     this.domainName = undefined;
                 }
+                const portsPackage = 'infrastructure';
+                const repositoryPort = 'secondary';
+                const controllerPort = 'primary';
 
                 this.domainPackage = this.domainName ? `${this.packageName}.${this.domainName}` : this.packageName;
                 const domainRelativeModelPackage =
                     this.configOptions.domainRelativeModelPackage || this.domainName ? 'domain.model' : 'domain';
                 const domainRelativeRepositoryPackage =
-                    this.configOptions.domainRelativeRepositoryPackage || this.domainName ? 'adapter.repository' : 'repository';
+                    this.configOptions.domainRelativeRepositoryPackage || this.domainName
+                        ? `${portsPackage}.${repositoryPort}`
+                        : 'repository';
                 const domainRelativeWebPackage =
-                    this.configOptions.domainRelativeWebPackage || this.domainName ? 'adapter.web' : 'web.rest';
+                    this.configOptions.domainRelativeWebPackage || this.domainName ? `${portsPackage}.${controllerPort}` : 'web.rest';
                 const domainRelativeServicePackage =
                     this.configOptions.domainRelativeServicePackage || this.domainName ? 'domain.service' : 'service';
 

--- a/generators/entity-server/templates/src/main/java/package/config/DomainConfiguration.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/config/DomainConfiguration.java.ejs
@@ -1,0 +1,32 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+package <%= domainModelPackageName %>.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+<%_ if (searchEngine === 'elasticsearch') { _%>
+import org.springframework.data.elasticsearch.repository.config.Enable<% if (reactive) { %>Reactive<% } %>ElasticsearchRepositories;
+<%_ } _%>
+
+@Configuration
+@EnableJpaRepositories({"<%= domainRepositoryPackageName %>"})
+<%_ if (searchEngine === 'elasticsearch') { _%>
+@Enable<% if (reactive) { %>Reactive<% } %>ElasticsearchRepositories("<%= domainRepositoryPackageName %>.search")
+<%_ } _%>
+public class <%= domainName %>DomainConfiguration {}

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.domain;
+package <%= domainModelPackageName %>;
 
 <%_
 
@@ -31,7 +31,12 @@ for (idx in fields) {
         break;
     }
 }
+
+relatedEntitiesFromAnotherDomain.forEach(entity => {
+_%>import <%= entity.entityClassPath %>;<%_
+});
 _%>
+
 <%_ if (databaseType === 'cassandra') { _%>
 import org.springframework.data.annotation.Id;
     <%_ if (fieldsContainBlob) { _%>
@@ -121,7 +126,7 @@ import java.util.UUID;
 <%_ }
 Object.keys(uniqueEnums).forEach(function(element) { _%>
 
-import <%= packageName %>.domain.enumeration.<%= element %>;
+import <%= domainModelPackageName %>.enumeration.<%= element %>;
 <%_ }); _%>
 
 <%_ if (databaseType === 'couchbase' && !embedded) { _%>

--- a/generators/entity-server/templates/src/main/java/package/domain/enumeration/Enum.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/enumeration/Enum.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.domain.enumeration;
+package <%= domainModelPackageName %>.enumeration;
 
 /**
  * The <%= enumName %> enumeration.

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepository.java.ejs
@@ -16,14 +16,14 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.repository;
+package <%= domainRepositoryPackageName %>;
 
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 <%_ if (databaseType === 'cassandra') { _%>
 import org.springframework.data.cassandra.repository.ReactiveCassandraRepository;
 <%_ } _%>
 <%_ if (searchEngine === 'couchbase') { _%>
-import <%= packageName %>.repository.search.SearchCouchbaseRepository;
+import <%= domainRepositoryPackageName %>.search.SearchCouchbaseRepository;
 <%_ } _%>
 <%_ if (databaseType === 'couchbase') { _%>
 import org.springframework.data.couchbase.core.query.Query;

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepositoryInternalImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepositoryInternalImpl.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.repository;
+package <%= domainRepositoryPackageName %>;
 
 import java.util.function.BiFunction;
 <%_ if (fieldsContainBigDecimal === true) { _%>
@@ -56,19 +56,19 @@ import org.springframework.data.relational.core.sql.SelectBuilder.SelectFromAndJ
 import org.springframework.data.relational.core.sql.Table;
 <%_ } _%>
 
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 <% relationships.forEach(function(rel) {
     if (rel.relationshipType === 'many-to-many' && rel.ownerSide) { _%>
-import <%= packageName %>.domain.<%= asEntity(rel.otherEntityNameCapitalized) %>;
+import <%= domainModelPackageName %>.<%= asEntity(rel.otherEntityNameCapitalized) %>;
     <%_ } _%>
 <%_ } ); _%>
 <%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
 
-import <%= packageName %>.domain.enumeration.<%= element %>;
+import <%= domainModelPackageName %>.enumeration.<%= element %>;
 <%_ }); _%>
 
 <%_ uniqueEntityTypes.forEach(function(element) { _%>
-import <%= packageName %>.repository.rowmapper.<%= element %>RowMapper;
+import <%= domainRepositoryPackageName %>.rowmapper.<%= element %>RowMapper;
 <%_ }); _%>
 import <%= packageName %>.service.EntityManager;
 <%_ if (fieldsContainOwnerManyToMany) { _%>

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -16,9 +16,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.repository;
+package <%= domainRepositoryPackageName %>;
 
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 
 <%_ if (relationshipsContainEagerLoad) { _%>
 import org.springframework.data.domain.Page;
@@ -40,7 +40,7 @@ import org.neo4j.springframework.data.repository.query.Query;
 import java.util.List;
 <%_ } _%>
 <%_ if (searchEngine === 'couchbase') { _%>
-import <%= packageName %>.repository.search.SearchCouchbaseRepository;
+import <%= domainRepositoryPackageName %>.search.SearchCouchbaseRepository;
 <%_ } _%>
 <%_ if (databaseType === 'couchbase' && relationshipsContainEagerLoad === true) { _%>
 import org.springframework.data.couchbase.core.query.Query;

--- a/generators/entity-server/templates/src/main/java/package/repository/rowmapper/EntityRowMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/rowmapper/EntityRowMapper.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.repository.rowmapper;
+package <%= domainRepositoryPackageName %>.rowmapper;
 
 <%_ if (fieldsContainBigDecimal === true) { _%>
 import java.math.BigDecimal;
@@ -35,11 +35,11 @@ import java.util.function.BiFunction;
 
 import org.springframework.stereotype.Service;
 
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 <%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
-import <%= packageName %>.domain.enumeration.<%= element %>;
+import <%= domainModelPackageName %>.enumeration.<%= element %>;
 <%_ }); _%>
-import <%= packageName %>.service.ColumnConverter;
+import <%= domainServicePackageName %>.ColumnConverter;
 
 import io.r2dbc.spi.Row;
 

--- a/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
@@ -16,9 +16,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.repository.search;
+package <%= domainRepositoryPackageName %>.search;
 
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 <%_ if (reactive) { _%>
     <%_ if (pagination !== 'no') { _%>
 import org.springframework.data.domain.Pageable;

--- a/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service;
+package <%= domainServicePackageName %>;
 
 <%_
 const serviceClassName = entityClass + 'QueryService';
@@ -44,14 +44,14 @@ import org.springframework.transaction.annotation.Transactional;
 
 import io.github.jhipster.service.QueryService;
 
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
-import <%= packageName %>.domain.*; // for static metamodels
-import <%= packageName %>.repository.<%= entityClass %>Repository;<% if (searchEngine === 'elasticsearch') { %>
-import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;<% } %>
-import <%= packageName %>.service.dto.<%= entityClass %>Criteria;
+import <%= entityClassPath %>;
+import <%= domainModelPackageName %>.*; // for static metamodels
+import <%= entityRepositoryClassPath %>;<% if (searchEngine === 'elasticsearch') { %>
+import <%= domainRepositoryPackageName %>.search.<%= entityClass %>SearchRepository;<% } %>
+import <%= domainServiceDtoPackageName %>.<%= entityClass %>Criteria;
 <%_ if (dto === 'mapstruct') { _%>
-import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
-import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
+import <%= entityServiceDtoClassPath %>;
+import <%= domainServicePackageName %>.mapper.<%= entityClass %>Mapper;
 <%_ } _%>
 
 /**

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service;
+package <%= domainServicePackageName %>;
 
 <%_
 const instanceType = (dto === 'mapstruct') ? asDto(entityClass) : asEntity(entityClass);
@@ -26,9 +26,9 @@ const listOrFlux = (reactive === true) ? 'Flux' : 'List';
 const pageOrFlux = (reactive === true) ? 'Flux' : 'Page';
 _%>
 <%_ if (dto === 'mapstruct') { _%>
-import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
+import <%= entityServiceDtoClassPath %>;
 <%_ } else { _%>
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 <%_ } _%>
 <%_ if (pagination !== 'no' || relationshipsContainEagerLoad) { _%>
 
@@ -53,7 +53,7 @@ import java.util.UUID;
 <%_ } _%>
 
 /**
- * Service Interface for managing {@link <% if (dto === 'mapstruct') { %><%= packageName %>.domain.<% } %><%= asEntity(entityClass) %>}.
+ * Service Interface for managing {@link <% if (dto === 'mapstruct') { %><%= domainModelPackageName %>.<% } %><%= asEntity(entityClass) %>}.
  */
 public interface <%= entityClass %>Service {
 

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
@@ -1,10 +1,10 @@
-package <%= packageName %>.service.dto;
+package <%= domainServiceDtoPackageName %>;
 
 import java.io.Serializable;
 import java.util.Objects;
 import io.github.jhipster.service.Criteria;
 <%_ for (idx in fields) { if (fields[idx].fieldIsEnum === true) { _%>
-import <%= packageName %>.domain.enumeration.<%= fields[idx].fieldType %>;
+import <%= domainModelPackageName %>.enumeration.<%= fields[idx].fieldType %>;
 <%_ } } _%>
 import io.github.jhipster.service.filter.BooleanFilter;
 import io.github.jhipster.service.filter.DoubleFilter;
@@ -68,8 +68,8 @@ filterVariables.push({ filterType : oauthAwareReferenceFilterType,
 });
 _%>
 /**
- * Criteria class for the {@link <%= packageName %>.domain.<%= asEntity(entityClass) %>} entity. This class is used
- * in {@link <%= packageName %>.web.rest.<%= entityClass %>Resource} to receive all the possible filtering options from
+ * Criteria class for the {@link <%= entityClassPath %>} entity. This class is used
+ * in {@link <%= domainWebPackageName %>.<%= entityClass %>Resource} to receive all the possible filtering options from
  * the Http GET request parameters.
  * For example the following could be a valid request:
  * {@code /<%= entityApiUrl %>?id.greaterThan=5&attr1.contains=something&attr2.specified=false}

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service.dto;
+package <%= domainServiceDtoPackageName %>;
 
 <%_ if (typeof javadoc != 'undefined') { _%>
 import io.swagger.annotations.ApiModel;
@@ -56,11 +56,11 @@ import java.util.UUID;
 import javax.persistence.Lob;
 <%_ } _%>
 <%_ Object.keys(uniqueEnums).forEach(function(element) { _%>
-import <%= packageName %>.domain.enumeration.<%= element %>;
+import <%= domainModelPackageName %>.enumeration.<%= element %>;
 <%_ }); _%>
 
 /**
- * A DTO for the {@link <%= packageName %>.domain.<%= asEntity(entityClass) %>} entity.
+ * A DTO for the {@link <%= entityClassPath %>} entity.
  */
 <%_ if (typeof javadoc !== 'undefined') { _%>
 @ApiModel(description = "<%- formatAsApiDescription(javadoc) %>")

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service<% if (service === 'serviceImpl') { %>.impl<% } %>;
+package <%= domainServicePackageName %><% if (service === 'serviceImpl') { %>.impl<% } %>;
 
 <%_
 const serviceClassName = service === 'serviceImpl' ? entityClass + 'ServiceImpl' : entityClass + 'Service';
@@ -34,19 +34,19 @@ const searchRepository = entityInstance  + 'SearchRepository';
 
 _%>
 <%_ if (service === 'serviceImpl') { _%>
-import <%= packageName %>.service.<%= entityClass %>Service;
+import <%= entityServiceClassPath %>;
 <%_ } _%>
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
-import <%= packageName %>.repository.<%= entityClass %>Repository;
+import <%= entityClassPath %>;
+import <%= entityRepositoryClassPath %>;
 <%_ if (isUsingMapsId === true) { _%>
-import <%= packageName %>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
+import <%= domainRepositoryPackageName %>.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
-import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;
+import <%= domainRepositoryPackageName %>.search.<%= entityClass %>SearchRepository;
 <%_ } _%>
 <%_ if (dto === 'mapstruct') { _%>
-import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
-import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
+import <%= entityServiceDtoClassPath %>;
+import <%= domainServicePackageName %>.mapper.<%= entityClass %>Mapper;
 <%_ } _%>
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/BaseEntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/BaseEntityMapper.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service.mapper;
+package <%= domainServicePackageName %>.mapper;
 
 import java.util.List;
 

--- a/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/mapper/EntityMapper.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service.mapper;
+package <%= domainServicePackageName %>.mapper;
 
 <%_
 let existingMappings = [];
@@ -44,8 +44,8 @@ for (idx in relationships) {
 }
 _%>
 
-import <%= packageName %>.domain.*;
-import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
+import <%= domainModelPackageName %>.*;
+import <%= entityServiceDtoClassPath %>;
 
 import org.mapstruct.*;
 <%_ if (uuidMapMethod) { _%>

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.web.rest;
+package <%= domainWebPackageName %>;
 
 <%_
 const viaService = service !== 'no';
@@ -30,17 +30,17 @@ for (idx in relationships) {
 }
 _%>
 <%_ if (dto !== 'mapstruct' || service === 'no') { _%>
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
 <%_ } _%>
 <%_ if (service !== 'no') { _%>
-import <%= packageName %>.service.<%= entityClass %>Service;
+import <%= entityServiceClassPath %>;
 <%_ } else { _%>
-import <%= packageName %>.repository.<%= entityClass %>Repository;
+import <%= entityRepositoryClassPath %>;
     <%_ if (isUsingMapsId === true) { _%>
-import <%= packageName %>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
+import <%= domainRepositoryPackageName %>.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
     <%_ } _%>
     <%_ if (searchEngine === 'elasticsearch') { _%>
-import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;
+import <%= domainRepositoryPackageName %>.search.<%= entityClass %>SearchRepository;
     <%_ } _%>
 <%_ } _%>
 <%_ if (saveUserSnapshot) { _%>
@@ -48,14 +48,14 @@ import <%= packageName %>.repository.UserRepository;
 <%_ } _%>
 import <%= packageName %>.web.rest.errors.BadRequestAlertException;
 <%_ if (dto === 'mapstruct') { _%>
-import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
+import <%= entityServiceDtoClassPath %>;
     <%_ if (service === 'no') { _%>
-import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
+import <%= domainServicePackageName %>.mapper.<%= entityClass %>Mapper;
     <%_ } _%>
 <%_ } _%>
 <%_ if (jpaMetamodelFiltering) {  _%>
-import <%= packageName %>.service.dto.<%= entityClass %>Criteria;
-import <%= packageName %>.service.<%= entityClass %>QueryService;
+import <%= domainServiceDtoPackageName %>.<%= entityClass %>Criteria;
+import <%= domainServicePackageName %>.<%= entityClass %>QueryService;
 <%_ } _%>
 
 import io.github.jhipster.web.util.HeaderUtil;
@@ -134,7 +134,7 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 <%_ } _%>
 
 /**
- * REST controller for managing {@link <%= packageName %>.domain.<%= asEntity(entityClass) %>}.
+ * REST controller for managing {@link <%= entityClassPath %>}.
  */
 @RestController
 @RequestMapping("/api")

--- a/generators/entity-server/templates/src/main/resources/config/couchmove/changelog/entity.fts.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/couchmove/changelog/entity.fts.ejs
@@ -21,7 +21,7 @@
             "store_dynamic": false,
             "type_field": "_type",
             "types": {
-                "<%= packageName %>.domain.<%= entityClass %>": {
+                "<%= entityClassPath %>": {
                     "dynamic": true,
                     "enabled": true
                 }

--- a/generators/entity-server/templates/src/test/java/package/domain/EntityTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/domain/EntityTest.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.domain;
+package <%= domainModelPackageName %>;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/generators/entity-server/templates/src/test/java/package/repository/search/EntitySearchRepositoryMockConfiguration.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/repository/search/EntitySearchRepositoryMockConfiguration.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.repository.search;
+package <%= domainRepositoryPackageName %>.search;
 
 import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.context.annotation.Configuration;

--- a/generators/entity-server/templates/src/test/java/package/service/dto/EntityDTOTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/service/dto/EntityDTOTest.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service.dto;
+package <%= domainServiceDtoPackageName %>;
 
 import org.junit.jupiter.api.Test;
 import static org.assertj.core.api.Assertions.assertThat;

--- a/generators/entity-server/templates/src/test/java/package/service/mapper/EntityMapperTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/service/mapper/EntityMapperTest.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.service.mapper;
+package <%= domainServicePackageName %>.mapper;
 
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-package <%= packageName %>.web.rest;
+package <%= domainWebPackageName %>;
 
 <%_
 
@@ -57,6 +57,9 @@ if (databaseType === 'sql' && !reactive) {
 }
 
 _%>
+<%_ if (!!domainName) { _%>
+import <%= packageName %>.web.rest.TestUtil;
+<%_ } _%>
 <%_ if (databaseType === 'cassandra') { _%>
 import <%= packageName %>.AbstractCassandraTest;
 <%_ } _%>
@@ -76,41 +79,38 @@ import <%= packageName %>.config.SecurityBeanOverrideConfiguration;
 <%_ if (authenticationType === 'oauth2') { _%>
 import <%= packageName %>.config.TestSecurityConfiguration;
 <%_ } _%>
-import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
+import <%= entityClassPath %>;
+<%_ relatedEntities.forEach(entity => { _%>
+import <%= entity.entityClassPath %>;
+<%_ });
+relatedEntitiesFromAnotherDomain.forEach(entity => { _%>
+import <%= entity.entityControllerClassPath %>IT;
 <%_
-    var imported = [];
-    for (idx in relationships) { // import entities in required relationships
-        const relationshipValidate = relationships[idx].relationshipValidate;
-        const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-        const isUsingMapsIdL1 = relationships[idx].useJPADerivedIdentifier;
-        if (imported.indexOf(otherEntityNameCapitalized) === -1) {
-            if ((relationshipValidate !== null && relationshipValidate === true) || jpaMetamodelFiltering || (isUsingMapsIdL1 === true)) { _%>
-import <%= packageName %>.domain.<%= asEntity(otherEntityNameCapitalized) %>;
-<%_         imported.push(otherEntityNameCapitalized);
-        } } } _%>
+}); _%>
+
 <%_ if (saveUserSnapshot) { _%>
 import <%= packageName %>.repository.UserRepository;
 <%_ } _%>
-import <%= packageName %>.repository.<%= entityClass %>Repository;
+import <%= entityRepositoryClassPath %>;
 <%_ if (databaseType === 'sql' && reactive) { _%>
 import <%= packageName %>.service.EntityManager;
 <%_ } _%>
 <%_ if (isUsingMapsId === true && ( dto !== 'mapstruct' && service === 'no')) { _%>
-import <%= packageName %>.repository.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
+import <%= domainRepositoryPackageName %>.<%= mapsIdAssoc.otherEntityNameCapitalized %>Repository;
 <%_ } _%>
 <%_ if (searchEngine === 'elasticsearch') { _%>
-import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;
+import <%= domainRepositoryPackageName %>.search.<%= entityClass %>SearchRepository;
 <%_ } _%>
 <%_ if (service !== 'no') { _%>
-import <%= packageName %>.service.<%= entityClass %>Service;
+import <%= entityServiceClassPath %>;
 <%_ } _%>
 <%_ if (dto === 'mapstruct') { _%>
-import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
-import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
+import <%= entityServiceDtoClassPath %>;
+import <%= domainServicePackageName %>.mapper.<%= entityClass %>Mapper;
 <%_ } _%>
 <%_ if (jpaMetamodelFiltering) { _%>
-import <%= packageName %>.service.dto.<%= entityClass %>Criteria;
-import <%= packageName %>.service.<%= entityClass %>QueryService;
+import <%= domainServiceDtoPackageName %>.<%= entityClass %>Criteria;
+import <%= domainServicePackageName %>.<%= entityClass %>QueryService;
 <%_ } _%>
 
 <%_ if (databaseType === 'sql' && reactive) { _%>
@@ -207,7 +207,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
 <%_ } _%>
 
-<%_ for (idx in fields) { if (fields[idx].fieldIsEnum === true) { _%>import <%= packageName %>.domain.enumeration.<%= fields[idx].fieldType %>;
+<%_ for (idx in fields) { if (fields[idx].fieldIsEnum === true) { _%>import <%= domainModelPackageName %>.enumeration.<%= fields[idx].fieldType %>;
 <%_ } } _%>
 /**
  * Integration tests for the {@link <%= entityClass %>Resource} REST controller.
@@ -236,7 +236,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 @AutoConfigureWebTestClient
 <%_ } _%>
 @WithMockUser
-class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
     <%_ for (idx in fields) {
     const defaultValueName = 'DEFAULT_' + fields[idx].fieldNameUnderscored.toUpperCase();
     const updatedValueName = 'UPDATED_' + fields[idx].fieldNameUnderscored.toUpperCase();
@@ -442,9 +442,9 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     <%_ } if (searchEngine === 'elasticsearch') { _%>
 
     /**
-     * This repository is mocked in the <%= packageName %>.repository.search test package.
+     * This repository is mocked in the <%= domainRepositoryPackageName %>.search test package.
      *
-     * @see <%= packageName %>.repository.search.<%= entityClass %>SearchRepositoryMockConfiguration
+     * @see <%= domainRepositoryPackageName %>.search.<%= entityClass %>SearchRepositoryMockConfiguration
      */
     @Autowired
     private <%= entityClass %>SearchRepository mock<%= entityClass %>SearchRepository;

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -76,6 +76,15 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
     }
 
     /**
+     * Convert java package to folder.
+     * @param {string} packageName - Package name to convert
+     * @return folder.
+     */
+    packageAsFolder(packageName) {
+        return packageName.replace(/\./g, '/');
+    }
+
+    /**
      * Install I18N Client Files By Language
      *
      * @param {any} _this reference to generator

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -722,7 +722,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {string} packageFolder - the Java package folder
      * @param {string} cacheProvider - the cache provider
      */
-    addEntryToCache(entry, packageFolder, cacheProvider) {
+    addEntryToCache(entry, packageFolder = this.jhipsterConfig.packageFolder, cacheProvider = this.jhipsterConfig.cacheProvider) {
         this.needleApi.serverCache.addEntryToCache(entry, packageFolder, cacheProvider);
     }
 
@@ -2097,6 +2097,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
                 }
             }
         }
+        this.debug(`Files written: ${JSON.stringify(filesOut, null, 4)}`);
         this.debug(`Time taken to write files: ${new Date() - startTime}ms`);
         return filesOut;
     }
@@ -2442,7 +2443,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {String} name entity name
      */
     asEntity(name) {
-        return name + this.entitySuffix;
+        return name + (this.entitySuffix || this.jhipsterConfig.entitySuffix || '');
     }
 
     /**
@@ -2450,7 +2451,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {String} name entity name
      */
     asDto(name) {
-        return name + this.dtoSuffix;
+        return name + (this.dtoSuffix || this.jhipsterConfig.dtoSuffix || 'DTO');
     }
 
     get needleApi() {

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -36,12 +36,15 @@ const prettierTransform = function (defaultOptions) {
                     // for better errors
                     filepath: file.relative,
                 };
+                const str = file.contents.toString('utf8');
                 try {
-                    const str = file.contents.toString('utf8');
                     const data = prettier.format(str, options);
                     file.contents = Buffer.from(data);
                 } catch (error) {
-                    callback(new Error(`Error parsing file ${file.relative}: ${error}`));
+                    callback(
+                        new Error(`Error parsing file ${file.relative}: ${error}
+                    At: ${str}`)
+                    );
                     return;
                 }
             }

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -149,7 +149,7 @@ import static org.springframework.security.test.web.reactive.server.SecurityMock
 <%_ if (reactiveSqlTestContainers) { _%>
 @ExtendWith(ReactiveSqlTestContainerExtension.class)
 <%_ } _%>
-class UserResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
+public class UserResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCassandraTest <% } %>{
 
     private static final String DEFAULT_LOGIN = "johndoe";
     <%_ if (authenticationType !== 'oauth2') { _%>

--- a/test-integration/samples/.jhipster/SuperMegaLargeTestEntity.json
+++ b/test-integration/samples/.jhipster/SuperMegaLargeTestEntity.json
@@ -1,5 +1,6 @@
 {
     "fluentMethods": true,
+    "domainName": "cool",
     "relationships": [
         {
             "relationshipName": "superMegaLargeTestManyToOne",


### PR DESCRIPTION
This PR implements domain support for entities.
```
@domainName(Bar)
entity Foo {}
```

`domainName` is been used instead if `domain` due to conflict with exiting `domain` property (probably EventEmitter class).
To use `domain` would require us to stop using the generator as template data.

Related to https://github.com/jhipster/generator-jhipster/issues/11122
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
