### PR TITLE
[angular] Clean and fix alert service and components

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/interceptor/notification.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/interceptor/notification.interceptor.ts.ejs
@@ -47,7 +47,15 @@ export class NotificationInterceptor implements HttpInterceptor {
           }
 
           if (alert) {
-            this.alertService.success(alert<% if (enableTranslation) { %>, { param: alertParams }<% } %>);
+            this.alertService.addAlert({
+              type: 'success',
+              <%_ if (enableTranslation) { _%>
+              translationKey: alert,
+              translationParams: { param: alertParams },
+              <%_ } else { _%>
+              message: alert,
+              <%_ } _%>
+            });
           }
         }
       })

--- a/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.ts.ejs
@@ -27,12 +27,14 @@ export type AlertType = 'success' | 'danger' | 'warning' | 'info';
 export interface Alert {
   id?: number;
   type: AlertType;
-  msg: string;
-  params?: any;
+  message?: string;
+  <%_ if (enableTranslation) { _%>
+  translationKey?: string;
+  translationParams?: { [key: string]: unknown };
+  <%_ } _%>
   timeout?: number;
   toast?: boolean;
   position?: string;
-  scoped?: boolean;
   close?: (alerts: Alert[]) => void;
 }
 
@@ -40,11 +42,13 @@ export interface Alert {
   providedIn: 'root',
 })
 export class AlertService {
+  timeout = 5000;
+  toast = false;
+  position = 'top right';
+
   // unique id for each alert. Starts from 0.
   private alertId = 0;
   private alerts: Alert[] = [];
-  private timeout = 5000;
-  private toast = false;
 
   constructor(
     private sanitizer: DomSanitizer,
@@ -55,92 +59,61 @@ export class AlertService {
   ) {}
 
   clear(): void {
-    this.alerts.splice(0, this.alerts.length);
+    this.alerts = [];
   }
 
   get(): Alert[] {
     return this.alerts;
   }
 
-  success(msg: string, params?: any, position?: string): Alert {
-    return this.createAlert('success', msg, params, position);
-  }
+  /**
+   * Adds alert to alerts array and returns added alert.
+   * @param alert      Alert to add. If `timeout`, `toast` or `position` is missing then applying default value.
+   <%_ if (enableTranslation) { _%>
+   *                   If `translateKey` is available then it's translation else `message` is used for showing.
+   <%_ } _%>
+   * @param extAlerts  If missing then adding `alert` to `AlertService` internal array and alerts can be retrieved by `get()`.
+   *                   Else adding `alert` to `extAlerts`.
+   * @returns  Added alert
+   */
+  addAlert(alert: Alert, extAlerts?: Alert[]): Alert {
+    alert.id = this.alertId++;
 
-  error(msg: string, params?: any, position?: string): Alert {
-    return this.createAlert('danger', msg, params, position);
-  }
-
-  warning(msg: string, params?: any, position?: string): Alert {
-    return this.createAlert('warning', msg, params, position);
-  }
-
-  info(msg: string, params?: any, position?: string): Alert {
-    return this.createAlert('info', msg, params, position);
-  }
-
-  addAlert(alertOptions: Alert, extAlerts: Alert[]): Alert {
-    alertOptions.id = this.alertId++;
     <%_ if (enableTranslation) { _%>
-    if (alertOptions.msg) {
-      alertOptions.msg = this.translateService.instant(alertOptions.msg, alertOptions.params);
+    if (alert.translationKey) {
+      alert.message = this.translateService.instant(alert.translationKey, alert.translationParams);
     }
     <%_ } _%>
-    const alert = this.factory(alertOptions);
-    if (alertOptions.timeout && alertOptions.timeout > 0) {
+
+    alert.message = this.sanitizer.sanitize(SecurityContext.HTML, alert.message ?? '') ?? '';
+    alert.timeout = alert.timeout ?? this.timeout;
+    alert.toast = alert.toast ?? this.toast;
+    alert.position = alert.position ?? this.position;
+    alert.close = (alertsArray: Alert[]) => this.closeAlert(alert.id!, alertsArray);
+
+    (extAlerts ?? this.alerts).push(alert);
+
+    if (alert.timeout > 0) {
       // Workaround protractor waiting for setTimeout.
       // Reference https://www.protractortest.org/#/timeouts
       this.ngZone.runOutsideAngular(() => {
         setTimeout(() => {
           this.ngZone.run(() => {
-            this.closeAlert(alertOptions.id!, extAlerts);
+            this.closeAlert(alert.id!, extAlerts ?? this.alerts);
           });
-        }, alertOptions.timeout);
+        }, alert.timeout);
       });
     }
+
     return alert;
   }
 
-  closeAlert(id: number, extAlerts?: Alert[]): Alert[] {
-    const thisAlerts: Alert[] = extAlerts && extAlerts.length > 0 ? extAlerts : this.alerts;
-    return this.closeAlertByIndex(thisAlerts.map(e => e.id).indexOf(id), thisAlerts);
-  }
-
-  closeAlertByIndex(index: number, thisAlerts: Alert[]): Alert[] {
-    return thisAlerts.splice(index, 1);
-  }
-
-  isToast(): boolean {
-    return this.toast;
-  }
-
-  private factory(alertOptions: Alert): Alert {
-    const alert: Alert = {
-      type: alertOptions.type,
-      msg: this.sanitizer.sanitize(SecurityContext.HTML, alertOptions.msg) ?? '',
-      id: alertOptions.id,
-      timeout: alertOptions.timeout,
-      toast: alertOptions.toast,
-      position: alertOptions.position ?? 'top right',
-      scoped: alertOptions.scoped,
-      close: (alerts: Alert[]) => this.closeAlert(alertOptions.id!, alerts),
-    };
-    if (!alert.scoped) {
-      this.alerts.push(alert);
+  private closeAlert(alertId: number, extAlerts?: Alert[]): void {
+    const alerts = extAlerts ?? this.alerts;
+    const alertIndex = alerts.map(alert => alert.id).indexOf(alertId);
+    // if found alert then remove
+    if (alertIndex >= 0) {
+      alerts.splice(alertIndex, 1);
     }
-    return alert;
-  }
-
-  private createAlert(type: AlertType, msg: string, params?: any, position?: string): Alert {
-    return this.addAlert(
-      {
-        type,
-        msg,
-        params,
-        timeout: this.timeout,
-        toast: this.isToast(),
-        position,
-      },
-      []
-    );
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -30,14 +30,13 @@ import { EventWithContent } from 'app/core/event-manager/event-with-content.mode
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-alert-error',
-  template: `
-    <div class="alerts" role="alert">
-      <div *ngFor="let alert of alerts" [ngClass]="setClasses(alert)">
-        <ngb-alert *ngIf="alert && alert.type && alert.msg" [type]="alert.type" (close)="close(alert)">
-          <pre [innerHTML]="alert.msg"></pre>
-        </ngb-alert>
-      </div>
-    </div>`,
+  template: ` <div class="alerts" role="alert">
+    <div *ngFor="let alert of alerts" [ngClass]="setClasses(alert)">
+      <ngb-alert *ngIf="alert.message" [type]="alert.type" (closed)="close(alert)">
+        <pre [innerHTML]="alert.message"></pre>
+      </ngb-alert>
+    </div>
+  </div>`,
 })
 export class AlertErrorComponent implements OnDestroy {
   alerts: Alert[] = [];
@@ -97,7 +96,7 @@ export class AlertErrorComponent implements OnDestroy {
           } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
             this.addErrorAlert(httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
           } else {
-            this.addErrorAlert(httpErrorResponse.error);
+            this.addErrorAlert(httpErrorResponse.error<% if (enableTranslation) { %>, httpErrorResponse.error<% } %>);
           }
           break;
         }
@@ -108,9 +107,9 @@ export class AlertErrorComponent implements OnDestroy {
 
         default:
           if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-            this.addErrorAlert(httpErrorResponse.error.message);
+            this.addErrorAlert(httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message<% } %>);
           } else {
-            this.addErrorAlert(httpErrorResponse.error);
+            this.addErrorAlert(httpErrorResponse.error<% if (enableTranslation) { %>, httpErrorResponse.error<% } %>);
           }
       }
     });
@@ -133,18 +132,7 @@ export class AlertErrorComponent implements OnDestroy {
     alert.close?.(this.alerts);
   }
 
-  private addErrorAlert(message: string<% if (enableTranslation) { %>, key?: string, data?: { [key: string]: unknown }<% } %>): void {
-    const newAlert: Alert = {
-      type: 'danger',
-      msg: <% if (enableTranslation) { %>key ?? <% } %>message,
-      <%_ if (enableTranslation) { _%>
-      params: data,
-      <%_ } _%>
-      timeout: 5000,
-      toast: this.alertService.isToast(),
-      scoped: true,
-    };
-
-    this.alerts.push(this.alertService.addAlert(newAlert, this.alerts));
+  private addErrorAlert(message?: string<% if (enableTranslation) { %>, translationKey?: string, translationParams?: { [key: string]: unknown }<% } %>): void {
+    this.alertService.addAlert({ type: 'danger', message<% if (enableTranslation) { %>, translationKey, translationParams<% } %> }, this.alerts);
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert.component.ts.ejs
@@ -22,14 +22,13 @@ import { AlertService, Alert } from 'app/core/util/alert.service';
 
 @Component({
   selector: '<%= jhiPrefixDashed %>-alert',
-  template: `
-    <div class="alerts" role="alert">
-      <div *ngFor="let alert of alerts" [ngClass]="setClasses(alert)">
-        <ngb-alert *ngIf="alert && alert.type && alert.msg" [type]="alert.type" (close)="close(alert)">
-          <pre [innerHTML]="alert.msg"></pre>
-        </ngb-alert>
-      </div>
-    </div>`
+  template: ` <div class="alerts" role="alert">
+    <div *ngFor="let alert of alerts" [ngClass]="setClasses(alert)">
+      <ngb-alert *ngIf="alert.message" [type]="alert.type" (closed)="close(alert)">
+        <pre [innerHTML]="alert.message"></pre>
+      </ngb-alert>
+    </div>
+  </div>`,
 })
 export class AlertComponent implements OnInit, OnDestroy {
   alerts: Alert[] = [];

--- a/generators/client/templates/angular/src/test/javascript/spec/app/core/util/alert.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/core/util/alert.service.spec.ts.ejs
@@ -25,6 +25,8 @@ import { Alert, AlertService } from 'app/core/util/alert.service';
 
 describe('Alert service test', () => {
   describe('Alert Service Test', () => {
+    let extAlerts: Alert[];
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         <%_ if (enableTranslation) { _%>
@@ -32,30 +34,26 @@ describe('Alert service test', () => {
         <%_ } _%>
       });
       jest.useFakeTimers();
+      extAlerts = [];
     });
 
     it('should produce a proper alert object and fetch it', inject([AlertService], (service: AlertService) => {
       expect(
-        service.addAlert(
-          {
-            type: 'success',
-            msg: 'Hello Jhipster',
-            params: {},
-            timeout: 3000,
-            toast: true,
-            position: 'top left',
-          },
-          []
-        )
+        service.addAlert({
+          type: 'success',
+          message: 'Hello Jhipster',
+          timeout: 3000,
+          toast: true,
+          position: 'top left',
+        })
       ).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
           id: 0,
           timeout: 3000,
           toast: true,
           position: 'top left',
-          scoped: undefined,
         } as Alert)
       );
 
@@ -63,22 +61,60 @@ describe('Alert service test', () => {
       expect(service.get()[0]).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
           id: 0,
           timeout: 3000,
           toast: true,
           position: 'top left',
-          scoped: undefined,
         } as Alert)
       );
     }));
 
+    it('should produce a proper alert object and add it to external alert objects array', inject(
+      [AlertService],
+      (service: AlertService) => {
+        expect(
+          service.addAlert(
+            {
+              type: 'success',
+              message: 'Hello Jhipster',
+              timeout: 3000,
+              toast: true,
+              position: 'top left',
+            },
+            extAlerts
+          )
+        ).toEqual(
+          jasmine.objectContaining({
+            type: 'success',
+            message: 'Hello Jhipster',
+            id: 0,
+            timeout: 3000,
+            toast: true,
+            position: 'top left',
+          } as Alert)
+        );
+
+        expect(extAlerts.length).toBe(1);
+        expect(extAlerts[0]).toEqual(
+          jasmine.objectContaining({
+            type: 'success',
+            message: 'Hello Jhipster',
+            id: 0,
+            timeout: 3000,
+            toast: true,
+            position: 'top left',
+          } as Alert)
+        );
+      }
+    ));
+
     it('should produce an alert object with correct id', inject([AlertService], (service: AlertService) => {
-      service.info('Hello Jhipster info');
-      expect(service.success('Hello Jhipster success')).toEqual(
+      service.addAlert({ type: 'info', message: 'Hello Jhipster info' });
+      expect(service.addAlert({ type: 'success', message: 'Hello Jhipster success' })).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster success',
+          message: 'Hello Jhipster success',
           id: 1,
         } as Alert)
       );
@@ -87,48 +123,49 @@ describe('Alert service test', () => {
       expect(service.get()[1]).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster success',
+          message: 'Hello Jhipster success',
           id: 1,
         } as Alert)
       );
     }));
 
     it('should close an alert correctly', inject([AlertService], (service: AlertService) => {
-      service.info('Hello Jhipster info');
-      service.info('Hello Jhipster info 2');
-      expect(service.success('Hello Jhipster success')).toEqual(
+      const alert0 = service.addAlert({ type: 'info', message: 'Hello Jhipster info' });
+      const alert1 = service.addAlert({ type: 'info', message: 'Hello Jhipster info 2' });
+      const alert2 = service.addAlert({ type: 'success', message: 'Hello Jhipster success' });
+      expect(alert2).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster success',
+          message: 'Hello Jhipster success',
           id: 2,
         } as Alert)
       );
 
       expect(service.get().length).toBe(3);
-      service.closeAlert(1);
+      alert1.close?.(service.get());
       expect(service.get().length).toBe(2);
       expect(service.get()[1]).not.toEqual(
         jasmine.objectContaining({
           type: 'info',
-          msg: 'Hello Jhipster info 2',
+          message: 'Hello Jhipster info 2',
           id: 1,
         } as Alert)
       );
-      service.closeAlert(2);
+      alert2.close?.(service.get());
       expect(service.get().length).toBe(1);
       expect(service.get()[0]).not.toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster success',
+          message: 'Hello Jhipster success',
           id: 2,
         } as Alert)
       );
-      service.closeAlert(0);
+      alert0.close?.(service.get());
       expect(service.get().length).toBe(0);
     }));
 
     it('should close an alert on timeout correctly', inject([AlertService], (service: AlertService) => {
-      service.info('Hello Jhipster info');
+      service.addAlert({ type: 'info', message: 'Hello Jhipster info' });
 
       expect(service.get().length).toBe(1);
 
@@ -138,9 +175,9 @@ describe('Alert service test', () => {
     }));
 
     it('should clear alerts', inject([AlertService], (service: AlertService) => {
-      service.info('Hello Jhipster info');
-      service.error('Hello Jhipster info');
-      service.success('Hello Jhipster info');
+      service.addAlert({ type: 'info', message: 'Hello Jhipster info' });
+      service.addAlert({ type: 'danger', message: 'Hello Jhipster info' });
+      service.addAlert({ type: 'success', message: 'Hello Jhipster info' });
       expect(service.get().length).toBe(3);
       service.clear();
       expect(service.get().length).toBe(0);
@@ -151,24 +188,21 @@ describe('Alert service test', () => {
         service.addAlert(
           {
             type: 'success',
-            msg: 'Hello Jhipster',
-            params: {},
+            message: 'Hello Jhipster',
             timeout: 3000,
             toast: true,
             position: 'top left',
-            scoped: true,
           },
           []
         )
       ).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
           id: 0,
           timeout: 3000,
           toast: true,
           position: 'top left',
-          scoped: true,
         } as Alert)
       );
 
@@ -176,47 +210,47 @@ describe('Alert service test', () => {
     }));
 
     it('should produce a success message', inject([AlertService], (service: AlertService) => {
-      expect(service.success('Hello Jhipster')).toEqual(
+      expect(service.addAlert({ type: 'success', message: 'Hello Jhipster' })).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
         } as Alert)
       );
     }));
 
     it('should produce a success message with custom position', inject([AlertService], (service: AlertService) => {
-      expect(service.success('Hello Jhipster', {}, 'bottom left')).toEqual(
+      expect(service.addAlert({ type: 'success', message: 'Hello Jhipster', position: 'bottom left' })).toEqual(
         jasmine.objectContaining({
           type: 'success',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
           position: 'bottom left',
         } as Alert)
       );
     }));
 
     it('should produce a error message', inject([AlertService], (service: AlertService) => {
-      expect(service.error('Hello Jhipster')).toEqual(
+      expect(service.addAlert({ type: 'danger', message: 'Hello Jhipster' })).toEqual(
         jasmine.objectContaining({
           type: 'danger',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
         } as Alert)
       );
     }));
 
     it('should produce a warning message', inject([AlertService], (service: AlertService) => {
-      expect(service.warning('Hello Jhipster')).toEqual(
+      expect(service.addAlert({ type: 'warning', message: 'Hello Jhipster' })).toEqual(
         jasmine.objectContaining({
           type: 'warning',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
         } as Alert)
       );
     }));
 
     it('should produce a info message', inject([AlertService], (service: AlertService) => {
-      expect(service.info('Hello Jhipster')).toEqual(
+      expect(service.addAlert({ type: 'info', message: 'Hello Jhipster' })).toEqual(
         jasmine.objectContaining({
           type: 'info',
-          msg: 'Hello Jhipster',
+          message: 'Hello Jhipster',
         } as Alert)
       );
     }));

--- a/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/spec/app/shared/alert/alert-error.component.spec.ts.ejs
@@ -16,6 +16,9 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_
+  const mainAlertField = enableTranslation ? 'translationKey' : 'message';
+_%>
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { HttpErrorResponse, HttpHeaders } from '@angular/common/http';
 <%_ if (enableTranslation) { _%>
@@ -24,7 +27,7 @@ import { TranslateModule } from '@ngx-translate/core';
 
 import { AlertErrorComponent } from 'app/shared/alert/alert-error.component';
 import { EventManager } from 'app/core/event-manager/event-manager.service';
-import { AlertService, Alert } from 'app/core/util/alert.service';
+import { Alert, AlertService } from 'app/core/util/alert.service';
 
 describe('Component Tests', () => {
   describe('Alert Error Component', () => {
@@ -52,7 +55,12 @@ describe('Component Tests', () => {
       comp = fixture.componentInstance;
       eventManager = TestBed.inject(EventManager);
       alertService = TestBed.inject(AlertService);
-      alertService.addAlert = (alert: Alert) => alert;
+      alertService.addAlert = (alert: Alert, alerts?: Alert[]) => {
+        if (alerts) {
+          alerts.push(alert);
+        }
+        return alert;
+      }
     });
 
     describe('Error Handling', () => {
@@ -61,7 +69,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: { status: 0 } });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].msg).toBe(<% if (enableTranslation) { %>'error.server.not.reachable'<% } else { %>'Server not reachable'<% } %>);
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe(<% if (enableTranslation) { %>'error.server.not.reachable'<% } else { %>'Server not reachable'<% } %>);
       });
 
       it('Should display an alert on status 404', () => {
@@ -69,7 +77,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: { status: 404 } });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].msg).toBe(<% if (enableTranslation) { %>'error.url.not.found'<% } else { %>'Not found'<% } %>);
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe(<% if (enableTranslation) { %>'error.url.not.found'<% } else { %>'Not found'<% } %>);
       });
 
       it('Should display an alert on generic error', () => {
@@ -78,8 +86,8 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: { error: 'Second Error Message' } });
         // THEN
         expect(comp.alerts.length).toBe(2);
-        expect(comp.alerts[0].msg).toBe('Error Message');
-        expect(comp.alerts[1].msg).toBe('Second Error Message');
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe('Error Message');
+        expect(comp.alerts[1].<%= mainAlertField %>).toBe('Second Error Message');
       });
 
       it('Should display an alert on status 400 for generic error', () => {
@@ -100,7 +108,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: response });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].msg).toBe('error.validation');
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe('error.validation');
       });
 
       it('Should display an alert on status 400 for generic error without message', () => {
@@ -114,7 +122,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: response });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].msg).toBe('Bad Request');
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe('Bad Request');
       });
 
       it('Should display an alert on status 400 for invalid parameters', () => {
@@ -136,7 +144,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: response });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].msg).toBe(<% if (enableTranslation) { %>'error.Size'<% } else { %>'Error on field "MinField"'<% } %>);
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe(<% if (enableTranslation) { %>'error.Size'<% } else { %>'Error on field "MinField"'<% } %>);
       });
 
       it('Should display an alert on status 400 for error headers', () => {
@@ -154,7 +162,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: response });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].msg).toBe('Error Message');
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe('Error Message');
       });
     });
   });


### PR DESCRIPTION
Follow up to #13022 and closes #12796

In the process of cleaning found and fixed couple of bugs.
* If manually closing alerts then space in HTML page was not released before alert timeout was reached. Reason: as per https://ng-bootstrap.github.io/#/components/alert/api the correct output for listening manual close events is `closed` but was `close`. Changed to `closed` which fixed this.
* If one alert is showed and user closes manually and second alert is showed before first alert timeout reaches then second alert was closed when first alert timeout reached. Fixed.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
