### PR TITLE
fix testcontainers gradle integration when using sql and reactive

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -148,7 +148,11 @@ task integrationTest(type: Test) {
 
 <%_ if (databaseType === 'sql') { _%>
     if (project.hasProperty('testcontainers')) {
+        <%_ if (!reactive) { _%>
         environment 'spring.profiles.active', 'testcontainers'
+        <%_ } else { _%>
+        environment 'SPRING_PROFILES_ACTIVE', 'testcontainers'
+        <%_ } _%>
     }
 <%_ } _%>
 


### PR DESCRIPTION
Before invoking e.g. `./gradlew verify -Ptestcontainers` did not start the containers as the reactive test extensions looks for en environment variable `SPRING_PROFILES_ACTIVE` which we don't set. Therefore containers where not used during integration tests. It works for non reactive sql as is.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
