### PR TITLE
CI-CD: add back tests

### DIFF
--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -281,6 +281,77 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.file(expectedFiles.github);
             });
         });
+        describe('GitHub Actions: Maven AngularX NPM with full options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'github',
+                        cicdIntegrations: ['deploy', 'sonar', 'publishDocker', 'heroku'],
+                        dockerImage: 'jhipster-publish-docker',
+                        artifactorySnapshotsId: 'snapshots',
+                        artifactorySnapshotsUrl: 'http://artifactory:8081/artifactory/libs-snapshot',
+                        artifactoryReleasesId: 'releases',
+                        artifactoryReleasesUrl: 'http://artifactory:8081/artifactory/libs-release',
+                        sonarUrl: 'http://sonar.com:9000',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.github);
+            });
+            it('contains Docker, Sonar, Heroku', () => {
+                assert.fileContent('.github/workflows/github-ci.yml', /mvnw.*sonar.com/);
+                assert.fileContent('.github/workflows/github-ci.yml', /mvnw.*jhipster-publish-docker/);
+                assert.fileContent('.github/workflows/github-ci.yml', /mvnw.*sample-mysql/);
+            });
+            it('contains distributionManagement in pom.xml', () => {
+                assert.fileContent('pom.xml', /distributionManagement/);
+            });
+        });
+        describe('GitHub Actions: Gradle AngularX NPM with full options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'github',
+                        cicdIntegrations: ['sonar', 'publishDocker', 'heroku'],
+                        dockerImage: 'jhipster-publish-docker',
+                        sonarUrl: 'http://sonar.com:9000',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.github);
+            });
+            it('contains Docker, Sonar, Heroku', () => {
+                assert.fileContent('.github/workflows/github-ci.yml', /gradlew.*jhipster-publish-docker/);
+                assert.fileContent('.github/workflows/github-ci.yml', /gradlew.*sonar.com/);
+                assert.fileContent('.github/workflows/github-ci.yml', /gradlew.*deployHeroku/);
+            });
+        });
+        describe('GitHub Actions: autoconfigure', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ autoconfigureGithub: true })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.github);
+            });
+        });
     });
 
     //--------------------------------------------------

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -18,7 +18,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Jenkins tests
     //--------------------------------------------------
     describe('Jenkins tests', () => {
-        describe('Jenkins: Maven AngularX NPM', () => {
+        describe('Jenkins: Maven Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -42,7 +42,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('Jenkinsfile', /heroku/);
             });
         });
-        describe('Jenkins: Gradle AngularX NPM', () => {
+        describe('Jenkins: Gradle Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -66,7 +66,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('Jenkinsfile', /heroku/);
             });
         });
-        describe('Jenkins: Maven AngularX NPM with full options', () => {
+        describe('Jenkins: Maven Angular NPM with full options', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -98,7 +98,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.fileContent('pom.xml', /distributionManagement/);
             });
         });
-        describe('Jenkins: Maven AngularX NPM inside Docker', () => {
+        describe('Jenkins: Maven Angular NPM inside Docker', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -134,7 +134,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // GitLab CI tests
     //--------------------------------------------------
     describe('GitLab CI tests', () => {
-        describe('GitLab CI: Maven AngularX NPM', () => {
+        describe('GitLab CI: Maven Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -158,7 +158,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('.gitlab-ci.yml', /heroku/);
             });
         });
-        describe('GitLab CI: Gradle AngularX NPM', () => {
+        describe('GitLab CI: Gradle Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -203,7 +203,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
             });
         });
-        describe('GitLab CI: Maven AngularX NPM with full options', () => {
+        describe('GitLab CI: Maven Angular NPM with full options', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -235,7 +235,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.fileContent('pom.xml', /distributionManagement/);
             });
         });
-        describe('GitLab CI: Maven AngularX NPM inside Docker', () => {
+        describe('GitLab CI: Maven Angular NPM inside Docker', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -267,7 +267,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.fileContent('pom.xml', /distributionManagement/);
             });
         });
-        describe('GitLab CI: Maven AngularX Yarn inside Docker Autoconfigure', () => {
+        describe('GitLab CI: Maven Angular Yarn inside Docker Autoconfigure', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -292,7 +292,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Travis CI tests
     //--------------------------------------------------
     describe('Travis CI tests', () => {
-        describe('Travis CI: Maven AngularX NPM', () => {
+        describe('Travis CI: Maven Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -314,7 +314,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('.travis.yml', /heroku/);
             });
         });
-        describe('Travis CI: Gradle AngularX NPM', () => {
+        describe('Travis CI: Gradle Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -336,7 +336,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('.travis.yml', /heroku/);
             });
         });
-        describe('Travis CI: Maven AngularX NPM with full options', () => {
+        describe('Travis CI: Maven Angular NPM with full options', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -372,7 +372,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Azure Pipelines tests
     //--------------------------------------------------
     describe('Azure Pipelines tests', () => {
-        describe('Azure Pipelines: Maven AngularX NPM', () => {
+        describe('Azure Pipelines: Maven Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -390,7 +390,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.file(expectedFiles.azure);
             });
         });
-        describe('Azure Pipelines: Gradle AngularX NPM', () => {
+        describe('Azure Pipelines: Gradle Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -428,7 +428,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // GitHub Actions tests
     //--------------------------------------------------
     describe('GitHub Actions tests', () => {
-        describe('GitHub Actions: Maven AngularX NPM', () => {
+        describe('GitHub Actions: Maven Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -447,7 +447,7 @@ describe('JHipster CI-CD Sub Generator', () => {
             });
         });
 
-        describe('GitHub Actions: Gradle AngularX NPM', () => {
+        describe('GitHub Actions: Gradle Angular NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -465,7 +465,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.file(expectedFiles.github);
             });
         });
-        describe('GitHub Actions: Maven AngularX NPM with full options', () => {
+        describe('GitHub Actions: Maven Angular NPM with full options', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -497,7 +497,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.fileContent('pom.xml', /distributionManagement/);
             });
         });
-        describe('GitHub Actions: Gradle AngularX NPM with full options', () => {
+        describe('GitHub Actions: Gradle Angular NPM with full options', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -542,7 +542,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Circle CI tests
     //--------------------------------------------------
     describe('Circle CI test', () => {
-        describe('Circle CI: Maven AngularX NPM', () => {
+        describe('Circle CI: Maven Angular NPM', () => {
             beforeEach(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -563,7 +563,7 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFile(expectedFiles.gitlab);
             });
         });
-        describe('Circle CI: Gradle AngularX NPM', () => {
+        describe('Circle CI: Gradle Angular NPM', () => {
             beforeEach(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -42,7 +42,6 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('Jenkinsfile', /heroku/);
             });
         });
-
         describe('Jenkins: Gradle AngularX NPM', () => {
             before(done => {
                 helpers
@@ -65,6 +64,68 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('Jenkinsfile', /docker/);
                 assert.noFileContent('Jenkinsfile', /sonar/);
                 assert.noFileContent('Jenkinsfile', /heroku/);
+            });
+        });
+        describe('Jenkins: Maven AngularX NPM with full options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'jenkins',
+                        insideDocker: false,
+                        cicdIntegrations: ['deploy', 'sonar', 'publishDocker', 'heroku'],
+                        artifactorySnapshotsId: 'snapshots',
+                        artifactorySnapshotsUrl: 'http://artifactory:8081/artifactory/libs-snapshot',
+                        artifactoryReleasesId: 'releases',
+                        artifactoryReleasesUrl: 'http://artifactory:8081/artifactory/libs-release',
+                        sonarName: 'sonarName',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.jenkins);
+            });
+            it('contains Docker, Sonar, Heroku', () => {
+                assert.fileContent('Jenkinsfile', /sonar/);
+                assert.fileContent('Jenkinsfile', /heroku/);
+                assert.fileContent('Jenkinsfile', /def dockerImage/);
+            });
+            it('contains distributionManagement in pom.xml', () => {
+                assert.fileContent('pom.xml', /distributionManagement/);
+            });
+        });
+        describe('Jenkins: Maven AngularX NPM inside Docker', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'jenkins',
+                        insideDocker: true,
+                        cicdIntegrations: ['deploy', 'sonar', 'publishDocker', 'heroku'],
+                        artifactorySnapshotsId: 'snapshots',
+                        artifactorySnapshotsUrl: 'http://artifactory:8081/artifactory/libs-snapshot',
+                        artifactoryReleasesId: 'releases',
+                        artifactoryReleasesUrl: 'http://artifactory:8081/artifactory/libs-release',
+                        sonarName: 'sonarName',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.jenkins);
+            });
+            it('contains Docker, Sonar, Heroku, dockerImage', () => {
+                assert.fileContent('Jenkinsfile', /docker/);
+                assert.fileContent('Jenkinsfile', /sonar/);
+                assert.fileContent('Jenkinsfile', /heroku/);
+                assert.fileContent('Jenkinsfile', /def dockerImage/);
             });
         });
     });
@@ -97,7 +158,6 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('.gitlab-ci.yml', /heroku/);
             });
         });
-
         describe('GitLab CI: Gradle AngularX NPM', () => {
             before(done => {
                 helpers
@@ -121,7 +181,6 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('.gitlab-ci.yml', /heroku/);
             });
         });
-
         describe('GitLab CI: npm skip server', () => {
             before(done => {
                 helpers

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -282,4 +282,52 @@ describe('JHipster CI-CD Sub Generator', () => {
             });
         });
     });
+
+    //--------------------------------------------------
+    // Circle CI tests
+    //--------------------------------------------------
+    describe('Circle CI test', () => {
+        describe('Circle CI: Maven AngularX NPM', () => {
+            beforeEach(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'circle',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.circle);
+                assert.noFile(expectedFiles.jenkins);
+                assert.noFile(expectedFiles.travis);
+                assert.noFile(expectedFiles.gitlab);
+            });
+        });
+        describe('Circle CI: Gradle AngularX NPM', () => {
+            beforeEach(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'circle',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.circle);
+                assert.noFile(expectedFiles.jenkins);
+                assert.noFile(expectedFiles.travis);
+                assert.noFile(expectedFiles.gitlab);
+            });
+        });
+    });
 });

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -17,264 +17,269 @@ describe('JHipster CI-CD Sub Generator', () => {
     //--------------------------------------------------
     // Jenkins tests
     //--------------------------------------------------
+    describe('Jenkins tests', () => {
+        describe('Jenkins: maven AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'jenkins',
+                        insideDocker: false,
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.jenkins);
+            });
+            it("doesn't contain Docker, Sonar, Heroku", () => {
+                assert.noFileContent('Jenkinsfile', /docker/);
+                assert.noFileContent('Jenkinsfile', /sonar/);
+                assert.noFileContent('Jenkinsfile', /heroku/);
+            });
+        });
 
-    describe('Jenkins: maven AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'jenkins',
-                    insideDocker: false,
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.jenkins);
-        });
-        it("doesn't contain Docker, Sonar, Heroku", () => {
-            assert.noFileContent('Jenkinsfile', /docker/);
-            assert.noFileContent('Jenkinsfile', /sonar/);
-            assert.noFileContent('Jenkinsfile', /heroku/);
-        });
-    });
-
-    describe('Jenkins: Gradle AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'jenkins',
-                    insideDocker: false,
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.jenkins);
-        });
-        it("doesn't contain Docker, Sonar, Heroku", () => {
-            assert.noFileContent('Jenkinsfile', /docker/);
-            assert.noFileContent('Jenkinsfile', /sonar/);
-            assert.noFileContent('Jenkinsfile', /heroku/);
+        describe('Jenkins: Gradle AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'jenkins',
+                        insideDocker: false,
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.jenkins);
+            });
+            it("doesn't contain Docker, Sonar, Heroku", () => {
+                assert.noFileContent('Jenkinsfile', /docker/);
+                assert.noFileContent('Jenkinsfile', /sonar/);
+                assert.noFileContent('Jenkinsfile', /heroku/);
+            });
         });
     });
 
     //--------------------------------------------------
     // GitLab CI tests
     //--------------------------------------------------
+    describe('GitLab CI tests', () => {
+        describe('GitLab: maven AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'gitlab',
+                        insideDocker: false,
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.gitlab);
+            });
+            it("doesn't contain image: jhipster, Sonar, Heroku", () => {
+                assert.noFileContent('.gitlab-ci.yml', /image: jhipster/);
+                assert.noFileContent('.gitlab-ci.yml', /sonar/);
+                assert.noFileContent('.gitlab-ci.yml', /heroku/);
+            });
+        });
 
-    describe('GitLab: maven AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'gitlab',
-                    insideDocker: false,
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
+        describe('GitLab: Gradle AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'gitlab',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.gitlab);
+            });
+            it("doesn't contain jhipster/jhipster, Sonar, Heroku", () => {
+                assert.noFileContent('.gitlab-ci.yml', /image: jhipster/);
+                assert.noFileContent('.gitlab-ci.yml', /sonar/);
+                assert.noFileContent('.gitlab-ci.yml', /heroku/);
+            });
         });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.gitlab);
-        });
-        it("doesn't contain image: jhipster, Sonar, Heroku", () => {
-            assert.noFileContent('.gitlab-ci.yml', /image: jhipster/);
-            assert.noFileContent('.gitlab-ci.yml', /sonar/);
-            assert.noFileContent('.gitlab-ci.yml', /heroku/);
-        });
-    });
 
-    describe('GitLab: Gradle AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'gitlab',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.gitlab);
-        });
-        it("doesn't contain jhipster/jhipster, Sonar, Heroku", () => {
-            assert.noFileContent('.gitlab-ci.yml', /image: jhipster/);
-            assert.noFileContent('.gitlab-ci.yml', /sonar/);
-            assert.noFileContent('.gitlab-ci.yml', /heroku/);
-        });
-    });
-
-    describe('GitLab: npm skip server', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/npm-skip-server'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'gitlab',
-                    insideDocker: true,
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.gitlab);
-        });
-        it('contains image: jhipster', () => {
-            assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
+        describe('GitLab: npm skip server', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/npm-skip-server'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'gitlab',
+                        insideDocker: true,
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.gitlab);
+            });
+            it('contains image: jhipster', () => {
+                assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
+            });
         });
     });
 
     //--------------------------------------------------
     // Travis CI tests
     //--------------------------------------------------
+    describe('Travis CI tests', () => {
+        describe('Travis CI: maven AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'travis',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.travis);
+            });
+            it("doesn't contain Sonar, Heroku", () => {
+                assert.noFileContent('.travis.yml', /sonar/);
+                assert.noFileContent('.travis.yml', /heroku/);
+            });
+        });
 
-    describe('Travis CI: maven AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'travis',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.travis);
-        });
-        it("doesn't contain Sonar, Heroku", () => {
-            assert.noFileContent('.travis.yml', /sonar/);
-            assert.noFileContent('.travis.yml', /heroku/);
-        });
-    });
-
-    describe('Travis CI: Gradle AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'travis',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.travis);
-        });
-        it("doesn't contain Sonar, Heroku", () => {
-            assert.noFileContent('.travis.yml', /sonar/);
-            assert.noFileContent('.travis.yml', /heroku/);
+        describe('Travis CI: Gradle AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'travis',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.travis);
+            });
+            it("doesn't contain Sonar, Heroku", () => {
+                assert.noFileContent('.travis.yml', /sonar/);
+                assert.noFileContent('.travis.yml', /heroku/);
+            });
         });
     });
 
     //--------------------------------------------------
     // Azure Pipelines tests
     //--------------------------------------------------
+    describe('Azure Pipelines tests', () => {
+        describe('Azure Pipelines: maven AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'azure',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.azure);
+            });
+        });
 
-    describe('Azure Pipelines: maven AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'azure',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.azure);
-        });
-    });
-
-    describe('Azure Pipelines: Gradle AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'azure',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.azure);
+        describe('Azure Pipelines: Gradle AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'azure',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.azure);
+            });
         });
     });
 
     //--------------------------------------------------
     // GitHub Actions tests
     //--------------------------------------------------
+    describe('GitHub Actions tests', () => {
+        describe('GitHub Actions: maven AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'github',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.github);
+            });
+        });
 
-    describe('GitHub Actions: maven AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'github',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.github);
-        });
-    });
-
-    describe('GitHub Actions: Gradle AngularX NPM', () => {
-        before(done => {
-            helpers
-                .run(require.resolve('../generators/ci-cd'))
-                .inTmpDir(dir => {
-                    fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
-                })
-                .withOptions({ skipChecks: true })
-                .withPrompts({
-                    pipeline: 'github',
-                    cicdIntegrations: [],
-                })
-                .on('end', done);
-        });
-        it('creates expected files', () => {
-            assert.file(expectedFiles.github);
+        describe('GitHub Actions: Gradle AngularX NPM', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/gradle-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'github',
+                        cicdIntegrations: [],
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.github);
+            });
         });
     });
 });

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -18,7 +18,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Jenkins tests
     //--------------------------------------------------
     describe('Jenkins tests', () => {
-        describe('Jenkins: maven AngularX NPM', () => {
+        describe('Jenkins: Maven AngularX NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -73,7 +73,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // GitLab CI tests
     //--------------------------------------------------
     describe('GitLab CI tests', () => {
-        describe('GitLab: maven AngularX NPM', () => {
+        describe('GitLab CI: Maven AngularX NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -98,7 +98,7 @@ describe('JHipster CI-CD Sub Generator', () => {
             });
         });
 
-        describe('GitLab: Gradle AngularX NPM', () => {
+        describe('GitLab CI: Gradle AngularX NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -122,7 +122,7 @@ describe('JHipster CI-CD Sub Generator', () => {
             });
         });
 
-        describe('GitLab: npm skip server', () => {
+        describe('GitLab CI: npm skip server', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -150,7 +150,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Travis CI tests
     //--------------------------------------------------
     describe('Travis CI tests', () => {
-        describe('Travis CI: maven AngularX NPM', () => {
+        describe('Travis CI: Maven AngularX NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -201,7 +201,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // Azure Pipelines tests
     //--------------------------------------------------
     describe('Azure Pipelines tests', () => {
-        describe('Azure Pipelines: maven AngularX NPM', () => {
+        describe('Azure Pipelines: Maven AngularX NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))
@@ -244,7 +244,7 @@ describe('JHipster CI-CD Sub Generator', () => {
     // GitHub Actions tests
     //--------------------------------------------------
     describe('GitHub Actions tests', () => {
-        describe('GitHub Actions: maven AngularX NPM', () => {
+        describe('GitHub Actions: Maven AngularX NPM', () => {
             before(done => {
                 helpers
                     .run(require.resolve('../generators/ci-cd'))

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -314,7 +314,6 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.noFileContent('.travis.yml', /heroku/);
             });
         });
-
         describe('Travis CI: Gradle AngularX NPM', () => {
             before(done => {
                 helpers
@@ -335,6 +334,36 @@ describe('JHipster CI-CD Sub Generator', () => {
             it("doesn't contain Sonar, Heroku", () => {
                 assert.noFileContent('.travis.yml', /sonar/);
                 assert.noFileContent('.travis.yml', /heroku/);
+            });
+        });
+        describe('Travis CI: Maven AngularX NPM with full options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'travis',
+                        cicdIntegrations: ['deploy', 'sonar', 'heroku'],
+                        artifactorySnapshotsId: 'snapshots',
+                        artifactorySnapshotsUrl: 'http://artifactory:8081/artifactory/libs-snapshot',
+                        artifactoryReleasesId: 'releases',
+                        artifactoryReleasesUrl: 'http://artifactory:8081/artifactory/libs-release',
+                        sonarUrl: 'http://localhost:9000',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.travis);
+            });
+            it('contains Sonar, Heroku', () => {
+                assert.fileContent('.travis.yml', /sonar/);
+                assert.fileContent('.travis.yml', /heroku/);
+            });
+            it('contains distributionManagement in pom.xml', () => {
+                assert.fileContent('pom.xml', /distributionManagement/);
             });
         });
     });

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -203,6 +203,89 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
             });
         });
+        describe('GitLab CI: Maven AngularX NPM with full options', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'gitlab',
+                        insideDocker: false,
+                        cicdIntegrations: ['deploy', 'sonar', 'heroku'],
+                        artifactorySnapshotsId: 'snapshots',
+                        artifactorySnapshotsUrl: 'http://artifactory:8081/artifactory/libs-snapshot',
+                        artifactoryReleasesId: 'releases',
+                        artifactoryReleasesUrl: 'http://artifactory:8081/artifactory/libs-release',
+                        sonarUrl: 'http://localhost:9000',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.gitlab);
+            });
+            it('contains Sonar, Heroku', () => {
+                assert.noFileContent('.gitlab-ci.yml', /image: jhipster/);
+                assert.fileContent('.gitlab-ci.yml', /sonar/);
+                assert.fileContent('.gitlab-ci.yml', /heroku/);
+            });
+            it('contains distributionManagement in pom.xml', () => {
+                assert.fileContent('pom.xml', /distributionManagement/);
+            });
+        });
+        describe('GitLab CI: Maven AngularX NPM inside Docker', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ skipChecks: true })
+                    .withPrompts({
+                        pipeline: 'gitlab',
+                        insideDocker: true,
+                        cicdIntegrations: ['deploy', 'sonar', 'heroku'],
+                        artifactorySnapshotsId: 'snapshots',
+                        artifactorySnapshotsUrl: 'http://artifactory:8081/artifactory/libs-snapshot',
+                        artifactoryReleasesId: 'releases',
+                        artifactoryReleasesUrl: 'http://artifactory:8081/artifactory/libs-release',
+                        sonarUrl: 'http://localhost:9000',
+                    })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.gitlab);
+            });
+            it('contains image: jhipster, Sonar, Heroku', () => {
+                assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
+                assert.fileContent('.gitlab-ci.yml', /sonar/);
+                assert.fileContent('.gitlab-ci.yml', /heroku/);
+            });
+            it('contains distributionManagement in pom.xml', () => {
+                assert.fileContent('pom.xml', /distributionManagement/);
+            });
+        });
+        describe('GitLab CI: Maven AngularX Yarn inside Docker Autoconfigure', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ autoconfigureGitlab: true })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.gitlab);
+            });
+            it('contains image: jhipster, Sonar, Heroku', () => {
+                assert.fileContent('.gitlab-ci.yml', /image: jhipster/);
+                assert.noFileContent('.gitlab-ci.yml', /sonar/);
+                assert.noFileContent('.gitlab-ci.yml', /heroku/);
+            });
+        });
     });
 
     //--------------------------------------------------

--- a/test/ci-cd.spec.js
+++ b/test/ci-cd.spec.js
@@ -390,7 +390,6 @@ describe('JHipster CI-CD Sub Generator', () => {
                 assert.file(expectedFiles.azure);
             });
         });
-
         describe('Azure Pipelines: Gradle AngularX NPM', () => {
             before(done => {
                 helpers
@@ -403,6 +402,20 @@ describe('JHipster CI-CD Sub Generator', () => {
                         pipeline: 'azure',
                         cicdIntegrations: [],
                     })
+                    .on('end', done);
+            });
+            it('creates expected files', () => {
+                assert.file(expectedFiles.azure);
+            });
+        });
+        describe('Azure Pipelines: autoconfigure', () => {
+            before(done => {
+                helpers
+                    .run(require.resolve('../generators/ci-cd'))
+                    .inTmpDir(dir => {
+                        fse.copySync(path.join(__dirname, './templates/ci-cd/maven-ngx-npm'), dir);
+                    })
+                    .withOptions({ autoconfigureAzure: true })
                     .on('end', done);
             });
             it('creates expected files', () => {

--- a/test/templates/ci-cd/maven-ngx-npm/pom.xml
+++ b/test/templates/ci-cd/maven-ngx-npm/pom.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+                             https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <!-- jhipster-needle-distribution-management -->
+</project>


### PR DESCRIPTION
Following this https://github.com/jhipster/generator-jhipster/pull/12134 when we dropped Yarn support, a lot of tests in CICD have been removed

cc @avdev4j for the review and some :beers:  ! :-)

preparing work on https://github.com/jhipster/generator-jhipster/issues/12441

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
