### PR TITLE
Fix docker-compose sub generator

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -12,7 +12,7 @@ insert_final_newline = true
 [*.md]
 trim_trailing_whitespace = false
 
-[{*.java,*.java.ejs,*.xml.ejs,*.gradle.ejs,*.sh,*.sh.ejs,*.n1ql.ejs,*.cql.ejs,*.scala.ejs,USAGE}]
+[{*.{java,java.ejs,xml.ejs,gradle.ejs,sh,sh.ejs,n1ql.ejs,cql.ejs,scala.ejs},USAGE}]
 indent_size = 4
 
 [generators/entity-server/templates/**/*_template.ejs]

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -198,7 +198,7 @@ module.exports = class extends BaseDockerGenerator {
           this.authenticationType = appConfig.authenticationType;
 
           // Dump the file
-          let yamlString = jsyaml.dump(parentConfiguration, { indent: 4, lineWidth: -1 });
+          let yamlString = jsyaml.dump(parentConfiguration, { indent: 2, lineWidth: -1 });
 
           // Add extra indentation for each lines
           const yamlArray = yamlString.split('\n');

--- a/generators/docker-compose/index.js
+++ b/generators/docker-compose/index.js
@@ -203,7 +203,7 @@ module.exports = class extends BaseDockerGenerator {
           // Add extra indentation for each lines
           const yamlArray = yamlString.split('\n');
           for (let j = 0; j < yamlArray.length; j++) {
-            yamlArray[j] = `    ${yamlArray[j]}`;
+            yamlArray[j] = `  ${yamlArray[j]}`;
           }
           yamlString = yamlArray.join('\n');
           this.appsYaml.push(yamlString);

--- a/generators/heroku/templates/heroku.gradle.ejs
+++ b/generators/heroku/templates/heroku.gradle.ejs
@@ -19,8 +19,8 @@
 apply plugin: "com.heroku.sdk.heroku-gradle"
 
 heroku {
-  appName = "<%= herokuAppName %>"
-  buildpacks = ["heroku/jvm"]
+    appName = "<%= herokuAppName %>"
+    buildpacks = ["heroku/jvm"]
 }
 <%_ if (herokuDeployType === 'git') { _%>
 


### PR DESCRIPTION
Follow up to #13713 - fixes bug introduced in `docker-compose` sub generator.
`npm test` logged error in log but continued without failing the job.
Couple other polishing while tracking why `npm test` constantly timeouts.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
