### PR TITLE
Export jdl with primary and secondary in relationship definition.

### DIFF
--- a/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.js
+++ b/jdl/converters/jdl-to-json/jdl-to-json-relationship-converter.js
@@ -89,6 +89,7 @@ function setRelationshipsFromEntity(relatedRelationships, entityName) {
         const splitField = extractField(relationshipToConvert.injectedFieldInFrom);
         convertedRelationship.relationshipName = camelCase(splitField.relationshipName || relationshipToConvert.to);
         convertedRelationship.otherEntityField = lowerFirst(splitField.otherEntityField);
+        convertedRelationship.primary = true;
         if (relationshipToConvert.type === ONE_TO_ONE) {
             convertedRelationship.ownerSide = true;
         } else if (relationshipToConvert.type === MANY_TO_MANY) {
@@ -134,6 +135,7 @@ function setRelationshipsToEntity(relatedRelationships, entityName) {
         const splitField = extractField(relationshipToConvert.injectedFieldInTo);
         convertedRelationship.relationshipName = camelCase(splitField.relationshipName || relationshipToConvert.from);
         convertedRelationship.otherEntityField = lowerFirst(splitField.otherEntityField);
+        convertedRelationship.secondary = true;
         if (relationshipToConvert.type === ONE_TO_ONE || relationshipToConvert.type === MANY_TO_MANY) {
             convertedRelationship.ownerSide = false;
         } else if (relationshipToConvert.type === ONE_TO_MANY) {


### PR DESCRIPTION
Add `primary` or `secondary` option to relationship.
Relationship annotations are set at both sides.
When developing blueprints to customize one side of the relationship using jdl is not possible.
```
relationship OneToMany {
  @customPrimaryOption
  A to B
}
```
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
