### PR TITLE
Protractor fix flaky tests

### DIFF
--- a/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/admin/administration.spec.ts.ejs
@@ -63,7 +63,6 @@ describe('administration', () => {
   });
   <%_ } _%>
 
-  /* This test tends to fail with Protractor, so we've disabled it. Please enable if it passes for you!
   it('should load metrics', async () => {
     await navBarPage.clickOnAdmin('metrics');
     const heading = element(by.id('metrics-page-heading'));
@@ -75,7 +74,7 @@ describe('administration', () => {
     <%_ } _%>
     const value1 = await heading.<%- elementGetter %>;
     expect(value1).to.eq(expect1);
-  }); */
+  });
 
   it('should load health', async () => {
     await navBarPage.clickOnAdmin('health');

--- a/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
+++ b/generators/client/templates/angular/src/test/javascript/e2e/page-objects/jhi-page-objects.ts.ejs
@@ -16,7 +16,7 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-import { element, by, ElementFinder<% if (authenticationType === 'oauth2') { _%>, browser, ExpectedConditions as ec<%_ } %> } from 'protractor';
+import { element, by, ElementFinder<% if (authenticationType === 'oauth2') { _%>, browser<%_ } %> } from 'protractor';
 
 <%_
 let elementGetter = `getText()`;
@@ -167,7 +167,7 @@ export class SignInPage {
   async loginWithOAuth(username: string, password: string): Promise<void> {
     // Entering non angular site, tell webdriver to switch to synchronous mode.
     await browser.waitForAngularEnabled(false);
-    await browser.wait(ec.presenceOf(this.username), 5000);
+    await browser.sleep(1000);
 
     if (await this.username.isPresent()) {
       await this.username.sendKeys(username);

--- a/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/modules/administration/administration.spec.ts.ejs
@@ -58,12 +58,11 @@ describe('Administration', () => {
   });
   <%_ } _%>
 
-  /* This test tends to fail with Protractor, so we've disabled it. Please enable if it passes for you!
   it('should load metrics', async () => {
     await navBarPage.clickOnAdminMenuItem('metrics');
     await waitUntilDisplayed(element(by.id('metrics-page-heading')));
     expect(await element(by.id('metrics-page-heading')).getText()).to.eq('Application Metrics');
-  }); */
+  });
 
   it('should load health', async () => {
     await navBarPage.clickOnAdminMenuItem('health');

--- a/generators/client/templates/react/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/react/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -1,4 +1,4 @@
-import { $, browser, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, ExpectedConditions as ec<% } %> } from 'protractor';
+import { $, browser, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by<% } %> } from 'protractor';
 
 import BasePage from './base-component';
 
@@ -54,7 +54,7 @@ export default class SignInPage extends BasePage {
   }
   <%_ } else { _%>
   async loginWithOAuth(username: string, password: string) {
-    await browser.wait(ec.presenceOf(this.username), 5000);
+    await browser.sleep(1000);
     if (await this.username.isPresent()) {
       await this.setUserName(username);
       await this.setPassword(password);

--- a/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/page-objects/signin-page.ts.ejs
@@ -1,4 +1,4 @@
-import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser, ExpectedConditions as ec<% } %>  } from 'protractor';
+import { $, ElementFinder<% if (authenticationType === 'oauth2') { _%>, element, by, browser<% } %>  } from 'protractor';
 
 import AlertPage from './alert-page';
 
@@ -29,7 +29,7 @@ export default class SignInPage extends AlertPage {
   }
 <%_ } else { _%>
   async login(username: string, password: string) {
-    await browser.wait(ec.presenceOf(this.username), 5000);
+    await browser.sleep(1000);
     if (await this.username.isPresent()) {
       await this.username.sendKeys(username);
       await this.password.sendKeys(password);


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/issues/13723

Finally, I managed to find the root cause of flaky tests. It's not related at all to metrics page.
It's the line `await browser.wait(ec.presenceOf(this.username), 5000);`

I replaced with `await browser.sleep(1000);`
So it shoud do the job. Don't hesitate to comment this @mraible plz, if you think it's wrong

I launch 5 consecutives builds with this fix, and it seems to work fine:

![Capture d’écran de 2021-01-31 21-22-51](https://user-images.githubusercontent.com/9156882/106396874-e4711980-640a-11eb-9a28-a2b08890d450.png)


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
