### PR TITLE
Improve page title logic for Angular client

### DIFF
--- a/generators/client/needle-api/needle-client-angular.js
+++ b/generators/client/needle-api/needle-client-angular.js
@@ -200,23 +200,28 @@ module.exports = class extends needleClientBase {
         this.addIcon(iconName);
     }
 
-    _addRoute(route, modulePath, moduleName, needleName, filePath) {
+    _addRoute(route, modulePath, moduleName, needleName, filePath, pageTitle) {
         const isRouteAlreadyAdded = jhipsterUtils.checkStringInFile(filePath, `path: '${route}'`, this.generator);
         if (isRouteAlreadyAdded) {
             return;
         }
         const errorMessage = `${chalk.yellow('Route ') + route + chalk.yellow(` not added to ${filePath}.\n`)}`;
+        let pageTitleTemplate = '';
+        if (pageTitle) {
+            pageTitleTemplate = `
+            |        data: { pageTitle: '${pageTitle}' },`;
+        }
         const routingEntry = this.generator.stripMargin(
             `{
-            |        path: '${route}',
-            |        loadChildren: () => import('${modulePath}').then(m => m.${moduleName})
+            |        path: '${route}',${pageTitleTemplate}
+            |        loadChildren: () => import('${modulePath}').then(m => m.${moduleName}),
             |      },`
         );
         const rewriteFileModel = this.generateFileModel(filePath, needleName, routingEntry);
         this.addBlockContentToFile(rewriteFileModel, errorMessage);
     }
 
-    addEntityToModule(entityInstance, entityClass, entityAngularName, entityFolderName, entityFileName, entityUrl, microServiceName) {
+    addEntityToModule(entityAngularName, entityFolderName, entityFileName, entityUrl, microServiceName, pageTitle) {
         const entityModulePath = `${this.CLIENT_MAIN_SRC_DIR}app/entities/entity-routing.module.ts`;
         try {
             const isSpecificEntityAlreadyGenerated = jhipsterUtils.checkStringInFile(
@@ -231,15 +236,15 @@ module.exports = class extends needleClientBase {
                     ? `${this.generator.upperFirstCamelCase(microServiceName)}${entityAngularName}RoutingModule`
                     : `${entityAngularName}RoutingModule`;
 
-                this._addRoute(entityUrl, modulePath, moduleName, 'jhipster-needle-add-entity-route', entityModulePath);
+                this._addRoute(entityUrl, modulePath, moduleName, 'jhipster-needle-add-entity-route', entityModulePath, pageTitle);
             }
         } catch (e) {
             this.generator.debug('Error:', e);
         }
     }
 
-    addAdminRoute(route, modulePath, moduleName) {
+    addAdminRoute(route, modulePath, moduleName, pageTitle) {
         const adminModulePath = `${this.CLIENT_MAIN_SRC_DIR}app/admin/admin-routing.module.ts`;
-        this._addRoute(route, modulePath, moduleName, 'jhipster-needle-add-admin-route', adminModulePath);
+        this._addRoute(route, modulePath, moduleName, 'jhipster-needle-add-admin-route', adminModulePath, pageTitle);
     }
 };

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -455,12 +455,14 @@ function writeFiles() {
             let clientMainSrcDir;
             let templatesDir;
             let microserviceName = this.microserviceName;
+            let pageTitle;
 
             if (this.clientFramework === ANGULAR) {
                 files = angularFiles;
                 clientMainSrcDir = ANGULAR_DIR;
                 templatesDir = CLIENT_NG2_TEMPLATES_DIR;
                 microserviceName = this.microserviceName;
+                pageTitle = this.enableTranslation ? `${this.i18nKeyPrefix}.home.title` : this.entityClassPlural;
             } else if (this.clientFramework === REACT) {
                 files = reactFiles;
                 clientMainSrcDir = REACT_DIR;
@@ -497,7 +499,8 @@ function writeFiles() {
                     this.entityUrl,
                     this.clientFramework,
                     microserviceName,
-                    this.readOnly
+                    this.readOnly,
+                    pageTitle
                 );
                 this.addEntityToMenu(
                     this.entityStateName,

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing.module.ts.ejs
@@ -33,12 +33,11 @@ const <%= entityInstance %>Route: Routes = [
     {
         path: '',
         component: <%= entityAngularName %>Component,
+        <%_ if (pagination === 'pagination') { _%>
         data: {
-            <%_ if (pagination === 'pagination') { _%>
             defaultSort: 'id,asc',
-            <%_ } _%>
-            pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
+        <%_ } _%>
         canActivate: [UserRouteAccessService]
     },
     {
@@ -46,9 +45,6 @@ const <%= entityInstance %>Route: Routes = [
         component: <%= entityAngularName %>DetailComponent,
         resolve: {
             <%= entityInstance %>: <%= entityAngularName %>RoutingResolveService
-        },
-        data: {
-            pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
     },
@@ -59,9 +55,6 @@ const <%= entityInstance %>Route: Routes = [
         resolve: {
             <%= entityInstance %>: <%= entityAngularName %>RoutingResolveService
         },
-        data: {
-            pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
-        },
         canActivate: [UserRouteAccessService]
     },
     {
@@ -69,9 +62,6 @@ const <%= entityInstance %>Route: Routes = [
         component: <%= entityAngularName %>UpdateComponent,
         resolve: {
             <%= entityInstance %>: <%= entityAngularName %>RoutingResolveService
-        },
-        data: {
-            pageTitle: <% if (enableTranslation) { %>'<%= i18nKeyPrefix %>.home.title'<% } else { %>'<%= entityClassPlural %>'<% } %>
         },
         canActivate: [UserRouteAccessService]
     },

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -429,6 +429,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {string} clientFramework - The name of the client framework
      * @param {string} microServiceName - Microservice Name
      * @param {boolean} readOnly - If the entity is read-only or not
+     * @param {string} pageTitle - The translation key or the text for the page title in the browser
      */
     addEntityToModule(
         entityInstance,
@@ -439,17 +440,17 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
         entityUrl,
         clientFramework,
         microServiceName,
-        readOnly
+        readOnly,
+        pageTitle
     ) {
         if (clientFramework === ANGULAR) {
             this.needleApi.clientAngular.addEntityToModule(
-                entityInstance,
-                entityClass,
                 entityName,
                 entityFolderName,
                 entityFileName,
                 entityUrl,
-                microServiceName
+                microServiceName,
+                pageTitle
             );
         } else if (clientFramework === REACT) {
             this.needleApi.clientReact.addEntityToModule(entityInstance, entityClass, entityName, entityFolderName, entityFileName);
@@ -488,9 +489,10 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {string} route - The route for the module. For example 'entity-audit'.
      * @param {string} modulePath - The path to the module file. For example './entity-audit/entity-audit.module'.
      * @param {string} moduleName - The name of the module. For example 'EntityAuditModule'.
+     * @param {string} pageTitle - The translation key or the text for the page title in the browser. For example 'entityAudit.home.title' or 'Entity audit'.
      */
-    addAdminRoute(route, modulePath, moduleName) {
-        this.needleApi.clientAngular.addAdminRoute(route, modulePath, moduleName);
+    addAdminRoute(route, modulePath, moduleName, pageTitle) {
+        this.needleApi.clientAngular.addAdminRoute(route, modulePath, moduleName, pageTitle);
     }
 
     /**

--- a/test/needle-api/needle-client-angular.spec.js
+++ b/test/needle-api/needle-client-angular.spec.js
@@ -56,11 +56,13 @@ const mockBlueprintSubGen = class extends ClientGenerator {
                     'entityFileName',
                     'entityUrl',
                     ANGULAR,
-                    'microServiceName'
+                    'microServiceName',
+                    false,
+                    'entity.home.title'
                 );
                 this.addAdminToModule('appName', 'adminAngularName', 'adminFolderName', 'adminFileName', true, ANGULAR);
                 this.addAngularModule('appName', 'angularName', 'folderName', 'fileName', true, ANGULAR);
-                this.addAdminRoute('entity-audit', './entity-audit/entity-audit.module', 'EntityAuditModule');
+                this.addAdminRoute('entity-audit', './entity-audit/entity-audit.module', 'EntityAuditModule', 'entityAudit.home.title');
             },
         };
         return { ...phaseFromJHipster, ...customPhaseSteps };
@@ -176,7 +178,8 @@ describe('needle API Angular: JHipster client generator with blueprint', () => {
             `${CLIENT_MAIN_SRC_DIR}app/entities/entity-routing.module.ts`,
             '      {\n' +
                 "        path: 'entityUrl',\n" +
-                "        loadChildren: () => import('./entityFolderName/entityFileName-routing.module').then(m => m.MicroServiceNameentityNameRoutingModule)\n" +
+                "        data: { pageTitle: 'entity.home.title' },\n" +
+                "        loadChildren: () => import('./entityFolderName/entityFileName-routing.module').then(m => m.MicroServiceNameentityNameRoutingModule),\n" +
                 '      }'
         );
     });
@@ -195,7 +198,8 @@ describe('needle API Angular: JHipster client generator with blueprint', () => {
             '      },\n' +
                 '      {\n' +
                 "        path: 'entity-audit',\n" +
-                "        loadChildren: () => import('./entity-audit/entity-audit.module').then(m => m.EntityAuditModule)\n" +
+                "        data: { pageTitle: 'entityAudit.home.title' },\n" +
+                "        loadChildren: () => import('./entity-audit/entity-audit.module').then(m => m.EntityAuditModule),\n" +
                 '      },'
         );
     });


### PR DESCRIPTION
Adds possibility to add page title through needle API to Angular client's entity and admin routes.

Uses this possibility to add page title to entity route in entity generation and removes page title 4-time copy from entity child routes.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
