### PR TITLE
Add support to JDL entities at CI scripts.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -147,6 +147,7 @@ jobs:
                       e2e: 1
                       testcontainers: 0
         env:
+            JHI_GENERATE_SKIP_CONFIG: 1
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.environment }}
@@ -222,8 +223,8 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'GENERATION: install JHipster'
               run: $JHI_SCRIPTS/10-install-jhipster.sh
-            - name: 'GENERATION: entities'
-              run: $JHI_SCRIPTS/11-generate-entities.sh
+            - name: 'GENERATION: config'
+              run: $JHI_SCRIPTS/11-generate-config.sh
             - name: 'GENERATION: project'
               run: $JHI_SCRIPTS/12-generate-project.sh
             - name: 'GENERATION: replace version in generated project'
@@ -250,7 +251,7 @@ jobs:
               if: steps.base-checkout.outcome == 'success'
               working-directory: ${{ github.workspace }}/base/app
               run: |
-                  $JHI_SCRIPTS/11-generate-entities.sh
+                  $JHI_SCRIPTS/11-generate-config.sh
                   # 11-generate-entities.sh removes current dir, we need to switch to the new one
                   cd ../app
                   $JHI_SCRIPTS/12-generate-project.sh --skip-install --skip-git

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -94,6 +94,7 @@ jobs:
                       testcontainers: 1
                     - app-type: ngx-mysql-es-noi18n-mapsid
                       entity: sqlfull
+                      jdl-entity: '*'
                       environment: prod
                       war: 0
                       e2e: 1
@@ -149,6 +150,7 @@ jobs:
         env:
             JHI_GENERATE_SKIP_CONFIG: 1
             JHI_ENTITY: ${{ matrix.entity }}
+            JHI_JDL_ENTITY: ${{ matrix.jdl-entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.environment }}
             JHI_WAR: ${{ matrix.war }}

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -140,6 +140,7 @@ jobs:
                     #   e2e: 1
                     #   testcontainers: 0
         env:
+            JHI_GENERATE_SKIP_CONFIG: 1
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.environment }}
@@ -215,8 +216,8 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'GENERATION: install JHipster'
               run: $JHI_SCRIPTS/10-install-jhipster.sh
-            - name: 'GENERATION: entities'
-              run: $JHI_SCRIPTS/11-generate-entities.sh
+            - name: 'GENERATION: config'
+              run: $JHI_SCRIPTS/11-generate-config.sh
             - name: 'GENERATION: project'
               run: $JHI_SCRIPTS/12-generate-project.sh
             - name: 'GENERATION: replace version in generated project'
@@ -243,7 +244,7 @@ jobs:
               if: steps.base-checkout.outcome == 'success'
               working-directory: ${{ github.workspace }}/base/app
               run: |
-                  $JHI_SCRIPTS/11-generate-entities.sh
+                  $JHI_SCRIPTS/11-generate-config.sh
                   # 11-generate-entities.sh removes current dir, we need to switch to the new one
                   cd ../app
                   $JHI_SCRIPTS/12-generate-project.sh --skip-install --skip-git
@@ -311,15 +312,15 @@ jobs:
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run ci:e2e:run --if-present
+            - name: 'E2E: Teardown'
+              if: always() && matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
+              run: npm run ci:e2e:teardown
             - name: 'BACKEND: Store failure logs'
               uses: actions/upload-artifact@v2
               if: always() && steps.backend.outcome == 'failure'
               with:
                   name: log-${{ matrix.app-type }}
                   path: ${{ github.workspace }}/app/build/test-results/**/*.xml
-            - name: 'E2E: Teardown'
-              if: always() && matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: npm run ci:e2e:teardown
             - name: 'E2E: Store failure screenshots'
               uses: actions/upload-artifact@v2
               if: always() && steps.e2e.outcome == 'failure'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -138,6 +138,7 @@ jobs:
                       e2e: 1
                       testcontainers: 1
         env:
+            JHI_GENERATE_SKIP_CONFIG: 1
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
             JHI_PROFILE: ${{ matrix.environment }}
@@ -213,8 +214,8 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'GENERATION: install JHipster'
               run: $JHI_SCRIPTS/10-install-jhipster.sh
-            - name: 'GENERATION: entities'
-              run: $JHI_SCRIPTS/11-generate-entities.sh
+            - name: 'GENERATION: config'
+              run: $JHI_SCRIPTS/11-generate-config.sh
             - name: 'GENERATION: project'
               run: $JHI_SCRIPTS/12-generate-project.sh
             - name: 'GENERATION: replace version in generated project'
@@ -241,7 +242,7 @@ jobs:
               if: steps.base-checkout.outcome == 'success'
               working-directory: ${{ github.workspace }}/base/app
               run: |
-                  $JHI_SCRIPTS/11-generate-entities.sh
+                  $JHI_SCRIPTS/11-generate-config.sh
                   # 11-generate-entities.sh removes current dir, we need to switch to the new one
                   cd ../app
                   $JHI_SCRIPTS/12-generate-project.sh --skip-install --skip-git

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -87,31 +87,31 @@ jobs:
                 include:
                     - app-type: webflux-mongodb
                       entity: mongodb
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: webflux-mongodb-es-session
                       entity: mongodb
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: webflux-mongodb-oauth2
                       entity: mongodb
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: webflux-gateway-jwt
                       entity: none
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
                     - app-type: webflux-gateway-oauth2
                       entity: none
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
@@ -127,7 +127,7 @@ jobs:
                     #                      e2e: 1
                     - app-type: webflux-psql
                       entity: sql
-                      profile: prod
+                      environment: prod
                       war: 0
                       e2e: 1
                       testcontainers: 1
@@ -144,12 +144,13 @@ jobs:
                     #  e2e: 1
                     #  testcontainers: 1
         env:
+            JHI_GENERATE_SKIP_CONFIG: 1
             JHI_ENTITY: ${{ matrix.entity }}
             JHI_APP: ${{ matrix.app-type }}
-            JHI_PROFILE: ${{ matrix.profile }}
+            JHI_PROFILE: ${{ matrix.environment }}
             JHI_WAR: ${{ matrix.war }}
-            JHI_TESTCONTAINERS: ${{ matrix.testcontainers }}
             JHI_E2E: ${{ matrix.e2e }}
+            SPRING_PROFILES_ACTIVE: ${{ fromJson('["", "testcontainers"]')[matrix.testcontainers] }}
         steps:
             #----------------------------------------------------------------------
             # Install all tools and check configuration
@@ -219,8 +220,8 @@ jobs:
             #----------------------------------------------------------------------
             - name: 'GENERATION: install JHipster'
               run: $JHI_SCRIPTS/10-install-jhipster.sh
-            - name: 'GENERATION: entities'
-              run: $JHI_SCRIPTS/11-generate-entities.sh
+            - name: 'GENERATION: config'
+              run: $JHI_SCRIPTS/11-generate-config.sh
             - name: 'GENERATION: project'
               run: $JHI_SCRIPTS/12-generate-project.sh
             - name: 'GENERATION: replace version in generated project'
@@ -247,7 +248,7 @@ jobs:
               if: steps.base-checkout.outcome == 'success'
               working-directory: ${{ github.workspace }}/base/app
               run: |
-                  $JHI_SCRIPTS/11-generate-entities.sh
+                  $JHI_SCRIPTS/11-generate-config.sh
                   # 11-generate-entities.sh removes current dir, we need to switch to the new one
                   cd ../app
                   $JHI_SCRIPTS/12-generate-project.sh --skip-install --skip-git
@@ -295,28 +296,41 @@ jobs:
             #----------------------------------------------------------------------
             # Launch tests
             #----------------------------------------------------------------------
-            - name: 'TESTS: Start docker-compose containers'
-              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/20-docker-compose.sh
+            - name: 'TESTS: Start docker-compose containers for e2e and backend tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers != 1
+              run: npm run ci:e2e:prepare
             - name: 'TESTS: backend'
+              id: backend
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/21-tests-backend.sh
+              run: npm run ci:backend:test
             - name: 'TESTS: frontend'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/22-tests-frontend.sh
+              run: npm run ci:frontend:test
             - name: 'TESTS: packaging'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/23-package.sh
+              run: npm run ci:e2e:package
+            - name: 'TESTS: Start docker-compose containers for e2e tests'
+              if: steps.tests-should-be-skipped.outputs.skip-tests != 'true' && matrix.testcontainers == 1
+              run: npm run ci:e2e:prepare
             - name: 'E2E: Run'
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: $JHI_SCRIPTS/24-tests-e2e.sh
+              run: npm run ci:e2e:run --if-present
+            - name: 'E2E: Teardown'
+              if: always() && matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
+              run: npm run ci:e2e:teardown
+            - name: 'BACKEND: Store failure logs'
+              uses: actions/upload-artifact@v2
+              if: always() && steps.backend.outcome == 'failure'
+              with:
+                  name: log-${{ matrix.app-type }}
+                  path: ${{ github.workspace }}/app/build/test-results/**/*.xml
             - name: 'E2E: Store failure screenshots'
               uses: actions/upload-artifact@v2
               if: always() && steps.e2e.outcome == 'failure'
               with:
                   name: screenshots-${{ matrix.app-type }}
-                  path: ${{ github.workspace }}/app/target/cypress/screenshots
+                  path: ${{ github.workspace }}/app/*/cypress/screenshots
             - name: 'ANALYSIS: Sonar analysis'
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: $JHI_SCRIPTS/25-sonar-analyze.sh

--- a/test-integration/samples/jdl-entities/entities.jdl
+++ b/test-integration/samples/jdl-entities/entities.jdl
@@ -1,3 +1,4 @@
+@ChangelogDate(20200804035352)
 entity JdlFieldTest {
   id Long
 }

--- a/test-integration/samples/jdl-entities/entities.jdl
+++ b/test-integration/samples/jdl-entities/entities.jdl
@@ -1,0 +1,5 @@
+entity JdlFieldTest {
+  id Long
+}
+
+dto JdlFieldTest with mapstruct

--- a/test-integration/scripts/00-init-env.sh
+++ b/test-integration/scripts/00-init-env.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-JHI_IT_DIR="$( cd "$( dirname $( dirname $( dirname "${BASH_SOURCE[0]}" ) ) )" >/dev/null 2>&1 && pwd )"
+JHI_DETECTED_DIR="$( cd "$( dirname $( dirname $( dirname "${BASH_SOURCE[0]}" ) ) )" >/dev/null 2>&1 && pwd )"
 
 init_var() {
     result=""
@@ -19,7 +19,7 @@ JHI_REPO=$(init_var "$BUILD_REPOSITORY_URI" "$GITHUB_WORKSPACE" )
 
 # folder where the repo is cloned
 if [[ "$JHI_HOME" == "" ]]; then
-    JHI_HOME=$(init_var "$BUILD_REPOSITORY_LOCALPATH" "$GITHUB_WORKSPACE" "$JHI_IT_DIR")
+    JHI_HOME=$(init_var "$BUILD_REPOSITORY_LOCALPATH" "$GITHUB_WORKSPACE" "$JHI_DETECTED_DIR")
 fi
 
 # folder for test-integration
@@ -39,12 +39,12 @@ fi
 
 # folder for app
 if [[ "$JHI_FOLDER_APP" == "" ]]; then
-    JHI_FOLDER_APP="$( pwd )"/app
+    JHI_FOLDER_APP="$HOME"/app
 fi
 
 # folder for uaa app
 if [[ "$JHI_FOLDER_UAA" == "" ]]; then
-    JHI_FOLDER_UAA="$( pwd )"/uaa
+    JHI_FOLDER_UAA="$HOME"/uaa
 fi
 
 # set correct OpenJDK version

--- a/test-integration/scripts/00-init-env.sh
+++ b/test-integration/scripts/00-init-env.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+JHI_IT_DIR="$( cd "$( dirname $( dirname $( dirname "${BASH_SOURCE[0]}" ) ) )" >/dev/null 2>&1 && pwd )"
+
 init_var() {
     result=""
     if [[ $1 != "" ]]; then
@@ -17,7 +19,7 @@ JHI_REPO=$(init_var "$BUILD_REPOSITORY_URI" "$GITHUB_WORKSPACE" )
 
 # folder where the repo is cloned
 if [[ "$JHI_HOME" == "" ]]; then
-    JHI_HOME=$(init_var "$BUILD_REPOSITORY_LOCALPATH" "$GITHUB_WORKSPACE")
+    JHI_HOME=$(init_var "$BUILD_REPOSITORY_LOCALPATH" "$GITHUB_WORKSPACE" "$JHI_IT_DIR")
 fi
 
 # folder for test-integration
@@ -37,12 +39,12 @@ fi
 
 # folder for app
 if [[ "$JHI_FOLDER_APP" == "" ]]; then
-    JHI_FOLDER_APP="$HOME"/app
+    JHI_FOLDER_APP="$( pwd )"/app
 fi
 
 # folder for uaa app
 if [[ "$JHI_FOLDER_UAA" == "" ]]; then
-    JHI_FOLDER_UAA="$HOME"/uaa
+    JHI_FOLDER_UAA="$( pwd )"/uaa
 fi
 
 # set correct OpenJDK version

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -1,11 +1,15 @@
 #!/bin/bash
 
 if [[ "$1" != "" ]]; then
-    JHI_APP=$1
+    JHI_FOLDER_APP=$1
 fi
 
 if [[ "$2" != "" ]]; then
-    JHI_ENTITY=$2
+    JHI_APP=$2
+fi
+
+if [[ "$3" != "" ]]; then
+    JHI_ENTITY=$3
 fi
 
 set -e

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -7,8 +7,6 @@ else
     echo "*** 00-init-env.sh not found"
 fi
 
-echo "11-generate-entities.sh script is deprecated, use 11-generate-config.sh instead"
-
 #-------------------------------------------------------------------------------
 # Functions
 #-------------------------------------------------------------------------------
@@ -27,6 +25,15 @@ prepareFolder() {
 
 if [[ $JHI_REPO != "" ]]; then
     prepareFolder
+fi
+
+cd "$JHI_FOLDER_APP"
+
+if [[ "$JHI_ENTITY" != "jdl" ]]; then
+    #-------------------------------------------------------------------------------
+    # Copy jhipster config
+    #-------------------------------------------------------------------------------
+    cp -f "$JHI_SAMPLES"/"$JHI_APP"/.yo-rc.json "$JHI_FOLDER_APP"/
 fi
 
 if [[ ("$JHI_ENTITY" == "mongodb") || ("$JHI_ENTITY" == "couchbase") ]]; then
@@ -135,6 +142,11 @@ elif [[ "$JHI_ENTITY" == "sqlfull" ]]; then
     moveEntity JpaFilteringRelationship
     moveEntity JpaFilteringOtherSide
 
+    #-------------------------------------------------------------------------------
+    # Generate jdl entities
+    #-------------------------------------------------------------------------------
+    jhipster --no-insight jdl "$JHI_SAMPLES"/jdl-entities/*.jdl --json-only
+
 elif [[ "$JHI_ENTITY" == "sql" ]]; then
     moveEntity BankAccount
     moveEntity Label
@@ -161,7 +173,15 @@ elif [[ "$JHI_ENTITY" == "sql" ]]; then
 fi
 
 #-------------------------------------------------------------------------------
-# Copy entities json
+# Print entities json
 #-------------------------------------------------------------------------------
 echo "*** Entities:"
 ls -al "$JHI_FOLDER_APP"/.jhipster/
+
+#-------------------------------------------------------------------------------
+# Force no insight
+#-------------------------------------------------------------------------------
+if [ "$JHI_FOLDER_APP" == "$HOME/app" ]; then
+    mkdir -p "$HOME"/.config/configstore/
+    cp "$JHI_INTEG"/configstore/*.json "$HOME"/.config/configstore/
+fi

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -1,5 +1,13 @@
 #!/bin/bash
 
+if [[ "$1" != "" ]]; then
+    JHI_APP=$1
+fi
+
+if [[ "$2" != "" ]]; then
+    JHI_ENTITY=$2
+fi
+
 set -e
 if [[ -a $(dirname $0)/00-init-env.sh ]]; then
     source $(dirname $0)/00-init-env.sh
@@ -17,7 +25,6 @@ moveEntity() {
 
 prepareFolder() {
     rm -rf "$JHI_FOLDER_APP"
-    mkdir -p "$JHI_FOLDER_APP"/.jhipster/
 }
 #-------------------------------------------------------------------------------
 # Copy entities json
@@ -27,6 +34,7 @@ if [[ $JHI_REPO != "" ]]; then
     prepareFolder
 fi
 
+mkdir -p "$JHI_FOLDER_APP"/.jhipster/
 cd "$JHI_FOLDER_APP"
 
 if [[ "$JHI_ENTITY" != "jdl" ]]; then

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -177,13 +177,15 @@ elif [[ "$JHI_ENTITY" == "sql" ]]; then
 
     moveEntity MapsIdUserProfileWithDTO
 
+elif [[ "$JHI_ENTITY" != "" ]]; then
+    JHI_JDL_ENTITY=$JHI_ENTITY
 fi
 
 #-------------------------------------------------------------------------------
 # Generate jdl entities
 #-------------------------------------------------------------------------------
-if [[ "$JHI_JDL_NAME" != "" ]]; then
-    jhipster --no-insight jdl "$JHI_SAMPLES"/jdl-entities/$JHI_JDL_NAME.jdl --json-only
+if [[ "$JHI_JDL_ENTITY" != "" ]]; then
+    jhipster --no-insight jdl "$JHI_SAMPLES"/jdl-entities/$JHI_JDL_ENTITY.jdl --json-only
 fi
 
 #-------------------------------------------------------------------------------

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -1,5 +1,8 @@
 #!/bin/bash
 
+#-------------------------------------------------------------------------------
+# Eg: 11-generate-config.sh ./ ngx-default sqlfull
+#-------------------------------------------------------------------------------
 if [[ "$1" != "" ]]; then
     JHI_FOLDER_APP=$1
 fi
@@ -177,14 +180,14 @@ elif [[ "$JHI_ENTITY" == "sql" ]]; then
 
     moveEntity MapsIdUserProfileWithDTO
 
-elif [[ "$JHI_ENTITY" != "" ]]; then
-    JHI_JDL_ENTITY=$JHI_ENTITY
+elif [[ "$3" != "" ]]; then
+    JHI_JDL_ENTITY=$3
 fi
 
 #-------------------------------------------------------------------------------
 # Generate jdl entities
 #-------------------------------------------------------------------------------
-if [[ "$JHI_JDL_ENTITY" != "" ]]; then
+if [[ "$JHI_JDL_ENTITY" != "" && "$JHI_JDL_ENTITY" != "none" ]]; then
     jhipster --no-insight jdl "$JHI_SAMPLES"/jdl-entities/$JHI_JDL_ENTITY.jdl --json-only
 fi
 

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -150,11 +150,6 @@ elif [[ "$JHI_ENTITY" == "sqlfull" ]]; then
     moveEntity JpaFilteringRelationship
     moveEntity JpaFilteringOtherSide
 
-    #-------------------------------------------------------------------------------
-    # Generate jdl entities
-    #-------------------------------------------------------------------------------
-    jhipster --no-insight jdl "$JHI_SAMPLES"/jdl-entities/*.jdl --json-only
-
 elif [[ "$JHI_ENTITY" == "sql" ]]; then
     moveEntity BankAccount
     moveEntity Label
@@ -178,6 +173,13 @@ elif [[ "$JHI_ENTITY" == "sql" ]]; then
 
     moveEntity MapsIdUserProfileWithDTO
 
+fi
+
+#-------------------------------------------------------------------------------
+# Generate jdl entities
+#-------------------------------------------------------------------------------
+if [[ "$JHI_JDL_NAME" != "" ]]; then
+    jhipster --no-insight jdl "$JHI_SAMPLES"/jdl-entities/$JHI_JDL_NAME.jdl --json-only
 fi
 
 #-------------------------------------------------------------------------------

--- a/test-integration/scripts/12-generate-project.sh
+++ b/test-integration/scripts/12-generate-project.sh
@@ -36,7 +36,13 @@ else
     # Generate project with jhipster
     #-------------------------------------------------------------------------------
     mkdir -p "$JHI_FOLDER_APP"
-    cp -f "$JHI_SAMPLES"/"$JHI_APP"/.yo-rc.json "$JHI_FOLDER_APP"/
+
+    if [[ "$JHI_GENERATE_SKIP_CONFIG" != "1" ]]; then
+        cp -f "$JHI_SAMPLES"/"$JHI_APP"/.yo-rc.json "$JHI_FOLDER_APP"/
+    else
+        echo "skipping config file"
+    fi
+
     cd "$JHI_FOLDER_APP"
     jhipster --force --no-insight --skip-checks --with-entities $@
 


### PR DESCRIPTION
JDL entities must be executed after copying `.yo-rc.json` and before generating the project (`jhipster --with-entities`).

- Create `11-generate-config.sh` and deprecate `11-generate-entities.sh`
`11-generate-config.sh` copy `.yo-rc.json`, json entities and generates entities from jdl afterwards.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
