### PR TITLE
refactor: use a logger to debug SQL

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -35,6 +35,7 @@ logging:
     level:
         ROOT: DEBUG
         tech.jhipster: DEBUG
+        org.hibernate.SQL: DEBUG
         <%_ if (packageName !== 'tech.jhipster') { _%>
         <%= packageName %>: DEBUG
         <%_ } _%>
@@ -156,7 +157,6 @@ spring:
         <%_ } else if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { _%>
         database-platform: tech.jhipster.domain.util.FixedH2Dialect
         <%_ } _%>
-        show-sql: true
     <%_ } _%>
     <%_ if (databaseType === 'mongodb' || databaseType === 'cassandra' || searchEngine === 'elasticsearch') { _%>
     data:

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -121,7 +121,6 @@ spring:
         <%_ if (prodDatabaseType === 'postgresql') { _%>
         database-platform: tech.jhipster.domain.util.FixedPostgreSQL10Dialect
         <%_ } _%>
-        show-sql: false
     <%_ } _%>
     <%_ if (databaseType === 'mongodb' || databaseType === 'cassandra' || (searchEngine === 'elasticsearch' && reactive)) { _%>
     data:

--- a/generators/server/templates/src/test/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/test/resources/config/application.yml.ejs
@@ -79,7 +79,6 @@ spring:
     jpa:
         database-platform: tech.jhipster.domain.util.FixedH2Dialect
         open-in-view: false
-        show-sql: false
         hibernate:
             ddl-auto: none
             naming:


### PR DESCRIPTION
Use a logger to debug SQL requests.
`spring.jpa.show-sql` writes to standard output.

(https://thorben-janssen.com/hibernate-logging-guide)
