### PR TITLE
update startingEntitiesCount at beginning of create e2e test

### DIFF
--- a/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
@@ -131,7 +131,8 @@ describe('<%= entityClass %> e2e test', () => {
     cy.intercept('GET', '/<%= baseApi + entityApiUrl %>*').as('entitiesRequest');
     cy.visit('/');
     cy.clickOnEntityMenuItem('<%= entityStateName %>');
-    cy.wait('@entitiesRequest');
+    cy.wait('@entitiesRequest')
+      .then(({ request, response }) => startingEntitiesCount = response.body.length);
     cy.get(entityCreateButtonSelector).click({force: true});
     cy.getEntityCreateUpdateHeading('<%= entityClass %>');
     <%_ fields.filter(field => !field.id).forEach((field) => {


### PR DESCRIPTION
The `startingEntitiesCount` is set in the [`before`](https://github.com/jhipster/generator-jhipster/blob/bb97052279a9870ef0871a4c1e444e366f4c7b7d/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs#L61-L72) method at the beginning of the entity E2E test.  If the "create entity" test fails after creating an entity, it will retry that specific test.  But the `before` method does not run again ([docs](https://docs.cypress.io/guides/guides/test-retries.html#How-It-Works)), leading to a stale `startingEntitiesCount` value.

You can see an example of the issue [in the CI logs here](https://github.com/jhipster/generator-jhipster/runs/1823783192?check_suite_focus=true#step:30:559).  You can validate the issue is happening by checking the screenshots uploaded [in the artifacts](https://github.com/jhipster/generator-jhipster/actions/runs/534372765#artifacts) after that CI run (uploaded here for reference: [attempt 1](https://user-images.githubusercontent.com/4294623/106796584-8f5f1e80-6629-11eb-8594-eb045e6bdff3.png), [attempt2](https://user-images.githubusercontent.com/4294623/106796578-8e2df180-6629-11eb-99e4-ee93a527ba34.png), [attempt3](https://user-images.githubusercontent.com/4294623/106796577-8cfcc480-6629-11eb-8a92-db34a473633e.png)).  I'm not sure why the first attempt failed, but the second and third attempts should be fixed by this PR.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
