### PR TITLE
fix: add hibernate fail pagination option in test config as well

### DIFF
--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -93,6 +93,7 @@ spring:
             hibernate.generate_statistics: false
             hibernate.hbm2ddl.auto: validate
             hibernate.jdbc.time_zone: UTC
+            hibernate.query.fail_on_pagination_over_collection_fetch: true
     <%_ } _%>
     <%_ if (databaseType === 'mongodb' || databaseType === 'cassandra') { _%>
     data:


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/13038

Apply `hibernate.query.fail_on_pagination_over_collection_fetch: true` in test config as well.
This will avoid to write working SQL requests (just showing a warning) during tests but failing in production.