### PR TITLE
fix Swagger UI for reactive applications

### DIFF
--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs
@@ -197,7 +197,7 @@ public class SecurityConfiguration {
         // @formatter:off
         http
             .securityMatcher(new NegatedServerWebExchangeMatcher(new OrServerWebExchangeMatcher(
-                pathMatchers("/app/**", "/i18n/**", "/content/**", "/swagger-ui/index.html", "/v2/api-docs", "/v3/api-docs", "/test/**"),
+                pathMatchers("/app/**", "/i18n/**", "/content/**", "/swagger-ui/**", "/swagger-resources/**", "/v2/api-docs", "/v3/api-docs", "/test/**"),
                 pathMatchers(HttpMethod.OPTIONS, "/**")
             )))
             .csrf()
@@ -268,7 +268,7 @@ public class SecurityConfiguration {
             .pathMatchers("/api/admin/**").hasAuthority(AuthoritiesConstants.ADMIN)
             .pathMatchers("/api/**").authenticated()
             <%_ if (applicationType === 'monolith' || applicationType === 'gateway') { _%>
-            .pathMatchers("/services/**", "/swagger-resources/**").authenticated()
+            .pathMatchers("/services/**").authenticated()
             <%_ } _%>
             .pathMatchers("/management/health").permitAll()
             .pathMatchers("/management/health/**").permitAll()


### PR DESCRIPTION
- prevent 401 errors on swagger-ui static resources
- open `swagger-resources` endpoint, it is not secured for non-reactive apps

Originally reported by @sanjitvimal https://github.com/jhipster/generator-jhipster/issues/10330#issuecomment-753611017

##### **Overview of the issue**
Swagger UI is broken for a monolith reactive application (did not test microservices).

The browser console logs 401 errors for static resources ([screenshot](https://user-images.githubusercontent.com/4294623/103564280-3d8d7200-4e8c-11eb-8abd-1912e9268731.png)).
https://github.com/jhipster/generator-jhipster/blob/f601be10d4305d9a81a022043d0b73fbdb62d5ca/generators/server/templates/src/main/java/package/config/SecurityConfiguration_reactive.java.ejs#L200

Changing `"/swagger-ui/index.html"` to `"/swagger-ui/**"` fixes the 401 errors for static resources, but then we get a 401 on `/swagger-resources` ([screenshot](https://user-images.githubusercontent.com/4294623/103564274-3cf4db80-4e8c-11eb-91b8-664114275e79.png)).

Removing ` "/swagger-resources/**"` from `.pathMatchers("/services/**", "/swagger-resources/**").authenticated()` makes the UI functional.  This endpoint is not restricted in non-reactive apps, so this seems like the right fix.  It does not contain any sensitive info either:
```
[ {
  "name" : "default",
  "url" : "/v3/api-docs",
  "swaggerVersion" : "3.0.3",
  "location" : "/v3/api-docs"
}, {
  "name" : "management",
  "url" : "/v3/api-docs?group=management",
  "swaggerVersion" : "3.0.3",
  "location" : "/v3/api-docs?group=management"
} ]
```
The issue can be reproduced with the following JDL, and attempting to open the Admin Swagger UI:
```
application {
  config {
    applicationType monolith
    reactive true
    withAdminUi true
  }
}
```

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
