### PR TITLE
Move fields processing to after entity fields preparing.

### DIFF
--- a/utils/entity.js
+++ b/utils/entity.js
@@ -19,7 +19,6 @@
 
 const _ = require('lodash');
 const pluralize = require('pluralize');
-const { fieldIsEnum } = require('./field');
 const { createFaker } = require('./faker');
 const { parseLiquibaseChangelogDate } = require('./liquibase');
 const { entityDefaultConfig } = require('../generators/generator-defaults');
@@ -251,53 +250,6 @@ function prepareEntityForTemplates(entityWithConfig, generator) {
       };
     }
   }
-
-  entityWithConfig.fields.forEach(field => {
-    const fieldType = field.fieldType;
-    if (!['Instant', 'ZonedDateTime', 'Boolean'].includes(fieldType)) {
-      entityWithConfig.fieldsIsReactAvField = true;
-    }
-
-    if (field.javadoc) {
-      entityWithConfig.haveFieldWithJavadoc = true;
-    }
-
-    if (fieldIsEnum(fieldType)) {
-      entityWithConfig.i18nToLoad.push(field.enumInstance);
-    }
-
-    if (fieldType === 'ZonedDateTime') {
-      entityWithConfig.fieldsContainZonedDateTime = true;
-      entityWithConfig.fieldsContainDate = true;
-    } else if (fieldType === 'Instant') {
-      entityWithConfig.fieldsContainInstant = true;
-      entityWithConfig.fieldsContainDate = true;
-    } else if (fieldType === 'Duration') {
-      entityWithConfig.fieldsContainDuration = true;
-    } else if (fieldType === 'LocalDate') {
-      entityWithConfig.fieldsContainLocalDate = true;
-      entityWithConfig.fieldsContainDate = true;
-    } else if (fieldType === 'BigDecimal') {
-      entityWithConfig.fieldsContainBigDecimal = true;
-    } else if (fieldType === 'UUID') {
-      entityWithConfig.fieldsContainUUID = true;
-    } else if (fieldType === 'byte[]' || fieldType === 'ByteBuffer') {
-      entityWithConfig.blobFields.push(field);
-      entityWithConfig.fieldsContainBlob = true;
-      if (field.fieldTypeBlobContent === 'image') {
-        entityWithConfig.fieldsContainImageBlob = true;
-      }
-      if (field.fieldTypeBlobContent !== 'text') {
-        entityWithConfig.fieldsContainBlobOrImage = true;
-      } else {
-        entityWithConfig.fieldsContainTextBlob = true;
-      }
-    }
-
-    if (Array.isArray(field.fieldValidateRules) && field.fieldValidateRules.length >= 1) {
-      entityWithConfig.validation = true;
-    }
-  });
 
   entityWithConfig.generateFakeData = type => {
     const fieldsToGenerate = type === 'cypress' ? entityWithConfig.fields.filter(field => !field.id) : entityWithConfig.fields;

--- a/utils/field.js
+++ b/utils/field.js
@@ -158,6 +158,18 @@ function prepareFieldForTemplates(entityWithConfig, field, generator) {
   });
   const fieldType = field.fieldType;
 
+  if (field.mapstructExpression) {
+    assert.equal(
+      entityWithConfig.dto,
+      'mapstruct',
+      `@MapstructExpression requires an Entity with mapstruct dto [${entityWithConfig.name}.${field.fieldName}].`
+    );
+    // Remove from Entity.java and liquibase.
+    field.transient = true;
+    // Disable update form.
+    field.readonly = true;
+  }
+
   if (field.id) {
     if (field.autoGenerate === false || !['Long', 'UUID'].includes(field.fieldType)) {
       field.liquibaseAutoIncrement = false;
@@ -274,18 +286,6 @@ function prepareFieldForTemplates(entityWithConfig, field, generator) {
     return data;
   };
   field.reference = fieldToReference(entityWithConfig, field);
-
-  if (field.mapstructExpression) {
-    assert.equal(
-      entityWithConfig.dto,
-      'mapstruct',
-      `@MapstructExpression requires an Entity with mapstruct dto [${entityWithConfig.name}.${field.fieldName}].`
-    );
-    // Remove from Entity.java and liquibase.
-    field.transient = true;
-    // Disable update form.
-    field.readonly = true;
-  }
 
   return field;
 }


### PR DESCRIPTION
There are some attributes that `prepareFieldForTemplates` can update.
So we should process the fields after  `prepareFieldForTemplates` been executed.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
