### PR TITLE
[Protractor] Sleep and wait for all admin pages to load

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -66,7 +66,7 @@ describe('administration', () => {
   it('should load metrics', async () => {
     await navBarPage.clickOnAdmin('metrics');
     const heading = element(by.id('metrics-page-heading'));
-    await browser.wait(ec.visibilityOf(heading), 2000);
+    await browser.wait(ec.visibilityOf(heading), 5000);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'metrics.title';
     <%_ } else { _%>
@@ -79,7 +79,7 @@ describe('administration', () => {
   it('should load health', async () => {
     await navBarPage.clickOnAdmin('health');
     const heading = element(by.id('health-page-heading'));
-    await browser.wait(ec.visibilityOf(heading), 2000);
+    await browser.wait(ec.visibilityOf(heading), 5000);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'health.title';
     <%_ } else { _%>

--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -65,6 +65,7 @@ describe('administration', () => {
 
   it('should load metrics', async () => {
     await navBarPage.clickOnAdmin('metrics');
+    await browser.sleep(500);
     const heading = element(by.id('metrics-page-heading'));
     await browser.wait(ec.visibilityOf(heading), 5000);
     <%_ if (enableTranslation) { _%>
@@ -78,6 +79,7 @@ describe('administration', () => {
 
   it('should load health', async () => {
     await navBarPage.clickOnAdmin('health');
+    await browser.sleep(500);
     const heading = element(by.id('health-page-heading'));
     await browser.wait(ec.visibilityOf(heading), 5000);
     <%_ if (enableTranslation) { _%>
@@ -91,8 +93,10 @@ describe('administration', () => {
 
   it('should load configuration', async () => {
     await navBarPage.clickOnAdmin('configuration');
+    await browser.sleep(500);
     const heading = element(by.id('configuration-page-heading'));
     await browser.wait(ec.visibilityOf(heading), 5000);
+    await browser.sleep(500);
     <%_ if (enableTranslation) { _%>
     const expect1 = 'configuration.title';
     <%_ } else { _%>
@@ -104,6 +108,7 @@ describe('administration', () => {
 
   it('should load logs', async () => {
     await navBarPage.clickOnAdmin('logs');
+    await browser.sleep(500);
     const heading = element(by.id('logs-page-heading'));
     await browser.wait(ec.visibilityOf(heading), 5000);
     <%_ if (enableTranslation) { _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -788,10 +788,10 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
         <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)<%= callBlock %>;
 
         List<<%= entityClass %>> <%= entityInstance %>List = webTestClient.get().uri("/api/<%= entityApiUrl %>")
-            .accept(MediaType.APPLICATION_NDJSON)
+            .accept(MediaType.APPLICATION_STREAM_JSON)
             .exchange()
             .expectStatus().isOk()
-            .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_NDJSON)
+            .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_STREAM_JSON)
             .returnResult(<%= dto !== 'no' ? asDto(entityClass) : asEntity(entityClass) %>.class)
             .getResponseBody()
             <%_ if (dto !== 'no') { _%>

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -788,10 +788,10 @@ class <%= entityClass %>ResourceIT <% if (databaseType === 'cassandra') { %>exte
         <%= entityInstance %>Repository.save(<%= asEntity(entityInstance) %>)<%= callBlock %>;
 
         List<<%= entityClass %>> <%= entityInstance %>List = webTestClient.get().uri("/api/<%= entityApiUrl %>")
-            .accept(MediaType.APPLICATION_STREAM_JSON)
+            .accept(MediaType.APPLICATION_NDJSON)
             .exchange()
             .expectStatus().isOk()
-            .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_STREAM_JSON)
+            .expectHeader().contentTypeCompatibleWith(MediaType.APPLICATION_NDJSON)
             .returnResult(<%= dto !== 'no' ? asDto(entityClass) : asEntity(entityClass) %>.class)
             .getResponseBody()
             <%_ if (dto !== 'no') { _%>


### PR DESCRIPTION
Another attempt to fix Protractor since [tests are still failing](https://github.com/hipster-labs/jhipster-daily-builds/runs/1771529176?check_suite_focus=true).
