### PR TITLE
Fix microservice: auth token now passing from gateway to microservice

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -809,9 +809,7 @@ const serverFiles = {
         },
         {
             condition: generator =>
-                !generator.reactive &&
-                generator.authenticationType === 'oauth2' &&
-                generator.applicationType === 'gateway',
+                !generator.reactive && generator.authenticationType === 'oauth2' && generator.applicationType === 'gateway',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -811,8 +811,7 @@ const serverFiles = {
             condition: generator =>
                 !generator.reactive &&
                 generator.authenticationType === 'oauth2' &&
-                generator.applicationType === 'gateway' &&
-                generator.serviceDiscoveryType,
+                generator.applicationType === 'gateway',
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -68,7 +68,7 @@ import org.springframework.security.oauth2.core.DelegatingOAuth2TokenValidator;
 import org.springframework.security.oauth2.core.OAuth2TokenValidator;
 import org.springframework.security.oauth2.jwt.*;
 import org.springframework.security.oauth2.server.resource.authentication.JwtAuthenticationConverter;
-        <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
+        <%_ if (applicationType === 'gateway') { _%>
 import <%= packageName %>.security.oauth2.AuthorizationHeaderFilter;
 import <%= packageName %>.security.oauth2.AuthorizationHeaderUtil;
         <%_ } _%>
@@ -352,7 +352,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
 
         return jwtDecoder;
     }
-        <%_ if (applicationType === 'gateway' && serviceDiscoveryType) { _%>
+        <%_ if (applicationType === 'gateway') { _%>
 
     @Bean
     public AuthorizationHeaderFilter authHeaderFilter(AuthorizationHeaderUtil headerUtil) {


### PR DESCRIPTION
This PR fixes the following scenario: Microservice architecture, Oauth2 Authentication, No Service Discovery.
In this scenario the gateway fails to relay authentication token to downstream microservice, resulting in status code 401 when querying microservice's api.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
