### PR TITLE
Rename master branch to main in the 6.x maintenance branch

### DIFF
--- a/.github/MAINTAINERS_REPLY_TEMPLATES/GUIDELINES_NOT_FOLLOWED.md
+++ b/.github/MAINTAINERS_REPLY_TEMPLATES/GUIDELINES_NOT_FOLLOWED.md
@@ -1,8 +1,8 @@
 This ticket has been closed as the **guidelines are not followed**.
 
-Tickets must follow our [Guidelines](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md), as mentioned in:
+Tickets must follow our [Guidelines](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md), as mentioned in:
 
-1.  our [Readme file on the front page of the project](https://github.com/jhipster/generator-jhipster/blob/master/README.md),
+1.  our [Readme file on the front page of the project](https://github.com/jhipster/generator-jhipster/blob/main/README.md),
 2.  the ["create a new ticket" page](https://github.com/jhipster/generator-jhipster/issues/new/choose) and
 3.  our [Help page](https://www.jhipster.tech/help/)
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -9,7 +9,7 @@ Please make sure the below checklist is followed for Pull Requests.
 -   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
 -   [ ] Tests are added where necessary
 -   [ ] Documentation is added/updated where necessary
--   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md) are followed
+-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
 
 When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
 

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -31,7 +31,7 @@ env:
     JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
     JHI_LIB_BRANCH: release
     JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
-    JHI_GEN_BRANCH: master
+    JHI_GEN_BRANCH: main
     SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
     SPRING_JPA_SHOW_SQL: false
     JHI_DISABLE_WEBPACK_LOGS: true

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -31,7 +31,7 @@ env:
     JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
     JHI_LIB_BRANCH: release
     JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
-    JHI_GEN_BRANCH: master
+    JHI_GEN_BRANCH: main
     SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
     SPRING_JPA_SHOW_SQL: false
     JHI_DISABLE_WEBPACK_LOGS: true

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -4,14 +4,14 @@ on:
     push:
         # branches to consider in the event; optional, defaults to all
         branches:
-            - master
+            - main
 
 jobs:
     update_release_draft:
         if: github.repository == 'jhipster/generator-jhipster'
         runs-on: ubuntu-latest
         steps:
-            # Drafts your next Release notes as Pull Requests are merged into "master"
+            # Drafts your next Release notes as Pull Requests are merged into "main"
             - uses: release-drafter/release-drafter@v5
               env:
                   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -31,7 +31,7 @@ env:
     JHI_LIB_REPO: https://github.com/jhipster/jhipster.git
     JHI_LIB_BRANCH: release
     JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
-    JHI_GEN_BRANCH: master
+    JHI_GEN_BRANCH: main
     SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
     SPRING_JPA_SHOW_SQL: false
     JHI_DISABLE_WEBPACK_LOGS: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,7 +99,7 @@ Before you submit your pull request consider the following guidelines:
 -   Make your changes in a new git branch
 
     ```shell
-    git checkout -b my-fix-branch master
+    git checkout -b my-fix-branch main
     ```
 
 -   Create your patch, **including appropriate test cases**.
@@ -133,7 +133,7 @@ Before you submit your pull request consider the following guidelines:
     git push origin my-fix-branch
     ```
 
--   In GitHub, send a pull request to `jhipster/generator-jhipster:master`.
+-   In GitHub, send a pull request to `jhipster/generator-jhipster:main`.
 -   If we suggest changes then
 
     -   Make the required updates.
@@ -141,7 +141,7 @@ Before you submit your pull request consider the following guidelines:
     -   Rebase your branch and force push to your GitHub repository (this will update your Pull Request):
 
         ```shell
-        git rebase master -i
+        git rebase main -i
         git push -f
         ```
 
@@ -149,18 +149,18 @@ That's it! Thank you for your contribution!
 
 #### Resolving merge conflicts ("This branch has conflicts that must be resolved")
 
-Sometimes your PR will have merge conflicts with the upstream repository's master branch. There are several ways to solve this but if not done correctly this can end up as a true nightmare. So here is one method that works quite well.
+Sometimes your PR will have merge conflicts with the upstream repository's main branch. There are several ways to solve this but if not done correctly this can end up as a true nightmare. So here is one method that works quite well.
 
--   First, fetch the latest information from the master
+-   First, fetch the latest information from the main
 
     ```shell
     git fetch upstream
     ```
 
--   Rebase your branch against the upstream/master
+-   Rebase your branch against the upstream/main
 
     ```shell
-    git rebase upstream/master
+    git rebase upstream/main
     ```
 
 -   Git will stop rebasing at the first merge conflict and indicate which file is in conflict. Edit the file, resolve the conflict then
@@ -189,10 +189,10 @@ from the main (upstream) repository:
     git push origin --delete my-fix-branch
     ```
 
--   Check out the master branch:
+-   Check out the main branch:
 
     ```shell
-    git checkout master -f
+    git checkout main -f
     ```
 
 -   Delete the local branch:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -35,7 +35,7 @@ jobs:
           JHI_LIB_BRANCH: release
           # if JHI_GEN_BRANCH value is release, use the release from NPM
           JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
-          JHI_GEN_BRANCH: master
+          JHI_GEN_BRANCH: main
           # specific config
           SPRING_OUTPUT_ANSI_ENABLED: NEVER
           SPRING_JPA_SHOW_SQL: false

--- a/generators/azure-app-service/templates/github/workflows/azure-app-service.yml.ejs
+++ b/generators/azure-app-service/templates/github/workflows/azure-app-service.yml.ejs
@@ -2,8 +2,8 @@ name: Build and deploy on Azure App Service
 
 on:
   push:
-    branches:    
-      - master
+    branches:
+      - main
 
 jobs:
   build-and-deploy:

--- a/generators/azure-spring-cloud/templates/github/workflows/azure-spring-cloud.yml.ejs
+++ b/generators/azure-spring-cloud/templates/github/workflows/azure-spring-cloud.yml.ejs
@@ -2,8 +2,8 @@ name: Build and deploy on Azure Spring Cloud
 
 on:
   push:
-    branches:    
-      - master
+    branches:
+      - main
 
 jobs:
   build-and-deploy:

--- a/generators/ci-cd/templates/github-ci.yml.ejs
+++ b/generators/ci-cd/templates/github-ci.yml.ejs
@@ -115,7 +115,7 @@ jobs:
               }
               if (cicdIntegrations.includes('heroku')) { _%>
             - name: Deploy to Heroku
-              if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+              if: github.event_name == 'push' && github.ref == 'refs/heads/main'
               env:
                   HEROKU_API_KEY: ${{ secrets.HEROKU_API_KEY }}
                   <%_ if (buildTool === 'maven') { _%>
@@ -126,10 +126,10 @@ jobs:
               <%_ } _%>
               <%_ if (cicdIntegrations.includes('publishDocker')) { _%>
             - name: Build and publish docker image
-              if: github.event_name == 'push' && (github.ref == 'refs/heads/master' || startsWith(github.ref, 'refs/tags/'))
+              if: github.event_name == 'push' && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/'))
               run: |
                   GIT_TAG=:${GITHUB_REF#refs/tags/}
-                  DOCKER_TAG=${GIT_TAG#:refs/heads/master}
+                  DOCKER_TAG=${GIT_TAG#:refs/heads/main}
                   <%_ if (buildTool === 'maven') { _%>
                   ./mvnw -ntp jib:build -Djib.to.image=<%= dockerImage %>${DOCKER_TAG} -Djib.to.auth.username="${{ secrets.DOCKER_USERNAME }}" -Djib.to.auth.password="${{ secrets.DOCKER_PASSWORD }}"
                   <%_ } else if (buildTool === 'gradle') { _%>

--- a/generators/client/templates/angular/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/index.html.ejs
@@ -72,7 +72,7 @@
 
                 <h3>If you have a bug or a feature request</h3>
                 <p>
-                    First read our <a href="https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributing guidelines</a>.
+                    First read our <a href="https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributing guidelines</a>.
                 </p>
                 <p>
                     Then, fill a ticket on our <a href="https://github.com/jhipster/generator-jhipster/issues/new/choose" target="_blank" rel="noopener noreferrer">bug tracker</a>, we'll be happy to resolve your issue!

--- a/generators/client/templates/react/src/main/webapp/index.html.ejs
+++ b/generators/client/templates/react/src/main/webapp/index.html.ejs
@@ -72,7 +72,7 @@
 
                 <h3>If you have a bug or a feature request</h3>
                 <p>
-                    First read our <a href="https://github.com/jhipster/generator-jhipster/blob/master/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributing guidelines</a>.
+                    First read our <a href="https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md" target="_blank" rel="noopener noreferrer">contributing guidelines</a>.
                 </p>
                 <p>
                     Then, fill a ticket on our <a href="https://github.com/jhipster/generator-jhipster/issues/new/choose" target="_blank" rel="noopener noreferrer">bug tracker</a>, we'll be happy to resolve your issue!

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -759,7 +759,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
                         this.log(chalk.bold('\nDeploying application'));
 
-                        const herokuPush = execCmd('git push heroku HEAD:master', { maxBuffer: 1024 * 10000 });
+                        const herokuPush = execCmd('git push heroku HEAD:main', { maxBuffer: 1024 * 10000 });
 
                         herokuPush.child.stdout.on('data', data => {
                             this.log(data);

--- a/generators/server/templates/src/main/docker/config/git2consul.json.ejs
+++ b/generators/server/templates/src/main/docker/config/git2consul.json.ejs
@@ -3,7 +3,7 @@
   "repos" : [{
     "name" : "config",
     "url" : "https://github.com/jhipster/generator-jhipster.git",
-    "branches" : ["master"],
+    "branches" : ["main"],
     "include_branch_name" : false,
     "source_root": "generators/server/src/main/docker/config/consul-config/",
     "hooks": [{

--- a/generators/server/templates/src/main/resources/config/bootstrap-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/bootstrap-prod.yml.ejs
@@ -33,7 +33,7 @@ spring:
             # name of the config server's property source (file.yml) that we want to use
             name: <%= baseName %>
             profile: prod # profile(s) of the property source
-            label: master # toggle to switch to a different version of the configuration as stored in git
+            label: main # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the configuration source Git repository
       <%_ } _%>
       <%_ if (serviceDiscoveryType === 'consul') { _%>

--- a/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
@@ -59,6 +59,6 @@ spring:
             # name of the config server's property source (file.yml) that we want to use
             name: <%= baseName %>
             profile: dev # profile(s) of the property source
-            label: master # toggle to switch to a different version of the configuration as stored in git
+            label: main # toggle to switch to a different version of the configuration as stored in git
             # it can be set to any label, branch or commit of the configuration source Git repository
         <%_ } _%>

--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -25,7 +25,7 @@ else
     if [ "$JHI_LIB_BRANCH" == "latest" ]; then
         LATEST=$(git describe --abbrev=0)
         git checkout "$LATEST"
-    elif [ "$JHI_LIB_BRANCH" != "master" ]; then
+    elif [ "$JHI_LIB_BRANCH" != "main" ]; then
         git checkout "$JHI_LIB_BRANCH"
     fi
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
@@ -61,7 +61,7 @@ else
     if [ "$JHI_GEN_BRANCH" == "latest" ]; then
         LATEST=$(git describe --abbrev=0)
         git checkout "$LATEST"
-    elif [ "$JHI_GEN_BRANCH" != "master" ]; then
+    elif [ "$JHI_GEN_BRANCH" != "main" ]; then
         git checkout "$JHI_GEN_BRANCH"
     fi
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit

--- a/test-integration/scripts/25-sonar-analyze.sh
+++ b/test-integration/scripts/25-sonar-analyze.sh
@@ -7,8 +7,8 @@ source $(dirname $0)/00-init-env.sh
 #--------------------------------------------------
 cd "$JHI_FOLDER_APP"
 
-if [[ "$JHI_APP" = "ngx-default" && "$GITHUB_REPOSITORY" = "jhipster/generator-jhipster" && "$GITHUB_REF" = "refs/heads/master" ]]; then
-    echo "*** Sonar analyze for master branch"
+if [[ "$JHI_APP" = "ngx-default" && "$GITHUB_REPOSITORY" = "jhipster/generator-jhipster" && "$GITHUB_REF" = "refs/heads/main" ]]; then
+    echo "*** Sonar analyze for main branch"
     ./mvnw -ntp --batch-mode initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=https://sonarcloud.io \
         -Dsonar.projectKey=jhipster-sample-application \
@@ -20,7 +20,7 @@ elif [[ $JHI_SONAR = 1 ]]; then
     ./mvnw -ntp --batch-mode initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=http://localhost:9001 \
         -Dsonar.projectKey=JHipsterSonar
-        
+
     sleep 30
     docker-compose -f src/main/docker/sonar.yml logs
     echo "*** Sonar results:"

--- a/test/heroku.spec.js
+++ b/test/heroku.spec.js
@@ -115,7 +115,7 @@ describe('JHipster Heroku Sub Generator', () => {
                     ''
                 );
                 stub.withArgs(`heroku buildpacks:add heroku/java --app ${herokuAppName}`).yields(false, '', '');
-                stub.withArgs('git push heroku HEAD:master').yields(false, '', '');
+                stub.withArgs('git push heroku HEAD:main').yields(false, '', '');
                 helpers
                     .run(require.resolve('../generators/heroku'))
                     .inTmpDir(dir => {

--- a/test/upgrade.spec.js
+++ b/test/upgrade.spec.js
@@ -75,11 +75,11 @@ describe('JHipster upgrade generator', function () {
         it('generates expected number of commits', () => {
             const commitsCount = shelljs.exec('git rev-list --count HEAD', { silent: false }).stdout.replace('\n', '');
             // Expecting 5 commits in history (because we used `force` option):
-            //   - master: initial commit
+            //   - main: initial commit
             //   - jhipster_upgrade; initial generation
-            //   - master: block-merge commit of jhipster_upgrade
+            //   - main: block-merge commit of jhipster_upgrade
             //   - jhipster_upgrade: new generation in jhipster_upgrade
-            //   - master: merge commit of jhipster_upgrade
+            //   - main: merge commit of jhipster_upgrade
             expect(commitsCount).to.equal('5');
         });
 


### PR DESCRIPTION
This is needed for jhispter-online to work correctly as jhipster-online is already migrated to main branch

Resolve https://github.com/jhipster/jhipster-online/issues/258

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
