### PR TITLE
Revert "[react] Fix default values in entity form"

### DIFF
--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -206,17 +206,10 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
         <%_ }) _%>
       <%_ } _%>
 
-      const cloneEntity = Object.assign({}, entity);
-      for (const property in entity) {
-        if (entity[property] === '') {
-          cloneEntity[property] = null;
-        }
-      }
-
       if (isNew) {
-        props.createEntity(cloneEntity);
+        props.createEntity(entity);
       } else {
-        props.updateEntity(cloneEntity);
+        props.updateEntity(entity);
       }
     }
   }


### PR DESCRIPTION
Simplify code, this part is no longer required.
Now, the use of normalized DTO ensures that a User is defined (linked to the entity) or not.
There is no "login" field in the handled Entity anymore that can be empty.

(The issue was only when DTO are used).
initial issue: https://github.com/jhipster/generator-jhipster/issues/12784
