### PR TITLE
fix export/import of otherModules property

### DIFF
--- a/jdl/converters/json-to-jdl-converter.js
+++ b/jdl/converters/json-to-jdl-converter.js
@@ -85,6 +85,9 @@ function cleanYoRcFileContent(yoRcFileContent) {
   if (yoRcFileContent[generatorName].blueprints) {
     yoRcFileContent[generatorName].blueprints = yoRcFileContent[generatorName].blueprints.map(blueprint => blueprint.name);
   }
+  if (yoRcFileContent[generatorName].otherModules) {
+    yoRcFileContent[generatorName].otherModules = yoRcFileContent[generatorName].otherModules.map(module => module.name);
+  }
   return yoRcFileContent;
 }
 

--- a/jdl/exporters/applications/jhipster-application-formatter.js
+++ b/jdl/exporters/applications/jhipster-application-formatter.js
@@ -78,5 +78,10 @@ function cleanUpOptions(application) {
       name: blueprintName,
     }));
   }
+  if (application[GENERATOR_NAME].otherModules) {
+    application[GENERATOR_NAME].otherModules = application[GENERATOR_NAME].otherModules.map(moduleName => ({
+      name: moduleName,
+    }));
+  }
   return application;
 }

--- a/jdl/parsing/validator.js
+++ b/jdl/parsing/validator.js
@@ -167,7 +167,7 @@ const configPropsValidations = {
   },
   OTHER_MODULES: {
     type: 'list',
-    pattern: ALPHANUMERIC,
+    pattern: BASIC_NPM_PACKAGE_NAME_PATTERN,
     msg: 'otherModules property',
   },
   PACKAGE_NAME: {

--- a/test/jdl/converters/json-to-jdl-converter.spec.js
+++ b/test/jdl/converters/json-to-jdl-converter.spec.js
@@ -63,7 +63,7 @@ describe('JSONToJDLConverter', () => {
     languages []
     messageBroker false
     nativeLanguage en
-    otherModules []
+    otherModules [generator-jhipster-vuejs, generator-jhipster-dotnetcore]
     packageName com.mycompany.myapp
     prodDatabaseType mysql
     reactive false

--- a/test/jdl/test-files/json_to_jdl_converter/only_app/.yo-rc.json
+++ b/test/jdl/test-files/json_to_jdl_converter/only_app/.yo-rc.json
@@ -27,7 +27,7 @@
     "jhiPrefix": "jhi",
     "entitySuffix": "",
     "dtoSuffix": "DTO",
-    "otherModules": [],
+    "otherModules": [{ "name": "generator-jhipster-vuejs" }, { "name": "generator-jhipster-dotnetcore" }],
     "enableTranslation": false,
     "clientPackageManager": "npm",
     "skipClient": true,


### PR DESCRIPTION
Exporting Application JDL containing `otherModules` (for example when a blueprint is used) results in a JDL with `otherModules [[object Object]]` which fails when attempting to import.

This PR aligns the logic related to the `otherModules` property with the `blueprints` property, which has the same format. With this change, apps generated with blueprints can export valid JDL.

I am not an expert with JDL parsing so any review is appreciated.

**To reproduce (also happens with beta v7):**
```
# setup
mkdir reproduction && cd reproduction
npm i generator-jhipster@6.10.5 generator-jhipster-quarkus@1.0.0
jhipster jdl --inline "application{ config{ blueprints [generator-jhipster-quarkus]} }" --skip-install

# export-jdl
# npm link generator-jhipster # if you want to use the main branch
jhipster export-jdl
cat jhipster.jdl | grep object
```
---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed