### PR TITLE
Fix many to many (React)

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/shared/util/entity-utils.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/util/entity-utils.ts.ejs
@@ -38,12 +38,7 @@ export const cleanEntity = entity => {
  * @param idList Elements to map.
  * @returns The list of objects with mapped ids.
  */
-export const mapIdList = (idList: ReadonlyArray<any>) => {
-  if (idList) {
-    return idList.filter((entityId: any) => entityId !== '').map((entityId: any) => ({ id: entityId }));
-  }
-  return [];
-};
+ export const mapIdList = (idList: ReadonlyArray<any>) => idList.filter((entityId: any) => entityId !== '').map((entityId: any) => ({ id: entityId }));
 
  export const overridePaginationStateWithQueryParams = (paginationBaseState: IPaginationBaseState , locationSearch: string) => {
   const params = new URLSearchParams(locationSearch);

--- a/generators/client/templates/react/src/test/javascript/spec/app/shared/util/entity-utils.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/spec/app/shared/util/entity-utils.spec.ts.ejs
@@ -72,11 +72,5 @@ describe('Entity utils', () => {
 
       expect(mapIdList(ids)).toEqual([]);
     });
-
-    it('should return an empty array when args is undefined', () => {
-      const ids = undefined;
-
-      expect(mapIdList(ids)).toEqual([]);
-    });
   });
 });

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -499,7 +499,7 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
               multiple
               className="form-control"
               name="<%= relationshipFieldNamePlural %>"
-              value={<%= entityInstance %>Entity.<%= relationshipFieldNamePlural %> && <%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>.map(e => e.id)}
+              value={!isNew && <%= entityInstance %>Entity.<%= relationshipFieldNamePlural %> && <%= entityInstance %>Entity.<%= relationshipFieldNamePlural %>.map(e => e.id)}
             >
               <option value="" key="0" />
               {


### PR DESCRIPTION
Fix the root issue of https://github.com/jhipster/generator-jhipster/issues/13182
And fix an underlying issue where the relations from a many-to-many are set from the previous save. 

the `value` from `AvInput` should be set once.

This same "solution" is already applied with: `AvForm model={isNew ? {} : fooEntity}`