### PR TITLE
Fix version of JHipster Control Center to v0.1.0

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -52,7 +52,7 @@ const PRETTIER_JAVA_VERSION = packagejs.dependencies['prettier-plugin-java'];
 // Version of docker images
 const DOCKER_COMPOSE_FORMAT_VERSION = '3.8';
 const DOCKER_JHIPSTER_REGISTRY = 'jhipster/jhipster-registry:v6.4.0';
-const DOCKER_JHIPSTER_CONTROL_CENTER = 'jhipster/jhipster-control-center:v0.1.O';
+const DOCKER_JHIPSTER_CONTROL_CENTER = 'jhipster/jhipster-control-center:v0.1.0';
 const DOCKER_JAVA_JRE = 'adoptopenjdk:11-jre-hotspot';
 const DOCKER_MYSQL = 'mysql:8.0.22';
 const DOCKER_MARIADB = 'mariadb:10.5.6';


### PR DESCRIPTION
The version of JHipster Control Center is wrong. Change version from v0.1.O to v0.1.0.

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
