### PR TITLE
Simplify again addEntityToModule and rename microServiceName to microserviceName

### DIFF
--- a/generators/client/needle-api/needle-client-angular.js
+++ b/generators/client/needle-api/needle-client-angular.js
@@ -221,7 +221,7 @@ module.exports = class extends needleClientBase {
         this.addBlockContentToFile(rewriteFileModel, errorMessage);
     }
 
-    addEntityToModule(entityAngularName, entityFolderName, entityFileName, entityUrl, microServiceName, pageTitle) {
+    addEntityToModule(entityAngularName, entityFolderName, entityFileName, entityUrl, microserviceName, pageTitle) {
         const entityModulePath = `${this.CLIENT_MAIN_SRC_DIR}app/entities/entity-routing.module.ts`;
         try {
             const isSpecificEntityAlreadyGenerated = jhipsterUtils.checkStringInFile(
@@ -232,8 +232,8 @@ module.exports = class extends needleClientBase {
 
             if (!isSpecificEntityAlreadyGenerated) {
                 const modulePath = `./${entityFolderName}/${entityFileName}-routing.module`;
-                const moduleName = microServiceName
-                    ? `${this.generator.upperFirstCamelCase(microServiceName)}${entityAngularName}RoutingModule`
+                const moduleName = microserviceName
+                    ? `${this.generator.upperFirstCamelCase(microserviceName)}${entityAngularName}RoutingModule`
                     : `${entityAngularName}RoutingModule`;
 
                 this._addRoute(entityUrl, modulePath, moduleName, 'jhipster-needle-add-entity-route', entityModulePath, pageTitle);

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -486,18 +486,7 @@ function writeFiles() {
             addEnumerationFiles(this, clientMainSrcDir);
 
             if (!this.embedded) {
-                this.addEntityToModule(
-                    this.entityInstance,
-                    this.entityClass,
-                    this.entityAngularName,
-                    this.entityFolderName,
-                    this.entityFileName,
-                    this.entityUrl,
-                    this.clientFramework,
-                    this.microserviceName,
-                    this.readOnly,
-                    this.enableTranslation ? `${this.i18nKeyPrefix}.home.title` : this.entityClassPlural
-                );
+                this.addEntityToModule();
                 this.addEntityToMenu(
                     this.entityStateName,
                     this.enableTranslation,

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -427,20 +427,20 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
      * @param {string} entityFileName - Entity File Name
      * @param {string} entityUrl - Entity router URL
      * @param {string} clientFramework - The name of the client framework
-     * @param {string} microServiceName - Microservice Name
+     * @param {string} microserviceName - Microservice Name
      * @param {boolean} readOnly - If the entity is read-only or not
      * @param {string} pageTitle - The translation key or the text for the page title in the browser
      */
     addEntityToModule(
-        entityInstance,
-        entityClass,
-        entityName,
-        entityFolderName,
-        entityFileName,
-        entityUrl,
-        clientFramework,
-        microServiceName,
-        readOnly,
+        entityInstance = this.entityInstance,
+        entityClass = this.entityClass,
+        entityName = this.entityAngularName,
+        entityFolderName = this.entityFolderName,
+        entityFileName = this.entityFileName,
+        entityUrl = this.entityUrl,
+        clientFramework = this.clientFramework,
+        microserviceName = this.microserviceName,
+        readOnly = this.readOnly,
         pageTitle = this.enableTranslation ? `${this.i18nKeyPrefix}.home.title` : this.entityClassPlural
     ) {
         if (clientFramework === ANGULAR) {
@@ -449,7 +449,7 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
                 entityFolderName,
                 entityFileName,
                 entityUrl,
-                microServiceName,
+                microserviceName,
                 pageTitle
             );
         } else if (clientFramework === REACT) {

--- a/test/needle-api/needle-client-angular.spec.js
+++ b/test/needle-api/needle-client-angular.spec.js
@@ -56,7 +56,7 @@ const mockBlueprintSubGen = class extends ClientGenerator {
                     'entityFileName',
                     'entityUrl',
                     ANGULAR,
-                    'microServiceName',
+                    'microserviceName',
                     false,
                     'entity.home.title'
                 );
@@ -179,7 +179,7 @@ describe('needle API Angular: JHipster client generator with blueprint', () => {
             '      {\n' +
                 "        path: 'entityUrl',\n" +
                 "        data: { pageTitle: 'entity.home.title' },\n" +
-                "        loadChildren: () => import('./entityFolderName/entityFileName-routing.module').then(m => m.MicroServiceNameentityNameRoutingModule),\n" +
+                "        loadChildren: () => import('./entityFolderName/entityFileName-routing.module').then(m => m.MicroserviceNameentityNameRoutingModule),\n" +
                 '      }'
         );
     });

--- a/test/needle-api/needle-client-vue.spec.js
+++ b/test/needle-api/needle-client-vue.spec.js
@@ -48,7 +48,7 @@ const mockBlueprintSubGen = class extends ClientGenerator {
                     'entityFileName',
                     'entityUrl',
                     VUE,
-                    'microServiceName'
+                    'microserviceName'
                 );
             },
         };


### PR DESCRIPTION
Follow up to #13198 and #13202

This reverts commits 5223cbf3d707bf832ea9f5acb445c36a9b2ffe50 and d46a732b9bf262657669f15af5f6100b18931025 and renames all `microServiceName` occurences to `microserviceName`.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
