### PR TITLE
fix: use batchsize on entities for *-to-many

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -48,6 +48,9 @@ import io.swagger.annotations.ApiModel;
 <%_ if (!hasDto && importApiModelProperty === true) { _%>
 import io.swagger.annotations.ApiModelProperty;
 <%_ } _%>
+<%_ if (databaseType === 'sql' && relationships.some(r => r.relationshipType === 'many-to-many' || r.relationshipType === 'one-to-many')) { _%>
+import org.hibernate.annotations.BatchSize;
+<%_ } _%>
 <%_ if (enableHibernateCache) { _%>
 import org.hibernate.annotations.Cache;
 import org.hibernate.annotations.CacheConcurrencyStrategy;
@@ -321,8 +324,9 @@ relationships.forEach((relationship, idx) => {
     @OneToMany(mappedBy = "<%= otherEntityRelationshipName %>")
         <%_ if (enableHibernateCache) { _%>
     @Cache(usage = CacheConcurrencyStrategy.READ_WRITE)
-        <%_ }
-        } else if (databaseType === 'mongodb' || databaseType === 'couchbase') {
+        <%_ } _%>
+    @BatchSize(size = 20)
+    <%_ } else if (databaseType === 'mongodb' || databaseType === 'couchbase') {
             if (databaseType === 'mongodb' && !otherEntityIsEmbedded) { _%>
     @DBRef
         <%_ } _%>
@@ -403,8 +407,9 @@ relationships.forEach((relationship, idx) => {
                    <%= idx === 0 ? '' : ',' %>@JoinColumn(name = "<%= `${relationship.columnName}_${field.columnName}` %>"))
                    <%_ }); _%>
                <%= relationship.otherEntity.primaryKey.fields.length > 1 ? '}' : '' %>
-        <%_ }
-        } else if ((databaseType === 'mongodb' || databaseType === 'couchbase') && !otherEntityIsEmbedded) {
+        <%_ } _%>
+    @BatchSize(size = 20)
+    <%_ } else if ((databaseType === 'mongodb' || databaseType === 'couchbase') && !otherEntityIsEmbedded) {
             if (databaseType === 'mongodb') { _%>
     @DBRef
         <%_ } _%>


### PR DESCRIPTION
candidate fix for https://github.com/jhipster/generator-jhipster/issues/13038

It solves the N+1 selects problem.
It adds a `@BatchSize` on relations that are `many-to-many` or `one-to-many`
This fix might bot be the targeted solution as mention in the issue (which is still in discussion ?).
This fix is also the one I would recommend.

So feel free to close it if it's really not what we want. (It's already how we solved it between `User` and `Authority` though)
It has to be fixed for v7 as it's a well known JPA problem and easy to solve.


