### PR TITLE
set STOMP protocol version

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs
@@ -67,7 +67,7 @@ export class TrackerService {
         }
         <%_ } _%>
         const socket: WebSocket = new SockJS(url);
-        this.stompClient = Stomp.over(socket);
+        this.stompClient = Stomp.over(socket, { protocols: ['v12.stomp'] });
         const headers: Stomp.ConnectionHeaders = {};
         <%_ if (authenticationType === 'session') { _%>
         headers['X-XSRF-TOKEN'] = this.csrfService.getCSRF('XSRF-TOKEN');

--- a/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
@@ -89,7 +89,7 @@ const connect = () => {
   }
 <%_ } _%>
   const socket = new SockJS(url);
-  stompClient = Stomp.over(socket);
+  stompClient = Stomp.over(socket, { protocols: ['v12.stomp'] });
 
   stompClient.connect(headers, () => {
     connectedPromise('success');

--- a/generators/client/templates/vue/src/main/webapp/app/admin/tracker/tracker.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/tracker/tracker.service.ts.ejs
@@ -37,7 +37,7 @@ export default class TrackerService {
     }
     <%_ } _%>
     const socket = new SockJS(url);
-    this.stompClient = Stomp.over(socket);
+    this.stompClient = Stomp.over(socket, { protocols: ['v12.stomp'] });
     const headers = {};
     <%_ if (authenticationType === 'session') { _%>
     headers['X-XSRF-TOKEN'] = (<any>this).$cookie.get('JSESSIONID') || (<any>this).$cookie.get('XSRF-TOKEN');


### PR DESCRIPTION
fixes deprecation notice in the browser console when using WebSockets:
"DEPRECATED: undefined is not a recognized STOMP version. In next major client version, this will close the connection."

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
