### PR TITLE
Add criteria (where statement) when using reactive and r2dbc

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepositoryInternalImpl.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityReactiveRepositoryInternalImpl.java.ejs
@@ -39,6 +39,7 @@ import java.util.Map.Entry;
 
 import org.springframework.data.domain.Pageable;
 <%_ if (databaseType === 'sql') { _%>
+import java.util.Optional;
 import io.r2dbc.spi.Row;
 import io.r2dbc.spi.RowMetadata;
 
@@ -92,26 +93,26 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
 <%_ }); _%>
 
     private final static Table entityTable = Table.aliased("<%= entityTableName %>", EntityManager.ENTITY_ALIAS);
-        <%_ eagerRelations.forEach(function(rel) { _%>
+<%_ eagerRelations.forEach(function(rel) { _%>
     private final static Table <%= rel.relationshipName %>Table = Table.aliased("<%= rel.otherEntityTableName %>", "<%= _generateSqlSafeName(rel.relationshipName) %>");
-        <%_ }); _%>
+<%_ }); _%>
 
-        <%_ relationships.forEach(function(rel) {
+<%_ relationships.forEach(function(rel) {
             if (rel.relationshipType === 'many-to-many' && rel.ownerSide) {
                 const joinTableName = getJoinTableName(entityTableName, rel.relationshipName, prodDatabaseType);
-        _%>
+_%>
     private final static EntityManager.LinkTable <%= rel.relationshipName %>Link = new LinkTable("<%= joinTableName %>", "<%= getColumnName(name) %>_id", "<%= getColumnName(rel.relationshipName) %>_id");
-        <%_ }
-        }); _%>
+  <%_ }
+}); _%>
 
-    public <%= entityClass %>RepositoryInternalImpl(DatabaseClient db, ReactiveDataAccessStrategy dataAccessStrategy, EntityManager entityManager<%_ 
+    public <%= entityClass %>RepositoryInternalImpl(DatabaseClient db, ReactiveDataAccessStrategy dataAccessStrategy, EntityManager entityManager<%_
             uniqueEntityTypes.forEach(function(element) { _%>, <%= element %>RowMapper <%= element.toLowerCase() %>Mapper<%_ }); _%>) {
         this.db = db;
         this.dataAccessStrategy = dataAccessStrategy;
         this.entityManager = entityManager;
-        <%_ uniqueEntityTypes.forEach(function(element) { _%>
+<%_ uniqueEntityTypes.forEach(function(element) { _%>
         this.<%= element.toLowerCase() %>Mapper = <%= element.toLowerCase() %>Mapper;
-        <%_ }); _%>
+<%_ }); _%>
     }
 
     @Override
@@ -126,16 +127,20 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
 
     RowsFetchSpec<<%= asEntity(entityClass) %>> createQuery(Pageable pageable, Criteria criteria) {
         List<Expression> columns = <%= asEntity(entityClass) %>SqlHelper.getColumns(entityTable, EntityManager.ENTITY_ALIAS);
-        <%_ eagerRelations.forEach(function(rel) { _%>
+<%_ eagerRelations.forEach(function(rel) { _%>
         columns.addAll(<%= rel.otherEntityNameCapitalized %>SqlHelper.getColumns(<%= rel.relationshipName %>Table, "<%= rel.relationshipName %>"));
-        <%_ }); _%>
-        SelectFromAndJoin<% if (eagerRelations.length > 0) { %>Condition<% } %> selectFrom = Select.builder().select(columns).from(entityTable)<%_ eagerRelations.forEach(function(rel) { 
+<%_ }); _%>
+        SelectFromAndJoin<% if (eagerRelations.length > 0) { %>Condition<% } %> selectFrom = Select.builder().select(columns).from(entityTable)<%_ eagerRelations.forEach(function(rel) {
             const colName = _getJoinColumnName(rel); %>
             .leftOuterJoin(<%= rel.relationshipName %>Table).on(Column.create("<%= colName %>", entityTable)).equals(Column.create("id", <%= rel.relationshipName %>Table ))<%_ }); _%>;
 
-        String select = entityManager.createSelect(selectFrom, <%= asEntity(entityClass) %>.class, pageable/*, criteria */);
-        return db.execute(select)
-                .map(this::process);
+        String select = entityManager.createSelect(selectFrom, <%= asEntity(entityClass) %>.class, pageable, criteria);
+<%_ if (databaseType === 'sql') { _%>
+        String selectWhere =
+                    Optional.ofNullable(criteria).map(crit ->
+                    new StringBuilder(select).append(" ").append("WHERE").append(" ").append(crit.toString()).toString()).orElse(select); // TODO remove once https://github.com/spring-projects/spring-data-jdbc/issues/907 will be fixed
+<%_ } _%>
+        return db.execute(select<% if (databaseType === 'sql') { %>Where<% } %>).map(this::process);
     }
 
     @Override
@@ -148,7 +153,7 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
         return createQuery(null, Criteria.where("id").is(id)).one();
     }
 
-    <%_ if (fieldsContainOwnerManyToMany) { _%>
+<%_ if (fieldsContainOwnerManyToMany) { _%>
 
     @Override
     public Mono<<%= asEntity(entityClass) %>> findOneWithEagerRelationships(Long id) {
@@ -165,7 +170,7 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
         return findAllBy(page);
     }
 
-    <%_ } _%>
+<%_ } _%>
     private <%= asEntity(entityClass) %> process(Row row, RowMetadata metadata) {
         <%= asEntity(entityClass) %> entity = <%= entityClass.toLowerCase() %>Mapper.apply(row, "e");
         <%_ eagerRelations.forEach(function(rel) { _%>
@@ -182,9 +187,9 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
     @Override
     public <S extends <%= asEntity(entityClass) %>> Mono<S> save(S entity) {
         if (entity.getId() == null) {
-            <%_ if (isUsingMapsId) { _%>
+<%_ if (isUsingMapsId) { _%>
             entity.setId(entity.get<%= mapsIdAssoc.relationshipNameCapitalized %>().getId());
-            <%_ } _%>
+<%_ } _%>
             return insert(entity)<% if (fieldsContainOwnerManyToMany) { %>.flatMap(savedEntity -> updateRelations(savedEntity))<% } %>;
         } else {
             return update(entity).map(numberOfUpdates -> {
@@ -198,15 +203,15 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
 
     @Override
     public Mono<Integer> update(<%= asEntity(entityClass) %> entity) {
-        <%_ if (fields.length + eagerRelations.length > 0) { _%>
+<%_ if (fields.length + eagerRelations.length > 0) { _%>
         return db.update().table(<%= asEntity(entityClass) %>.class).using(entity).fetch().rowsUpdated();
-        <%_ } else { _%>
+<%_ } else { _%>
         // What can we update on this field?
         return Mono.just(1);
-        <%_ } _%>
+<%_ } _%>
     }
 
-    <%_ if (fieldsContainOwnerManyToMany) { _%>
+<%_ if (fieldsContainOwnerManyToMany) { _%>
 
     @Override
     public Mono<Void> deleteById(Long entityId) {
@@ -216,40 +221,39 @@ class <%= entityClass %>RepositoryInternalImpl implements <%= entityClass %>Repo
     }
 
     protected <S extends <%= asEntity(entityClass) %>> Mono<S> updateRelations(S entity) {
-        <%_ relationships.filter(function(rel) {
-                return (rel.relationshipType === 'many-to-many' && rel.ownerSide);
-            }).forEach(function(rel, idx) {
-                if (idx === 0) { _%>
+  <%_ relationships.filter(function(rel) {
+          return (rel.relationshipType === 'many-to-many' && rel.ownerSide);
+      }).forEach(function(rel, idx) {
+          if (idx === 0) { _%>
         Mono<Void> result = entityManager.updateLinkTable(<%= rel.relationshipName %>Link, entity.getId(), entity.get<%= rel.relationshipNameCapitalizedPlural %>().stream().map(<%= asEntity(rel.otherEntityNameCapitalized) %>::getId)).then();
-        <%_     } else { _%>
+  <%_     } else { _%>
         result = result.and(entityManager.updateLinkTable(<%= rel.relationshipName %>Link, entity.getId(), entity.get<%= rel.relationshipNameCapitalizedPlural %>().stream().map(<%= asEntity(rel.otherEntityNameCapitalized) %>::getId)));
-        <%_
-                }
-            }); _%>
+  <%_
+          }
+      }); _%>
         return result.thenReturn(entity);
     }
 
     protected Mono<Void> deleteRelations(Long entityId) {
-        <%_ relationships.filter(function(rel) {
-                return (rel.relationshipType === 'many-to-many' && rel.ownerSide);
-            }).forEach(function(rel, idx) {
-                if (idx === 0) { _%>
-        return entityManager.deleteFromLinkTable(<%= rel.relationshipName %>Link, entityId)<% 
+  <%_ relationships.filter(function(rel) {
+          return (rel.relationshipType === 'many-to-many' && rel.ownerSide);
+      }).forEach(function(rel, idx) {
+          if (idx === 0) { _%>
+        return entityManager.deleteFromLinkTable(<%= rel.relationshipName %>Link, entityId)<%
                 } else { %>
-                .and(entityManager.deleteFromLinkTable(<%= rel.relationshipName %>Link, entityId))<% } 
+                .and(entityManager.deleteFromLinkTable(<%= rel.relationshipName %>Link, entityId))<% }
             }); %>;
     }
 
-    <%_ } _%>
+  <%_ } _%>
 }
 
 class <%= entityClass %>SqlHelper {
     static List<Expression> getColumns(Table table, String columnPrefix) {
         List<Expression> columns = new ArrayList<>();
         columns.add(Column.aliased("id", table, columnPrefix + "_id"));
-<%_ fields.forEach(function(field) { 
-    let col = field.fieldNameAsDatabaseColumn;
-    _%>
+  <%_ fields.forEach(function(field) {
+    let col = field.fieldNameAsDatabaseColumn; _%>
         columns.add(Column.aliased("<%= col %>", table, columnPrefix + "_<%= col %>"));
    <%_  if ((field.fieldType === 'byte[]' || field.fieldType === 'ByteBuffer') && field.fieldTypeBlobContent !== 'text') { _%>
         columns.add(Column.aliased("<%= col %>_content_type", table, columnPrefix + "_<%= col %>_content_type"));

--- a/generators/server/templates/src/main/java/package/service/EntityManager.java.ejs
+++ b/generators/server/templates/src/main/java/package/service/EntityManager.java.ejs
@@ -51,7 +51,7 @@ import reactor.core.publisher.Mono;
 
 /**
  * Helper class to create SQL selects based on the entity, paging parameters and criteria.
- * 
+ *
  */
 @Service
 public class EntityManager {
@@ -92,11 +92,19 @@ public class EntityManager {
      * @param pageable page parameter, or null, if everything needs to be returned
      * @return sql select statement
      */
-    public String createSelect(SelectFromAndJoin selectFrom, Class<?> entityType, Pageable pageable) {
+    public String createSelect(SelectFromAndJoin selectFrom, Class<?> entityType, Pageable pageable, Criteria criteria) {
         if (pageable != null) {
-            return createSelectImpl(selectFrom.limitOffset(pageable.getPageSize(), pageable.getOffset()), entityType, pageable.getSort());
+            if (null != criteria) {
+                return createSelectImpl(selectFrom.limitOffset(pageable.getPageSize(), pageable.getOffset()).where(Conditions.just(criteria.toString())), entityType, pageable.getSort());
+            } else {
+                return createSelectImpl(selectFrom.limitOffset(pageable.getPageSize(), pageable.getOffset()), entityType, pageable.getSort());
+            }
         } else {
-            return createSelectImpl(selectFrom, entityType, null);
+            if (null != criteria) {
+                return createSelectImpl(selectFrom.where(Conditions.just(criteria.toString())), entityType, null);
+            } else {
+                return createSelectImpl(selectFrom, entityType, null);
+            }
         }
     }
 
@@ -107,11 +115,19 @@ public class EntityManager {
      * @param pageable page parameter, or null, if everything needs to be returned
      * @return sql select statement
      */
-    public String createSelect(SelectFromAndJoinCondition selectFrom, Class<?> entityType, Pageable pageable) {
+    public String createSelect(SelectFromAndJoinCondition selectFrom, Class<?> entityType, Pageable pageable, Criteria criteria) {
         if (pageable != null) {
-            return createSelectImpl(selectFrom.limitOffset(pageable.getPageSize(), pageable.getOffset()), entityType, pageable.getSort());
+            if (null != criteria) {
+                return createSelectImpl(selectFrom.limitOffset(pageable.getPageSize(), pageable.getOffset()).where(Conditions.just(criteria.toString())), entityType, pageable.getSort());
+            } else {
+                return createSelectImpl(selectFrom.limitOffset(pageable.getPageSize(), pageable.getOffset()), entityType, pageable.getSort());
+            }
         } else {
-            return createSelectImpl(selectFrom, entityType, null);
+            if (null != criteria) {
+                return createSelectImpl(selectFrom.where(Conditions.just(criteria.toString())), entityType, null);
+            } else {
+                return createSelectImpl(selectFrom, entityType, null);
+            }
         }
     }
 


### PR DESCRIPTION
FindById is not filtering the data (where statement) when using r2dbc.
Thus making entity update and entity detail page to fail.

This patch ensures that the 'Where' statement is added on the sql statement.
However, spring relational has a bug (not interpreting the 'just' statement while rendering sql thus leading to add a hack on the repository side.

See code comment for more info
---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
