### PR TITLE
allow ManyToOne to also use back reference

### DIFF
--- a/jdl/validators/relationship-validator.js
+++ b/jdl/validators/relationship-validator.js
@@ -118,14 +118,6 @@ function checkOneToOneRelationship(jdlRelationship) {
 }
 
 function checkManyToOneRelationship(jdlRelationship, skippedUserManagementOption) {
-    const bidirectionalRelationship = jdlRelationship.injectedFieldInFrom && jdlRelationship.injectedFieldInTo;
-    if (bidirectionalRelationship) {
-        throw new Error(
-            `In the Many-to-One relationship from ${jdlRelationship.from} to ${jdlRelationship.to}, ` +
-                'only unidirectionality is supported, you should either create a bidirectional One-to-Many relationship or ' +
-                'remove the injected field in the destination entity instead.'
-        );
-    }
     const unidirectionalRelationship = !jdlRelationship.injectedFieldInFrom || !jdlRelationship.injectedFieldInTo;
     const userIsTheSourceEntity = isUserManagementEntity(jdlRelationship.from);
     const userIsTheDestinationEntity = isUserManagementEntity(jdlRelationship.to);

--- a/test/jdl/validators/relationship-validator.spec.js
+++ b/test/jdl/validators/relationship-validator.spec.js
@@ -182,10 +182,8 @@ describe('RelationshipValidator', () => {
                         });
                     });
 
-                    it('should fail', () => {
-                        expect(() => validator.validate(relationship)).to.throw(
-                            /^In the Many-to-One relationship from A to B, only unidirectionality is supported, you should either create a bidirectional One-to-Many relationship or remove the injected field in the destination entity instead\.$/
-                        );
+                    it('should not fail', () => {
+                        expect(() => validator.validate(relationship)).not.to.throw();
                     });
                 });
             });


### PR DESCRIPTION
 is no more difference on the code when creating a OneToMany or a ManyToOne relationship (with sides inverted), and the resulting code expected is the same.
So I just disabled the check, and it seems to work perfectly

---

Please make sure the below checklist is followed for Pull Requests.

-   [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Tests are added where necessary
-   [X] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [X] Documentation is added/updated where necessary
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
