### PR TITLE
fix: add missing mapstruct version property

### DIFF
--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -584,10 +584,12 @@
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct</artifactId>
+            <version>${mapstruct.version}</version>
         </dependency>
         <dependency>
             <groupId>org.mapstruct</groupId>
             <artifactId>mapstruct-processor</artifactId>
+            <version>${mapstruct.version}</version>
             <scope>provided</scope>
         </dependency>
         <dependency>
@@ -1779,6 +1781,7 @@
                 <dependency>
                     <groupId>org.mapstruct</groupId>
                     <artifactId>mapstruct-processor</artifactId>
+                    <version>${mapstruct.version}</version>
                 </dependency>
 <%_ if (databaseType === 'sql') { _%>
                 <dependency>


### PR DESCRIPTION
Add some missing `<version>${mapstruct.version}</version>` to honor the version defined in the current POM.
Otherwise it takes the one from the BOM.

(or should we remove the `<mapstruct.version>1.4.1.Final</mapstruct.version>` from the properties of the current POM ?)

I realized this after upgrading to IntelliJ 2020.3 that requires mapstruct 1.4.1 to build mapping implementation