### PR TITLE
Change skipGeneratedFlag to withGeneratedFlag

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -92,7 +92,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
         });
 
         this.option('with-generated-flag', {
-            desc: 'Adding a GeneratedByJHipster annotation to all generated java classes and interfaces',
+            desc: 'Add a GeneratedByJHipster annotation to all generated java classes and interfaces',
             type: Boolean,
         });
 
@@ -2362,9 +2362,6 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
         if (options.skipFakeData) {
             this.jhipsterConfig.skipFakeData = true;
         }
-        if (options.withGeneratedFlag) {
-            this.jhipsterConfig.withGeneratedFlag = true;
-        }
         if (options.skipUserManagement) {
             this.jhipsterConfig.skipUserManagement = true;
         }
@@ -2456,7 +2453,6 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
         dest.reactive = config.reactive;
         dest.jhiPrefix = config.jhiPrefix;
         dest.skipFakeData = config.skipFakeData;
-        dest.withGeneratedFlag = config.withGeneratedFlag;
         dest.entitySuffix = config.entitySuffix;
         dest.dtoSuffix = config.dtoSuffix;
         dest.skipUserManagement = config.skipUserManagement;

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -91,8 +91,8 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
             hide: true,
         });
 
-        this.option('skip-generated-flag', {
-            desc: 'Skip adding a GeneratedByJhipster annotation to all generated java classes and interfaces',
+        this.option('with-generated-flag', {
+            desc: 'Adding a GeneratedByJHipster annotation to all generated java classes and interfaces',
             type: Boolean,
         });
 
@@ -137,8 +137,8 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
             this.config.set(this.options.localConfig);
         }
 
-        if (this.options.skipGeneratedFlag !== undefined) {
-            this.jhipsterConfig.skipGeneratedFlag = this.options.skipGeneratedFlag;
+        if (this.options.withGeneratedFlag !== undefined) {
+            this.jhipsterConfig.withGeneratedFlag = this.options.withGeneratedFlag;
         }
 
         // Load common runtime options.
@@ -146,7 +146,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
 
         this.registerCommitPriorityFilesTask();
 
-        if (!this.jhipsterConfig.skipGeneratedFlag) {
+        if (this.jhipsterConfig.withGeneratedFlag) {
             this.registerGeneratedAnnotationTransform();
         }
 
@@ -2362,6 +2362,9 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
         if (options.skipFakeData) {
             this.jhipsterConfig.skipFakeData = true;
         }
+        if (options.withGeneratedFlag) {
+            this.jhipsterConfig.withGeneratedFlag = true;
+        }
         if (options.skipUserManagement) {
             this.jhipsterConfig.skipUserManagement = true;
         }
@@ -2453,6 +2456,7 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
         dest.reactive = config.reactive;
         dest.jhiPrefix = config.jhiPrefix;
         dest.skipFakeData = config.skipFakeData;
+        dest.withGeneratedFlag = config.withGeneratedFlag;
         dest.entitySuffix = config.entitySuffix;
         dest.dtoSuffix = config.dtoSuffix;
         dest.skipUserManagement = config.skipUserManagement;

--- a/generators/generator-defaults.js
+++ b/generators/generator-defaults.js
@@ -32,6 +32,7 @@ const appDefaultConfig = {
     skipUserManagement: false,
     skipCheckLengthOfIdentifier: false,
     skipFakeData: false,
+    withGeneratedFlag: false,
     jhiPrefix: 'jhi',
     entitySuffix: '',
     dtoSuffix: 'DTO',

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -52,7 +52,7 @@ const prettierTransform = function (defaultOptions) {
 const generatedAnnotationTransform = generator => {
     return through.obj(function (file, encoding, callback) {
         if (
-            !generator.configOptions.skipGeneratedFlag &&
+            generator.jhipsterConfig.withGeneratedFlag &&
             !file.path.endsWith('package-info.java') &&
             !file.path.endsWith('MavenWrapperDownloader.java') &&
             path.extname(file.path) === '.java' &&

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -52,7 +52,6 @@ const prettierTransform = function (defaultOptions) {
 const generatedAnnotationTransform = generator => {
     return through.obj(function (file, encoding, callback) {
         if (
-            generator.jhipsterConfig.withGeneratedFlag &&
             !file.path.endsWith('package-info.java') &&
             !file.path.endsWith('MavenWrapperDownloader.java') &&
             path.extname(file.path) === '.java' &&

--- a/test/app.spec.js
+++ b/test/app.spec.js
@@ -22,7 +22,7 @@ describe('JHipster generator', () => {
             before(() => {
                 return helpers
                     .create(path.join(__dirname, '../generators/app'))
-                    .withOptions({ fromCli: true, skipInstall: true, skipChecks: true, jhiPrefix: 'test' })
+                    .withOptions({ fromCli: true, skipInstall: true, skipChecks: true, jhiPrefix: 'test', withGeneratedFlag: true })
                     .withPrompts({
                         baseName: 'jhipster',
                         clientFramework: ANGULAR,
@@ -2155,7 +2155,7 @@ describe('JHipster generator', () => {
             before(done => {
                 helpers
                     .run(path.join(__dirname, '../generators/app'))
-                    .withOptions({ fromCli: true, skipInstall: true, skipChecks: true, skipGeneratedFlag: true })
+                    .withOptions({ fromCli: true, skipInstall: true, skipChecks: true, withGeneratedFlag: false })
                     .withPrompts({
                         applicationType: 'microservice',
                         baseName: 'jhipster',


### PR DESCRIPTION
After some discussions with @jdubois, we think it's better to not generate this annotation by default.
It will be available by flag + config.

Related to https://github.com/jhipster/generator-jhipster/issues/12459
Following these PRs: https://github.com/jhipster/generator-jhipster/pull/12569 https://github.com/jhipster/generator-jhipster/pull/12811

Is it ok for your blueprint @sendilkumarn ?

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
