### PR TITLE
[angular] Use standard Angular pipe keyvalue instead of ng-jhipster keys

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -34,7 +34,7 @@
             <tr *ngFor="let bean of beans">
                 <td><span>{{ bean.prefix }}</span></td>
                 <td>
-                    <div class="row" *ngFor="let property of bean.properties | keys">
+                    <div class="row" *ngFor="let property of bean.properties | keyvalue">
                         <div class="col-md-4">{{ property.key }}</div>
                         <div class="col-md-8">
                             <span class="float-right badge-secondary break">{{ property.value | json }}</span>
@@ -56,7 +56,7 @@
                 </tr>
             </thead>
             <tbody>
-                <tr *ngFor="let property of propertySource.properties | keys">
+                <tr *ngFor="let property of propertySource.properties | keyvalue">
                     <td class="break">{{ property.key }}</td>
                     <td class="break">
                         <span class="float-right badge-secondary break">{{ property.value.value }}</span>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway.component.html.ejs
@@ -54,7 +54,7 @@
                                         <div *ngIf="!instance.instanceInfo" class="badge badge-warning">?</div>
                                     </td>
                                     <td>
-                                        <span *ngFor="let entry of (instance.metadata | keys )">
+                                        <span *ngFor="let entry of (instance.metadata | keyvalue )">
                                             <span class="badge badge-default font-weight-normal">
                                                 <span class="badge badge-pill badge-info font-weight-normal">{{ entry.key }}</span>
                                                 {{ entry.value }}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.html.ejs
@@ -43,7 +43,7 @@
                     </tr>
                 </thead>
                 <tbody>
-                    <tr *ngFor="let healthDetail of health.value.details | keys">
+                    <tr *ngFor="let healthDetail of health.value.details! | keyvalue">
                         <td class="text-left">{{ healthDetail.key }}</td>
                         <td class="text-left">{{ readableValue(healthDetail.value) }}</td>
                     </tr>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health-modal.component.ts.ejs
@@ -31,7 +31,7 @@ export class HealthModalComponent {
     constructor(public activeModal: NgbActiveModal) {}
 
     readableValue(value: any): string {
-        if (this.health && this.health.key === 'diskSpace') {
+        if (this.health?.key === 'diskSpace') {
             // Should display storage space in an human readable unit
             const val = value / 1073741824;
             if (val > 1) { // Value

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.html.ejs
@@ -35,7 +35,7 @@
                 </tr>
             </thead>
             <tbody *ngIf="health">
-                <tr *ngFor="let componentHealth of health.components | keys">
+                <tr *ngFor="let componentHealth of health.components | keyvalue">
                     <td>
                         <%_ if (enableTranslation) { _%>
                         {{ 'health.indicator.' + componentHealth.key | translate }}
@@ -44,12 +44,12 @@
                         <%_ } _%>
                     </td>
                     <td class="text-center">
-                        <span class="badge" [ngClass]="getBadgeClass(componentHealth.value.status)" jhiTranslate="{{ 'health.status.' + componentHealth.value.status }}">
-                            {{ componentHealth.value.status }}
+                        <span class="badge" [ngClass]="getBadgeClass(componentHealth.value!.status)" jhiTranslate="{{ 'health.status.' + componentHealth.value!.status }}">
+                            {{ componentHealth.value!.status }}
                         </span>
                     </td>
                     <td class="text-center">
-                        <a class="hand" (click)="showHealth(componentHealth)" *ngIf="componentHealth.value.details">
+                        <a class="hand" (click)="showHealth({ key: componentHealth.key, value: componentHealth.value! })" *ngIf="componentHealth.value!.details">
                             <fa-icon icon="eye"></fa-icon>
                         </a>
                     </td>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.component.ts.ejs
@@ -20,7 +20,7 @@ import { Component, OnInit } from '@angular/core';
 import { HttpErrorResponse } from '@angular/common/http';
 import { NgbModal } from '@ng-bootstrap/ng-bootstrap';
 
-import { HealthService, HealthStatus, Health, HealthKey, HealthDetails } from './health.service';
+import { HealthService, HealthStatus, Health, HealthDetails } from './health.service';
 import { HealthModalComponent } from './health-modal.component';
 
 @Component({
@@ -58,7 +58,7 @@ export class HealthComponent implements OnInit {
         );
     }
 
-    showHealth(health: { key: HealthKey; value: HealthDetails }): void {
+    showHealth(health: { key: string; value: HealthDetails }): void {
         const modalRef = this.modalService.open(HealthModalComponent);
         modalRef.componentInstance.health = health;
     }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
@@ -63,7 +63,7 @@ export interface Health {
 
 export interface HealthDetails {
     status: HealthStatus;
-    details: any;
+    details?: { [key: string]: unknown };
 }
 
 @Injectable({ providedIn: 'root' })

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/health/health.component.spec.ts.ejs
@@ -57,7 +57,7 @@ describe('Component Tests', () => {
         describe('refresh', () => {
             it('should call refresh on init', () => {
                 // GIVEN
-                const health: Health = { status: 'UP', components: { mail: { status: 'UP', details: 'mailDetails' } } };
+                const health: Health = { status: 'UP', components: { mail: { status: 'UP', details: { mailDetail: 'mail' } } } };
                 spyOn(service, 'checkHealth').and.returnValue(of(health));
 
                 // WHEN
@@ -70,7 +70,7 @@ describe('Component Tests', () => {
 
             it('should handle a 503 on refreshing health data', () => {
                 // GIVEN
-                const health: Health = { status: 'DOWN', components: { mail: { status: 'DOWN', details: 'mailDetails' } } };
+                const health: Health = { status: 'DOWN', components: { mail: { status: 'DOWN' } } };
                 spyOn(service, 'checkHealth').and.returnValue(throwError(new HttpErrorResponse({ status: 503, error: health })));
 
                 // WHEN


### PR DESCRIPTION
The only difference is that Angular `keyvalue` orders keys by default but ng-jhipster `keys` doesn't.
The only place where Spring doesn't return ordered keys is configuration properties, but ordered keys is also there better, can find values easier.

Related to #12909, moves `keys.pipe` to unused list.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
