### PR TITLE
Allow generators/blueprints to force skipGeneratedFlag

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -117,16 +117,10 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
             this.config.set(this.options.localConfig);
         }
 
-        if (this.options.skipGeneratedFlag !== undefined) {
-            this.jhipsterConfig.skipGeneratedFlag = this.options.skipGeneratedFlag;
-        }
-
         // Load common runtime options.
         this.parseCommonRuntimeOptions();
 
-        if (!this.jhipsterConfig.skipGeneratedFlag) {
-            this.registerGeneratedAnnotationTransform();
-        }
+        this.registerGeneratedAnnotationTransform();
 
         // Register .yo-resolve file
         if (!this.options.skipYoResolve) {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -117,10 +117,16 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
             this.config.set(this.options.localConfig);
         }
 
+        if (this.options.skipGeneratedFlag !== undefined) {	
+            this.jhipsterConfig.skipGeneratedFlag = this.options.skipGeneratedFlag;	
+        }
+
         // Load common runtime options.
         this.parseCommonRuntimeOptions();
 
-        this.registerGeneratedAnnotationTransform();
+        if (!this.jhipsterConfig.skipGeneratedFlag) {
+            this.registerGeneratedAnnotationTransform();
+        }
 
         // Register .yo-resolve file
         if (!this.options.skipYoResolve) {

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -117,8 +117,8 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
             this.config.set(this.options.localConfig);
         }
 
-        if (this.options.skipGeneratedFlag !== undefined) {	
-            this.jhipsterConfig.skipGeneratedFlag = this.options.skipGeneratedFlag;	
+        if (this.options.skipGeneratedFlag !== undefined) {
+            this.jhipsterConfig.skipGeneratedFlag = this.options.skipGeneratedFlag;
         }
 
         // Load common runtime options.

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -52,7 +52,9 @@ const prettierTransform = function (defaultOptions) {
 const generatedAnnotationTransform = generator => {
     return through.obj(function (file, encoding, callback) {
         if (
-            !generator.options.skipGeneratedFlag &&
+            !generator.configOptions.skipGeneratedFlag &&
+            !file.path.endsWith('package-info.java') &&
+            !file.path.endsWith('MavenWrapperDownloader.java') &&
             path.extname(file.path) === '.java' &&
             file.state !== 'deleted' &&
             !file.path.endsWith('GeneratedByJHipster.java')

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -51,7 +51,12 @@ const prettierTransform = function (defaultOptions) {
 
 const generatedAnnotationTransform = generator => {
     return through.obj(function (file, encoding, callback) {
-        if (path.extname(file.path) === '.java' && file.state !== 'deleted' && !file.path.endsWith('GeneratedByJHipster.java')) {
+        if (
+            !generator.options.skipGeneratedFlag &&
+            path.extname(file.path) === '.java' &&
+            file.state !== 'deleted' &&
+            !file.path.endsWith('GeneratedByJHipster.java')
+        ) {
             const packageName = generator.jhipsterConfig.packageName;
             const content = file.contents.toString('utf8');
 


### PR DESCRIPTION
<!--
PR description.
-->

Moving the `skip-generated-flag` check during the runtime. Adding a sub-generator for `fu` but this blocks me from generating the application. 

Also it looks like we are adding & checking this flag in the base generator, I think this should be in the server, entity-server, spring-{service, controller} generator only. 

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
