### PR TITLE
Drop primaryKeyType in favor of primaryKey.type

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/detail/user-management-detail.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/detail/user-management-detail.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 jest.mock('@angular/router');
 jest.mock('app/core/auth/account.service');

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.ts.ejs
@@ -72,7 +72,7 @@ export class UserManagementComponent implements OnInit {
     this.userService.update({ ...user, activated: isActivated }).subscribe(() => this.loadAll());
   }
 
-  trackIdentity(index: number, item: User): <%= getTypescriptKeyType(user.primaryKeyType) %> {
+  trackIdentity(index: number, item: User): <%= getTypescriptKeyType(user.primaryKey.type) %> {
     return item.id!;
   }
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/update/user-management-update.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/update/user-management-update.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 import { ComponentFixture, TestBed, waitForAsync, inject, fakeAsync, tick } from '@angular/core/testing';
 import { HttpClientTestingModule } from '@angular/common/http/testing';

--- a/generators/client/templates/angular/src/main/webapp/app/core/user/user.model.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/user/user.model.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-  const idType = getTypescriptKeyType(user.primaryKeyType);
+  const idType = getTypescriptKeyType(user.primaryKey.type);
 _%>
 export interface IUser {
   id?: <%= idType %>;

--- a/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/user/user.service.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 import { TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-edit.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-edit.component.ts.ejs
@@ -65,7 +65,7 @@ export default class <%=jhiPrefixCapitalized%>UserManagementEdit extends Vue {
       });
   }
 
-  public init(userId: <% if (user.primaryKeyType === 'String' || user.primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %>): void {
+  public init(userId: <% if (user.primaryKey.type === 'String' || user.primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %>): void {
     this.userManagementService().get(userId).then(res => {
       this.userAccount = res.data;
     });

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-view.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management-view.component.ts.ejs
@@ -14,7 +14,7 @@ export default class <%=jhiPrefixCapitalized%>UserManagementView extends Vue {
       }
     });
   }
-  public init(userId: <% if (user.primaryKeyType === 'String' || user.primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %>): void {
+  public init(userId: <% if (user.primaryKey.type === 'String' || user.primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %>): void {
     this.userManagementService().get(userId).then(res => {
       this.user = res.data;
     });

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.component.ts.ejs
@@ -19,7 +19,7 @@ export default class <%=jhiPrefixCapitalized%>UserManagementComponent extends Vu
   public reverse = false;
   public totalItems = 0;
   public isLoading = false;
-  public removeId: <% if (user.primaryKeyType === 'String' || user.primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %> = null;
+  public removeId: <% if (user.primaryKey.type === 'String' || user.primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %> = null;
 
   public mounted(): void {
     this.loadAll();

--- a/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/admin/user-management/user-management.service.ts.ejs
@@ -6,7 +6,7 @@ import {Authority} from '@/shared/security/authority'
 
 export default class UserManagementService {
 
-  public get(userId: <% if (user.primaryKeyType === 'String' || user.primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %>): Promise<any> {
+  public get(userId: <% if (user.primaryKey.type === 'String' || user.primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %>): Promise<any> {
     return axios.get(`api/users/${userId}`);
   }
 
@@ -18,7 +18,7 @@ export default class UserManagementService {
     return axios.put('api/users', user);
   }
 
-  public remove(userId: <% if (user.primaryKeyType === 'String' || user.primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %>): Promise<any> {
+  public remove(userId: <% if (user.primaryKey.type === 'String' || user.primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %>): Promise<any> {
     return axios.delete(`api/users/${userId}`);
   }
 

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-edit.component.spec.ts.ejs
@@ -1,5 +1,5 @@
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import axios from 'axios';

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management-view.component.spec.ts.ejs
@@ -1,5 +1,5 @@
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import axios from 'axios';

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/user-management/user-management.component.spec.ts.ejs
@@ -1,5 +1,5 @@
 <%_
-const tsKeyId = generateTestEntityId(user.primaryKeyType);
+const tsKeyId = generateTestEntityId(user.primaryKey.type);
 _%>
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';
 import axios from 'axios';

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -47,7 +47,9 @@ module.exports = class extends BaseBlueprintGenerator {
     _preparing() {
         return {
             setup() {
-                this.tsKeyType = this.getTypescriptKeyType(this.primaryKeyType);
+                if (!this.embedded) {
+                    this.tsKeyType = this.getTypescriptKeyType(this.primaryKey.type);
+                }
             },
         };
     }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/delete/entity-management-delete-dialog.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/delete/entity-management-delete-dialog.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 jest.mock('@ng-bootstrap/ng-bootstrap');
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/detail/entity-management-detail.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/detail/entity-management-detail.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ActivatedRoute } from '@angular/router';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKey, fields, relationships, dto, undefined, embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 const entityArrayOptionalChainSymbol = pagination === 'infinite-scroll' ? '' : '?.';
 _%>
 <%_ if (pagination !== 'no' || searchEngine !== false) { _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/route/entity-management-routing-resolve.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/route/entity-management-routing-resolve.service.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 jest.mock('@angular/router');
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.spec.ts.ejs
@@ -17,8 +17,8 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, undefined, embedded);
+const tsKeyId = generateTestEntityId(primaryKey.type);
+const variablesWithTypes = generateEntityClientFields(primaryKey, fields, relationships, dto, undefined, embedded);
 const enumImports = generateEntityClientEnumImports(fields);
 _%>
 import { TestBed } from '@angular/core/testing';

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/update/entity-management-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/update/entity-management-update.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 jest.mock('@angular/router');
 

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, 'string', embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKey, fields, relationships, dto, 'string', embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields, 'react');
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/spec/app/entities/entity-reducer.spec.ts.ejs
@@ -337,7 +337,7 @@ describe('Entities reducer tests', () => {
         }
         <%_ } _%>
       ];
-      await store.dispatch(createEntity({ id: <% if (primaryKeyType === 'Long') { %>1<% } else { %>'1'<% } %> })).then(() => expect(store.getActions()).toEqual(expectedActions));
+      await store.dispatch(createEntity({ id: <% if (primaryKey.type === 'Long') { %>1<% } else { %>'1'<% } %> })).then(() => expect(store.getActions()).toEqual(expectedActions));
     });
 
     it('dispatches ACTION_TYPES.UPDATE_<%= entityActionName %> actions', async () => {
@@ -350,7 +350,7 @@ describe('Entities reducer tests', () => {
           payload: resolvedObject
         }
       ];
-      await store.dispatch(updateEntity({ id: <% if (primaryKeyType === 'Long') { %>1<% } else { %>'1'<% } %> })).then(() => expect(store.getActions()).toEqual(expectedActions));
+      await store.dispatch(updateEntity({ id: <% if (primaryKey.type === 'Long') { %>1<% } else { %>'1'<% } %> })).then(() => expect(store.getActions()).toEqual(expectedActions));
     });
 
     it('dispatches ACTION_TYPES.DELETE_<%= entityActionName %> actions', async () => {

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.component.ts.ejs
@@ -16,7 +16,7 @@ export default class <%= entityAngularName %> extends <% if (fieldsContainBlob |
   <%_ if (searchEngine === 'elasticsearch') { _%>
   public currentSearch = '';
   <%_ } _%>
-  private removeId: <% if (primaryKeyType === 'String'  || primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %> = null;
+  private removeId: <% if (primaryKey.type === 'String'  || primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %> = null;
   <%_ if (pagination !== 'no') { _%>
   public itemsPerPage = 20;
   public queryCount: number = null;

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(primaryKeyType, fields, relationships, dto, customDateType = 'Date', embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKey, fields, relationships, dto, customDateType = 'Date', embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
 const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
 const enumImports = generateEntityClientEnumImports(fields);

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.service.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.service.ts.ejs
@@ -24,7 +24,7 @@ export default class <%= entityAngularName %>Service {
   }
   <%_ } _%>
 
-  public find(id: <% if (primaryKeyType === 'String'  || primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %>) : Promise<I<%= entityAngularName %>> {
+  public find(id: <% if (primaryKey.type === 'String'  || primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %>) : Promise<I<%= entityAngularName %>> {
     return new Promise<I<%= entityAngularName %>>((resolve, reject) => {
       axios.get(`${baseApiUrl}/${id}`).then(res => {
         resolve(res.data);
@@ -42,7 +42,7 @@ export default class <%= entityAngularName %>Service {
   <%_
   if (!readOnly) { _%>
 
-  public delete(id: <% if (primaryKeyType === 'String'  || primaryKeyType === 'UUID') { %>string<% } else { %>number<% } %>) : Promise<any> {
+  public delete(id: <% if (primaryKey.type === 'String'  || primaryKey.type === 'UUID') { %>string<% } else { %>number<% } %>) : Promise<any> {
     return new Promise<any>((resolve, reject) => {
       axios.delete(`${baseApiUrl}/${id}`).then(res => {
         resolve(res);

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-details.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-details.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 /* tslint:disable max-line-length */
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 /* tslint:disable max-line-length */
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.component.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 _%>
 /* tslint:disable max-line-length */
 import { shallowMount, createLocalVue, Wrapper } from '@vue/test-utils';

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.service.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.service.spec.ts.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 <%_
-const tsKeyId = generateTestEntityId(primaryKeyType);
+const tsKeyId = generateTestEntityId(primaryKey.type);
 const enumImports = generateEntityClientEnumImports(fields);
 _%>
 /* tslint:disable max-line-length */
@@ -66,7 +66,7 @@ describe('Service Tests', () => {
       currentDate = new Date();
       <%_ } _%>
       elemDefault = new <%= entityAngularName %>(
-        <%_ if (primaryKeyType === 'String'  || primaryKeyType === 'UUID') { _%>
+        <%_ if (primaryKey.type === 'String'  || primaryKey.type === 'UUID') { _%>
         'ID',
         <%_ } else { _%>
         0,
@@ -127,7 +127,7 @@ describe('Service Tests', () => {
 <%_ if (!readOnly) { _%>
       it('should create a <%= entityAngularName %>', async () => {
         const returnedFromService = Object.assign({
-  <%_ if (primaryKeyType === 'String'  || primaryKeyType === 'UUID') { _%>
+  <%_ if (primaryKey.type === 'String'  || primaryKey.type === 'UUID') { _%>
           id: 'ID',
   <%_ } else { _%>
           id: 0,

--- a/generators/entity-server/templates/partials/it_patch_update.partial.java.ejs
+++ b/generators/entity-server/templates/partials/it_patch_update.partial.java.ejs
@@ -17,7 +17,7 @@
  limitations under the License.
 -%>
 // Initialize the database
-<%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+<%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
     <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
 <%_ } _%>
 <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;

--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -122,7 +122,7 @@ import java.util.Set;
 <%_ } if (databaseType === 'couchbase' && hasRelationship) { _%>
 import java.util.stream.Collectors;
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID' || fieldsContainUUID === true) { _%>
+<%_ if ((!embedded && primaryKey.type === 'UUID') || fieldsContainUUID === true) { _%>
 import java.util.UUID;
 <%_ }
 Object.keys(uniqueEnums).forEach(function(element) { _%>
@@ -197,7 +197,7 @@ public class <%= asEntity(entityClass) %> implements Serializable {
     <%_ } else if (databaseType === 'neo4j') { _%>
     @GeneratedValue(UUIDStringGenerator.class)
     <%_ } _%>
-    private <%= primaryKeyType %> <%= primaryKey.name %>;
+    private <%= primaryKey.type %> <%= primaryKey.name %>;
 
 <%_ } _%>
 <%_ for (idx in fields) {
@@ -473,16 +473,16 @@ relationships.forEach((relationship, idx) => {
 }); _%>
     // jhipster-needle-entity-add-field - JHipster will add fields here
 <%_ if (!embedded) { _%>
-    public <%= primaryKeyType %> get<%= primaryKey.nameCapitalized %>() {
+    public <%= primaryKey.type %> get<%= primaryKey.nameCapitalized %>() {
         return <%= primaryKey.name %>;
     }
 
-    public void set<%= primaryKey.nameCapitalized %>(<%= primaryKeyType %> <%= primaryKey.name %>) {
+    public void set<%= primaryKey.nameCapitalized %>(<%= primaryKey.type %> <%= primaryKey.name %>) {
         this.<%= primaryKey.name %> = <%= primaryKey.name %>;
     }
 
     <%_ if (fluentMethods) { _%>
-    public <%= asEntity(entityClass) %> <%= primaryKey.name %>(<%= primaryKeyType %> <%= primaryKey.name %>) {
+    public <%= asEntity(entityClass) %> <%= primaryKey.name %>(<%= primaryKey.type %> <%= primaryKey.name %>) {
         this.<%= primaryKey.name %> = <%= primaryKey.name %>;
         return this;
     }

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -65,7 +65,7 @@ import java.util.List;
 import java.util.Optional;
     <%_ } _%>
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID') { _%>
+<%_ if (primaryKey.type === 'UUID') { _%>
 
 import java.util.UUID;
 <%_ } _%>
@@ -77,7 +77,7 @@ import java.util.UUID;
 @SuppressWarnings("unused")
 <%_ } _%>
 @Repository
-public interface <%= entityClass %>Repository extends <% if (databaseType === 'sql') { %>JpaRepository<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<% } %><% if (databaseType === 'neo4j') { %>Neo4jRepository<% } %><% if (databaseType === 'cassandra') { %>CassandraRepository<% } %><% if (databaseType === 'couchbase') { %>N1qlCouchbaseRepository<% } %><<%= asEntity(entityClass) %>, <%= primaryKeyType %>><% if (jpaMetamodelFiltering) { %>, JpaSpecificationExecutor<<%= asEntity(entityClass) %>><% } %><% if (searchEngine === 'couchbase') { %>, SearchCouchbaseRepository<<%= asEntity(entityClass) %>, <%= primaryKeyType %>><% } %> {
+public interface <%= entityClass %>Repository extends <% if (databaseType === 'sql') { %>JpaRepository<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<% } %><% if (databaseType === 'neo4j') { %>Neo4jRepository<% } %><% if (databaseType === 'cassandra') { %>CassandraRepository<% } %><% if (databaseType === 'couchbase') { %>N1qlCouchbaseRepository<% } %><<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% if (jpaMetamodelFiltering) { %>, JpaSpecificationExecutor<<%= asEntity(entityClass) %>><% } %><% if (searchEngine === 'couchbase') { %>, SearchCouchbaseRepository<<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% } %> {
     <%_ for (idx in relationships) {
         if (relationships[idx].relationshipType === 'many-to-one' && relationships[idx].otherEntityName === 'user' && databaseType === 'sql') { _%>
 
@@ -104,7 +104,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     for (idx in relationships) {
         if (relationships[idx].relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationships[idx].relationshipFieldNamePlural %><% }
     } %> where <%= entityInstance %>.id =:id")
-    Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(@Param("id") <%= primaryKeyType %> id);
+    Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(@Param("id") <%= primaryKey.type %> id);
     <%_
         } else if (databaseType === 'mongodb' || databaseType === 'couchbase')  { _%>
 
@@ -115,7 +115,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     List<<%= asEntity(entityClass) %>> findAllWithEagerRelationships();
 
     @Query("<%- (databaseType === 'mongodb') ? "{'id': ?0}" : "#{#n1ql.selectEntity} USE KEYS $1 WHERE #{#n1ql.filter}" %>")
-    Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKeyType %> id);
+    Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKey.type %> id);
     <%_
         } else if (databaseType === 'neo4j') { _%>
 
@@ -123,7 +123,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     Page<<%= asEntity(entityClass) %>> findAllWithEagerRelationships(Pageable pageable);
 
     @Query("MATCH (e:<%= asEntity(entityClass) %> {id: $id}) RETURN e")
-    Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKeyType %> id);
+    Optional<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKey.type %> id);
     <%_ }
     } _%>
 }

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepositoryInternalImpl_reactive.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepositoryInternalImpl_reactive.java.ejs
@@ -143,7 +143,7 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
     }
 
     @Override
-    public Mono<<%= asEntity(entityClass) %>> findById(<%= primaryKeyType %> id) {
+    public Mono<<%= asEntity(entityClass) %>> findById(<%= primaryKey.type %> id) {
         return createQuery(null, Criteria.where("id").is(id)).one();
     }
 

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository_reactive.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository_reactive.java.ejs
@@ -54,7 +54,7 @@ import reactor.core.publisher.Flux;
 <%_ if (relationshipsContainEagerLoad || databaseType === 'sql') { _%>
 import reactor.core.publisher.Mono;
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID') { _%>
+<%_ if (primaryKey.type === 'UUID') { _%>
 
 import java.util.UUID;
 <%_ } _%>
@@ -64,7 +64,7 @@ import java.util.UUID;
  */
 @SuppressWarnings("unused")
 @Repository
-public interface <%= entityClass %>Repository extends <% if (databaseType === 'sql') { %>R2dbc<% } if (databaseType === 'mongodb') { %>ReactiveMongo<% } if (databaseType === 'couchbase') { %>ReactiveN1qlCouchbase<% } if (databaseType === 'neo4j') { %>ReactiveNeo4j<% } if (databaseType === 'cassandra') { %>ReactiveCassandra<% } %>Repository<<%= asEntity(entityClass) %>, <%= primaryKeyType %>><% if (searchEngine === 'couchbase') { %>, SearchCouchbaseRepository<<%= asEntity(entityClass) %>, <%= primaryKeyType %>><% } %><% if (databaseType === 'sql') { %>, <%= entityClass %>RepositoryInternal<% } %> {
+public interface <%= entityClass %>Repository extends <% if (databaseType === 'sql') { %>R2dbc<% } if (databaseType === 'mongodb') { %>ReactiveMongo<% } if (databaseType === 'couchbase') { %>ReactiveN1qlCouchbase<% } if (databaseType === 'neo4j') { %>ReactiveNeo4j<% } if (databaseType === 'cassandra') { %>ReactiveCassandra<% } %>Repository<<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% if (searchEngine === 'couchbase') { %>, SearchCouchbaseRepository<<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% } %><% if (databaseType === 'sql') { %>, <%= entityClass %>RepositoryInternal<% } %> {
 
     <%_ if (pagination !== 'no') { _%>
 
@@ -80,7 +80,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     Flux<<%= asEntity(entityClass) %>> findAllWithEagerRelationships();
 
     @Query("<%- (databaseType === 'mongodb') ? "{'id': ?0}" : "#{#n1ql.selectEntity} USE KEYS $1 WHERE #{#n1ql.filter}" %>")
-    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKeyType %> id);
+    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKey.type %> id);
         <%_ } _%>
         <%_ if (databaseType === 'neo4j') { _%>
     @Query("MATCH (n:<%= asEntity(entityClass) %>)<-[]-(m) RETURN n,m")
@@ -90,14 +90,14 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     Flux<<%= asEntity(entityClass) %>> findAllWithEagerRelationships();
 
     @Query("MATCH (e:<%= asEntity(entityClass) %> {id: $id}) RETURN e")
-    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKeyType %> id);
+    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKey.type %> id);
         <%_ } _%>
     <%_ } _%>
     <%_ if (databaseType === 'sql') {
             if (fieldsContainOwnerManyToMany) { _%>
 
     @Override
-    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKeyType %> id);
+    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKey.type %> id);
 
     @Override
     Flux<<%= asEntity(entityClass) %>> findAllWithEagerRelationships();
@@ -118,7 +118,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
                   if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true)) { _%>
 
     @Query("SELECT * FROM <%= entityTableName %> entity WHERE entity.<%= getColumnName(relationshipName) %>_id = :id")
-    Flux<<%= asEntity(entityClass) %>> findBy<%= relationships[idx].relationshipNameCapitalized %>(<%= primaryKeyType %> id);
+    Flux<<%= asEntity(entityClass) %>> findBy<%= relationships[idx].relationshipNameCapitalized %>(<%= primaryKey.type %> id);
 
     @Query("SELECT * FROM <%= entityTableName %> entity WHERE entity.<%= getColumnName(relationshipName) %>_id IS NULL")
     Flux<<%= asEntity(entityClass) %>> findAllWhere<%= relationships[idx].relationshipNameCapitalized %>IsNull();
@@ -126,7 +126,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
                   _%>
 
     @Query("SELECT entity.* FROM <%= entityTableName %> entity JOIN <%= relationship.joinTable.name %> joinTable ON entity.id = joinTable.<%= getColumnName(name) %>_id WHERE joinTable.<%= getColumnName(relationshipName) %>_id = :id")
-    Flux<<%= asEntity(entityClass) %>> findBy<%= relationships[idx].relationshipNameCapitalized %>(<%= primaryKeyType %> id);
+    Flux<<%= asEntity(entityClass) %>> findBy<%= relationships[idx].relationshipNameCapitalized %>(<%= primaryKey.type %> id);
               <%_ } else if (relationshipType === 'one-to-one' && ownerSide === false) {
                   let otherEntityRelationshipName = relationships[idx].otherEntityRelationshipName;
                   let otherEntityTableName = relationships[idx].otherEntityTableName;
@@ -157,13 +157,13 @@ interface <%= entityClass %>RepositoryInternal {
     Mono<Integer> update(<%= asEntity(entityClass) %> entity);
 
     Flux<<%= asEntity(entityClass) %>> findAll();
-    Mono<<%= asEntity(entityClass) %>> findById(<%= primaryKeyType %> id);
+    Mono<<%= asEntity(entityClass) %>> findById(<%= primaryKey.type %> id);
     Flux<<%= asEntity(entityClass) %>> findAllBy(Pageable pageable);
     Flux<<%= asEntity(entityClass) %>> findAllBy(Pageable pageable, Criteria criteria);
 
     <%_ if (fieldsContainOwnerManyToMany) { _%>
 
-    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKeyType %> id);
+    Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(<%= primaryKey.type %> id);
 
     Flux<<%= asEntity(entityClass) %>> findAllWithEagerRelationships();
 

--- a/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/search/EntitySearchRepository.java.ejs
@@ -31,7 +31,7 @@ import org.springframework.data.elasticsearch.repository.<% if (reactive) {%>Rea
 <%_ if (reactive) { _%>
 import reactor.core.publisher.Flux;
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID') { _%>
+<%_ if (primaryKey.type === 'UUID') { _%>
 
 import java.util.UUID;
 <% } %>
@@ -43,7 +43,7 @@ import static org.elasticsearch.index.query.QueryBuilders.queryStringQuery;
 /**
  * Spring Data Elasticsearch repository for the {@link <%= asEntity(entityClass) %>} entity.
  */
-public interface <%= entityClass %>SearchRepository extends <% if (reactive) {%>Reactive<% } %>ElasticsearchRepository<<%= asEntity(entityClass) %>, <%= primaryKeyType %>><% if (reactive) {%>, <%= entityClass %>SearchRepositoryInternal<% } %> {
+public interface <%= entityClass %>SearchRepository extends <% if (reactive) {%>Reactive<% } %>ElasticsearchRepository<<%= asEntity(entityClass) %>, <%= primaryKey.type %>><% if (reactive) {%>, <%= entityClass %>SearchRepositoryInternal<% } %> {
 }
 <%_ if (reactive) { _%>
 

--- a/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
@@ -122,7 +122,7 @@ public class <%= serviceClassName %> extends QueryService<<%= asEntity(entityCla
         Specification<<%= asEntity(entityClass) %>> specification = Specification.where(null);
         if (criteria != null) {
             if (criteria.get<%= primaryKey.nameCapitalized %>() != null) {
-                specification = specification.and(<%= getSpecificationBuilder(primaryKeyType) %>(criteria.get<%= primaryKey.nameCapitalized %>(), <%= asEntity(entityClass) %>_.id));
+                specification = specification.and(<%= getSpecificationBuilder(primaryKey.type) %>(criteria.get<%= primaryKey.nameCapitalized %>(), <%= asEntity(entityClass) %>_.id));
             }
             <%_
             fields.forEach((field) => {

--- a/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityService.java.ejs
@@ -48,7 +48,7 @@ import java.util.List;
 <%_ if (!reactive) { _%>
 import java.util.Optional;
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID') { _%>
+<%_ if (primaryKey.type === 'UUID') { _%>
 import java.util.UUID;
 <%_ } _%>
 
@@ -123,7 +123,7 @@ public interface <%= entityClass %>Service {
      * @param id the id of the entity.
      * @return the entity.
      */
-    <%= optionalOrMono %><<%= instanceType %>> findOne(<%= primaryKeyType %> id);
+    <%= optionalOrMono %><<%= instanceType %>> findOne(<%= primaryKey.type %> id);
 
     /**
      * Delete the "id" <%= entityInstance %>.
@@ -133,7 +133,7 @@ public interface <%= entityClass %>Service {
      * @return a Mono to signal the deletion
 <%_ } _%>
      */
-    <%- reactive ? 'Mono<Void>' : 'void' %> delete(<%= primaryKeyType %> id);<% if (searchEngine !== false) { %>
+    <%- reactive ? 'Mono<Void>' : 'void' %> delete(<%= primaryKey.type %> id);<% if (searchEngine !== false) { %>
 
     /**
      * Search for the <%= entityInstance %> corresponding to the query.

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityCriteria.java.ejs
@@ -54,7 +54,7 @@ if (isFilterableType(fieldType)) {
 }
 });
 relationships.forEach((relationship) => {
-const relationshipType = relationship.otherEntity.primaryKeyType;
+const relationshipType = relationship.otherEntity.primaryKey.type;
 const referenceFilterType = '' + relationshipType + 'Filter';
 // user has a String PK when using OAuth, so change relationships accordingly
 let oauthAwareReferenceFilterType = referenceFilterType;

--- a/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/dto/EntityDTO.java.ejs
@@ -50,7 +50,7 @@ import java.nio.ByteBuffer;
 import java.util.HashSet;
 import java.util.Set;
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID' || fieldsContainUUID === true) { _%>
+<%_ if ((!embedded && primaryKey.type === 'UUID') || fieldsContainUUID === true) { _%>
 import java.util.UUID;
 <%_ } _%>
 <%_ if (fieldsContainBlob && databaseType === 'sql') { _%>

--- a/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/impl/EntityServiceImpl.java.ejs
@@ -75,7 +75,7 @@ import java.util.List;
 <%_ if (!reactive) { _%>
 import java.util.Optional;
 <%_ } _%>
-<%_ if (primaryKeyType === 'UUID') { _%>
+<%_ if (primaryKey.type === 'UUID') { _%>
 import java.util.UUID;
 <%_ } _%>
 <%_ if (fieldsContainNoOwnerOneToOne === true || (pagination === 'no' && ((searchEngine !== false) || dto === 'mapstruct'))) { _%>
@@ -214,7 +214,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     <%_ if (databaseType === 'sql') { _%>
     @Transactional(readOnly = true)
     <%_ } _%>
-    public <%= optionalOrMono %><<%= instanceType %>> findOne(<%= primaryKeyType %> id) {
+    public <%= optionalOrMono %><<%= instanceType %>> findOne(<%= primaryKey.type %> id) {
         log.debug("Request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {asEntity, asDto, viaService: false, returnDirectly:true}); -%>
     }
 
@@ -231,7 +231,7 @@ public class <%= serviceClassName %><% if (service === 'serviceImpl') { %> imple
     <%_ if (service === 'serviceImpl') { _%>
     @Override
     <%_ } _%>
-    public <%- reactive ? 'Mono<Void>' : 'void' %> delete(<%= primaryKeyType %> id) {
+    public <%- reactive ? 'Mono<Void>' : 'void' %> delete(<%= primaryKey.type %> id) {
         log.debug("Request to delete <%= entityClass %> : {}", id);
 <%- include('../../common/delete_template', {viaService: false, fromResource: false}); -%>
     }

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -119,7 +119,7 @@ import java.util.List;
 import java.util.Objects;
 <%_ } _%>
 import java.util.Optional;
-<%_ if (primaryKeyType === 'UUID') { _%>
+<%_ if (primaryKey.type === 'UUID') { _%>
 import java.util.UUID;
 <%_ } _%>
 <%_ if ((searchEngine !== false || fieldsContainNoOwnerOneToOne === true) && !reactive) { _%>
@@ -189,20 +189,20 @@ public class <%= entityClass %>Resource {
         }
             <%_ } _%>
         <%_ } _%>
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= instanceName %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%_ if (!reactive) { _%>
 <%- include('../../common/save_template', {asEntity, asDto, viaService: viaService, returnDirectly: false, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: true}); -%>
         return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.get<%= primaryKey.nameCapitalized %>()))
-            .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
+            .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
             .body(result);
         <%_ } else { _%>
 <%- include('../../common/save_template_reactive', {asEntity, asDto, viaService: viaService, returnDirectly: false}); -%>
             .map(result -> {
                 try {
                     return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.get<%= primaryKey.nameCapitalized %>()))
-                        .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
+                        .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
                         .body(result);
                 } catch (URISyntaxException e) {
                     throw new RuntimeException(e);
@@ -242,13 +242,13 @@ public class <%= entityClass %>Resource {
     <%_ if (!reactive) { _%>
 <%- include('../../common/save_template', {asEntity, asDto, viaService: viaService, returnDirectly: false, isUsingMapsId: false, mapsIdAssoc: mapsIdAssoc}); -%>
         return ResponseEntity.ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
             .body(result);
     <%_ } else { _%>
 <%- include('../../common/save_template_reactive', {asEntity, asDto, viaService: viaService, returnDirectly: false}); -%>
             .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND)))
             .map(result -> ResponseEntity.ok()
-                .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
+                .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
                 .body(result)
             );
     <%_ } _%>
@@ -289,13 +289,13 @@ public class <%= entityClass %>Resource {
             <%_ if (!reactive) { _%>
         return ResponseUtil.wrapOrNotFound(
             result,
-            HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)
+            HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, <%= instanceName %>.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>)
         );
             <%_ } else { _%>
         return result
             .switchIfEmpty(Mono.error(new ResponseStatusException(HttpStatus.NOT_FOUND)))
             .map(res -> ResponseEntity.ok()
-            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, res.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType !== 'String') { %>.toString()<% } %>))
+            .headers(HeaderUtil.createEntityUpdateAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, res.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
             .body(res)
         );
             <%_ } _%>
@@ -356,7 +356,7 @@ public class <%= entityClass %>Resource {
     <%_ if (databaseType === 'sql' && isUsingMapsId === true && !viaService) { _%>
     @Transactional(readOnly = true)
     <%_ } _%>
-    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> get<%= entityClass %>(@PathVariable <%= primaryKeyType %> id) {
+    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> get<%= entityClass %>(@PathVariable <%= primaryKey.type %> id) {
         log.debug("REST request to get <%= entityClass %> : {}", id);<%- include('../../common/get_template', {asEntity, asDto, viaService, returnDirectly:false}); -%>
         return ResponseUtil.wrapOrNotFound(<%= instanceName %>);
     }
@@ -372,19 +372,19 @@ public class <%= entityClass %>Resource {
     <%_ if (reactive) { _%>
     @ResponseStatus(code = HttpStatus.NO_CONTENT)
     <%_ } _%>
-    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<Void><% if (reactive) { %>><% } %> delete<%= entityClass %>(@PathVariable <%= primaryKeyType %> id) {
+    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<Void><% if (reactive) { %>><% } %> delete<%= entityClass %>(@PathVariable <%= primaryKey.type %> id) {
         log.debug("REST request to delete <%= entityClass %> : {}", id);
 <%- include('../../common/delete_template', {viaService: viaService, fromResource: true}); -%>
     <%_ if (!reactive) { _%>
-        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build();
+        return ResponseEntity.noContent().headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>)).build();
     <%_ } else { _%>
         <%_ if (databaseType === 'couchbase') { _%>
             .then(Mono.just(ResponseEntity.noContent()
-                .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build())
+                .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>)).build())
             );
         <%_ } else { %>
             .map(result -> ResponseEntity.noContent()
-            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKeyType !== 'String') { %>.toString()<% } %>)).build()
+            .headers(HeaderUtil.createEntityDeletionAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, id<% if (primaryKey.type !== 'String') { %>.toString()<% } %>)).build()
         );
         <%_ } _%>
     <%_ } _%>

--- a/generators/entity-server/templates/src/test/java/package/domain/EntityTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/domain/EntityTest.java.ejs
@@ -28,7 +28,7 @@ if (isUsingMapsId) {
     hasOauthUser = mapsIdAssoc.otherEntityName === 'user' && authenticationType === 'oauth2';
 }
 _%>
-<%_ if (primaryKeyType === 'UUID' || (databaseType === 'sql' && hasOauthUser === true)) { _%>
+<%_ if ((!embedded && primaryKey.type === 'UUID') || (databaseType === 'sql' && hasOauthUser === true)) { _%>
 import java.util.UUID;
 <%_ } _%>
 
@@ -39,11 +39,11 @@ class <%= entityClass %>Test {
         TestUtil.equalsVerifier(<%= asEntity(entityClass) %>.class);
     <%_if (!embedded) { _%>
         <%= asEntity(entityClass) %> <%= asEntity(entityInstance) %>1 = new <%= asEntity(entityClass) %>();
-        <%= asEntity(entityInstance) %>1.set<%= primaryKey.nameCapitalized %>(<% if (databaseType === 'sql' && hasOauthUser === true) { %>UUID.randomUUID().toString()<% } else if (primaryKeyType === 'Long') { %>1L<% } else if (primaryKeyType === 'String') { %>"id1"<% } else if (primaryKeyType === 'UUID') { %>UUID.randomUUID()<% } %>);
+        <%= asEntity(entityInstance) %>1.set<%= primaryKey.nameCapitalized %>(<% if (databaseType === 'sql' && hasOauthUser === true) { %>UUID.randomUUID().toString()<% } else if (primaryKey.type === 'Long') { %>1L<% } else if (primaryKey.type === 'String') { %>"id1"<% } else if (primaryKey.type === 'UUID') { %>UUID.randomUUID()<% } %>);
         <%= asEntity(entityClass) %> <%= asEntity(entityInstance) %>2 = new <%= asEntity(entityClass) %>();
         <%= asEntity(entityInstance) %>2.set<%= primaryKey.nameCapitalized %>(<%= asEntity(entityInstance) %>1.get<%= primaryKey.nameCapitalized %>());
         assertThat(<%= asEntity(entityInstance) %>1).isEqualTo(<%= asEntity(entityInstance) %>2);
-        <%= asEntity(entityInstance) %>2.set<%= primaryKey.nameCapitalized %>(<% if (databaseType === 'sql' && hasOauthUser === true) { %>UUID.randomUUID().toString()<% } else if (primaryKeyType === 'Long') { %>2L<% } else if (primaryKeyType === 'String') { %>"id2"<% } else if (primaryKeyType === 'UUID') { %>UUID.randomUUID()<% } %>);
+        <%= asEntity(entityInstance) %>2.set<%= primaryKey.nameCapitalized %>(<% if (databaseType === 'sql' && hasOauthUser === true) { %>UUID.randomUUID().toString()<% } else if (primaryKey.type === 'Long') { %>2L<% } else if (primaryKey.type === 'String') { %>"id2"<% } else if (primaryKey.type === 'UUID') { %>UUID.randomUUID()<% } %>);
         assertThat(<%= asEntity(entityInstance) %>1).isNotEqualTo(<%= asEntity(entityInstance) %>2);
         <%= asEntity(entityInstance) %>1.set<%= primaryKey.nameCapitalized %>(null);
         assertThat(<%= asEntity(entityInstance) %>1).isNotEqualTo(<%= asEntity(entityInstance) %>2);

--- a/generators/entity-server/templates/src/test/java/package/service/dto/EntityDTOTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/service/dto/EntityDTOTest.java.ejs
@@ -25,8 +25,8 @@ import <%= packageName %>.web.rest.TestUtil;
 let id1;
 let id2;
 if (!embedded) { 
-    id1 = getPrimaryKeyValue(primaryKeyType, databaseType, '1');
-    id2 = getPrimaryKeyValue(primaryKeyType, databaseType, '2');
+    id1 = getPrimaryKeyValue(primaryKey.type, databaseType, '1');
+    id2 = getPrimaryKeyValue(primaryKey.type, databaseType, '2');
     if (id1.includes('UUID')) { _%>
 import java.util.UUID;
     <%_ }

--- a/generators/entity-server/templates/src/test/java/package/service/mapper/EntityMapperTest.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/service/mapper/EntityMapperTest.java.ejs
@@ -24,7 +24,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 <%_
 let id;
 if (!embedded) {
-    id = getPrimaryKeyValue(primaryKeyType, databaseType, '1');
+    id = getPrimaryKeyValue(primaryKey.type, databaseType, '1');
     if (id.includes('UUID')) { _%>
 import java.util.UUID;
     <%_ }

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -46,9 +46,9 @@ if (databaseType === 'sql' && reactive) {
     createEntityPostfix = ').block()';
 }
 let idValue = `${asEntity(entityInstance)}.get${primaryKey.nameCapitalized}()`;
-if (primaryKeyType === 'Long') {
+if (primaryKey.type === 'Long') {
     idValue = idValue + '.intValue()';
-} else if (primaryKeyType === 'UUID') {
+} else if (primaryKey.type === 'UUID') {
     idValue = idValue + '.toString()';
 }
 let transactionalAnnotation = '';
@@ -175,7 +175,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 <%_ } _%>
 import java.util.List;
-<%_ if (primaryKeyType === 'UUID' || fieldsContainUUID === true || (databaseType === 'sql' && hasOauthUser === true)) { _%>
+<%_ if (primaryKey.type === 'UUID' || fieldsContainUUID === true || (databaseType === 'sql' && hasOauthUser === true)) { _%>
 import java.util.UUID;
 <%_ } _%>
 
@@ -630,10 +630,10 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     @Test<%= transactionalAnnotation %>
     void create<%= entityClass %>WithExistingId() throws Exception {
         // Create the <%= entityClass %> with an existing ID
-        <%_ if (primaryKeyType === 'UUID' && databaseType === 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType === 'sql') { _%>
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;
         <%_ } else { _%>
-        <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(<% if (primaryKeyType === 'UUID') { %>UUID.randomUUID()<% } else if (primaryKeyType === 'Long') { %>1L<% } else { %>"existing_id"<% } %>);
+        <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(<% if (primaryKey.type === 'UUID') { %>UUID.randomUUID()<% } else if (primaryKey.type === 'Long') { %>1L<% } else { %>"existing_id"<% } %>);
         <%_ } _%>
         <%_ if (dto === 'mapstruct') { _%>
         <%= asDto(entityClass) %> <%= asDto(entityInstance) %> = <%= entityInstance %>Mapper.toDto(<%= asEntity(entityInstance) %>);
@@ -781,7 +781,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     @Test
     void getAll<%= entityClassPlural %>AsStream() {
         // Initialize the database
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)<%= callBlock %>;
@@ -819,7 +819,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     @Test<%= transactionalAnnotation %>
     void getAll<%= entityClassPlural %>() <% if (!reactive) { %>throws Exception <% } %>{
         // Initialize the database
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;
@@ -910,7 +910,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     @Test<%= transactionalAnnotation %>
     void get<%= entityClass %>() <% if (!reactive) { %>throws Exception <% } %>{
         // Initialize the database
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;
@@ -955,7 +955,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
         // Initialize the database
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;
 
-        <%= primaryKeyType %> id = <%= asEntity(entityInstance) %>.get<%= primaryKey.nameCapitalized %>();
+        <%= primaryKey.type %> id = <%= asEntity(entityInstance) %>.get<%= primaryKey.nameCapitalized %>();
 
         default<%= entityClass %>ShouldBeFound("id.equals=" + id);
         default<%= entityClass %>ShouldNotBeFound("id.notEquals=" + id);
@@ -1141,7 +1141,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
             <%_ } _%>
         <%_ } _%>
         <%= entityInstance %>Repository.saveAndFlush(<%= asEntity(entityInstance) %>);
-        <%= relationship.otherEntity.primaryKeyType %> <%= relationship.relationshipFieldName %>Id = <%= relationship.relationshipFieldName %>.get<%= primaryKey.nameCapitalized %>();
+        <%= relationship.otherEntity.primaryKey.type %> <%= relationship.relationshipFieldName %>Id = <%= relationship.relationshipFieldName %>.get<%= primaryKey.nameCapitalized %>();
 
         // Get all the <%= entityInstance %>List where <%= relationship.relationshipFieldName %> equals to <%= relationship.relationshipFieldName %>Id
         default<%= entityClass %>ShouldBeFound("<%= relationship.relationshipFieldName %>Id.equals=" + <%= relationship.relationshipFieldName %>Id);
@@ -1192,7 +1192,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
         rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityApiUrl %>?sort=id,desc&" + filter))
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON_VALUE))
-            .andExpect(jsonPath("$.[*].<%= primaryKey.name %>").value(hasItem(<%= asEntity(entityInstance) %><% if (primaryKeyType !== 'Long') { %>.get<%= primaryKey.nameCapitalized %>()<% } else { %>.get<%= primaryKey.nameCapitalized %>().intValue()<% } %>)))<% fields.filter(field => !field.id).forEach((field) => { %>
+            .andExpect(jsonPath("$.[*].<%= primaryKey.name %>").value(hasItem(<%= asEntity(entityInstance) %><% if (primaryKey.type !== 'Long') { %>.get<%= primaryKey.nameCapitalized %>()<% } else { %>.get<%= primaryKey.nameCapitalized %>().intValue()<% } %>)))<% fields.filter(field => !field.id).forEach((field) => { %>
             <%_ if ((field.fieldType === 'byte[]' || field.fieldType === 'ByteBuffer') && field.fieldTypeBlobContent !== 'text') { _%>
             .andExpect(jsonPath("$.[*].<%= field.fieldName %>ContentType").value(hasItem(<%= 'DEFAULT_' + field.fieldNameUnderscored.toUpperCase() %>_CONTENT_TYPE)))
             <%_ } _%>
@@ -1261,10 +1261,10 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     void getNonExisting<%= entityClass %>() <% if (!reactive) { %>throws Exception <% } %>{
         // Get the <%= entityInstance %>
         <%_ if (!reactive) { _%>
-        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityApiUrl %>/{id}", <% if (['Long', 'String'].includes(primaryKeyType)) { %>Long.MAX_VALUE<% } else if (primaryKeyType === 'UUID') { %>UUID.randomUUID().toString()<% } %>))
+        rest<%= entityClass %>MockMvc.perform(get("/api/<%= entityApiUrl %>/{id}", <% if (['Long', 'String'].includes(primaryKey.type)) { %>Long.MAX_VALUE<% } else if (primaryKey.type === 'UUID') { %>UUID.randomUUID().toString()<% } %>))
             .andExpect(status().isNotFound());
         <%_ } else { _%>
-        webTestClient.get().uri("/api/<%= entityApiUrl %>/{id}", <% if (['Long', 'String'].includes(primaryKeyType)) { %>Long.MAX_VALUE<% } else if (primaryKeyType === 'UUID') { %>UUID.randomUUID().toString()<% } %>)
+        webTestClient.get().uri("/api/<%= entityApiUrl %>/{id}", <% if (['Long', 'String'].includes(primaryKey.type)) { %>Long.MAX_VALUE<% } else if (primaryKey.type === 'UUID') { %>UUID.randomUUID().toString()<% } %>)
             .accept(MediaType.APPLICATION_JSON)
             .exchange()
             .expectStatus().isNotFound();
@@ -1280,7 +1280,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
             .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
     <%_ } _%>
         // Initialize the database
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;
@@ -1431,10 +1431,10 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
         when(mock<%= entityClass %>SearchRepository.save(any()))
             .thenAnswer(invocation -> Mono.just(invocation.getArgument(0)));
     <%_ } _%>
-        when(mock<%= entityClass %>SearchRepository.deleteById(any<%= primaryKeyType %>())).thenReturn(Mono.empty());
+        when(mock<%= entityClass %>SearchRepository.deleteById(any<%= primaryKey.type %>())).thenReturn(Mono.empty());
 <%_ } _%>
         // Initialize the database
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;
@@ -1443,7 +1443,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
 
         // Delete the <%= entityInstance %>
         <%_ if (!reactive) { _%>
-        rest<%= entityClass %>MockMvc.perform(delete("/api/<%= entityApiUrl %>/{id}", <%= asEntity(entityInstance) %>.get<%= primaryKey.nameCapitalized %>()<% if (primaryKeyType === 'UUID' && databaseType === 'sql') { %>.toString()<% } %>)<% if (testsNeedCsrf) { %>.with(csrf())<% }%>
+        rest<%= entityClass %>MockMvc.perform(delete("/api/<%= entityApiUrl %>/{id}", <%= asEntity(entityInstance) %>.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type === 'UUID' && databaseType === 'sql') { %>.toString()<% } %>)<% if (testsNeedCsrf) { %>.with(csrf())<% }%>
             .accept(MediaType.APPLICATION_JSON))
             .andExpect(status().isNoContent());
         <%_ } else { _%>
@@ -1481,7 +1481,7 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
     <%_ } _%>
 <%_ } _%>
         // Initialize the database
-        <%_ if (primaryKeyType === 'UUID' && databaseType !== 'sql') { _%>
+        <%_ if (primaryKey.type === 'UUID' && databaseType !== 'sql') { _%>
         <%= asEntity(entityInstance) %>.set<%= primaryKey.nameCapitalized %>(UUID.randomUUID());
         <%_ } _%>
         <%= entityInstance %>Repository.<%= saveMethod %>(<%= asEntity(entityInstance) %>)<%= callBlock %>;

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -542,7 +542,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 const idFields = this.context.primaryKey.derivedFields;
                 this.context.idFields = idFields;
                 this.context.fields.unshift(...idFields);
-                this.context.primaryKeyType = this.context.primaryKey.type;
             },
 
             prepareReferences() {

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -966,11 +966,14 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
     /**
      * Find key type for Typescript
      *
-     * @param {string} pkType - primary key type in database
+     * @param {string} primaryKey - primary key definition
      * @returns {string} primary key type in Typescript
      */
-    getTypescriptKeyType(pkType) {
-        if (pkType === 'String' || pkType === 'UUID') {
+    getTypescriptKeyType(primaryKey) {
+        if (typeof primaryKey === 'object') {
+            primaryKey = primaryKey.type;
+        }
+        if (primaryKey === 'String' || primaryKey === 'UUID') {
             return 'string';
         }
         return 'number';
@@ -979,18 +982,20 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
     /**
      * Generate Entity Client Field Declarations
      *
-     * @param {string} pkType - type of primary key
+     * @param {string} primaryKey - primary key definition
      * @param {Array|Object} fields - array of fields
      * @param {Array|Object} relationships - array of relationships
      * @param {string} dto - dto
      * @param {boolean} embedded - either the actual entity is embedded or not
      * @returns variablesWithTypes: Array
      */
-    generateEntityClientFields(pkType, fields, relationships, dto, customDateType = 'dayjs.Dayjs', embedded = false) {
+    generateEntityClientFields(primaryKey, fields, relationships, dto, customDateType = 'dayjs.Dayjs', embedded = false) {
         const variablesWithTypes = [];
-        const tsKeyType = this.getTypescriptKeyType(pkType);
-        if (!embedded && this.jhipsterConfig.clientFramework !== ANGULAR) {
-            variablesWithTypes.push(`id?: ${tsKeyType}`);
+        if (!embedded && primaryKey) {
+            const tsKeyType = this.getTypescriptKeyType(primaryKey);
+            if (this.jhipsterConfig.clientFramework !== ANGULAR) {
+                variablesWithTypes.push(`id?: ${tsKeyType}`);
+            }
         }
         fields.forEach(field => {
             const fieldType = field.fieldType;
@@ -1206,14 +1211,17 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
     /**
      * Generate a primary key, according to the type
      *
-     * @param {any} pkType - the type of the primary key
+     * @param {any} primaryKey - primary key definition
      * @param {number} index - the index of the primary key, currently it's possible to generate 2 values, index = 0 - first key (default), otherwise second key
      */
-    generateTestEntityId(pkType, index = 0) {
-        if (pkType === 'String') {
+    generateTestEntityId(primaryKey, index = 0) {
+        if (typeof primaryKey === 'object') {
+            primaryKey = primaryKey.type;
+        }
+        if (primaryKey === 'String') {
             return index === 0 ? "'123'" : "'456'";
         }
-        if (pkType === 'UUID') {
+        if (primaryKey === 'UUID') {
             return index === 0 ? "'9fec3727-3421-4967-b213-ba36557ca194'" : "'1361f429-3817-4123-8ee3-fdf8943310b2'";
         }
         return index === 0 ? 123 : 456;

--- a/generators/server/templates/src/main/java/package/domain/User.java.ejs
+++ b/generators/server/templates/src/main/java/package/domain/User.java.ejs
@@ -171,7 +171,7 @@ public class <%= asEntity('User') %><% if (databaseType === 'sql' || databaseTyp
     @org.springframework.data.elasticsearch.annotations.Field(type = FieldType.Keyword)
     <%_ } _%>
 <%_ } _%>
-    private <%= user.primaryKeyType %> id;
+    private <%= user.primaryKey.type %> id;
 
     @NotNull
     @Pattern(regexp = Constants.LOGIN_REGEX)

--- a/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
@@ -155,7 +155,7 @@ import static <%= packageName %>.config.Constants.ID_DELIMITER;
 _%>
 <%_ if ((databaseType === 'sql' && !reactive) || databaseType === 'mongodb' || databaseType === 'neo4j' || databaseType === 'couchbase') { _%>
 @Repository
-public interface UserRepository extends <% if (databaseType === 'sql') { %>JpaRepository<<%= asEntity('User') %>, <%= user.primaryKeyType %>><% } %><% if (reactive) { %>Reactive<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<<%= asEntity('User') %>, String><% } %><% if (databaseType === 'neo4j') { %>Neo4jRepository<<%= asEntity('User') %>, String><% } %><% if (databaseType === 'couchbase') { %>N1qlCouchbaseRepository<<%= asEntity('User') %>, String><%if (searchEngine === 'couchbase') { %>, SearchCouchbaseRepository<<%= asEntity('User') %>, String><% } } %> {
+public interface UserRepository extends <% if (databaseType === 'sql') { %>JpaRepository<<%= asEntity('User') %>, <%= user.primaryKey.type %>><% } %><% if (reactive) { %>Reactive<% } %><% if (databaseType === 'mongodb') { %>MongoRepository<<%= asEntity('User') %>, String><% } %><% if (databaseType === 'neo4j') { %>Neo4jRepository<<%= asEntity('User') %>, String><% } %><% if (databaseType === 'couchbase') { %>N1qlCouchbaseRepository<<%= asEntity('User') %>, String><%if (searchEngine === 'couchbase') { %>, SearchCouchbaseRepository<<%= asEntity('User') %>, String><% } } %> {
     <%_ if (cacheManagerIsAvailable === true) { _%>
 
     String USERS_BY_LOGIN_CACHE = "usersByLogin";
@@ -258,7 +258,7 @@ public interface UserRepository extends R2dbcRepository<User, <% if (authenticat
     Mono<Long> count();
 
     @Query("INSERT INTO <%= jhiTablePrefix %>_user_authority VALUES(:userId, :authority)")
-    Mono<Void> saveUserAuthority(<%= user.primaryKeyType %> userId, String authority);
+    Mono<Void> saveUserAuthority(<%= user.primaryKey.type %> userId, String authority);
 
     @Query("DELETE FROM <%= jhiTablePrefix %>_user_authority")
     Mono<Void> deleteAllUserAuthorities();

--- a/generators/server/templates/src/main/java/package/service/dto/AdminUserDTO.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/dto/AdminUserDTO.java.ejs
@@ -39,7 +39,7 @@ import java.util.stream.Collectors;
  */
 public class <%= asDto('AdminUser') %> {
 
-    private <%= user.primaryKeyType %> id;
+    private <%= user.primaryKey.type %> id;
 
     @NotBlank
     @Pattern(regexp = Constants.LOGIN_REGEX)
@@ -110,11 +110,11 @@ public class <%= asDto('AdminUser') %> {
     }
 
     <%_ } _%>
-    public <%= user.primaryKeyType %> getId() {
+    public <%= user.primaryKey.type %> getId() {
         return id;
     }
 
-    public void setId(<%= user.primaryKeyType %> id) {
+    public void setId(<%= user.primaryKey.type %> id) {
         this.id = id;
     }
 

--- a/generators/server/templates/src/main/java/package/service/dto/UserDTO.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/dto/UserDTO.java.ejs
@@ -27,7 +27,7 @@ import <%= packageName %>.domain.<%= asEntity('User') %>;
  */
 public class <%= asDto('User') %> {
 
-    private <%= user.primaryKeyType %> id;
+    private <%= user.primaryKey.type %> id;
     private String login;
 
     <%_ if (databaseType !== 'no') { _%>
@@ -42,11 +42,11 @@ public class <%= asDto('User') %> {
     }
 
     <%_ } _%>
-    public <%= user.primaryKeyType %> getId() {
+    public <%= user.primaryKey.type %> getId() {
         return id;
     }
 
-    public void setId(<%= user.primaryKeyType %> id) {
+    public void setId(<%= user.primaryKey.type %> id) {
         this.id = id;
     }
 

--- a/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
+++ b/generators/server/templates/src/main/resources/config/liquibase/changelog/initial_schema.xml.ejs
@@ -40,7 +40,7 @@
     <changeSet id="00000000000001" author="jhipster">
 <%_ if (!skipUserManagement || authenticationType === 'oauth2') { _%>
         <createTable tableName="<%= user.entityTableName %>">
-            <%_ if (user.primaryKeyType !== 'Long') { _%>
+            <%_ if (user.primaryKey.type !== 'Long') { _%>
             <column name="id" type="varchar(100)">
                 <constraints primaryKey="true" nullable="false"/>
             </column>

--- a/utils/entity.js
+++ b/utils/entity.js
@@ -26,7 +26,7 @@ const { entityDefaultConfig } = require('../generators/generator-defaults');
 const { stringHashCode } = require('../generators/utils');
 
 const BASE_TEMPLATE_DATA = {
-    primaryKeyType: undefined,
+    primaryKey: undefined,
     skipUiGrouping: false,
     haveFieldWithJavadoc: false,
     existingEnum: false,
@@ -248,7 +248,6 @@ function prepareEntityForTemplates(entityWithConfig, generator) {
                 references: entityWithConfig.idFields.map(field => field.reference),
                 composite: entityWithConfig.idFields.length > 1,
             };
-            entityWithConfig.primaryKeyType = idField.fieldType;
         }
     }
 


### PR DESCRIPTION
`primaryKeyType` field is a copy of `primaryKey.type`, we should drop it for v7.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
