### PR TITLE
correct comparison of big decimals in integration tests

### DIFF
--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -126,7 +126,7 @@ jobs:
                       entity: sql
                       profile: prod
                       war: 0
-                      protractor: 1
+                      e2e: 1
                       testcontainers: 1
                     - app-type: webflux-mysql
                       entity: sqlfull

--- a/generators/entity-server/templates/partials/it_patch_update.partial.java.ejs
+++ b/generators/entity-server/templates/partials/it_patch_update.partial.java.ejs
@@ -71,6 +71,8 @@ assertThat(<%= entityInstance %>List).hasSize(databaseSizeBeforeUpdate);
 <%_ } else if ((field.fieldType === 'byte[]' || field.fieldType === 'ByteBuffer') && field.fieldTypeBlobContent !== 'text') { _%>
     assertThat(test<%= entityClass %>.get<%= field.fieldInJavaBeanMethod %>()).isEqualTo(<%= field.testWithConstant %>);
     assertThat(test<%= entityClass %>.get<%= field.fieldInJavaBeanMethod %>ContentType()).isEqualTo(<%= field.testWithConstant %>_CONTENT_TYPE);
+<%_ } else if (field.fieldType === 'BigDecimal'){ _%>
+    assertThat(test<%= entityClass %>.get<%= field.fieldInJavaBeanMethod %>()).isEqualByComparingTo(<%= field.testWithConstant %>);
 <%_ } else { _%>
     assertThat(test<%= entityClass %>.get<%= field.fieldInJavaBeanMethod %>()).isEqualTo(<%= field.testWithConstant %>);
 <%_ } } _%>

--- a/test-integration/samples/webflux-mysql/.yo-rc.json
+++ b/test-integration/samples/webflux-mysql/.yo-rc.json
@@ -17,7 +17,7 @@
         "enableTranslation": true,
         "nativeLanguage": "en",
         "languages": ["en", "fr"],
-        "testFrameworks": ["gatling", "protractor"],
+        "testFrameworks": ["gatling", "cypress"],
         "serverPort": "8080",
         "jhiPrefix": "jhi",
         "clientPackageManager": "npm",


### PR DESCRIPTION
This PR uses `isEqualByComparingTo` instead of `isEqualTo` to compare `BigDecimal`s in integration tests

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
