### PR TITLE
Revert "Bump css-loader from 3.6.0 to 5.0.0 in /generators/client/templates/angular"

### DIFF
--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -24,7 +24,7 @@
     "browser-sync-webpack-plugin": "2.2.2",
     "codelyzer": "6.0.1",
     "copy-webpack-plugin": "6.2.1",
-    "css-loader": "5.0.0",
+    "css-loader": "3.6.0",
     "eslint-loader": "4.0.2",
     "file-loader": "6.1.1",
     "friendly-errors-webpack-plugin": "1.7.0",


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#12755

Fixes https://github.com/jhipster/generator-jhipster/issues/12803