### PR TITLE
entity: replace `reactiveRepositories` variable by `reactive`

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -37,7 +37,7 @@ import org.springframework.data.domain.Page;
     <%_ } _%>
 import org.springframework.data.domain.Pageable;
 <%_ } _%>
-<%_ if (reactiveRepositories) { _%>
+<%_ if (reactive) { _%>
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -61,7 +61,7 @@ import org.springframework.stereotype.Service;
 <%_ if (databaseType === 'sql') { _%>
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
-<%_ if (reactiveRepositories) { _%>
+<%_ if (reactive) { _%>
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 <%_ } _%>

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -82,10 +82,10 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
     <%_ } else { _%>
 import org.springframework.web.util.UriComponentsBuilder;
     <%_ } _%>
-<%_ } else if (reactiveRepositories) { _%>
+<%_ } else if (reactive) { _%>
 import org.springframework.http.HttpStatus;
 <%_ } _%>
-<%_ if (reactiveRepositories) { _%>
+<%_ if (reactive) { _%>
 import org.springframework.http.MediaType;
 <%_ } _%>
 import org.springframework.http.ResponseEntity;
@@ -93,7 +93,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.transaction.annotation.Transactional;
 <%_ } _%>
 import org.springframework.web.bind.annotation.*;
-<%_ if (reactiveRepositories) { _%>
+<%_ if (reactive) { _%>
 import org.springframework.web.server.ResponseStatusException;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
@@ -327,7 +327,7 @@ public class <%= entityClass %>Resource {
     <%_ } _%>
 <%- include('../../common/get_all_template', {asEntity, asDto, viaService}); -%>
 
-    <%_ if (reactiveRepositories && pagination === 'no') { _%>
+    <%_ if (reactive && pagination === 'no') { _%>
     /**
      * {@code GET  /<%= entityApiUrl %>} : get all the <%= entityInstancePlural %> as a stream.
      * @return the {@link Flux} of <%= entityInstancePlural %>.

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -140,7 +140,7 @@ import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.test.context.TestSecurityContextHolder;
 <%_ } _%>
 import org.springframework.security.test.context.support.WithMockUser;
-<%_ if (reactiveRepositories) { _%>
+<%_ if (reactive) { _%>
 import org.springframework.test.web.reactive.server.WebTestClient;
 <%_ } _%>
 <%_ if (!reactive) { _%>
@@ -159,7 +159,7 @@ import reactor.core.publisher.Mono;
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 import javax.persistence.EntityManager;<% } %><% if (fieldsContainBigDecimal === true) { %>
 import java.math.BigDecimal;<% } %><% if (fieldsContainBlob === true && databaseType === 'cassandra') { %>
-import java.nio.ByteBuffer;<% } %><% if (reactiveRepositories || fieldsContainDuration === true) { %>
+import java.nio.ByteBuffer;<% } %><% if (reactive || fieldsContainDuration === true) { %>
 import java.time.Duration;<% } %><% if (fieldsContainLocalDate === true) { %>
 import java.time.LocalDate;<% } %><% if (fieldsContainInstant === true || fieldsContainZonedDateTime === true) { %>
 import java.time.Instant;<% } %><% if (fieldsContainZonedDateTime === true) { %>
@@ -786,7 +786,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     }
 <%_ } } } _%>
 <%_ } _%>
-<%_ if (reactiveRepositories && pagination === 'no') { _%>
+<%_ if (reactive && pagination === 'no') { _%>
 
     @Test
     void getAll<%= entityClassPlural %>AsStream() {

--- a/utils/entity.js
+++ b/utils/entity.js
@@ -151,8 +151,6 @@ function prepareEntityForTemplates(entityWithConfig, generator) {
             : entityWithConfig.entityStateName
     );
 
-    entityWithConfig.reactiveRepositories = entityWithConfig.reactive;
-
     entityWithConfig.differentTypes.push(entityWithConfig.entityClass);
     entityWithConfig.i18nToLoad.push(entityWithConfig.entityInstance);
     entityWithConfig.i18nKeyPrefix = `${entityWithConfig.frontendAppName}.${entityWithConfig.entityTranslationKey}`;


### PR DESCRIPTION
Both variables are strictly identical since reactive sql has been supported in entity generator, no need to keep both

See https://github.com/jhipster/generator-jhipster/pull/11742#discussion_r489004426

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
