### PR TITLE
[angular] Fix UserRouteAccessService

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.route.ts.ejs
@@ -24,7 +24,6 @@ export const activateRoute: Route = {
   path: 'activate',
   component: ActivateComponent,
   data: {
-    authorities: [],
     pageTitle: 'activate.title',
   },
 };

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.route.ts.ejs
@@ -24,7 +24,6 @@ export const passwordResetFinishRoute: Route = {
   path: 'reset/finish',
   component: PasswordResetFinishComponent,
   data: {
-    authorities: [],
     pageTitle: 'global.menu.account.password',
   },
 };

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/init/password-reset-init.route.ts.ejs
@@ -24,7 +24,6 @@ export const passwordResetInitRoute: Route = {
   path: 'reset/request',
   component: PasswordResetInitComponent,
   data: {
-    authorities: [],
     pageTitle: 'global.menu.account.password',
   },
 };

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.route.ts.ejs
@@ -20,13 +20,11 @@ import { Route } from '@angular/router';
 
 import { UserRouteAccessService } from 'app/core/auth/user-route-access.service';
 import { PasswordComponent } from './password.component';
-import { Authority } from 'app/config/authority.constants';
 
 export const passwordRoute: Route = {
   path: 'password',
   component: PasswordComponent,
   data: {
-    authorities: [Authority.USER],
     pageTitle: 'global.menu.account.password',
   },
   canActivate: [UserRouteAccessService],

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.route.ts.ejs
@@ -24,7 +24,6 @@ export const registerRoute: Route = {
   path: 'register',
   component: RegisterComponent,
   data: {
-    authorities: [],
     pageTitle: 'register.title',
   },
 };

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.route.ts.ejs
@@ -18,7 +18,6 @@
 -%>
 import { Route } from '@angular/router';
 
-import { Authority } from 'app/config/authority.constants';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access.service';
 import { SessionsComponent } from './sessions.component';
 
@@ -26,7 +25,6 @@ export const sessionsRoute: Route = {
   path: 'sessions',
   component: SessionsComponent,
   data: {
-    authorities: [Authority.USER],
     pageTitle: 'global.menu.account.sessions',
   },
   canActivate: [UserRouteAccessService],

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.route.ts.ejs
@@ -20,13 +20,11 @@ import { Route } from '@angular/router';
 
 import { UserRouteAccessService } from 'app/core/auth/user-route-access.service';
 import { SettingsComponent } from './settings.component';
-import { Authority } from 'app/config/authority.constants';
 
 export const settingsRoute: Route = {
   path: 'settings',
   component: SettingsComponent,
   data: {
-    authorities: [Authority.USER],
     pageTitle: 'global.menu.account.settings',
   },
   canActivate: [UserRouteAccessService],

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/user-route-access.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/user-route-access.service.ts.ejs
@@ -39,21 +39,19 @@ export class UserRouteAccessService implements CanActivate {
   ) {}
 
   canActivate(route: ActivatedRouteSnapshot, state: RouterStateSnapshot): Observable<boolean> {
-    const authorities = route.data['authorities'];
-    // We need to call the accountService.identity() function, to ensure,
-    // that the client has a principal too, if they already logged in by the server.
-    // This could happen on a page refresh.
     return this.accountService.identity().pipe(
       map(account => {
-        if (!authorities || authorities.length === 0) {
-          return true;
-        }
-
         if (account) {
-          const hasAnyAuthority = this.accountService.hasAnyAuthority(authorities);
-          if (hasAnyAuthority) {
+          const authorities = route.data['authorities'];
+
+          if (!authorities || authorities.length === 0) {
             return true;
           }
+
+          if (this.accountService.hasAnyAuthority(authorities)) {
+            return true;
+          }
+
           if (isDevMode()) {
             console.error('User has not any of required authorities: ', authorities);
           }

--- a/generators/client/templates/angular/src/main/webapp/app/home/home.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/home/home.route.ts.ejs
@@ -24,7 +24,6 @@ export const HOME_ROUTE: Route = {
   path: '',
   component: HomeComponent,
   data: {
-    authorities: [],
     pageTitle: 'home.title',
   },
 };

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/error/error.route.ts.ejs
@@ -25,7 +25,6 @@ export const errorRoute: Routes = [
     path: 'error',
     component: ErrorComponent,
     data: {
-      authorities: [],
       pageTitle: 'error.title',
     },
   },
@@ -33,7 +32,6 @@ export const errorRoute: Routes = [
     path: 'accessdenied',
     component: ErrorComponent,
     data: {
-      authorities: [],
       pageTitle: 'error.title',
       errorMessage: 'error.http.403',
     },
@@ -42,7 +40,6 @@ export const errorRoute: Routes = [
     path: '404',
     component: ErrorComponent,
     data: {
-      authorities: [],
       pageTitle: 'error.title',
       errorMessage: 'error.http.404',
     },

--- a/generators/client/templates/angular/src/main/webapp/app/login/login.route.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/login/login.route.ts.ejs
@@ -23,7 +23,6 @@ export const LOGIN_ROUTE: Route = {
   path: '',
   component: LoginComponent,
   data: {
-    authorities: [],
     pageTitle: 'login.title',
   },
 };

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing.module.ts.ejs
@@ -20,7 +20,6 @@
 import { NgModule } from '@angular/core';
 import { RouterModule, Routes } from '@angular/router';
 
-import { Authority } from 'app/config/authority.constants';
 import { UserRouteAccessService } from 'app/core/auth/user-route-access.service';
 import { <%= entityAngularName %>Component } from './list/<%= entityFileName %>.component';
 import { <%= entityAngularName %>DetailComponent } from './detail/<%= entityFileName %>-detail.component';
@@ -35,7 +34,6 @@ const <%= entityInstance %>Route: Routes = [
         path: '',
         component: <%= entityAngularName %>Component,
         data: {
-            authorities: [Authority.USER],
             <%_ if (pagination === 'pagination') { _%>
             defaultSort: 'id,asc',
             <%_ } _%>
@@ -50,7 +48,6 @@ const <%= entityInstance %>Route: Routes = [
             <%= entityInstance %>: <%= entityAngularName %>RoutingResolveService
         },
         data: {
-            authorities: [Authority.USER],
             pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
@@ -63,7 +60,6 @@ const <%= entityInstance %>Route: Routes = [
             <%= entityInstance %>: <%= entityAngularName %>RoutingResolveService
         },
         data: {
-            authorities: [Authority.USER],
             pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
@@ -75,7 +71,6 @@ const <%= entityInstance %>Route: Routes = [
             <%= entityInstance %>: <%= entityAngularName %>RoutingResolveService
         },
         data: {
-            authorities: [Authority.USER],
             pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]


### PR DESCRIPTION
This PR fixes the following problems related to `UserRouteAccessService` and it's usages.

Some routes require `ROLE_USER` role, but data shown in those routes and operations done there are allowed in back end without role restriction.
Developer can assume that if route is protected in front end then data and operations related to this route should be protected also in back end and this can lead to security issues.
This PR removes role restrictions from such routes in the front end.

If developer defines routes without restricting those to some roles then `UserRouteAccessService` allowed unauthenticated users to go to that page (but page was empty).
Correct is to route to login page and after successful login user is landing in requested page as this is after this PR.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
