### PR TITLE
[angular] Change delete dialog component to receive event name to bro…

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-delete-dialog.component.ts.ejs
@@ -28,6 +28,7 @@ import { EventManager } from 'app/core/event-manager/event-manager.service';
 })
 export class <%= entityAngularName %>DeleteDialogComponent {
     <%= entityInstance %>?: I<%= entityAngularName %>;
+    eventName?: string;
 
     constructor(
         protected <%= entityInstance %>Service: <%= entityAngularName %>Service,
@@ -41,7 +42,9 @@ export class <%= entityAngularName %>DeleteDialogComponent {
 
     confirmDelete(id: <%= tsKeyType %>): void {
         this.<%= entityInstance %>Service.delete(id).subscribe(() => {
-            this.eventManager.broadcast('<%= entityInstance %>ListModification');
+            if (this.eventName) {
+                this.eventManager.broadcast(this.eventName);
+            }
             this.activeModal.close();
         });
     }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management.component.ts.ejs
@@ -94,6 +94,7 @@ export class <%= entityAngularName %>Component implements OnInit, OnDestroy {
     delete(<%= entityInstance %>: I<%= entityAngularName %>): void {
         const modalRef = this.modalService.open(<%= entityAngularName %>DeleteDialogComponent, { size: 'lg', backdrop: 'static' });
         modalRef.componentInstance.<%= entityInstance %> = <%= entityInstance %>;
+        modalRef.componentInstance.eventName = '<%= entityInstance %>ListModification';
     }
     <%_ } _%>
 

--- a/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/spec/app/entities/entity-management-delete-dialog.component.spec.ts.ejs
@@ -49,6 +49,7 @@ describe('Component Tests', () => {
             .compileComponents();
             fixture = TestBed.createComponent(<%= entityAngularName %>DeleteDialogComponent);
             comp = fixture.componentInstance;
+            comp.eventName = 'myEventToBroadcast';
             service = TestBed.inject(<%= entityAngularName %>Service);
             mockEventManager = TestBed.inject(EventManager);
             mockActiveModal = TestBed.inject(NgbActiveModal);


### PR DESCRIPTION
…adcast

This allow to reuse the delete component on other pages.
It simplifies also the definition of the event name, since it is defined only in the component that trigger the delete dialog.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
