### PR TITLE
Register generator-base at Environment

### DIFF
--- a/generators/base/index.js
+++ b/generators/base/index.js
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2013-2021 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+const BaseGenerator = require('../generator-base');
+
+/*
+ * Register generator-base at yeoman-environment
+ */
+module.exports = BaseGenerator;

--- a/test/base/base.spec.js
+++ b/test/base/base.spec.js
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2013-2021 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable no-unused-expressions */
+const expect = require('chai').expect;
+
+const EnvironmentBuilder = require('../../cli/environment-builder');
+const BaseGenerator = require('../../generators/generator-base');
+
+const { prepareTempDir } = require('../utils/utils');
+
+describe('jhipster:base generator', () => {
+  let cleanup;
+  before(() => {
+    cleanup = prepareTempDir();
+  });
+  after(() => cleanup());
+
+  describe('create', () => {
+    let envBuilder;
+    before(() => {
+      envBuilder = EnvironmentBuilder.createDefaultBuilder();
+    });
+    it('should be registered as jhipster:base at yeoman-environment', () => {
+      expect(envBuilder.getEnvironment().get('jhipster:base')).to.equal(BaseGenerator);
+    });
+  });
+});


### PR DESCRIPTION
Make generator-base available at yeoman-environment at `jhipster:base` namespace.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
