### PR TITLE
[angular] Improve logs view

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -21,17 +21,17 @@
 
     <p jhiTranslate="logs.nbloggers" [translateValues]="{ total: loggers.length }">There are {{ loggers.length }} loggers.</p>
 
-    <span jhiTranslate="logs.filter">Filter</span> <input type="text" [(ngModel)]="filter" class="form-control">
+    <span jhiTranslate="logs.filter">Filter</span> <input type="text" [(ngModel)]="filter" (ngModelChange)="filterAndSort()" class="form-control">
 
     <table class="table table-sm table-striped table-bordered" aria-describedby="logs-page-heading">
         <thead>
-            <tr title="click to order">
-                <th scope="col" (click)="orderProp = 'name'; reverse=!reverse"><span jhiTranslate="logs.table.name">Name</span></th>
-                <th scope="col" (click)="orderProp = 'level'; reverse=!reverse"><span jhiTranslate="logs.table.level">Level</span></th>
+            <tr jhiSort [(predicate)]="orderProp" [(ascending)]="ascending" [callback]="filterAndSort.bind(this)">
+                <th jhiSortBy="name" scope="col"><span jhiTranslate="logs.table.name">Name</span> <fa-icon icon="sort"></fa-icon></th>
+                <th jhiSortBy="level" scope="col"><span jhiTranslate="logs.table.level">Level</span> <fa-icon icon="sort"></fa-icon></th>
             </tr>
         </thead>
 
-        <tr *ngFor="let logger of (loggers | pureFilter:filter:'name' | orderBy:orderProp:reverse)">
+        <tr *ngFor="let logger of filteredAndOrderedLoggers">
             <td><small>{{ logger.name | slice:0:140 }}</small></td>
             <td>
                 <button (click)="changeLevel(logger.name, 'TRACE')" [ngClass]="(logger.level=='TRACE') ? 'btn-primary' : 'btn-light'" class="btn btn-sm">TRACE</button>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.ts.ejs
@@ -27,9 +27,10 @@ import { LogsService } from './logs.service';
 })
 export class LogsComponent implements OnInit {
     loggers?: Log[];
+    filteredAndOrderedLoggers?: Log[];
     filter = '';
     orderProp = 'name';
-    reverse = false;
+    ascending = true;
 
     constructor(private logsService: LogsService) {}
 
@@ -41,12 +42,25 @@ export class LogsComponent implements OnInit {
         this.logsService.changeLevel(name, level).subscribe(() => this.findAndExtractLoggers());
     }
 
+    filterAndSort(): void {
+        this.filteredAndOrderedLoggers = this.loggers!.filter(
+            logger => !this.filter || logger.name.toLowerCase().includes(this.filter.toLowerCase())
+        ).sort((a, b) => {
+            if (a[this.orderProp] < b[this.orderProp]) {
+                return this.ascending ? -1 : 1;
+            } else if (a[this.orderProp] > b[this.orderProp]) {
+                return this.ascending ? 1 : -1;
+            } else if (this.orderProp === 'level') {
+                return a.name < b.name ? -1 : 1;
+            }
+            return 0;
+        });
+    }
+
     private findAndExtractLoggers(): void {
-        this.logsService
-            .findAll()
-            .subscribe(
-                (response: LoggersResponse) =>
-                    (this.loggers = Object.entries(response.loggers).map(([key, logger]) => new Log(key, logger.effectiveLevel)))
-            );
+        this.logsService.findAll().subscribe((response: LoggersResponse) => {
+            this.loggers = Object.entries(response.loggers).map(([key, logger]) => new Log(key, logger.effectiveLevel));
+            this.filterAndSort();
+        });
     }
 }

--- a/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/admin/logs/logs.component.spec.ts.ejs
@@ -50,7 +50,7 @@ describe('Component Tests', () => {
             it('should set all default values correctly', () => {
                 expect(comp.filter).toBe('');
                 expect(comp.orderProp).toBe('name');
-                expect(comp.reverse).toBe(false);
+                expect(comp.ascending).toBe(true);
             });
 
             it('Should call load all on init', () => {


### PR DESCRIPTION
Add sorting icons on table header to reflect sorting status.  
If sorted by level then now secondary sorting is done by name ascending (was random order before).  
This also removes need for `ng-jhipster` pipes `filter.pipe`, `pure-filter.pipe` and `order-by.pipe` in `generator-jhipster`.  

As those are last pipes used from `ng-jhipster` then no pipes is used from `ng-jhipster` in `generator-jhipster` any more after this PR.

FYI:
* exists https://github.com/danrevah/ngx-pipes so if we want to use general purpose pipes in future then we should first consider using this or similar library
* in Vue we are using external library: https://github.com/freearhey/vue2-filters

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
