### PR TITLE
Fix Triage Github Action Failure on Already Existing Labels

### DIFF
--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -46,5 +46,7 @@ jobs:
                         if (missingTheme) {
                           missingLabel.push('theme: undefined')
                         }
-                        github.issues.addLabels({...issue, labels: missingLabel})
+                        if (missingArea || missingTheme) {
+                            github.issues.addLabels({...issue, labels: missingLabel})
+                        }
                       })


### PR DESCRIPTION
This adds support to the triage action to gracefully handle the case where both area and theme labels are already added.

Related to https://github.com/jhipster/generator-jhipster/pull/12641

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
