### PR TITLE
Remove lint-staged warning about git add

### DIFF
--- a/generators/common/templates/.lintstagedrc.js.ejs
+++ b/generators/common/templates/.lintstagedrc.js.ejs
@@ -17,5 +17,5 @@
  limitations under the License.
 -%>
 module.exports = {
-  '{,src/**/<%= !skipClient ? ',webpack/' : '' %>}*.{<%= getPrettierExtensions() %>}': ['prettier --write', 'git add']
+  '{,src/**/<%= !skipClient ? ',webpack/' : '' %>}*.{<%= getPrettierExtensions() %>}': ['prettier --write']
 };


### PR DESCRIPTION
Remove the following `lint-staged` warning:
‼ Some of your tasks use `git add` command. Please remove it from the config since all modifications made by tasks will be automatically added to the git commit index.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
