### PR TITLE
Generate applications without entities among a mixed list in JDL

### DIFF
--- a/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.js
+++ b/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.js
@@ -168,11 +168,9 @@ function formatEntitiesForEachApplication(entitiesForEachApplication) {
 }
 
 function addApplicationsWithoutEntities(entitiesForEachApplication) {
-    const applicationsWithoutEntities = jdlObject
-        .getApplications()
-        .filter(jdlApplication => jdlApplication.getEntityNames().length === 0)
-        .map(jdlApplication => jdlApplication.getConfigurationOptionValue('baseName'));
-    if (applicationsWithoutEntities.length > 0) {
-        applicationsWithoutEntities.forEach(applicationName => entitiesForEachApplication.set(applicationName, []));
-    }
+    jdlObject.forEachApplication(jdlApplication => {
+        if (jdlApplication.getEntityNames().length === 0) {
+            entitiesForEachApplication.set(jdlApplication.getConfigurationOptionValue('baseName'), []);
+        }
+    });
 }

--- a/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.js
+++ b/jdl/converters/jdl-to-json/jdl-with-applications-to-json-converter.js
@@ -57,6 +57,7 @@ function convert(args = {}) {
     const entitiesForEachApplication = getEntitiesForEachApplicationMap();
     setOptions(entitiesForEachApplication);
     formatEntitiesForEachApplication(entitiesForEachApplication);
+    addApplicationsWithoutEntities(entitiesForEachApplication);
     return entitiesForEachApplication;
 }
 
@@ -164,4 +165,14 @@ function formatEntitiesForEachApplication(entitiesForEachApplication) {
     entitiesForEachApplication.forEach((applicationEntities, applicationName) => {
         entitiesForEachApplication.set(applicationName, Object.values(applicationEntities));
     });
+}
+
+function addApplicationsWithoutEntities(entitiesForEachApplication) {
+    const applicationsWithoutEntities = jdlObject
+        .getApplications()
+        .filter(jdlApplication => jdlApplication.getEntityNames().length === 0)
+        .map(jdlApplication => jdlApplication.getConfigurationOptionValue('baseName'));
+    if (applicationsWithoutEntities.length > 0) {
+        applicationsWithoutEntities.forEach(applicationName => entitiesForEachApplication.set(applicationName, []));
+    }
 }

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -534,6 +534,39 @@ describe('JHipster generator import jdl', () => {
         });
     });
 
+    describe('imports multiple JDL apps one with and one without entities', () => {
+        const options = { skipInstall: true, noInsight: true, interactive: false, skipGit: false };
+        beforeEach(() => {
+            return testInTempDir(dir => {
+                fse.copySync(path.join(__dirname, '../templates/import-jdl'), dir);
+                fse.removeSync(`${dir}/.yo-rc.json`);
+                return loadImportJdl()(['apps-with-and-without-entities.jdl'], options, env);
+            });
+        });
+
+        afterEach(() => revertTempDir(originalCwd));
+
+        it('creates the applications', () => {
+            assert.file([path.join('app1', '.yo-rc.json'), path.join('app2', '.yo-rc.json')]);
+        });
+        it('creates the entities in one app only', () => {
+            assert.noFile([path.join('app1', '.jhipster', 'BankAccount.json')]);
+            assert.file([path.join('app2', '.jhipster', 'BankAccount.json')]);
+        });
+        it('calls application generator', () => {
+            expect(subGenCallParams.count).to.equal(2);
+            expect(subGenCallParams.commands).to.eql(['app', 'app']);
+            expect(subGenCallParams.options[0]).to.eql([
+                '--force',
+                '--with-entities',
+                '--skip-install',
+                '--no-insight',
+                '--no-skip-git',
+                '--from-jdl',
+            ]);
+        });
+    });
+
     describe('skips JDL apps with --ignore-application', () => {
         const options = { skipInstall: true, ignoreApplication: true, fork: true, skipGit: false };
         beforeEach(() => {

--- a/test/jdl/converters/JDLToJSON/jdl-with-applications-to-json-converter.spec.js
+++ b/test/jdl/converters/JDLToJSON/jdl-with-applications-to-json-converter.spec.js
@@ -56,6 +56,31 @@ describe('JDLWithApplicationsToJSONConverter', () => {
                 });
             });
         });
+        context('when passing a JDL object with two applications one with and one without entities', () => {
+            let result;
+
+            before(() => {
+                const jdlObject = new JDLObject();
+                const application1 = createJDLApplication({ applicationType: MONOLITH, baseName: 'app1' });
+                jdlObject.addApplication(application1);
+                const entity = new JDLEntity({
+                    name: 'EntityA',
+                });
+                const application2 = createJDLApplication({ applicationType: MONOLITH, baseName: 'app2' });
+                application2.addEntityName('EntityA');
+                jdlObject.addEntity(entity);
+                jdlObject.addApplication(application2);
+                result = convert({
+                    jdlObject,
+                });
+            });
+
+            it('should return a map with two applications', () => {
+                expect(result.size).to.equal(2);
+                expect(result.get('app1').length).to.equal(0);
+                expect(result.get('app2').length).to.equal(1);
+            });
+        });
         context('when passing a JDL object without entities', () => {
             let result;
 

--- a/test/jdl/jdl-importer.spec.js
+++ b/test/jdl/jdl-importer.spec.js
@@ -576,6 +576,57 @@ relationship OneToOne {
                 });
             });
         });
+        context('when parsing two JDL applications with and without entities ', () => {
+            let returned;
+            const APPLICATION_NAMES = ['app1', 'app2'];
+
+            before(() => {
+                const importer = createImporterFromFiles([
+                    path.join(__dirname, 'test-files', 'applications_with_and_without_entities.jdl'),
+                ]);
+                returned = importer.import();
+            });
+
+            after(() => {
+                APPLICATION_NAMES.forEach(applicationName => {
+                    fse.removeSync(applicationName);
+                });
+            });
+
+            it('should return the import state', () => {
+                expect(returned.exportedEntities).to.have.lengthOf(1);
+                expect(returned.exportedApplications).to.have.lengthOf(2);
+                expect(Object.keys(returned.exportedApplicationsWithEntities).length).to.equal(2);
+                expect(returned.exportedDeployments).to.have.lengthOf(0);
+            });
+            it('should create the folders and the .yo-rc.json files', () => {
+                APPLICATION_NAMES.forEach(applicationName => {
+                    expect(fse.statSync(path.join(applicationName, '.yo-rc.json')).isFile()).to.be.true;
+                    expect(fse.statSync(applicationName).isDirectory()).to.be.true;
+                });
+            });
+            it('should create the entity folder in only one app folder', () => {
+                expect(fse.existsSync(path.join(APPLICATION_NAMES[0], '.jhipster'))).to.be.false;
+                expect(fse.statSync(path.join(APPLICATION_NAMES[1], '.jhipster')).isDirectory()).to.be.true;
+                expect(fse.statSync(path.join(APPLICATION_NAMES[1], '.jhipster', 'BankAccount.json')).isFile()).to.be.true;
+            });
+            it('should export the application contents', () => {
+                expect(returned.exportedApplicationsWithEntities[APPLICATION_NAMES[0]].entities).to.have.lengthOf(0);
+                expect(returned.exportedApplicationsWithEntities[APPLICATION_NAMES[1]].entities).to.have.lengthOf(1);
+            });
+            it('should return the corresponding exportedApplicationsWithEntities', () => {
+                returned.exportedApplications.forEach(application => {
+                    const applicationConfig = application['generator-jhipster'];
+                    const entityNames = application.entities || [];
+                    const applicationWithEntities = returned.exportedApplicationsWithEntities[applicationConfig.baseName];
+                    expect(applicationConfig).to.be.eql(applicationWithEntities.config);
+                    expect(applicationWithEntities.entities.map(entity => entity.name)).to.be.eql(entityNames);
+                    expect(returned.exportedEntities.filter(entity => entityNames.includes(entity.name))).to.be.eql(
+                        applicationWithEntities.entities
+                    );
+                });
+            });
+        });
         context('when parsing one JDL application and entities passed as string', () => {
             let returned;
 
@@ -653,6 +704,7 @@ relationship OneToOne {
                 expect(content['generator-jhipster'].entitySuffix).to.equal('Entity');
                 expect(content['generator-jhipster'].dtoSuffix).to.equal('DTO');
             });
+
             it('should return the corresponding exportedApplicationsWithEntities', () => {
                 returned.exportedApplications.forEach(application => {
                     const applicationConfig = application['generator-jhipster'];

--- a/test/jdl/test-files/applications_with_and_without_entities.jdl
+++ b/test/jdl/test-files/applications_with_and_without_entities.jdl
@@ -1,0 +1,17 @@
+application {
+  config {
+    baseName app1,
+    applicationType monolith,
+    packageName com.my.app1
+  }
+}
+application {
+  config {
+    baseName app2,
+    applicationType monolith,
+    packageName com.my.app2
+  }
+  entities BankAccount
+}
+
+entity BankAccount

--- a/test/templates/import-jdl/apps-with-and-without-entities.jdl
+++ b/test/templates/import-jdl/apps-with-and-without-entities.jdl
@@ -1,0 +1,17 @@
+application {
+  config {
+    baseName app1,
+    applicationType monolith,
+    packageName com.my.app1
+  }
+}
+application {
+  config {
+    baseName app2,
+    applicationType monolith,
+    packageName com.my.app2
+  }
+  entities BankAccount
+}
+
+entity BankAccount


### PR DESCRIPTION
Fixes bug to include applications with or without entities from the
config file, where applications without entities was ignored from a list
of applications with atleast one application with entities

Fix #13141

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
