### PR TITLE
[angular] Remove NOSONAR as latest SonarHTML supports Angular attribute binding

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -48,7 +48,7 @@
     <div *ngFor="let propertySource of propertySources; let i = index">
         <h4 [id]="'property-source-' + i"><span>{{ propertySource.name }}</span></h4>
 
-        <table class="table table-sm table-striped table-bordered table-responsive d-table" [attr.aria-describedby]="'property-source-' + i"><!-- //NOSONAR -->
+        <table class="table table-sm table-striped table-bordered table-responsive d-table" [attr.aria-describedby]="'property-source-' + i">
             <thead>
                 <tr>
                     <th scope="col" class="w-40">Property</th>


### PR DESCRIPTION
Working fine in SonarQube 8.6.0 and should work in SonarCloud too as Prettier for HTML anyway moved NOSONAR comment to the next line and no Sonar bug in JHipster default application in SonarCloud.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
