### PR TITLE
Change github actions caching

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -19,6 +19,8 @@
 
 name: Angular
 on:
+    schedule:
+        - cron: '0 0 * * *'
     push:
         branches-ignore:
             - 'dependabot/**'
@@ -74,6 +76,7 @@ jobs:
             matrix:
                 node_version: [14.15.0]
                 os: [ubuntu-20.04]
+                cache: [angular]
                 app-type:
                     - ngx-default
                     - ngx-mysql-es-noi18n-mapsid
@@ -183,16 +186,25 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
             - name: 'SETUP: load maven cache'
+              if: "!contains(matrix.app-type, 'gradle')"
               uses: actions/cache@v2
               with:
                   path: ~/.m2/repository
-                  key: ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
+                  key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
+            - name: 'SETUP: load jhipster-bom maven cache'
+              if: contains(matrix.app-type, 'gradle')
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
+                  restore-keys: |
+                      ${{ runner.os }}-maven-jhipster-bom-
             - name: 'SETUP: load gradle cache'
               if: contains(matrix.app-type, 'gradle')
               uses: actions/cache@v2
@@ -200,17 +212,17 @@ jobs:
                   path: |
                       ~/.gradle/caches
                       ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-gradle-${{ matrix.app-type }}-
+                      ${{ runner.os }}-gradle-
             - name: 'SETUP: load e2e cache'
               if: matrix.e2e == 1
               uses: actions/cache@v2
               with:
                   path: ~/.cache/Cypress/
-                  key: ${{ runner.os }}-e2e-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-e2e-${{ matrix.app-type }}-
+                      ${{ runner.os }}-cypress-
             - name: 'ENV: display variables'
               run: $JHI_SCRIPTS/01-display-configuration.sh
             - name: 'TOOLS: configure tools installed by the system'

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -19,6 +19,8 @@
 
 name: React
 on:
+    schedule:
+        - cron: '0 0 * * *'
     push:
         branches-ignore:
             - 'dependabot/**'
@@ -74,6 +76,7 @@ jobs:
             matrix:
                 node_version: [14.15.0]
                 os: [ubuntu-20.04]
+                cache: [react]
                 app-type:
                     - react-default
                     - react-maven-mysql-es-noi18n-mapsid
@@ -176,16 +179,25 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
             - name: 'SETUP: load maven cache'
+              if: "!contains(matrix.app-type, 'gradle')"
               uses: actions/cache@v2
               with:
                   path: ~/.m2/repository
-                  key: ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
+                  key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
+            - name: 'SETUP: load jhipster-bom maven cache'
+              if: contains(matrix.app-type, 'gradle')
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
+                  restore-keys: |
+                      ${{ runner.os }}-maven-jhipster-bom-
             - name: 'SETUP: load gradle cache'
               if: contains(matrix.app-type, 'gradle')
               uses: actions/cache@v2
@@ -193,17 +205,17 @@ jobs:
                   path: |
                       ~/.gradle/caches
                       ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-gradle-${{ matrix.app-type }}-
+                      ${{ runner.os }}-gradle-
             - name: 'SETUP: load e2e cache'
               if: matrix.e2e == 1
               uses: actions/cache@v2
               with:
                   path: ~/.cache/Cypress/
-                  key: ${{ runner.os }}-e2e-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-e2e-${{ matrix.app-type }}-
+                      ${{ runner.os }}-cypress-
             - name: 'ENV: display variables'
               run: $JHI_SCRIPTS/01-display-configuration.sh
             - name: 'TOOLS: configure tools installed by the system'
@@ -311,15 +323,15 @@ jobs:
               id: e2e
               if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
               run: npm run ci:e2e:run --if-present
+            - name: 'E2E: Teardown'
+              if: always() && matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
+              run: npm run ci:e2e:teardown
             - name: 'BACKEND: Store failure logs'
               uses: actions/upload-artifact@v2
               if: always() && steps.backend.outcome == 'failure'
               with:
                   name: log-${{ matrix.app-type }}
                   path: ${{ github.workspace }}/app/build/test-results/**/*.xml
-            - name: 'E2E: Teardown'
-              if: always() && matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
-              run: npm run ci:e2e:teardown
             - name: 'E2E: Store failure screenshots'
               uses: actions/upload-artifact@v2
               if: always() && steps.e2e.outcome == 'failure'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -19,6 +19,8 @@
 
 name: Vue
 on:
+    schedule:
+        - cron: '0 0 * * *'
     push:
         branches-ignore:
             - 'dependabot/**'
@@ -74,6 +76,7 @@ jobs:
             matrix:
                 node_version: [14.15.0]
                 os: [ubuntu-20.04]
+                cache: [vue]
                 app-type:
                     - vue-default
                     - vue-noi18n
@@ -174,16 +177,25 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
             - name: 'SETUP: load maven cache'
+              if: "!contains(matrix.app-type, 'gradle')"
               uses: actions/cache@v2
               with:
                   path: ~/.m2/repository
-                  key: ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
+                  key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
+            - name: 'SETUP: load jhipster-bom maven cache'
+              if: contains(matrix.app-type, 'gradle')
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
+                  restore-keys: |
+                      ${{ runner.os }}-maven-jhipster-bom-
             - name: 'SETUP: load gradle cache'
               if: contains(matrix.app-type, 'gradle')
               uses: actions/cache@v2
@@ -191,17 +203,17 @@ jobs:
                   path: |
                       ~/.gradle/caches
                       ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-gradle-${{ matrix.app-type }}-
+                      ${{ runner.os }}-gradle-
             - name: 'SETUP: load e2e cache'
               if: matrix.e2e == 1
               uses: actions/cache@v2
               with:
                   path: ~/.cache/Cypress/
-                  key: ${{ runner.os }}-e2e-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-e2e-${{ matrix.app-type }}-
+                      ${{ runner.os }}-cypress-
             - name: 'ENV: display variables'
               run: $JHI_SCRIPTS/01-display-configuration.sh
             - name: 'TOOLS: configure tools installed by the system'

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -19,6 +19,8 @@
 
 name: Webflux
 on:
+    schedule:
+        - cron: '0 0 * * *'
     push:
         branches-ignore:
             - 'dependabot/**'
@@ -73,6 +75,7 @@ jobs:
             matrix:
                 node_version: [14.15.0]
                 os: [ubuntu-20.04]
+                cache: [webflux]
                 app-type:
                     - webflux-mongodb
                     - webflux-mongodb-es-session
@@ -180,16 +183,25 @@ jobs:
               uses: actions/cache@v2
               with:
                   path: ~/.npm
-                  key: ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
             - name: 'SETUP: load maven cache'
+              if: "!contains(matrix.app-type, 'gradle')"
               uses: actions/cache@v2
               with:
                   path: ~/.m2/repository
-                  key: ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
+                  key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+                      ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
+            - name: 'SETUP: load jhipster-bom maven cache'
+              if: contains(matrix.app-type, 'gradle')
+              uses: actions/cache@v2
+              with:
+                  path: ~/.m2/repository
+                  key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
+                  restore-keys: |
+                      ${{ runner.os }}-maven-jhipster-bom-
             - name: 'SETUP: load gradle cache'
               if: contains(matrix.app-type, 'gradle')
               uses: actions/cache@v2
@@ -197,17 +209,17 @@ jobs:
                   path: |
                       ~/.gradle/caches
                       ~/.gradle/wrapper
-                  key: ${{ runner.os }}-gradle-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+                  key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
                   restore-keys: |
-                      ${{ runner.os }}-gradle-${{ matrix.app-type }}-
+                      ${{ runner.os }}-gradle-
             - name: 'SETUP: load e2e cache'
               if: matrix.e2e == 1
               uses: actions/cache@v2
               with:
                   path: ~/.cache/Cypress/
-                  key: ${{ runner.os }}-e2e-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/package.json.ejs') }}
+                  key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
                   restore-keys: |
-                      ${{ runner.os }}-e2e-${{ matrix.app-type }}-
+                      ${{ runner.os }}-cypress-
             - name: 'ENV: display variables'
               run: $JHI_SCRIPTS/01-display-configuration.sh
             - name: 'TOOLS: configure tools installed by the system'


### PR DESCRIPTION
Github actions cache limit is 5gb.
Each test creates ~500mb cache, with ~40 tests, the limit is reached by a lot.
So github cache approach is doing too many overwrites, making unstable.

Change to:
- Schedule a full build to create the cache.
- Change to 1 cache per related technology.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
