### PR TITLE
Add detail field in angular alert component

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.spec.ts.ejs
@@ -18,7 +18,8 @@
 -%>
 import { inject, TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
-import { TranslateModule } from '@ngx-translate/core';
+import { TranslateModule, TranslateService, MissingTranslationHandler  } from '@ngx-translate/core';
+import { missingTranslationHandler } from '../../config/translation.config';
 <%_ } _%>
 
 import { Alert, AlertService } from './alert.service';
@@ -30,7 +31,11 @@ describe('Alert service test', () => {
     beforeEach(() => {
       TestBed.configureTestingModule({
         <%_ if (enableTranslation) { _%>
-        imports: [TranslateModule.forRoot()],
+        imports: [TranslateModule.forRoot({
+            missingTranslationHandler: {
+            provide: MissingTranslationHandler,
+            useFactory: missingTranslationHandler
+          }})],
         <%_ } _%>
       });
       jest.useFakeTimers();
@@ -254,5 +259,37 @@ describe('Alert service test', () => {
         } as Alert)
       );
     }));
+    <%_ if (enableTranslation) { _%>
+    
+    it('should produce a info message with translated message if key exists', inject([AlertService, TranslateService], (service: AlertService, translateService: TranslateService) => {
+      translateService.setTranslation('en', {
+          'hello.jhipster': 'Translated message'
+      })
+      expect(service.addAlert({ type: 'info', message: 'Hello Jhipster', translationKey: 'hello.jhipster' })).toEqual(
+        jasmine.objectContaining({
+          type: 'info',
+          message: 'Translated message',
+        } as Alert)
+      );
+    }));
+
+    it('should produce a info message with provided message if key does not exists', inject([AlertService, TranslateService], (service: AlertService) => {
+      expect(service.addAlert({ type: 'info', message: 'Hello Jhipster', translationKey: 'hello.jhipster' })).toEqual(
+        jasmine.objectContaining({
+          type: 'info',
+          message: 'Hello Jhipster',
+        } as Alert)
+      );
+    }));
+
+    it('should produce a info message with provided key if transltion key does not exist in translations and message is not provided', inject([AlertService, TranslateService], (service: AlertService) => {
+      expect(service.addAlert({ type: 'info', translationKey: 'hello.jhipster' })).toEqual(
+        jasmine.objectContaining({
+          type: 'info',
+          message: 'hello.jhipster',
+        } as Alert)
+      );
+    }));
+    <%_ } _%>
   });
 });

--- a/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.spec.ts.ejs
@@ -38,6 +38,10 @@ describe('Alert service test', () => {
           }})],
         <%_ } _%>
       });
+      <%_ if (enableTranslation) { _%>
+      const translateService = TestBed.inject(TranslateService);
+      translateService.setDefaultLang('en');
+      <%_ } _%>
       jest.useFakeTimers();
       extAlerts = [];
     });

--- a/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.ts.ejs
@@ -20,6 +20,7 @@ import { Injectable, SecurityContext, NgZone } from '@angular/core';
 import { DomSanitizer } from '@angular/platform-browser';
 <%_ if (enableTranslation) { _%>
 import { TranslateService } from '@ngx-translate/core';
+import { translationNotFoundMessage } from 'app/config/translation.config';
 <%_ } _%>
 
 export type AlertType = 'success' | 'danger' | 'warning' | 'info';
@@ -81,7 +82,11 @@ export class AlertService {
 
     <%_ if (enableTranslation) { _%>
     if (alert.translationKey) {
-      alert.message = this.translateService.instant(alert.translationKey, alert.translationParams);
+      const translatedMessage = this.translateService.instant(alert.translationKey, alert.translationParams);
+      // if translation key exists
+      if (translatedMessage !== `${translationNotFoundMessage}[${alert.translationKey}]`) {
+        alert.message = translatedMessage;
+      }
     }
     <%_ } _%>
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/alert.service.ts.ejs
@@ -86,6 +86,8 @@ export class AlertService {
       // if translation key exists
       if (translatedMessage !== `${translationNotFoundMessage}[${alert.translationKey}]`) {
         alert.message = translatedMessage;
+      } else if (!alert.message) {
+        alert.message = alert.translationKey;
       }
     }
     <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.spec.ts.ejs
@@ -165,6 +165,25 @@ describe('Component Tests', () => {
         expect(comp.alerts.length).toBe(1);
         expect(comp.alerts[0].<%= mainAlertField %>).toBe('Error Message');
       });
+
+       it('Should display an alert on status 500 with detail', () => {
+        // GIVEN
+        const response = new HttpErrorResponse({
+          url: 'http://localhost:8080/api/foos',
+          headers: new HttpHeaders(),
+          status: 500,
+          statusText: 'Internal server error',
+          error: {
+            status: 500,
+            message: 'error.http.500',
+            detail: 'Detailed error message'
+          },
+        });
+        eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: response });
+        // THEN
+        expect(comp.alerts.length).toBe(1);
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe('Detailed error message');
+      });
     });
   });
 });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.spec.ts.ejs
@@ -182,7 +182,7 @@ describe('Component Tests', () => {
         eventManager.broadcast({ name: '<%= frontendAppName %>.httpError', content: response });
         // THEN
         expect(comp.alerts.length).toBe(1);
-        expect(comp.alerts[0].<%= mainAlertField %>).toBe('Detailed error message');
+        expect(comp.alerts[0].<%= mainAlertField %>).toBe(<% if (enableTranslation) { %>'error.http.500'<% } else { %>'Detailed error message'<% } %>);
       });
     });
   });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -87,7 +87,7 @@ export class AlertErrorComponent implements OnDestroy {
               this.addErrorAlert(`Error on field "${fieldName}"`<% if (enableTranslation) { %>, `error.${fieldError.message as string}`, { fieldName }<% } %>);
             }
           } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-            this.addErrorAlert(httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
+            this.addErrorAlert(httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.detail ?? httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
           } else {
             this.addErrorAlert(httpErrorResponse.error<% if (enableTranslation) { %>, httpErrorResponse.error<% } %>);
           }
@@ -100,7 +100,7 @@ export class AlertErrorComponent implements OnDestroy {
 
         default:
           if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-            this.addErrorAlert(httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message<% } %>);
+            this.addErrorAlert(httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% } %>);
           } else {
             this.addErrorAlert(httpErrorResponse.error<% if (enableTranslation) { %>, httpErrorResponse.error<% } %>);
           }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/alert/alert-error.component.ts.ejs
@@ -87,7 +87,7 @@ export class AlertErrorComponent implements OnDestroy {
               this.addErrorAlert(`Error on field "${fieldName}"`<% if (enableTranslation) { %>, `error.${fieldError.message as string}`, { fieldName }<% } %>);
             }
           } else if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-            this.addErrorAlert(httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.detail ?? httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
+            this.addErrorAlert(httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
           } else {
             this.addErrorAlert(httpErrorResponse.error<% if (enableTranslation) { %>, httpErrorResponse.error<% } %>);
           }
@@ -100,7 +100,7 @@ export class AlertErrorComponent implements OnDestroy {
 
         default:
           if (httpErrorResponse.error !== '' && httpErrorResponse.error.message) {
-            this.addErrorAlert(httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% } %>);
+            this.addErrorAlert(httpErrorResponse.error.detail ?? httpErrorResponse.error.message<% if (enableTranslation) { %>, httpErrorResponse.error.message, httpErrorResponse.error.params<% } %>);
           } else {
             this.addErrorAlert(httpErrorResponse.error<% if (enableTranslation) { %>, httpErrorResponse.error<% } %>);
           }


### PR DESCRIPTION
Instead of showing the 'message' field, the alert component will use 'detail' field if present

Fix #13316

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
