### PR TITLE
[jdl] Support annotation with array value at entities.

### DIFF
--- a/jdl/parsing/ast-builder.js
+++ b/jdl/parsing/ast-builder.js
@@ -159,6 +159,13 @@ class JDLAstBuilderVisitor extends BaseJDLCSTVisitor {
     }
 
     annotationDeclaration(context) {
+        if (context.list) {
+            return {
+                optionName: context.option[0].image,
+                optionValue: this.visit(context.list),
+                type: 'BINARY',
+            };
+        }
         if (!context.value) {
             return { optionName: context.option[0].image, type: 'UNARY' };
         }

--- a/jdl/parsing/jdl-parser.js
+++ b/jdl/parsing/jdl-parser.js
@@ -147,6 +147,7 @@ module.exports = class JDLParser extends CstParser {
             this.OPTION(() => {
                 this.CONSUME(LexerTokens.LPAREN);
                 this.OR([
+                    { ALT: () => this.SUBRULE(this.list) },
                     { ALT: () => this.CONSUME2(LexerTokens.STRING, { LABEL: 'value' }) },
                     { ALT: () => this.CONSUME2(LexerTokens.NAME, { LABEL: 'value' }) },
                     { ALT: () => this.CONSUME3(LexerTokens.INTEGER, { LABEL: 'value' }) },

--- a/test/jdl/jdl-importer.spec.js
+++ b/test/jdl/jdl-importer.spec.js
@@ -1128,6 +1128,7 @@ relationship OneToOne {
                 expect(returned.exportedEntities[0].skipClient).to.equal(true);
                 expect(returned.exportedEntities[0].myCustomUnaryOption).to.equal(true);
                 expect(returned.exportedEntities[0].myCustomBinaryOption).to.equal('customValue');
+                expect(returned.exportedEntities[0].myCustomArrayBinaryOption).to.deep.equal(['value1', 'value2']);
                 expect(returned.exportedEntities[1].pagination).to.equal('pagination');
                 expect(returned.exportedEntities[1].dto).to.equal('mapstruct');
                 expect(returned.exportedEntities[1].service).to.equal('serviceClass');
@@ -1137,6 +1138,13 @@ relationship OneToOne {
                 expect(returned.exportedEntities[2].myCustomBinaryOption).to.equal('customValue2');
                 expect(returned.exportedEntities[0].fields[0].options.id).to.equal(true);
                 expect(returned.exportedEntities[0].fields[0].options.multiValue).to.deep.equal(['value1', 'value2', 'value3']);
+            });
+
+            it('sets relationships options', () => {
+                expect(returned.exportedEntities[0].relationships[0].options.id).to.be.true;
+                expect(returned.exportedEntities[0].relationships[0].options.multiValue).to.deep.equal(['value1', 'value2', 'value3']);
+                expect(returned.exportedEntities[1].relationships[0].options.id).to.be.true;
+                expect(returned.exportedEntities[1].relationships[0].options.multiValue).to.deep.equal(['value1', 'value2', 'value3']);
             });
         });
         context('when parsing a JDL with a pattern validation', () => {

--- a/test/jdl/test-files/annotations.jdl
+++ b/test/jdl/test-files/annotations.jdl
@@ -3,7 +3,7 @@
 @skipClient
 @myCustomUnaryOption
 @myCustomBinaryOption(customValue)
-@myCustomBinaryOption(customValue)
+@myCustomArrayBinaryOption([value1, value2])
 entity A {
   @id @multiValue(value1) @multiValue(value2) @multiValue(value3) name String
   noAnnotation String
@@ -22,5 +22,5 @@ entity B
 entity C
 
 relationship OneToMany {
-  @id A{b required} to B{a}
+  @id @multiValue(value1) @multiValue(value2) @multiValue(value3) A{b required} to B{a}
 }


### PR DESCRIPTION
Add supports to `@arrayOption([value1],[value2]) entity MyEntity{}` 
Fields and relationships supports same annotation multiple times to create an array.
Entity due to how binary option is implemented, this seems quite complicated.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
