### PR TITLE
generate random password for initial okta login with heroku

### DIFF
--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -228,7 +228,7 @@ module.exports = class extends BaseBlueprintGenerator {
             type: 'list',
             name: 'useOkta',
             message:
-              'You are using OAuth 2.0. Do you want to use Okta as your identity provider it yourself? When you choose Okta, the automated configuration of users and groups requires cURL and jq.',
+              'You are using OAuth 2.0. Do you want to use Okta? When you choose Okta, the automated configuration of users and groups requires cURL and jq.',
             choices: [
               {
                 value: true,
@@ -816,7 +816,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.log(chalk.yellow('After you have installed jq execute ./provision-okta-addon.sh manually.'));
               }
               if (curlAvailable && jqAvailable) {
-                this.log(chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.'));
+                this.log(chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with JHipster.'));
                 try {
                   await execCmd('./provision-okta-addon.sh');
                   this.log(chalk.bold('\nOkta configured successfully!'));
@@ -824,7 +824,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 } catch (err) {
                   this.log(
                     chalk.red(
-                      'Failed to execute ./provision-okta-addon.sh. Make sure to setup Okta according to https://www.jhipster.tech/heroku/.'
+                      'Failed to execute ./provision-okta-addon.sh. Make sure to set up Okta according to https://www.jhipster.tech/heroku/.'
                     )
                   );
                 }

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -255,8 +255,10 @@ module.exports = class extends BaseBlueprintGenerator {
           {
             type: 'confirm',
             name: 'oktaAdminPassword',
-            message: `Take note of this password! You will need it on your first login: ${this.randomPassword}`,
-            default: true
+            message: `${chalk.blue('Take note of this password!')} You will need it on your first login: ${chalk.blue(
+              this.randomPassword
+            )}`,
+            default: true,
           },
         ];
 
@@ -747,11 +749,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 try {
                   await execCmd('./provision-okta-addon.sh');
                   this.log(chalk.bold('\nOkta configured successfully!'));
-                  this.log(
-                    chalk.green(
-                      `\nUse ${chalk.bold(this.oktaAdminLogin/this.oktaAdminPassword)} to login. You will need to change your password afterwards.\n`
-                    )
-                  );
+                  this.log(chalk.green(`\nUse ${chalk.bold(`${this.oktaAdminLogin}/${this.oktaAdminPassword}`)} to login.\n`));
                 } catch (err) {
                   this.log(
                     chalk.red(
@@ -822,11 +820,7 @@ module.exports = class extends BaseBlueprintGenerator {
                 try {
                   await execCmd('./provision-okta-addon.sh');
                   this.log(chalk.bold('\nOkta configured successfully!'));
-                  this.log(
-                    chalk.green(
-                      `\nUse ${chalk.bold(this.oktaAdminLogin/this.oktaAdminPassword)} to login. You will need to change your password afterwards.`
-                    )
-                  );
+                  this.log(chalk.green(`\nUse ${chalk.bold(`${this.oktaAdminLogin}/${this.oktaAdminPassword}`)} to login.`));
                 } catch (err) {
                   this.log(
                     chalk.red(

--- a/generators/heroku/index.js
+++ b/generators/heroku/index.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 /* eslint-disable consistent-return */
+const crypto = require('crypto');
 const _ = require('lodash');
 const fs = require('fs');
 const ChildProcess = require('child_process');
@@ -53,6 +54,7 @@ module.exports = class extends BaseBlueprintGenerator {
       return;
     }
 
+    this.randomPassword = crypto.randomBytes(20).toString('hex');
     this.herokuSkipBuild = this.options.skipBuild;
     this.herokuSkipDeploy = this.options.skipDeploy || this.options.skipBuild;
 
@@ -251,31 +253,17 @@ module.exports = class extends BaseBlueprintGenerator {
             },
           },
           {
-            type: 'password',
+            type: 'confirm',
             name: 'oktaAdminPassword',
-            message:
-              'Initial password for the JHipster Admin user. Password requirements: at least 8 characters, a lowercase letter, an uppercase letter, a number, no parts of your username.',
-            mask: true,
-            validate: input => {
-              if (!input) {
-                return 'You must enter an initial password for the JHipster admin';
-              }
-              // try to mimic the password requirements by the okta addon
-              const passwordRegex = new RegExp('^(?=.*d)(?=.*[a-z])(?=.*[A-Z]).{8,}$');
-
-              if (passwordRegex.test(input)) {
-                return true;
-              }
-
-              return 'Your password must be at least 8 characters long and contain a lowercase letter, an uppercase letter, a number, and no parts of your username!';
-            },
+            message: `Take note of this password! You will need it on your first login: ${this.randomPassword}`,
+            default: true
           },
         ];
 
         return this.prompt(prompts).then(props => {
           this.useOkta = props.useOkta;
           this.oktaAdminLogin = props.oktaAdminLogin;
-          this.oktaAdminPassword = props.oktaAdminPassword;
+          this.oktaAdminPassword = this.randomPassword;
         });
       },
     };
@@ -758,6 +746,12 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.log(chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.'));
                 try {
                   await execCmd('./provision-okta-addon.sh');
+                  this.log(chalk.bold('\nOkta configured successfully!'));
+                  this.log(
+                    chalk.green(
+                      `\nUse ${chalk.bold(this.oktaAdminLogin/this.oktaAdminPassword)} to login. You will need to change your password afterwards.\n`
+                    )
+                  );
                 } catch (err) {
                   this.log(
                     chalk.red(
@@ -827,10 +821,16 @@ module.exports = class extends BaseBlueprintGenerator {
                 this.log(chalk.green('Running ./provision-okta-addon.sh to create all required roles and users to use with jhipster.'));
                 try {
                   await execCmd('./provision-okta-addon.sh');
+                  this.log(chalk.bold('\nOkta configured successfully!'));
+                  this.log(
+                    chalk.green(
+                      `\nUse ${chalk.bold(this.oktaAdminLogin/this.oktaAdminPassword)} to login. You will need to change your password afterwards.`
+                    )
+                  );
                 } catch (err) {
                   this.log(
                     chalk.red(
-                      'Failed to execute ./provision-okta-addon.sh. Make sure to setup okta according to https://www.jhipster.tech/heroku/.'
+                      'Failed to execute ./provision-okta-addon.sh. Make sure to setup Okta according to https://www.jhipster.tech/heroku/.'
                     )
                   );
                 }


### PR DESCRIPTION
This PR generates a random password for the initial okta login when using heroku. The password is printed to the console afterwards (or can be checked in configuration as before). 

closes #13768

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
