### PR TITLE
Revert "chore(deps-dev): bump css-loader from 3.5.3 to 4.3.0 in /generators/client/templates/vue"

### DIFF
--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -37,7 +37,7 @@
     "browser-sync": "2.26.13",
     "browser-sync-webpack-plugin": "2.3.0",
     "copy-webpack-plugin": "6.4.1",
-    "css-loader": "4.3.0",
+    "css-loader": "3.5.3",
     "file-loader": "6.2.0",
     "fork-ts-checker-webpack-plugin": "4.1.6",
     "friendly-errors-webpack-plugin": "1.7.0",


### PR DESCRIPTION
Reverts jhipster/generator-jhipster#13556