### PR TITLE
Polish Cypress related logic

### DIFF
--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -196,7 +196,7 @@ jobs:
               if: always() && steps.e2e.outcome == 'failure'
               with:
                   name: screenshots-${{ matrix.app-type }}
-                  path: ${{ github.workspace }}/app/target/cypress/screenshots
+                  path: ${{ github.workspace }}/app/*/cypress/screenshots
             - name: 'ANALYSIS: Sonar analysis'
               run: $JHI_SCRIPTS/25-sonar-analyze.sh
               env:

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -45,6 +45,8 @@
     "strictTemplates": true,
     "strictInputAccessModifiers": true,
     "preserveWhitespaces": true
-  },
-  "exclude": ["<%= CLIENT_TEST_SRC_DIR %>cypress"]
+  }
+  <%_ if (cypressTests) { _%>
+  ,"exclude": ["<%= CLIENT_TEST_SRC_DIR %>cypress"]
+  <%_ } _%>
 }

--- a/generators/cypress/templates/cypress.json.ejs
+++ b/generators/cypress/templates/cypress.json.ejs
@@ -6,7 +6,7 @@
   "integrationFolder": "<%= CLIENT_TEST_SRC_DIR %>cypress/integration",
   "fixturesFolder": "<%= CLIENT_TEST_SRC_DIR %>cypress/fixtures",
   "pluginsFile": "<%= CLIENT_TEST_SRC_DIR %>cypress/plugins/index.ts",
-  "screenshotsFolder": "target/cypress/screenshots",
+  "screenshotsFolder": "<%= BUILD_DIR %>cypress/screenshots",
   "chromeWebSecurity": <% if(authenticationType === 'oauth2') { %>false<% } else { %>true<% } %>,
   "viewportWidth": 1200,
   "viewportHeight": 720,


### PR DESCRIPTION
Don't generate Cypress exclude in Angular `tsconfig.json` if Cypress tests are not selected.

Use `BUILD_DIR` constant instead of Maven specific `target` for Cypress screenshots folder.

`incremental-changelog.yml` GitHub Actions workflow was only one containing `app/target/cypress/screenshots` as screenshots path, all other GitHub Actions workflows already use `app/*/cypress/screenshots`.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
