### PR TITLE
Integrate scripts blueprint into generator-jhipster.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -266,8 +266,8 @@ jobs:
             #----------------------------------------------------------------------
             # Launch tests
             #----------------------------------------------------------------------
-            - name: 'TESTS: Start docker-compose containers'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
+            - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '0'
               run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
               id: backend
@@ -283,6 +283,9 @@ jobs:
               if: matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
               working-directory: ${{ github.workspace }}/app
+            - name: 'TESTS: Start docker-compose containers for e2e tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '1'
+              run: npm run ci:e2e:prepare:docker
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -88,71 +88,71 @@ jobs:
                 include:
                     - app-type: ngx-default
                       entity: sql
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: ngx-mysql-es-noi18n-mapsid
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: ngx-mariadb-oauth2-infinispan
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: ngx-mongodb-kafka-cucumber
                       entity: mongodb
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: ngx-h2mem-ws-nol2
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 0 # TODO: need change to 1, when maven+war is fixed
                       e2e: 1
                       testcontainers: 0
                     - app-type: ngx-gradle-fr
                       entity: sql
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: ngx-gradle-mysql-es-noi18n-mapsid
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: ngx-gradle-mariadb-oauth2-infinispan
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: ngx-gradle-mongodb-kafka-cucumber
                       entity: mongodb
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: ngx-gradle-h2disk-ws-nocache
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 1
                       e2e: 1
                       testcontainers: 0
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
-            JHI_PROFILE: ${{ matrix.profile }}
+            JHI_PROFILE: ${{ matrix.environment }}
             JHI_WAR: ${{ matrix.war }}
             JHI_E2E: ${{ matrix.e2e }}
-            JHI_TESTCONTAINERS: ${{ matrix.testcontainers }}
+            SPRING_PROFILES_ACTIVE: ${{ fromJson('["", "testcontainers"]')[matrix.testcontainers] }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration
@@ -268,16 +268,17 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'TESTS: Start docker-compose containers'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/20-docker-compose.sh
+              run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
+              id: backend
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/21-tests-backend.sh
+              run: npm run ci:backend:test
             - name: 'TESTS: frontend'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/22-tests-frontend.sh
+              run: npm run ci:frontend:test
             - name: 'TESTS: packaging'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/23-package.sh
+              run: npm run ci:e2e:package
             - name: 'E2E: Synchronize chromedriver version'
               if: matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
@@ -285,13 +286,19 @@ jobs:
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/24-tests-e2e.sh
+              run: npm run ci:e2e:run --if-present
+            - name: 'BACKEND: Store failure logs'
+              uses: actions/upload-artifact@v2
+              if: always() && steps.backend.outcome == 'failure'
+              with:
+                  name: log-${{ matrix.app-type }}
+                  path: ${{ github.workspace }}/app/build/test-results/**/*.xml
             - name: 'E2E: Store failure screenshots'
               uses: actions/upload-artifact@v2
               if: always() && steps.e2e.outcome == 'failure'
               with:
                   name: screenshots-${{ matrix.app-type }}
-                  path: ${{ github.workspace }}/app/target/cypress/screenshots
+                  path: ${{ github.workspace }}/app/*/cypress/screenshots
             - name: 'ANALYSIS: Sonar analysis'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: $JHI_SCRIPTS/25-sonar-analyze.sh

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -267,7 +267,7 @@ jobs:
             # Launch tests
             #----------------------------------------------------------------------
             - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '0'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers != 1
               run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
               id: backend
@@ -284,7 +284,7 @@ jobs:
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
               working-directory: ${{ github.workspace }}/app
             - name: 'TESTS: Start docker-compose containers for e2e tests'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '1'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == 1
               run: npm run ci:e2e:prepare:docker
             - name: 'E2E: Run'
               id: e2e

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -132,7 +132,7 @@ jobs:
                       environment: prod
                       war: 0
                       e2e: 1
-                      testcontainers: 0
+                      testcontainers: 1
                     # - app-type: react-gradle-couchbase-caffeine
                     #   entity: couchbase
                     #   environment: prod
@@ -259,8 +259,8 @@ jobs:
             #----------------------------------------------------------------------
             # Launch tests
             #----------------------------------------------------------------------
-            - name: 'TESTS: Start docker-compose containers'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
+            - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '0'
               run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
               id: backend
@@ -276,6 +276,9 @@ jobs:
               if: matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
               working-directory: ${{ github.workspace }}/app
+            - name: 'TESTS: Start docker-compose containers for e2e tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '1'
+              run: npm run ci:e2e:prepare:docker
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -87,65 +87,65 @@ jobs:
                 include:
                     - app-type: react-default
                       entity: sql
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: react-maven-mysql-es-noi18n-mapsid
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: react-maven-h2mem-memcached
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 0 # TODO: need change to 1, when maven+war is fixed
                       e2e: 1
                       testcontainers: 0
                     - app-type: react-maven-cassandra-session-redis
                       entity: cassandra
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     # - app-type: react-maven-couchbase-caffeine
                     #   entity: couchbase
-                    #   profile: prod
+                    #   environment: prod
                     #   war: 0
                     #   e2e: 0
                     #   testcontainers: 0
                     - app-type: react-gradle-mysql-es-noi18n-mapsid
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     - app-type: react-gradle-h2mem-memcached
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 1
                       e2e: 1
                       testcontainers: 0
                     - app-type: react-gradle-cassandra-session-redis
                       entity: cassandra
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 0
                     # - app-type: react-gradle-couchbase-caffeine
                     #   entity: couchbase
-                    #   profile: prod
+                    #   environment: prod
                     #   war: 0
                     #   e2e: 1
                     #   testcontainers: 0
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
-            JHI_PROFILE: ${{ matrix.profile }}
+            JHI_PROFILE: ${{ matrix.environment }}
             JHI_WAR: ${{ matrix.war }}
             JHI_E2E: ${{ matrix.e2e }}
-            JHI_TESTCONTAINERS: ${{ matrix.testcontainers }}
+            SPRING_PROFILES_ACTIVE: ${{ fromJson('["", "testcontainers"]')[matrix.testcontainers] }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration
@@ -261,16 +261,17 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'TESTS: Start docker-compose containers'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/20-docker-compose.sh
+              run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
+              id: backend
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/21-tests-backend.sh
+              run: npm run ci:backend:test
             - name: 'TESTS: frontend'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/22-tests-frontend.sh
+              run: npm run ci:frontend:test
             - name: 'TESTS: packaging'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/23-package.sh
+              run: npm run ci:e2e:package
             - name: 'E2E: Synchronize chromedriver version'
               if: matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
@@ -278,13 +279,19 @@ jobs:
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/24-tests-e2e.sh
+              run: npm run ci:e2e:run --if-present
+            - name: 'BACKEND: Store failure logs'
+              uses: actions/upload-artifact@v2
+              if: always() && steps.backend.outcome == 'failure'
+              with:
+                  name: log-${{ matrix.app-type }}
+                  path: ${{ github.workspace }}/app/build/test-results/**/*.xml
             - name: 'E2E: Store failure screenshots'
               uses: actions/upload-artifact@v2
               if: always() && steps.e2e.outcome == 'failure'
               with:
                   name: screenshots-${{ matrix.app-type }}
-                  path: ${{ github.workspace }}/app/target/cypress/screenshots
+                  path: ${{ github.workspace }}/app/*/cypress/screenshots
             - name: 'ANALYSIS: Sonar analysis'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: $JHI_SCRIPTS/25-sonar-analyze.sh

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -108,7 +108,7 @@ jobs:
                       environment: prod
                       war: 0
                       e2e: 1
-                      testcontainers: 0
+                      testcontainers: 1
                     # - app-type: react-maven-couchbase-caffeine
                     #   entity: couchbase
                     #   environment: prod
@@ -260,7 +260,7 @@ jobs:
             # Launch tests
             #----------------------------------------------------------------------
             - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '0'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers != 1
               run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
               id: backend
@@ -277,7 +277,7 @@ jobs:
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
               working-directory: ${{ github.workspace }}/app
             - name: 'TESTS: Start docker-compose containers for e2e tests'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '1'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == 1
               run: npm run ci:e2e:prepare:docker
             - name: 'E2E: Run'
               id: e2e

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -256,8 +256,8 @@ jobs:
             #----------------------------------------------------------------------
             # Launch tests
             #----------------------------------------------------------------------
-            - name: 'TESTS: Start docker-compose containers'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
+            - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '0'
               run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
               id: backend
@@ -273,6 +273,9 @@ jobs:
               if: matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
               working-directory: ${{ github.workspace }}/app
+            - name: 'TESTS: Start docker-compose containers for e2e tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '1'
+              run: npm run ci:e2e:prepare:docker
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -88,60 +88,61 @@ jobs:
                 include:
                     - app-type: vue-default
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                     - app-type: vue-noi18n
                       entity: sqlfull
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                     - app-type: vue-fulli18n-es
                       entity: sql
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                     - app-type: vue-gateway
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
                     - app-type: vue-gradle-session
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
                     - app-type: vue-ws-theme
                       entity: sql
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
                     - app-type: vue-oauth2
                       entity: sql
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                     # - app-type: vue-couchbase
                     #   entity: couchbase
-                    #   profile: dev,webpack
+                    #   environment: dev
                     #   war: 0
                     #   e2e: 1
                     - app-type: vue-mongodb-kafka-cucumber
                       entity: mongodb
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
                     - app-type: vue-session-cassandra-fr
                       entity: cassandra
-                      profile: dev,webpack
+                      environment: dev
                       war: 0
                       e2e: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
-            JHI_PROFILE: ${{ matrix.profile }}
+            JHI_PROFILE: ${{ matrix.environment }}
             JHI_WAR: ${{ matrix.war }}
             JHI_E2E: ${{ matrix.e2e }}
+            SPRING_PROFILES_ACTIVE: ${{ fromJson('["", "testcontainers"]')[matrix.testcontainers] }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration
@@ -257,16 +258,17 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'TESTS: Start docker-compose containers'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/20-docker-compose.sh
+              run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
+              id: backend
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/21-tests-backend.sh
+              run: npm run ci:backend:test
             - name: 'TESTS: frontend'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/22-tests-frontend.sh
+              run: npm run ci:frontend:test
             - name: 'TESTS: packaging'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/23-package.sh
+              run: npm run ci:e2e:package
             - name: 'E2E: Synchronize chromedriver version'
               if: matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
@@ -274,13 +276,19 @@ jobs:
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/24-tests-e2e.sh
+              run: npm run ci:e2e:run --if-present
+            - name: 'BACKEND: Store failure logs'
+              uses: actions/upload-artifact@v2
+              if: always() && steps.backend.outcome == 'failure'
+              with:
+                  name: log-${{ matrix.app-type }}
+                  path: ${{ github.workspace }}/app/build/test-results/**/*.xml
             - name: 'E2E: Store failure screenshots'
               uses: actions/upload-artifact@v2
               if: always() && steps.e2e.outcome == 'failure'
               with:
                   name: screenshots-${{ matrix.app-type }}
-                  path: ${{ github.workspace }}/app/target/cypress/screenshots
+                  path: ${{ github.workspace }}/app/*/cypress/screenshots
             - name: 'ANALYSIS: Sonar analysis'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: $JHI_SCRIPTS/25-sonar-analyze.sh

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -136,6 +136,7 @@ jobs:
                       environment: dev
                       war: 0
                       e2e: 1
+                      testcontainers: 1
         env:
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
@@ -257,7 +258,7 @@ jobs:
             # Launch tests
             #----------------------------------------------------------------------
             - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '0'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers != 1
               run: npm run ci:e2e:prepare:docker
             - name: 'TESTS: backend'
               id: backend
@@ -274,7 +275,7 @@ jobs:
               run: npm run e2e:update-webdriver -- --versions.chrome ${{ steps.chromedriver-version.outputs.version }}
               working-directory: ${{ github.workspace }}/app
             - name: 'TESTS: Start docker-compose containers for e2e tests'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == '1'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == 1
               run: npm run ci:e2e:prepare:docker
             - name: 'E2E: Run'
               id: e2e

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -306,6 +306,40 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
     // Public API method used by the getter and also by Blueprints
     _postWriting() {
         return {
+            packageJsonScripts() {
+                if (this.skipClient) return;
+                const packageJsonStorage = this.createStorage('package.json');
+                const scriptsStorage = packageJsonStorage.createStorage('scripts');
+
+                const packageJsonConfigStorage = packageJsonStorage.createStorage('config').createProxy();
+                if (process.env.JHI_PROFILE) {
+                    packageJsonConfigStorage.default_enviroment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
+                }
+
+                const devDependencies = packageJsonStorage.createStorage('devDependencies');
+                devDependencies.set('wait-on', 'VERSION_MANAGED_BY_CLIENT_COMMON');
+                devDependencies.set('concurrently', 'VERSION_MANAGED_BY_CLIENT_COMMON');
+
+                if (this.clientFramework === 'react') {
+                    scriptsStorage.set(
+                        'ci:frontend:test',
+                        'npm run webpack:build:$npm_package_config_default_enviroment && npm run test-ci'
+                    );
+                } else {
+                    scriptsStorage.set('ci:frontend:test', 'npm run webpack:build:$npm_package_config_default_enviroment && npm test');
+                }
+
+                if (scriptsStorage.get('e2e')) {
+                    scriptsStorage.set({
+                        'ci:server:await':
+                            'echo "Waiting for server at port $npm_package_config_backend_port to start" && wait-on http-get://localhost:$npm_package_config_backend_port/management/health && echo "Server at port $npm_package_config_backend_port started"',
+                        'pree2e:headless': 'npm run ci:server:await',
+                        'ci:e2e:run': 'concurrently -k -s first "npm run ci:e2e:server:start" "npm run e2e:headless"',
+                        'e2e:dev': 'concurrently -k -s first "./mvnw" "e2e:run"',
+                    });
+                }
+            },
+
             packageJson() {
                 if (this.skipClient) return;
                 this.replacePackageJsonVersions(

--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -313,7 +313,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
 
                 const packageJsonConfigStorage = packageJsonStorage.createStorage('config').createProxy();
                 if (process.env.JHI_PROFILE) {
-                    packageJsonConfigStorage.default_enviroment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
+                    packageJsonConfigStorage.default_environment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
                 }
 
                 const devDependencies = packageJsonStorage.createStorage('devDependencies');
@@ -323,10 +323,10 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
                 if (this.clientFramework === 'react') {
                     scriptsStorage.set(
                         'ci:frontend:test',
-                        'npm run webpack:build:$npm_package_config_default_enviroment && npm run test-ci'
+                        'npm run webpack:build:$npm_package_config_default_environment && npm run test-ci'
                     );
                 } else {
-                    scriptsStorage.set('ci:frontend:test', 'npm run webpack:build:$npm_package_config_default_enviroment && npm test');
+                    scriptsStorage.set('ci:frontend:test', 'npm run webpack:build:$npm_package_config_default_environment && npm test');
                 }
 
                 if (scriptsStorage.get('e2e')) {

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -170,11 +170,11 @@ limitations under the License.
     "node": ">=<%= NODE_VERSION %>"
   },
   "config": {
-    "default_enviroment": "prod"
+    "default_environment": "prod"
   },
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
-    "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
+    "lint": "eslint . --ext .js,.ts",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "ngc": "ngc -p tsconfig.app.json",
     "cleanup": "rimraf <%= DIST_DIR %>",
@@ -210,7 +210,7 @@ limitations under the License.
     "pretest": "<%= clientPackageManager %> run lint",
     "test": "<%= clientPackageManager %> run jest",
     "test:watch": "<%= clientPackageManager %> run jest -- --watch",
-    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_enviroment",
+    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_environment",
     "webpack:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --env.stats=minimal",
     "webpack:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --inline --hot --port=9060 --watch-content-base --env.stats=minimal",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -169,9 +169,12 @@ limitations under the License.
   "engines": {
     "node": ">=<%= NODE_VERSION %>"
   },
+  "config": {
+    "default_enviroment": "prod"
+  },
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
-    "lint": "eslint . --ext .js,.ts",
+    "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
     "lint:fix": "<%= clientPackageManager %> run lint -- --fix",
     "ngc": "ngc -p tsconfig.app.json",
     "cleanup": "rimraf <%= DIST_DIR %>",
@@ -196,21 +199,23 @@ limitations under the License.
     "postinstall": "<%= clientPackageManager %> run e2e:update-webdriver",
     "e2e:update-webdriver": "webdriver-manager update --gecko false",
     <%_ } _%>
+    "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config <%= CLIENT_TEST_SRC_DIR %>jest.conf.js",
     "start": "<%= clientPackageManager %> run webpack:dev",
+    "start-tls": "<%= clientPackageManager %> run webpack:dev -- --env.tls",
     <%_ if (skipServer) { _%>
     "sonar": "sonar-scanner",
     <%_ } _%>
-    "start-tls": "<%= clientPackageManager %> run webpack:dev -- --env.tls",
     "serve": "<%= clientPackageManager %> run start",
     "build": "<%= clientPackageManager %> run webpack:prod",
-    "test": "<%= clientPackageManager %> run lint && jest --coverage --logHeapUsage -w=2 --config <%= CLIENT_TEST_SRC_DIR %>jest.conf.js",
-    "test:watch": "<%= clientPackageManager %> run test -- --watch",
+    "pretest": "<%= clientPackageManager %> run lint",
+    "test": "<%= clientPackageManager %> run jest",
+    "test:watch": "<%= clientPackageManager %> run jest -- --watch",
+    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_enviroment",
+    "webpack:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --env.stats=minimal",
+    "webpack:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --inline --hot --port=9060 --watch-content-base --env.stats=minimal",
     "webpack:dev-verbose": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --inline --hot --port=9060 --watch-content-base --profile --progress --env.stats=normal",
-    "webpack:build:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --env.stats=minimal",
-    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:main",
-    "webpack:prod:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile",
-    "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:prod:main && <%= clientPackageManager %> run clean-www",
+    "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:prod && <%= clientPackageManager %> run clean-www",
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -180,7 +180,7 @@ limitations under the License.
     "e2e": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:headless": "<%= clientPackageManager %> run e2e:protractor:headless",
     <%_ } else if ((cypressTests && !protractorTests) || (protractorTests && cypressTests)) {  _%>
-    "e2e": "<%= clientPackageManager %> run cypress",
+    "e2e": "<%= clientPackageManager %> run e2e:cypress",
     "e2e:headless": "<%= clientPackageManager %> run e2e:cypress:headless",
     <%_ } _%>
     <%_ if (protractorTests) { _%>
@@ -188,7 +188,8 @@ limitations under the License.
     "e2e:protractor": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
     <%_ } _%>
     <%_ if (cypressTests) { _%>
-    "e2e:cypress:headless": "cypress run --browser chrome --headless",
+    "e2e:cypress:headless": "<%= clientPackageManager %> run e2e:cypress -- --headless",
+    "e2e:cypress": "cypress run --browser chrome",
     "cypress": "cypress open",
     <%_ } _%>
     <%_ if (protractorTests || cypressTests) { _%>

--- a/generators/client/templates/common/package.json
+++ b/generators/client/templates/common/package.json
@@ -1,6 +1,8 @@
 {
   "devDependencies": {
+    "concurrently": "5.3.0",
     "cypress": "5.3.0",
-    "typescript": "4.0.3"
+    "typescript": "4.0.3",
+    "wait-on": "5.2.0"
   }
 }

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -184,6 +184,9 @@ limitations under the License.
   "engines": {
     "node": ">=<%= NODE_VERSION %>"
   },
+  "config": {
+    "default_enviroment": "prod"
+  },
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
     "lint": "eslint . --ext .js,.ts,.jsx,.tsx",
@@ -209,22 +212,23 @@ limitations under the License.
     "postinstall": "<%= clientPackageManager %> run e2e:update-webdriver",
     "e2e:update-webdriver": "webdriver-manager update --gecko false",
     <%_ } _%>
+    "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config <%= CLIENT_TEST_SRC_DIR %>jest.conf.js",
+    "jest:update": "<%= clientPackageManager %> run jest -- --updateSnapshot",
+    "start": "<%= clientPackageManager %> run webpack:dev",
+    "start-tls": "<%= clientPackageManager %> run webpack:dev -- --env.tls",
     <%_ if (skipServer) { _%>
     "sonar": "sonar-scanner",
     <%_ } _%>
-    "start": "<%= clientPackageManager %> run webpack:dev",
-    "start-tls": "<%= clientPackageManager %> run webpack:dev -- --env.tls",
-    "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config <%= CLIENT_TEST_SRC_DIR %>jest.conf.js",
-    "jest:update": "<%= clientPackageManager %> run jest -- --updateSnapshot",
-    "test": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest",
+    "pretest": "<%= clientPackageManager %> run lint",
+    "test": "<%= clientPackageManager %> run jest",
     "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
-    "test:watch": "<%= clientPackageManager %> test -- --watch",
+    "test:watch": "<%= clientPackageManager %> run jest -- --watch",
+    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_enviroment",
+    "webpack:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --env.stats=minimal",
+    "webpack:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --inline --port=9060 --env.stats=minimal",
     "webpack:dev-verbose": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --inline --port=9060 --profile --progress --env.stats=normal",
-    "webpack:build:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --env.stats=minimal",
-    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:main",
-    "webpack:prod:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile",
-    "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:prod:main",
+    "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:prod",
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
     "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -185,7 +185,7 @@ limitations under the License.
     "node": ">=<%= NODE_VERSION %>"
   },
   "config": {
-    "default_enviroment": "prod"
+    "default_environment": "prod"
   },
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
@@ -223,7 +223,7 @@ limitations under the License.
     "test": "<%= clientPackageManager %> run jest",
     "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
     "test:watch": "<%= clientPackageManager %> run jest -- --watch",
-    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_enviroment",
+    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_environment",
     "webpack:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --env.stats=minimal",
     "webpack:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --inline --port=9060 --env.stats=minimal",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -193,7 +193,7 @@ limitations under the License.
     "e2e": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:headless": "<%= clientPackageManager %> run e2e:protractor:headless",
     <%_ } else if ((cypressTests && !protractorTests) || (protractorTests && cypressTests)) {  _%>
-    "e2e": "<%= clientPackageManager %> run cypress",
+    "e2e": "<%= clientPackageManager %> run e2e:cypress",
     "e2e:headless": "<%= clientPackageManager %> run e2e:cypress:headless",
     <%_ } _%>
     <%_ if (protractorTests) { _%>
@@ -201,7 +201,8 @@ limitations under the License.
     "e2e:protractor": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
     <%_ } _%>
     <%_ if (cypressTests) { _%>
-    "e2e:cypress:headless": "cypress run --browser chrome --headless",
+    "e2e:cypress:headless": "<%= clientPackageManager %> run e2e:cypress -- --headless",
+    "e2e:cypress": "cypress run --browser chrome",
     "cypress": "cypress open",
     <%_ } _%>
     <%_ if (protractorTests || cypressTests) { _%>

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -156,8 +156,11 @@ limitations under the License.
     "webpack-merge": "5.0.9"
   },
   "engines": {
-    "node": ">= 10.17.0",
+    "node": ">=<%= NODE_VERSION %>",
     "npm": ">= 6.13.4"
+  },
+  "config": {
+    "default_enviroment": "prod"
   },
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
@@ -191,17 +194,18 @@ limitations under the License.
     <%_ } _%>
     "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --no-cache --config <%= CLIENT_TEST_SRC_DIR %>jest.conf.js",
     "jest:update": "<%= clientPackageManager %> run jest -- --updateSnapshot",
-    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:main",
-    "webpack:build:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --profile --env.stats=minimal",
-    "webpack:prod:main": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile --env.stats=minimal",
-    "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:prod:main && <%= clientPackageManager %> run clean-www",
+    "pretest": "<%= clientPackageManager %> run lint",
+    "test": "<%= clientPackageManager %> run jest",
+    "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
+    "test:watch": "<%= clientPackageManager %> run jest -- --watch",
+    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_enviroment",
+    "webpack:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --profile --env.stats=minimal",
+    "webpack:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile --env.stats=minimal",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress --inline --env.stats=normal",
+    "webpack:prod": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:prod && <%= clientPackageManager %> run clean-www",
     "webpack:test": "<%= clientPackageManager %> run test",
     "webpack-dev-server": "node --max_old_space_size=4096 node_modules/webpack-dev-server/bin/webpack-dev-server.js",
-    "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js",
-    "test": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest",
-    "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
-    "test:watch": "<%= clientPackageManager %> run jest -- --watch"
+    "webpack": "node --max_old_space_size=4096 node_modules/webpack/bin/webpack.js"
   },
   "jestSonar": {
     "reportPath": "<%= BUILD_DIR %>test-results/jest",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -160,7 +160,7 @@ limitations under the License.
     "npm": ">= 6.13.4"
   },
   "config": {
-    "default_enviroment": "prod"
+    "default_environment": "prod"
   },
   "scripts": {
     "prettier:format": "prettier --write \"{,src/**/,webpack/}*.{<%= getPrettierExtensions() %>}\"",
@@ -198,7 +198,7 @@ limitations under the License.
     "test": "<%= clientPackageManager %> run jest",
     "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
     "test:watch": "<%= clientPackageManager %> run jest -- --watch",
-    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_enviroment",
+    "webpack:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webpack:build:$npm_package_config_default_environment",
     "webpack:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --profile --env.stats=minimal",
     "webpack:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --profile --env.stats=minimal",
     "webpack:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress --inline --env.stats=normal",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -173,7 +173,7 @@ limitations under the License.
     "e2e": "<%= clientPackageManager %> run e2e:protractor",
     "e2e:headless": "<%= clientPackageManager %> run e2e:protractor:headless",
     <%_ } else if ((cypressTests && !protractorTests) || (protractorTests && cypressTests)) {  _%>
-    "e2e": "<%= clientPackageManager %> run cypress",
+    "e2e": "<%= clientPackageManager %> run e2e:cypress",
     "e2e:headless": "<%= clientPackageManager %> run e2e:cypress:headless",
     <%_ } _%>
     <%_ if (protractorTests) { _%>
@@ -181,7 +181,8 @@ limitations under the License.
     "e2e:protractor": "protractor <%= TEST_SRC_DIR %>protractor.conf.js",
     <%_ } _%>
     <%_ if (cypressTests) { _%>
-    "e2e:cypress:headless": "cypress run --browser chrome --headless",
+    "e2e:cypress:headless": "<%= clientPackageManager %> run e2e:cypress -- --headless",
+    "e2e:cypress": "cypress run --browser chrome",
     "cypress": "cypress open",
     <%_ } _%>
     <%_ if (protractorTests || cypressTests) { _%>

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -342,6 +342,120 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
         return this._writing();
     }
 
+    _postWriting() {
+        return {
+            packageJsonScripts() {
+                const packageJsonStorage = this.createStorage('package.json');
+                const packageJsonConfigStorage = packageJsonStorage.createStorage('config').createProxy();
+                packageJsonConfigStorage.backend_port = this.serverPort;
+                packageJsonConfigStorage.packaging = process.env.JHI_WAR === '1' ? 'war' : 'jar';
+                if (process.env.JHI_PROFILE) {
+                    packageJsonConfigStorage.default_enviroment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
+                }
+            },
+            packageJsonDockerScripts() {
+                const packageJsonStorage = this.createStorage('package.json');
+                const scriptsStorage = packageJsonStorage.createStorage('scripts');
+                const databaseType = this.jhipsterConfig.databaseType;
+                if (databaseType === 'sql') {
+                    const prodDatabaseType = this.jhipsterConfig.prodDatabaseType;
+                    if (prodDatabaseType === 'no' || prodDatabaseType === 'oracle') {
+                        scriptsStorage.set(
+                            'docker:db',
+                            `echo "Docker for db ${prodDatabaseType} not configured for application ${this.baseName}"`
+                        );
+                    } else {
+                        scriptsStorage.set('docker:db', `docker-compose -f src/main/docker/${prodDatabaseType}.yml up -d`);
+                    }
+                } else {
+                    const dockerFile = `src/main/docker/${databaseType}.yml`;
+                    if (databaseType === 'couchbase' || databaseType === 'cassandra') {
+                        scriptsStorage.set({
+                            'docker:db:build': `docker-compose -f ${dockerFile} build`,
+                            'docker:db': `docker-compose -f ${dockerFile} up -d`,
+                        });
+                    } else if (this.fs.exists(this.destinationPath(dockerFile))) {
+                        scriptsStorage.set('docker:db', `docker-compose -f ${dockerFile} up -d`);
+                    } else {
+                        scriptsStorage.set(
+                            'docker:db',
+                            `echo "Docker for db ${databaseType} not configured for application ${this.baseName}"`
+                        );
+                    }
+                }
+
+                this.dockerOthers = [];
+                ['keycloak', 'elasticsearch', 'kafka', 'consul', 'redis', 'memcached', 'jhipster-registry', 'sonar'].forEach(
+                    dockerConfig => {
+                        const dockerFile = `src/main/docker/${dockerConfig}.yml`;
+                        if (this.fs.exists(this.destinationPath(dockerFile))) {
+                            scriptsStorage.set(`docker:${dockerConfig}`, `docker-compose -f ${dockerFile} up -d`);
+                            this.dockerOthers.push(`npm run docker:${dockerConfig}`);
+                        }
+                    }
+                );
+                scriptsStorage.set({
+                    'docker:others': this.dockerOthers.join(' && '),
+                    'ci:e2e:prepare:docker': 'npm run docker:db && npm run docker:others && docker ps -a',
+                });
+            },
+            packageJsonBackendScripts() {
+                const packageJsonStorage = this.createStorage('package.json');
+                const scriptsStorage = packageJsonStorage.createStorage('scripts');
+                const javaCommonLog = `-Dlogging.level.ROOT=OFF -Dlogging.level.org.zalando=OFF -Dlogging.level.io.github.jhipster=OFF -Dlogging.level.${this.jhipsterConfig.packageName}=OFF`;
+                const javaTestLog =
+                    '-Dlogging.level.org.springframework=OFF -Dlogging.level.org.springframework.web=OFF -Dlogging.level.org.springframework.security=OFF';
+
+                const buildTool = this.jhipsterConfig.buildTool;
+                let e2ePackage = 'target/e2e';
+                if (buildTool === 'maven') {
+                    scriptsStorage.set({
+                        'backend:info': './mvnw -ntp enforcer:display-info --batch-mode',
+                        'backend:doc:test': './mvnw -ntp javadoc:javadoc --batch-mode',
+                        'backend:nohttp:test': './mvnw -ntp checkstyle:check --batch-mode',
+                        'java:jar': './mvnw -ntp verify -DskipTests --batch-mode',
+                        'java:war': './mvnw -ntp verify -DskipTests --batch-mode -Pwar',
+                        'java:docker': './mvnw -ntp verify -DskipTests jib:dockerBuild',
+                        'backend:unit:test': `./mvnw -ntp -P-webpack verify --batch-mode ${javaCommonLog} ${javaTestLog}`,
+                    });
+                } else if (buildTool === 'gradle') {
+                    const excludeWebpack = this.jhipsterConfig.skipClient ? '' : '-x webpack';
+                    e2ePackage = 'e2e';
+                    scriptsStorage.set({
+                        'backend:info': './gradlew -v',
+                        'backend:doc:test': `./gradlew javadoc ${excludeWebpack}`,
+                        'backend:nohttp:test': `./gradlew checkstyleNohttp ${excludeWebpack}`,
+                        'java:jar': './gradlew bootJar -x test',
+                        'java:war': './gradlew bootWar -Pwar -x test',
+                        'java:docker': './gradlew bootJar jibDockerBuild',
+                        'backend:unit:test': `./gradlew test integrationTest ${excludeWebpack} -Ptestcontainers ${javaCommonLog} ${javaTestLog}`,
+                        'postci:e2e:package': 'cp build/libs/*SNAPSHOT.$npm_package_config_packaging e2e.$npm_package_config_packaging',
+                    });
+                }
+
+                scriptsStorage.set({
+                    'java:jar:dev': 'npm run java:jar -- -Pdev,webpack',
+                    'java:jar:prod': 'npm run java:jar -- -Pprod',
+                    'java:war:dev': 'npm run java:war -- -Pdev,webpack',
+                    'java:war:prod': 'npm run java:war -- -Pprod',
+                    'java:docker:dev': 'npm run java:docker -- -Pdev,webpack',
+                    'java:docker:prod': 'npm run java:docker -- -Pprod',
+                    'ci:backend:test':
+                        'npm run backend:info && npm run backend:doc:test && npm run backend:nohttp:test && npm run backend:unit:test',
+                    'server:package': 'npm run java:$npm_package_config_packaging:$npm_package_config_default_enviroment',
+                    'ci:e2e:package':
+                        'npm run java:$npm_package_config_packaging:$npm_package_config_default_enviroment -- -Pe2e -Denforcer.skip=true',
+                    'ci:e2e:server:start': `java -jar ${e2ePackage}.$npm_package_config_packaging --spring.profiles.active=$npm_package_config_default_enviroment ${javaCommonLog} --logging.level.org.springframework.web=ERROR`,
+                });
+            },
+        };
+    }
+
+    get postWriting() {
+        if (useBlueprints) return;
+        return this._postWriting();
+    }
+
     _install() {
         return {
             installing() {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -386,19 +386,17 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
 
                 const dockerOthers = [];
                 const dockerBuild = [];
-                ['keycloak', 'elasticsearch', 'kafka', 'consul', 'redis', 'memcached', 'jhipster-registry'].forEach(
-                    dockerConfig => {
-                        const dockerFile = `src/main/docker/${dockerConfig}.yml`;
-                        if (this.fs.exists(this.destinationPath(dockerFile))) {
-                            if (['cassandra', 'couchbase'].includes(dockerConfig)) {
-                                scriptsStorage.set(`docker:${dockerConfig}:build`, `docker-compose -f ${dockerFile} build`);
-                                dockerBuild.push(`npm run docker:${dockerConfig}:build`);
-                            }
-                            scriptsStorage.set(`docker:${dockerConfig}`, `docker-compose -f ${dockerFile} up -d`);
-                            dockerOthers.push(`npm run docker:${dockerConfig}`);
+                ['keycloak', 'elasticsearch', 'kafka', 'consul', 'redis', 'memcached', 'jhipster-registry'].forEach(dockerConfig => {
+                    const dockerFile = `src/main/docker/${dockerConfig}.yml`;
+                    if (this.fs.exists(this.destinationPath(dockerFile))) {
+                        if (['cassandra', 'couchbase'].includes(dockerConfig)) {
+                            scriptsStorage.set(`docker:${dockerConfig}:build`, `docker-compose -f ${dockerFile} build`);
+                            dockerBuild.push(`npm run docker:${dockerConfig}:build`);
                         }
+                        scriptsStorage.set(`docker:${dockerConfig}`, `docker-compose -f ${dockerFile} up -d`);
+                        dockerOthers.push(`npm run docker:${dockerConfig}`);
                     }
-                );
+                });
                 scriptsStorage.set({
                     'predocker:others': dockerBuild.join(' && '),
                     'docker:others': dockerOthers.join(' && '),
@@ -451,7 +449,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                     'server:package': 'npm run java:$npm_package_config_packaging:$npm_package_config_default_environment',
                     'ci:e2e:package':
                         'npm run java:$npm_package_config_packaging:$npm_package_config_default_environment -- -Pe2e -Denforcer.skip=true',
-                    'ci:e2e:server:start': `java -jar ${e2ePackage}.$npm_package_config_packaging --spring.profiles.active=$npm_package_config_default_enviroment ${javaCommonLog} --logging.level.org.springframework.web=ERROR`,
+                    'ci:e2e:server:start': `java -jar ${e2ePackage}.$npm_package_config_packaging --spring.profiles.active=$npm_package_config_default_environment ${javaCommonLog} --logging.level.org.springframework.web=ERROR`,
                 });
             },
         };

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -369,6 +369,11 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                     }
                 } else {
                     const dockerFile = `src/main/docker/${databaseType}.yml`;
+                    if (databaseType === 'cassandra') {
+                        scriptsStorage.set({
+                            'docker:db:await': 'wait-on tcp:9042',
+                        });
+                    }
                     if (databaseType === 'couchbase' || databaseType === 'cassandra') {
                         scriptsStorage.set({
                             'docker:db:build': `docker-compose -f ${dockerFile} build`,
@@ -449,6 +454,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                     'server:package': 'npm run java:$npm_package_config_packaging:$npm_package_config_default_environment',
                     'ci:e2e:package':
                         'npm run java:$npm_package_config_packaging:$npm_package_config_default_environment -- -Pe2e -Denforcer.skip=true',
+                    'preci:e2e:server:start': 'npm run docker:db:await --if-present && npm run docker:others:await --if-present',
                     'ci:e2e:server:start': `java -jar ${e2ePackage}.$npm_package_config_packaging --spring.profiles.active=$npm_package_config_default_environment ${javaCommonLog} --logging.level.org.springframework.web=ERROR`,
                 });
             },

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -350,7 +350,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                 packageJsonConfigStorage.backend_port = this.serverPort;
                 packageJsonConfigStorage.packaging = process.env.JHI_WAR === '1' ? 'war' : 'jar';
                 if (process.env.JHI_PROFILE) {
-                    packageJsonConfigStorage.default_enviroment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
+                    packageJsonConfigStorage.default_environment = process.env.JHI_PROFILE.includes('dev') ? 'dev' : 'prod';
                 }
             },
             packageJsonDockerScripts() {
@@ -386,7 +386,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
 
                 const dockerOthers = [];
                 const dockerBuild = [];
-                ['keycloak', 'elasticsearch', 'kafka', 'consul', 'redis', 'memcached', 'jhipster-registry', 'sonar'].forEach(
+                ['keycloak', 'elasticsearch', 'kafka', 'consul', 'redis', 'memcached', 'jhipster-registry'].forEach(
                     dockerConfig => {
                         const dockerFile = `src/main/docker/${dockerConfig}.yml`;
                         if (this.fs.exists(this.destinationPath(dockerFile))) {
@@ -434,7 +434,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                         'java:jar': './gradlew bootJar -x test',
                         'java:war': './gradlew bootWar -Pwar -x test',
                         'java:docker': './gradlew bootJar jibDockerBuild',
-                        'backend:unit:test': `./gradlew test integrationTest ${excludeWebpack} -Ptestcontainers ${javaCommonLog} ${javaTestLog}`,
+                        'backend:unit:test': `./gradlew test integrationTest ${excludeWebpack} ${javaCommonLog} ${javaTestLog}`,
                         'postci:e2e:package': 'cp build/libs/*SNAPSHOT.$npm_package_config_packaging e2e.$npm_package_config_packaging',
                     });
                 }
@@ -448,9 +448,9 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                     'java:docker:prod': 'npm run java:docker -- -Pprod',
                     'ci:backend:test':
                         'npm run backend:info && npm run backend:doc:test && npm run backend:nohttp:test && npm run backend:unit:test',
-                    'server:package': 'npm run java:$npm_package_config_packaging:$npm_package_config_default_enviroment',
+                    'server:package': 'npm run java:$npm_package_config_packaging:$npm_package_config_default_environment',
                     'ci:e2e:package':
-                        'npm run java:$npm_package_config_packaging:$npm_package_config_default_enviroment -- -Pe2e -Denforcer.skip=true',
+                        'npm run java:$npm_package_config_packaging:$npm_package_config_default_environment -- -Pe2e -Denforcer.skip=true',
                     'ci:e2e:server:start': `java -jar ${e2ePackage}.$npm_package_config_packaging --spring.profiles.active=$npm_package_config_default_enviroment ${javaCommonLog} --logging.level.org.springframework.web=ERROR`,
                 });
             },

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -371,7 +371,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
                     const dockerFile = `src/main/docker/${databaseType}.yml`;
                     if (databaseType === 'cassandra') {
                         scriptsStorage.set({
-                            'docker:db:await': 'wait-on tcp:9042',
+                            'docker:db:await': 'wait-on tcp:9042 && sleep 20',
                         });
                     }
                     if (databaseType === 'couchbase' || databaseType === 'cassandra') {

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1884,6 +1884,30 @@
                 </pluginManagement>
             </build>
         </profile>
+<%_ if (testFrameworks.includes('cypress') || testFrameworks.includes('protractor')) { _%>
+        <profile>
+            <id>e2e</id>
+            <build>
+                <finalName>e2e</finalName>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.springframework.boot</groupId>
+                            <artifactId>spring-boot-maven-plugin</artifactId>
+                            <executions>
+                                <execution>
+                                    <id>repackage</id>
+                                    <goals>
+                                        <goal>repackage</goal>
+                                    </goals>
+                                </execution>
+                            </executions>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
+            </build>
+        </profile>
+<%_ } _%>
         <!-- jhipster-needle-maven-add-profile -->
     </profiles>
 </project>

--- a/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/UserResourceIT.java.ejs
@@ -687,7 +687,7 @@ class UserResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCa
         // Validate the User in the database
         assertPersistedUsers(users -> {
             assertThat(users).hasSize(databaseSizeBeforeUpdate);
-            <%= asEntity('User') %> testUser = users.get(users.size() - 1);
+            <%= asEntity('User') %> testUser = users.stream().filter(usr -> usr.getId().equals(updatedUser.getId())).findFirst().get();
             assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
             assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);
             assertThat(testUser.getEmail()).isEqualTo(UPDATED_EMAIL);
@@ -753,7 +753,7 @@ class UserResourceIT <% if (databaseType === 'cassandra') { %>extends AbstractCa
         // Validate the User in the database
         assertPersistedUsers(users -> {
             assertThat(users).hasSize(databaseSizeBeforeUpdate);
-            <%= asEntity('User') %> testUser = users.get(users.size() - 1);
+            <%= asEntity('User') %> testUser = users.stream().filter(usr -> usr.getId().equals(updatedUser.getId())).findFirst().get();
             assertThat(testUser.getLogin()).isEqualTo(UPDATED_LOGIN);
             assertThat(testUser.getFirstName()).isEqualTo(UPDATED_FIRSTNAME);
             assertThat(testUser.getLastName()).isEqualTo(UPDATED_LASTNAME);


### PR DESCRIPTION
This PR adds npm scripts to easily run e2e, create packages, start docker containers..
- Allows e2e to run with 2 commands: `npm run ci:e2e:prepare` and `npm run ci:e2e:run`.
- Switches our GitHub Actions to use those generated scripts.
- Reduce angular/react/vue package.json differences.
- Fix tests failures.

Related to https://github.com/jhipster/generator-jhipster/issues/12489

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
