### PR TITLE
[angular] Remove redundant export from entity routed module

### DIFF
--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing.module.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity-management-routing.module.ts.ejs
@@ -73,8 +73,5 @@ const <%= entityInstance %>Route: Routes = [
         RouterModule.forChild(<%= entityInstance %>Route),
         <%= microservicePrefix %><%= entityAngularName %>Module,
     ],
-    exports: [
-        <%= microservicePrefix %><%= entityAngularName %>Module,
-    ],
 })
 export class <%= microservicePrefix %><%= entityAngularName %>RoutingModule {}


### PR DESCRIPTION
According to https://angular.io/guide/module-types#summary-of-ngmodule-categories routed modules should not export anything. This export is just redundant, no use from this.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
