### PR TITLE
Drop fieldsNoId.

### DIFF
--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -22,7 +22,7 @@ const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const {
-    SUPPORTED_CLIENT_FRAMEWORKS: { VUE },
+    SUPPORTED_CLIENT_FRAMEWORKS: { ANGULAR },
 } = require('../generator-constants');
 
 let useBlueprints;
@@ -31,11 +31,6 @@ module.exports = class extends BaseBlueprintGenerator {
     constructor(args, opts) {
         super(args, opts);
         this.entity = opts.context;
-
-        if (this.jhipsterConfig.clientFramework === VUE) {
-            // Remove fields with custom ids, drop once templates supports them
-            this.entity = { ...this.entity, fields: this.entity.fieldsNoId };
-        }
 
         utils.copyObjectProps(this, this.entity);
         this.jhipsterContext = opts.jhipsterContext || opts.context;

--- a/generators/entity-client/index.js
+++ b/generators/entity-client/index.js
@@ -22,7 +22,7 @@ const writeFiles = require('./files').writeFiles;
 const utils = require('../utils');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');
 const {
-    SUPPORTED_CLIENT_FRAMEWORKS: { ANGULAR },
+    SUPPORTED_CLIENT_FRAMEWORKS: { VUE },
 } = require('../generator-constants');
 
 let useBlueprints;
@@ -32,7 +32,7 @@ module.exports = class extends BaseBlueprintGenerator {
         super(args, opts);
         this.entity = opts.context;
 
-        if (this.jhipsterConfig.clientFramework !== ANGULAR) {
+        if (this.jhipsterConfig.clientFramework === VUE) {
             // Remove fields with custom ids, drop once templates supports them
             this.entity = { ...this.entity, fields: this.entity.fieldsNoId };
         }

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -107,7 +107,7 @@ describe('<%= entityClass %> e2e test', () => {
         await <%= entityInstance %>ComponentsPage.clickOnCreateButton();
 
         await promise.all([
-        <%_ fieldsNoId.forEach((field) => {
+        <%_ fields.filter(field => !field.id).forEach((field) => {
             const fieldName = field.fieldName;
             const fieldNameCapitalized = field.fieldNameCapitalized;
             const fieldType = field.fieldType;
@@ -151,7 +151,7 @@ describe('<%= entityClass %> e2e test', () => {
         <%_ }); _%>
         ]);
 
-    <%_ fieldsNoId.forEach((field) => {
+    <%_ fields.filter(field => !field.id).forEach((field) => {
         const fieldName = field.fieldName;
         const fieldNameCapitalized = field.fieldNameCapitalized;
         const fieldType = field.fieldType;

--- a/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
@@ -143,7 +143,7 @@ describe('<%= entityClass %> e2e test', () => {
     cy.wait('@entitiesRequest');
     cy.get(entityCreateButtonSelector).click({force: true});
     cy.getEntityCreateUpdateHeading('<%= entityClass %>');
-    <%_ fieldsNoId.forEach((field) => {
+    <%_ fields.filter(field => !field.id).forEach((field) => {
       const fieldName = field.fieldName;
       const fieldNameCapitalized = field.fieldNameCapitalized;
       const fieldType = field.fieldType;

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -56,10 +56,10 @@ export const <%= entityReactName %>Detail = (props: I<%= entityReactName %>Detai
           <Translate contentKey="<%= i18nKeyPrefix %>.detail.title"><%= entityClass %></Translate> [<strong>{<%= entityInstance %>Entity.id}</strong>]
         </h2>
           <dl className="jh-entity-details">
-          <%_ for (idx in fields) {
-              const fieldType = fields[idx].fieldType;
-              const fieldName = fields[idx].fieldName;
-              const fieldNameHumanized = fields[idx].fieldNameHumanized;
+          <%_ for (field of fields) {
+              const fieldType = field.fieldType;
+              const fieldName = field.fieldName;
+              const fieldNameHumanized = field.fieldNameHumanized;
           _%>
             <dt>
               <span id="<%= fieldName %>">
@@ -67,12 +67,12 @@ export const <%= entityReactName %>Detail = (props: I<%= entityReactName %>Detai
                   <%= fieldNameHumanized %>
                 </Translate>
               </span>
-              <%_ if (fields[idx].javadoc) { _%>
+              <%_ if (field.javadoc) { _%>
               <UncontrolledTooltip target="<%= fieldName %>">
                 <%_ if (enableTranslation) { _%>
                 <Translate contentKey="<%= i18nKeyPrefix %>.help.<%= fieldName %>"/>
                 <%_ } else { _%>
-                <%= fields[idx].javadoc %>
+                <%= field.javadoc %>
                 <%_ } _%>
               </UncontrolledTooltip>
               <%_ } _%>
@@ -89,7 +89,7 @@ export const <%= entityReactName %>Detail = (props: I<%= entityReactName %>Detai
             <%_
                 } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) {
 
-                  const fieldBlobType = fields[idx].fieldTypeBlobContent;
+                  const fieldBlobType = field.fieldTypeBlobContent;
                   if (fieldBlobType !== 'text') {
             _%>
                 {<%= entityInstance %>Entity.<%= fieldName %> ? (
@@ -107,24 +107,24 @@ export const <%= entityReactName %>Detail = (props: I<%= entityReactName %>Detai
                   </div>
                 ) : null}
               <%_ } else { _%>
-                {<%= entityInstance %>Entity.<%= fields[idx].fieldName %>}
+                {<%= entityInstance %>Entity.<%= field.fieldName %>}
               <%_ } _%>
             <%_ } else { _%>
-            {<%= entityInstance %>Entity.<%= fields[idx].fieldName %>}
+            {<%= entityInstance %>Entity.<%= field.fieldName %>}
             <%_ } _%>
             </dd>
             <%_ } _%>
-            <%_ for (idx in relationships) {
-                const relationshipType = relationships[idx].relationshipType;
-                const ownerSide = relationships[idx].ownerSide;
-                const relationshipName = relationships[idx].relationshipName;
-                const relationshipFieldName = relationships[idx].relationshipFieldName;
-                const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
-                const otherEntityName = relationships[idx].otherEntityName;
-                const otherEntityStateName = relationships[idx].otherEntityStateName;
-                const otherEntityField = relationships[idx].otherEntityField;
-                const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
+            <%_ for (relationship of relationships) {
+                const relationshipType = relationship.relationshipType;
+                const ownerSide = relationship.ownerSide;
+                const relationshipName = relationship.relationshipName;
+                const relationshipFieldName = relationship.relationshipFieldName;
+                const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
+                const relationshipNameHumanized = relationship.relationshipNameHumanized;
+                const otherEntityName = relationship.otherEntityName;
+                const otherEntityStateName = relationship.otherEntityStateName;
+                const otherEntityField = relationship.otherEntityField;
+                const otherEntityFieldCapitalized = relationship.otherEntityFieldCapitalized;
                 if (relationshipType === 'many-to-one'
                 || (relationshipType === 'one-to-one' && ownerSide === true)
                 || (relationshipType === 'many-to-many' && ownerSide === true)) { _%>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-detail.tsx.ejs
@@ -56,7 +56,7 @@ export const <%= entityReactName %>Detail = (props: I<%= entityReactName %>Detai
           <Translate contentKey="<%= i18nKeyPrefix %>.detail.title"><%= entityClass %></Translate> [<strong>{<%= entityInstance %>Entity.id}</strong>]
         </h2>
           <dl className="jh-entity-details">
-          <%_ for (field of fields) {
+          <%_ for (field of fields.filter(field => !field.id)) {
               const fieldType = field.fieldType;
               const fieldName = field.fieldName;
               const fieldNameHumanized = field.fieldNameHumanized;

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -18,7 +18,7 @@
 -%>
 <%_
 const i18nToLoad = [entityInstance];
-for (const field of fields) {
+for (const field of fields.filter(field => !field.id)) {
     if (field.fieldIsEnum === true) {
         i18nToLoad.push(field.enumInstance);
     }
@@ -183,7 +183,7 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
   }, [props.updateSuccess]);
 
   const saveEntity = (event, errors, values) => {
-    <%_ for (field of fields) {
+    <%_ for (field of fields.filter(field => !field.id)) {
         const fieldType = field.fieldType;
         const fieldName = field.fieldName;
     _%>
@@ -234,7 +234,7 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
             </AvGroup>
             : null
           }
-          <%_ for (field of fields) {
+          <%_ for (field of fields.filter(field => !field.id)) {
               const fieldType = field.fieldType;
               const fieldName = field.fieldName;
               const fieldNameHumanized = field.fieldNameHumanized;

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity-update.tsx.ejs
@@ -18,9 +18,9 @@
 -%>
 <%_
 const i18nToLoad = [entityInstance];
-for (const idx in fields) {
-    if (fields[idx].fieldIsEnum === true) {
-        i18nToLoad.push(fields[idx].enumInstance);
+for (const field of fields) {
+    if (field.fieldIsEnum === true) {
+        i18nToLoad.push(field.enumInstance);
     }
 }
 _%>
@@ -183,9 +183,9 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
   }, [props.updateSuccess]);
 
   const saveEntity = (event, errors, values) => {
-    <%_ for (idx in fields) {
-        const fieldType = fields[idx].fieldType;
-        const fieldName = fields[idx].fieldName;
+    <%_ for (field of fields) {
+        const fieldType = field.fieldType;
+        const fieldName = field.fieldName;
     _%>
     <%_ if (fieldType === 'Instant' || fieldType === 'ZonedDateTime')  { _%>
     values.<%= fieldName %> = convertDateTimeToServer(values.<%= fieldName %>);
@@ -234,10 +234,10 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
             </AvGroup>
             : null
           }
-          <%_ for (idx in fields) {
-              const fieldType = fields[idx].fieldType;
-              const fieldName = fields[idx].fieldName;
-              const fieldNameHumanized = fields[idx].fieldNameHumanized;
+          <%_ for (field of fields) {
+              const fieldType = field.fieldType;
+              const fieldName = field.fieldName;
+              const fieldNameHumanized = field.fieldNameHumanized;
           _%>
           <AvGroup <% if (fieldType === 'Boolean') { %> check <% } %>>
           <%_ if (fieldType === 'Boolean') { _%>
@@ -278,8 +278,8 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
               <%- include('react_validators'); %>
             />
           <%_
-            } else if (fields[idx].fieldIsEnum) {
-              const enumValues = fields[idx].enumValues;
+            } else if (field.fieldIsEnum) {
+              const enumValues = field.enumValues;
           _%>
             <Label id="<%= fieldName %>Label" for="<%= entityFileName %>-<%= fieldName %>">
               <Translate contentKey="<%= i18nKeyPrefix %>.<%= fieldName %>">
@@ -317,7 +317,7 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
           <%_
           } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) {
 
-            const fieldBlobType = fields[idx].fieldTypeBlobContent;
+            const fieldBlobType = field.fieldTypeBlobContent;
             if (fieldBlobType !== 'text') {
               const isAnImage = fieldBlobType === 'image';
               const capitalizedFirstLetter =  _.upperFirst(fieldName);
@@ -373,12 +373,12 @@ export const <%= entityReactName %>Update = (props: I<%= entityReactName %>Updat
           </Label>
           <AvField id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>" type="text" name="<%= fieldName %>" <%- include('react_validators'); %>/>
         <%_ } _%>
-          <%_ if (fields[idx].javadoc) { _%>
+          <%_ if (field.javadoc) { _%>
           <UncontrolledTooltip target="<%= fieldName %>Label">
             <%_ if (enableTranslation) { _%>
             <Translate contentKey="<%= i18nKeyPrefix %>.help.<%= fieldName %>"/>
             <%_ } else { _%>
-            <%= fields[idx].javadoc %>
+            <%= field.javadoc %>
             <%_ } _%>
           </UncontrolledTooltip>
           <%_ } _%>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,10 +17,10 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(primaryKey, fields, relationships, dto, 'string', embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKey, fields.filter(field => !field.id), relationships, dto, 'string', embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
-const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields, 'react');
-const enumImports = generateEntityClientEnumImports(fields);
+const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields.filter(field => !field.id), 'react');
+const enumImports = generateEntityClientEnumImports(fields.filter(field => !field.id));
 %>
 <%_ if (fieldsContainInstant || fieldsContainZonedDateTime || fieldsContainLocalDate) { _%>
 import dayjs from 'dayjs';

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
@@ -304,7 +304,7 @@ export const <%= entityReactName %> = (props: I<%= entityReactName %>Props) => {
               <thead>
                 <tr>
                   <th <% if (pagination !== 'no') { %> className="hand" onClick={sort('id')} <%_ } _%>><Translate contentKey="global.field.id">ID</Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
-                  <%_ for (field of fields) { _%>
+                  <%_ for (field of fields.filter(field => !field.id)) { _%>
                   <th<% if (pagination !== 'no') { %> className="hand" onClick={sort('<%= field.fieldName %>')} <%_ } _%>><Translate contentKey="<%= `${i18nKeyPrefix}.${field.fieldName}` %>"><%= field.fieldNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
                   <%_ } _%>
                   <%_ for (relationship of relationships) { _%>
@@ -327,7 +327,7 @@ export const <%= entityReactName %> = (props: I<%= entityReactName %>Props) => {
                         {<%= entityInstance %>.id}
                       </Button>
                     </td>
-                    <%_ for (field of fields) {
+                    <%_ for (field of fields.filter(field => !field.id)) {
                       const fieldType = field.fieldType;
                       const fieldName = field.fieldName;
                       const fieldIsEnum = field.fieldIsEnum;

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/entity.tsx.ejs
@@ -304,15 +304,15 @@ export const <%= entityReactName %> = (props: I<%= entityReactName %>Props) => {
               <thead>
                 <tr>
                   <th <% if (pagination !== 'no') { %> className="hand" onClick={sort('id')} <%_ } _%>><Translate contentKey="global.field.id">ID</Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
-                  <%_ for (idx in fields) { _%>
-                  <th<% if (pagination !== 'no') { %> className="hand" onClick={sort('<%= fields[idx].fieldName %>')} <%_ } _%>><Translate contentKey="<%= `${i18nKeyPrefix}.${fields[idx].fieldName}` %>"><%= fields[idx].fieldNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
+                  <%_ for (field of fields) { _%>
+                  <th<% if (pagination !== 'no') { %> className="hand" onClick={sort('<%= field.fieldName %>')} <%_ } _%>><Translate contentKey="<%= `${i18nKeyPrefix}.${field.fieldName}` %>"><%= field.fieldNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
                   <%_ } _%>
-                  <%_ for (idx in relationships) { _%>
-                      <%_ if (relationships[idx].relationshipType === 'many-to-one'
-                      || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
-                      || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
-                      const fieldName = "." + relationships[idx].otherEntityField; _%>
-                  <th<% if (pagination !== 'no') { %> <% } %>><Translate contentKey="<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>"><%= relationships[idx].relationshipNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
+                  <%_ for (relationship of relationships) { _%>
+                      <%_ if (relationship.relationshipType === 'many-to-one'
+                      || (relationship.relationshipType === 'one-to-one' && relationship.ownerSide === true)
+                      || (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === true && pagination === 'no')) {
+                      const fieldName = "." + relationship.otherEntityField; _%>
+                  <th<% if (pagination !== 'no') { %> <% } %>><Translate contentKey="<%= `${i18nKeyPrefix}.${relationship.relationshipName}` %>"><%= relationship.relationshipNameHumanized %></Translate><% if (pagination !== 'no') { %> <FontAwesomeIcon icon="sort" /><% } %></th>
                       <%_ } _%>
                   <%_ } _%>
                   <th />
@@ -327,14 +327,14 @@ export const <%= entityReactName %> = (props: I<%= entityReactName %>Props) => {
                         {<%= entityInstance %>.id}
                       </Button>
                     </td>
-                    <%_ for (idx in fields) {
-                      const fieldType = fields[idx].fieldType;
-                      const fieldName = fields[idx].fieldName;
-                      const fieldIsEnum = fields[idx].fieldIsEnum;
+                    <%_ for (field of fields) {
+                      const fieldType = field.fieldType;
+                      const fieldName = field.fieldName;
+                      const fieldIsEnum = field.fieldIsEnum;
                     _%>
                     <td>
                     <%_ if (fieldType === 'Boolean') { _%>
-                      {<%= entityInstance %>.<%= fields[idx].fieldName %> ? 'true' : 'false'}
+                      {<%= entityInstance %>.<%= field.fieldName %> ? 'true' : 'false'}
                     <%_ } else if (fieldType === 'Instant' || fieldType === 'ZonedDateTime') { _%>
                       {<%= entityInstance %>.<%= fieldName %> ? <TextFormat type="date" value={<%= entityInstance %>.<%= fieldName %>} format={APP_DATE_FORMAT} />: null}
                     <%_ } else if (fieldType === 'Duration') { _%>
@@ -346,7 +346,7 @@ export const <%= entityReactName %> = (props: I<%= entityReactName %>Props) => {
                     <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType)) { _%>
                       <%_
                         // blobFields
-                        const fieldBlobType = fields[idx].fieldTypeBlobContent;
+                        const fieldBlobType = field.fieldTypeBlobContent;
                         if (fieldBlobType !== 'text') {
                       _%>
                         {<%= entityInstance %>.<%= fieldName %> ? (
@@ -372,15 +372,15 @@ export const <%= entityReactName %> = (props: I<%= entityReactName %>Props) => {
                     <%_ } _%>
                     </td>
                     <%_ } _%>
-                    <%_ for (idx in relationships) {
-                      const relationshipType = relationships[idx].relationshipType;
-                      const ownerSide = relationships[idx].ownerSide;
-                      const relationshipFieldName = relationships[idx].relationshipFieldName;
-                      const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                      const otherEntityName = relationships[idx].otherEntityName;
-                      const otherEntityStateName = relationships[idx].otherEntityStateName;
-                      const otherEntityField = relationships[idx].otherEntityField;
-                      const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized; _%>
+                    <%_ for (relationship of relationships) {
+                      const relationshipType = relationship.relationshipType;
+                      const ownerSide = relationship.ownerSide;
+                      const relationshipFieldName = relationship.relationshipFieldName;
+                      const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
+                      const otherEntityName = relationship.otherEntityName;
+                      const otherEntityStateName = relationship.otherEntityStateName;
+                      const otherEntityField = relationship.otherEntityField;
+                      const otherEntityFieldCapitalized = relationship.otherEntityFieldCapitalized; _%>
                       <%_ if (relationshipType === 'many-to-one'
                       || (relationshipType === 'one-to-one' && ownerSide === true)
                       || (relationshipType === 'many-to-many' && ownerSide === true && pagination === 'no')) { _%>

--- a/generators/entity-client/templates/react/src/main/webapp/app/entities/react_validators.ejs
+++ b/generators/entity-client/templates/react/src/main/webapp/app/entities/react_validators.ejs
@@ -18,7 +18,6 @@
 -%>
 <%# Returns a string of all react validators required for the input field. -%>
 <%
-const field = fields[idx];
 let result = '';
 
 if (field.fieldValidate === true) {

--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity-update-page-object.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity-update-page-object.ts.ejs
@@ -47,7 +47,7 @@ export default class <%= entityClass %>UpdatePage {
     pageTitle: ElementFinder = element(by.id('<%= i18nKeyPrefix %>.home.createOrEditLabel'));
     saveButton: ElementFinder = element(by.id('save-entity'));
     cancelButton: ElementFinder = element(by.id('cancel-save'));
-    <%_ fields.forEach((field) => {
+    <%_ fields.filter(field => !field.id).forEach((field) => {
             const fieldName = field.fieldName;
             const fieldType = field.fieldType;
             const fieldIsEnum = field.fieldIsEnum;
@@ -77,7 +77,7 @@ export default class <%= entityClass %>UpdatePage {
         return this.pageTitle;
     }
 
-    <%_ fields.forEach((field) => {
+    <%_ fields.filter(field => !field.id).forEach((field) => {
             const fieldName = field.fieldName;
             const fieldNameCapitalized = field.fieldNameCapitalized;
             const fieldNameHumanized = field.fieldNameHumanized;
@@ -160,7 +160,7 @@ export default class <%= entityClass %>UpdatePage {
     }
 
     async enterData() {
-        <%_ fields.forEach((field) => {
+        <%_ fields.filter(field => !field.id).forEach((field) => {
             const fieldName = field.fieldName;
             const fieldNameCapitalized = field.fieldNameCapitalized;
             const fieldType = field.fieldType;

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
@@ -4,7 +4,7 @@
             <div v-if="<%= entityInstance %>">
                 <h2 class="jh-entity-heading" data-cy="<%= entityInstance %>DetailsHeading"><span v-text="$t('<%= i18nKeyPrefix %>.detail.title')"><%= entityAngularName %></span> {{<%= entityInstance %>.id}}</h2>
                 <dl class="row jh-entity-details">
-                    <%_ for (field of fields) {
+                    <%_ for (field of fields.filter(field => !field.id)) {
                         const fieldName = field.fieldName;
                         const fieldType = field.fieldType;
                         const fieldTypeBlobContent = field.fieldTypeBlobContent; _%>

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-details.vue.ejs
@@ -4,15 +4,15 @@
             <div v-if="<%= entityInstance %>">
                 <h2 class="jh-entity-heading" data-cy="<%= entityInstance %>DetailsHeading"><span v-text="$t('<%= i18nKeyPrefix %>.detail.title')"><%= entityAngularName %></span> {{<%= entityInstance %>.id}}</h2>
                 <dl class="row jh-entity-details">
-                    <%_ for (idx in fields) {
-                        const fieldName = fields[idx].fieldName;
-                        const fieldType = fields[idx].fieldType;
-                        const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent; _%>
+                    <%_ for (field of fields) {
+                        const fieldName = field.fieldName;
+                        const fieldType = field.fieldType;
+                        const fieldTypeBlobContent = field.fieldTypeBlobContent; _%>
                     <dt>
-                        <span v-text="$t('<%= i18nKeyPrefix %>.<%= fieldName %>')"><%= fields[idx].fieldNameHumanized %></span>
+                        <span v-text="$t('<%= i18nKeyPrefix %>.<%= fieldName %>')"><%= field.fieldNameHumanized %></span>
                     </dt>
                     <dd>
-                        <%_ if (fields[idx].fieldIsEnum) { _%>
+                        <%_ if (field.fieldIsEnum) { _%>
                         <span v-text="$t('<%= frontendAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>)">{{<%= entityInstance %>.<%= fieldName %>}}</span>
                         <%_ } else if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
                         <div v-if="<%= entityInstance %>.<%= fieldName %>">
@@ -39,19 +39,19 @@
                         <%_ } _%>
                     </dd>
                     <%_ } _%>
-                    <%_ for (idx in relationships) {
-                        const relationshipType = relationships[idx].relationshipType;
-                        const ownerSide = relationships[idx].ownerSide;
-                        const relationshipName = relationships[idx].relationshipName;
-                        const relationshipFieldName = relationships[idx].relationshipFieldName;
-                        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                        const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
-                        const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
-                        const otherEntityName = relationships[idx].otherEntityName;
-                        const otherEntityStateName = relationships[idx].otherEntityStateName;
-                        const otherEntityField = relationships[idx].otherEntityField;
-                        const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
-                        const otherEntityAngularName = relationships[idx].otherEntityAngularName;
+                    <%_ for (relationship of relationships) {
+                        const relationshipType = relationship.relationshipType;
+                        const ownerSide = relationship.ownerSide;
+                        const relationshipName = relationship.relationshipName;
+                        const relationshipFieldName = relationship.relationshipFieldName;
+                        const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
+                        const relationshipNameHumanized = relationship.relationshipNameHumanized;
+                        const relationshipNameCapitalized = relationship.relationshipNameCapitalized;
+                        const otherEntityName = relationship.otherEntityName;
+                        const otherEntityStateName = relationship.otherEntityStateName;
+                        const otherEntityField = relationship.otherEntityField;
+                        const otherEntityFieldCapitalized = relationship.otherEntityFieldCapitalized;
+                        const otherEntityAngularName = relationship.otherEntityAngularName;
                         if (relationshipType === 'many-to-one'
                         || (relationshipType === 'one-to-one' && ownerSide === true)
                         || (relationshipType === 'many-to-many' && ownerSide === true)) { _%>

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
@@ -5,33 +5,33 @@ import { Component,<% if (!fieldsContainBlob) { %> Vue,<% } %> Inject } from 'vu
 <% } %>
 <%_
   let fieldsContainedValidators = [];
-  for (idx in fields) {
-    if (fields[idx].fieldValidate === true) {
-      if (!fieldsContainedValidators.includes('numeric') && ['Integer', 'Long'].includes(fields[idx].fieldType)) {
+  for (field of fields) {
+    if (field.fieldValidate === true) {
+      if (!fieldsContainedValidators.includes('numeric') && ['Integer', 'Long'].includes(field.fieldType)) {
         fieldsContainedValidators.push('numeric');
       }
-      if (!fieldsContainedValidators.includes('decimal') && ['Float', 'Double', 'BigDecimal'].includes(fields[idx].fieldType)) {
+      if (!fieldsContainedValidators.includes('decimal') && ['Float', 'Double', 'BigDecimal'].includes(field.fieldType)) {
         fieldsContainedValidators.push('decimal');
       }
-      if (!fieldsContainedValidators.includes('required') && fields[idx].fieldValidateRules.includes('required')) {
+      if (!fieldsContainedValidators.includes('required') && field.fieldValidateRules.includes('required')) {
         fieldsContainedValidators.push('required');
       }
-      if (!fieldsContainedValidators.includes('minLength') && fields[idx].fieldValidateRules.includes('minlength')) {
+      if (!fieldsContainedValidators.includes('minLength') && field.fieldValidateRules.includes('minlength')) {
         fieldsContainedValidators.push('minLength');
       }
-      if (!fieldsContainedValidators.includes('maxLength') && fields[idx].fieldValidateRules.includes('maxlength')) {
+      if (!fieldsContainedValidators.includes('maxLength') && field.fieldValidateRules.includes('maxlength')) {
         fieldsContainedValidators.push('maxLength');
       }
-      if (!fieldsContainedValidators.includes('minValue') && fields[idx].fieldValidateRules.includes('min')) {
+      if (!fieldsContainedValidators.includes('minValue') && field.fieldValidateRules.includes('min')) {
         fieldsContainedValidators.push('minValue');
       }
-      if (!fieldsContainedValidators.includes('maxValue') && fields[idx].fieldValidateRules.includes('max')) {
+      if (!fieldsContainedValidators.includes('maxValue') && field.fieldValidateRules.includes('max')) {
         fieldsContainedValidators.push('maxValue');
       }
     }
   }
-  for (idx in relationships) {
-    if (relationships[idx].relationshipValidate === true) {
+  for (relationship of relationships) {
+    if (relationship.relationshipValidate === true) {
       if (!fieldsContainedValidators.includes('required')) {
         fieldsContainedValidators.push('required');
       }
@@ -43,9 +43,9 @@ import { Component,<% if (!fieldsContainBlob) { %> Vue,<% } %> Inject } from 'vu
 <%_ } _%>
 <%_
     let dayJsIncluded = false;
-    for (idx in fields) {
-        const fieldName = fields[ idx ].fieldName;
-        const fieldType = fields[idx].fieldType;
+    for (field of fields) {
+        const fieldName = field.fieldName;
+        const fieldType = field.fieldType;
         if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dayJsIncluded) {
             dayJsIncluded = true;
 _%>
@@ -56,14 +56,14 @@ import { DATE_TIME_LONG_FORMAT } from '@/shared/date/filters';
 <%_
     const importEntitiesSeen = [entityAngularName];
     let hasManyToMany = false;
-    for (idx in relationships) {
-      if (!relationships[idx].otherEntityIsEmbedded) {
-        const otherEntityAngularName = relationships[idx].otherEntityAngularName;
-        const otherEntityFileName = relationships[idx].otherEntityFileName;
-        const otherEntityFolderName = relationships[idx].otherEntityFileName;
-        const otherEntityClientRootFolder = relationships[idx].otherEntityClientRootFolder;
-        const otherEntityModelName = relationships[idx].otherEntityModelName;
-        if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) {
+    for (relationship of relationships) {
+      if (!relationship.otherEntityIsEmbedded) {
+        const otherEntityAngularName = relationship.otherEntityAngularName;
+        const otherEntityFileName = relationship.otherEntityFileName;
+        const otherEntityFolderName = relationship.otherEntityFileName;
+        const otherEntityClientRootFolder = relationship.otherEntityClientRootFolder;
+        const otherEntityModelName = relationship.otherEntityModelName;
+        if (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === true) {
           hasManyToMany = true;
         }
         if (!importEntitiesSeen.includes(otherEntityAngularName)) {
@@ -80,20 +80,20 @@ import <%= entityAngularName %>Service from './<%= entityFileName %>.service';
 
 const validations: any = {
   <%= entityInstance %>: {
-    <%_ for (idx in fields) {
-      const fieldName = fields[idx].fieldName;
-      const fieldType = fields[idx].fieldType;
+    <%_ for (field of fields) {
+      const fieldName = field.fieldName;
+      const fieldType = field.fieldType;
     _%>
     <%= fieldName %>:  {
-    <%_ if (fields[idx].fieldValidate === true) { _%>
-    <%_ if (fields[idx].fieldValidateRules.includes('required')) { _%>
+    <%_ if (field.fieldValidate === true) { _%>
+    <%_ if (field.fieldValidateRules.includes('required')) { _%>
     required,
     <%_ } _%>
-    <%_ if (fields[idx].fieldValidateRules.includes('minlength')) { _%>
-      minLength: minLength(<%= fields[idx].fieldValidateRulesMinlength %>),
+    <%_ if (field.fieldValidateRules.includes('minlength')) { _%>
+      minLength: minLength(<%= field.fieldValidateRulesMinlength %>),
     <%_ } _%>
-    <%_ if (fields[idx].fieldValidateRules.includes('maxlength')) { _%>
-      maxLength: maxLength(<%= fields[idx].fieldValidateRulesMaxlength %>),
+    <%_ if (field.fieldValidateRules.includes('maxlength')) { _%>
+      maxLength: maxLength(<%= field.fieldValidateRulesMaxlength %>),
     <%_ } _%>
     <%_ if (['Integer', 'Long'].includes(fieldType)) { _%>
       numeric,
@@ -101,20 +101,20 @@ const validations: any = {
     <%_ if (['Float', 'Double', 'BigDecimal'].includes(fieldType)) { _%>
       decimal,
     <%_ } _%>
-    <%_ if (fields[idx].fieldValidateRules.includes('min')) { _%>
-      min: minValue(<%= fields[idx].fieldValidateRulesMin %>),
+    <%_ if (field.fieldValidateRules.includes('min')) { _%>
+      min: minValue(<%= field.fieldValidateRulesMin %>),
     <%_ } _%>
-    <%_ if (fields[idx].fieldValidateRules.includes('max')) { _%>
-      max: maxValue(<%= fields[idx].fieldValidateRulesMax %>),
+    <%_ if (field.fieldValidateRules.includes('max')) { _%>
+      max: maxValue(<%= field.fieldValidateRulesMax %>),
     <%_ } _%>
 
     <%_ } _%>
     },
     <%_ } _%>
     <%_
-    for (idx in relationships) {
-      if (relationships[idx].relationshipValidate === true) { _%>
-    <%= relationships[idx].relationshipFieldName %>: {
+    for (relationship of relationships) {
+      if (relationship.relationshipValidate === true) { _%>
+    <%= relationship.relationshipFieldName %>: {
       required
     },
     <%_ } _%>
@@ -130,11 +130,11 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
   public <%= entityInstance %>: I<%= entityAngularName %> = new <%= entityAngularName %>();
   <%_
     const entitiesSeen = [entityAngularName];
-    for (idx in relationships) {
-      if (!relationships[idx].otherEntityIsEmbedded) {
-        const otherEntityName = relationships[idx].otherEntityName;
-        const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-        const otherEntityAngularName = relationships[idx].otherEntityAngularName;
+    for (relationship of relationships) {
+      if (!relationship.otherEntityIsEmbedded) {
+        const otherEntityName = relationship.otherEntityName;
+        const otherEntityNamePlural = relationship.otherEntityNamePlural;
+        const otherEntityAngularName = relationship.otherEntityAngularName;
         if (!(otherEntityAngularName === 'User' && authenticationType === "oauth2")) {
   _%>
   <%_ if (!entitiesSeen.includes(otherEntityAngularName)) { %>
@@ -168,10 +168,10 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
     );
     <%_ if (hasManyToMany) { _%>
     <%_
-      for (idx in relationships) {
-      const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-      if (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) {
-      const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
+      for (relationship of relationships) {
+      const otherEntityNamePlural = relationship.otherEntityNamePlural;
+      if (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === true) {
+      const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
     _%>
     this.<%= entityInstance %>.<%= relationshipFieldNamePlural %> = [];
     <%_ } } _%>
@@ -180,9 +180,9 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
 
   public save() : void {
     this.isSaving = true;
-    <%_ for (idx in fields) {
-        const fieldName = fields[ idx ].fieldName;
-        const fieldType = fields[idx].fieldType;
+    <%_ for (field of fields) {
+        const fieldName = field.fieldName;
+        const fieldType = field.fieldType;
     } _%>
     if (this.<%= entityInstance %>.id) {
       this.<%= entityInstance %>Service().update(this.<%= entityInstance %>).then((param) => {
@@ -223,9 +223,9 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
 
   <%_
     let dateFunctionIncluded = false;
-    for (idx in fields) {
-        const fieldName = fields[ idx ].fieldName;
-        const fieldType = fields[idx].fieldType;
+    for (field of fields) {
+        const fieldName = field.fieldName;
+        const fieldType = field.fieldType;
         if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dateFunctionIncluded) {
             dateFunctionIncluded = true;
   _%>
@@ -256,9 +256,9 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
   public retrieve<%= entityAngularName %>(<%= entityInstance %>Id) : void {
     this.<%= entityInstance %>Service().find(<%= entityInstance %>Id).then((res) => {
 <%_
-        for (idx in fields) {
-            const fieldName = fields[idx].fieldName;
-            const fieldType = fields[idx].fieldType;
+        for (field of fields) {
+            const fieldName = field.fieldName;
+            const fieldType = field.fieldType;
             if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType)) {
 _%>
       res.<%= fieldName %> = new Date(res.<%= fieldName %>);
@@ -290,11 +290,11 @@ _%>
   public initRelationships() : void {
     <%_
         let entitiesSet = new Set();
-        for (idx in relationships) {
-          if (!relationships[idx].otherEntityIsEmbedded) {
-          const otherEntityName = relationships[idx].otherEntityName;
-          const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-          const otherEntityAngularName = relationships[idx].otherEntityAngularName;
+        for (relationship of relationships) {
+          if (!relationship.otherEntityIsEmbedded) {
+          const otherEntityName = relationship.otherEntityName;
+          const otherEntityNamePlural = relationship.otherEntityNamePlural;
+          const otherEntityAngularName = relationship.otherEntityAngularName;
           if (!(otherEntityAngularName === 'User' && authenticationType === "oauth2") && !entitiesSet.has(otherEntityName)) {
             entitiesSet.add(otherEntityName);
     _%>

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
@@ -5,7 +5,7 @@ import { Component,<% if (!fieldsContainBlob) { %> Vue,<% } %> Inject } from 'vu
 <% } %>
 <%_
   let fieldsContainedValidators = [];
-  for (field of fields) {
+  for (field of fields.filter(field => !field.id)) {
     if (field.fieldValidate === true) {
       if (!fieldsContainedValidators.includes('numeric') && ['Integer', 'Long'].includes(field.fieldType)) {
         fieldsContainedValidators.push('numeric');
@@ -43,7 +43,7 @@ import { Component,<% if (!fieldsContainBlob) { %> Vue,<% } %> Inject } from 'vu
 <%_ } _%>
 <%_
     let dayJsIncluded = false;
-    for (field of fields) {
+    for (field of fields.filter(field => !field.id)) {
         const fieldName = field.fieldName;
         const fieldType = field.fieldType;
         if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dayJsIncluded) {
@@ -80,7 +80,7 @@ import <%= entityAngularName %>Service from './<%= entityFileName %>.service';
 
 const validations: any = {
   <%= entityInstance %>: {
-    <%_ for (field of fields) {
+    <%_ for (field of fields.filter(field => !field.id)) {
       const fieldName = field.fieldName;
       const fieldType = field.fieldType;
     _%>
@@ -180,7 +180,7 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
 
   public save() : void {
     this.isSaving = true;
-    <%_ for (field of fields) {
+    <%_ for (field of fields.filter(field => !field.id)) {
         const fieldName = field.fieldName;
         const fieldType = field.fieldType;
     } _%>
@@ -223,7 +223,7 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
 
   <%_
     let dateFunctionIncluded = false;
-    for (field of fields) {
+    for (field of fields.filter(field => !field.id)) {
         const fieldName = field.fieldName;
         const fieldType = field.fieldType;
         if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dateFunctionIncluded) {
@@ -256,7 +256,7 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
   public retrieve<%= entityAngularName %>(<%= entityInstance %>Id) : void {
     this.<%= entityInstance %>Service().find(<%= entityInstance %>Id).then((res) => {
 <%_
-        for (field of fields) {
+        for (field of fields.filter(field => !field.id)) {
             const fieldName = field.fieldName;
             const fieldType = field.fieldType;
             if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType)) {

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.vue.ejs
@@ -9,12 +9,12 @@
                         <input type="text" class="form-control" id="id" name="id"
                                v-model="<%= entityInstance %>.id" readonly />
                     </div>
-                    <%_ for (idx in fields) {
-                        const fieldName = fields[idx].fieldName;
-                        const fieldNameCapitalized = fields[idx].fieldNameCapitalized;
-                        const fieldNameHumanized = fields[idx].fieldNameHumanized;
-                        const fieldType = fields[idx].fieldType;
-                        const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent;
+                    <%_ for (field of fields) {
+                        const fieldName = field.fieldName;
+                        const fieldNameCapitalized = field.fieldNameCapitalized;
+                        const fieldNameHumanized = field.fieldNameHumanized;
+                        const fieldType = field.fieldType;
+                        const fieldTypeBlobContent = field.fieldTypeBlobContent;
                         let fieldInputType = 'text';
                         let fieldInputClass = 'form-control';
                         let ngModelOption = '';
@@ -34,10 +34,10 @@
                     _%>
                     <div class="form-group">
                         <label class="form-control-label" v-text="$t('<%= translationKey %>')" for="<%= entityFileName %>-<%= fieldName %>"><%= fieldNameHumanized %></label>
-                        <%_ if (fields[idx].fieldIsEnum) { _%>
-                        <select class="form-control" name="<%= fieldName %>" :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }" v-model="$v.<%= entityInstance %>.<%= fieldName %>.$model" id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>" <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) { %> required<% } %>>
+                        <%_ if (field.fieldIsEnum) { _%>
+                        <select class="form-control" name="<%= fieldName %>" :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }" v-model="$v.<%= entityInstance %>.<%= fieldName %>.$model" id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>" <% if (field.fieldValidate === true && field.fieldValidateRules.includes('required')) { %> required<% } %>>
                         <%_ const enumPrefix = frontendAppName + '.'+ fieldType;
-                            const values = fields[idx].enumValues;
+                            const values = field.enumValues;
                             for (key in values) {
                                 const enumValue = values[key]; _%>
                             <option value="<%= enumValue.name %>" v-bind:label="$t('<%=enumPrefix%>.<%= enumValue.name %>')"><%= enumValue.value %></option>
@@ -85,62 +85,62 @@
                                 </b-form-datepicker>
                             </b-input-group-prepend>
                             <b-form-input id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>" type="text" class="<%= fieldInputClass %>" name="<%= fieldName %>"  :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }"
-                            v-model="$v.<%= entityInstance %>.<%= fieldName %>.$model" <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) { %> required<% } %> />
+                            v-model="$v.<%= entityInstance %>.<%= fieldName %>.$model" <% if (field.fieldValidate === true && field.fieldValidateRules.includes('required')) { %> required<% } %> />
                         </b-input-group>
                         <%_ } else if (['Instant'].includes(fieldType)) { _%>
                         <div class="d-flex">
                             <input id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>" type="datetime-local" class="<%= fieldInputClass %>" name="<%= fieldName %>" :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }"
-                            <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) { %> required<% } %>
+                            <% if (field.fieldValidate === true && field.fieldValidateRules.includes('required')) { %> required<% } %>
                             :value="convertDateTimeFromServer($v.<%= entityInstance %>.<%= fieldName %>.$model)"
                             @change="updateInstantField('<%= fieldName %>', $event)"/>
                         </div>
                         <%_ } else if (['ZonedDateTime'].includes(fieldType)) { _%>
                         <div class="d-flex">
                             <input id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>" type="datetime-local" class="<%= fieldInputClass %>" name="<%= fieldName %>" :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }"
-                            <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) { %> required<% } %>
+                            <% if (field.fieldValidate === true && field.fieldValidateRules.includes('required')) { %> required<% } %>
                             :value="convertDateTimeFromServer($v.<%= entityInstance %>.<%= fieldName %>.$model)"
                             @change="updateZonedDateTimeField('<%= fieldName %>', $event)"/>
                         </div>
                         <%_ } else if (fieldTypeBlobContent === 'text') { _%>
                         <textarea class="<%= fieldInputClass %>" name="<%= fieldName %>" id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>"
-                            :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }" v-model="$v.<%= entityInstance %>.<%= fieldName %>.$model" <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) { %> required<% } %>></textarea>
+                            :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }" v-model="$v.<%= entityInstance %>.<%= fieldName %>.$model" <% if (field.fieldValidate === true && field.fieldValidateRules.includes('required')) { %> required<% } %>></textarea>
                         <%_ } else { _%>
                         <input type="<%= fieldInputType %>" class="<%= fieldInputClass %>" name="<%= fieldName %>" id="<%= entityFileName %>-<%= fieldName %>" data-cy="<%= fieldName %>"
-                            :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }" v-model<% if (fieldInputType === 'number') { %>.number<% } %>="$v.<%= entityInstance %>.<%= fieldName %>.$model" <% if (fields[idx].fieldValidate === true && fields[idx].fieldValidateRules.includes('required')) { %> required<% } %>/>
+                            :class="{'valid': !$v.<%= entityInstance %>.<%= fieldName %>.$invalid, 'invalid': $v.<%= entityInstance %>.<%= fieldName %>.$invalid }" v-model<% if (fieldInputType === 'number') { %>.number<% } %>="$v.<%= entityInstance %>.<%= fieldName %>.$model" <% if (field.fieldValidate === true && field.fieldValidateRules.includes('required')) { %> required<% } %>/>
                             <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent !== 'text') { _%>
                         <input type="hidden" class="<%= fieldInputClass %>" name="<%= fieldName %>ContentType" id="<%= entityFileName %>-<%= fieldName %>ContentType"
                             v-model="<%= entityInstance %>.<%= fieldName %>ContentType" />
                             <%_ } _%>
                         <%_ } _%>
                         <%_ } _%>
-                        <%_ if (fields[idx].fieldValidate === true) { _%>
+                        <%_ if (field.fieldValidate === true) { _%>
                         <div v-if="$v.<%= entityInstance %>.<%= fieldName %>.$anyDirty && $v.<%= entityInstance %>.<%= fieldName %>.$invalid">
-                            <%_ if (fields[idx].fieldValidateRules.includes('required')) { _%>
+                            <%_ if (field.fieldValidateRules.includes('required')) { _%>
                             <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.required" v-text="$t('entity.validation.required')">
                                 This field is required.
                             </small>
                             <%_ } _%>
-                            <%_ if (fields[idx].fieldValidateRules.includes('minlength')) { _%>
-                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.minLength" v-text="$t('entity.validation.minlength', {min: <%= fields[idx].fieldValidateRulesMinlength %>})">
-                                This field is required to be at least <%= fields[idx].fieldValidateRulesMinlength %> characters.
+                            <%_ if (field.fieldValidateRules.includes('minlength')) { _%>
+                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.minLength" v-text="$t('entity.validation.minlength', {min: <%= field.fieldValidateRulesMinlength %>})">
+                                This field is required to be at least <%= field.fieldValidateRulesMinlength %> characters.
                             </small>
                             <%_ } _%>
-                            <%_ if (fields[idx].fieldValidateRules.includes('maxlength')) { _%>
-                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.maxLength" v-text="$t('entity.validation.maxlength', {max: <%= fields[idx].fieldValidateRulesMaxlength %>})">
-                                This field cannot be longer than <%= fields[idx].fieldValidateRulesMaxlength %> characters.
+                            <%_ if (field.fieldValidateRules.includes('maxlength')) { _%>
+                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.maxLength" v-text="$t('entity.validation.maxlength', {max: <%= field.fieldValidateRulesMaxlength %>})">
+                                This field cannot be longer than <%= field.fieldValidateRulesMaxlength %> characters.
                             </small>
                             <%_ } _%>
-                            <%_ if (fields[idx].fieldValidateRules.includes('min')) { _%>
-                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.min" v-text="$t('entity.validation.min', {min: <%= fields[idx].fieldValidateRulesMin %>})">
-                                This field should be at least <%= fields[idx].fieldValidateRulesMin %>.
+                            <%_ if (field.fieldValidateRules.includes('min')) { _%>
+                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.min" v-text="$t('entity.validation.min', {min: <%= field.fieldValidateRulesMin %>})">
+                                This field should be at least <%= field.fieldValidateRulesMin %>.
                             </small>
                             <%_ } _%>
-                            <%_ if (fields[idx].fieldValidateRules.includes('max')) { _%>
-                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.max" v-text="$t('entity.validation.max', {max: <%= fields[idx].fieldValidateRulesMax %>})">
-                                This field cannot be longer than <%= fields[idx].fieldValidateRulesMax %> characters.
+                            <%_ if (field.fieldValidateRules.includes('max')) { _%>
+                            <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.max" v-text="$t('entity.validation.max', {max: <%= field.fieldValidateRulesMax %>})">
+                                This field cannot be longer than <%= field.fieldValidateRulesMax %> characters.
                             </small>
                             <%_ } _%>
-                            <%_ if (fields[idx].fieldValidateRules.includes('pattern')) { _%>
+                            <%_ if (field.fieldValidateRules.includes('pattern')) { _%>
                             <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= fieldName %>.pattern" v-text="$t('entity.validation.pattern', {pattern: '<%= fieldNameHumanized %>'})">
                                 This field should follow pattern for "<%= fieldNameHumanized %>".
                             </small>
@@ -159,19 +159,19 @@
                         <%_ } _%>
                     </div>
                     <%_ } _%>
-                    <%_ for (idx in relationships) {
-                        const relationshipType = relationships[idx].relationshipType;
-                        const ownerSide = relationships[idx].ownerSide;
-                        const otherEntityName = relationships[idx].otherEntityName;
-                        const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-                        const otherEntityNameCapitalized = relationships[idx].otherEntityNameCapitalized;
-                        const relationshipName = relationships[idx].relationshipName;
-                        const relationshipNameHumanized = relationships[idx].relationshipNameHumanized;
-                        const relationshipFieldName = relationships[idx].relationshipFieldName;
-                        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                        const otherEntityField = relationships[idx].otherEntityField;
-                        const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
-                        const relationshipRequired = relationships[idx].relationshipRequired;
+                    <%_ for (relationship of relationships) {
+                        const relationshipType = relationship.relationshipType;
+                        const ownerSide = relationship.ownerSide;
+                        const otherEntityName = relationship.otherEntityName;
+                        const otherEntityNamePlural = relationship.otherEntityNamePlural;
+                        const otherEntityNameCapitalized = relationship.otherEntityNameCapitalized;
+                        const relationshipName = relationship.relationshipName;
+                        const relationshipNameHumanized = relationship.relationshipNameHumanized;
+                        const relationshipFieldName = relationship.relationshipFieldName;
+                        const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
+                        const otherEntityField = relationship.otherEntityField;
+                        const otherEntityFieldCapitalized = relationship.otherEntityFieldCapitalized;
+                        const relationshipRequired = relationship.relationshipRequired;
                         const translationKey = `${i18nKeyPrefix}.${relationshipName}`; _%>
                     <%_ if (relationshipType === 'many-to-one' || (relationshipType === 'one-to-one' && ownerSide === true && otherEntityName === 'user')) { _%>
                     <div class="form-group">
@@ -197,7 +197,7 @@
                             <option v-bind:value="<%= entityInstance %>.<%=relationshipFieldName %> && <%=otherEntityName %>Option.id === <%= entityInstance %>.<%=relationshipFieldName %>.id ? <%= entityInstance %>.<%=relationshipFieldName %> : <%=otherEntityName %>Option" v-for="<%=otherEntityName %>Option in <%=relationshipFieldNamePlural %>" :key="<%=otherEntityName %>Option.id">{{<%=otherEntityName %>Option.<%=otherEntityField %>}}</option>
                         </select>
                     </div>
-                    <%_ } else if (relationshipType === 'many-to-many' && relationships[idx].ownerSide === true) { _%>
+                    <%_ } else if (relationshipType === 'many-to-many' && relationship.ownerSide === true) { _%>
                     <div class="form-group">
                         <label v-text="$t('<%= translationKey %>')" for="<%= entityFileName %>-<%= relationshipName %>"><%= relationshipNameHumanized %></label>
                         <select class="form-control" id="<%= entityFileName %>-<%= relationshipName %>" data-cy="<%= relationshipFieldName %>" multiple name="<%= relationshipName %>" v-if="<%=entityInstance %>.<%=relationshipFieldNamePlural %> !== undefined" v-model="<%=entityInstance %>.<%=relationshipFieldNamePlural %>"<% if (relationshipRequired) { %> required<% } %>>
@@ -205,7 +205,7 @@
                         </select>
                     </div>
                     <%_ } _%>
-                    <%_ if (relationships[idx].relationshipValidate === true) { _%>
+                    <%_ if (relationship.relationshipValidate === true) { _%>
                     <div v-if="$v.<%= entityInstance %>.<%= relationshipName %>.$anyDirty && $v.<%= entityInstance %>.<%= relationshipName %>.$invalid">
                         <%_ if (relationshipRequired) { _%>
                         <small class="form-text text-danger" v-if="!$v.<%= entityInstance %>.<%= relationshipName %>.required" v-text="$t('entity.validation.required')">

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.vue.ejs
@@ -9,7 +9,7 @@
                         <input type="text" class="form-control" id="id" name="id"
                                v-model="<%= entityInstance %>.id" readonly />
                     </div>
-                    <%_ for (field of fields) {
+                    <%_ for (field of fields.filter(field => !field.id)) {
                         const fieldName = field.fieldName;
                         const fieldNameCapitalized = field.fieldNameCapitalized;
                         const fieldNameHumanized = field.fieldNameHumanized;

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.model.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.model.ts.ejs
@@ -17,10 +17,10 @@
  limitations under the License.
 -%>
 <%
-const variablesWithTypes = generateEntityClientFields(primaryKey, fields, relationships, dto, customDateType = 'Date', embedded);
+const variablesWithTypes = generateEntityClientFields(primaryKey, fields.filter(field => !field.id), relationships, dto, customDateType = 'Date', embedded);
 const typeImports = generateEntityClientImports(relationships, dto);
-const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields);
-const enumImports = generateEntityClientEnumImports(fields);
+const defaultVariablesValues = generateEntityClientFieldDefaultValues(fields.filter(field => !field.id));
+const enumImports = generateEntityClientEnumImports(fields.filter(field => !field.id));
 %>
 <%_ typeImports.forEach( (importedPath, importedType) => {
   importedPath = importedPath.replace('core/user/user.model', 'shared/model/user.model');

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.vue.ejs
@@ -45,15 +45,15 @@
                 <thead>
                 <tr>
                     <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('id')"<% } %>><span v-text="$t('global.field.id')">ID</span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'id'"></jhi-sort-indicator><% } %></th>
-                    <%_ for (idx in fields) { _%>
-                    <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('<%= fields[idx].fieldName%>')"<% } %>><span v-text="$t('<%=`${i18nKeyPrefix}.${fields[idx].fieldName}` %>')"><%= fields[idx].fieldNameHumanized %></span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'<%= fields[idx].fieldName%>'"></jhi-sort-indicator><% } %></th>
+                    <%_ for (field of fields) { _%>
+                    <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('<%= field.fieldName%>')"<% } %>><span v-text="$t('<%=`${i18nKeyPrefix}.${field.fieldName}` %>')"><%= field.fieldNameHumanized %></span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'<%= field.fieldName%>'"></jhi-sort-indicator><% } %></th>
                     <%_ } _%>
-                    <%_ for (idx in relationships) { _%>
-                        <%_ if (relationships[idx].relationshipType === 'many-to-one'
-                        || (relationships[idx].relationshipType === 'one-to-one' && relationships[idx].ownerSide === true)
-                        || (relationships[idx].relationshipType === 'many-to-many' && relationships[idx].ownerSide === true && pagination === 'no')) {
-                            const fieldName = "." + relationships[idx].otherEntityField; _%>
-                    <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('<%=relationships[idx].relationshipName + (fieldName)%>')"<% } %>><span v-text="$t('<%= `${i18nKeyPrefix}.${relationships[idx].relationshipName}` %>')"><%= relationships[idx].relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'<%=relationships[idx].relationshipName + (fieldName)%>'"></jhi-sort-indicator><% } %></th>
+                    <%_ for (relationship of relationships) { _%>
+                        <%_ if (relationship.relationshipType === 'many-to-one'
+                        || (relationship.relationshipType === 'one-to-one' && relationship.ownerSide === true)
+                        || (relationship.relationshipType === 'many-to-many' && relationship.ownerSide === true && pagination === 'no')) {
+                            const fieldName = "." + relationship.otherEntityField; _%>
+                    <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('<%=relationship.relationshipName + (fieldName)%>')"<% } %>><span v-text="$t('<%= `${i18nKeyPrefix}.${relationship.relationshipName}` %>')"><%= relationship.relationshipNameHumanized %></span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'<%=relationship.relationshipName + (fieldName)%>'"></jhi-sort-indicator><% } %></th>
                         <%_ } _%>
                     <%_ } _%>
                     <th scope="row"></th>
@@ -65,11 +65,11 @@
                     <td>
                         <router-link :to="{name: '<%= entityAngularName %>View', params: {<%= entityInstance %>Id: <%= entityInstance %>.id}}">{{<%= entityInstance %>.id}}</router-link>
                     </td>
-                    <%_ for (idx in fields) {
-                        const fieldName = fields[idx].fieldName;
-                        const fieldNameCapitalized = fields[idx].fieldNameCapitalized;
-                        const fieldType = fields[idx].fieldType;
-                        const fieldTypeBlobContent = fields[idx].fieldTypeBlobContent; _%>
+                    <%_ for (field of fields) {
+                        const fieldName = field.fieldName;
+                        const fieldNameCapitalized = field.fieldNameCapitalized;
+                        const fieldType = field.fieldType;
+                        const fieldTypeBlobContent = field.fieldTypeBlobContent; _%>
                         <%_ if (['byte[]', 'ByteBuffer'].includes(fieldType) && fieldTypeBlobContent === 'image') { _%>
                     <td>
                         <a v-if="<%= entityInstance %>.<%= fieldName %>" v-on:click="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)">
@@ -82,7 +82,7 @@
                         <a v-if="<%= entityInstance %>.<%= fieldName %>" v-on:click="openFile(<%= entityInstance %>.<%= fieldName %>ContentType, <%= entityInstance %>.<%= fieldName %>)" v-text="$t('entity.action.open')">open</a>
                         <span v-if="<%= entityInstance %>.<%= fieldName %>">{{<%= entityInstance %>.<%= fieldName %>ContentType}}, {{byteSize(<%= entityInstance %>.<%= fieldName %>)}}</span>
                     </td>
-                        <%_ } else if (fields[idx].fieldIsEnum) { _%>
+                        <%_ } else if (field.fieldIsEnum) { _%>
                     <td v-text="$t('<%= frontendAppName %>.<%= fieldType %>.' + <%= entityInstance %>.<%= fieldName %>)">{{<%= entityInstance %>.<%= fieldName %>}}</td>
                         <%_ } else if (['Duration'].includes(fieldType)) { _%>
                     <td>{{<%=entityInstance %>.<%=fieldName%> | duration}}</td>
@@ -96,17 +96,17 @@
                     <td>{{<%=entityInstance %>.<%=fieldName%>}}</td>
                         <%_ } _%>
                     <%_ } _%>
-                    <%_ for (idx in relationships) {
-                        const relationshipType = relationships[idx].relationshipType;
-                        const ownerSide = relationships[idx].ownerSide;
-                        const relationshipFieldName = relationships[idx].relationshipFieldName;
-                        const relationshipFieldNamePlural = relationships[idx].relationshipFieldNamePlural;
-                        const relationshipNameCapitalized = relationships[idx].relationshipNameCapitalized;
-                        const otherEntityName = relationships[idx].otherEntityName;
-                        const otherEntityStateName = relationships[idx].otherEntityStateName;
-                        const otherEntityField = relationships[idx].otherEntityField;
-                        const otherEntityFieldCapitalized = relationships[idx].otherEntityFieldCapitalized;
-                        const otherEntityAngularName = relationships[idx].otherEntityAngularName; _%>
+                    <%_ for (relationship of relationships) {
+                        const relationshipType = relationship.relationshipType;
+                        const ownerSide = relationship.ownerSide;
+                        const relationshipFieldName = relationship.relationshipFieldName;
+                        const relationshipFieldNamePlural = relationship.relationshipFieldNamePlural;
+                        const relationshipNameCapitalized = relationship.relationshipNameCapitalized;
+                        const otherEntityName = relationship.otherEntityName;
+                        const otherEntityStateName = relationship.otherEntityStateName;
+                        const otherEntityField = relationship.otherEntityField;
+                        const otherEntityFieldCapitalized = relationship.otherEntityFieldCapitalized;
+                        const otherEntityAngularName = relationship.otherEntityAngularName; _%>
                         <%_ if (relationshipType === 'many-to-one'
                         || (relationshipType === 'one-to-one' && ownerSide === true)
                         || (relationshipType === 'many-to-many' && ownerSide === true && pagination === 'no')) { _%>

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.vue.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.vue.ejs
@@ -45,7 +45,7 @@
                 <thead>
                 <tr>
                     <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('id')"<% } %>><span v-text="$t('global.field.id')">ID</span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'id'"></jhi-sort-indicator><% } %></th>
-                    <%_ for (field of fields) { _%>
+                    <%_ for (field of fields.filter(field => !field.id)) { _%>
                     <th scope="row"<% if (pagination !== 'no') { %> v-on:click="changeOrder('<%= field.fieldName%>')"<% } %>><span v-text="$t('<%=`${i18nKeyPrefix}.${field.fieldName}` %>')"><%= field.fieldNameHumanized %></span><% if (pagination !== 'no') { %> <jhi-sort-indicator :current-order="propOrder" :reverse="reverse" :field-name="'<%= field.fieldName%>'"></jhi-sort-indicator><% } %></th>
                     <%_ } _%>
                     <%_ for (relationship of relationships) { _%>
@@ -65,7 +65,7 @@
                     <td>
                         <router-link :to="{name: '<%= entityAngularName %>View', params: {<%= entityInstance %>Id: <%= entityInstance %>.id}}">{{<%= entityInstance %>.id}}</router-link>
                     </td>
-                    <%_ for (field of fields) {
+                    <%_ for (field of fields.filter(field => !field.id)) {
                         const fieldName = field.fieldName;
                         const fieldNameCapitalized = field.fieldNameCapitalized;
                         const fieldType = field.fieldType;

--- a/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity-update-page-object.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity-update-page-object.ts.ejs
@@ -42,7 +42,7 @@ footer: ElementFinder = element(by.id('footer'));
 saveButton: ElementFinder = element(by.id('save-entity'));
 cancelButton: ElementFinder = element(by.id('cancel-save'));
 
-<%_ fields.forEach((field) => {
+<%_ fields.filter(field => !field.id).forEach((field) => {
   const fieldName = field.fieldName;
   const fieldType = field.fieldType;
   const fieldTypeBlobContent = field.fieldTypeBlobContent;

--- a/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -117,7 +117,7 @@ describe('<%= entityClass %> e2e test', () => {
     });
 
    <%= openBlockComment %> it('should create and save <%= entityClassPlural %>', async () => {
-      <%_ fields.forEach((field) => {
+      <%_ fields.filter(field => !field.id).forEach((field) => {
         const fieldName = field.fieldName;
         const fieldNameCapitalized = field.fieldNameCapitalized;
         const fieldType = field.fieldType;
@@ -253,7 +253,7 @@ describe('<%= entityClass %> e2e test', () => {
 
         expect(await updatePage.title.getText()).not.to.be.empty;
 
-        <%_ fields.forEach((field) => {
+        <%_ fields.filter(field => !field.id).forEach((field) => {
           const fieldName = field.fieldName;
           const fieldNameCapitalized = field.fieldNameCapitalized;
           const fieldType = field.fieldType;

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
@@ -26,9 +26,9 @@ import Router from 'vue-router';
 
 <%_
     let dayJsIncluded = false;
-    for (idx in fields) {
-        const fieldName = fields[ idx ].fieldName;
-        const fieldType = fields[idx].fieldType;
+    for (field of fields) {
+        const fieldName = field.fieldName;
+        const fieldType = field.fieldType;
         if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dayJsIncluded) {
             dayJsIncluded = true;
 _%>
@@ -43,13 +43,13 @@ import <%= entityAngularName %>Service from '@/entities/<%= entityFolderName %>/
 
 <%_
     const importEntitiesSeen = [entityAngularName];
-    for (idx in relationships) {
-      if (!relationships[idx].otherEntityIsEmbedded) {
-        const otherEntityAngularName = relationships[idx].otherEntityAngularName;
-        const otherEntityFileName = relationships[idx].otherEntityFileName;
-        const otherEntityFolderName = relationships[idx].otherEntityFileName;
-        const otherEntityClientRootFolder = relationships[idx].otherEntityClientRootFolder;
-        const otherEntityModelName = relationships[idx].otherEntityModelName;
+    for (relationship of relationships) {
+      if (!relationship.otherEntityIsEmbedded) {
+        const otherEntityAngularName = relationship.otherEntityAngularName;
+        const otherEntityFileName = relationship.otherEntityFileName;
+        const otherEntityFolderName = relationship.otherEntityFileName;
+        const otherEntityClientRootFolder = relationship.otherEntityClientRootFolder;
+        const otherEntityModelName = relationship.otherEntityModelName;
         if (!importEntitiesSeen.includes(otherEntityAngularName)) {
 _%>
   <% if (otherEntityAngularName === 'User' && authenticationType !== 'oauth2') { %>
@@ -95,11 +95,11 @@ describe('Component Tests', () => {
           <%= entityInstance %>Service: () => <%= entityInstance %>ServiceStub,
           <%_
             const entitiesSeen = [entityAngularName];
-            for (idx in relationships) {
-              if (!relationships[idx].otherEntityIsEmbedded) {
-                const otherEntityName = relationships[idx].otherEntityName;
-                const otherEntityNamePlural = relationships[idx].otherEntityNamePlural;
-                const otherEntityAngularName = relationships[idx].otherEntityAngularName;
+            for (relationship of relationships) {
+              if (!relationship.otherEntityIsEmbedded) {
+                const otherEntityName = relationship.otherEntityName;
+                const otherEntityNamePlural = relationship.otherEntityNamePlural;
+                const otherEntityAngularName = relationship.otherEntityAngularName;
                 if (!(otherEntityAngularName === 'User' && authenticationType === "oauth2")) {
           _%>
           <%_ if (!entitiesSeen.includes(otherEntityAngularName)) { %>
@@ -114,9 +114,9 @@ describe('Component Tests', () => {
 
     <%_
       let dateTestsIncluded = false;
-      for (idx in fields) {
-          const fieldName = fields[ idx ].fieldName;
-          const fieldType = fields[idx].fieldType;
+      for (field of fields) {
+          const fieldName = field.fieldName;
+          const fieldType = field.fieldType;
           if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dateTestsIncluded) {
               dateTestsIncluded = true;
     _%>

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity-update.component.spec.ts.ejs
@@ -26,7 +26,7 @@ import Router from 'vue-router';
 
 <%_
     let dayJsIncluded = false;
-    for (field of fields) {
+    for (field of fields.filter(field => !field.id)) {
         const fieldName = field.fieldName;
         const fieldType = field.fieldType;
         if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dayJsIncluded) {
@@ -114,7 +114,7 @@ describe('Component Tests', () => {
 
     <%_
       let dateTestsIncluded = false;
-      for (field of fields) {
+      for (field of fields.filter(field => !field.id)) {
           const fieldName = field.fieldName;
           const fieldType = field.fieldType;
           if ([ 'Instant', 'ZonedDateTime' ].includes(fieldType) && !dateTestsIncluded) {

--- a/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.service.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/spec/app/entities/entity.service.spec.ts.ejs
@@ -18,7 +18,7 @@
 -%>
 <%_
 const tsKeyId = generateTestEntityId(primaryKey.type);
-const enumImports = generateEntityClientEnumImports(fields);
+const enumImports = generateEntityClientEnumImports(fields.filter(field => !field.id));
 _%>
 /* tslint:disable max-line-length */
 import axios from 'axios';
@@ -71,7 +71,7 @@ describe('Service Tests', () => {
         <%_ } else { _%>
         0,
         <%_ } _%>
-        <%_ fields.forEach((field) => {
+        <%_ fields.filter(field => !field.id).forEach((field) => {
             const fieldType = field.fieldType; _%>
             <%_ if (field.fieldIsEnum) { _%>
         <%= fieldType + '.' + field.enumValues[0].name %>,
@@ -98,7 +98,7 @@ describe('Service Tests', () => {
     describe('Service methods', () => {
       it('should find an element', async () => {
         const returnedFromService = Object.assign({
-<%_ fields.forEach((field) => {
+<%_ fields.filter(field => !field.id).forEach((field) => {
     const fieldType = field.fieldType; _%>
     <%_ if (['LocalDate'].includes(fieldType)) { _%>
           <%= field.fieldName%>: dayjs(currentDate).format(DATE_FORMAT),
@@ -132,7 +132,7 @@ describe('Service Tests', () => {
   <%_ } else { _%>
           id: 0,
   <%_ } _%>
-  <%_ fields.forEach((field) => {
+  <%_ fields.filter(field => !field.id).forEach((field) => {
       const fieldType = field.fieldType; _%>
       <%_ if (['LocalDate'].includes(fieldType)) { _%>
           <%= field.fieldName%>: dayjs(currentDate).format(DATE_FORMAT),
@@ -142,7 +142,7 @@ describe('Service Tests', () => {
   <%_ }) _%>
         }, elemDefault);
         const expected = Object.assign({
-  <%_ fields.forEach((field) => {
+  <%_ fields.filter(field => !field.id).forEach((field) => {
       const fieldType = field.fieldType; _%>
       <%_ if (['LocalDate'].includes(fieldType)) { _%>
           <%= field.fieldName%>: currentDate,
@@ -170,7 +170,7 @@ describe('Service Tests', () => {
 
       it('should update a <%= entityAngularName %>', async () => {
         const returnedFromService = Object.assign({
-  <%_ fields.forEach((field) => {
+  <%_ fields.filter(field => !field.id).forEach((field) => {
       const fieldType = field.fieldType; _%>
       <%_ if (fieldType === 'Boolean') { _%>
           <%= field.fieldName%>: true,
@@ -191,7 +191,7 @@ describe('Service Tests', () => {
           }, elemDefault);
 
           const expected = Object.assign({
-  <%_ fields.forEach((field) => {
+  <%_ fields.filter(field => !field.id).forEach((field) => {
       const fieldType = field.fieldType; _%>
       <%_ if (['LocalDate'].includes(fieldType)) { _%>
           <%= field.fieldName%>: currentDate,
@@ -220,7 +220,7 @@ describe('Service Tests', () => {
 <%_ } _%>
       it('should return a list of <%= entityAngularName %>', async () => {
         const returnedFromService = Object.assign({
-    <%_ fields.forEach((field) => {
+    <%_ fields.filter(field => !field.id).forEach((field) => {
         const fieldType = field.fieldType; _%>
         <%_ if (fieldType === 'Boolean') { _%>
           <%= field.fieldName%>: true,
@@ -240,7 +240,7 @@ describe('Service Tests', () => {
     <%_ }) _%>
         }, elemDefault);
         const expected = Object.assign({
-    <%_ fields.forEach((field) => {
+    <%_ fields.filter(field => !field.id).forEach((field) => {
         const fieldType = field.fieldType; _%>
         <%_ if (['LocalDate'].includes(fieldType)) { _%>
           <%= field.fieldName%>: currentDate,

--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -503,7 +503,6 @@ class EntityGenerator extends BaseBlueprintGenerator {
                 this.context.fields.forEach(field => {
                     prepareFieldForTemplates(entity, field, this);
                 });
-                this.context.fieldsNoId = this.context.fields.filter(field => !field.id);
             },
 
             loadRelationships() {


### PR DESCRIPTION
This is api bugfix for blueprints.

`fields` should contain id fields now, but as workaround for react an vue not supporting id fields, I've filtered ids at `fields`.
Once the react and vue supports ids, `fields` should not be filtered anymore, becoming a breaking change for blueprints.

- Don't remove ids from fields anymore.
- Filter ids at templates.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
