### PR TITLE
Replace deprecated `StringUtils.isEmpty()` by `ObjectUtils.isEmpty()` and cover its usage with tests

### DIFF
--- a/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs
@@ -31,7 +31,7 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.User;
 import org.springframework.stereotype.Component;
-import org.springframework.util.StringUtils;
+import org.springframework.util.ObjectUtils;
 
 import tech.jhipster.config.JHipsterProperties;
 import io.jsonwebtoken.*;
@@ -59,7 +59,7 @@ public class TokenProvider {
     public TokenProvider(JHipsterProperties jHipsterProperties) {
         byte[] keyBytes;
         String secret = jHipsterProperties.getSecurity().getAuthentication().getJwt().getSecret();
-        if (!StringUtils.isEmpty(secret)) {
+        if (!ObjectUtils.isEmpty(secret)) {
             log.warn("Warning: the JWT key used is not Base64-encoded. " +
                 "We recommend using the `jhipster.security.authentication.jwt.base64-secret` key for optimum security.");
             keyBytes = secret.getBytes(StandardCharsets.UTF_8);

--- a/generators/server/templates/src/test/java/package/security/jwt/TokenProviderTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/jwt/TokenProviderTest.java.ejs
@@ -37,6 +37,8 @@ import io.jsonwebtoken.SignatureAlgorithm;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
 
+import java.nio.charset.StandardCharsets;
+
 import static org.assertj.core.api.Assertions.assertThat;
 
 class TokenProviderTest {
@@ -101,6 +103,32 @@ class TokenProviderTest {
         boolean isTokenValid = tokenProvider.validateToken("");
 
         assertThat(isTokenValid).isFalse();
+    }
+
+    @Test
+    public void testKeyIsSetFromSecretWhenSecretIsNotEmpty() {
+        final String secret = "NwskoUmKHZtzGRKJKVjsJF7BtQMMxNWi";
+        JHipsterProperties jHipsterProperties = new JHipsterProperties();
+        jHipsterProperties.getSecurity().getAuthentication().getJwt().setSecret(secret);
+
+        TokenProvider tokenProvider = new TokenProvider(jHipsterProperties);
+
+        Key key = (Key) ReflectionTestUtils.getField(tokenProvider, "key");
+        assertThat(key).isNotNull();
+        assertThat(key).isEqualTo(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)));
+    }
+
+    @Test
+    public void testKeyIsSetFromBase64SecretWhenSecretIsEmpty() {
+        final String base64Secret = "fd54a45s65fds737b9aafcb3412e07ed99b267f33413274720ddbb7f6c5e64e9f14075f2d7ed041592f0b7657baf8";
+        JHipsterProperties jHipsterProperties = new JHipsterProperties();
+        jHipsterProperties.getSecurity().getAuthentication().getJwt().setBase64Secret(base64Secret);
+
+        TokenProvider tokenProvider = new TokenProvider(jHipsterProperties);
+
+        Key key = (Key) ReflectionTestUtils.getField(tokenProvider, "key");
+        assertThat(key).isNotNull();
+        assertThat(key).isEqualTo(Keys.hmacShaKeyFor(Decoders.BASE64.decode(base64Secret)));
     }
 
     private Authentication createAuthentication() {


### PR DESCRIPTION
`StringUtils.isEmpty()` [has been deprecated](https://github.com/spring-projects/spring-framework/issues/25945), so this PR replaces it by `ObjectUtils.isEmpty()` in the constructor of `TokenProvider`.

Besides, as `isEmpty()` is used in a conditional block that is not being tested, I added two unit tests to `TokenProviderTest`.
