### PR TITLE
fix: some application.yml were still using secret rather than the recommended base64-secret key

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -129,7 +129,7 @@ const serverFiles = {
             templates: [
                 'consul.yml',
                 { file: 'config/git2consul.json', method: 'copy' },
-                { file: 'config/consul-config/application.yml', method: 'copy', renameTo: () => 'central-server-config/application.yml' },
+                { file: 'config/consul-config/application.yml', renameTo: () => 'central-server-config/application.yml' },
             ],
         },
         {
@@ -139,12 +139,10 @@ const serverFiles = {
                 'jhipster-registry.yml',
                 {
                     file: 'config/docker-config/application.yml',
-                    method: 'copy',
                     renameTo: () => 'central-server-config/docker-config/application.yml',
                 },
                 {
                     file: 'config/localhost-config/application.yml',
-                    method: 'copy',
                     renameTo: () => 'central-server-config/localhost-config/application.yml',
                 },
             ],

--- a/generators/server/templates/src/main/docker/config/consul-config/application.yml.ejs
+++ b/generators/server/templates/src/main/docker/config/consul-config/application.yml.ejs
@@ -6,4 +6,4 @@ jhipster:
     security:
         authentication:
             jwt:
-                secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
+                base64-secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded

--- a/generators/server/templates/src/main/docker/config/consul-config/application.yml.ejs
+++ b/generators/server/templates/src/main/docker/config/consul-config/application.yml.ejs
@@ -6,4 +6,5 @@ jhipster:
     security:
         authentication:
             jwt:
-                base64-secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
+                # secret key which should be base64 encoded and changed in production
+                base64-secret: <%= jwtSecretKey %>

--- a/generators/server/templates/src/main/docker/config/docker-config/application.yml.ejs
+++ b/generators/server/templates/src/main/docker/config/docker-config/application.yml.ejs
@@ -7,7 +7,7 @@ jhipster:
     security:
         authentication:
             jwt:
-                secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
+                base64-secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
 
 eureka:
     client:

--- a/generators/server/templates/src/main/docker/config/docker-config/application.yml.ejs
+++ b/generators/server/templates/src/main/docker/config/docker-config/application.yml.ejs
@@ -7,7 +7,8 @@ jhipster:
     security:
         authentication:
             jwt:
-                base64-secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
+                # secret key which should be base64 encoded and changed in production
+                base64-secret: <%= jwtSecretKey %>
 
 eureka:
     client:

--- a/generators/server/templates/src/main/docker/config/localhost-config/application.yml.ejs
+++ b/generators/server/templates/src/main/docker/config/localhost-config/application.yml.ejs
@@ -7,7 +7,7 @@ jhipster:
     security:
         authentication:
             jwt:
-                secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
+                base64-secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
 
 eureka:
     client:

--- a/generators/server/templates/src/main/docker/config/localhost-config/application.yml.ejs
+++ b/generators/server/templates/src/main/docker/config/localhost-config/application.yml.ejs
@@ -7,7 +7,8 @@ jhipster:
     security:
         authentication:
             jwt:
-                base64-secret: my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
+                # secret key which should be base64 encoded and changed in production
+                base64-secret: <%= jwtSecretKey %>
 
 eureka:
     client:


### PR DESCRIPTION
BTW, I wonder if we should not remove support for the non base64 encoded config.
WDYT?
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
