### PR TITLE
Do not set location header (security issue)

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -66,6 +66,7 @@ import tech.jhipster.web.util.<% if (reactive) { %>reactive.<% } %>ResponseUtil;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatus;
 <%_ if (pagination !== 'no') { _%>
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -73,7 +74,6 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.PageImpl;
     <%_ } _%>
 import org.springframework.http.HttpHeaders;
-import org.springframework.http.HttpStatus;
     <%_ if (reactive) { _%>
 import org.springframework.http.server.reactive.ServerHttpRequest;
     <%_ } _%>
@@ -82,8 +82,6 @@ import org.springframework.web.servlet.support.ServletUriComponentsBuilder;
     <%_ } else { _%>
 import org.springframework.web.util.UriComponentsBuilder;
     <%_ } _%>
-<%_ } else if (reactive) { _%>
-import org.springframework.http.HttpStatus;
 <%_ } _%>
 <%_ if (reactive) { _%>
 import org.springframework.http.MediaType;
@@ -106,8 +104,6 @@ import javax.validation.Valid;
 <%_ if (validation && !readOnly) { _%>
 import javax.validation.constraints.NotNull;
 <%_ } _%>
-import java.net.URI;
-import java.net.URISyntaxException;
 <%_ if (pagination === 'no' && dto === 'mapstruct' && !viaService && fieldsContainNoOwnerOneToOne === true) { _%>
 import java.util.LinkedList;
 <%_ } _%>
@@ -168,10 +164,9 @@ public class <%= entityClass %>Resource {
      *
      * @param <%= instanceName %> the <%= instanceName %> to create.
      * @return the {@link ResponseEntity} with status {@code 201 (Created)} and with body the new <%= instanceName %>, or with status {@code 400 (Bad Request)} if the <%= entityInstance %> has already an ID.
-     * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PostMapping("/<%= entityApiUrl %>")
-    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> create<%= entityClass %>(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) throws URISyntaxException {
+    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> create<%= entityClass %>(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) {
         log.debug("REST request to save <%= entityClass %> : {}", <%= instanceName %>);
         if (<%= instanceName %>.get<%= primaryKey.nameCapitalized %>() != null) {
             throw new BadRequestAlertException("A new <%= entityInstance %> cannot already have an ID", ENTITY_NAME, "idexists");
@@ -194,19 +189,16 @@ public class <%= entityClass %>Resource {
         <%_ } _%>
         <%_ if (!reactive) { _%>
 <%- include('../../common/save_template', {asEntity, asDto, viaService: viaService, returnDirectly: false, isUsingMapsId: isUsingMapsId, mapsIdAssoc: mapsIdAssoc, isController: true}); -%>
-        return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.get<%= primaryKey.nameCapitalized %>()))
+        return ResponseEntity.status(HttpStatus.CREATED)
             .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
             .body(result);
         <%_ } else { _%>
 <%- include('../../common/save_template_reactive', {asEntity, asDto, viaService: viaService, returnDirectly: false}); -%>
             .map(result -> {
-                try {
-                    return ResponseEntity.created(new URI("/api/<%= entityApiUrl %>/" + result.get<%= primaryKey.nameCapitalized %>()))
-                        .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
-                        .body(result);
-                } catch (URISyntaxException e) {
-                    throw new RuntimeException(e);
-                }
+                return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .headers(HeaderUtil.createEntityCreationAlert(applicationName, <%= enableTranslation %>, ENTITY_NAME, result.get<%= primaryKey.nameCapitalized %>()<% if (primaryKey.type !== 'String') { %>.toString()<% } %>))
+                    .body(result);
             });
         <%_ } _%>
     }
@@ -218,10 +210,9 @@ public class <%= entityClass %>Resource {
      * @return the {@link ResponseEntity} with status {@code 200 (OK)} and with body the updated <%= instanceName %>,
      * or with status {@code 400 (Bad Request)} if the <%= instanceName %> is not valid,
      * or with status {@code 500 (Internal Server Error)} if the <%= instanceName %> couldn't be updated.
-     * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PutMapping("/<%= entityApiUrl %>")
-    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> update<%= entityClass %>(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) throws URISyntaxException {
+    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> update<%= entityClass %>(<% if (validation) { %>@Valid <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) {
         log.debug("REST request to update <%= entityClass %> : {}", <%= instanceName %>);
         if (<%= instanceName %>.get<%= primaryKey.nameCapitalized %>() == null) {
             throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");
@@ -263,10 +254,9 @@ public class <%= entityClass %>Resource {
      * or with status {@code 400 (Bad Request)} if the <%= instanceName %> is not valid,
      * or with status {@code 404 (Not Found)} if the <%= instanceName %> is not found,
      * or with status {@code 500 (Internal Server Error)} if the <%= instanceName %> couldn't be updated.
-     * @throws URISyntaxException if the Location URI syntax is incorrect.
      */
     @PatchMapping(value = "/<%= entityApiUrl %>", consumes = "application/merge-patch+json")
-    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> partialUpdate<%= entityClass %>(<% if (validation) { %>@NotNull <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) throws URISyntaxException {
+    public <% if (reactive) { %>Mono<<% } %>ResponseEntity<<%= instanceType %>><% if (reactive) { %>><% } %> partialUpdate<%= entityClass %>(<% if (validation) { %>@NotNull <% } %>@RequestBody <%= instanceType %> <%= instanceName %>) {
         log.debug("REST request to update <%= entityClass %> partially : {}", <%= instanceName %>);
         if (<%= instanceName %>.get<%= primaryKey.nameCapitalized %>() == null) {
             throw new BadRequestAlertException("Invalid id", ENTITY_NAME, "idnull");

--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -81,8 +81,6 @@ import reactor.core.publisher.Mono;
 import javax.validation.constraints.Pattern;
 <%_ if (authenticationType !== 'oauth2') { _%>
 import javax.validation.Valid;
-import java.net.URI;
-import java.net.URISyntaxException;
 <%_ } _%>
 <%_ if (!reactive) { _%>
 import java.util.*;
@@ -161,14 +159,11 @@ public class UserResource {
      *
      * @param userDTO the user to create.
      * @return the {@link ResponseEntity} with status {@code 201 (Created)} and with body the new user, or with status {@code 400 (Bad Request)} if the login or email is already in use.
-    <%_ if (!reactive) { _%>
-     * @throws URISyntaxException if the Location URI syntax is incorrect.
-    <%_ } _%>
      * @throws BadRequestAlertException {@code 400 (Bad Request)} if the login or email is already in use.
      */
     @PostMapping("/users")
     @PreAuthorize("hasAuthority(\"" + AuthoritiesConstants.ADMIN + "\")")
-    public <% if (reactive) { %>Mono<ResponseEntity<<%= asEntity('User') %>>><% } else { %>ResponseEntity<<%= asEntity('User') %>><% } %> createUser(@Valid @RequestBody <%= asDto('AdminUser') %> userDTO)<% if (!reactive) { %> throws URISyntaxException<% } %> {
+    public <% if (reactive) { %>Mono<ResponseEntity<<%= asEntity('User') %>>><% } else { %>ResponseEntity<<%= asEntity('User') %>><% } %> createUser(@Valid @RequestBody <%= asDto('AdminUser') %> userDTO) {
         log.debug("REST request to save User : {}", userDTO);
 
         if (userDTO.getId() != null) {
@@ -182,7 +177,7 @@ public class UserResource {
         } else {
             <%= asEntity('User') %> newUser = userService.createUser(userDTO);
             mailService.sendCreationEmail(newUser);
-            return ResponseEntity.created(new URI("/api/admin/users/" + newUser.getLogin()))
+            return ResponseEntity.status(HttpStatus.CREATED)
                 .headers(HeaderUtil.createAlert(applicationName, <% if (enableTranslation) { %> "userManagement.created"<% } else { %> "A user is created with identifier " + newUser.getLogin()<% } %>, newUser.getLogin()))
                 .body(newUser);
         }
@@ -205,13 +200,10 @@ public class UserResource {
             })
             .doOnSuccess(mailService::sendCreationEmail)
             .map(user -> {
-                try {
-                    return ResponseEntity.created(new URI("/api/admin/users/" + user.getLogin()))
-                        .headers(HeaderUtil.createAlert(applicationName, "userManagement.created", user.getLogin()))
-                        .body(user);
-                } catch (URISyntaxException e) {
-                    throw new RuntimeException(e);
-                }
+                return ResponseEntity
+                    .status(HttpStatus.CREATED)
+                    .headers(HeaderUtil.createAlert(applicationName, "userManagement.created", user.getLogin()))
+                    .body(user);
             });
         <%_ } _%>
     }


### PR DESCRIPTION
Remove _location_ header after a user or entity creation.

My understanding of this header is:
The URI that is passed could be used to **redirect** to this url from the browser right after creation, but we do not use this.
Also the current URI that is set is the API path (ex: /api/admin/users/user) and for me it is a not a URL that makes sense to be redirected on it. (I may be wrong be why redirect to the JSON resource instead of the "UI" of this resource).

Also it will fix the sonar security issue.