### PR TITLE
Fix: don't generate liquibase changelogs for microservice entities on gateway

### DIFF
--- a/generators/database-changelog-liquibase/index.js
+++ b/generators/database-changelog-liquibase/index.js
@@ -85,7 +85,7 @@ module.exports = class extends BaseGenerator {
     _writing() {
         return {
             setupReproducibility() {
-                if (this.jhipsterConfig.skipServer) {
+                if (this.jhipsterConfig.skipServer || this.entity.skipServer) {
                     return;
                 }
 
@@ -95,7 +95,7 @@ module.exports = class extends BaseGenerator {
 
             writeLiquibaseFiles() {
                 const config = this.jhipsterConfig;
-                if (config.skipServer || config.databaseType !== 'sql') {
+                if (config.skipServer || this.entity.skipServer || config.databaseType !== 'sql') {
                     return;
                 }
 

--- a/utils/entity.js
+++ b/utils/entity.js
@@ -87,7 +87,7 @@ function prepareEntityForTemplates(entityWithConfig, generator) {
     }
 
     entityWithConfig.useMicroserviceJson = entityWithConfig.useMicroserviceJson || entityWithConfig.microserviceName !== undefined;
-    if (entityWithConfig.applicationType === 'gateway' && entityWithConfig.useMicroserviceJson) {
+    if (generator.jhipsterConfig.applicationType === 'gateway' && entityWithConfig.useMicroserviceJson) {
         if (!entityWithConfig.microserviceName) {
             throw new Error('Microservice name for the entity is not found. Entity cannot be generated!');
         }


### PR DESCRIPTION
Currently, if you generate a gateway + microservice with a JDL such as https://github.com/hipster-labs/jhipster-daily-builds/blob/master/test-integration/jdl-samples/templates/microservice-demo.jdl.ejs, the gateway will contain non required liquibase changelogs for entities.
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
