### PR TITLE
Upgrade to Jhipster Control Center image Docker to v0.2.0

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -56,7 +56,7 @@ const PRETTIER_JAVA_VERSION = packagejs.dependencies['prettier-plugin-java'];
 // Version of docker images
 const DOCKER_COMPOSE_FORMAT_VERSION = '3.8';
 const DOCKER_JHIPSTER_REGISTRY = 'jhipster/jhipster-registry:v6.4.0';
-const DOCKER_JHIPSTER_CONTROL_CENTER = 'jhipster/jhipster-control-center:v0.1.0';
+const DOCKER_JHIPSTER_CONTROL_CENTER = 'jhipster/jhipster-control-center:v0.2.0';
 const DOCKER_JAVA_JRE = 'adoptopenjdk:11-jre-hotspot';
 const DOCKER_MYSQL = 'mysql:8.0.22';
 const DOCKER_MARIADB = 'mariadb:10.5.8';

--- a/generators/server/templates/src/main/docker/jhipster-control-center.yml.ejs
+++ b/generators/server/templates/src/main/docker/jhipster-control-center.yml.ejs
@@ -38,6 +38,16 @@
 # Or add a new application named MyNewApp
 #       - SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_MYNEWAPP_0_URI=http://host.docker.internal:8080
 # This configuration is intended for development purpose, it's **your** responsibility to harden it for production
+
+
+#### IMPORTANT
+# If you choose Consul or Eureka mode:
+# Do not forget to remove the prefix "127.0.0.1" in front of their port in order to expose them.
+# This is required because JHCC need to communicate with Consul or Eureka.
+# - In Consul mode, the ports are in the consul.yml file.
+# - In Eureka mode, the ports are in the jhipster-registry.yml file.
+
+
 <%_ let discoveryProfile = serviceDiscoveryType ? serviceDiscoveryType : 'static'; _%>
 version: '<%= DOCKER_COMPOSE_FORMAT_VERSION %>'
 services:
@@ -50,12 +60,11 @@ services:
       - echo "`ip route | grep default | cut -d ' ' -f3` host.docker.internal" | tee -a /etc/hosts > /dev/null && java -jar /jhipster-control-center.jar
     environment:
       - _JAVA_OPTIONS=-Xmx512m -Xms256m
-      # TODO change 'swagger' to 'api-docs' when JHCC will be migrated to 7.x JHipster version. https://github.com/jhipster/jhipster/pull/764
-      - SPRING_PROFILES_ACTIVE=prod,swagger,<%= discoveryProfile %><% if (authenticationType === 'oauth2') { %>,oauth2<% } %>
+      - SPRING_PROFILES_ACTIVE=prod,api-docs,<%= discoveryProfile %><% if (authenticationType === 'oauth2') { %>,oauth2<% } %>
       - JHIPSTER_SLEEP=30 # gives time for other services to boot before the application
       <%_ if (authenticationType === 'jwt') { _%>
       - SPRING_SECURITY_USER_PASSWORD=admin
-      - JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64_SECRET=<%= jwtSecretKey %>
+      - JHIPSTER_SECURITY_AUTHENTICATION_JWT_BASE64_SECRET=my-secret-key-which-should-be-changed-in-production-and-be-base64-encoded
       <%_ } else if (authenticationType === 'oauth2') { _%>
       # For keycloak to work, you need to add '127.0.0.1 keycloak' to your hosts file
       - SPRING_SECURITY_OAUTH2_CLIENT_PROVIDER_OIDC_ISSUER_URI=http://keycloak:9080/auth/realms/jhipster
@@ -70,7 +79,7 @@ services:
       <%_ } else { _%>
       - SPRING_CLOUD_DISCOVERY_CLIENT_SIMPLE_INSTANCES_<%= baseName.toUpperCase() %>_0_URI=http://host.docker.internal:<%= serverPort %>
       <%_ } _%>
-    # If you want to expose these ports outside your dev PC, 
+    # If you want to expose these ports outside your dev PC,
     # remove the "127.0.0.1:" prefix
     ports:
       - 127.0.0.1:7419:7419


### PR DESCRIPTION
- [X] upgrade to Jhipster Control Center image Docker to v0.2.0
- [X] replace swagger profile by api-docs
- [X] add comment to explain how to use jhipster-control-center.yml with Consul or Eureka

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.