### PR TITLE
Clear security context after tests

### DIFF
--- a/generators/server/templates/src/test/java/package/security/SecurityUtilsUnitTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/security/SecurityUtilsUnitTest.java.ejs
@@ -18,6 +18,8 @@
 -%>
 package <%= packageName %>.security;
 
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.GrantedAuthority;
@@ -58,6 +60,12 @@ import static org.springframework.security.oauth2.core.oidc.endpoint.OidcParamet
 class SecurityUtilsUnitTest {
 
 <%_ if (!reactive) { _%>
+    @BeforeEach
+    @AfterEach
+    void cleanup() {
+        SecurityContextHolder.clearContext();
+    }
+
     @Test
     void testGetCurrentUserLogin() {
         SecurityContext securityContext = SecurityContextHolder.createEmptyContext();


### PR DESCRIPTION
Since this test is setting a security context, it should clear it afterwards.
I'm also cleaning it upfront with `@BeforeEach` just to make sure it's also clean when starting the test. It's not necessary if all tests are cautious.

A similar code should be added to the reactive part I guess. But I wanted to make sure you agree with the PR first.

Another thing: When the security context is retrieve, it is created directly. So the following code
```java
SecurityContext securityContext = SecurityContextHolder.createEmptyContext();
securityContext.setAuthentication(new UsernamePasswordAuthenticationToken("admin", "admin"));
SecurityContextHolder.setContext(securityContext);
```

can be simplified to
```java
SecurityContextHolder.getContext().setAuthentication(new UsernamePasswordAuthenticationToken("admin", "admin"));
```

I can add this to the PR too if you are interested.
