### PR TITLE
only call disconnect when stompClient is connected

### DIFF
--- a/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/config/websocket-middleware.ts.ejs
@@ -101,10 +101,11 @@ const connect = () => {
 
 const disconnect = () => {
   if (stompClient !== null) {
-    stompClient.disconnect();
+    if (stompClient.connected) {
+      stompClient.disconnect();
+    }
     stompClient = null;
   }
-  window.onhashchange = () => {};
   alreadyConnectedOnce = false;
 };
 


### PR DESCRIPTION
Only call disconnect when `stompClient` is connected.  Also remove unused `onhashchange` method

Currently it is possible to call `stompClient.disconnect` (on logout) before `stompClient` is connected, which throws an error.  Checking the [Angular websocket implementation](https://github.com/jhipster/generator-jhipster/blob/main/generators/client/templates/angular/src/main/webapp/app/core/tracker/tracker.service.ts.ejs#L97-L99), we can see it checks for `stompClient.connected` before calling `stompClient.disconnect`.  With that fix, it works as expected.

related to #13334 and the comment: https://github.com/jhipster/generator-jhipster/pull/13334#issuecomment-748823466

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

