### PR TITLE
Fix double slash, missing space, links and Angular Gradle input

### DIFF
--- a/generators/client/templates/angular/tsconfig.app.json.ejs
+++ b/generators/client/templates/angular/tsconfig.app.json.ejs
@@ -19,5 +19,5 @@
 {
   "extends": "./tsconfig.json",
   "files": ["<%= MAIN_SRC_DIR %>main.ts", "<%= MAIN_SRC_DIR %>polyfills.ts"],
-  "include": ["<%= MAIN_SRC_DIR %>/**/*.d.ts"]
+  "include": ["<%= MAIN_SRC_DIR %>**/*.d.ts"]
 }

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -58,7 +58,7 @@ You will only need to run this command when dependencies change in [package.json
 <%= clientPackageManager %> install
 ```
 
-We use <%= clientPackageManager %> scripts and [<%_ if (clientFramework === ANGULAR) { _%>Angular CLI with <%_ } _%> Webpack][] as our build system.
+We use <%= clientPackageManager %> scripts and <% if (clientFramework === ANGULAR) { %>[Angular CLI][] with <% } %>[Webpack][] as our build system.
 
 <%_ if (['hazelcast', 'memcached', 'redis'].includes(cacheProvider)) { _%>
 If you are using <%= cacheProvider %> as a cache, you will have to launch a cache server.

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -130,6 +130,8 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
 
                 this.JACKSON_DATABIND_NULLABLE_VERSION = constants.JACKSON_DATABIND_NULLABLE_VERSION;
 
+                this.ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
+
                 this.packagejs = packagejs;
             },
 

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -50,11 +50,17 @@ bootRun {
 task webpack(type: <%= _.upperFirst(clientPackageManager) %>Task) {
     inputs.files("package-lock.json")
     inputs.files("build.gradle")
+    <%_ if (clientFramework === ANGULAR) { _%>
+    inputs.files("angular.json")
+    inputs.dir("<%= CLIENT_WEBPACK_DIR %>")
+    <%_ } _%>
     inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
+    <%_ if (clientFramework !== ANGULAR) { _%>
 
-    def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>/")
+    def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>")
     webpackDevFiles.exclude("webpack.prod.js")
     inputs.files(webpackDevFiles)
+    <%_ } _%>
 
     outputs.dir("<%= CLIENT_DIST_DIR %>")
 


### PR DESCRIPTION
Follow up to Angular CLI migration, minor fixes.

In `tsconfig` and `Gradle` (applies also to React and Vue) part replacing double slash `//` with one slash `/` (variables already are ending with `/`)
In readme replacing "**withWebpack**" with "**with Webpack**" and fixing links to Webpack and Angular CLI sites
In Gradle part: in Angular after moving to Angular CLI there is no more file` webpack.prod.js` and build depends also on file `angular.json` now

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
