### PR TITLE
Exit jhipster process on unhandledRejection.

### DIFF
--- a/cli/cli.js
+++ b/cli/cli.js
@@ -195,3 +195,7 @@ Object.entries(allCommands).forEach(([key, opts]) => {
 initHelp(program, CLI_NAME);
 
 program.parse(process.argv);
+
+process.on('unhandledRejection', up => {
+    throw up;
+});


### PR DESCRIPTION
Since removing meow dependency, jhipster exists with code 0 on prettier errors.
This workarounds this bug.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
