### PR TITLE
Fix Okta login failure message and add Okta CLI to docs

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -73,7 +73,7 @@ describe('account', () => {
         } else {
             // Okta
             const error = element(by.css('.infobox-error'));
-            expect(await error.getText()).to.eq('Sign in failed!');
+            expect(await error.getText()).to.eq('Unable to sign in');
         }
     <%_ } _%>
     });

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -90,7 +90,7 @@ describe('Account', () => {
       // Okta
       const error = element(by.css('.infobox-error'));
       await waitUntilDisplayed(error);
-      expect(await error.getText()).to.eq('Sign in failed!');
+      expect(await error.getText()).to.eq('Unable to sign in');
     }
     await signInPage.clearUserName();
     await signInPage.clearPassword();
@@ -115,7 +115,6 @@ describe('Account', () => {
     await navBarPage.autoSignOut();
       <%_ } _%>
     <%_ } else { _%>
-    // Keycloak credentials by default, change them to be able to use oauth2 with Okta
     await signInPage.loginWithOAuth(username, password);
     const success = element(by.className('alert-success'));
     await waitUntilDisplayed(success);

--- a/generators/client/templates/vue/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/core/jhi-navbar/jhi-navbar.component.ts.ejs
@@ -55,7 +55,7 @@ export default class JhiNavbar extends Vue {
       if (logoutUrl.indexOf('/protocol') > -1) {
         logoutUrl = logoutUrl + '?redirect_uri=' + window.location.origin;
       } else {
-      // Okta
+        // Okta
         logoutUrl = logoutUrl + '?id_token_hint=' +
         data.idToken + '&post_logout_redirect_uri=' + window.location.origin;
       }

--- a/generators/client/templates/vue/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -18,9 +18,10 @@ import {isVisible, waitUntilDisplayed, waitUntilHidden,} from '../../util/utils'
 const expect = chai.expect;
 
 describe('Account', () => {
-
   let navBarPage: NavBarPage = new NavBarPage();
   let signInPage: SignInPage;
+  const username = process.env.E2E_USERNAME || 'admin';
+  const password = process.env.E2E_PASSWORD || 'admin';
 <%_ if (!skipUserManagement) { _%>
   let passwordPage: PasswordPage;
   let settingsPage: SettingsPage;
@@ -50,7 +51,7 @@ describe('Account', () => {
       expect(await signInPage.getTitle()).to.eq(loginPageTitle);
       expect(await isVisible(signInPage.dangerAlert)).to.be.false;
 
-      await signInPage.login('admin', 'foo');
+      await signInPage.login(username, 'foo');
 
       await waitUntilDisplayed(signInPage.dangerAlert);
       expect(await signInPage.dangerAlert.isDisplayed()).to.be.true;
@@ -58,7 +59,7 @@ describe('Account', () => {
       await signInPage.closeButton.click();
       await waitUntilHidden(signInPage.loginForm);
 <%_ } else { _%>
-      await signInPage.login('admin', 'foo');
+      await signInPage.login(username, 'foo');
       const alert = element(by.css('.alert-error'));
       if (await alert.isPresent()) {
         // Keycloak
@@ -67,7 +68,7 @@ describe('Account', () => {
         // Okta
         const error = element(by.css('.infobox-error'));
         await waitUntilDisplayed(error);
-        expect(await error.getText()).to.eq('Sign in failed!');
+        expect(await error.getText()).to.eq('Unable to sign in');
       }
       await signInPage.username.clear();
       await signInPage.password.clear();
@@ -81,9 +82,9 @@ describe('Account', () => {
       expect(await isVisible(signInPage.dangerAlert)).to.be.false;
 
       await signInPage.username.clear();
-      await signInPage.username.sendKeys('admin');
+      await signInPage.username.sendKeys(username);
       await signInPage.password.clear();
-      await signInPage.password.sendKeys('admin');
+      await signInPage.password.sendKeys(password);
       await signInPage.loginButton.click();
 
       await waitUntilHidden(signInPage.loginForm);
@@ -93,8 +94,7 @@ describe('Account', () => {
   <%_ } else { _%>
       await browser.get('/');
       signInPage = await navBarPage.getSignInPage();
-      // Keycloak credentials by default, change them to be able to use oauth2 with Okta
-      await signInPage.login('admin', 'admin');
+      await signInPage.login(username, password);
       const success = element(by.className('alert-success'));
       await waitUntilDisplayed(success);
 

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -140,7 +140,21 @@ docker-compose -f src/main/docker/jhipster-control-center.yml up
 
 ### Okta
 
-If you'd like to use Okta instead of Keycloak, you'll need to change a few things. First, you'll need to create a free developer account at <https://developer.okta.com/signup/>. After doing so, you'll get your own Okta domain, that has a name like `https://dev-123456.okta.com`.
+If you'd like to use Okta instead of Keycloak, it's pretty quick using the [Okta CLI](https://cli.okta.com/). After you've installed it, run:
+
+```shell
+okta register
+```
+
+Then, in your JHipster app's directory, run `okta apps create` and select **JHipster**. This will set up an Okta app for you, create `ROLE_ADMIN` and `ROLE_USER` groups, create a `.okta.env` file with your Okta settings, and configure a `groups` claim in your ID token.
+
+Run `source .okta.env` and start your app with Maven or Gradle. You should be able to sign in with the credentials you registered with.
+
+If you're on Windows, you should install [WSL](https://docs.microsoft.com/en-us/windows/wsl/install-win10) so the `source` command will work.
+
+If you'd like to configure things manually through the Okta developer console, see the instructions below.
+
+First, you'll need to create a free developer account at <https://developer.okta.com/signup/>. After doing so, you'll get your own Okta domain, that has a name like `https://dev-123456.okta.com`.
 
 Modify `src/main/resources/config/application.yml` to use your Okta settings.
 


### PR DESCRIPTION
Question: If I can't find `Sign in failed!` in Cypress tests, does that mean they're not configured to test Okta?

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

Related: I was unable to get `run run e2e` to pass even after this change. I did set `E2E_USERNAME` and `E2E_PASSWORD` beforehand.

It seems to be because the failure happens too fast. Modifying `account.spec.ts` to have the following seems to fix it:

```ts
const error = element(by.css('.infobox-error'));      
await browser.sleep(1000);
expect(await error.getText()).to.eq('Unable to sign in');
```

The other error I found is the successful login test appends the correct password instead of replacing it. Not sure what changed. This code used to work when I last tried it.