### PR TITLE
improve check for existing heroku app

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -105,7 +105,7 @@ module.exports = class extends BaseBlueprintGenerator {
         const done = this.async();
 
         if (this.herokuAppName) {
-          ChildProcess.exec('heroku apps:info --json', (err, stdout) => {
+          ChildProcess.exec(`heroku apps:info --json ${this.herokuAppName}`, (err, stdout) => {
             if (err) {
               this.abort = true;
               this.log.error(`Could not find application: ${chalk.cyan(this.herokuAppName)}`);

--- a/test/heroku.spec.js
+++ b/test/heroku.spec.js
@@ -211,7 +211,9 @@ describe('JHipster Heroku Sub Generator', () => {
     describe('with existing app', () => {
       const existingHerokuAppName = 'jhipster-existing';
       beforeEach(done => {
-        stub.withArgs('heroku apps:info --json').yields(false, `{"app":{"name":"${existingHerokuAppName}"}, "dynos":[]}`);
+        stub
+          .withArgs(`heroku apps:info --json ${existingHerokuAppName}`)
+          .yields(false, `{"app":{"name":"${existingHerokuAppName}"}, "dynos":[]}`);
         stub.withArgs(`heroku addons:create jawsdb:kitefin --as DATABASE --app ${existingHerokuAppName}`).yields(false, '', '');
         helpers
           .run(require.resolve('../generators/heroku'))


### PR DESCRIPTION
If the `herokuAppName` is set, we check for the existence of the app.  This only works if it has previously been deployed from the same device and directory (it checks for the Heroku git remote).  If a developer clones the project from a repository then tries to run `jhipster heroku`, it will not find the existing app and reset the `herokuAppName` in the `yo-rc.json`

By passing the `herokuAppName` as a param to `heroku apps:info`, we can find out if the app exists. We also find out if the user has access to the application, otherwise an error is returned.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
