### PR TITLE
Remove Sonar <i> and <b> exclusions

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.component.html.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <div>
-    <h2 id="session-page-heading" <%= jhiPrefix %>Translate="sessions.title" [translateValues]="{ username: account.login }" *ngIf="account">Active sessions for [<b>{{ account.login }}</b>]</h2>
+    <h2 id="session-page-heading" <%= jhiPrefix %>Translate="sessions.title" [translateValues]="{ username: account.login }" *ngIf="account">Active sessions for [<strong>{{ account.login }}</strong>]</h2>
 
     <div class="alert alert-success" *ngIf="success" <%= jhiPrefix %>Translate="sessions.messages.success">
         <strong>Session invalidated!</strong>

--- a/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/settings/settings.component.html.ejs
@@ -19,7 +19,7 @@
 <div>
     <div class="row justify-content-center">
         <div class="col-md-8">
-            <h2 <%= jhiPrefix %>Translate="settings.title" [translateValues]="{ username: account.login }" *ngIf="account">User settings for [<b>{{ account.login }}</b>]</h2>
+            <h2 <%= jhiPrefix %>Translate="settings.title" [translateValues]="{ username: account.login }" *ngIf="account">User settings for [<strong>{{ account.login }}</strong>]</h2>
 
             <div class="alert alert-success" *ngIf="success" <%= jhiPrefix %>Translate="settings.messages.success">
                 <strong>Settings saved!</strong>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/detail/user-management-detail.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/detail/user-management-detail.component.html.ejs
@@ -20,7 +20,7 @@
     <div class="col-8">
         <div *ngIf="user">
             <h2>
-                <span <%= jhiPrefix %>Translate="userManagement.detail.title">User</span> [<b>{{ user.login }}</b>]
+                <span <%= jhiPrefix %>Translate="userManagement.detail.title">User</span> [<strong>{{ user.login }}</strong>]
             </h2>
 
             <dl class="row-md jh-entity-details">

--- a/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/account/sessions/sessions.tsx.ejs
@@ -47,7 +47,7 @@ export class SessionsPage extends React.Component<ISessionsProps> {
       <div>
         <h2>
           <Translate contentKey="sessions.title" interpolate={{ username: account.login }}>
-            Active sessions for [<b>{account.login}</b>]
+            Active sessions for [<strong>{account.login}</strong>]
           </Translate>
         </h2>
 

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management-detail.tsx.ejs
@@ -40,7 +40,7 @@ export const UserManagementDetail = (props: IUserManagementDetailProps) => {
   return (
     <div>
       <h2>
-        <Translate contentKey="userManagement.detail.title">User</Translate> [<b>{user.login}</b>]
+        <Translate contentKey="userManagement.detail.title">User</Translate> [<strong>{user.login}</strong>]
       </h2>
       <Row size="md">
         <dl className="jh-entity-details">

--- a/generators/client/templates/vue/src/main/webapp/app/account/change-password/change-password.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/change-password/change-password.vue.ejs
@@ -4,7 +4,7 @@
             <div class="col-md-8 toastify-container">
                 <h2 v-if="account" id="password-title">
                     <span v-html="$t('password.title', { username: username })">
-                      Password for [<b>{{ username }}</b>]</span>
+                      Password for [<strong>{{ username }}</strong>]</span>
                 </h2>
 
                 <div class="alert alert-success" role="alert" v-if="success" v-html="$t('password.messages.success')">

--- a/generators/client/templates/vue/src/main/webapp/app/account/sessions/sessions.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/sessions/sessions.vue.ejs
@@ -1,6 +1,6 @@
 <template>
     <div>
-        <h2 v-if="authenticated"><span v-bind:value="$t('sessions.title')">Active sessions for [<b>{{username}}</b>]</span></h2>
+        <h2 v-if="authenticated"><span v-bind:value="$t('sessions.title')">Active sessions for [<strong>{{username}}</strong>]</span></h2>
 
         <div class="alert alert-success" v-if="success" v-html="$t('sessions.messages.success')">
             <strong>Session invalidated!</strong>

--- a/generators/client/templates/vue/src/main/webapp/app/account/settings/settings.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/account/settings/settings.vue.ejs
@@ -3,7 +3,7 @@
     <div class="row justify-content-center">
       <div class="col-md-8 toastify-container">
         <h2 v-if="username" id="settings-title">
-          <span v-html="$t('settings.title', { 'username': username })">User settings for [<b>{{username}}</b>]</span>
+          <span v-html="$t('settings.title', { 'username': username })">User settings for [<strong>{{username}}</strong>]</span>
         </h2>
 
         <div class="alert alert-success" role="alert" v-if="success" v-html="$t('settings.messages.success')">

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-view.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-view.vue.ejs
@@ -3,7 +3,7 @@
     <div class="col-8">
       <div v-if="user">
         <h2 class="jh-entity-heading">
-          <span v-text="$t('userManagement.detail.title')">User</span> [<b>{{user.login}}</b>]
+          <span v-text="$t('userManagement.detail.title')">User</span> [<strong>{{user.login}}</strong>]
         </h2>
         <dl class="row jh-entity-details">
           <dt><span v-text="$t('userManagement.login')">Login</span></dt>

--- a/generators/common/templates/sonar-project.properties.ejs
+++ b/generators/common/templates/sonar-project.properties.ejs
@@ -27,7 +27,7 @@ sonar.javascript.lcov.reportPaths=<%_ if (buildTool === 'maven') { _%>target<%_ 
 sonar.sourceEncoding=UTF-8
 sonar.exclusions=<%= CLIENT_MAIN_SRC_DIR %>content/**/*.*, <%= CLIENT_MAIN_SRC_DIR %>i18n/*.js, <%= CLIENT_DIST_DIR %>**/*.*
 
-sonar.issue.ignore.multicriteria=<%_ if (!skipServer) { _%>S3437,<% if (authenticationType === 'jwt') { %>S4502,<% } %>S4684,UndocumentedApi<%_ } _%><%_ if (!skipClient) { _%><%_ if (!skipServer) { _%>,<%_ } _%>BoldAndItalicTagsCheck<%_ } _%>
+sonar.issue.ignore.multicriteria=<%_ if (!skipServer) { _%>S3437,<% if (authenticationType === 'jwt') { %>S4502,<% } %>S4684,UndocumentedApi<%_ } _%>
 
 <%_ if (!skipServer) { _%>
 # Rule https://sonarcloud.io/coding_rules?open=squid%3AS3437&rule_key=squid%3AS3437 is ignored, as a JPA-managed field cannot be transient
@@ -44,9 +44,4 @@ sonar.issue.ignore.multicriteria.S4502.ruleKey=squid:S4502
 # Rule https://sonarcloud.io/coding_rules?open=java%3AS4684&rule_key=java%3AS4684
 sonar.issue.ignore.multicriteria.S4684.resourceKey=<%= MAIN_DIR %>java/**/*
 sonar.issue.ignore.multicriteria.S4684.ruleKey=java:S4684
-<%_ } _%>
-<%_ if (!skipClient) { _%>
-# Rule https://sonarcloud.io/coding_rules?open=Web%3ABoldAndItalicTagsCheck&rule_key=Web%3ABoldAndItalicTagsCheck is ignored. Even if we agree that using the "i" tag is an awful practice, this is what is recommended by http://fontawesome.io/examples/
-sonar.issue.ignore.multicriteria.BoldAndItalicTagsCheck.resourceKey=<%= CLIENT_MAIN_SRC_DIR %>app/**/*.*
-sonar.issue.ignore.multicriteria.BoldAndItalicTagsCheck.ruleKey=Web:BoldAndItalicTagsCheck
 <%_ } _%>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -53,7 +53,7 @@ export const <%= entityReactName %>Detail = (props: I<%= entityReactName %>Detai
     <Row>
       <Col md="8">
         <h2 data-cy="<%= entityInstance %>DetailsHeading">
-          <Translate contentKey="<%= i18nKeyPrefix %>.detail.title"><%= entityClass %></Translate> [<b>{<%= entityInstance %>Entity.id}</b>]
+          <Translate contentKey="<%= i18nKeyPrefix %>.detail.title"><%= entityClass %></Translate> [<strong>{<%= entityInstance %>Entity.id}</strong>]
         </h2>
           <dl className="jh-entity-details">
           <%_ for (idx in fields) {

--- a/generators/languages/templates/src/main/webapp/i18n/hr/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/hr/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "Aktivne sjednice za [<b>{{username}}</b>]",
+        "title": "Aktivne sjednice za [<strong>{{username}}</strong>]",
         "table": {
             "ipaddress": "IP adresa",
             "useragent": "Korisnički agent",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/password.json
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/password.json
@@ -1,6 +1,6 @@
 {
     "password": {
-        "title": "[<b>{{username}}</b>] учун парол",
+        "title": "[<strong>{{username}}</strong>] учун парол",
         "form": {
             "button": "Сақлаш"
         },

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}}</b>] учун фаол сессиялар",
+        "title": "[<strong>{{username}}</strong>] учун фаол сессиялар",
         "table": {
             "ipaddress": "IP манзил",
             "useragent": "Фойдаланувчи Агент",

--- a/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/settings.json
+++ b/generators/languages/templates/src/main/webapp/i18n/uz-Cyrl-uz/settings.json
@@ -1,6 +1,6 @@
 {
     "settings": {
-        "title": "[<b>{{username}}</b>] созламалари",
+        "title": "[<strong>{{username}}</strong>] созламалари",
         "form": {
             "firstname": "Исм",
             "firstname.placeholder": "Исмингиз",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-cn/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-cn/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}} 使用中的 Sessions</b>]",
+        "title": "[<strong>{{username}} 使用中的 Sessions</strong>]",
         "table": {
             "ipaddress": "IP 位址",
             "useragent": "用户代理",

--- a/generators/languages/templates/src/main/webapp/i18n/zh-tw/sessions.json
+++ b/generators/languages/templates/src/main/webapp/i18n/zh-tw/sessions.json
@@ -1,6 +1,6 @@
 {
     "sessions": {
-        "title": "[<b>{{username}} 使用中的工作階段</b>]",
+        "title": "[<strong>{{username}} 使用中的工作階段</strong>]",
         "table": {
             "ipaddress": "IP 位址",
             "useragent": "使用者代理",


### PR DESCRIPTION
As we are not using `<i>` any more for Font Awesome icons then we can enable `BoldAndItalicTagsCheck` in Sonar.
Replaced some `<b>` with `<strong>` to pass Sonar.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
