### PR TITLE
fix entity query to use unflattened DTO

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -911,13 +911,9 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
                                     this.${variableName} = resBody;
                                 } else {
                                     this.${relationship.otherEntityName}Service
-                                        .find(${entityInstance}.${relationshipFieldName}${dto !== 'no' ? 'Id' : '.id'})
-                                        .pipe(map((subRes: HttpResponse<I${
-                                            relationship.otherEntityAngularName
-                                        }>) => subRes.body ? [subRes.body].concat(resBody) : resBody))
-                                        .subscribe((concatRes: I${
-                                            relationship.otherEntityAngularName
-                                        }[]) => this.${variableName} = concatRes);
+                                        .find(${entityInstance}.${relationshipFieldName}.id)
+                                        .pipe(map((subRes: HttpResponse<I${relationship.otherEntityAngularName}>) => subRes.body ? [subRes.body].concat(resBody) : resBody))
+                                        .subscribe((concatRes: I${relationship.otherEntityAngularName}[]) => this.${variableName} = concatRes);
                                 }
                             });`;
                 } else {


### PR DESCRIPTION
In the example:
```
entity Department
entity Location
relationship OneToOne {
  Department{location} to Location
}
dto * with mapstruct
```
DTOs are now unflattend (in https://github.com/jhipster/generator-jhipster/pull/12947). Instead of calling for `this.locationService.find(department.locationId)`, we should call `this.locationService.find(department.location.id)`.

Fix #13080

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

