### PR TITLE
Update lint-staged version

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -44,8 +44,7 @@ const JACKSON_DATABIND_NULLABLE_VERSION = '0.2.1';
 
 // NPM packages version
 const HUSKY_VERSION = '4.2.5';
-// Not using the latest version because of https://github.com/jhipster/generator-jhipster/issues/11131
-const LINT_STAGED_VERSION = '8.2.1';
+const LINT_STAGED_VERSION = '10.4.2';
 // The installed prettier version should be the same that the one used during JHipster generation to avoid formatting differences
 const PRETTIER_VERSION = packagejs.dependencies.prettier;
 const PRETTIER_JAVA_VERSION = packagejs.dependencies['prettier-plugin-java'];


### PR DESCRIPTION
The latest `lint-staged` version is working fine in Windows. So updating this dependency.

Related to #10312 and #11131

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
