### PR TITLE
[v6] 12072 rollback reactive

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -366,7 +366,7 @@
         <dependency>
             <groupId>io.springfox</groupId>
             <artifactId>springfox-bean-validators</artifactId>
-            <version>2.10.5</version>
+            <version>${springfox.version}</version>
         </dependency>
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -150,7 +150,7 @@
         <typesafe.version>1.4.0</typesafe.version>
 <%_ } _%>
 <%_ if (reactive && (applicationType === 'gateway' || applicationType === 'monolith')) { _%>
-        <springfox.version>3.0.0-SNAPSHOT</springfox.version>
+        <springfox.version>2.10.5</springfox.version>
 <%_ } _%>
         <!-- Plugin versions -->
         <maven-clean-plugin.version>3.1.0</maven-clean-plugin.version>
@@ -357,6 +357,16 @@
             <groupId>io.springfox</groupId>
             <artifactId>springfox-spring-webflux</artifactId>
             <version>${springfox.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-schema</artifactId>
+            <version>${springfox.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>io.springfox</groupId>
+            <artifactId>springfox-bean-validators</artifactId>
+            <version>2.10.5</version>
         </dependency>
 <%_ } _%>
 <%_ if (databaseType === 'sql') { _%>

--- a/generators/server/templates/src/main/java/package/config/apidoc/SwaggerConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/apidoc/SwaggerConfiguration.java.ejs
@@ -21,6 +21,7 @@ package <%= packageName %>.config.apidoc;
 import io.github.jhipster.config.JHipsterConstants;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.ComponentScan;
 import org.springframework.context.annotation.Primary;
 import org.springframework.context.annotation.Profile;
 import springfox.documentation.builders.PathSelectors;
@@ -32,7 +33,7 @@ import springfox.documentation.swagger2.annotations.EnableSwagger2WebFlux;
 @Primary
 @Profile(JHipsterConstants.SPRING_PROFILE_SWAGGER)
 @Configuration
-@EnableSwagger2WebFlux
+@ComponentScan({"springfox.documentation.schema"})
 public class SwaggerConfiguration {
 
     @Bean

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -199,7 +199,7 @@ spring:
             <%_ } else if (devDatabaseType === 'oracle') { _%>
         url: <%- getJDBCUrl(devDatabaseType, { databaseName: 'xe', hostname: 'localhost' }) %>
             <%_ } else if (devDatabaseType === 'h2Disk') { _%>
-        url: <%- getJDBCUrl(devDatabaseType, { databaseName: lowercaseBaseName, localDirectory: `${BUILD_DIR}h2db/db` }) %>
+        url: <%- getJDBCUrl(devDatabaseType, { databaseName: lowercaseBaseName, localDirectory: `./${BUILD_DIR}h2db/db` }) %>
             <%_ } else if (devDatabaseType === 'h2Memory') { _%>
         url: <%- getJDBCUrl(devDatabaseType, { databaseName: lowercaseBaseName }) %>
             <%_ } _%>


### PR DESCRIPTION
This PR rolls back the reactive Springfox version to something that is closer to compatible with the core jhipster-dependencies version. See associated ticket for details.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ x] Tests are added where necessary
-   [ x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x ] Documentation is added/updated where necessary
-   [ x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
