### PR TITLE
fixed turkish character problem

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1046,6 +1046,12 @@
                     <configuration>
                         <source>${java.version}</source>
                         <target>${java.version}</target>
+                        <fork>true</fork>
+                        <compilerArgs>
+                            <compilerArg>-J-Duser.language=en</compilerArg>
+                            <compilerArg>-J-Duser.country=US</compilerArg>
+                            <compilerArg>-J-Dfile.encoding=UTF-8</compilerArg>
+                        </compilerArgs>
                         <annotationProcessorPaths>
                             <path>
                                 <groupId>org.springframework.boot</groupId>


### PR DESCRIPTION
Fixed jpa metamodel generation character encoding problem. Details: https://stackoverflow.com/questions/57182568/hibernate-jpa-2-metamodel-generator-turkish-char-problem