### PR TITLE
Fixes for npm 7.

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -28,6 +28,7 @@ const files = {
     common: [
         {
             templates: [
+                '.npmrc',
                 'package.json',
                 'tsconfig.json',
                 'tsconfig.app.json',

--- a/generators/client/files-react.js
+++ b/generators/client/files-react.js
@@ -28,6 +28,7 @@ const files = {
     common: [
         {
             templates: [
+                '.npmrc',
                 'package.json',
                 '.eslintrc.json',
                 'tsconfig.json',

--- a/generators/client/files-vue.js
+++ b/generators/client/files-vue.js
@@ -29,6 +29,7 @@ const vueFiles = {
     common: [
         {
             templates: [
+                '.npmrc',
                 'package.json',
                 'tsconfig.json',
                 '.postcssrc.js',

--- a/generators/client/templates/angular/.npmrc.ejs
+++ b/generators/client/templates/angular/.npmrc.ejs
@@ -1,0 +1,1 @@
+legacy-peer-deps = true

--- a/generators/client/templates/react/.npmrc.ejs
+++ b/generators/client/templates/react/.npmrc.ejs
@@ -1,0 +1,1 @@
+legacy-peer-deps = true

--- a/generators/client/templates/vue/.npmrc.ejs
+++ b/generators/client/templates/vue/.npmrc.ejs
@@ -1,0 +1,1 @@
+legacy-peer-deps = true

--- a/generators/upgrade/index.js
+++ b/generators/upgrade/index.js
@@ -199,8 +199,8 @@ module.exports = class extends BaseGenerator {
         const commandPrefix = 'npm show';
         const pkgInfo = shelljs.exec(`${commandPrefix} ${packageName} version`, { silent: this.silent });
         if (pkgInfo.stderr) {
-            this.warning(`Something went wrong fetching the latest ${packageName} version number...\n${pkgInfo.stderr}`);
-            this.error('Exiting process');
+            this.warning(pkgInfo.stderr);
+            throw new Error(`Something went wrong fetching the latest ${packageName} version number...\n${pkgInfo.stderr}`);
         }
         const msg = pkgInfo.stdout;
         return msg.replace('\n', '');
@@ -211,7 +211,7 @@ module.exports = class extends BaseGenerator {
         const commandPrefix = 'npm install';
         const devDependencyParam = '--save-dev';
         const noPackageLockParam = '--no-package-lock';
-        const generatorCommand = `${commandPrefix} ${npmPackage}@${version} ${devDependencyParam} ${noPackageLockParam} --ignore-scripts`;
+        const generatorCommand = `${commandPrefix} ${npmPackage}@${version} ${devDependencyParam} ${noPackageLockParam} --ignore-scripts --legacy-peer-deps`;
         this.info(generatorCommand);
 
         const npmIntall = shelljs.exec(generatorCommand, { silent: this.silent });
@@ -324,8 +324,8 @@ module.exports = class extends BaseGenerator {
                 const gitStatus = this.gitExec(['status', '--porcelain'], { silent: this.silent });
                 if (gitStatus.code !== 0) this.error(`Unable to check for local changes:\n${gitStatus.stdout} ${gitStatus.stderr}`);
                 if (gitStatus.stdout) {
-                    this.warning(' local changes found.\n\tPlease commit/stash them before upgrading');
-                    this.error('Exiting process');
+                    this.warning(gitStatus.stdout);
+                    throw new Error(' local changes found.\n\tPlease commit/stash them before upgrading');
                 }
             },
 

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
     },
     "main": "cli/index.js",
     "bin": {
-        "jhipster": "./cli/jhipster.js"
+        "jhipster": "cli/jhipster.js"
     },
     "files": [
         "cli",

--- a/test/upgrade.spec.js
+++ b/test/upgrade.spec.js
@@ -7,24 +7,20 @@ const expect = require('chai').expect;
 const expectedFiles = require('./utils/expected-files');
 const packageJson = require('../package.json');
 const constants = require('../generators/generator-constants');
+const { prepareTempDir } = require('./utils/utils');
 
 const ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
 
 describe('JHipster upgrade generator', function () {
     this.timeout(400000);
+
     describe('default application', () => {
-        const cwd = process.cwd();
-        before(done => {
-            let workingDirectory;
-            helpers
-                .run(path.join(__dirname, '../generators/app'))
+        let cleanup;
+        before(() => {
+            cleanup = prepareTempDir();
+            return helpers
+                .create(path.join(__dirname, '../generators/app'), { tmpdir: false })
                 .withOptions({ skipInstall: true, skipChecks: true, fromCli: true })
-                .inTmpDir(dir => {
-                    /* eslint-disable-next-line no-console */
-                    console.log(`Generating JHipster application in directory: ${dir}`);
-                    // Save directory, in order to run the upgrade generator in the same directory
-                    workingDirectory = dir;
-                })
                 .withPrompts({
                     baseName: 'jhipster',
                     clientFramework: ANGULAR,
@@ -47,23 +43,21 @@ describe('JHipster upgrade generator', function () {
                     serverSideOptions: [],
                     upgradeConfig: false,
                 })
-                .on('end', () => {
-                    helpers
-                        .run(path.join(__dirname, '../generators/upgrade'))
+                .run()
+                .then(() => {
+                    return helpers
+                        .create(path.join(__dirname, '../generators/upgrade'), { tmpdir: false })
                         .withOptions({
                             fromCli: true,
                             force: true,
                             silent: false,
                             targetVersion: packageJson.version,
                         })
-                        .inTmpDir(() => {
-                            /* eslint-disable-next-line no-console */
-                            console.log('Upgrading the JHipster application');
-                            process.chdir(workingDirectory);
-                        })
-                        .on('end', done);
+                        .run();
                 });
         });
+
+        after(() => cleanup());
 
         it('creates expected files for default configuration', () => {
             assert.file(expectedFiles.common);
@@ -82,36 +76,29 @@ describe('JHipster upgrade generator', function () {
             //   - master: merge commit of jhipster_upgrade
             expect(commitsCount).to.equal('5');
         });
-
-        after(() => {
-            process.chdir(cwd);
-        });
     });
     describe('blueprint application', () => {
-        const cwd = process.cwd();
         const blueprintName = 'generator-jhipster-sample-blueprint';
         const blueprintVersion = '0.1.1';
-        before(done => {
-            let workingDirectory;
-            helpers
-                .run(path.join(__dirname, '../generators/app'))
+        let cleanup;
+        before(() => {
+            cleanup = prepareTempDir();
+            const dir = process.cwd();
+            /* eslint-disable-next-line no-console */
+            console.log(`Generating JHipster application in directory: ${dir}`);
+            // Fake the presence of the blueprint in node_modules: we don't install it, but we need its version
+            const packagejs = {
+                name: blueprintName,
+                version: blueprintVersion,
+            };
+            const fakeBlueprintModuleDir = path.join(dir, `node_modules/${blueprintName}`);
+            fse.ensureDirSync(path.join(fakeBlueprintModuleDir, 'generators', 'fake'));
+            fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
+            // Create an fake generator, otherwise env.lookup doesn't find it.
+            fse.writeFileSync(path.join(fakeBlueprintModuleDir, 'generators', 'fake', 'index.js'), '');
+            return helpers
+                .create(path.join(__dirname, '../generators/app'), { tmpdir: false })
                 .withOptions({ skipInstall: true, skipChecks: true, fromCli: true, blueprints: blueprintName })
-                .inTmpDir(dir => {
-                    /* eslint-disable-next-line no-console */
-                    console.log(`Generating JHipster application in directory: ${dir}`);
-                    // Save directory, in order to run the upgrade generator in the same directory
-                    workingDirectory = dir;
-                    // Fake the presence of the blueprint in node_modules: we don't install it, but we need its version
-                    const packagejs = {
-                        name: blueprintName,
-                        version: blueprintVersion,
-                    };
-                    const fakeBlueprintModuleDir = path.join(dir, `node_modules/${blueprintName}`);
-                    fse.ensureDirSync(path.join(fakeBlueprintModuleDir, 'generators', 'fake'));
-                    fse.writeJsonSync(path.join(fakeBlueprintModuleDir, 'package.json'), packagejs);
-                    // Create an fake generator, otherwise env.lookup doesn't find it.
-                    fse.writeFileSync(path.join(fakeBlueprintModuleDir, 'generators', 'fake', 'index.js'), '');
-                })
                 .withPrompts({
                     baseName: 'jhipster',
                     clientFramework: ANGULAR,
@@ -134,9 +121,10 @@ describe('JHipster upgrade generator', function () {
                     serverSideOptions: [],
                     upgradeConfig: false,
                 })
-                .on('end', () => {
-                    helpers
-                        .run(path.join(__dirname, '../generators/upgrade'))
+                .run()
+                .then(() => {
+                    return helpers
+                        .create(path.join(__dirname, '../generators/upgrade'), { tmpdir: false })
                         .withOptions({
                             fromCli: true,
                             force: true,
@@ -144,14 +132,11 @@ describe('JHipster upgrade generator', function () {
                             skipChecks: true,
                             targetVersion: packageJson.version,
                         })
-                        .inTmpDir(() => {
-                            /* eslint-disable-next-line no-console */
-                            console.log('Upgrading the JHipster application');
-                            process.chdir(workingDirectory);
-                        })
-                        .on('end', done);
+                        .run();
                 });
         });
+
+        after(() => cleanup());
 
         it('creates expected files for default configuration', () => {
             assert.file(expectedFiles.common);
@@ -176,10 +161,6 @@ describe('JHipster upgrade generator', function () {
                 'generator-jhipster': { blueprints: [{ name: blueprintName, version: blueprintVersion }] },
             });
             assert.fileContent('package.json', new RegExp(`"${blueprintName}": "${blueprintVersion}"`));
-        });
-
-        after(() => {
-            process.chdir(cwd);
         });
     });
 });

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -383,6 +383,7 @@ const expectedFiles = {
         'angular.json',
         'ngsw-config.json',
         '.eslintrc.json',
+        '.npmrc',
         'package.json',
         '.browserslistrc',
         `${CLIENT_MAIN_SRC_DIR}404.html`,


### PR DESCRIPTION
- Add `.npmrc` file to run npm use `legacy-peer-deps` option.
- Change upgrade generator to use `legacy-peer-deps` option.

Related to https://github.com/jhipster/generator-jhipster/issues/12747
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
