### PR TITLE
[angular] Add dependency on webpack, to help dependabot.

### DIFF
--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -36,6 +36,7 @@
     "merge-jsons-webpack-plugin": "1.0.21",
     "rimraf": "3.0.2",
     "simple-progress-webpack-plugin": "1.1.2",
+    "webpack": "4.44.2",
     "webpack-bundle-analyzer": "4.2.0",
     "webpack-notifier": "1.12.0"
   }

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -126,6 +126,7 @@
     "rimraf": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     "simple-progress-webpack-plugin": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     "typescript": "VERSION_MANAGED_BY_CLIENT_COMMON",
+    "webpack": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     "webpack-bundle-analyzer": "VERSION_MANAGED_BY_CLIENT_ANGULAR",
     "webpack-notifier": "VERSION_MANAGED_BY_CLIENT_ANGULAR"
   },


### PR DESCRIPTION
Should prevent dependabot from creating PRs that contains peer dependency on webpack 5 like https://github.com/jhipster/generator-jhipster/pull/13239
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
