### PR TITLE
replaced 31 with getClass().hashCode() for Entity hashCode

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -708,6 +708,7 @@ relationships.forEach((relationship, idx) => {
 
     @Override
     public int hashCode() {
+        // see https://vladmihalcea.com/how-to-implement-equals-and-hashcode-using-the-jpa-entity-identifier/
         return getClass().hashCode();
     }
 

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -708,7 +708,7 @@ relationships.forEach((relationship, idx) => {
 
     @Override
     public int hashCode() {
-        return 31;
+        return getClass().hashCode();
     }
 
     // prettier-ignore

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -166,7 +166,7 @@ _%>
     <%_ if (!embedded) { _%>
         return Objects.hash(<%- idNames.map(n => `this.${n}`).join(', ') %>);
     <%_ } else { _%>
-        return 31;
+        return getClass().hashCode();
     <%_ } _%>
     }
 

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -506,6 +506,7 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
 
     @Override
     public int hashCode() {
+        // see https://vladmihalcea.com/how-to-implement-equals-and-hashcode-using-the-jpa-entity-identifier/
         return getClass().hashCode();
     }
 

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -506,7 +506,7 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
 
     @Override
     public int hashCode() {
-        return 31;
+        return getClass().hashCode();
     }
 
     // prettier-ignore


### PR DESCRIPTION
<!--
PR description.
-->

Use `getClass().hashCode()` instead of `31` as Entity hashCode, as mentioned in #10097 (initially #8656).

I noticed that @Shaolans copied this implementation to `EntityDTO.hashCode` (commit 6a66c401), so I also updated it even if I'm not sure why it absolutely needs to be aligned, as DTOs don't have the same constraints as JPA Entities regarding equals and hashCode.

---

Please make sure the below checklist is followed for Pull Requests.

-   [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [X] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
