### PR TITLE
Postpone prettier registering and add option to ignore prettier errors.

### DIFF
--- a/generators/app/index.js
+++ b/generators/app/index.js
@@ -207,6 +207,11 @@ module.exports = class JHipsterAppGenerator extends BaseBlueprintGenerator {
             type: Boolean,
         });
 
+        this.option('ignore-errors', {
+            desc: "Don't fail on prettier errors.",
+            type: Boolean,
+        });
+
         this.option('native-language', {
             alias: 'n',
             desc: 'Set application native language',

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1436,7 +1436,11 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
                 const filterPatternForPrettier = `{,.,**/,.jhipster/**/}*.{${this.getPrettierExtensions()}}`;
                 const prettierFilter = filter(['.yo-rc.json', filterPatternForPrettier], { restore: true });
                 // this pipe will pass through (restore) anything that doesn't match typescriptFilter
-                generator.registerTransformStream([prettierFilter, prettierTransform(prettierOptions), prettierFilter.restore]);
+                generator.registerTransformStream([
+                    prettierFilter,
+                    prettierTransform(prettierOptions, this, this.options.ignoreErrors),
+                    prettierFilter.restore,
+                ]);
             },
             taskName: 'queuePrettierTransform',
             queueName: 'jhipster:preConflicts',

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1426,15 +1426,21 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
             return;
         }
 
-        const prettierOptions = { plugins: [prettierPluginPackagejson] };
-        if (!this.skipServer && !this.jhipsterConfig.skipServer) {
-            prettierOptions.plugins.push(prettierPluginJava);
-        }
-        // Prettier is clever, it uses correct rules and correct parser according to file extension.
-        const filterPatternForPrettier = `{,.,**/,.jhipster/**/}*.{${this.getPrettierExtensions()}}`;
-        const prettierFilter = filter(['.yo-rc.json', filterPatternForPrettier], { restore: true });
-        // this pipe will pass through (restore) anything that doesn't match typescriptFilter
-        generator.registerTransformStream([prettierFilter, prettierTransform(prettierOptions), prettierFilter.restore]);
+        this.queueTask({
+            method: () => {
+                const prettierOptions = { plugins: [prettierPluginPackagejson] };
+                if (!this.skipServer && !this.jhipsterConfig.skipServer) {
+                    prettierOptions.plugins.push(prettierPluginJava);
+                }
+                // Prettier is clever, it uses correct rules and correct parser according to file extension.
+                const filterPatternForPrettier = `{,.,**/,.jhipster/**/}*.{${this.getPrettierExtensions()}}`;
+                const prettierFilter = filter(['.yo-rc.json', filterPatternForPrettier], { restore: true });
+                // this pipe will pass through (restore) anything that doesn't match typescriptFilter
+                generator.registerTransformStream([prettierFilter, prettierTransform(prettierOptions), prettierFilter.restore]);
+            },
+            taskName: 'queuePrettierTransform',
+            queueName: 'jhipster:preConflicts',
+        });
     }
 
     registerGeneratedAnnotationTransform() {

--- a/generators/generator-transforms.js
+++ b/generators/generator-transforms.js
@@ -20,7 +20,7 @@ const path = require('path');
 const through = require('through2');
 const prettier = require('prettier');
 
-const prettierTransform = function (defaultOptions) {
+const prettierTransform = function (defaultOptions, generator, ignoreErrors = false) {
     return through.obj((file, encoding, callback) => {
         if (file.state === 'deleted') {
             callback(null, file);
@@ -44,11 +44,15 @@ const prettierTransform = function (defaultOptions) {
                 callback(null, file);
             })
             .catch(error => {
-                callback(
-                    new Error(`Error parsing file ${file.relative}: ${error}
+                const errorMessage = `Error parsing file ${file.relative}: ${error}
 
-At: ${fileContent}`)
-                );
+At: ${fileContent}`;
+                if (ignoreErrors) {
+                    generator.warning(errorMessage);
+                    callback(null, file);
+                } else {
+                    callback(new Error(errorMessage));
+                }
             });
     });
 };


### PR DESCRIPTION
- When using vue app using prompts, configuration must be ready when registering prettier.
See https://github.com/jhipster/generator-jhipster/pull/12639#issuecomment-748351773.
- Files with prettier errors are not written to disk, making it more difficult to debug.
Add option to ignore prettier errors, so the broken file is written to disk.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
