### PR TITLE
Fix Azure CI pipeline template for E2E tests

### DIFF
--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -26,6 +26,7 @@ jobs:
     SPRING_JPA_SHOW_SQL: false
     JHI_DISABLE_WEBPACK_LOGS: true
     NG_CLI_ANALYTICS: "false"
+    JHI_E2E_HEADLESS: true
 
   steps:
 <%_ if (!skipClient) { _%>

--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -38,6 +38,16 @@ jobs:
       versionSpec: $(NODE_VERSION)
     displayName: 'TOOLS: install Node.js'
 <%_ } _%>
+<%_ if (testFrameworks.includes('cypress') || testFrameworks.includes('protractor')) {
+  const commented = applicationType === 'gateway' ? '# ' : ''; _%>
+  <%= commented %>- task: Bash@3
+  <%= commented %>  inputs:
+  <%= commented %>    targetType: 'inline'
+  <%= commented %>    script: |
+  <%= commented %>      wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  <%= commented %>      sudo apt install ./google-chrome-stable_current_amd64.deb
+  <%= commented %>  displayName: 'TOOLS: install Chrome'
+<%_ } _%>
   #----------------------------------------------------------------------
   # Tests
   #----------------------------------------------------------------------


### PR DESCRIPTION
Our Azure Pipeline failed on E2E tests. These changes fixed it.

We had to enable the headless mode via env variable and install the latest Chrome, because the Azure Ubuntu VM does not include it.

Furthermore we had to change the `protractor.conf.js` file and add the `--no-sandbox` parameter to the Chrome args. I did not know whether I should include this change to the PR, so I left it out for now. But I update the PR and add this if you wish (probably all 3 template files should be changed - for Angular, React and Vue).

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
