### PR TITLE
Fix Sonar code smell about assertThat

### DIFF
--- a/generators/server/templates/src/test/java/package/security/jwt/TokenProviderTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/jwt/TokenProviderTest.java.ejs
@@ -114,8 +114,7 @@ class TokenProviderTest {
         TokenProvider tokenProvider = new TokenProvider(jHipsterProperties);
 
         Key key = (Key) ReflectionTestUtils.getField(tokenProvider, "key");
-        assertThat(key).isNotNull();
-        assertThat(key).isEqualTo(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)));
+        assertThat(key).isNotNull().isEqualTo(Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8)));
     }
 
     @Test
@@ -127,8 +126,7 @@ class TokenProviderTest {
         TokenProvider tokenProvider = new TokenProvider(jHipsterProperties);
 
         Key key = (Key) ReflectionTestUtils.getField(tokenProvider, "key");
-        assertThat(key).isNotNull();
-        assertThat(key).isEqualTo(Keys.hmacShaKeyFor(Decoders.BASE64.decode(base64Secret)));
+        assertThat(key).isNotNull().isEqualTo(Keys.hmacShaKeyFor(Decoders.BASE64.decode(base64Secret)));
     }
 
     private Authentication createAuthentication() {


### PR DESCRIPTION
Sonar description below.

Consecutive AssertJ "assertThat" statements should be chained.
AssertJ assertions methods targeting the same object can be chained instead of using multiple assertThat. It avoids duplication and increases the clarity of the code.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
