### PR TITLE
[react] Fix tests ts-jest warnings

### DIFF
--- a/generators/client/templates/react/tsconfig.test.json.ejs
+++ b/generators/client/templates/react/tsconfig.test.json.ejs
@@ -20,7 +20,6 @@
   "extends": "./tsconfig",
   "compilerOptions": {
     "module": "commonjs",
-    "allowSyntheticDefaultImports": false,
     "types": ["jest", "webpack-env"]
   }
 }


### PR DESCRIPTION
Without this change a lot of warnings on running `npm test` first time after generation (or after deleting `build`/`target` folder).

Noticed while reviewed #13425 

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
