### PR TITLE
fix race condition during react protractor e2e tests

### DIFF
--- a/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -282,6 +282,15 @@ describe('Account', () => {
     expect(await passwordPage.getTitle()).to.eq(passwordPageTitle);
 
     await passwordPage.autoChangePassword('new_password', password, password);
+    <%_ if (enableTranslation) { _%>
+    const toast = getToastByInnerText('Password changed!');
+    <% } else { %>
+    const toast = getToastByInnerText('<strong>Password changed!</strong>');
+    <%_ } _%>
+    await waitUntilDisplayed(toast);
+
+    // Success toast should appear
+    expect(await toast.isPresent()).to.be.true;
 
     await navBarPage.autoSignOut();
   });


### PR DESCRIPTION
The e2e test changes the admin password to `new-password`, then attempts to change the password back to `admin`.  Before the request is completed, the test would finish and the window reloads in preparation for the next test.

This fix waits for the password to be changed, then moves on to the next test.

related to https://github.com/jhipster/generator-jhipster/issues/13361#issuecomment-752270050

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
