### PR TITLE
Exclude translation of DataAccessException when there's no database

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/errors/ExceptionTranslator.java.ejs
@@ -25,6 +25,8 @@ import org.apache.commons.lang3.StringUtils;
 import org.springframework.beans.factory.annotation.Value;
 <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
 import org.springframework.dao.ConcurrencyFailureException;
+<%_ } _%>
+<%_ if (databaseType !== 'no') { _%>
 import org.springframework.dao.DataAccessException;
 <%_ } _%>
 import org.springframework.http.ResponseEntity;
@@ -206,7 +208,7 @@ _%>
 
     @Override
     public ProblemBuilder prepare(final Throwable throwable, final StatusType status, final URI type) {
-        
+
         Collection<String> activeProfiles = Arrays.asList(env.getActiveProfiles());
 
         if (activeProfiles.contains(JHipsterConstants.SPRING_PROFILE_PRODUCTION)) {
@@ -221,8 +223,7 @@ _%>
                         .map(this::toProblem)
                         .orElse(null));
             }
-            <%_ if (databaseType !== 'no' && databaseType !== 'cassandra') { _%>
-    
+            <%_ if (databaseType !== 'no') { _%>
             if (throwable instanceof DataAccessException) {
                 return Problem.builder()
                     .withType(type)
@@ -235,7 +236,6 @@ _%>
                         .orElse(null));
             }
             <%_ } _%>
-
             if (containsPackageName(throwable.getMessage())) {
                 return Problem.builder()
                     .withType(type)


### PR DESCRIPTION
Backported from main branch to 6.x

Fix #12829

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
