### PR TITLE
fix :  Updating Helm Chart repository for stable and incubator

### DIFF
--- a/generators/kubernetes-helm/templates/README-KUBERNETES-HELM.md.ejs
+++ b/generators/kubernetes-helm/templates/README-KUBERNETES-HELM.md.ejs
@@ -20,8 +20,8 @@ at [https://github.com/helm/helm](https://github.com/helm/helm)
 
 Once Helm is installed you need to add the below repositories:
 ```
-helm repo add stable https://kubernetes-charts.storage.googleapis.com
-helm repo add incubator https://kubernetes-charts-incubator.storage.googleapis.com
+helm repo add stable https://charts.helm.sh/stable
+helm repo add incubator https://charts.helm.sh/incubator
 ```
 These repositories should be added to the local cache, because this sub-generator will pull some charts from them.
 

--- a/generators/kubernetes-helm/templates/app/requirements.yml.ejs
+++ b/generators/kubernetes-helm/templates/app/requirements.yml.ejs
@@ -2,21 +2,21 @@ dependencies:
 <%_ if (app.prodDatabaseType === 'mysql') { _%>
   - name: mysql
     version: <%= HELM_MYSQL %>
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: mysql.enabled
 <%_ } else if (app.prodDatabaseType === 'postgresql') { _%>
   - name: postgresql
     version: <%= HELM_POSTGRESQL %>
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: postgresql.enabled
 <%_ } else if (app.prodDatabaseType === 'mariadb') { _%>
   - name: mariadb
     version: <%= HELM_MARIADB %>
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: mariadb.enabled
 <%_ } else if (app.prodDatabaseType === 'mongodb') { _%>
   - name: mongodb-replicaset
     version: <%= HELM_MOGODB_REPLICASET %>
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: mongodb.enabled
 <%_ } _%>

--- a/generators/kubernetes-helm/templates/csvc/requirements.yml.ejs
+++ b/generators/kubernetes-helm/templates/csvc/requirements.yml.ejs
@@ -2,16 +2,16 @@ dependencies:
 <%_ if (useKafka) { _%>
   - name: kafka
     version: <%= HELM_KAFKA %>
-    repository: https://kubernetes-charts-incubator.storage.googleapis.com
+    repository: https://charts.helm.sh/incubator
     condition: kafka.enabled
 <%_ } _%>
 <%_ if (monitoring === 'prometheus') { _%>
   - name: prometheus
     version: <%= HELM_PROMETHEUS %>
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: prometheus.enabled
   - name: grafana
     version: <%= HELM_GRAFANA %>
-    repository: https://kubernetes-charts.storage.googleapis.com
+    repository: https://charts.helm.sh/stable
     condition: prometheus.enabled
 <%_ } _%>


### PR DESCRIPTION
As, Helm chart repositories are moved from
 "https://kubernetes-charts-incubator.storage.googleapis.com" and "https://kubernetes-charts.storage.googleapis.com" to
 "https://charts.helm.sh/incubator" and "https://charts.helm.sh/stable" respectively so updating.

Also , this suggestion is given by "Helm Cli" upon running
"helm dependency build " on generated helm charts by "kubernetes-helm" sub-generator of "jhipster-generator".

`
Error: repo "https://kubernetes-charts.storage.googleapis.com" is no longer available; try "https://charts.helm.sh/stable" instead
Error: repo "https://kubernetes-charts-incubator.storage.googleapis.com" is no longer available; try "https://charts.helm.sh/incubator" instead
`

Signed-off-by: Pratik raj <rajpratik71@gmail.com>