### PR TITLE
Fix EntityRoutingModule in Angular for microservices

### DIFF
--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -486,7 +486,18 @@ function writeFiles() {
             addEnumerationFiles(this, clientMainSrcDir);
 
             if (!this.embedded) {
-                this.addEntityToModule();
+                this.addEntityToModule(
+                    this.entityInstance,
+                    this.entityClass,
+                    this.entityAngularName,
+                    this.entityFolderName,
+                    this.entityFileName,
+                    this.entityUrl,
+                    this.clientFramework,
+                    this.microserviceName,
+                    this.readOnly,
+                    this.enableTranslation ? `${this.i18nKeyPrefix}.home.title` : this.entityClassPlural
+                );
                 this.addEntityToMenu(
                     this.entityStateName,
                     this.enableTranslation,

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -441,7 +441,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
         clientFramework,
         microServiceName,
         readOnly,
-        pageTitle
+        pageTitle = this.enableTranslation ? `${this.i18nKeyPrefix}.home.title` : this.entityClassPlural
     ) {
         if (clientFramework === ANGULAR) {
             this.needleApi.clientAngular.addEntityToModule(

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -432,16 +432,16 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {string} pageTitle - The translation key or the text for the page title in the browser
      */
     addEntityToModule(
-        entityInstance = this.entityInstance,
-        entityClass = this.entityClass,
-        entityName = this.entityAngularName,
-        entityFolderName = this.entityFolderName,
-        entityFileName = this.entityFileName,
-        entityUrl = this.entityUrl,
-        clientFramework = this.clientFramework,
-        microServiceName = this.microServiceName,
-        readOnly = this.readOnly,
-        pageTitle = this.enableTranslation ? `${this.i18nKeyPrefix}.home.title` : this.entityClassPlural
+        entityInstance,
+        entityClass,
+        entityName,
+        entityFolderName,
+        entityFileName,
+        entityUrl,
+        clientFramework,
+        microServiceName,
+        readOnly,
+        pageTitle
     ) {
         if (clientFramework === ANGULAR) {
             this.needleApi.clientAngular.addEntityToModule(


### PR DESCRIPTION
Follow up to #13198 
`microserviceName` is missing from `this` in `generator-base.js` but is available in `files.js` (other variables are available in both places). So reverting partially #13198

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
