### PR TITLE
[angular] Clean app.module

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -369,7 +369,6 @@ const files = {
         {
             path: ANGULAR_DIR,
             templates: [
-                'core/auth/csrf.service.ts',
                 'core/auth/state-storage.service.ts',
                 'shared/has-any-authority.directive.ts',
                 'core/auth/account.service.ts',
@@ -385,6 +384,11 @@ const files = {
             condition: generator => generator.authenticationType === 'session' || generator.authenticationType === 'oauth2',
             path: ANGULAR_DIR,
             templates: ['core/auth/auth-session.service.ts'],
+        },
+        {
+            condition: generator => generator.authenticationType === 'session' && generator.websocket === 'spring-websocket',
+            path: ANGULAR_DIR,
+            templates: ['core/auth/csrf.service.ts'],
         },
     ],
     clientTestFw: [

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -47,7 +47,9 @@ limitations under the License.
     "bootswatch": "VERSION_MANAGED_BY_CLIENT_ANGULAR#dependencies#bootstrap",
     <%_ } _%>
     "dayjs": "VERSION_MANAGED_BY_CLIENT_COMMON",
+    <%_ if (authenticationType === 'session' && websocket === 'spring-websocket') { _%>
     "ngx-cookie-service": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
+    <%_ } _%>
     "ngx-infinite-scroll": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     "ngx-webstorage": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     "rxjs": "VERSION_MANAGED_BY_CLIENT_ANGULAR",

--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -20,13 +20,15 @@
   const localeId = getLocaleId(nativeLanguage);
 _%>
 import { NgModule, LOCALE_ID } from '@angular/core';
-import { DatePipe, registerLocaleData } from '@angular/common';
+import { registerLocaleData } from '@angular/common';
 import { <% if (enableTranslation) { %>HttpClient, <% } %>HttpClientModule } from '@angular/common/http';
 import locale from '@angular/common/locales/<%= localeId %>';
 import { BrowserModule, Title } from '@angular/platform-browser';
 import { ServiceWorkerModule } from '@angular/service-worker';
 import { FaIconLibrary } from '@fortawesome/angular-fontawesome';
+<%_ if (authenticationType === 'session' && websocket === 'spring-websocket') { _%>
 import { CookieService } from 'ngx-cookie-service';
+<%_ } _%>
 <%_ if (enableTranslation) { _%>
 import { TranslateModule, TranslateService, TranslateLoader, MissingTranslationHandler } from '@ngx-translate/core';
 <%_ } _%>
@@ -86,20 +88,14 @@ import { ErrorComponent } from './layouts/error/error.component';
   ],
   providers: [
     Title,
+    <%_ if (authenticationType === 'session' && websocket === 'spring-websocket') { _%>
     CookieService,
-    {
-      provide: LOCALE_ID,
-      <%_ if (skipLanguageForLocale(nativeLanguage)) { _%>
-      useValue: 'en',
-      <%_ } else { _%>
-      useValue: '<%= localeId %>',
-      <%_ } _%>
-    },
+    <%_ } _%>
+    { provide: LOCALE_ID, useValue: '<%= skipLanguageForLocale(nativeLanguage) ? 'en' : localeId %>' },
     { provide: NgbDateAdapter, useClass: NgbDateDayjsAdapter },
     <%_ if (enableI18nRTL) { _%>
     FindLanguageFromKeyPipe,
     <%_ } _%>
-    DatePipe,
     httpInterceptorProviders,
   ],
   declarations: [

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -436,7 +436,6 @@ const expectedFiles = {
         `${CLIENT_MAIN_SRC_DIR}app/shared/alert/alert-error.model.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/alert/alert.component.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/auth/account.service.ts`,
-        `${CLIENT_MAIN_SRC_DIR}app/core/auth/csrf.service.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/config/font-awesome-icons.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/shared/has-any-authority.directive.ts`,
         `${CLIENT_MAIN_SRC_DIR}app/core/auth/state-storage.service.ts`,


### PR DESCRIPTION
`DatePipe` as provider was used only in `audits` module. As `audits` module was deleted then we can remove also `DatePipe` from application providers.
`CookieService` is used only on `session` + `websocket` combination, so removing this for other configurations.
Polished code a bit.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
