### PR TITLE
Move reactive answer from askForOptionalItems to askForServerSideOpts

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -309,6 +309,7 @@ function askForServerSideOpts() {
 
     return this.prompt(prompts).then(answers => {
         this.serviceDiscoveryType = this.jhipsterConfig.serviceDiscoveryType = answers.serviceDiscoveryType;
+        this.reactive = this.jhipsterConfig.reactive = answers.reactive;
         this.authenticationType = this.jhipsterConfig.authenticationType = answers.authenticationType;
 
         this.packageName = this.jhipsterConfig.packageName = answers.packageName;
@@ -372,7 +373,6 @@ function askForOptionalItems() {
 
     if (choices.length > 0) {
         return this.prompt(PROMPTS).then(answers => {
-            this.reactive = this.jhipsterConfig.reactive = answers.reactive;
             this.serverSideOptions = this.jhipsterConfig.serverSideOptions = answers.serverSideOptions;
             this.websocket = this.jhipsterConfig.websocket = this.getOptionFromArray(answers.serverSideOptions, 'websocket');
             this.searchEngine = this.jhipsterConfig.searchEngine = this.getOptionFromArray(answers.serverSideOptions, 'searchEngine');


### PR DESCRIPTION
Fix for Reactive generation. CLI did not take into account reactive answer in server side options.
---

Please make sure the below checklist is followed for Pull Requests.

-   [X] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

Fix #13298 