### PR TITLE
[angular] Fix Protractor tests in Angular

### DIFF
--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -27,6 +27,9 @@
     "strict": true,
     "noImplicitReturns": true,
     "noFallthroughCasesInSwitch": true,
+    <%_ if (protractorTests) { _%>
+    "skipLibCheck": true,
+    <%_ } _%>
     "outDir": "<%= DIST_DIR %>app",
     "lib": ["es7", "dom"],
     "baseUrl": "./",


### PR DESCRIPTION
Daily builds using Angular with Protractor are failing because of #13075  
For example https://github.com/hipster-labs/jhipster-daily-builds/runs/1417030608  
Reason: Jest and Mocha types are conflicting.  
This PR puts `skipLibCheck` back if Protractor tests are used which fixes Protractor tests in Angular.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
