### PR TITLE
[Protractor] Remove sleep because React doesn't need it

### DIFF
--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -60,7 +60,7 @@ describe('Administration', () => {
 
   it('should load metrics', async () => {
     await navBarPage.clickOnAdminMenuItem('metrics');
-    browser.sleep(1000);
+    await browser.sleep(1000);
     await waitUntilDisplayed(element(by.id('metrics-page-heading')));
     expect(await element(by.id('metrics-page-heading')).getText()).to.eq('Application Metrics');
   });

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -60,6 +60,7 @@ describe('Administration', () => {
 
   it('should load metrics', async () => {
     await navBarPage.clickOnAdminMenuItem('metrics');
+    browser.sleep(1000);
     await waitUntilDisplayed(element(by.id('metrics-page-heading')));
     expect(await element(by.id('metrics-page-heading')).getText()).to.eq('Application Metrics');
   });

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -60,7 +60,6 @@ describe('Administration', () => {
 
   it('should load metrics', async () => {
     await navBarPage.clickOnAdminMenuItem('metrics');
-    await browser.sleep(500);
     await waitUntilDisplayed(element(by.id('metrics-page-heading')));
     expect(await element(by.id('metrics-page-heading')).getText()).to.eq('Application Metrics');
   });


### PR DESCRIPTION
Still trying to fix the failing [React + OAuth 2.0](https://github.com/hipster-labs/jhipster-daily-builds/actions/runs/513038454) daily build. 

NOTE: We might be able to reduce the e2e times on these jobs by specifying a lighter set of entities, or none at all. Currently, there's a lot.

<img width="1128" alt="Screen Shot 2021-01-26 at 6 55 42 PM" src="https://user-images.githubusercontent.com/17892/105931261-1a2b9200-6008-11eb-9f53-414a7bad597a.png">
