### PR TITLE
[angular] Use config similar to Angular strict mode

### DIFF
--- a/generators/client/templates/angular/angular.json.ejs
+++ b/generators/client/templates/angular/angular.json.ejs
@@ -111,6 +111,9 @@
         },
         "@schematics/angular:service": {
           "skipTests": true
+        },
+        "@schematics/angular:application": {
+          "strict": true
         }
       },
       "prefix": "<%= jhiPrefixDashed %>"

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.ts.ejs
@@ -29,7 +29,7 @@ export class LogsComponent implements OnInit {
   loggers?: Log[];
   filteredAndOrderedLoggers?: Log[];
   filter = '';
-  orderProp = 'name';
+  orderProp: keyof Log = 'name';
   ascending = true;
 
   constructor(private logsService: LogsService) {}

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics-system/metrics-system.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics-system/metrics-system.component.ts.ejs
@@ -46,14 +46,14 @@ export class MetricsSystemComponent {
       second: 1000,
     };
     let timeString = '';
-    for (const key in times) {
-      if (Math.floor(ms / times[key]) > 0) {
+    for (const [key, value] of Object.entries(times)) {
+      if (Math.floor(ms / value) > 0) {
         let plural = '';
-        if (Math.floor(ms / times[key]) > 1) {
+        if (Math.floor(ms / value) > 1) {
           plural = 's';
         }
-        timeString += Math.floor(ms / times[key]).toString() + ' ' + key.toString() + plural + ' ';
-        ms = ms - times[key] * Math.floor(ms / times[key]);
+        timeString += Math.floor(ms / value).toString() + ' ' + key.toString() + plural + ' ';
+        ms = ms - value * Math.floor(ms / value);
       }
     }
     return timeString;

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.component.ts.ejs
@@ -48,11 +48,11 @@ export class MetricsComponent implements OnInit {
     });
   }
 
-  metricsKeyExists(key: string): boolean {
+  metricsKeyExists(key: keyof Metrics): boolean {
     return Boolean(this.metrics?.[key]);
   }
 
-  metricsKeyExistsAndObjectNotEmpty(key: string): boolean {
-    return this.metrics?.[key] && JSON.stringify(this.metrics[key]) !== '{}';
+  metricsKeyExistsAndObjectNotEmpty(key: keyof Metrics): boolean {
+    return Boolean(this.metrics?.[key] && JSON.stringify(this.metrics[key]) !== '{}');
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.model.ts.ejs
@@ -108,9 +108,12 @@ export enum HttpMethod {
 
 export interface ProcessMetrics {
   'system.cpu.usage': number;
-  'process.start.time': number;
   'system.cpu.count': number;
+  'system.load.average.1m'?: number;
   'process.cpu.usage': number;
+  'process.files.max'?: number;
+  'process.files.open'?: number;
+  'process.start.time': number;
   'process.uptime': number;
 }
 

--- a/generators/client/templates/angular/src/main/webapp/app/app.main.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.main.ts.ejs
@@ -27,8 +27,8 @@ if (!DEBUG_INFO_ENABLED) {
   enableProdMode();
 }
 
-if (module['hot']) {
-  module['hot'].accept();
+if ((module as any).hot) {
+  (module as any).hot.accept();
 }
 
 platformBrowserDynamic()

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.ts.ejs
@@ -27,8 +27,8 @@ import { SortDirective } from './sort.directive';
 @Directive({
   selector: '[<%= jhiPrefix %>SortBy]',
 })
-export class SortByDirective implements AfterContentInit, OnDestroy {
-  @Input() <%= jhiPrefix %>SortBy?: string;
+export class SortByDirective<T> implements AfterContentInit, OnDestroy {
+  @Input() <%= jhiPrefix %>SortBy?: T;
 
   @ContentChild(FaIconComponent, { static: true })
   iconComponent?: FaIconComponent;
@@ -39,7 +39,7 @@ export class SortByDirective implements AfterContentInit, OnDestroy {
 
   private readonly destroy$ = new Subject<void>();
 
-  constructor(@Host() private sort: SortDirective) {
+  constructor(@Host() private sort: SortDirective<T>) {
     sort.predicateChange.pipe(takeUntil(this.destroy$)).subscribe(() => this.updateIconDefinition());
     sort.ascendingChange.pipe(takeUntil(this.destroy$)).subscribe(() => this.updateIconDefinition());
   }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.ts.ejs
@@ -21,35 +21,35 @@ import { Directive, EventEmitter, Input, Output } from '@angular/core';
 @Directive({
   selector: '[<%= jhiPrefix %>Sort]',
 })
-export class SortDirective {
+export class SortDirective<T> {
   @Input()
-  get predicate(): string {
+  get predicate(): T | undefined {
     return this._predicate;
   }
-  set predicate(predicate: string) {
+  set predicate(predicate: T | undefined) {
     this._predicate = predicate;
     this.predicateChange.emit(predicate);
   }
 
   @Input()
-  get ascending(): boolean {
+  get ascending(): boolean | undefined {
     return this._ascending;
   }
-  set ascending(ascending: boolean) {
+  set ascending(ascending: boolean | undefined) {
     this._ascending = ascending;
     this.ascendingChange.emit(ascending);
   }
 
   @Input() callback?: () => void;
 
-  @Output() predicateChange: EventEmitter<string> = new EventEmitter();
-  @Output() ascendingChange: EventEmitter<boolean> = new EventEmitter();
+  @Output() predicateChange = new EventEmitter<T>();
+  @Output() ascendingChange = new EventEmitter<boolean>();
 
-  private _predicate = '';
-  private _ascending = true;
+  private _predicate?: T;
+  private _ascending?: boolean;
 
-  sort(field?: string): void {
-    if (field && this.predicate !== '_score') {
+  sort(field?: T): void {
+    if (String(this.predicate) !== '_score') {
       this.ascending = field !== this.predicate ? true : !this.ascending;
       this.predicate = field;
       this.predicateChange.emit(field);

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -27,7 +27,6 @@
     "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
-    "suppressImplicitAnyIndexErrors": true,
     "skipLibCheck": true,
     "outDir": "<%= DIST_DIR %>app",
     "lib": ["es7", "dom"],
@@ -42,8 +41,8 @@
   },
   "angularCompilerOptions": {
     "strictInjectionParameters": true,
-    "fullTemplateTypeCheck": true,
     "strictTemplates": true,
+    "strictInputAccessModifiers": true,
     "preserveWhitespaces": true
   },
   "exclude": ["<%= CLIENT_TEST_SRC_DIR %>cypress"]


### PR DESCRIPTION
Reference: https://angular.io/guide/strict-mode

`fullTemplateTypeCheck` is subset of `strictTemplates` so no need to specify this.

Removed `suppressImplicitAnyIndexErrors` and added `strictInputAccessModifiers` and fixed errors after that, some comments:
* in my Windows 10 metrics for `system.load.average.1m`, `process.files.max` and `process.files.open` are not coming from back end, but those are used in templates, so added those as optional to model
* HMR support is improved lately (see https://github.com/angular/angular-cli/pull/18788), maybe in Angular 11 manual `module.hot` fork can be removed at all

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
