### PR TITLE
chore : use `--no-install-recommends` flag to `apt-get` in dockerfile to save space

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN \
   ln -snf /usr/share/zoneinfo/$TZ /etc/localtime && echo $TZ > /etc/timezone && \
   apt-get update && \
   # install utilities
-  apt-get install -y \
+  apt-get --no-install-recommends install -y \
     wget \
     curl \
     vim \
@@ -27,7 +27,7 @@ RUN \
   # install OpenJDK 11
   add-apt-repository ppa:openjdk-r/ppa && \
   apt-get update && \
-  apt-get install -y openjdk-11-jdk && \
+  apt-get --no-install-recommends install -y openjdk-11-jdk && \
   update-java-alternatives -s java-1.11.0-openjdk-amd64 && \
   # install node.js
   wget https://nodejs.org/dist/v12.18.3/node-v12.18.3-linux-x64.tar.gz -O /tmp/node.tar.gz && \


### PR DESCRIPTION
By default, Ubuntu or Debian based "apt" or "apt-get" system installs recommended but not suggested packages .

By passing "--no-install-recommends" option, the user lets apt-get know not to consider recommended packages as a dependency to install.

This results in smaller downloads and installation of packages .

Refer to blog at [Ubuntu Blog](https://ubuntu.com/blog/we-reduced-our-docker-images-by-60-with-no-install-recommends) .

Signed-off-by: Pratik Raj <rajpratik71@gmail.com>