### PR TITLE
Fix name for generated csv file with incremental changelog option

### DIFF
--- a/generators/database-changelog-liquibase/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
+++ b/generators/database-changelog-liquibase/templates/src/main/resources/config/liquibase/changelog/added_entity.xml.ejs
@@ -103,7 +103,7 @@
     -->
     <changeSet id="<%= changelogDate %>-1-data" author="jhipster" context="faker">
         <loadData
-                  file="config/liquibase/fake-data/<%= !entity.incrementalChangelog ? entity.entityTableName : databaseChangelog.changelogDate + '_entity_' + entity.entityClass %>.csv"
+                  file="config/liquibase/fake-data/<%= !entity.incrementalChangelog ? entity.entityTableName : databaseChangelog.changelogDate + '_entity_' + entity.entityTableName %>.csv"
                   separator=";"
                   tableName="<%= entity.entityTableName %>">
             <%_ for (field of fields) {


### PR DESCRIPTION
When using incremental changelog option, the generated file for CSV doesn't match with the one used in XML.

Here an extract of `src/main/resources/config/liquibase/changelog/20210122125559_added_entity_Beer.xml` :

```xml
    <changeSet id="20210122125559-1-data" author="jhipster" context="faker">
        <loadData
                  file="config/liquibase/fake-data/20210122125559_entity_Beer.csv"
                  separator=";"
                  tableName="beer">
            <column name="id" type="numeric"/>
            <column name="name" type="string"/>
            <!-- jhipster-needle-liquibase-add-loadcolumn - JHipster (and/or extensions) can add load columns here -->
        </loadData>
    </changeSet>
```

Here the generated CSV file: `src/main/resources/config/liquibase/fake-data/20210122125559_entity_beer.csv`




---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
