### PR TITLE
Implement entities generator.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -278,7 +278,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: merge project diff'
               continue-on-error: true
               id: merge-is-equal
@@ -292,7 +293,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: tests should be skipped'
               id: tests-should-be-skipped
               if: >

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -271,7 +271,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: merge project diff'
               continue-on-error: true
               id: merge-is-equal
@@ -285,7 +286,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: tests should be skipped'
               id: tests-should-be-skipped
               if: >

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -269,7 +269,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: merge project diff'
               continue-on-error: true
               id: merge-is-equal
@@ -283,7 +284,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: tests should be skipped'
               id: tests-should-be-skipped
               if: >

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -272,7 +272,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: merge project diff'
               continue-on-error: true
               id: merge-is-equal
@@ -286,7 +287,8 @@ jobs:
                   # File package-lock.json is not generated
                   # Verify if the generated source has changed
                   git add .
-                  git -c color.ui=always diff -R --cached --exit-code -- . ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
+                  git -c color.ui=always diff -R --cached -- '.yo-rc.json' '.jhipster/**'
+                  git -c color.ui=always diff -R --cached --exit-code -- . ':!.yo-rc.json' ':!.jhipster/**' ':!package-lock.json' ':!src/main/resources/config/tls/keystore.p12' || echo "::set-output name=has-changes::true"
             - name: 'MERGE: tests should be skipped'
               id: tests-should-be-skipped
               if: >

--- a/cli/cli.js
+++ b/cli/cli.js
@@ -197,7 +197,6 @@ Object.entries(allCommands).forEach(([key, opts]) => {
                 ...getCommandOptions(packageJson, unknownArgs),
                 ...program.opts(),
                 ...cmdOptions,
-                fromCli: true,
             };
 
             if (opts.cliOnly) {

--- a/cli/environment-builder.js
+++ b/cli/environment-builder.js
@@ -34,8 +34,8 @@ module.exports = class EnvironmentBuilder {
      */
     static create(args, options = {}, adapter) {
         // Remove after migration to environment 3.
-        options.newErrorHandler = true;
-        const env = Environment.createEnv(args, options, adapter);
+        const sharedOptions = { fromCli: true, localConfigOnly: true, ...options.sharedOptions };
+        const env = Environment.createEnv(args, { newErrorHandler: true, ...options, sharedOptions }, adapter);
         return new EnvironmentBuilder(env);
     }
 

--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -131,11 +131,11 @@ function writeApplicationConfig(applicationWithEntities, basePath) {
 /**
  * Run the generator.
  * @param {string} command
- * @param {Object} generatorOptions
  * @param {Object} options
  * @param {string} options.cwd
  * @param {boolean} options.fork
  * @param {Environment} options.env
+ * @param {Object} generatorOptions
  * @param {Promise}
  */
 function runGenerator(command, { cwd, fork, env }, generatorOptions = {}) {

--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -431,18 +431,9 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
                 cleanup.upgradeFiles(this);
             },
 
-            regenerateEntities() {
-                if (this.withEntities && !this.configOptions.skipComposeEntity) {
-                    this.configOptions.skipComposeEntity = true;
-                    this.getExistingEntities().forEach(entity => {
-                        this.composeWithJHipster('entity', {
-                            regenerate: true,
-                            skipDbChangelog: this.jhipsterConfig.databaseType === 'sql',
-                            skipInstall: true,
-                            arguments: [entity.name],
-                        });
-                    });
-                }
+            composeEntities() {
+                if (!this.withEntities) return;
+                this.composeWithJHipster('entities', { skipInstall: true }, true);
             },
 
             regeneratePages() {
@@ -454,20 +445,6 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
                         arguments: [page.name],
                         page,
                     });
-                });
-            },
-
-            databaseChangelog() {
-                if (this.skipServer || this.jhipsterConfig.databaseType !== 'sql') {
-                    return;
-                }
-                const existingEntities = this.getExistingEntities();
-                if (existingEntities.length === 0) {
-                    return;
-                }
-
-                this.composeWithJHipster('database-changelog', {
-                    arguments: existingEntities.map(entity => entity.name),
                 });
             },
 

--- a/generators/entities-client/index.js
+++ b/generators/entities-client/index.js
@@ -1,0 +1,67 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
+
+let useBlueprints;
+
+module.exports = class extends BaseBlueprintGenerator {
+    constructor(args, opts) {
+        super(args, opts);
+
+        this.option('from-cli', {
+            desc: 'Indicates the command is run from JHipster CLI',
+            type: Boolean,
+            defaults: false,
+        });
+
+        if (this.options.help) return;
+
+        this.clientEntities = this.options.clientEntities;
+
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('entities-client');
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _initializing() {
+        return {
+            validateFromCli() {
+                this.checkInvocationFromCLI();
+            },
+        };
+    }
+
+    get initializing() {
+        return useBlueprints ? undefined : this._initializing();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _end() {
+        return {
+            end() {
+                if (!this.options.skipInstall) {
+                    this.rebuildClient();
+                }
+            },
+        };
+    }
+
+    get end() {
+        return useBlueprints ? undefined : this._end();
+    }
+};

--- a/generators/entities/index.js
+++ b/generators/entities/index.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2013-2020 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
+const { JHIPSTER_CONFIG_DIR } = require('../generator-constants');
+
+let useBlueprints;
+
+module.exports = class extends BaseBlueprintGenerator {
+    constructor(args, opts) {
+        super(args, opts);
+
+        this.option('from-cli', {
+            desc: 'Indicates the command is run from JHipster CLI',
+            type: Boolean,
+            defaults: false,
+        });
+
+        this.option('skip-db-changelog', {
+            desc: 'Skip the generation of database changelog (liquibase for sql databases)',
+            type: Boolean,
+        });
+
+        this.option('composed-entities', {
+            desc: 'Entities to be that already have been composed',
+            type: Array,
+            defaults: [],
+        });
+
+        this.option('entities-to-import', {
+            desc: 'Entities to be imported',
+            type: Array,
+            defaults: [],
+            hide: true,
+        });
+
+        if (this.options.help) return;
+
+        useBlueprints = !this.fromBlueprint && this.instantiateBlueprints('entities');
+
+        if (this.options.entitiesToImport) {
+            const entities = this.jhipsterConfig.entities || [];
+            this.options.entitiesToImport.forEach(entity => {
+                if (!entities.includes(entity.name)) {
+                    entities.push(entity.name);
+                }
+                this.fs.writeJSON(this.destinationPath(JHIPSTER_CONFIG_DIR, `${entity.name}.json`), entity);
+            });
+            this.jhipsterConfig.entities = entities;
+        }
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _initializing() {
+        return {
+            validateFromCli() {
+                this.checkInvocationFromCLI();
+            },
+        };
+    }
+
+    get initializing() {
+        return useBlueprints ? undefined : this._initializing();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _composing() {
+        return {
+            composeEachEntity() {
+                this.getExistingEntityNames().forEach(entityName => {
+                    if (this.options.composedEntities && this.options.composedEntities.includes(entityName)) return;
+                    this.composeWithJHipster('entity', {
+                        regenerate: true,
+                        skipDbChangelog: this.jhipsterConfig.databaseType === 'sql' || this.options.skipDbChangelog,
+                        skipInstall: true,
+                        arguments: [entityName],
+                    });
+                });
+            },
+
+            databaseChangelog() {
+                if (this.jhipsterConfig.skipServer || this.jhipsterConfig.databaseType !== 'sql' || this.options.skipDbChangelog) {
+                    return;
+                }
+                const existingEntities = this.getExistingEntities();
+                if (existingEntities.length === 0) {
+                    return;
+                }
+
+                this.composeWithJHipster('database-changelog', {
+                    arguments: existingEntities.map(entity => entity.name),
+                });
+            },
+        };
+    }
+
+    get composing() {
+        return useBlueprints ? undefined : this._composing();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _default() {
+        return {
+            composeEntitiesClient() {
+                if (this.jhipsterConfig.skipClient) return;
+                const clientEntities = this.getExistingEntityNames()
+                    .map(entityName => {
+                        const entity = this.configOptions.sharedEntities[entityName];
+                        if (entity === undefined) {
+                            throw new Error(`${entityName} shared entity data not found`);
+                        }
+                        return entity;
+                    })
+                    .filter(entity => !entity.skipClient);
+                if (clientEntities.length === 0) return;
+                this.composeWithJHipster('entities-client', {
+                    clientEntities,
+                    skipInstall: this.options.skipInstall,
+                });
+            },
+        };
+    }
+
+    get default() {
+        return useBlueprints ? undefined : this._default();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _writing() {
+        return {};
+    }
+
+    get writing() {
+        return useBlueprints ? undefined : this._writing();
+    }
+};

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -17,7 +17,6 @@
  * limitations under the License.
  */
 /* eslint-disable consistent-return */
-const chalk = require('chalk');
 const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
@@ -76,22 +75,5 @@ module.exports = class extends BaseBlueprintGenerator {
     get writing() {
         if (useBlueprints) return;
         return this._writing();
-    }
-
-    // Public API method used by the getter and also by Blueprints
-    _end() {
-        return {
-            end() {
-                if (!this.options.skipInstall && !this.skipClient) {
-                    this.rebuildClient();
-                }
-                this.log(chalk.bold.green(`Entity ${this.entityNameCapitalized} generated successfully.`));
-            },
-        };
-    }
-
-    get end() {
-        if (useBlueprints) return;
-        return this._end();
     }
 };

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -432,12 +432,44 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 });
                 this.entityConfig.relationships = relationships;
             },
+
+            addToYoRc() {
+                if (this.jhipsterConfig.entities === undefined) {
+                    this.jhipsterConfig.entities = [];
+                }
+                if (!this.jhipsterConfig.entities.find(entityName => entityName === this.context.name)) {
+                    this.jhipsterConfig.entities = this.jhipsterConfig.entities.concat([this.context.name]);
+                }
+            },
         };
     }
 
     get configuring() {
         if (useBlueprints) return;
         return this._configuring();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _composing() {
+        return {
+            composeEntities() {
+                // We need to compose with others entities to update relationships.
+                this.composeWithJHipster(
+                    'entities',
+                    {
+                        composedEntities: [this.context.name],
+                        skipDbChangelog: this.options.skipDbChangelog,
+                        skipInstall: this.options.skipInstall,
+                    },
+                    true
+                );
+            },
+        };
+    }
+
+    get composing() {
+        if (useBlueprints) return;
+        return this._composing();
     }
 
     // Public API method used by the getter and also by Blueprints
@@ -601,15 +633,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 }
             },
 
-            databaseChangelog() {
-                if (this.options.skipDbChangelog) {
-                    return;
-                }
-                this.composeWithJHipster('database-changelog', {
-                    arguments: [this.context.name],
-                });
-            },
-
             ...super._missingPostWriting(),
         };
     }
@@ -623,7 +646,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
     _install() {
         return {
             afterRunHook() {
-                const done = this.async();
                 try {
                     const modules = this.getModuleHooks();
                     if (modules.length > 0) {
@@ -631,6 +653,7 @@ class EntityGenerator extends BaseBlueprintGenerator {
                         // form the data to be passed to modules
                         const context = this.context;
 
+                        const done = this.async();
                         // run through all post entity creation module hooks
                         this.callHooks(
                             'entity',
@@ -641,13 +664,10 @@ class EntityGenerator extends BaseBlueprintGenerator {
                             },
                             done
                         );
-                    } else {
-                        done();
                     }
                 } catch (err) {
                     this.log(`\n${chalk.bold.red('Running post run module hooks failed. No modification done to the generated entity.')}`);
                     this.debug('Error:', err);
-                    done();
                 }
             },
         };
@@ -656,6 +676,20 @@ class EntityGenerator extends BaseBlueprintGenerator {
     get install() {
         if (useBlueprints) return;
         return this._install();
+    }
+
+    // Public API method used by the getter and also by Blueprints
+    _end() {
+        return {
+            end() {
+                this.log(chalk.bold.green(`Entity ${this.context.entityNameCapitalized} generated successfully.`));
+            },
+        };
+    }
+
+    get end() {
+        if (useBlueprints) return;
+        return this._end();
     }
 
     /**

--- a/jdl/jdl-importer.js
+++ b/jdl/jdl-importer.js
@@ -150,16 +150,26 @@ function getJDLObject(parsedJDLContent, configuration) {
 }
 
 function checkForErrors(jdlObject, configuration) {
-    let applicationType = configuration.applicationType;
-    let databaseType = configuration.databaseType;
-    let skippedUserManagement = false;
-    if (configuration.application) {
-        applicationType = configuration.application['generator-jhipster'].applicationType;
-        databaseType = configuration.application['generator-jhipster'].databaseType;
-        skippedUserManagement = configuration.application['generator-jhipster'].skipUserManagement;
-    }
     let validator;
     if (jdlObject.getApplicationQuantity() === 0) {
+        let application = configuration.application;
+        if (!application && doesFileExist('.yo-rc.json')) {
+            application = readJSONFile('.yo-rc.json');
+        }
+        let applicationType = configuration.applicationType;
+        let databaseType = configuration.databaseType;
+        let skippedUserManagement = configuration.skipUserManagement;
+        if (application && application['generator-jhipster']) {
+            if (applicationType === undefined) {
+                applicationType = application['generator-jhipster'].applicationType;
+            }
+            if (databaseType === undefined) {
+                databaseType = application['generator-jhipster'].databaseType;
+            }
+            if (skippedUserManagement === undefined) {
+                skippedUserManagement = application['generator-jhipster'].skipUserManagement;
+            }
+        }
         validator = JDLWithoutApplicationValidator.createValidator(jdlObject, {
             applicationType,
             databaseType,

--- a/jdl/validators/jdl-without-application-validator.js
+++ b/jdl/validators/jdl-without-application-validator.js
@@ -67,6 +67,9 @@ function createValidator(jdlObject, applicationSettings = {}, logger = console) 
         if (jdlObject.getEntityQuantity() === 0) {
             return;
         }
+        if (!applicationSettings.databaseType) {
+            throw new Error('Database type is required to validate entities.');
+        }
         const validator = new EntityValidator();
         jdlObject.forEachEntity(jdlEntity => {
             validator.validate(jdlEntity);
@@ -166,6 +169,7 @@ function getTypeCheckingFunction(entityName, applicationSettings) {
     }
     return FieldTypes.getIsType(applicationSettings.databaseType);
 }
+
 function checkForAbsentEntities({ jdlRelationship, doesEntityExist, skippedUserManagementOption }) {
     const absentEntities = [];
     if (!doesEntityExist(jdlRelationship.from)) {

--- a/test/app/application-with-entities.js
+++ b/test/app/application-with-entities.js
@@ -1,17 +1,7 @@
-const fse = require('fs-extra');
-const path = require('path');
 const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
-const { JHIPSTER_CONFIG_DIR } = require('../../generators/generator-constants');
 
-const mockedComposedGenerators = [
-    'jhipster:common',
-    'jhipster:server',
-    'jhipster:client',
-    'jhipster:languages',
-    'jhipster:entity',
-    'jhipster:database-changelog',
-];
+const mockedComposedGenerators = ['jhipster:common', 'jhipster:server', 'jhipster:client', 'jhipster:languages', 'jhipster:entities'];
 
 describe('jhipster:app with applicationWithEntities option', () => {
     describe('with default options', () => {
@@ -46,7 +36,7 @@ describe('jhipster:app with applicationWithEntities option', () => {
     });
 
     describe('with --with-entities', () => {
-        describe('and single entity', () => {
+        describe('and a single entity', () => {
             let runResult;
             before(() => {
                 return helpers
@@ -80,154 +70,9 @@ describe('jhipster:app with applicationWithEntities option', () => {
                 runResult.assertFile('.jhipster/Foo.json');
                 runResult.assertFileContent('.jhipster/Foo.json', /"name": "Foo"/);
             });
-            it('should compose with entity generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                assert(EntityGenerator.calledOnce);
-                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
-            });
-        });
-
-        describe('and 2 entities', () => {
-            let runResult;
-            before(() => {
-                return helpers
-                    .create(require.resolve('../../generators/app'))
-                    .withOptions({
-                        applicationWithEntities: {
-                            config: {
-                                baseName: 'jhipster',
-                            },
-                            entities: [{ name: 'Foo' }, { name: 'Bar' }],
-                        },
-                        fromCli: true,
-                        skipInstall: true,
-                        defaults: true,
-                        withEntities: true,
-                    })
-                    .withMockedGenerators(mockedComposedGenerators)
-                    .run()
-                    .then(result => {
-                        runResult = result;
-                    });
-            });
-
-            after(() => runResult.cleanup());
-
-            it('writes .yo-rc.json', () => {
-                runResult.assertFile('.yo-rc.json');
-                runResult.assertFileContent('.yo-rc.json', /"baseName": "jhipster"/);
-            });
-            it('writes entity config file', () => {
-                runResult.assertFile('.jhipster/Foo.json');
-                runResult.assertFileContent('.jhipster/Foo.json', /"name": "Foo"/);
-                runResult.assertFile('.jhipster/Bar.json');
-                runResult.assertFileContent('.jhipster/Bar.json', /"name": "Bar"/);
-            });
-            it('should compose with entity generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                assert(EntityGenerator.callCount === 2);
-                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
-                assert.equal(EntityGenerator.getCall(1).args[0], 'Bar');
-            });
-            it('should compose with database-changelog generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                assert.equal(EntityGenerator.callCount, 1);
-                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo', 'Bar']);
-            });
-        });
-
-        describe('and 1 entity and 1 entity file', () => {
-            let runResult;
-            before(() => {
-                return helpers
-                    .create(require.resolve('../../generators/app'))
-                    .withOptions({
-                        applicationWithEntities: {
-                            config: {
-                                baseName: 'jhipster',
-                            },
-                            entities: [{ name: 'Foo', changelogDate: 1 }],
-                        },
-                        fromCli: true,
-                        skipInstall: true,
-                        defaults: true,
-                        withEntities: true,
-                    })
-                    .doInDir(dir => {
-                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
-                        fse.ensureDirSync(entitiesPath);
-                        const entityPath = path.join(entitiesPath, 'Bar.json');
-                        fse.writeFileSync(entityPath, '{"changelogDate": 2}');
-                    })
-                    .withMockedGenerators(mockedComposedGenerators)
-                    .run()
-                    .then(result => {
-                        runResult = result;
-                    });
-            });
-
-            after(() => runResult.cleanup());
-
-            it('should compose with mocked entity generator ordered by changelogDate', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                assert.equal(EntityGenerator.callCount, 2);
-                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo']);
-                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Bar']);
-            });
-            it('should compose with database-changelog generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                assert.equal(EntityGenerator.callCount, 1);
-                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo', 'Bar']);
-            });
-        });
-
-        describe('and more than 1 entity and than 1 entity files', () => {
-            let runResult;
-            before(() => {
-                return helpers
-                    .create(require.resolve('../../generators/app'))
-                    .withOptions({
-                        applicationWithEntities: {
-                            config: {
-                                baseName: 'jhipster',
-                            },
-                            entities: [
-                                { name: 'Four', changelogDate: 0 },
-                                { name: 'Two', changelogDate: 2 },
-                            ],
-                        },
-                        fromCli: true,
-                        skipInstall: true,
-                        defaults: true,
-                        withEntities: true,
-                    })
-                    .doInDir(dir => {
-                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
-                        fse.ensureDirSync(entitiesPath);
-                        fse.writeFileSync(path.join(entitiesPath, 'One.json'), '{"changelogDate": 3}');
-                        fse.writeFileSync(path.join(entitiesPath, 'Three.json'), '{"changelogDate": 1}');
-                    })
-                    .withMockedGenerators(mockedComposedGenerators)
-                    .run()
-                    .then(result => {
-                        runResult = result;
-                    });
-            });
-
-            after(() => runResult.cleanup());
-
-            it('should compose with mocked entity generator ordered by changelogDate', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                assert.equal(EntityGenerator.callCount, 4);
-                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Four']);
-                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Three']);
-                assert.deepStrictEqual(EntityGenerator.getCall(2).args[0], ['Two']);
-                assert.deepStrictEqual(EntityGenerator.getCall(3).args[0], ['One']);
-            });
-            it('should compose with database-changelog generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                assert.equal(EntityGenerator.callCount, 1);
-                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Four', 'Three', 'Two', 'One']);
+            it('should compose with entities generator', () => {
+                const MockedGenerator = runResult.mockedGenerators['jhipster:entities'];
+                assert(MockedGenerator.calledOnce);
             });
         });
     });

--- a/test/app/composing.js
+++ b/test/app/composing.js
@@ -4,7 +4,13 @@ const assert = require('yeoman-assert');
 const helpers = require('yeoman-test');
 const { JHIPSTER_CONFIG_DIR } = require('../../generators/generator-constants');
 
-const mockedComposedGenerators = ['jhipster:common', 'jhipster:languages', 'jhipster:entity', 'jhipster:database-changelog'];
+const mockedComposedGenerators = [
+    'jhipster:common',
+    'jhipster:languages',
+    'jhipster:entities',
+    'jhipster:entity',
+    'jhipster:database-changelog',
+];
 
 const allMockedComposedGenerators = [...mockedComposedGenerators, 'jhipster:server', 'jhipster:client'];
 
@@ -46,13 +52,17 @@ describe('jhipster:app composing', () => {
                 const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
                 assert(LanguagesGenerator.calledOnce);
             });
+            it('should not compose with entities generator', () => {
+                const MockedGenerator = runResult.mockedGenerators['jhipster:entities'];
+                assert.equal(MockedGenerator.callCount, 0);
+            });
             it('should not compose with entity generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                assert.equal(EntityGenerator.callCount, 0);
+                const MockedGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert.equal(MockedGenerator.callCount, 0);
             });
             it('should not compose with database-changelog generator', () => {
-                const IncrementalChangelogGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                assert.equal(IncrementalChangelogGenerator.callCount, 0);
+                const MockedGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                assert.equal(MockedGenerator.callCount, 0);
             });
         });
 
@@ -93,13 +103,17 @@ describe('jhipster:app composing', () => {
                 const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
                 assert(LanguagesGenerator.calledOnce);
             });
+            it('should not compose with entities generator', () => {
+                const MockedGenerator = runResult.mockedGenerators['jhipster:entities'];
+                assert.equal(MockedGenerator.callCount, 0);
+            });
             it('should not compose with entity generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                assert.equal(EntityGenerator.callCount, 0);
+                const MockedGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert.equal(MockedGenerator.callCount, 0);
             });
             it('should not compose with database-changelog generator', () => {
-                const IncrementalChangelogGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                assert.equal(IncrementalChangelogGenerator.callCount, 0);
+                const MockedGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                assert.equal(MockedGenerator.callCount, 0);
             });
         });
 
@@ -136,13 +150,17 @@ describe('jhipster:app composing', () => {
                 const ClientGenerator = runResult.mockedGenerators['jhipster:client'];
                 assert(ClientGenerator.calledOnce);
             });
-            it('should compose with entity generator', () => {
-                const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
+            it('should not compose with entities generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entities'];
                 assert.equal(EntityGenerator.callCount, 0);
             });
-            it('should compose with database-changelog generator', () => {
-                const IncrementalChangelogGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                assert.equal(IncrementalChangelogGenerator.callCount, 0);
+            it('should not compose with entity generator', () => {
+                const MockedGenerator = runResult.mockedGenerators['jhipster:entity'];
+                assert.equal(MockedGenerator.callCount, 0);
+            });
+            it('should not compose with database-changelog generator', () => {
+                const MockedGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                assert.equal(MockedGenerator.callCount, 0);
             });
         });
 
@@ -190,15 +208,17 @@ describe('jhipster:app composing', () => {
                     const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
                     assert(LanguagesGenerator.calledOnce);
                 });
-                it('should compose with entity generator once', () => {
-                    const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                    assert(EntityGenerator.calledOnce);
-                    assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo']);
+                it('should compose with entities generator once', () => {
+                    const MockedGenerator = runResult.mockedGenerators['jhipster:entities'];
+                    assert(MockedGenerator.calledOnce);
                 });
-                it('should compose with database-changelog generator', () => {
-                    const IncrementalChangelogGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                    assert.equal(IncrementalChangelogGenerator.callCount, 1);
-                    assert.deepStrictEqual(IncrementalChangelogGenerator.getCall(0).args[0], ['Foo']);
+                it('should not compose with entity generator', () => {
+                    const MockedGenerator = runResult.mockedGenerators['jhipster:entity'];
+                    assert.equal(MockedGenerator.callCount, 0);
+                });
+                it('should not compose with database-changelog generator', () => {
+                    const MockedGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                    assert.equal(MockedGenerator.callCount, 0);
                 });
             });
 
@@ -246,17 +266,13 @@ describe('jhipster:app composing', () => {
                     const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
                     assert(LanguagesGenerator.calledOnce);
                 });
-                it('should compose with entity generator ordered by changelogDate', () => {
+                it('should not compose with entity generator', () => {
                     const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];
-                    assert.equal(EntityGenerator.callCount, 3);
-                    assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Three']);
-                    assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Two']);
-                    assert.deepStrictEqual(EntityGenerator.getCall(2).args[0], ['One']);
+                    assert.equal(EntityGenerator.callCount, 0);
                 });
-                it('should compose with database-changelog generator', () => {
+                it('should not compose with database-changelog generator', () => {
                     const IncrementalChangelogGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
-                    assert.equal(IncrementalChangelogGenerator.callCount, 1);
-                    assert.deepStrictEqual(IncrementalChangelogGenerator.getCall(0).args[0], ['Three', 'Two', 'One']);
+                    assert.equal(IncrementalChangelogGenerator.callCount, 0);
                 });
             });
         });
@@ -289,6 +305,10 @@ describe('jhipster:app composing', () => {
             it('should compose with languages generator once', () => {
                 const LanguagesGenerator = runResult.mockedGenerators['jhipster:languages'];
                 assert(LanguagesGenerator.calledOnce);
+            });
+            it('should not compose with entities generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entities'];
+                assert.equal(EntityGenerator.callCount, 0);
             });
             it('should not compose with entity generator', () => {
                 const EntityGenerator = runResult.mockedGenerators['jhipster:entity'];

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -100,14 +100,6 @@ describe('jhipster cli', () => {
         });
 
         const commonTests = () => {
-            it('should pass a truthy fromCli', done => {
-                callback = (_command, options) => {
-                    expect(options.fromCli).to.be.true;
-                    expect(options.fromCli).to.be.true;
-                    done();
-                };
-                proxyquire('../../cli/cli', { './commands': commands });
-            });
             it('should pass a defined command', done => {
                 callback = (command, _options) => {
                     expect(command).to.not.be.undefined;
@@ -188,14 +180,6 @@ describe('jhipster cli', () => {
         });
 
         const commonTests = () => {
-            it('should pass a truthy fromCli', done => {
-                const cb = (_args, options, _env) => {
-                    expect(options.fromCli).to.be.true;
-                    expect(options.fromCli).to.be.true;
-                    done();
-                };
-                proxyquire('../../cli/cli', { './commands': commands, './mocked': cb });
-            });
             it('should pass a defined environment', done => {
                 const cb = (_args, _options, env) => {
                     expect(env).to.not.be.undefined;

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -11,6 +11,7 @@ let subGenCallParams = {
     count: 0,
     commands: [],
     options: [],
+    entities: [],
 };
 
 const removeFieldsWithUndefinedValues = options => Object.fromEntries(Object.entries(options).filter(([_, value]) => value !== undefined));
@@ -21,6 +22,10 @@ const pushCall = (command, options) => {
     if (!Array.isArray(options)) {
         options = removeFieldsWithUndefinedValues(options);
     }
+    if (options.entitiesToImport) {
+        subGenCallParams.entities = options.entitiesToImport.map(entity => entity.name);
+    }
+    delete options.entitiesToImport;
     subGenCallParams.options.push(options);
 };
 
@@ -72,35 +77,18 @@ const loadImportJdl = options => {
     return proxyquire('../../cli/import-jdl', options);
 };
 
-const defaultAddedOptions = {
-    fromCli: true,
-    localConfigOnly: true,
-};
+const defaultAddedOptions = {};
 
 function testDocumentsRelationships() {
     it('creates entity json files', () => {
-        assert.file([
-            '.jhipster/Customer.json',
-            '.jhipster/CustomerOrder.json',
-            '.jhipster/OrderedItem.json',
-            '.jhipster/PaymentDetails.json',
-            '.jhipster/ShippingDetails.json',
-        ]);
+        expect(subGenCallParams.entities).to.eql(['Customer', 'CustomerOrder', 'OrderedItem', 'PaymentDetails', 'ShippingDetails']);
     });
     it('calls entity subgenerator', () => {
-        expect(subGenCallParams.count).to.equal(5);
-        expect(subGenCallParams.commands).to.eql([
-            'jhipster:entity Customer',
-            'jhipster:entity CustomerOrder',
-            'jhipster:entity OrderedItem',
-            'jhipster:entity PaymentDetails',
-            'jhipster:entity ShippingDetails',
-        ]);
+        expect(subGenCallParams.count).to.equal(1);
+        expect(subGenCallParams.commands).to.eql(['jhipster:entities']);
         expect(subGenCallParams.options[0]).to.eql({
             ...defaultAddedOptions,
             regenerate: true,
-            interactive: true,
-            skipInstall: true,
         });
     });
 }
@@ -115,6 +103,7 @@ describe('JHipster generator import jdl', () => {
             count: 0,
             commands: [],
             options: [],
+            entities: [],
         };
     });
     // this test for some reason works only when put at the beginning.
@@ -133,27 +122,13 @@ describe('JHipster generator import jdl', () => {
         it('calls generator in order', () => {
             expect(subGenCallParams.count).to.equal(5);
             expect(subGenCallParams.commands).to.eql(['app', 'app', 'app', 'docker-compose', 'kubernetes']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--with-entities',
-                '--skip-install',
-                '--no-insight',
-                '--interactive',
-                '--from-cli',
-                '--local-config-only',
-            ]);
-            expect(subGenCallParams.options[3]).to.eql([
-                '--skip-install',
-                '--no-insight',
-                '--interactive',
-                '--skip-prompts',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--with-entities', '--skip-install', '--no-insight']);
+            expect(subGenCallParams.options[3]).to.eql(['--force', '--skip-install', '--no-insight', '--skip-prompts']);
         });
     });
 
     describe('imports a JDL entity model from single file with --json-only flag', () => {
-        const options = { jsonOnly: true, skipInstall: true };
+        const options = { jsonOnly: true, skipInstall: true, databaseType: 'postgresql', baseName: 'jhipster' };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
@@ -181,7 +156,7 @@ describe('JHipster generator import jdl', () => {
     });
 
     describe('imports a JDL entity model from single file with --skip-db-changelog', () => {
-        const options = { skipDbChangelog: true };
+        const options = { skipDbChangelog: true, databaseType: 'postgresql', baseName: 'jhipster' };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
@@ -191,30 +166,21 @@ describe('JHipster generator import jdl', () => {
 
         afterEach(() => revertTempDir(originalCwd));
 
-        it('creates entity json files', () => {
-            assert.file([
-                '.jhipster/Department.json',
-                '.jhipster/JobHistory.json',
-                '.jhipster/Job.json',
-                '.jhipster/Employee.json',
-                '.jhipster/Location.json',
-                '.jhipster/Task.json',
-                '.jhipster/Country.json',
-                '.jhipster/Region.json',
+        it('passes entities to entities generator', () => {
+            expect(subGenCallParams.entities).to.eql([
+                'Region',
+                'Country',
+                'Location',
+                'Department',
+                'Task',
+                'Employee',
+                'Job',
+                'JobHistory',
             ]);
         });
         it('calls entity subgenerator', () => {
-            expect(subGenCallParams.count).to.equal(8);
-            expect(subGenCallParams.commands).to.eql([
-                'jhipster:entity Region',
-                'jhipster:entity Country',
-                'jhipster:entity Location',
-                'jhipster:entity Department',
-                'jhipster:entity Task',
-                'jhipster:entity Employee',
-                'jhipster:entity Job',
-                'jhipster:entity JobHistory',
-            ]);
+            expect(subGenCallParams.count).to.equal(1);
+            expect(subGenCallParams.commands).to.eql(['jhipster:entities']);
         });
 
         it('calls entity subgenerator with correct options', () => {
@@ -224,23 +190,14 @@ describe('JHipster generator import jdl', () => {
                     ...defaultAddedOptions,
                     skipInstall: true,
                     regenerate: true,
-                    interactive: true,
+                    interactive: false,
                 });
-            });
-        });
-
-        it('last entity subgenerator should be called without skipInstall', () => {
-            expect(subGenCallParams.options[subGenCallParams.options.length - 1]).to.eql({
-                ...options,
-                ...defaultAddedOptions,
-                regenerate: true,
-                interactive: true,
             });
         });
     });
 
     describe('imports a JDL entity model from single file in interactive mode by default', () => {
-        const options = { skipInstall: true };
+        const options = { skipInstall: true, databaseType: 'postgresql', baseName: 'jhipster' };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
@@ -250,41 +207,31 @@ describe('JHipster generator import jdl', () => {
 
         afterEach(() => revertTempDir(originalCwd));
 
-        it('creates entity json files', () => {
-            assert.file([
-                '.jhipster/Department.json',
-                '.jhipster/JobHistory.json',
-                '.jhipster/Job.json',
-                '.jhipster/Employee.json',
-                '.jhipster/Location.json',
-                '.jhipster/Task.json',
-                '.jhipster/Country.json',
-                '.jhipster/Region.json',
+        it('passes entities to entities generator', () => {
+            expect(subGenCallParams.entities).to.eql([
+                'Region',
+                'Country',
+                'Location',
+                'Department',
+                'Task',
+                'Employee',
+                'Job',
+                'JobHistory',
             ]);
         });
-        it('calls entity subgenerator', () => {
-            expect(subGenCallParams.count).to.equal(8);
-            expect(subGenCallParams.commands).to.eql([
-                'jhipster:entity Region',
-                'jhipster:entity Country',
-                'jhipster:entity Location',
-                'jhipster:entity Department',
-                'jhipster:entity Task',
-                'jhipster:entity Employee',
-                'jhipster:entity Job',
-                'jhipster:entity JobHistory',
-            ]);
+        it('calls entities subgenerator', () => {
+            expect(subGenCallParams.count).to.equal(1);
+            expect(subGenCallParams.commands).to.eql(['jhipster:entities']);
             expect(subGenCallParams.options[0]).to.eql({
                 ...options,
                 ...defaultAddedOptions,
                 regenerate: true,
-                interactive: true,
             });
         });
     });
 
     describe('imports a JDL entity model from multiple files', () => {
-        const options = { skipInstall: true };
+        const options = { skipInstall: true, databaseType: 'postgresql', baseName: 'jhipster' };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
@@ -294,72 +241,55 @@ describe('JHipster generator import jdl', () => {
 
         afterEach(() => revertTempDir(originalCwd));
 
-        it('creates entity json files', () => {
-            assert.file([
-                '.jhipster/Department.json',
-                '.jhipster/JobHistory.json',
-                '.jhipster/Job.json',
-                '.jhipster/Employee.json',
-                '.jhipster/Location.json',
-                '.jhipster/Task.json',
-                '.jhipster/Country.json',
-                '.jhipster/Region.json',
-                '.jhipster/DepartmentAlt.json',
-                '.jhipster/JobHistoryAlt.json',
-                '.jhipster/Listing.json',
-                '.jhipster/Profile.json',
-                '.jhipster/WishList.json',
+        it('passes entities to entities generator', () => {
+            expect(subGenCallParams.entities).to.eql([
+                'Region',
+                'Country',
+                'Location',
+                'Department',
+                'Task',
+                'Employee',
+                'Job',
+                'JobHistory',
+                'DepartmentAlt',
+                'JobHistoryAlt',
+                'WishList',
+                'Profile',
+                'Listing',
             ]);
         });
-        it('calls entity subgenerator', () => {
-            expect(subGenCallParams.count).to.equal(13);
-            expect(subGenCallParams.commands).to.eql([
-                'jhipster:entity Region',
-                'jhipster:entity Country',
-                'jhipster:entity Location',
-                'jhipster:entity Department',
-                'jhipster:entity Task',
-                'jhipster:entity Employee',
-                'jhipster:entity Job',
-                'jhipster:entity JobHistory',
-                'jhipster:entity DepartmentAlt',
-                'jhipster:entity JobHistoryAlt',
-                'jhipster:entity WishList',
-                'jhipster:entity Profile',
-                'jhipster:entity Listing',
-            ]);
+        it('calls entities subgenerator', () => {
+            expect(subGenCallParams.count).to.equal(1);
+            expect(subGenCallParams.commands).to.eql(['jhipster:entities']);
             expect(subGenCallParams.options[0]).to.eql({
                 ...options,
                 ...defaultAddedOptions,
                 regenerate: true,
-                interactive: true,
             });
         });
     });
 
     describe('imports a JDL entity model which excludes Elasticsearch for a class', () => {
-        const options = { skipInstall: true, interactive: false };
+        const options = { skipInstall: true };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
-                return loadImportJdl()(['search.jdl'], options, env);
+                return loadImportJdl()(['search.jdl'], { ...options, interactive: false }, env);
             });
         });
 
         afterEach(() => revertTempDir(originalCwd));
 
-        it('creates entity json files', () => {
-            assert.file(['.jhipster/WithSearch.json', '.jhipster/WithoutSearch.json']);
-            assert.fileContent('.jhipster/WithoutSearch.json', /"searchEngine": false/);
+        it('should not create entity json files', () => {
+            assert.noFile(['.jhipster/WithSearch.json', '.jhipster/WithoutSearch.json']);
         });
-        it('calls entity subgenerator', () => {
-            expect(subGenCallParams.count).to.equal(2);
-            expect(subGenCallParams.commands).to.eql(['jhipster:entity WithSearch', 'jhipster:entity WithoutSearch']);
+        it('calls entities subgenerator', () => {
+            expect(subGenCallParams.count).to.equal(1);
+            expect(subGenCallParams.commands).to.eql(['jhipster:entities']);
             expect(subGenCallParams.options[0]).to.eql({
                 ...options,
                 ...defaultAddedOptions,
                 regenerate: true,
-                force: true,
             });
         });
     });
@@ -389,15 +319,7 @@ describe('JHipster generator import jdl', () => {
         it('calls application generator', () => {
             expect(subGenCallParams.count).to.equal(1);
             expect(subGenCallParams.commands).to.eql(['app']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--with-entities',
-                '--skip-install',
-                '--no-insight',
-                '--no-skip-git',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--with-entities', '--skip-install', '--no-insight', '--no-skip-git']);
         });
     });
 
@@ -424,12 +346,13 @@ describe('JHipster generator import jdl', () => {
             expect(subGenCallParams.count).to.equal(1);
             expect(subGenCallParams.commands).to.eql(['jhipster:app']);
             expect(subGenCallParams.options[0].applicationWithEntities).to.not.be.undefined;
+        });
+        it('calls application generator with options', () => {
             expect({ ...subGenCallParams.options[0], applicationWithEntities: undefined }).to.eql({
                 ...options,
                 ...defaultAddedOptions,
                 withEntities: true,
                 force: true,
-                localConfigOnly: true,
                 applicationWithEntities: undefined,
             });
         });
@@ -459,17 +382,7 @@ describe('JHipster generator import jdl', () => {
         it('calls application generator', () => {
             expect(subGenCallParams.count).to.equal(1);
             expect(subGenCallParams.commands).to.eql(['app']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--with-entities',
-                '--skip-install',
-                '--no-insight',
-                '--no-skip-git',
-                '--inline',
-                'application { config { baseName jhapp } entities * } entity Customer',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--with-entities', '--skip-install', '--no-insight', '--no-skip-git']);
         });
     });
 
@@ -478,11 +391,14 @@ describe('JHipster generator import jdl', () => {
             skipInstall: true,
             noInsight: true,
             skipGit: false,
-            inline: 'application { config { baseName jhapp } entities * } entity Customer',
         };
         beforeEach(() => {
             return testInTempDir(dir => {
-                return loadImportJdl()([], options, env);
+                return loadImportJdl()(
+                    [],
+                    { ...options, inline: 'application { config { baseName jhapp } entities * } entity Customer' },
+                    env
+                );
             });
         });
 
@@ -503,7 +419,6 @@ describe('JHipster generator import jdl', () => {
                 ...defaultAddedOptions,
                 withEntities: true,
                 force: true,
-                localConfigOnly: true,
                 applicationWithEntities: undefined,
             });
         });
@@ -527,25 +442,17 @@ describe('JHipster generator import jdl', () => {
         it('calls application generator', () => {
             expect(subGenCallParams.count).to.equal(1);
             expect(subGenCallParams.commands).to.eql(['app']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--skip-install',
-                '--no-insight',
-                '--no-interactive',
-                '--no-skip-git',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--skip-install', '--no-insight', '--no-skip-git']);
         });
     });
 
     describe('imports single app only', () => {
-        const options = { skipInstall: true, noInsight: true, interactive: false, skipGit: false };
+        const options = { skipInstall: true, noInsight: true, skipGit: false };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
                 fse.removeSync(`${dir}/.yo-rc.json`);
-                return loadImportJdl()(['single-app-only.jdl'], options, env);
+                return loadImportJdl()(['single-app-only.jdl'], { ...options, interactive: false }, env);
             });
         });
 
@@ -562,7 +469,6 @@ describe('JHipster generator import jdl', () => {
                 ...options,
                 ...defaultAddedOptions,
                 force: true,
-                localConfigOnly: true,
                 applicationWithEntities: undefined,
             });
         });
@@ -600,21 +506,12 @@ describe('JHipster generator import jdl', () => {
         it('calls application generator', () => {
             expect(subGenCallParams.count).to.equal(3);
             expect(subGenCallParams.commands).to.eql(['app', 'app', 'app']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--with-entities',
-                '--skip-install',
-                '--no-insight',
-                '--no-interactive',
-                '--no-skip-git',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--with-entities', '--skip-install', '--no-insight', '--no-skip-git']);
         });
     });
 
     describe('skips JDL apps with --ignore-application', () => {
-        const options = { skipInstall: true, ignoreApplication: true, interactive: false, skipGit: false };
+        const options = { skipInstall: true, ignoreApplication: true, fork: true, skipGit: false };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
@@ -625,8 +522,8 @@ describe('JHipster generator import jdl', () => {
 
         afterEach(() => revertTempDir(originalCwd));
 
-        it('creates the application config', () => {
-            assert.file([
+        it('should not create the application config', () => {
+            assert.noFile([
                 path.join('myFirstApp', '.yo-rc.json'),
                 path.join('mySecondApp', '.yo-rc.json'),
                 path.join('myThirdApp', '.yo-rc.json'),
@@ -643,18 +540,9 @@ describe('JHipster generator import jdl', () => {
             ]);
         });
         it('does not call application generator', () => {
-            expect(subGenCallParams.count).to.equal(6);
-            expect(subGenCallParams.commands).to.eql(['entity A', 'entity B', 'entity E', 'entity E', 'entity F', 'entity F']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--skip-install',
-                '--ignore-application',
-                '--no-interactive',
-                '--no-skip-git',
-                '--regenerate',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.count).to.equal(3);
+            expect(subGenCallParams.commands).to.eql(['entities', 'entities', 'entities']);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--skip-install', '--no-skip-git', '--regenerate']);
         });
     });
 
@@ -680,15 +568,7 @@ describe('JHipster generator import jdl', () => {
             const invokedSubgens = ['docker-compose', 'kubernetes', 'openshift'];
             expect(subGenCallParams.commands).to.eql(invokedSubgens);
             expect(subGenCallParams.count).to.equal(invokedSubgens.length);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--skip-install',
-                '--no-interactive',
-                '--no-skip-git',
-                '--skip-prompts',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--skip-install', '--no-skip-git', '--skip-prompts']);
         });
     });
 
@@ -713,20 +593,14 @@ describe('JHipster generator import jdl', () => {
                     '--with-entities',
                     '--skip-install',
                     '--no-insight',
-                    '--no-interactive',
                     '--no-skip-git',
-                    '--from-cli',
-                    '--local-config-only',
                 ]);
                 expect(subGenCallParams.options[3]).to.eql([
                     '--force',
                     '--skip-install',
                     '--no-insight',
-                    '--no-interactive',
                     '--no-skip-git',
                     '--skip-prompts',
-                    '--from-cli',
-                    '--local-config-only',
                 ]);
             });
         });
@@ -780,17 +654,7 @@ describe('JHipster generator import jdl', () => {
         it('calls generator in order', () => {
             expect(subGenCallParams.count).to.equal(3);
             expect(subGenCallParams.commands).to.eql(['app', 'app', 'app']);
-            expect(subGenCallParams.options[0]).to.eql([
-                '--force',
-                '--with-entities',
-                '--skip-install',
-                '--no-insight',
-                '--ignore-deployments',
-                '--no-interactive',
-                '--no-skip-git',
-                '--from-cli',
-                '--local-config-only',
-            ]);
+            expect(subGenCallParams.options[0]).to.eql(['--force', '--with-entities', '--skip-install', '--no-insight', '--no-skip-git']);
         });
     });
 

--- a/test/entities/composing.js
+++ b/test/entities/composing.js
@@ -1,0 +1,187 @@
+const fse = require('fs-extra');
+const path = require('path');
+const assert = require('yeoman-assert');
+const helpers = require('yeoman-test');
+const { JHIPSTER_CONFIG_DIR } = require('../../generators/generator-constants');
+const { appDefaultConfig, serverDefaultConfig } = require('../../generators/generator-defaults');
+
+const mockedComposedGenerators = ['jhipster:entity-client', 'jhipster:entity-server', 'jhipster:database-changelog'];
+
+describe('jhipster:entities with entitiesToImport option', () => {
+    const localConfig = { baseName: 'jhipster', ...appDefaultConfig, ...serverDefaultConfig };
+    describe('with --with-entities', () => {
+        describe('and single entity', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/entities'))
+                    .withOptions({
+                        localConfig,
+                        entitiesToImport: [{ name: 'Foo' }],
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('writes .yo-rc.json', () => {
+                runResult.assertFile('.yo-rc.json');
+                runResult.assertFileContent('.yo-rc.json', /"baseName": "jhipster"/);
+            });
+            it('writes entity config file', () => {
+                runResult.assertFile('.jhipster/Foo.json');
+                runResult.assertFileContent('.jhipster/Foo.json', /"name": "Foo"/);
+            });
+            it('should compose with entity-client generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity-client'];
+                assert(EntityGenerator.calledOnce);
+                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
+            });
+            it('should compose with entity-server generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity-server'];
+                assert(EntityGenerator.calledOnce);
+                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
+            });
+        });
+
+        describe('and 2 entities', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/entities'))
+                    .withOptions({
+                        localConfig,
+                        entitiesToImport: [{ name: 'Foo' }, { name: 'Bar' }],
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('writes .yo-rc.json', () => {
+                runResult.assertFile('.yo-rc.json');
+                runResult.assertFileContent('.yo-rc.json', /"baseName": "jhipster"/);
+            });
+            it('writes entity config file', () => {
+                runResult.assertFile('.jhipster/Foo.json');
+                runResult.assertFileContent('.jhipster/Foo.json', /"name": "Foo"/);
+                runResult.assertFile('.jhipster/Bar.json');
+                runResult.assertFileContent('.jhipster/Bar.json', /"name": "Bar"/);
+            });
+            it('should compose with entity-client generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity-client'];
+                assert.equal(EntityGenerator.callCount, 2);
+                assert.equal(EntityGenerator.getCall(0).args[0], 'Foo');
+                assert.equal(EntityGenerator.getCall(1).args[0], 'Bar');
+            });
+            it('should compose with database-changelog generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                assert.equal(EntityGenerator.callCount, 1);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo', 'Bar']);
+            });
+        });
+
+        describe('and 1 entity and 1 entity file', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/entities'))
+                    .withOptions({
+                        localConfig,
+                        entitiesToImport: [{ name: 'Foo', changelogDate: '20201012010501' }],
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .doInDir(dir => {
+                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
+                        fse.ensureDirSync(entitiesPath);
+                        const entityPath = path.join(entitiesPath, 'Bar.json');
+                        fse.writeFileSync(entityPath, '{"changelogDate": "20201012010502"}');
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('should compose with mocked entity-client generator ordered by changelogDate', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity-client'];
+                assert.equal(EntityGenerator.callCount, 2);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo']);
+                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Bar']);
+            });
+            it('should compose with database-changelog generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                assert.equal(EntityGenerator.callCount, 1);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Foo', 'Bar']);
+            });
+        });
+
+        describe('and more than 1 entity and more than 1 entity file', () => {
+            let runResult;
+            before(() => {
+                return helpers
+                    .create(require.resolve('../../generators/entities'))
+                    .withOptions({
+                        localConfig,
+                        entitiesToImport: [
+                            { name: 'Four', changelogDate: '20201012010500' },
+                            { name: 'Two', changelogDate: '20201012010502' },
+                        ],
+                        fromCli: true,
+                        skipInstall: true,
+                        defaults: true,
+                        withEntities: true,
+                    })
+                    .doInDir(dir => {
+                        const entitiesPath = path.join(dir, JHIPSTER_CONFIG_DIR);
+                        fse.ensureDirSync(entitiesPath);
+                        fse.writeFileSync(path.join(entitiesPath, 'One.json'), '{"changelogDate": "20201012010503"}');
+                        fse.writeFileSync(path.join(entitiesPath, 'Three.json'), '{"changelogDate": "20201012010501"}');
+                    })
+                    .withMockedGenerators(mockedComposedGenerators)
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    });
+            });
+
+            after(() => runResult.cleanup());
+
+            it('should compose with mocked entity-client generator ordered by changelogDate', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:entity-client'];
+                assert.equal(EntityGenerator.callCount, 4);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Four']);
+                assert.deepStrictEqual(EntityGenerator.getCall(1).args[0], ['Three']);
+                assert.deepStrictEqual(EntityGenerator.getCall(2).args[0], ['Two']);
+                assert.deepStrictEqual(EntityGenerator.getCall(3).args[0], ['One']);
+            });
+            it('should compose with database-changelog generator', () => {
+                const EntityGenerator = runResult.mockedGenerators['jhipster:database-changelog'];
+                assert.equal(EntityGenerator.callCount, 1);
+                assert.deepStrictEqual(EntityGenerator.getCall(0).args[0], ['Four', 'Three', 'Two', 'One']);
+            });
+        });
+    });
+});

--- a/test/entity/database-changelog.spec.js
+++ b/test/entity/database-changelog.spec.js
@@ -29,5 +29,37 @@ describe('jhipster:entity database changelogs', () => {
                 runResult.assertFile([`${SERVER_MAIN_RES_DIR}config/cql/changelog/20160926101210_added_entity_Foo.cql`]);
             });
         });
+        describe('with gateway application type', () => {
+            let runResult;
+            before(() =>
+                helpers
+                    .create(require.resolve('../../generators/entity'))
+                    .doInDir(dir => {
+                        fse.copySync(path.join(__dirname, '../templates/compose/01-gateway'), dir);
+                        const jsonFile = path.join(dir, '.jhipster/Foo.json');
+                        fse.copySync(path.join(__dirname, '../templates/.jhipster/Simple.json'), jsonFile);
+                        fse.writeJsonSync(jsonFile, {
+                            ...fse.readJsonSync(jsonFile),
+                            microservicePath: 'microservice1',
+                            microserviceName: 'microservice1',
+                        });
+                    })
+                    .withArguments(['Foo'])
+                    .withOptions({ regenerate: true, force: true })
+                    .run()
+                    .then(result => {
+                        runResult = result;
+                    })
+            );
+
+            after(() => runResult.cleanup());
+
+            it('should not create database changelogs', () => {
+                runResult.assertNoFile([
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/20160926101210_added_entity_Foo.xml`,
+                    `${SERVER_MAIN_RES_DIR}config/liquibase/changelog/20160926101210_added_entity_constraints_Foo.xml`,
+                ]);
+            });
+        });
     });
 });

--- a/test/jdl/validators/jdl-without-application-validator.spec.js
+++ b/test/jdl/validators/jdl-without-application-validator.spec.js
@@ -51,7 +51,7 @@ describe('JDLWithoutApplicationValidator', () => {
                         name: 'Continue',
                     })
                 );
-                validator = createValidator(jdlObject);
+                validator = createValidator(jdlObject, { databaseType: DatabaseTypes.SQL });
             });
 
             it('should fail', () => {


### PR DESCRIPTION
Changes in this PR:
- Implement entities generator.
  - Update entity generator to compose with entities, so relationships can use otherEntity.
- Implement entities-client generator.
  - Move rebuild webpack trigger to to entities-client instead of running at the last composed entity generator.
- Refactor import-jdl to use entities generator:
  - Changes the behavior to fork only when no application config was found.
  - Don't forward jdl exclusive options to generators due to unknown option.
Makes multiples applications compatible with incremental changelog.

Closes https://github.com/jhipster/generator-jhipster/issues/12696
Related to https://github.com/jhipster/generator-jhipster/issues/11896.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
