### PR TITLE
add RTL support for vue

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/app/locale/translation.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/locale/translation.service.ts.ejs
@@ -28,5 +28,19 @@ export default class TranslationService {
       this.i18n.locale = currentLanguage;
       this.store.commit('currentLanguage', currentLanguage);
     }
+    <%_ if (enableI18nRTL) { _%>
+      this.updatePageDirection(currentLanguage);
+    <%_ } _%>
   }
+
+  <%_ if (enableI18nRTL) { _%>
+    private isRTL(lang: string): boolean {
+      const languages = this.store.getters.languages;
+      return languages[lang] && languages[lang].rtl;
+    }
+
+    private updatePageDirection(currentLanguage: string): void {
+      document.querySelector('html').setAttribute('dir', this.isRTL(currentLanguage) ? 'rtl' : 'ltr');
+    }
+  <%_ } _%>
 }


### PR DESCRIPTION
change the bahavior in vue to match Angular/React so that when
changing to an RTL laguage (or initially showing an RTL language)
the `dir` attribute will change to `rtl`

Fix #12384

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
