### PR TITLE
[angular] Remove deprecated functionality

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.component.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 import { Component, OnInit } from '@angular/core';
 import { ActivatedRoute } from '@angular/router';
-import { flatMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 import { LoginModalService } from 'app/core/login/login-modal.service';
 import { ActivateService } from './activate.service';
@@ -38,7 +38,7 @@ export class ActivateComponent implements OnInit {
     ) {}
 
     ngOnInit(): void {
-        this.route.queryParams.pipe(flatMap(params => this.activateService.get(params.key))).subscribe(
+        this.route.queryParams.pipe(mergeMap(params => this.activateService.get(params.key))).subscribe(
             () => this.success = true,
             () => this.error = true
         );

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
@@ -17,9 +17,9 @@
  limitations under the License.
 -%>
 import { Component, OnInit, ChangeDetectionStrategy, ChangeDetectorRef } from '@angular/core';
-import { flatMap } from 'rxjs/operators';
+import { combineLatest } from 'rxjs';
 
-import { MetricsService, Metrics, MetricsKey, ThreadDump, Thread } from './metrics.service';
+import { MetricsService, Metrics, MetricsKey, Thread } from './metrics.service';
 
 @Component({
     selector: '<%= jhiPrefixDashed %>-metrics',
@@ -39,20 +39,12 @@ export class MetricsComponent implements OnInit {
 
     refresh(): void {
         this.updatingMetrics = true;
-        this.metricsService
-            .getMetrics()
-            .pipe(
-                flatMap(
-                    () => this.metricsService.threadDump(),
-                    (metrics: Metrics, threadDump: ThreadDump) => {
-                        this.metrics = metrics;
-                        this.threads = threadDump.threads;
-                        this.updatingMetrics = false;
-                        this.changeDetector.detectChanges();
-                    }
-                )
-            )
-            .subscribe();
+        combineLatest([this.metricsService.getMetrics(), this.metricsService.threadDump()]).subscribe(([metrics, threadDump]) => {
+            this.metrics = metrics;
+            this.threads = threadDump.threads;
+            this.updatingMetrics = false;
+            this.changeDetector.detectChanges();
+        });
     }
 
     metricsKeyExists(key: MetricsKey): boolean {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -21,7 +21,7 @@ import { HttpResponse, <%_ if (prodDatabaseType !== 'cassandra') { _%> HttpHeade
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 import { Subscription, combineLatest } from 'rxjs';
 <%_ if (prodDatabaseType !== 'cassandra') { _%>
-import { ActivatedRoute, ParamMap, Router, Data } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 import { JhiEventManager } from 'ng-jhipster';
 
 import { ITEMS_PER_PAGE } from 'app/shared/constants/pagination.constants';
@@ -108,14 +108,14 @@ export class UserManagementComponent implements OnInit, OnDestroy {
     }
 
     private handleNavigation(): void {
-        combineLatest(this.activatedRoute.data, this.activatedRoute.queryParamMap, (data: Data, params: ParamMap) => {
+        combineLatest([this.activatedRoute.data, this.activatedRoute.queryParamMap]).subscribe(([data, params]) => {
             const page = params.get('page');
             this.page = page !== null ? +page : 1;
             const sort = (params.get('sort') ?? data['defaultSort']).split(',');
             this.predicate = sort[0];
             this.ascending = sort[1] === 'asc';
             this.loadAll();
-        }).subscribe();
+        });
     }
     <%_ } _%>
 

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -42,23 +42,27 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
     ) {}
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
-            if (err.status === 401 && err.url && !err.url.includes('api/account') && this.accountService.isAuthenticated()) {
-                <%_ if (authenticationType === 'session' || authenticationType === 'uaa') { _%>
-                if (err.url.includes(this.loginService.logoutUrl())) {
-                    this.loginService.logoutInClient();
-                    return;
+        return next.handle(request).pipe(
+            tap({
+                error: (err: HttpErrorResponse) => {
+                    if (err.status === 401 && err.url && !err.url.includes('api/account') && this.accountService.isAuthenticated()) {
+                        <%_ if (authenticationType === 'session' || authenticationType === 'uaa') { _%>
+                        if (err.url.includes(this.loginService.logoutUrl())) {
+                            this.loginService.logoutInClient();
+                            return;
+                        }
+                        <%_ } _%>
+                        this.stateStorageService.storeUrl(this.router.routerState.snapshot.url);
+                        <%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
+                        this.loginService.logout();
+                        this.router.navigate(['']);
+                        this.loginModalService.open();
+                        <%_ } else { _%>
+                        this.loginService.login();
+                        <%_ } _%>
+                    }
                 }
-                <%_ } _%>
-                this.stateStorageService.storeUrl(this.router.routerState.snapshot.url);
-                <%_ if (['session', 'jwt', 'uaa'].includes(authenticationType)) { _%>
-                this.loginService.logout();
-                this.router.navigate(['']);
-                this.loginModalService.open();
-                <%_ } else { _%>
-                this.loginService.login();
-                <%_ } _%>
-            }
-        }));
+            })
+        );
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/auth-expired.interceptor.ts.ejs
@@ -27,6 +27,7 @@ import { LoginService } from 'app/core/login/login.service';
 import { LoginModalService } from 'app/core/login/login-modal.service';
 <%_ } _%>
 import { StateStorageService } from 'app/core/auth/state-storage.service';
+import { AccountService } from '../../core/auth/account.service';
 
 @Injectable()
 export class AuthExpiredInterceptor implements HttpInterceptor {
@@ -36,12 +37,13 @@ export class AuthExpiredInterceptor implements HttpInterceptor {
         private loginModalService: LoginModalService,
         <%_ } _%>
         private stateStorageService: StateStorageService,
-        private router: Router
+        private router: Router,
+        private accountService: AccountService
     ) {}
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
         return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
-            if (err.status === 401 && err.url && !err.url.includes('api/account')) {
+            if (err.status === 401 && err.url && !err.url.includes('api/account') && this.accountService.isAuthenticated()) {
                 <%_ if (authenticationType === 'session' || authenticationType === 'uaa') { _%>
                 if (err.url.includes(this.loginService.logoutUrl())) {
                     this.loginService.logoutInClient();

--- a/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/error-handler.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/blocks/interceptor/error-handler.interceptor.ts.ejs
@@ -27,10 +27,14 @@ export class ErrorHandlerInterceptor implements HttpInterceptor {
     constructor(private eventManager: JhiEventManager) {}
 
     intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-        return next.handle(request).pipe(tap(null, (err: HttpErrorResponse) => {
-            if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('api/account'))))) {
-                this.eventManager.broadcast(new JhiEventWithContent('<%= frontendAppName %>.httpError', err));
-            }
-        }));
+        return next.handle(request).pipe(
+            tap({
+                error: (err: HttpErrorResponse) => {
+                    if (!(err.status === 401 && (err.message === '' || (err.url && err.url.includes('api/account'))))) {
+                        this.eventManager.broadcast(new JhiEventWithContent('<%= frontendAppName %>.httpError', err));
+                    }
+                }
+            })
+        );
     }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -22,7 +22,7 @@ import { Location } from '@angular/common';
 
 <%_ } else { _%>
 import { Observable } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 import { Account } from 'app/core/user/account.model';
 import { AccountService } from 'app/core/auth/account.service';
@@ -57,7 +57,7 @@ export class LoginService {
     }
     <%_ } else { _%>
     login(credentials: Login): Observable<Account | null> {
-        return this.authServerProvider.login(credentials).pipe(flatMap(() => this.accountService.identity(true)));
+        return this.authServerProvider.login(credentials).pipe(mergeMap(() => this.accountService.identity(true)));
     }
     <%_ } _%>
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/login/login.service.ts.ejs
@@ -88,7 +88,7 @@ export class LoginService {
             window.location.href = logoutUrl;
         });
         <%_ } else { _%>
-        this.authServerProvider.logout().subscribe(null, null, () => this.accountService.authenticate(null));
+        this.authServerProvider.logout().subscribe({ complete: () => this.accountService.authenticate(null) });
         <%_ } _%>
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/activate/activate.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/activate/activate.component.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { TestBed, async, tick, fakeAsync, inject } from '@angular/core/testing';
+import { TestBed, waitForAsync, tick, fakeAsync, inject } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of, throwError } from 'rxjs';
@@ -28,7 +28,7 @@ describe('Component Tests', () => {
     describe('ActivateComponent', () => {
         let comp: ActivateComponent;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [ActivateComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password-strength-bar.component.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { PasswordStrengthBarComponent } from 'app/account/password/password-strength-bar.component';
 
@@ -25,7 +25,7 @@ describe('Component Tests', () => {
         let comp: PasswordStrengthBarComponent;
         let fixture: ComponentFixture<PasswordStrengthBarComponent>;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [PasswordStrengthBarComponent]
             })

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/password/password.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 jest.mock('app/core/auth/account.service');
 
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormBuilder } from '@angular/forms';
@@ -34,7 +34,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<PasswordComponent>;
         let service: PasswordService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [PasswordComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/register/register.component.spec.ts.ejs
@@ -20,7 +20,7 @@
 jest.mock('ng-jhipster');
 <%_ } _%>
 
-import { ComponentFixture, TestBed, async, inject, tick, fakeAsync } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, inject, tick, fakeAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormBuilder } from '@angular/forms';
 import { of, throwError } from 'rxjs';
@@ -37,7 +37,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<RegisterComponent>;
         let comp: RegisterComponent;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [RegisterComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/account/settings/settings.component.spec.ts.ejs
@@ -21,7 +21,7 @@ jest.mock('ng-jhipster');
 <%_ } _%>
 jest.mock('app/core/auth/account.service');
 
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { FormBuilder } from '@angular/forms';
 import { throwError, of } from 'rxjs';
@@ -49,7 +49,7 @@ describe('Component Tests', () => {
             imageUrl: ''
         };
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [SettingsComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.component.spec.ts.ejs
@@ -1,22 +1,22 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-    This file is part of the JHipster project, see https://www.jhipster.tech/
-    for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
@@ -29,7 +29,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<ConfigurationComponent>;
         let service: ConfigurationService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [ConfigurationComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -1,20 +1,20 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-    This file is part of the JHipster project, see https://www.jhipster.tech/
-    for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of, throwError } from 'rxjs';
@@ -30,7 +30,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<HealthComponent>;
         let service: HealthService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [HealthComponent]

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
@@ -1,22 +1,22 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-    This file is part of the JHipster project, see https://www.jhipster.tech/
-    for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
@@ -30,7 +30,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<LogsComponent>;
         let service: LogsService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [LogsComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.service.spec.ts.ejs
@@ -1,20 +1,20 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-    This file is part of the JHipster project, see https://www.jhipster.tech/
-    for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.component.spec.ts.ejs
@@ -1,22 +1,22 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-    This file is part of the JHipster project, see https://www.jhipster.tech/
-    for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { of } from 'rxjs';
 
@@ -29,7 +29,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<MetricsComponent>;
         let service: MetricsService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [MetricsComponent]

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/metrics/metrics.service.spec.ts.ejs
@@ -1,20 +1,20 @@
 <%#
-Copyright 2013-2020 the original author or authors from the JHipster project.
+ Copyright 2013-2020 the original author or authors from the JHipster project.
 
-    This file is part of the JHipster project, see https://www.jhipster.tech/
-    for more information.
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
 
-        Licensed under the Apache License, Version 2.0 (the "License");
-you may not use this file except in compliance with the License.
-    You may obtain a copy of the License at
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
 
-http://www.apache.org/licenses/LICENSE-2.0
+      http://www.apache.org/licenses/LICENSE-2.0
 
-    Unless required by applicable law or agreed to in writing, software
-distributed under the License is distributed on an "AS IS" BASIS,
-    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-    See the License for the specific language governing permissions and
-limitations under the License.
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
 -%>
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-delete-dialog.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 jest.mock('ng-jhipster');
 jest.mock('@ng-bootstrap/ng-bootstrap');
 
-import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { NgbActiveModal } from '@ng-bootstrap/ng-bootstrap';
 import { of } from 'rxjs';
@@ -36,7 +36,7 @@ describe('Component Tests', () => {
         let mockEventManager: JhiEventManager;
         let mockActiveModal: NgbActiveModal;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [UserManagementDeleteDialogComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-detail.component.spec.ts.ejs
@@ -1,4 +1,22 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';
 import { of } from 'rxjs';
 
@@ -11,7 +29,7 @@ describe('Component Tests', () => {
         let comp: UserManagementDetailComponent;
         let fixture: ComponentFixture<UserManagementDetailComponent>;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [UserManagementDetailComponent],
                 providers: [

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management-update.component.spec.ts.ejs
@@ -19,7 +19,7 @@
 <%_
 const tsKeyId = generateTestEntityId(pkType);
 _%>
-import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { HttpResponse } from '@angular/common/http';
 import { FormBuilder } from '@angular/forms';
@@ -37,7 +37,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<UserManagementUpdateComponent>;
         let service: UserService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [UserManagementUpdateComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -23,7 +23,7 @@ jest.mock('@angular/router');
 jest.mock('ng-jhipster');
 jest.mock('app/core/auth/account.service');
 
-import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
 import { HttpHeaders, HttpResponse } from '@angular/common/http';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { ActivatedRoute, Router } from '@angular/router';
@@ -52,7 +52,7 @@ describe('Component Tests', () => {
             })
         );
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [UserManagementComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/login/login-modal.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/login/login-modal.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 jest.mock('@ng-bootstrap/ng-bootstrap');
 
-import { ComponentFixture, TestBed, async, inject, fakeAsync, tick } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
 import { FormBuilder } from '@angular/forms';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
@@ -35,7 +35,7 @@ describe('Component Tests', () => {
         let mockRouter: Router;
         let mockActiveModal: NgbActiveModal;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [LoginModalComponent],
                 providers : [

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/login/login-modal.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/login/login-modal.service.spec.ts.ejs
@@ -1,3 +1,21 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 import { TestBed } from '@angular/core/testing';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/account.service.spec.ts.ejs
@@ -1,3 +1,21 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 jest.mock('@angular/router');
 jest.mock('ng-jhipster');
 jest.mock('app/core/auth/state-storage.service');

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/user/user.service.spec.ts.ejs
@@ -87,8 +87,8 @@ describe('Service Tests', () => {
             it('should propagate not found response', () => {
                 let expectedResult = 0;
 
-                service.find('user').subscribe(null, (error: HttpErrorResponse) => {
-                    expectedResult = error.status;
+                service.find('user').subscribe({
+                    error: (error: HttpErrorResponse) => expectedResult = error.status
                 });
 
                 const req = httpMock.expectOne({ method: 'GET' });

--- a/generators/client/templates/angular/src/test/javascript/spec/app/home/home.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/home/home.component.spec.ts.ejs
@@ -1,3 +1,21 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 jest.mock('app/core/auth/account.service');
 <%_ if (authenticationType !== 'oauth2') { _%>
 jest.mock('app/core/login/login-modal.service');
@@ -5,7 +23,7 @@ jest.mock('app/core/login/login-modal.service');
 jest.mock('app/core/login/login.service');
 <%_ } _%>
 
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { of } from 'rxjs';
 
 import { HomeComponent } from 'app/home/home.component';
@@ -25,7 +43,7 @@ describe('Component Tests', () => {
         let mockLoginModalService: LoginModalService;
         <%_ } _%>
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [HomeComponent],
                 providers: [AccountService, <% if (authenticationType !== 'oauth2') { %>LoginModalService<% } else { %>LoginService<% } %>]

--- a/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/layouts/main/main.component.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 jest.mock('app/core/auth/account.service');
 
-import { async, ComponentFixture, TestBed } from '@angular/core/testing';
+import { waitForAsync, ComponentFixture, TestBed } from '@angular/core/testing';
 import { Router, RouterEvent, NavigationEnd } from '@angular/router';
 import { Title } from '@angular/platform-browser';
 import { Subject, of } from 'rxjs';
@@ -48,7 +48,7 @@ describe('Component Tests', () => {
       routerState = routerState;
     }
 
-    beforeEach(async(() => {
+    beforeEach(waitForAsync(() => {
       TestBed.configureTestingModule({
         imports: [
           <%_ if (enableTranslation) { _%>

--- a/generators/client/templates/angular/src/test/javascript/spec/app/layouts/navbar/navbar.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/layouts/navbar/navbar.component.spec.ts.ejs
@@ -1,3 +1,21 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 jest.mock('@angular/router');
 <%_ if (enableTranslation) { _%>
 jest.mock('ngx-webstorage');
@@ -6,7 +24,7 @@ jest.mock('ng-jhipster');
 jest.mock('app/core/auth/account.service');
 jest.mock('app/core/login/login.service');
 
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';
 import { Router } from '@angular/router';
 import { of } from 'rxjs';
@@ -28,7 +46,7 @@ describe('Component Tests', () => {
         let mockAccountService: AccountService;
         let profileService: ProfileService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 imports: [HttpClientTestingModule],
                 declarations: [NavbarComponent],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
@@ -1,4 +1,22 @@
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 import { JhiAlertService, JhiAlert, JhiEventManager } from 'ng-jhipster';
 <%_ if (enableTranslation) { _%>
@@ -14,7 +32,7 @@ describe('Component Tests', () => {
         let eventManager: JhiEventManager;
         let alertService: JhiAlertService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 <%_ if (enableTranslation) { _%>
                 imports: [TranslateModule.forRoot()],

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert.component.spec.ts.ejs
@@ -1,6 +1,24 @@
+<%#
+ Copyright 2013-2020 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
 jest.mock('ng-jhipster');
 
-import { ComponentFixture, TestBed, async } from '@angular/core/testing';
+import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { JhiAlertService } from 'ng-jhipster';
 
 import { AlertComponent } from 'app/shared/alert/alert.component';
@@ -11,7 +29,7 @@ describe('Component Tests', () => {
         let fixture: ComponentFixture<AlertComponent>;
         let mockAlertService: JhiAlertService;
 
-        beforeEach(async(() => {
+        beforeEach(waitForAsync(() => {
             TestBed.configureTestingModule({
                 declarations: [AlertComponent],
                 providers: [JhiAlertService]

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing-resolve.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing-resolve.service.ts.ejs
@@ -20,7 +20,7 @@ import { Injectable } from '@angular/core';
 import { HttpResponse } from '@angular/common/http';
 import { Resolve, ActivatedRouteSnapshot, Router } from '@angular/router';
 import { Observable, of, EMPTY } from 'rxjs';
-import { flatMap } from 'rxjs/operators';
+import { mergeMap } from 'rxjs/operators';
 
 import { I<%= entityAngularName %>, <%= entityAngularName %> } from 'app/shared/model/<%= entityModelFileName %>.model';
 import { <%= entityAngularName %>Service } from './<%= entityFileName %>.service';
@@ -33,7 +33,7 @@ export class <%= entityAngularName %>RoutingResolveService implements Resolve<I<
         const id = route.params['id'];
         if (id) {
             return this.service.find(id).pipe(
-                flatMap((<%= entityInstance %>: HttpResponse<<%= entityAngularName %>>) => {
+                mergeMap((<%= entityInstance %>: HttpResponse<<%= entityAngularName %>>) => {
                     if (<%= entityInstance %>.body) {
                         return of(<%= entityInstance %>.body);
                     } else {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-update.component.ts.ejs
@@ -253,10 +253,11 @@ _%>
     }
 
     setFileData(event: any, field: string, isImage: boolean): void {
-        this.dataUtils.loadFileToForm(event, this.editForm, field, isImage).subscribe(null, (err: JhiFileLoadError) => {
-            this.eventManager.broadcast(
-                new JhiEventWithContent<AlertError>('<%= frontendAppName %>.error', { <% if (enableTranslation) { %>...err, key: 'error.file.' + err.key<% } else { %>message: err.message<% } %> })
-            );
+        this.dataUtils.loadFileToForm(event, this.editForm, field, isImage).subscribe({
+            error: (err: JhiFileLoadError) =>
+                this.eventManager.broadcast(
+                    new JhiEventWithContent<AlertError>('<%= frontendAppName %>.error', { <% if (enableTranslation) { %>...err, key: 'error.file.' + err.key<% } else { %>message: err.message<% } %> })
+                )
         });
     }
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -19,7 +19,7 @@
 import { Component, OnInit, OnDestroy } from '@angular/core';
 import { <%_ if (pagination !== 'no') { _%>HttpHeaders, <% } %>HttpResponse } from '@angular/common/http';
 <%_ if (pagination === 'pagination') { _%>
-import { ActivatedRoute, ParamMap, Router, Data } from '@angular/router';
+import { ActivatedRoute, Router } from '@angular/router';
 <%_ } else if (searchEngine !== false) { _%>
 import { ActivatedRoute } from '@angular/router';
 <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/pagination-template.ejs
@@ -103,7 +103,7 @@
     }
 
     protected handleNavigation(): void {
-        combineLatest(this.activatedRoute.data, this.activatedRoute.queryParamMap, (data: Data, params: ParamMap) => {
+        combineLatest([this.activatedRoute.data, this.activatedRoute.queryParamMap]).subscribe(([data, params]) => {
             const page = params.get('page');
             const pageNumber = page !== null ? +page : 1;
             const sort = (params.get('sort') ?? data['defaultSort']).split(',');
@@ -114,5 +114,5 @@
               this.ascending = ascending;
               this.loadPage(pageNumber, true);
             }
-        }).subscribe();
+        });
     }


### PR DESCRIPTION
Closes #12813

I separated changes into 5 commits. Below is the commit history.

`rxjs` `flatMap` is synonym of `mergeMap` and is deprecated now, so replaced `flatMap` with `mergeMap`.  
In this process I noticed that metrics is loaded sequentially: if metrics loading is finished then thread dump loading starts. Now turned this to parallel load.  
After switching metrics to parallel loading noticed that `AuthExpiredInterceptor` is not working correctly if page loads several data at the same time - then first call routes to home page and second call saves home page as page where to return after relogin. This is fixed now.

Replaced deprecated `async` from `@angular/core/testing` with it's replacement `waitForAsync`. Noticed that some test files are missing license. Added license where it was missing. In some places license format was broken, fixed those formattings too.

`rxjs` `combineLatest` with `resultSelector` is deprecated. Transferred to another form.

Fix "Use an observer instead of error/complete callback" deprecation.

Add ESLint deprecation plugin and set deprecation to error level.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
