### PR TITLE
Fix rewrite when value is undefined

### DIFF
--- a/generators/utils.js
+++ b/generators/utils.js
@@ -142,6 +142,11 @@ function rewrite(args) {
         }
     });
 
+    if (otherwiseLineIndex === -1) {
+        console.warn(`Needle ${args.needle} not found at file ${args.file}`);
+        return args.haystack;
+    }
+
     let spaces = 0;
     while (lines[otherwiseLineIndex].charAt(spaces) === ' ') {
         spaces += 1;


### PR DESCRIPTION
It is to fix the issue when `lines[otherwiseLineIndex]` is undefined.
I don't know how to reproduce it, but I encounter this issue several times.

This is for securing our code

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
