### PR TITLE
remove services prefix for istio gateway

### DIFF
--- a/generators/kubernetes/templates/istio/gateway.yml.ejs
+++ b/generators/kubernetes/templates/istio/gateway.yml.ejs
@@ -58,7 +58,7 @@ spec:
     <%_ appConfigs.filter(config => config.baseName !== app.baseName).forEach(config => { _%>
   - match:
     - uri:
-        prefix: /services/<%= config.baseName.toLowerCase() %>/
+        prefix: /<%= config.baseName.toLowerCase() %>/
     route:
     - destination:
         host: <%= config.baseName.toLowerCase() %>


### PR DESCRIPTION
remove extra services prefix for istio gateway.


Tagging @saturnism since he updated this previously. Last week when I was demo-ing this on current Istio version, this caused an error. Can we remove this?


Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
