### PR TITLE
[vue] let dependabot manage some vue dependencies

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -80,7 +80,7 @@ limitations under the License.
 <%_ } _%>
 <%_ if (!skipCommitHook) { _%>
     "husky": "VERSION_MANAGED_BY_CLIENT_COMMON",
-    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON,
+    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON",
 <%_ } _%>
 <%_ if (cypressTests) { _%>
     "cypress": "VERSION_MANAGED_BY_CLIENT_COMMON",

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -79,8 +79,8 @@ limitations under the License.
     "@types/sockjs-client": "1.1.1",
 <%_ } _%>
 <%_ if (!skipCommitHook) { _%>
-    "husky": "<%= HUSKY_VERSION %>",
-    "lint-staged": "<%= LINT_STAGED_VERSION %>",
+    "husky": "VERSION_MANAGED_BY_CLIENT_COMMON",
+    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON,
 <%_ } _%>
 <%_ if (cypressTests) { _%>
     "cypress": "VERSION_MANAGED_BY_CLIENT_COMMON",

--- a/generators/client/templates/common/package.json
+++ b/generators/client/templates/common/package.json
@@ -3,7 +3,9 @@
     "concurrently": "5.3.0",
     "cypress": "5.5.0",
     "typescript": "4.0.5",
-    "wait-on": "5.2.0"
+    "wait-on": "5.2.0",
+    "husky": "4.3.0",
+    "lint-staged": "10.5.1"
   },
   "dependencies": {
     "dayjs": "1.9.5"

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -116,16 +116,14 @@ limitations under the License.
         <%_ });
     } _%>
     "html-webpack-plugin": "4.3.0",
-    <%_ if (!skipCommitHook) { _%>
-    "husky": "<%= HUSKY_VERSION %>",
-    <%_ } _%>
     "identity-obj-proxy": "3.0.0",
     "jest": "26.4.2",
     "jest-junit": "11.1.0",
     "jest-sonar-reporter": "2.0.0",
     "json-loader": "0.5.7",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "<%= LINT_STAGED_VERSION %>",
+    "husky": "VERSION_MANAGED_BY_CLIENT_COMMON",
+    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON,
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.21",

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -123,7 +123,7 @@ limitations under the License.
     "json-loader": "0.5.7",
     <%_ if (!skipCommitHook) { _%>
     "husky": "VERSION_MANAGED_BY_CLIENT_COMMON",
-    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON,
+    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON",
     <%_ } _%>
     <%_ if (enableTranslation) { _%>
     "merge-jsons-webpack-plugin": "1.0.21",

--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -1,5 +1,18 @@
 {
+  "dependencies": {
+    "@fortawesome/fontawesome-svg-core": "1.2.32",
+    "@fortawesome/free-solid-svg-icons": "5.15.1",
+    "@fortawesome/vue-fontawesome": "2.0.0",
+    "vue-i18n": "8.22.1",
+    "axios": "0.21.0",
+    "bootstrap": "4.5.3",
+    "bootswatch": "4.5.3",
+    "bootstrap-vue": "2.19.0"
+  },
   "devDependencies": {
-    "webpack": "4.44.2"
+    "webpack": "4.44.2",
+    "webpack-bundle-analyzer": "4.1.0",
+    "vue-jest": "3.0.7",
+    "vue-loader": "15.9.5"
   }
 }

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -27,14 +27,14 @@ limitations under the License.
   ],
   "dependencies": {
     "@openapitools/openapi-generator-cli": "1.0.13-4.3.1",
-    "@fortawesome/fontawesome-svg-core": "1.2.32",
-    "@fortawesome/free-solid-svg-icons": "5.15.1",
-    "@fortawesome/vue-fontawesome": "2.0.0",
-    "axios": "0.21.0",
-    "bootstrap": "4.5.3",
-    "bootstrap-vue": "2.18.1",
+    "@fortawesome/fontawesome-svg-core": "VERSION_MANAGED_BY_CLIENT_VUE",
+    "@fortawesome/free-solid-svg-icons": "VERSION_MANAGED_BY_CLIENT_VUE",
+    "@fortawesome/vue-fontawesome": "VERSION_MANAGED_BY_CLIENT_VUE",
+    "axios": "VERSION_MANAGED_BY_CLIENT_VUE",
+    "bootstrap": "VERSION_MANAGED_BY_CLIENT_VUE",
+    "bootstrap-vue": "VERSION_MANAGED_BY_CLIENT_VUE",
     <%_ if (clientTheme !== 'none') { _%>
-    "bootswatch": "4.5.3",
+    "bootswatch": "VERSION_MANAGED_BY_CLIENT_VUE",
     <%_ } _%>
     "dayjs": "VERSION_MANAGED_BY_CLIENT_COMMON",
     "swagger-ui-dist": "3.25.4",
@@ -45,7 +45,7 @@ limitations under the License.
     "vue": "2.6.12",
     "vue-class-component": "7.2.6",
     "vue-cookie": "1.1.4",
-    "vue-i18n": "8.22.1",
+    "vue-i18n": "VERSION_MANAGED_BY_CLIENT_VUE",
     "vue-infinite-loading": "2.4.5",
     "vue-property-decorator": "9.0.2",
     "vue-router": "3.4.9",
@@ -67,10 +67,10 @@ limitations under the License.
     <%_ if (protractorTests) { _%>
     "@types/selenium-webdriver": "4.0.9",
     <%_ } _%>
-    "@types/sinon": "9.0.3",
+    "@types/sinon": "9.0.8",
     "@types/vuelidate": "0.7.13",
-    "@typescript-eslint/eslint-plugin": "4.6.1",
-    "@typescript-eslint/parser": "4.6.1",
+    "@typescript-eslint/eslint-plugin": "4.7.0",
+    "@typescript-eslint/parser": "4.7.0",
     "@vue/cli-plugin-eslint": "4.5.8",
     "@vue/cli-plugin-typescript": "4.5.8",
     "@vue/cli-service": "4.5.8",
@@ -85,7 +85,7 @@ limitations under the License.
     "chai-as-promised": "7.1.1",
     "chai-string": "1.5.0",
     <%_ } _%>
-    "copy-webpack-plugin": "6.0.2",
+    "copy-webpack-plugin": "6.3.0",
     "css-loader": "3.5.3",
     "file-loader": "6.2.0",
     "fork-ts-checker-webpack-plugin": "4.1.6",
@@ -96,9 +96,9 @@ limitations under the License.
     "<%= module.name %>": "<%= module.version %>",
     <%_ });
 } _%>
-    "html-webpack-plugin": "4.3.0",
+    "html-webpack-plugin": "4.5.0",
     <%_ if (!skipCommitHook) { _%>
-    "husky": "4.3.0",
+    "husky": "<%= HUSKY_VERSION %>",
     <%_ } _%>
     "jest": "26.4.2",
     "jest-junit": "11.1.0",
@@ -106,7 +106,7 @@ limitations under the License.
     "jest-sonar-reporter": "2.0.0",
     "jest-vue-preprocessor": "1.7.1",
     <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "10.2.9",
+    "lint-staged": "<%= LINT_STAGED_VERSION %>",
     <%_ } _%>
     "merge-jsons-webpack-plugin": "1.0.21",
     <%_ if (protractorTests) { _%>
@@ -135,32 +135,32 @@ limitations under the License.
     "sass": "1.29.0",
     "sass-loader": "10.0.5",
     "sinon": "9.2.1",
-    "terser-webpack-plugin": "3.1.0",
+    "terser-webpack-plugin": "4.2.3",
     "ts-jest": "26.2.0",
     "ts-loader": "7.0.4",
     <%_ if (protractorTests) { _%>
     "ts-node": "8.10.1",
     <%_ } _%>
     "tslib": "2.0.0",
-    "eslint": "7.12.1",
+    "eslint": "7.13.0",
     "tslint-config-prettier": "1.18.0",
     "eslint-plugin-prettier": "3.1.4",
     "tslint-eslint-rules": "5.4.0",
     "eslint-plugin-vue": "6.2.2",
     "tslint-loader": "3.6.0",
     "typescript": "VERSION_MANAGED_BY_CLIENT_COMMON",
-    "url-loader": "4.1.0",
-    "vue-jest": "3.0.6",
-    "vue-loader": "15.9.3",
+    "url-loader": "4.1.1",
+    "vue-jest": "VERSION_MANAGED_BY_CLIENT_VUE",
+    "vue-loader": "VERSION_MANAGED_BY_CLIENT_VUE",
     "vue-template-compiler": "2.6.12",
     <%_ if (protractorTests) { _%>
     "webdriver-manager": "12.1.7",
     <%_ } _%>
     "webpack": "VERSION_MANAGED_BY_CLIENT_VUE",
-    "webpack-bundle-analyzer": "3.9.0",
+    "webpack-bundle-analyzer": "VERSION_MANAGED_BY_CLIENT_VUE",
     "webpack-cli": "3.3.11",
     "webpack-dev-server": "3.11.0",
-    "webpack-merge": "5.0.9"
+    "webpack-merge": "5.3.0"
   },
   "engines": {
     "node": ">=<%= NODE_VERSION %>",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -98,16 +98,14 @@ limitations under the License.
 } _%>
     "html-webpack-plugin": "4.5.0",
     <%_ if (!skipCommitHook) { _%>
-    "husky": "<%= HUSKY_VERSION %>",
+    "husky": "VERSION_MANAGED_BY_CLIENT_COMMON",
+    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON,
     <%_ } _%>
     "jest": "26.4.2",
     "jest-junit": "11.1.0",
     "jest-serializer-vue": "2.0.2",
     "jest-sonar-reporter": "2.0.0",
     "jest-vue-preprocessor": "1.7.1",
-    <%_ if (!skipCommitHook) { _%>
-    "lint-staged": "<%= LINT_STAGED_VERSION %>",
-    <%_ } _%>
     "merge-jsons-webpack-plugin": "1.0.21",
     <%_ if (protractorTests) { _%>
     "mocha": "7.1.2",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -99,7 +99,7 @@ limitations under the License.
     "html-webpack-plugin": "4.5.0",
     <%_ if (!skipCommitHook) { _%>
     "husky": "VERSION_MANAGED_BY_CLIENT_COMMON",
-    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON,
+    "lint-staged": "VERSION_MANAGED_BY_CLIENT_COMMON",
     <%_ } _%>
     "jest": "26.4.2",
     "jest-junit": "11.1.0",

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -47,9 +47,6 @@ const JACOCO_VERSION = '0.8.6';
 const KAFKA_VERSION = '5.5.2';
 const JACKSON_DATABIND_NULLABLE_VERSION = '0.2.1';
 
-// NPM packages version
-const HUSKY_VERSION = '4.3.0';
-const LINT_STAGED_VERSION = '10.5.1';
 // The installed prettier version should be the same that the one used during JHipster generation to avoid formatting differences
 const PRETTIER_VERSION = packagejs.dependencies.prettier;
 const PRETTIER_JAVA_VERSION = packagejs.dependencies['prettier-plugin-java'];
@@ -399,8 +396,6 @@ const constants = {
     JACKSON_DATABIND_NULLABLE_VERSION,
 
     // NPM
-    HUSKY_VERSION,
-    LINT_STAGED_VERSION,
     PRETTIER_VERSION,
     PRETTIER_JAVA_VERSION,
 

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -48,8 +48,8 @@ const KAFKA_VERSION = '5.5.2';
 const JACKSON_DATABIND_NULLABLE_VERSION = '0.2.1';
 
 // NPM packages version
-const HUSKY_VERSION = '4.2.5';
-const LINT_STAGED_VERSION = '10.4.2';
+const HUSKY_VERSION = '4.3.0';
+const LINT_STAGED_VERSION = '10.5.1';
 // The installed prettier version should be the same that the one used during JHipster generation to avoid formatting differences
 const PRETTIER_VERSION = packagejs.dependencies.prettier;
 const PRETTIER_JAVA_VERSION = packagejs.dependencies['prettier-plugin-java'];

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -28,6 +28,8 @@ const clientFrameworks = applicationOptions.OptionValues[applicationOptions.Opti
 const JAVA_VERSION = '11'; // Java version is forced to be 11. We keep the variable as it might be useful in the future.
 
 // Version of Node, NPM
+const HUSKY_VERSION = '4.3.0';
+const LINT_STAGED_VERSION = '10.5.1';
 const NODE_VERSION = '12.18.3';
 const NPM_VERSION = '6.14.8';
 
@@ -396,6 +398,8 @@ const constants = {
     JACKSON_DATABIND_NULLABLE_VERSION,
 
     // NPM
+    HUSKY_VERSION,
+    LINT_STAGED_VERSION,
     PRETTIER_VERSION,
     PRETTIER_JAVA_VERSION,
 


### PR DESCRIPTION
This PR follows https://github.com/jhipster/generator-jhipster/pull/12972

It uses husky and lint-staged from constants, updates some vue dependencies where possible and save (e.g. terser plugin 5.x is not compatible with webpack 4). Some of the common dependencies are can now be managed by dependabot. Didn't put vue core on purpose yet until we are on vue3.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
