### PR TITLE
remove the sample Swagger UI request body if present fix #12412

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/swagger-ui/index.html.ejs
@@ -92,6 +92,10 @@
                 <%_ if (authenticationType === 'session' || authenticationType === 'oauth2' || authenticationType === 'uaa') { _%>
                 requestInterceptor: function(req) {
                     req.headers['X-XSRF-TOKEN'] = getCSRF();
+                    // Remove the sample Swagger UI request body if present
+                    if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                        req.body = undefined;
+                    }
                     return req;
                 }
                 <%_ } _%>
@@ -101,6 +105,10 @@
                         || sessionStorage.getItem("<%= jhiPrefixDashed %>-authenticationtoken"));
                     if (authToken) {
                         req.headers['Authorization'] = "Bearer " + authToken;
+                    }
+                    // Remove the sample Swagger UI request body if present
+                    if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                        req.body = undefined;
                     }
                     return req;
                 }

--- a/generators/client/templates/react/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/swagger-ui/index.html.ejs
@@ -92,6 +92,10 @@
                 <%_ if (authenticationType === 'session' || authenticationType === 'oauth2' || authenticationType === 'uaa') { _%>
                 requestInterceptor: function(req) {
                     req.headers['X-XSRF-TOKEN'] = getCSRF();
+                    // Remove the sample Swagger UI request body if present
+                    if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                        req.body = undefined;
+                    }
                     return req;
                 }
                 <%_ } _%>
@@ -101,6 +105,10 @@
                         || sessionStorage.getItem("<%= jhiPrefixDashed %>-authenticationToken"));
                     if (authToken) {
                         req.headers['Authorization'] = "Bearer " + authToken;
+                    }
+                    // Remove the sample Swagger UI request body if present
+                    if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                        req.body = undefined;
                     }
                     return req;
                 }

--- a/generators/client/templates/vue/src/main/webapp/swagger-ui/index.html.ejs
+++ b/generators/client/templates/vue/src/main/webapp/swagger-ui/index.html.ejs
@@ -88,6 +88,10 @@
                 <%_ if (authenticationType === 'session' || authenticationType === 'oauth2' || authenticationType === 'uaa') { _%>
                 requestInterceptor: function(req) {
                     req.headers['X-XSRF-TOKEN'] = getCSRF();
+                    // Remove the sample Swagger UI request body if present
+                    if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                        req.body = undefined;
+                    }
                     return req;
                 }
                 <%_ } _%>
@@ -97,6 +101,10 @@
                         || sessionStorage.getItem("<%=jhiPrefixDashed %>-authenticationToken");
                     if (authToken) {
                         req.headers['Authorization'] = "Bearer " + authToken;
+                    }
+                    // Remove the sample Swagger UI request body if present
+                    if (req.method === 'GET' && req.body === '{"additionalProp1":"string","additionalProp2":"string","additionalProp3":"string"}') {
+                        req.body = undefined;
                     }
                     return req;
                 }


### PR DESCRIPTION
This is my workaround for #12412. It does not remove the Swagger UI `additionalProps: "string"` content but it patches it when detected so that requests to management endpoints from Swagger UI work out of the box (no need to remove the sample request anymore).

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [X] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
