### PR TITLE
Allow ElasticSearch to start in Kubernetes using single-node discovery mode

### DIFF
--- a/generators/kubernetes/templates/db/elasticsearch.yml.ejs
+++ b/generators/kubernetes/templates/db/elasticsearch.yml.ejs
@@ -74,6 +74,9 @@ spec:
       containers:
       - name: elasticsearch
         image: <%= DOCKER_ELASTICSEARCH %>
+        env:
+        - name: discovery.type
+          value: single-node
         ports:
         - containerPort: 9200
           name: http


### PR DESCRIPTION
Fix #13432 
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
