### PR TITLE
[angular] Move emitDecoratorMetadata from tsConfig to tsConfig.spec

### DIFF
--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -22,7 +22,6 @@
     "module": "es2020",
     "moduleResolution": "node",
     "sourceMap": true,
-    "emitDecoratorMetadata": true,
     "experimentalDecorators": true,
     "strict": true,
     "noImplicitReturns": true,

--- a/generators/client/templates/angular/tsconfig.spec.json.ejs
+++ b/generators/client/templates/angular/tsconfig.spec.json.ejs
@@ -19,6 +19,7 @@
 {
   "extends": "./tsconfig.json",
   "compilerOptions": {
+    "emitDecoratorMetadata": true,
     "outDir": "<%= BUILD_DIR %>out-tsc/spec",
     "types": ["jest", "node"]
   },


### PR DESCRIPTION
Follow up to #13065 and #13075  
As `Jest` needs `emitDecoratorMetadata` then moved this to `tsConfig.spec`  
After this PR (in conjuction with #13065 and #13075) Angular strict mode: https://angular.io/guide/strict-mode is achieved.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
