### PR TITLE
Align .editorconfig with .prettierrc in HTML tabWidth

### DIFF
--- a/generators/common/templates/editorconfig.ejs
+++ b/generators/common/templates/editorconfig.ejs
@@ -16,7 +16,7 @@ insert_final_newline = true
 indent_style = space
 indent_size = 4
 
-[*.{ts,tsx,js,jsx,json,css,scss,yml}]
+[*.{ts,tsx,js,jsx,json,css,scss,yml,html}]
 indent_size = 2
 
 [*.md]


### PR DESCRIPTION
Prettier indents HTML with 2 spaces. Aligning `.editorconfig` also to that value.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
