### PR TITLE
[angular] Fix Angular CLI 11.1 camel case arguments deprecation warning

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -175,7 +175,7 @@
     "serve": "<%= clientPackageManager %> run start",
     "build": "<%= clientPackageManager %> run webapp:prod",
     "pretest": "<%= clientPackageManager %> run lint",
-    "test": "ng test --coverage --logHeapUsage -w=2",
+    "test": "ng test --coverage --log-heap-usage -w=2",
     "test:watch": "<%= clientPackageManager %> run test -- --watch",
     "webapp:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webapp:build:dev",
     "webapp:build:dev": "ng build",


### PR DESCRIPTION
Fix warning since Angular CLI version 11.1 while running `npm test`
```
Support for camel case arguments has been deprecated and will be removed in a future major version.
Use '--log-heap-usage' instead of '--logHeapUsage'.
```

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
