### PR TITLE
Change Sonar deprecated property to non deprecated one

### DIFF
--- a/generators/common/templates/sonar-project.properties.ejs
+++ b/generators/common/templates/sonar-project.properties.ejs
@@ -21,7 +21,7 @@ sonar.junit.reportPaths=<%_ if (buildTool === 'maven') { _%>target<%_ } else { _
 <%_ } _%>
 <%_ if (!skipClient) { _%>
 sonar.testExecutionReportPaths=<%_ if (buildTool === 'maven') { _%>target<%_ } else { _%> build<%_ } _%>/test-results/jest/TESTS-results-sonar.xml
-sonar.typescript.lcov.reportPaths=<%_ if (buildTool === 'maven') { _%>target<%_ } else { _%> build<%_ } _%>/test-results/lcov.info
+sonar.javascript.lcov.reportPaths=<%_ if (buildTool === 'maven') { _%>target<%_ } else { _%> build<%_ } _%>/test-results/lcov.info
 <%_ } _%>
 
 sonar.sourceEncoding=UTF-8


### PR DESCRIPTION
Fixes warning "The use of sonar.typescript.lcov.reportPaths for coverage import is deprecated, use sonar.javascript.lcov.reportPaths instead.".

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
