### PR TITLE
[angular] Fix WebSockets in Browsersync

### DIFF
--- a/generators/client/templates/angular/webpack/webpack.custom.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.custom.js.ejs
@@ -51,6 +51,9 @@ module.exports = (config, options) => {
           https: tls,
           proxy: {
             target: `http${tls ? 's' : ''}://localhost:4200`,
+            <%_ if (websocket === 'spring-websocket') { _%>
+            ws: true,
+            <%_ } _%>
             proxyOptions: {
               changeOrigin: false, //pass the Host header to the backend unchanged  https://github.com/Browsersync/browser-sync/issues/430
             },


### PR DESCRIPTION
While migrating to Angular CLI in #10624 this websockets block was lost which causes Websockets not to work with Browsersync. Putting back which fixes this issue.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
