### PR TITLE
[angular] Update angular-eslint

### DIFF
--- a/generators/client/templates/angular/package.json
+++ b/generators/client/templates/angular/package.json
@@ -19,7 +19,7 @@
   "devDependencies": {
     "@angular/cli": "11.0.4",
     "@angular-builders/custom-webpack": "11.0.0-beta.2",
-    "@angular-eslint/eslint-plugin": "0.6.0-beta.0",
+    "@angular-eslint/eslint-plugin": "0.8.0-beta.5",
     "@types/jest": "26.0.19",
     "@typescript-eslint/eslint-plugin": "4.10.0",
     "browser-sync": "2.26.13",


### PR DESCRIPTION
As dependabot in some reason is not doing PR-s for `@angular-eslint` then updating manually this version before v7.

In #12835 was migrated from TSLint to Angular ESLint.

As Angular ESLint is still in beta then some comments about that.

In https://github.com/angular-eslint/angular-eslint is list of codelyzer rules which need to be converted to Angular ESLint. Total 53 rules, ATM 44 is done and 9 to do.
If I understand correctly then their aim for 1.0.0 is to offer seemless migration from TSLint to Angular ESLint through Angular CLI. But as 9 rules is not yet migrated then this goal has not yet been met.
So if someone uses some of those 9 unmigrated rules then this user must add TSLint + Codelyzer back after migrating to JHipster v7.

Angular CLI is still generating code with TSLint but in Angular 11 release notes https://blog.angular.io/version-11-of-angular-now-available-74721b7952f7 is given link to migration guide from TSLint to Angular ESLint beta version. And TSLint is deprecated in Angular 11.
We have done this migration step for rules our generated application used.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
