### PR TITLE
Revert "Bump zone.js from 0.10.3 to 0.11.1 in /generators/client/templates/angular"

### DIFF
--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -15,7 +15,7 @@
     "rxjs": "6.6.3",
     "swagger-ui-dist": "3.35.1",
     "tslib": "2.0.3",
-    "zone.js": "0.11.1"
+    "zone.js": "0.10.3"
   },
   "devDependencies": {
     "@angular/cli": "10.1.6",


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#12775

Reference https://github.com/jhipster/generator-jhipster/pull/12762.