### PR TITLE
GitHub Actions: improve triage

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -31,9 +31,7 @@ jobs:
                       const issue = { owner: context.issue.owner, repo: context.issue.repo, issue_number: context.issue.number }
                       github.issues.listLabelsOnIssue({...issue}).then(response => {
                         const labels = response.data
-                        let missingLabel = []
-                        let missingArea = true
-                        let missingTheme = true
+                        let missingLabel = [], missingArea = true, missingTheme = true
                         for (const label of labels) {
                           if (label.name.includes('area: ')) {
                             missingArea = false

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -29,4 +29,24 @@ jobs:
                   github-token: ${{secrets.GITHUB_TOKEN}}
                   script: |
                       const issue = { owner: context.issue.owner, repo: context.issue.repo, issue_number: context.issue.number }
-                      github.issues.addLabels({...issue, labels: ['area: triage', 'theme: undefined']})
+                      github.issues.listLabelsOnIssue({...issue}).then(response => {
+                        const labels = response.data
+                        let missingLabel = []
+                        let missingArea = true
+                        let missingTheme = true
+                        for (const label of labels) {
+                          if (label.name.includes('area: ')) {
+                            missingArea = false
+                          }
+                          if (label.name.includes('theme: ')) {
+                            missingTheme = false
+                          }
+                        }
+                        if (missingArea) {
+                          missingLabel.push('area: triage')
+                        }
+                        if (missingTheme) {
+                          missingLabel.push('theme: undefined')
+                        }
+                        github.issues.addLabels({...issue, labels: missingLabel})
+                      })


### PR DESCRIPTION
Before applying these labels: `area: triage` and `theme: undefined`, it will check if one `area` or `theme` already exists.
It will help the core developers to create a new tickets with appropriate labels, without waiting for removing `area: triage` and `theme: undefined`

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
