### PR TITLE
Remove compile in gitlab-ci Docker flow

### DIFF
--- a/generators/ci-cd/templates/.gitlab-ci.yml.ejs
+++ b/generators/ci-cd/templates/.gitlab-ci.yml.ejs
@@ -291,7 +291,7 @@ maven-package:
 #    dependencies:
 #        - maven-package
 #    script:
-#        - ./mvnw -ntp compile jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
+#        - ./mvnw -ntp jib:build -Pprod -Djib.to.image=$IMAGE_TAG -Djib.to.auth.username=gitlab-ci-token  -Djib.to.auth.password=$CI_BUILD_TOKEN -Dmaven.repo.local=$MAVEN_USER_HOME
 
 <%_ if (cicdIntegrations.includes('heroku')) { _%>
 deploy-to-production:


### PR DESCRIPTION
Small fix for gitlab-ci, which has a redondant compilation which increases time of pipeline.
--

See #13854 


---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
