### PR TITLE
[angular] Fix garbage collection title translation

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/blocks/metrics-garbagecollector/metrics-garbagecollector.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/blocks/metrics-garbagecollector/metrics-garbagecollector.component.html.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-<h3 id="garbageCollectorMetrics" jhiTranslate="metrics.jvm.gc.title">Garbage collector statistics</h3>
+<h3 id="garbageCollectorMetrics" <%= jhiPrefix %>Translate="metrics.jvm.gc.title">Garbage collector statistics</h3>
 
 <div class="row">
     <div class="col-md-4">


### PR DESCRIPTION
Garbage collection title was not translated if `jhiPrefix` was not `jhi`, this PR fixes that.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
