### PR TITLE
Use humanized app name and remove double https

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -235,6 +235,7 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
                 this.capitalizedBaseName = _.upperFirst(this.baseName);
                 this.dasherizedBaseName = _.kebabCase(this.baseName);
                 this.lowercaseBaseName = this.baseName.toLowerCase();
+                this.humanizedBaseName = this.baseName.toLowerCase() === 'jhipster' ? 'JHipster' : _.startCase(this.baseName);
 
                 if (this.authenticationType === 'oauth2' || (this.databaseType === 'no' && this.authenticationType !== 'uaa')) {
                     this.skipUserManagement = true;

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.spec.ts.ejs
@@ -86,7 +86,7 @@ describe('Component Tests', () => {
     });
 
     describe('page title', () => {
-      const defaultPageTitle = '<% if (enableTranslation) { %>global.title<% } else { %><%= capitalizedBaseName %><% } %>';
+      const defaultPageTitle = '<% if (enableTranslation) { %>global.title<% } else { %><%= humanizedBaseName %><% } %>';
       const parentRoutePageTitle = 'parentTitle';
       const childRoutePageTitle = 'childTitle';
       const navigationEnd = new NavigationEnd(1, '', '');

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/main/main.component.ts.ejs
@@ -91,7 +91,7 @@ export class MainComponent implements OnInit {
   private updateTitle(): void {
     let pageTitle = this.getPageTitle(this.router.routerState.snapshot.root);
     if (!pageTitle) {
-      pageTitle = '<% if (enableTranslation) { %>global.title<% } else { %><%= capitalizedBaseName %><% } %>';
+      pageTitle = '<% if (enableTranslation) { %>global.title<% } else { %><%= humanizedBaseName %><% } %>';
     }
     <%_ if (enableTranslation) { _%>
     this.translateService.get(pageTitle).subscribe(title => this.titleService.setTitle(title));

--- a/generators/client/templates/angular/webpack/webpack.custom.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.custom.js.ejs
@@ -40,12 +40,11 @@ module.exports = (config, options) => {
       }),
       new FriendlyErrorsWebpackPlugin(),
       new WebpackNotifierPlugin({
-        title: 'JHipster',
+        title: '<%= humanizedBaseName %>',
         contentImage: path.join(__dirname, 'logo-jhipster.png'),
       }),
       new BrowserSyncPlugin(
         {
-          https: false,
           host: 'localhost',
           port: 9000,
           https: tls,

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -128,7 +128,7 @@ module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
       utils.root('src/test'),
     ]),
     new WebpackNotifierPlugin({
-      title: 'JHipster',
+      title: '<%= humanizedBaseName %>',
       contentImage: path.join(__dirname, 'logo-jhipster.png')
     })
   ].filter(Boolean)


### PR DESCRIPTION
Use humanized app name in Webpack notifier in Angular and React and in no i18n page title in Angular.
Remove double https in Angular Webpack configuration.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
