### PR TITLE
Align with Java 8 API.

### DIFF
--- a/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/jwt/TokenProvider.java.ejs
@@ -105,7 +105,7 @@ public class TokenProvider {
 
         Collection<? extends GrantedAuthority> authorities =
             Arrays.stream(claims.get(AUTHORITIES_KEY).toString().split(","))
-                .filter(auth -> !auth.isBlank())
+                .filter(auth -> !auth.trim().isEmpty())
                 .map(SimpleGrantedAuthority::new)
                 .collect(Collectors.toList());
 


### PR DESCRIPTION
Since Java 8 support is not dropped in JHipster for now as discussed in https://github.com/jhipster/generator-jhipster/pull/12021#issuecomment-652968697 , the usage of Java 9+ APIs should be prevented.


Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->

