### PR TITLE
Rename master branch to main in the the heroku sub-generator

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -745,7 +745,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
                         this.log(chalk.bold('\nDeploying application'));
 
-                        const herokuPush = execCmd('git push heroku HEAD:master', { maxBuffer: 1024 * 10000 });
+                        const herokuPush = execCmd('git push heroku HEAD:main', { maxBuffer: 1024 * 10000 });
 
                         herokuPush.child.stdout.on('data', data => {
                             this.log(data);


### PR DESCRIPTION
The heroku sub-generator still seems to use the master branch instead of main. This resolves that.

Related to https://github.com/jhipster/generator-jhipster/pull/12718 and #11935

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
