### PR TITLE
Fix Protractor tests so they work with Okta {angular, react, vue}

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/account/account.spec.ts.ejs
@@ -73,6 +73,7 @@ describe('account', () => {
     } else {
       // Okta
       const error = element(by.css('.infobox-error'));
+      await browser.wait(ec.presenceOf(error), 5000);
       expect(await error.getText()).to.eq('Unable to sign in');
     }
   <%_ } _%>
@@ -92,6 +93,7 @@ describe('account', () => {
     expect(value1).to.eq(expect1);
     await signInPage.autoSignInUsing(username, password);
   <%_ } else { _%>
+    await signInPage.clearPassword();
     await signInPage.loginWithOAuth('', password);
   <%_ } _%>
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -65,47 +65,53 @@ describe('administration', () => {
 
   it('should load metrics', async () => {
     await navBarPage.clickOnAdmin('metrics');
+    const heading = element(by.id('metrics-page-heading'));
+    await browser.wait(ec.visibilityOf(heading), 2000);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'metrics.title';
     <%_ } else { _%>
     const expect1 = 'Application Metrics';
     <%_ } _%>
-    const value1 = await element(by.id('metrics-page-heading')).<%- elementGetter %>;
+    const value1 = await heading.<%- elementGetter %>;
     expect(value1).to.eq(expect1);
   });
 
   it('should load health', async () => {
     await navBarPage.clickOnAdmin('health');
+    const heading = element(by.id('health-page-heading'));
+    await browser.wait(ec.visibilityOf(heading), 2000);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'health.title';
     <%_ } else { _%>
     const expect1 = 'Health Checks';
     <%_ } _%>
-    const value1 = await element(by.id('health-page-heading')).<%- elementGetter %>;
+    const value1 = await heading.<%- elementGetter %>;
     expect(value1).to.eq(expect1);
   });
 
   it('should load configuration', async () => {
     await navBarPage.clickOnAdmin('configuration');
-    await browser.sleep(500);
+    const heading = element(by.id('configuration-page-heading'));
+    await browser.wait(ec.visibilityOf(heading), 2000);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'configuration.title';
     <%_ } else { _%>
     const expect1 = 'Configuration';
     <%_ } _%>
-    const value1 = await element(by.id('configuration-page-heading')).<%- elementGetter %>;
+    const value1 = await heading.<%- elementGetter %>;
     expect(value1).to.eq(expect1);
   });
 
   it('should load logs', async () => {
     await navBarPage.clickOnAdmin('logs');
-    await browser.sleep(500);
+    const heading = element(by.id('logs-page-heading'));
+    await browser.wait(ec.visibilityOf(heading), 2000);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'logs.title';
     <%_ } else { _%>
     const expect1 = 'Logs';
     <%_ } _%>
-    const value1 = await element(by.id('logs-page-heading')).<%- elementGetter %>;
+    const value1 = await heading.<%- elementGetter %>;
     expect(value1).to.eq(expect1);
   });
 

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { element, by, ElementFinder<% if (authenticationType === 'oauth2') { _%>, browser<%_ } %> } from 'protractor';
+import { element, by, ElementFinder<% if (authenticationType === 'oauth2') { _%>, browser, ExpectedConditions as ec<%_ } %> } from 'protractor';
 
 <%_
 let elementGetter = `getText()`;
@@ -167,6 +167,7 @@ export class SignInPage {
   async loginWithOAuth(username: string, password: string): Promise<void> {
     // Entering non angular site, tell webdriver to switch to synchronous mode.
     await browser.waitForAngularEnabled(false);
+    await browser.wait(ec.presenceOf(this.username), 5000);
 
     if (await this.username.isPresent()) {
       await this.username.sendKeys(username);

--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -166,7 +166,7 @@
     <%_ } _%>
     "typescript": "VERSION_MANAGED_BY_CLIENT_REACT",
     <%_ if (protractorTests) { _%>
-    "webdriver-manager": "12.1.7",
+    "webdriver-manager": "12.1.8",
     <%_ } _%>
     "webpack": "VERSION_MANAGED_BY_CLIENT_REACT",
     "webpack-cli": "3.3.11",

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/administration.reducer.spec.ts.ejs
@@ -41,7 +41,7 @@ import administration, {
 } from './administration.reducer';
 
 describe('Administration reducer tests', () => {
-  const username = process.env.E2E_USERNAME || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
 
   function isEmpty(element): boolean {
     if (element instanceof Array) {

--- a/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/modules/administration/user-management/user-management.reducer.spec.ts.ejs
@@ -39,7 +39,7 @@ import { defaultValue } from 'app/shared/model/user.model';
 import { AUTHORITIES } from 'app/config/constants';
 
 describe('User management reducer tests', () => {
-  const username = process.env.E2E_USERNAME || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
 
   function isEmpty(element): boolean {
     if (element instanceof Array) {

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -47,8 +47,8 @@ const expect = chai.expect;
 describe('Account', () => {
   let navBarPage: NavBarPage;
   let signInPage: SignInPage;
-  const username = process.env.E2E_USERNAME || 'admin';
-  const password = process.env.E2E_PASSWORD || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
+  const password = process.env.E2E_PASSWORD ?? 'admin';
   <%_ if (!skipUserManagement) { _%>
   let passwordPage: PasswordPage;
   let settingsPage: SettingsPage;

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -27,8 +27,8 @@ const expect = chai.expect;
 describe('Administration', () => {
   let navBarPage: NavBarPage;
   let signInPage: SignInPage;
-  const username = process.env.E2E_USERNAME || 'admin';
-  const password = process.env.E2E_PASSWORD || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
+  const password = process.env.E2E_PASSWORD ?? 'admin';
 
   before(async () => {
     await browser.get('/');

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/navbar-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/navbar-page.ts.ejs
@@ -89,8 +89,8 @@ export default class NavBarPage extends BasePage {
 
   async autoSignIn() {
     await this.signInPage.get();
-    const username = process.env.E2E_USERNAME || 'admin';
-    const password = process.env.E2E_PASSWORD || 'admin';
+    const username = process.env.E2E_USERNAME ?? 'admin';
+    const password = process.env.E2E_PASSWORD ?? 'admin';
     <%_ if (authenticationType !== 'oauth2') { _%>
     await this.signInPage.autoSignInUsing(username, password);
     <%_ } else { _%>

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -1,4 +1,4 @@
-import { $, browser, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by<% } %> } from 'protractor';
+import { $, browser, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, ExpectedConditions as ec<% } %> } from 'protractor';
 
 import BasePage from './base-component';
 
@@ -54,6 +54,7 @@ export default class SignInPage extends BasePage {
   }
   <%_ } else { _%>
   async loginWithOAuth(username: string, password: string) {
+    await browser.wait(ec.presenceOf(this.username), 5000);
     if (await this.username.isPresent()) {
       await this.setUserName(username);
       await this.setPassword(password);

--- a/generators/client/templates/react/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/protractor.conf.js.ejs
@@ -61,7 +61,7 @@ exports.config = {
     // @ts-ignore
     browser.driver.manage().window().setSize(1280, 1024);
     // @ts-ignore
-    browser.ignoreSynchronization = true;
+    browser.waitForAngularEnabled(false);;
     // Disable animations
     // @ts-ignore
     browser.executeScript('document.body.className += " notransition";');

--- a/generators/client/templates/react/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/react/src/test/javascript/protractor.conf.js.ejs
@@ -61,7 +61,7 @@ exports.config = {
     // @ts-ignore
     browser.driver.manage().window().setSize(1280, 1024);
     // @ts-ignore
-    browser.waitForAngularEnabled(false);;
+    browser.waitForAngularEnabled(false);
     // Disable animations
     // @ts-ignore
     browser.executeScript('document.body.className += " notransition";');

--- a/generators/client/templates/vue/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -20,8 +20,8 @@ const expect = chai.expect;
 describe('Account', () => {
   let navBarPage: NavBarPage = new NavBarPage();
   let signInPage: SignInPage;
-  const username = process.env.E2E_USERNAME || 'admin';
-  const password = process.env.E2E_PASSWORD || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
+  const password = process.env.E2E_PASSWORD ?? 'admin';
 <%_ if (!skipUserManagement) { _%>
   let passwordPage: PasswordPage;
   let settingsPage: SettingsPage;

--- a/generators/client/templates/vue/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -9,8 +9,8 @@ const expect = chai.expect;
 
 describe('Administration', () => {
   let navBarPage: NavBarPage;
-  const username = process.env.E2E_USERNAME || 'admin';
-  const password = process.env.E2E_PASSWORD || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
+  const password = process.env.E2E_PASSWORD ?? 'admin';
 
   before(async () => {
     await browser.get('/');

--- a/generators/client/templates/vue/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -9,11 +9,13 @@ const expect = chai.expect;
 
 describe('Administration', () => {
   let navBarPage: NavBarPage;
+  const username = process.env.E2E_USERNAME || 'admin';
+  const password = process.env.E2E_PASSWORD || 'admin';
 
   before(async () => {
     await browser.get('/');
     navBarPage = new NavBarPage();
-    await navBarPage.login('admin', 'admin');
+    await navBarPage.login(username, password);
     await waitUntilDisplayed(navBarPage.adminMenu);
   });
 

--- a/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -1,4 +1,4 @@
-import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser, protractor<% } %>  } from 'protractor';
+import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser, ExpectedConditions as ecs<% } %>  } from 'protractor';
 
 import AlertPage from './alert-page';
 
@@ -29,8 +29,7 @@ export default class SignInPage extends AlertPage {
   }
 <%_ } else { _%>
   async login(username: string, password: string) {
-    const EC = protractor.ExpectedConditions;
-    await browser.wait(EC.presenceOf(this.username), 5000);
+    await browser.wait(ec.presenceOf(this.username), 5000);
     if (await this.username.isPresent()) {
       await this.username.sendKeys(username);
       await this.password.sendKeys(password);

--- a/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -1,4 +1,4 @@
-import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser, ExpectedConditions as ecs<% } %>  } from 'protractor';
+import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser, ExpectedConditions as ec<% } %>  } from 'protractor';
 
 import AlertPage from './alert-page';
 

--- a/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -1,4 +1,4 @@
-import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by<% } %>  } from 'protractor';
+import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser, protractor<% } %>  } from 'protractor';
 
 import AlertPage from './alert-page';
 
@@ -29,6 +29,8 @@ export default class SignInPage extends AlertPage {
   }
 <%_ } else { _%>
   async login(username: string, password: string) {
+    const EC = protractor.ExpectedConditions;
+    await browser.wait(EC.presenceOf(this.username), 5000);
     if (await this.username.isPresent()) {
       await this.username.sendKeys(username);
       await this.password.sendKeys(password);

--- a/generators/client/templates/vue/src/test/javascript/protractor.conf.js.ejs
+++ b/generators/client/templates/vue/src/test/javascript/protractor.conf.js.ejs
@@ -45,7 +45,7 @@ exports.config = {
       .window()
       .setSize(1280, 1024);
     // @ts-ignore
-    browser.ignoreSynchronization = true;
+    browser.waitForAngularEnabled(false);
     // Disable animations
     // @ts-ignore
     browser.executeScript('document.body.className += " notransition";');

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -60,15 +60,17 @@ describe('<%= entityClass %> e2e test', () => {
     const fileToUpload = '../../../../../../<%= entityParentPathAddition %><%= CLIENT_MAIN_SRC_DIR %>content/images/' + fileNameToUpload;
     const absolutePath = path.resolve(__dirname, fileToUpload);
     <%_ } _%>
+    const username = process.env.E2E_USERNAME || 'admin';
+    const password = process.env.E2E_PASSWORD || 'admin';
 
     before(async () => {
         await browser.get('/');
         navBarPage = new NavBarPage();
         signInPage = await navBarPage.getSignInPage();
         <%_ if (authenticationType === 'oauth2') { _%>
-        await signInPage.loginWithOAuth('admin', 'admin');
+        await signInPage.loginWithOAuth(username, password);
         <%_ } else { _%>
-        await signInPage.autoSignInUsing('admin', 'admin');
+        await signInPage.autoSignInUsing(username, password);
         <%_ } _%>
         await browser.wait(ec.visibilityOf(navBarPage.entityMenu), 5000);
     });
@@ -208,6 +210,7 @@ describe('<%= entityClass %> e2e test', () => {
             .to.eq('Are you sure you want to delete this <%= entityClassHumanized %>?');
         <%_ } _%>
         await <%= entityInstance %>DeleteDialog.clickOnConfirmButton();
+        await browser.wait(ec.visibilityOf(<%= entityInstance %>ComponentsPage.title), 5000);
 
         expect(await <%= entityInstance %>ComponentsPage.countDeleteButtons()).to.eq(nbButtonsBeforeDelete - 1);
     });<%= closeBlockComment %>

--- a/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -60,8 +60,8 @@ describe('<%= entityClass %> e2e test', () => {
     const fileToUpload = '../../../../../../<%= entityParentPathAddition %><%= CLIENT_MAIN_SRC_DIR %>content/images/' + fileNameToUpload;
     const absolutePath = path.resolve(__dirname, fileToUpload);
     <%_ } _%>
-    const username = process.env.E2E_USERNAME || 'admin';
-    const password = process.env.E2E_PASSWORD || 'admin';
+    const username = process.env.E2E_USERNAME ?? 'admin';
+    const password = process.env.E2E_PASSWORD ?? 'admin';
 
     before(async () => {
         await browser.get('/');

--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -48,8 +48,8 @@ describe('<%= entityClass %> e2e test', () => {
 <%_ if (!readOnly) { _%>
     let <%= entityInstance %>UpdatePage: <%= entityClass %>UpdatePage;
 <%_ } _%>
-    const username = process.env.E2E_USERNAME || 'admin';
-    const password = process.env.E2E_PASSWORD || 'admin';
+    const username = process.env.E2E_USERNAME ?? 'admin';
+    const password = process.env.E2E_PASSWORD ?? 'admin';
 
     before(async () => {
         await browser.get('/');

--- a/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/react/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -48,6 +48,8 @@ describe('<%= entityClass %> e2e test', () => {
 <%_ if (!readOnly) { _%>
     let <%= entityInstance %>UpdatePage: <%= entityClass %>UpdatePage;
 <%_ } _%>
+    const username = process.env.E2E_USERNAME || 'admin';
+    const password = process.env.E2E_PASSWORD || 'admin';
 
     before(async () => {
         await browser.get('/');
@@ -55,13 +57,12 @@ describe('<%= entityClass %> e2e test', () => {
         signInPage = await navBarPage.getSignInPage();
         <%_ if (authenticationType !== 'oauth2') { _%>
         await signInPage.waitUntilDisplayed();
-
-        await signInPage.username.sendKeys('admin');
-        await signInPage.password.sendKeys('admin');
+        await signInPage.username.sendKeys(username);
+        await signInPage.password.sendKeys(password);
         await signInPage.loginButton.click();
         await signInPage.waitUntilHidden();
         <%_ } else { _%>
-        await signInPage.loginWithOAuth('admin', 'admin');
+        await signInPage.loginWithOAuth(username, password);
         <%_ } _%>
         await waitUntilDisplayed(navBarPage.entityMenu);
         await waitUntilDisplayed(navBarPage.adminMenu);

--- a/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -72,8 +72,8 @@ describe('<%= entityClass %> e2e test', () => {
   const absolutePath = path.resolve(__dirname, fileToUpload);
   <%_ } _%>
   let beforeRecordsCount = 0;
-  const username = process.env.E2E_USERNAME || 'admin';
-  const password = process.env.E2E_PASSWORD || 'admin';
+  const username = process.env.E2E_USERNAME ?? 'admin';
+  const password = process.env.E2E_PASSWORD ?? 'admin';
 
   before(async () => {
     await browser.get('/');

--- a/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/vue/src/test/javascript/e2e/entities/entity.spec.ts.ejs
@@ -72,11 +72,13 @@ describe('<%= entityClass %> e2e test', () => {
   const absolutePath = path.resolve(__dirname, fileToUpload);
   <%_ } _%>
   let beforeRecordsCount = 0;
+  const username = process.env.E2E_USERNAME || 'admin';
+  const password = process.env.E2E_PASSWORD || 'admin';
 
   before(async () => {
     await browser.get('/');
     navBarPage = new NavBarPage();
-    await navBarPage.login('admin', 'admin');
+    await navBarPage.login(username, password);
   });
 
 

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -36,7 +36,12 @@ services:
             <%_ if (databaseType === 'sql') {
                 const databaseName = ['mysql', 'mariadb'].includes(prodDatabaseType) ? baseName.toLowerCase() : baseName;
             _%>
+                <%_ if (reactive) { _%>
+            - SPRING_R2DBC_URL=<%- getR2DBCUrl(prodDatabaseType, { hostname: `${baseName.toLowerCase()}-${prodDatabaseType}`, databaseName: databaseName }) %>
+                <%_ } else { %>
             - SPRING_DATASOURCE_URL=<%- getJDBCUrl(prodDatabaseType, { hostname: `${baseName.toLowerCase()}-${prodDatabaseType}`, databaseName: databaseName }) %>
+                <%_ } _%>
+            - SPRING_LIQUIBASE_URL=<%- getJDBCUrl(prodDatabaseType, { hostname: `${baseName.toLowerCase()}-${prodDatabaseType}`, databaseName: databaseName }) %>
             <%_ } _%>
             <%_ if (prodDatabaseType === 'mongodb') { _%>
             - SPRING_DATA_MONGODB_URI=mongodb://<%= baseName.toLowerCase() %>-mongodb:27017<% if (reactive) { %>/?waitQueueMultiple=1000<% } %>


### PR DESCRIPTION
It should be possible to set username and password environment variables, then run Protractor tests against Okta.

```
export E2E_USERNAME="foo"
export E2E_PASSWORD="bar"
npm run e2e
```

This PR makes it so Angular, React, and Vue tests all pass against Okta.

---

Please make sure the below checklist is followed for Pull Requests.

-   [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [x] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [x] Documentation is added/updated where necessary
-   [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
