### PR TITLE
Fix Vue entities translation keys create, update, delete

### DIFF
--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity-update.component.ts.ejs
@@ -189,7 +189,7 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
         this.isSaving = false;
         this.$router.go(-1);
         <%_ if (enableTranslation) { _%>
-        const message = this.$t('<%= i18nKeyPrefix %>.updated', { 'param' : param.id });
+        const message = this.$t('<%= i18nAlertHeaderPrefix %>.updated', { 'param' : param.id });
         <%_ } else {_%>
         const message = 'A <%= entityAngularName %> is updated with identifier ' + param.id;
         <%_ } _%>
@@ -206,7 +206,7 @@ export default class <%= entityAngularName %>Update extends <% if (fieldsContain
         this.isSaving = false;
         this.$router.go(-1);
         <%_ if (enableTranslation) { _%>
-        const message = this.$t('<%= i18nKeyPrefix %>.created', { 'param' : param.id });
+          const message = this.$t('<%= i18nAlertHeaderPrefix %>.created', { 'param' : param.id });
         <%_ } else {_%>
         const message = 'A <%= entityAngularName %> is created with identifier ' + param.id;
         <%_ } _%>

--- a/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.component.ts.ejs
+++ b/generators/entity-client/templates/vue/src/main/webapp/app/entities/entity.component.ts.ejs
@@ -163,7 +163,7 @@ export default class <%= entityAngularName %> extends <% if (fieldsContainBlob |
   public remove<%= entityAngularName %>() : void {
     this.<%= entityInstance %>Service().delete(this.removeId).then(() => {
       <%_ if (enableTranslation) { _%>
-      const message = this.$t('<%= i18nKeyPrefix %>.deleted', { 'param' : this.removeId });
+      const message = this.$t('<%= i18nAlertHeaderPrefix %>.deleted', { 'param' : this.removeId });
       <%_ } else {_%>
       const message = 'A <%= entityAngularName %> is deleted with identifier ' + this.removeId;
       <%_ } _%>

--- a/utils/entity.js
+++ b/utils/entity.js
@@ -154,6 +154,10 @@ function prepareEntityForTemplates(entityWithConfig, generator) {
     entityWithConfig.differentTypes.push(entityWithConfig.entityClass);
     entityWithConfig.i18nToLoad.push(entityWithConfig.entityInstance);
     entityWithConfig.i18nKeyPrefix = `${entityWithConfig.frontendAppName}.${entityWithConfig.entityTranslationKey}`;
+    entityWithConfig.i18nAlertHeaderPrefix = entityWithConfig.i18nKeyPrefix;
+    if (entityWithConfig.microserviceAppName) {
+        entityWithConfig.i18nAlertHeaderPrefix = `${entityWithConfig.microserviceAppName}.${entityWithConfig.entityTranslationKey}`;
+    }
 
     const hasBuiltInUserField = entityWithConfig.relationships.some(relationship => generator.isBuiltInUser(relationship.otherEntityName));
     entityWithConfig.saveUserSnapshot =


### PR DESCRIPTION
In microservices applications, vue uses keys with prefix as
'microserviceAppName.translationKey' rather than
'frontendAppName.translationKey'. This commit fixes the key using a new
variable i18nAssetHeaderPrefix for entities.

Fix #13384

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
