### PR TITLE
Fix R2DBC with OAuth

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -389,7 +389,7 @@ relationships.forEach((relationship, idx) => {
 
     <%_ if (databaseType === 'sql' && reactive) { _%>
     @Column("<%= getColumnName(relationshipName) %>_id")
-    private Long <%= relationshipFieldName %>Id;
+    private <% if (relationshipFieldName === 'user' && authenticationType === 'oauth2') { %>String<% } else { %>Long<% } %> <%= relationshipFieldName %>Id;
     <%_ } _%>
 
 <%_ } else if (relationshipType === 'many-to-many') {

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1078,7 +1078,14 @@ const serverFiles = {
             ],
         },
         {
+<<<<<<< HEAD
             condition: generator => generator.databaseType === 'sql' && generator.reactive && !generator.skipUserManagement,
+=======
+            condition: generator =>
+                generator.databaseType === 'sql' &&
+                generator.reactive &&
+                (!generator.skipUserManagement || generator.authenticationType === 'oauth2'),
+>>>>>>> 9756f77f79... Fix formatting
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {

--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -1078,14 +1078,10 @@ const serverFiles = {
             ],
         },
         {
-<<<<<<< HEAD
-            condition: generator => generator.databaseType === 'sql' && generator.reactive && !generator.skipUserManagement,
-=======
             condition: generator =>
                 generator.databaseType === 'sql' &&
                 generator.reactive &&
                 (!generator.skipUserManagement || generator.authenticationType === 'oauth2'),
->>>>>>> 9756f77f79... Fix formatting
             path: SERVER_MAIN_SRC_DIR,
             templates: [
                 {

--- a/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
+++ b/generators/server/templates/src/main/java/package/repository/UserRepository.java.ejs
@@ -365,17 +365,20 @@ class UserSqlHelper {
         List<Expression> columns = new ArrayList<>();
         columns.add(Column.aliased("id", table, columnPrefix + "_id"));
         columns.add(Column.aliased("login", table, columnPrefix + "_login"));
+        <%_ if (authenticationType !== 'oauth2') { _%>
         columns.add(Column.aliased("password_hash", table, columnPrefix + "_password"));
+        <%_ } _%>
         columns.add(Column.aliased("first_name", table, columnPrefix + "_first_name"));
         columns.add(Column.aliased("last_name", table, columnPrefix + "_last_name"));
         columns.add(Column.aliased("email", table, columnPrefix + "_email"));
         columns.add(Column.aliased("activated", table, columnPrefix + "_activated"));
         columns.add(Column.aliased("lang_key", table, columnPrefix + "_lang_key"));
         columns.add(Column.aliased("image_url", table, columnPrefix + "_image_url"));
+        <%_ if (authenticationType !== 'oauth2') { _%>
         columns.add(Column.aliased("activation_key", table, columnPrefix + "_activation_key"));
         columns.add(Column.aliased("reset_key", table, columnPrefix + "_reset_key"));
         columns.add(Column.aliased("reset_date", table, columnPrefix + "_reset_date"));
-
+        <%_ } _%>
         return columns;
     }
 }


### PR DESCRIPTION
Should fix #13467, eventually.

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

Status: Jan 12 21:56 MST, I get the following error when I try to view or edit a blog entity.

```
2021-01-12 21:50:30.846 ERROR 86651 --- [ctor-http-nio-3] o.z.problem.spring.common.AdviceTraits   : Internal Server Error

org.springframework.dao.IncorrectResultSizeDataAccessException: Query [SELECT e.id AS e_id, e.name AS e_name, e.handle AS e_handle, e.user_id AS e_user_id, e_user.id AS user_id, e_user.login AS user_login, e_user.first_name AS user_first_name, e_user.last_name AS user_last_name, e_user.email AS user_email, e_user.activated AS user_activated, e_user.lang_key AS user_lang_key, e_user.image_url AS user_image_url FROM blog e LEFT OUTER JOIN jhi_user AS e_user ON e.user_id = e_user.id] returned non unique result.
	at org.springframework.data.r2dbc.core.DefaultFetchSpec.lambda$one$0(DefaultFetchSpec.java:61)
	Suppressed: reactor.core.publisher.FluxOnAssembly$OnAssemblyException:
Assembly trace from producer [reactor.core.publisher.FluxFlatMap] :
	reactor.core.publisher.Flux.flatMap(Flux.java:4927)
	org.springframework.data.r2dbc.core.DefaultFetchSpec.one(DefaultFetchSpec.java:53)
Error has been observed at the following site(s):
	|_       Flux.flatMap ⇢ at org.springframework.data.r2dbc.core.DefaultFetchSpec.one(DefaultFetchSpec.java:53)
	|_          Flux.next ⇢ at org.springframework.data.r2dbc.core.DefaultFetchSpec.one(DefaultFetchSpec.java:65)
	|_ Mono.switchIfEmpty ⇢ at tech.jhipster.web.util.reactive.ResponseUtil.wrapOrNotFound(ResponseUtil.java:36)
	|_           Mono.map ⇢ at tech.jhipster.web.util.reactive.ResponseUtil.wrapOrNotFound(ResponseUtil.java:37)
	|_     Mono.usingWhen ⇢ at org.springframework.transaction.interceptor.TransactionAspectSupport$ReactiveTransactionSupport.lambda$null$3(TransactionAspectSupport.java:870)
```

Here's the JDL I'm testing with:

```
application {
  config {
    baseName blog
    applicationType monolith
    authenticationType oauth2
    packageName com.jhipster.demo.blog
    prodDatabaseType mysql
    buildTool maven
    clientFramework vue
    reactive true
    testFrameworks [cypress]
  }
  entities *
}

entity Blog {
  name String required minlength(3)
  handle String required minlength(2)
}

entity Post {
  title String required
  content TextBlob required
  date Instant required
}

entity Tag {
  name String required minlength(2)
}

relationship ManyToOne {
  Blog{user(login)} to User
  Post{blog(name)} to Blog
}

relationship ManyToMany {
  Post{tag(name)} to Tag{entry}
}

paginate Post, Tag with infinite-scroll
``` 