### PR TITLE
support neo4j with k8s subgenerator

### DIFF
--- a/generators/generator-base-docker.js
+++ b/generators/generator-base-docker.js
@@ -69,6 +69,7 @@ module.exports = class extends BaseGenerator {
                 this.DOCKER_MARIADB = constants.DOCKER_MARIADB;
                 this.DOCKER_POSTGRESQL = constants.DOCKER_POSTGRESQL;
                 this.DOCKER_MONGODB = constants.DOCKER_MONGODB;
+                this.DOCKER_NEO4J = constants.DOCKER_NEO4J;
                 this.DOCKER_COUCHBASE = constants.DOCKER_COUCHBASE;
                 this.DOCKER_MEMCACHED = constants.DOCKER_MEMCACHED;
                 this.DOCKER_REDIS = constants.DOCKER_REDIS;

--- a/generators/kubernetes/templates/db/neo4j.yml.ejs
+++ b/generators/kubernetes/templates/db/neo4j.yml.ejs
@@ -1,0 +1,107 @@
+<%#
+ Copyright 2013-2021 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+<%_ if (kubernetesUseDynamicStorage) { _%>
+apiVersion: <%= KUBERNETES_CORE_API_VERSION %>
+kind: PersistentVolumeClaim
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-neo4j-pvc
+  namespace: <%= kubernetesNamespace %>
+spec:
+  accessModes:
+  - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  <%_ if (kubernetesStorageClassName) { _%>
+  storageClassName: <%= kubernetesStorageClassName %>
+  <%_ } _%>
+  ---
+<%_ } _%>
+apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
+kind: Secret
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-neo4j
+  namespace: <%= kubernetesNamespace %>
+  labels:
+    app: <%= app.baseName.toLowerCase() %>-neo4j
+type: Opaque
+data:
+  neo4j-password: <%= Buffer.from(dbRandomPassword).toString('base64') %>
+---
+apiVersion: <%= KUBERNETES_STATEFULSET_API_VERSION %>
+kind: StatefulSet
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-neo4j
+  namespace: <%= kubernetesNamespace %>
+spec:
+  serviceName: <%= app.baseName.toLowerCase() %>-neo4j
+  replicas: 1
+  selector:
+    matchLabels:
+      app: <%= app.baseName.toLowerCase() %>-neo4j
+  template:
+    metadata:
+      labels:
+        app: <%= app.baseName.toLowerCase() %>-neo4j
+     <%_ if (istio) { _%>
+      annotations:
+        sidecar.istio.io/inject: "false"
+     <%_ } _%>
+    spec:
+      volumes:
+      - name: data
+        <%_ if (kubernetesUseDynamicStorage) { _%>
+        persistentVolumeClaim:
+          claimName: <%= app.baseName.toLowerCase() %>-neo4j-pvc
+        <%_ } else { _%>
+        emptyDir: {}
+        <%_ } _%>
+      containers:
+      - name: neo4j
+        image: <%= DOCKER_NEO4J %>
+        env:
+        - name: NEO4J_AUTH
+          value: 'none'
+        ports:
+        - containerPort: 7474
+        - containerPort: 7687
+        volumeMounts:
+        - name: data
+          mountPath: /var/lib/neo4j/data
+        resources:
+          requests:
+            memory: "512Mi"
+            cpu: "500m"
+          limits:
+            memory: "1Gi"
+            cpu: "1"
+---
+apiVersion: <%= KUBERNETES_CORE_API_VERSION  %>
+kind: Service
+metadata:
+  name: <%= app.baseName.toLowerCase() %>-neo4j
+  namespace: <%= kubernetesNamespace %>
+spec:
+  selector:
+    app: <%= app.baseName.toLowerCase() %>-neo4j
+  ports:
+    - name: web
+      port: 7474
+    - name: bolt
+      port: 7687

--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -69,6 +69,9 @@ spec:
                 <%_ if (app.prodDatabaseType === 'couchbase') { _%>
                   rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-couchbase 8091)
                 <%_ } _%>
+                <%_ if (app.prodDatabaseType === 'neo4j') { _%>
+                  rt=$(nc -z -w 1 <%= app.baseName.toLowerCase() %>-neo4j 7474)
+                <%_ } _%>
                   if [ $? -eq 0 ]; then
                     echo "DB is UP"
                     break
@@ -167,6 +170,10 @@ spec:
           value: <%= app.baseName %>
         - name: SPRING_DATA_MONGODB_URI
           value: "mongodb://<% for (let i = 0; i < app.dbPeerCount; i++) { %><%= app.baseName.toLowerCase() %>-mongodb-<%= i %>.<%= app.baseName.toLowerCase() %>-mongodb.<%= kubernetesNamespace %>:27017<% if (app.reactive) { %>/?waitQueueMultiple=1000<% } %><% if (i < (app.dbPeerCount-1)) { %>,<% }} %>"
+        <%_ } _%>
+        <%_ if (app.prodDatabaseType === 'neo4j') { _%>
+        - name: ORG_NEO4J_DRIVER_URI
+          value: bolt://<%= app.baseName.toLowerCase() %>-neo4j.<%= kubernetesNamespace %>.svc.cluster.local:7687
         <%_ } _%>
         <%_ if (app.prodDatabaseType === 'couchbase') { _%>
         - name: SPRING_COUCHBASE_BOOTSTRAP_HOSTS

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -70,7 +70,7 @@ aptPluginVersion=0.21
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 liquibasePluginVersion=2.0.4
 <%_ } _%>
-sonarqubePluginVersion=3.0
+sonarqubePluginVersion=3.1
 <%_ if (enableSwaggerCodegen) { _%>
 openapiPluginVersion=4.3.1
 <%_ } _%>


### PR DESCRIPTION
This adds a simple stateful set for neo4j community database. There are some gotchas to note:

* the docker image only supports setting the initial password, not a database password, therefore we use auth `none`
* the neo4j helm chart does not support the community edition, so we don't have neo4j for the helm part
* tested with minikube (monolith and example from issue) both worked well (after giving the vm some more power)

closes #13477

---

Please make sure the below checklist is followed for Pull Requests.

-   [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
-   [ ] Tests are added where necessary
-   [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
-   [ ] Documentation is added/updated where necessary
-   [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
