### PR TITLE
Upgrade Protractor to v7 for React and Vue

### DIFF
--- a/generators/client/templates/react/package.json.ejs
+++ b/generators/client/templates/react/package.json.ejs
@@ -139,7 +139,7 @@
     "prettier-plugin-java": "VERSION_MANAGED_BY_CLIENT_REACT",
     <%_ } _%>
     <%_ if (protractorTests) { _%>
-    "protractor": "5.4.4",
+    "protractor": "7.0.0",
     <%_ } _%>
     "react-infinite-scroller": "VERSION_MANAGED_BY_CLIENT_REACT",
     "redux-mock-store": "VERSION_MANAGED_BY_CLIENT_REACT",

--- a/generators/client/templates/vue/package.json.ejs
+++ b/generators/client/templates/vue/package.json.ejs
@@ -62,7 +62,7 @@
     "chai-as-promised": "7.1.1",
     "chai-string": "1.5.0",
     "mocha": "7.1.2",
-    "protractor": "5.4.4",
+    "protractor": "7.0.0",
     "ts-node": "8.10.1",
     "webdriver-manager": "12.1.8",
     <%_ } _%>
@@ -193,7 +193,7 @@
     "test": "<%= clientPackageManager %> run jest",
     "test-ci": "<%= clientPackageManager %> run lint && <%= clientPackageManager %> run jest:update",
     "test:watch": "<%= clientPackageManager %> run jest -- --watch",
-    "webapp:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webapp:build:dev",    
+    "webapp:build": "<%= clientPackageManager %> run cleanup && <%= clientPackageManager %> run webapp:build:dev",
     "webapp:build:dev": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.dev.js --progress=profile --env stats=minimal",
     "webapp:build:prod": "<%= clientPackageManager %> run webpack -- --config webpack/webpack.prod.js --progress=profile --env stats=minimal",
     "webapp:dev": "<%= clientPackageManager %> run webpack-dev-server -- --config webpack/webpack.dev.js --progress=profile --inline --env stats=normal",


### PR DESCRIPTION
This fixes a vulnerability in the 5.4.4 version.

Before:

```
┌─────────────────────┬──────────────────────────────────────────────────┐
│ low                 │ Prototype Pollution                              │
├─────────────────────┼──────────────────────────────────────────────────┤
│ Package             │ yargs-parser                                     │
├─────────────────────┼──────────────────────────────────────────────────┤
│ Vulnerable versions │ <13.1.2 || >=14.0.0 <15.0.1 || >=16.0.0 <18.1.2  │
├─────────────────────┼──────────────────────────────────────────────────┤
│ Patched versions    │ >=13.1.2 <14.0.0 || >=15.0.1 <16.0.0 || >=18.1.2 │
├─────────────────────┼──────────────────────────────────────────────────┤
│ More info           │ https://npmjs.com/advisories/1500                │
└─────────────────────┴──────────────────────────────────────────────────┘
1 vulnerabilities found
```

After:

```
No known vulnerabilities found
```

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

