### PR TITLE
JDL changes.

### DIFF
--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -27,6 +27,7 @@ on:
         branches:
             - '*'
         paths:
+            - 'jdl/**'
             - 'utils/**'
             - 'test-integration/incremental-changelog-samples/**'
             - 'generators/entity/**'

--- a/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter.js
+++ b/jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter.js
@@ -18,7 +18,7 @@
  */
 
 const JSONEntity = require('../../jhipster/json-entity');
-const { formatComment, formatDateForLiquibase } = require('../../utils/format-utils');
+const { formatComment } = require('../../utils/format-utils');
 const { getTableNameFromEntityName } = require('../../jhipster/entity-table-name-creator');
 const logger = require('../../utils/objects/logger');
 
@@ -33,17 +33,16 @@ module.exports = {
 /**
  * Converts JDL entities to JSONEntity objects with basic information.
  * @param {Array<JDLEntity>} jdlEntities - the JDL entities to convert.
- * @param {Date} creationTimestamp - the creation timestamp to use when creating JSON entity, optional.
  * @return {Map<String, JSONEntity>} a map having for keys entity names and for values the corresponding JSON entities.
  */
-function convert(jdlEntities, creationTimestamp) {
+function convert(jdlEntities) {
     if (!jdlEntities) {
         throw new Error('JDL entities must be passed to get the basic entity information.');
     }
-    return createJSONEntities(jdlEntities, creationTimestamp || new Date());
+    return createJSONEntities(jdlEntities);
 }
 
-function createJSONEntities(jdlEntities, creationTimestamp) {
+function createJSONEntities(jdlEntities) {
     const convertedEntities = new Map();
     jdlEntities.forEach((jdlEntity, index) => {
         const entityName = jdlEntity.name;
@@ -64,7 +63,6 @@ function createJSONEntities(jdlEntities, creationTimestamp) {
             new JSONEntity({
                 entityName,
                 entityTableName: getTableNameFromEntityName(jdlEntity.tableName),
-                changelogDate: formatDateForLiquibase({ date: new Date(creationTimestamp), increment: index + 1 }),
                 javadoc: formatComment(jdlEntity.comment),
             })
         );

--- a/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.js
+++ b/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.js
@@ -38,7 +38,6 @@ module.exports = {
  * Converts a JDLObject to ready-to-be exported JSON entities.
  * @param {Object} args - the configuration object, keys:
  * @param {JDLObject} args.jdlObject - the JDLObject to convert to JSON
- * @param {Date} args.creationTimestamp - the creation timestamp, for entities
  * @returns {Map} entities that can be exported to JSON
  */
 function convert(args = {}) {
@@ -51,7 +50,7 @@ function convert(args = {}) {
         const applicationNames = jdlObject.getApplications().map(jdlApplication => jdlApplication.getConfigurationOptionValue('baseName'));
         return new Map(applicationNames.map(applicationName => [applicationName, []]));
     }
-    setBasicEntityInformation(args.creationTimestamp);
+    setBasicEntityInformation();
     setFields();
     setRelationships();
     setApplicationToEntities();
@@ -86,8 +85,8 @@ function setEntitiesPerApplication() {
     });
 }
 
-function setBasicEntityInformation(creationTimestamp = new Date()) {
-    const convertedEntities = BasicEntityConverter.convert(jdlObject.getEntities(), creationTimestamp);
+function setBasicEntityInformation() {
+    const convertedEntities = BasicEntityConverter.convert(jdlObject.getEntities());
     convertedEntities.forEach((jsonEntity, entityName) => {
         entities[entityName] = jsonEntity;
     });

--- a/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.js
+++ b/jdl/converters/jdl-to-json/jdl-without-application-to-json-converter.js
@@ -40,7 +40,6 @@ module.exports = {
  * @param {String} args.applicationName - the application's name
  * @param {String} args.databaseType - the database type
  * @param {applicationType} args.applicationType - the application's type
- * @param {Date} args.creationTimestamp - the creation timestamp, for entities
  * @returns {Map} entities that can be exported to JSON
  */
 function convert(args = {}) {
@@ -48,7 +47,7 @@ function convert(args = {}) {
         throw new Error("The JDL object, the application's name and its the database type are mandatory.");
     }
     init(args);
-    setBasicEntityInformation(args.creationTimestamp);
+    setBasicEntityInformation();
     setOptions();
     setFields();
     setRelationships();
@@ -69,8 +68,8 @@ function resetState() {
     entities = null;
 }
 
-function setBasicEntityInformation(creationTimestamp = new Date()) {
-    const convertedEntities = BasicEntityConverter.convert(jdlObject.getEntities(), creationTimestamp);
+function setBasicEntityInformation() {
+    const convertedEntities = BasicEntityConverter.convert(jdlObject.getEntities());
     convertedEntities.forEach((jsonEntity, entityName) => {
         entities[entityName] = jsonEntity;
     });

--- a/jdl/converters/parsed-jdl-to-jdl-object/application-converter.js
+++ b/jdl/converters/parsed-jdl-to-jdl-object/application-converter.js
@@ -27,7 +27,6 @@ module.exports = { convertApplications };
  * @param {Array<Object>} parsedApplications - the parsed applications.
  * @param {Object} configuration - a configuration object.
  * @param {String} configuration.generatorVersion - the generator's version to use when converting applications.
- * @param {Number} configuration.creationTimestamp - a creation timestamp to use for entities.
  * @param {Array<String>} entityNames - the entity names.
  * @return {Array} the converted JDL applications.
  */
@@ -52,9 +51,6 @@ function addCustomValuesToApplication(parsedApplication, configuration) {
     const application = { ...parsedApplication };
     if (configuration.generatorVersion) {
         application.config.jhipsterVersion = configuration.generatorVersion;
-    }
-    if (configuration.creationTimestamp) {
-        application.config.creationTimestamp = configuration.creationTimestamp;
     }
     return application;
 }

--- a/jdl/exporters/applications/jhipster-application-formatter.js
+++ b/jdl/exporters/applications/jhipster-application-formatter.js
@@ -41,24 +41,20 @@ function formatApplicationsToExport(applications, configuration) {
 /**
  * Exports JDL a application to a JDL file in the current directory.
  * @param {Object} application - the JDL application to export.
- * @param {Object} configuration - the configuration object.
- * @param {Integer} configuration.creationTimestampConfig - date representation to be written to creationTimestamp at .yo-rc.json.
  * @return {Object} the exported application in its final form.
  */
 function formatApplicationToExport(application, configuration = {}) {
     return setUpApplicationStructure(application, configuration);
 }
 
-function setUpApplicationStructure(application, { creationTimestampConfig }) {
+function setUpApplicationStructure(application) {
     let applicationToExport = {
         [GENERATOR_NAME]: {},
     };
     applicationToExport[GENERATOR_NAME] = getApplicationConfig(application);
     applicationToExport.entities = application.getEntityNames();
     if (application.hasConfigurationOption('creationTimestamp')) {
-        applicationToExport[GENERATOR_NAME].creationTimestamp = application.getConfigurationOptionValue('creationTimestamp');
-    } else if (creationTimestampConfig) {
-        applicationToExport[GENERATOR_NAME].creationTimestamp = creationTimestampConfig;
+        applicationToExport[GENERATOR_NAME].creationTimestamp = parseInt(application.getConfigurationOptionValue('creationTimestamp'), 10);
     }
     applicationToExport = cleanUpOptions(applicationToExport);
     return applicationToExport;

--- a/jdl/exporters/jhipster-entity-exporter.js
+++ b/jdl/exporters/jhipster-entity-exporter.js
@@ -105,7 +105,7 @@ function updateEntityToGenerateWithExistingOne(filePath, entity) {
         const fileOnDisk = readJSONFile(filePath);
         if (fileOnDisk && fileOnDisk.changelogDate) {
             entity.changelogDate = fileOnDisk.changelogDate;
-            return { ...fileOnDisk, ...entity, changelogDate: fileOnDisk.changelogDate };
+            return { ...fileOnDisk, ...entity };
         }
     }
     return entity;

--- a/jdl/jdl-importer.js
+++ b/jdl/jdl-importer.js
@@ -173,9 +173,15 @@ function importOnlyEntities(jdlObject, configuration) {
         application = readJSONFile('.yo-rc.json');
     }
     if (application && application['generator-jhipster']) {
-        if (applicationType === undefined) applicationType = application['generator-jhipster'].applicationType;
-        if (applicationName === undefined) applicationName = application['generator-jhipster'].baseName;
-        if (databaseType === undefined) databaseType = application['generator-jhipster'].databaseType;
+        if (applicationType === undefined) {
+            applicationType = application['generator-jhipster'].applicationType;
+        }
+        if (applicationName === undefined) {
+            applicationName = application['generator-jhipster'].baseName;
+        }
+        if (databaseType === undefined) {
+            databaseType = application['generator-jhipster'].databaseType;
+        }
     }
 
     const entitiesPerApplicationMap = JDLWithoutApplicationToJSONConverter.convert({

--- a/jdl/jdl-importer.js
+++ b/jdl/jdl-importer.js
@@ -17,6 +17,8 @@
  */
 const { uniqBy } = require('lodash');
 const JDLReader = require('./readers/jdl-reader');
+const { readJSONFile } = require('./readers/json-file-reader');
+const { doesFileExist } = require('./utils/file-utils');
 const DocumentParser = require('./converters/parsed-jdl-to-jdl-object/parsed-jdl-to-jdl-object-converter');
 const JDLWithoutApplicationToJSONConverter = require('./converters/jdl-to-json/jdl-without-application-to-json-converter');
 const JDLWithApplicationsToJSONConverter = require('./converters/jdl-to-json/jdl-with-applications-to-json-converter');
@@ -46,7 +48,6 @@ module.exports = {
  * @param {String} configuration.generatorVersion - deprecated, the generator's version, optional if parsing applications
  * @param {String} configuration.forceNoFiltering - whether to force filtering
  * @param {Boolean} configuration.skipFileGeneration - whether not to generate the .yo-rc.json file
- * @param {Date} configuration.creationTimestamp - the creation timestamp to use when generating entities
  * @returns {Object} a JDL importer.
  * @throws {Error} if files aren't passed.
  */
@@ -73,7 +74,6 @@ function createImporterFromFiles(files, configuration) {
  * @param {String} configuration.generatorVersion - deprecated, the generator's version, optional if parsing applications
  * @param {String} configuration.forceNoFiltering - whether to force filtering
  * @param {Boolean} configuration.skipFileGeneration - whether not to generate the .yo-rc.json file
- * @param {Date} configuration.creationTimestamp - the creation timestamp to use when generating entities
  * @returns {Object} a JDL importer.
  * @throws {Error} if the content isn't passed.
  */
@@ -102,7 +102,6 @@ function makeJDLImporter(content, configuration) {
          *          - exportedEntities: the exported entities, or an empty list
          */
         import: () => {
-            configuration.creationTimestampConfig = getCreationTimestampToUse(configuration.creationTimestamp);
             const jdlObject = getJDLObject(content, configuration);
             checkForErrors(jdlObject, configuration);
             if (jdlObject.getApplicationQuantity() === 0 && jdlObject.getEntityQuantity() > 0) {
@@ -120,19 +119,6 @@ function makeJDLImporter(content, configuration) {
     };
 }
 
-function getCreationTimestampToUse(passedCreationTimestamp) {
-    let creationTimestampConfig = new Date();
-    // We don't need seconds precision, discard it.
-    creationTimestampConfig.setSeconds(0);
-    if (passedCreationTimestamp) {
-        const parsedTimestamp = Date.parse(passedCreationTimestamp);
-        if (parsedTimestamp) {
-            creationTimestampConfig = new Date(parsedTimestamp);
-        }
-    }
-    return creationTimestampConfig.getTime();
-}
-
 function parseFiles(files) {
     return JDLReader.parseFromFiles(files);
 }
@@ -141,7 +127,6 @@ function getJDLObject(parsedJDLContent, configuration) {
     let baseName = configuration.applicationName;
     let applicationType = configuration.applicationType;
     let generatorVersion = configuration.generatorVersion;
-    let creationTimestamp = configuration.creationTimestampConfig;
     let databaseType = configuration.databaseType;
     let skippedUserManagement = false;
 
@@ -149,7 +134,6 @@ function getJDLObject(parsedJDLContent, configuration) {
         baseName = configuration.application['generator-jhipster'].baseName;
         applicationType = configuration.application['generator-jhipster'].applicationType;
         generatorVersion = configuration.application['generator-jhipster'].jhipsterVersion;
-        creationTimestamp = configuration.application['generator-jhipster'].creationTimestamp;
         skippedUserManagement = configuration.application['generator-jhipster'].skipUserManagement;
         databaseType = configuration.application['generator-jhipster'].databaseType;
     }
@@ -159,7 +143,6 @@ function getJDLObject(parsedJDLContent, configuration) {
         applicationType,
         applicationName: baseName,
         generatorVersion,
-        creationTimestamp,
         skippedUserManagement,
         databaseType,
     });
@@ -183,20 +166,22 @@ function checkForErrors(jdlObject, configuration) {
 }
 
 function importOnlyEntities(jdlObject, configuration) {
-    let { applicationName, applicationType, databaseType, creationTimestamp } = configuration;
+    let { applicationName, applicationType, databaseType } = configuration;
 
-    if (configuration.application) {
-        applicationType = configuration.application['generator-jhipster'].applicationType;
-        applicationName = configuration.application['generator-jhipster'].baseName;
-        databaseType = configuration.application['generator-jhipster'].databaseType;
-        creationTimestamp = configuration.application['generator-jhipster'].creationTimestamp;
+    let application = configuration.application;
+    if (!configuration.application && doesFileExist('.yo-rc.json')) {
+        application = readJSONFile('.yo-rc.json');
+    }
+    if (application && application['generator-jhipster']) {
+        if (applicationType === undefined) applicationType = application['generator-jhipster'].applicationType;
+        if (applicationName === undefined) applicationName = application['generator-jhipster'].baseName;
+        if (databaseType === undefined) databaseType = application['generator-jhipster'].databaseType;
     }
 
     const entitiesPerApplicationMap = JDLWithoutApplicationToJSONConverter.convert({
         jdlObject,
         applicationName,
         applicationType,
-        creationTimestamp,
         databaseType,
     });
     const jsonEntities = entitiesPerApplicationMap.get(applicationName);
@@ -204,7 +189,7 @@ function importOnlyEntities(jdlObject, configuration) {
 }
 
 function importOneApplicationAndEntities(jdlObject, configuration) {
-    const { creationTimestamp, skipFileGeneration } = configuration;
+    const { skipFileGeneration } = configuration;
 
     const importState = {
         exportedApplications: [],
@@ -221,7 +206,6 @@ function importOneApplicationAndEntities(jdlObject, configuration) {
     const applicationName = jdlApplication.getConfigurationOptionValue('baseName');
     const entitiesPerApplicationMap = JDLWithApplicationsToJSONConverter.convert({
         jdlObject,
-        creationTimestamp,
     });
     const jsonEntities = entitiesPerApplicationMap.get(applicationName);
     importState.exportedApplicationsWithEntities[applicationName] = {
@@ -242,7 +226,7 @@ function importOneApplicationAndEntities(jdlObject, configuration) {
 }
 
 function importApplicationsAndEntities(jdlObject, configuration) {
-    const { creationTimestamp, skipFileGeneration } = configuration;
+    const { skipFileGeneration } = configuration;
 
     const importState = {
         exportedApplications: [],
@@ -258,7 +242,6 @@ function importApplicationsAndEntities(jdlObject, configuration) {
     }
     const entitiesPerApplicationMap = JDLWithApplicationsToJSONConverter.convert({
         jdlObject,
-        creationTimestamp,
     });
     entitiesPerApplicationMap.forEach((jsonEntities, applicationName) => {
         const jdlApplication = jdlObject.getApplication(applicationName);

--- a/jdl/jhipster/application-options.js
+++ b/jdl/jhipster/application-options.js
@@ -119,7 +119,6 @@ const optionValues = {
     },
     [optionNames.CLIENT_THEME]: 'none',
     [optionNames.CLIENT_THEME_VARIANT]: { none: '', default: 'primary' },
-    [optionNames.CREATION_TIMESTAMP]: new Date().getTime(),
     [optionNames.DATABASE_TYPE]: {
         [SQL]: SQL,
         [MONGODB]: MONGODB,

--- a/jdl/jhipster/json-entity.js
+++ b/jdl/jhipster/json-entity.js
@@ -18,7 +18,7 @@
  */
 
 const { merge } = require('../utils/object-utils');
-const { formatDateForLiquibase, formatComment } = require('../utils/format-utils');
+const { formatComment } = require('../utils/format-utils');
 const { upperFirst } = require('../utils/string-utils');
 const { getTableNameFromEntityName } = require('./entity-table-name-creator');
 
@@ -32,7 +32,6 @@ class JSONEntity {
      *        - entityName, the entity name (mandatory)
      *        - fields, a field iterable
      *        - relationships, a relationship iterable
-     *        - changelogDate,
      *        - javadoc,
      *        - entityTableName, defaults to the snake-cased entity name,
      *        - dto, defaults to 'no',
@@ -52,7 +51,6 @@ class JSONEntity {
         this.name = merged.name;
         this.fields = merged.fields;
         this.relationships = merged.relationships;
-        this.changelogDate = merged.changelogDate;
         this.javadoc = merged.javadoc;
         this.entityTableName = merged.entityTableName;
         this.dto = merged.dto;
@@ -120,7 +118,6 @@ function defaults(entityName) {
         name: upperFirst(entityName),
         fields: [],
         relationships: [],
-        changelogDate: formatDateForLiquibase(),
         javadoc: formatComment(),
         entityTableName: getTableNameFromEntityName(entityName),
         dto: 'no',

--- a/jdl/utils/format-utils.js
+++ b/jdl/utils/format-utils.js
@@ -17,11 +17,8 @@
  * limitations under the License.
  */
 
-const { merge } = require('./object-utils');
-
 module.exports = {
     formatComment,
-    formatDateForLiquibase,
 };
 
 /**
@@ -47,58 +44,4 @@ function formatComment(comment) {
         }
         return previousValue.concat(delimiter, currentValue.trim().replace(/[*]*\s*/, ''));
     }, '');
-}
-
-/**
- * Formats an optional date to be used by Liquibase.
- * @param {Object} args - the function's arguments.
- * @param {Date} args.date - the date to format, optional.
- * @param {Number} args.increment - an increment to be used to set minutes, optional.
- * @return {string} the formatted Date.
- */
-function formatDateForLiquibase(args) {
-    if (args && args.date) {
-        // to safely handle the date, we create a copy of the date
-        args.date = new Date(args.date.getTime());
-    }
-    const merged = merge(defaultsForLiquibaseDateFormatting(), args);
-    merged.date.setMinutes(merged.date.getMinutes() + merged.increment);
-
-    const nowUtc = new Date(
-        merged.date.getUTCFullYear(),
-        merged.date.getUTCMonth(),
-        merged.date.getUTCDate(),
-        merged.date.getUTCHours(),
-        merged.date.getUTCMinutes(),
-        merged.date.getUTCSeconds()
-    );
-    const year = `${nowUtc.getFullYear()}`;
-    let month = `${nowUtc.getMonth() + 1}`;
-    if (month.length === 1) {
-        month = `0${month}`;
-    }
-    let day = `${nowUtc.getDate()}`;
-    if (day.length === 1) {
-        day = `0${day}`;
-    }
-    let hour = `${nowUtc.getHours()}`;
-    if (hour.length === 1) {
-        hour = `0${hour}`;
-    }
-    let minute = `${nowUtc.getMinutes()}`;
-    if (minute.length === 1) {
-        minute = `0${minute}`;
-    }
-    let second = `${nowUtc.getSeconds()}`;
-    if (second.length === 1) {
-        second = `0${second}`;
-    }
-    return `${year}${month}${day}${hour}${minute}${second}`;
-}
-
-function defaultsForLiquibaseDateFormatting() {
-    return {
-        date: new Date(),
-        increment: 0,
-    };
 }

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -365,7 +365,7 @@ describe('JHipster generator import jdl', () => {
     });
 
     describe('imports single app and entities with --fork', () => {
-        const options = { skipInstall: true, noInsight: true, skipGit: false, creationTimestamp: '2019-01-01' };
+        const options = { skipInstall: true, noInsight: true, skipGit: false };
         beforeEach(() => {
             return testInTempDir(dir => {
                 fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
@@ -381,16 +381,10 @@ describe('JHipster generator import jdl', () => {
             assert.JSONFileContent('.yo-rc.json', {
                 'generator-jhipster': { baseName: 'jhipsterApp' },
             });
-            assert.JSONFileContent('.yo-rc.json', {
-                'generator-jhipster': { creationTimestamp: 1546300800000 },
-            });
         });
         it('creates the entities', () => {
             const aFile = path.join('.jhipster', 'A.json');
             assert.file([aFile, path.join('.jhipster', 'B.json')]);
-            assert.JSONFileContent(aFile, {
-                changelogDate: '20190101000100',
-            });
         });
         it('calls application generator', () => {
             expect(subGenCallParams.count).to.equal(1);
@@ -401,8 +395,6 @@ describe('JHipster generator import jdl', () => {
                 '--skip-install',
                 '--no-insight',
                 '--no-skip-git',
-                '--creation-timestamp',
-                '2019-01-01',
                 '--from-cli',
                 '--local-config-only',
             ]);

--- a/test/jdl/converters/JDLToJSON/jdl-to-json-basic-entity-information-converter.spec.js
+++ b/test/jdl/converters/JDLToJSON/jdl-to-json-basic-entity-information-converter.spec.js
@@ -28,7 +28,6 @@ const { expect } = require('chai');
 const JDLEntity = require('../../../../jdl/models/jdl-entity');
 const { convert } = require('../../../../jdl/converters/jdl-to-json/jdl-to-json-basic-entity-converter');
 const logger = require('../../../../jdl/utils/objects/logger');
-const { formatDateForLiquibase } = require('../../../../jdl/utils/format-utils');
 
 describe('JDLToJSONBasicEntityConverter', () => {
     describe('convert', () => {
@@ -99,7 +98,6 @@ describe('JDLToJSONBasicEntityConverter', () => {
                 it('should convert the entity', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: [],
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',

--- a/test/jdl/converters/JDLToJSON/jdl-with-applications-to-json-converter.spec.js
+++ b/test/jdl/converters/JDLToJSON/jdl-with-applications-to-json-converter.spec.js
@@ -44,7 +44,6 @@ const { ONE_TO_ONE, MANY_TO_MANY, MANY_TO_ONE, ONE_TO_MANY } = require('../../..
 const { JPA_DERIVED_IDENTIFIER } = require('../../../../jdl/jhipster/relationship-options');
 const logger = require('../../../../jdl/utils/objects/logger');
 const { convert } = require('../../../../jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter');
-const { formatDateForLiquibase } = require('../../../../jdl/utils/format-utils');
 
 describe('JDLWithApplicationsToJSONConverter', () => {
     describe('convert', () => {
@@ -66,7 +65,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                 jdlObject.addApplication(application);
                 result = convert({
                     jdlObject,
-                    creationTimestamp: Date.now(),
                 });
             });
 
@@ -104,7 +102,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     jdlObject.addApplication(application);
                     const returnedMap = convert({
                         jdlObject,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                     });
                     customEntitiesAreConverted = returnedMap.get('toto').every(entity => entity.name === 'A');
                     builtInEntitiesAreConverted = returnedMap
@@ -135,7 +132,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     jdlObject.addEntity(entityA);
                     const returnedMap = convert({
                         jdlObject,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                     });
                     convertedEntity = returnedMap.get('toto')[0];
                 });
@@ -143,7 +139,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                 it('should convert the entity', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: ['toto'],
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -239,7 +234,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -249,7 +243,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     expect(convertedEntity).to.deep.equal({
                         angularJSSuffix: 'suffix',
                         applications: ['toto'],
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         clientRootFolder: '../client_root_folder',
                         dto: 'mapstruct',
                         embedded: true,
@@ -295,7 +288,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     );
                     const returnedMap = convert({
                         jdlObject,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                     });
                     convertedEntity = returnedMap.get('toto')[0];
                 });
@@ -313,7 +305,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                 it('should set the service option to serviceClass', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: ['toto'],
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'mapstruct',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -355,7 +346,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -374,7 +364,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                 it('should set the service option to serviceClass', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: ['toto'],
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -416,7 +405,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -425,7 +413,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                 it('should prevent the entities from being searched', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: ['toto'],
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -471,7 +458,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -480,7 +466,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: ['toto'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -543,7 +528,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -552,7 +536,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: ['toto'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -613,7 +596,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -622,7 +604,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: ['toto'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'a',
@@ -668,7 +649,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -677,7 +657,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: ['toto'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -778,7 +757,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -787,7 +765,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: ['toto'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -854,7 +831,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -863,7 +839,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: ['toto'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -941,7 +916,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             applicationName: 'toto',
                             applicationType: MONOLITH,
                             databaseType: SQL,
-                            creationTimestamp: Date.now(),
                         });
                         relationshipsForA = returned.get('toto').find(entity => entity.name === 'A').relationships;
                         relationshipsForB = returned.get('toto').find(entity => entity.name === 'B').relationships;
@@ -1044,7 +1018,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             convertedRelationship = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                         });
@@ -1092,7 +1065,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             convertedRelationship = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                         });
@@ -1139,7 +1111,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             applicationName: 'toto',
                             applicationType: MONOLITH,
                             databaseType: SQL,
-                            creationTimestamp: Date.now(),
                         });
                         relationshipsForA = returned.get('toto').find(entity => entity.name === 'A').relationships;
                         relationshipsForB = returned.get('toto').find(entity => entity.name === 'B').relationships;
@@ -1199,7 +1170,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                             applicationName: 'toto',
                             applicationType: MONOLITH,
                             databaseType: SQL,
-                            creationTimestamp: Date.now(),
                         });
                         relationshipsForA = returned.get('toto').find(entity => entity.name === 'A').relationships;
                         relationshipsForB = returned.get('toto').find(entity => entity.name === 'B').relationships;
@@ -1257,7 +1227,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1303,7 +1272,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1354,7 +1322,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1399,7 +1366,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1455,7 +1421,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1509,7 +1474,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1561,7 +1525,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1613,7 +1576,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1714,7 +1676,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     jdlObject.addApplication(tutuApplication);
                     const returnedMap = convert({
                         jdlObject,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                     });
                     convertedEntitiesForTataApplication = returnedMap.get('tata');
                     convertedEntitiesForTutuApplication = returnedMap.get('tutu');
@@ -1724,7 +1685,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     expect(convertedEntitiesForTataApplication).to.deep.equal([
                         {
                             applications: ['tata'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -1740,7 +1700,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         },
                         {
                             applications: ['tata'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 2 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_b',
@@ -1756,7 +1715,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         },
                         {
                             applications: ['tata', 'tutu'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 3 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_c',
@@ -1774,7 +1732,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                     expect(convertedEntitiesForTutuApplication).to.deep.equal([
                         {
                             applications: ['tata', 'tutu'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 3 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_c',
@@ -1790,7 +1747,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         },
                         {
                             applications: ['tutu'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 4 }),
                             dto: 'mapstruct',
                             embedded: false,
                             entityTableName: 'entity_d',
@@ -1806,7 +1762,6 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                         },
                         {
                             applications: ['tutu'],
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 5 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_e',

--- a/test/jdl/converters/JDLToJSON/jdl-without-application-to-json-converter.spec.js
+++ b/test/jdl/converters/JDLToJSON/jdl-without-application-to-json-converter.spec.js
@@ -43,7 +43,6 @@ const BinaryOptions = require('../../../../jdl/jhipster/binary-options');
 const { ONE_TO_ONE, MANY_TO_MANY, MANY_TO_ONE, ONE_TO_MANY } = require('../../../../jdl/jhipster/relationship-types');
 const { JPA_DERIVED_IDENTIFIER } = require('../../../../jdl/jhipster/relationship-options');
 const logger = require('../../../../jdl/utils/objects/logger');
-const { formatDateForLiquibase } = require('../../../../jdl/utils/format-utils');
 
 describe('JDLWithoutApplicationToJSONConverter', () => {
     describe('convert', () => {
@@ -80,7 +79,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     applicationName: 'toto',
                     applicationType: MONOLITH,
                     databaseType: SQL,
-                    creationTimestamp: Date.now(),
                 });
             });
 
@@ -113,7 +111,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     customEntitiesAreConverted = returnedMap.get('toto').every(entity => entity.name === 'A');
@@ -144,7 +141,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -153,7 +149,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                 it('should convert the entity', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: '*',
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -246,7 +241,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -256,7 +250,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     expect(convertedEntity).to.deep.equal({
                         angularJSSuffix: 'suffix',
                         applications: '*',
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         clientRootFolder: '../client_root_folder',
                         dto: 'mapstruct',
                         embedded: true,
@@ -301,7 +294,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -320,7 +312,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                 it('should set the service option to serviceClass', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: '*',
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'mapstruct',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -359,7 +350,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -378,7 +368,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                 it('should set the service option to serviceClass', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: '*',
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -417,7 +406,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                         jdlObject,
                         applicationName: 'toto',
                         applicationType: MONOLITH,
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         databaseType: SQL,
                     });
                     convertedEntity = returnedMap.get('toto')[0];
@@ -426,7 +414,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                 it('should prevent the entities from being searched', () => {
                     expect(convertedEntity).to.deep.equal({
                         applications: '*',
-                        changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                         dto: 'no',
                         embedded: false,
                         entityTableName: 'entity_a',
@@ -469,7 +456,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -478,7 +464,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: '*',
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -538,7 +523,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -547,7 +531,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: '*',
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -605,7 +588,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -614,7 +596,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: '*',
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'a',
@@ -657,7 +638,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -666,7 +646,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: '*',
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -764,7 +743,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -773,7 +751,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: '*',
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -837,7 +814,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             jdlObject,
                             applicationName: 'toto',
                             applicationType: MONOLITH,
-                            creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                             databaseType: SQL,
                         });
                         convertedEntity = returnedMap.get('toto')[0];
@@ -846,7 +822,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                     it('should convert them', () => {
                         expect(convertedEntity).to.deep.equal({
                             applications: '*',
-                            changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                             dto: 'no',
                             embedded: false,
                             entityTableName: 'entity_a',
@@ -920,7 +895,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             applicationName: 'toto',
                             applicationType: MONOLITH,
                             databaseType: SQL,
-                            creationTimestamp: Date.now(),
                         });
                         relationshipsForA = returned.get('toto').find(entity => entity.name === 'A').relationships;
                         relationshipsForB = returned.get('toto').find(entity => entity.name === 'B').relationships;
@@ -1019,7 +993,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             convertedRelationship = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                         });
@@ -1063,7 +1036,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             convertedRelationship = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                         });
@@ -1106,7 +1078,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             applicationName: 'toto',
                             applicationType: MONOLITH,
                             databaseType: SQL,
-                            creationTimestamp: Date.now(),
                         });
                         relationshipsForA = returned.get('toto').find(entity => entity.name === 'A').relationships;
                         relationshipsForB = returned.get('toto').find(entity => entity.name === 'B').relationships;
@@ -1162,7 +1133,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                             applicationName: 'toto',
                             applicationType: MONOLITH,
                             databaseType: SQL,
-                            creationTimestamp: Date.now(),
                         });
                         relationshipsForA = returned.get('toto').find(entity => entity.name === 'A').relationships;
                         relationshipsForB = returned.get('toto').find(entity => entity.name === 'B').relationships;
@@ -1216,7 +1186,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1258,7 +1227,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1305,7 +1273,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1346,7 +1313,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1398,7 +1364,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1448,7 +1413,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1496,7 +1460,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];
@@ -1544,7 +1507,6 @@ describe('JDLWithoutApplicationToJSONConverter', () => {
                                 applicationName: 'toto',
                                 applicationType: MONOLITH,
                                 databaseType: SQL,
-                                creationTimestamp: Date.now(),
                             });
                             relationshipFromSourceToDestination = returned.get('toto').find(entity => entity.name === 'A').relationships[0];
                             relationshipFromDestinationToSource = returned.get('toto').find(entity => entity.name === 'B').relationships[0];

--- a/test/jdl/converters/parsedJDLToJDLObject/application-converter.spec.js
+++ b/test/jdl/converters/parsedJDLToJDLObject/application-converter.spec.js
@@ -66,23 +66,21 @@ describe('ApplicationConverter', () => {
                     let expectedApplication;
 
                     before(() => {
-                        convertedApplication = convertApplications(
-                            [
-                                {
-                                    config: {
-                                        applicationType: MONOLITH,
-                                        baseName: 'mono',
-                                    },
-                                    entities: {
-                                        entityList: [],
-                                        excluded: [],
-                                    },
-                                    options: {},
-                                    useOptions: [],
+                        convertedApplication = convertApplications([
+                            {
+                                config: {
+                                    applicationType: MONOLITH,
+                                    baseName: 'mono',
+                                    creationTimestamp: 42,
                                 },
-                            ],
-                            { creationTimestamp: 42 }
-                        );
+                                entities: {
+                                    entityList: [],
+                                    excluded: [],
+                                },
+                                options: {},
+                                useOptions: [],
+                            },
+                        ]);
                         expectedApplication = [
                             createJDLApplication({
                                 applicationType: MONOLITH,

--- a/test/jdl/jdl-importer.spec.js
+++ b/test/jdl/jdl-importer.spec.js
@@ -25,7 +25,6 @@ const { expect } = require('chai');
 const ApplicationTypes = require('../../jdl/jhipster/application-types');
 const DatabaseTypes = require('../../jdl/jhipster/database-types');
 const { createImporterFromFiles, createImporterFromContent } = require('../../jdl/jdl-importer');
-const { formatDateForLiquibase } = require('../../jdl/utils/format-utils');
 
 describe('JDLImporter', () => {
     describe('createImporterFromFiles', () => {
@@ -84,7 +83,6 @@ describe('JDLImporter', () => {
                     skipServer: true,
                     microserviceName: 'mymicroservice',
                     javadoc: '',
-                    changelogDate: '20190101000700',
                 },
                 Department: {
                     fields: [
@@ -147,7 +145,6 @@ describe('JDLImporter', () => {
                     applications: '*',
                     microserviceName: 'mymicroservice',
                     javadoc: '',
-                    changelogDate: '20190101000100',
                 },
                 Employee: {
                     fields: [
@@ -233,7 +230,6 @@ describe('JDLImporter', () => {
                     applications: '*',
                     microserviceName: 'mymicroservice',
                     searchEngine: 'elasticsearch',
-                    changelogDate: '20190101000400',
                 },
                 Job: {
                     fields: [
@@ -295,7 +291,6 @@ describe('JDLImporter', () => {
                     applications: '*',
                     microserviceName: 'mymicroservice',
                     javadoc: '',
-                    changelogDate: '20190101000300',
                 },
                 JobHistory: {
                     fields: [
@@ -355,7 +350,6 @@ describe('JDLImporter', () => {
                     fluentMethods: true,
                     applications: '*',
                     microserviceName: 'mymicroservice',
-                    changelogDate: '20190101000200',
                 },
                 Location: {
                     fields: [
@@ -397,7 +391,6 @@ describe('JDLImporter', () => {
                     applications: '*',
                     microserviceName: 'mymicroservice',
                     javadoc: '',
-                    changelogDate: '20190101000500',
                 },
                 Region: {
                     fields: [
@@ -427,7 +420,6 @@ describe('JDLImporter', () => {
                     applications: '*',
                     microserviceName: 'mymicroservice',
                     javadoc: '',
-                    changelogDate: '20190101000800',
                 },
                 Task: {
                     fields: [
@@ -462,7 +454,6 @@ describe('JDLImporter', () => {
                     applications: '*',
                     microserviceName: 'mymicroservice',
                     javadoc: '',
-                    changelogDate: '20190101000600',
                 },
             };
 
@@ -471,7 +462,6 @@ describe('JDLImporter', () => {
                     applicationName: 'MyApp',
                     applicationType: ApplicationTypes.MONOLITH,
                     databaseType: DatabaseTypes.SQL,
-                    creationTimestamp: '2019-01-01',
                 });
                 returned = importer.import();
                 returned.exportedEntities = returned.exportedEntities
@@ -711,7 +701,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -747,7 +736,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -778,7 +766,6 @@ relationship OneToOne {
                         nativeLanguage: 'en',
                         skipUserManagement: true,
                         skipClient: true,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -814,16 +801,13 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
             ];
             const APPLICATION_NAMES = ['tata', 'titi', 'toto', 'tutu'];
 
             before(() => {
-                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'applications2.jdl')], {
-                    creationTimestamp: '2019-01-01',
-                });
+                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'applications2.jdl')]);
                 importer.import();
                 APPLICATION_NAMES.forEach(applicationName => {
                     contents.push(JSON.parse(fse.readFileSync(path.join(applicationName, '.yo-rc.json'), 'utf-8')));
@@ -883,7 +867,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -914,7 +897,6 @@ relationship OneToOne {
                         nativeLanguage: 'en',
                         skipUserManagement: true,
                         skipClient: true,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -945,7 +927,6 @@ relationship OneToOne {
                         nativeLanguage: 'en',
                         skipUserManagement: true,
                         skipClient: true,
-                        creationTimestamp: 1546300800000,
                     },
                 },
             ];
@@ -1010,15 +991,10 @@ relationship OneToOne {
             ];
             let importState;
             before(() => {
-                const importer = createImporterFromFiles(
-                    [
-                        path.join(__dirname, 'test-files', 'integration', 'file1.jdl'),
-                        path.join(__dirname, 'test-files', 'integration', 'file2.jdl'),
-                    ],
-                    {
-                        creationTimestamp: '2019-01-01',
-                    }
-                );
+                const importer = createImporterFromFiles([
+                    path.join(__dirname, 'test-files', 'integration', 'file1.jdl'),
+                    path.join(__dirname, 'test-files', 'integration', 'file2.jdl'),
+                ]);
                 importState = importer.import();
             });
 
@@ -1053,21 +1029,15 @@ relationship OneToOne {
                                 readJSON = JSON.parse(
                                     fse.readFileSync(path.join(applicationName, '.jhipster', `${entityName}.json`), 'utf-8').toString()
                                 );
-                                expect(readJSON.changelogDate).not.to.be.undefined;
-                                delete readJSON.changelogDate;
                                 expect(readJSON).to.deep.equal(expectedEntities[index]);
                             });
                             break;
                         case 'mySecondApp': // only E
                             readJSON = JSON.parse(fse.readFileSync(path.join(applicationName, '.jhipster', 'E.json'), 'utf-8').toString());
-                            expect(readJSON.changelogDate).not.to.be.undefined;
-                            delete readJSON.changelogDate;
                             expect(readJSON).to.deep.equal(expectedEntities[2]);
                             break;
                         case 'myThirdApp': // only F
                             readJSON = JSON.parse(fse.readFileSync(path.join(applicationName, '.jhipster', 'F.json'), 'utf-8').toString());
-                            expect(readJSON.changelogDate).not.to.be.undefined;
-                            delete readJSON.changelogDate;
                             expect(readJSON).to.deep.equal(expectedEntities[3]);
                             break;
                         default:
@@ -1220,7 +1190,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -1256,7 +1225,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -1287,7 +1255,6 @@ relationship OneToOne {
                         nativeLanguage: 'en',
                         skipUserManagement: true,
                         skipClient: true,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -1323,7 +1290,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         skipClient: false,
                         skipServer: false,
-                        creationTimestamp: 1546300800000,
                     },
                 },
                 {
@@ -1343,9 +1309,7 @@ relationship OneToOne {
             const APPLICATION_NAMES = ['tata', 'titi', 'toto', 'tutu'];
 
             before(() => {
-                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'applications3.jdl')], {
-                    creationTimestamp: '2019-01-01',
-                });
+                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'applications3.jdl')]);
                 importer.import();
                 APPLICATION_NAMES.forEach(applicationName => {
                     contents.push(JSON.parse(fse.readFileSync(path.join(applicationName, '.yo-rc.json'), 'utf-8')));
@@ -1484,7 +1448,6 @@ relationship OneToOne {
                         skipUserManagement: false,
                         clientPackageManager: 'npm',
                         serverPort: '8080',
-                        creationTimestamp: 1546300800000,
                     },
                     entities: [
                         'Customer',
@@ -1524,7 +1487,6 @@ relationship OneToOne {
                         serverPort: '8081',
                         skipUserManagement: true,
                         clientPackageManager: 'npm',
-                        creationTimestamp: 1546300800000,
                     },
                     entities: ['Product', 'ProductCategory', 'ProductOrder', 'OrderItem'],
                 },
@@ -1555,7 +1517,6 @@ relationship OneToOne {
                         skipUserManagement: true,
                         clientPackageManager: 'npm',
                         cacheProvider: 'hazelcast',
-                        creationTimestamp: 1546300800000,
                     },
                     entities: ['Invoice', 'Shipment'],
                 },
@@ -1586,7 +1547,6 @@ relationship OneToOne {
                         serverPort: '8083',
                         skipUserManagement: true,
                         clientPackageManager: 'npm',
-                        creationTimestamp: 1546300800000,
                     },
                     entities: ['Notification'],
                 },
@@ -1624,9 +1584,7 @@ relationship OneToOne {
             const FOLDER_NAMES = ['store', 'product', 'invoice', 'notification', 'docker-compose', 'kubernetes'];
 
             before(() => {
-                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'realistic_sample.jdl')], {
-                    creationTimestamp: '2019-01-01',
-                });
+                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'realistic_sample.jdl')]);
                 importer.import();
                 FOLDER_NAMES.forEach(applicationName => {
                     contents.push(JSON.parse(fse.readFileSync(path.join(applicationName, '.yo-rc.json'), 'utf-8')));
@@ -1710,7 +1668,6 @@ entity F
 paginate * with infinite-scroll
 `,
                     {
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         generatorVersion: '7.0.0',
                     }
                 );
@@ -1734,7 +1691,6 @@ paginate * with infinite-scroll
             it('should set them', () => {
                 expect(entityA).to.deep.equal({
                     applications: ['tata'],
-                    changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 1 }),
                     dto: 'no',
                     embedded: false,
                     entityTableName: 'a',
@@ -1749,7 +1705,6 @@ paginate * with infinite-scroll
                 });
                 expect(entityB).to.deep.equal({
                     applications: ['tata'],
-                    changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 2 }),
                     dto: 'no',
                     embedded: false,
                     entityTableName: 'b',
@@ -1764,7 +1719,6 @@ paginate * with infinite-scroll
                 });
                 expect(entityCInTata).to.deep.equal({
                     applications: ['tata', 'tutu'],
-                    changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 3 }),
                     dto: 'no',
                     embedded: false,
                     entityTableName: 'c',
@@ -1779,7 +1733,6 @@ paginate * with infinite-scroll
                 });
                 expect(entityCInTutu).to.deep.equal({
                     applications: ['tata', 'tutu'],
-                    changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 3 }),
                     dto: 'no',
                     embedded: false,
                     entityTableName: 'c',
@@ -1794,7 +1747,6 @@ paginate * with infinite-scroll
                 });
                 expect(entityD).to.deep.equal({
                     applications: ['tutu'],
-                    changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 4 }),
                     dto: 'mapstruct',
                     embedded: false,
                     entityTableName: 'd',
@@ -1809,7 +1761,6 @@ paginate * with infinite-scroll
                 });
                 expect(entityE).to.deep.equal({
                     applications: ['tutu'],
-                    changelogDate: formatDateForLiquibase({ date: new Date(2020, 0, 1, 1, 0, 0), increment: 5 }),
                     dto: 'no',
                     embedded: false,
                     entityTableName: 'e',
@@ -1847,7 +1798,6 @@ entity A
 paginate * with infinite-scroll
 `,
                     {
-                        creationTimestamp: new Date(2020, 0, 1, 1, 0, 0),
                         generatorVersion: '7.0.0',
                         skipFileGeneration: true,
                     }
@@ -1865,9 +1815,7 @@ paginate * with infinite-scroll
         });
         context('when not exporting entities but only applications', () => {
             before(() => {
-                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'application.jdl')], {
-                    creationTimestamp: '2019-01-01',
-                });
+                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'application.jdl')]);
                 importer.import();
             });
             after(() => {
@@ -1884,9 +1832,7 @@ paginate * with infinite-scroll
             let importState;
 
             before(() => {
-                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'application_with_blueprints.jdl')], {
-                    creationTimestamp: '2019-01-01',
-                });
+                const importer = createImporterFromFiles([path.join(__dirname, 'test-files', 'application_with_blueprints.jdl')]);
                 importState = importer.import();
             });
             after(() => {
@@ -1908,7 +1854,6 @@ paginate * with infinite-scroll
                             clientPackageManager: 'npm',
                             clientTheme: 'none',
                             clientThemeVariant: '',
-                            creationTimestamp: 1546300800000,
                             databaseType: 'sql',
                             devDatabaseType: 'h2Disk',
                             enableHibernateCache: true,

--- a/test/jdl/jhipster/json-entity.spec.js
+++ b/test/jdl/jhipster/json-entity.spec.js
@@ -47,8 +47,6 @@ describe('JSONEntity', () => {
             });
 
             it('should set default values', () => {
-                expect(entity.changelogDate).not.to.be.undefined;
-                delete entity.changelogDate;
                 expect(entity).to.deep.equal({
                     name: 'Toto',
                     dto: 'no',
@@ -83,7 +81,6 @@ describe('JSONEntity', () => {
                     embedded: true,
                     relationships: [42, 43],
                     service: 'serviceClass',
-                    changelogDate: 'aaa',
                     microserviceName: 'nope',
                     angularJSSuffix: 'yes',
                     clientRootFolder: 'oh',
@@ -107,7 +104,6 @@ describe('JSONEntity', () => {
                     embedded: true,
                     relationships: [42, 43],
                     service: 'serviceClass',
-                    changelogDate: 'aaa',
                     microserviceName: 'nope',
                     angularJSSuffix: 'yes',
                     clientRootFolder: 'oh',
@@ -255,7 +251,6 @@ describe('JSONEntity', () => {
             before(() => {
                 jsonEntity = new JSONEntity({
                     entityName: 'Toto',
-                    changelogDate: 42,
                     javadoc: 'A comment',
                 });
                 jsonEntity.setOptions({
@@ -267,7 +262,6 @@ describe('JSONEntity', () => {
             it('should set them', () => {
                 expect(jsonEntity).to.deep.equal({
                     applications: [],
-                    changelogDate: 42,
                     dto: 'mapstruct',
                     embedded: false,
                     entityTableName: 'toto',

--- a/test/jdl/utils/format-utils.spec.js
+++ b/test/jdl/utils/format-utils.spec.js
@@ -19,7 +19,7 @@
 
 /* eslint-disable no-new, no-unused-expressions */
 const { expect } = require('chai');
-const { formatDateForLiquibase, formatComment } = require('../../../jdl/utils/format-utils');
+const { formatComment } = require('../../../jdl/utils/format-utils');
 
 describe('FormatUtils', () => {
     describe('formatComment', () => {
@@ -81,35 +81,6 @@ describe('FormatUtils', () => {
                 it(`should return ${buildTestTitle(expectedResult3)}`, () => {
                     expect(formatComment(multiLineComment3)).to.equal(expectedResult3);
                 });
-            });
-        });
-    });
-    describe('formatDateForLiquibase', () => {
-        context('when passing both arguments', () => {
-            let result;
-
-            before(() => {
-                result = formatDateForLiquibase({ date: new Date(Date.UTC(0, 0, 0, 0, 0, 0)), increment: 1 });
-            });
-
-            it('should use the increment with the passed date', () => {
-                expect(result).to.equal('18991231000100');
-            });
-        });
-        context('when not passing the date', () => {
-            it('should not fail', () => {
-                expect(formatDateForLiquibase().length).to.equal(14);
-            });
-        });
-        context('when not passing the increment', () => {
-            let result;
-
-            before(() => {
-                result = formatDateForLiquibase({ date: new Date(Date.UTC(0, 0, 0, 0, 0, 0)) });
-            });
-
-            it('should format the current time for liquibase with no increment', () => {
-                expect(result).to.equal('18991231000000');
             });
         });
     });


### PR DESCRIPTION
Contains the following changes:
- When importing entities only jdls, read `.yo-rc.json` on demand, current it requires `import-jdl` command to always pass `.yo-rc.json` data.
- Stop creating creationTimestamp
- When creationTimestamp exists in jdl, it should be passed as an int.
- Stop creating changelogDate.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
