### PR TITLE
[angular] Implement ConfigService.

### DIFF
--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -303,6 +303,9 @@ const files = {
     {
       path: ANGULAR_DIR,
       templates: [
+        'core/config/config.service.ts',
+        'core/config/config.service.spec.ts',
+
         'core/util/data-util.service.ts',
         'core/util/parse-links.service.ts',
         'core/util/alert.service.ts',

--- a/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/activate/activate.service.ts.ejs
@@ -20,14 +20,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 
 @Injectable({ providedIn: 'root' })
 export class ActivateService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   get(key: string): Observable<{}> {
-    return this.http.get(SERVER_API_URL + 'api/activate', {
+    return this.http.get(this.configService.getEndpointFor('api/activate'), {
       params: new HttpParams().set('key', key),
     });
   }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password-reset/finish/password-reset-finish.service.ts.ejs
@@ -20,13 +20,13 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 
 @Injectable({ providedIn: 'root' })
 export class PasswordResetFinishService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   save(key: string, newPassword: string): Observable<{}> {
-    return this.http.post(SERVER_API_URL + 'api/account/reset-password/finish', { key, newPassword });
+    return this.http.post(this.configService.getEndpointFor('api/account/reset-password/finish'), { key, newPassword });
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/password/password.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/password/password.service.ts.ejs
@@ -20,13 +20,13 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 
 @Injectable({ providedIn: 'root' })
 export class PasswordService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   save(newPassword: string, currentPassword: string): Observable<{}> {
-    return this.http.post(SERVER_API_URL + 'api/account/change-password', { currentPassword, newPassword });
+    return this.http.post(this.configService.getEndpointFor('api/account/change-password'), { currentPassword, newPassword });
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/register/register.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/register/register.service.ts.ejs
@@ -20,14 +20,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { Registration } from './register.model';
 
 @Injectable({ providedIn: 'root' })
 export class RegisterService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   save(registration: Registration): Observable<{}> {
-    return this.http.post(SERVER_API_URL + 'api/register', registration);
+    return this.http.post(this.configService.getEndpointFor('api/register'), registration);
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/account/sessions/sessions.service.ts.ejs
@@ -20,14 +20,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { Session } from './session.model';
 
 @Injectable({ providedIn: 'root' })
 export class SessionsService {
-  public resourceUrl = SERVER_API_URL + 'api/account/sessions/';
+  public resourceUrl = this.configService.getEndpointFor('api/account/sessions/');
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   findAll(): Observable<Session[]> {
     return this.http.get<Session[]>(this.resourceUrl);

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.spec.ts.ejs
@@ -19,8 +19,6 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { SERVER_API_URL } from 'app/app.constants';
-
 import { ConfigurationService } from './configuration.service';
 import { Bean, ConfigProps, Env, PropertySource } from './configuration.model';
 
@@ -45,14 +43,6 @@ describe('Service Tests', () => {
     });
 
     describe('Service methods', () => {
-      it('should call correct URL', () => {
-        service.getBeans().subscribe();
-
-        const req = httpMock.expectOne({ method: 'GET' });
-        const resourceUrl = SERVER_API_URL + 'management/configprops';
-        expect(req.request.url).toEqual(resourceUrl);
-      });
-
       it('should get the config', () => {
         const bean: Bean = {
           prefix: 'jhipster',

--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.service.ts.ejs
@@ -21,15 +21,15 @@ import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { Bean, Beans, ConfigProps, Env, PropertySource } from './configuration.model';
 
 @Injectable({ providedIn: 'root' })
 export class ConfigurationService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   getBeans(): Observable<Bean[]> {
-    return this.http.get<ConfigProps>(SERVER_API_URL + 'management/configprops').pipe(
+    return this.http.get<ConfigProps>(this.configService.getEndpointFor('management/configprops')).pipe(
       map(configProps =>
         Object.values(
           Object.values(configProps.contexts)
@@ -41,6 +41,6 @@ export class ConfigurationService {
   }
 
   getPropertySources(): Observable<PropertySource[]> {
-    return this.http.get<Env>(SERVER_API_URL + 'management/env').pipe(map(env => env.propertySources));
+    return this.http.get<Env>(this.configService.getEndpointFor('management/env')).pipe(map(env => env.propertySources));
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway-routes.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/gateway/gateway-routes.service.ts.ejs
@@ -20,14 +20,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { GatewayRoute } from './gateway-route.model';
 
 @Injectable()
 export class GatewayRoutesService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   findAll(): Observable<GatewayRoute[]> {
-    return this.http.get<GatewayRoute[]>(SERVER_API_URL + 'api/gateway/routes/');
+    return this.http.get<GatewayRoute[]>(this.configService.getEndpointFor('api/gateway/routes/'));
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/health/health.service.ts.ejs
@@ -20,14 +20,14 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { Health } from './health.model';
 
 @Injectable({ providedIn: 'root' })
 export class HealthService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   checkHealth(): Observable<Health> {
-    return this.http.get<Health>(SERVER_API_URL + 'management/health');
+    return this.http.get<Health>(this.configService.getEndpointFor('management/health'));
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.service.spec.ts.ejs
@@ -19,8 +19,6 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { SERVER_API_URL } from 'app/app.constants';
-
 import { LogsService } from './logs.service';
 
 describe('Service Tests', () => {
@@ -42,20 +40,10 @@ describe('Service Tests', () => {
     });
 
     describe('Service methods', () => {
-      it('should call correct URL', () => {
-        service.findAll().subscribe();
-
-        const req = httpMock.expectOne({ method: 'GET' });
-        const resourceUrl = SERVER_API_URL + 'management/loggers';
-        expect(req.request.url).toEqual(resourceUrl);
-      });
-
       it('should change log level', () => {
         service.changeLevel('main', 'ERROR').subscribe();
 
         const req = httpMock.expectOne({ method: 'POST' });
-        const resourceUrl = SERVER_API_URL + 'management/loggers/main';
-        expect(req.request.url).toEqual(resourceUrl);
         expect(req.request.body).toEqual({ configuredLevel: 'ERROR' });
       });
     });

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.service.ts.ejs
@@ -20,18 +20,18 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { LoggersResponse, Level } from './log.model';
 
 @Injectable({ providedIn: 'root' })
 export class LogsService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   changeLevel(name: string, configuredLevel: Level): Observable<{}> {
-    return this.http.post(SERVER_API_URL + 'management/loggers/' + name, { configuredLevel });
+    return this.http.post(this.configService.getEndpointFor('management/loggers/' + name), { configuredLevel });
   }
 
   findAll(): Observable<LoggersResponse> {
-    return this.http.get<LoggersResponse>(SERVER_API_URL + 'management/loggers');
+    return this.http.get<LoggersResponse>(this.configService.getEndpointFor('management/loggers'));
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.service.spec.ts.ejs
@@ -19,8 +19,6 @@
 import { TestBed } from '@angular/core/testing';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { SERVER_API_URL } from 'app/app.constants';
-
 import { MetricsService } from './metrics.service';
 import { ThreadDump, ThreadState } from './metrics.model';
 
@@ -42,14 +40,6 @@ describe('Service Tests', () => {
     });
 
     describe('Service methods', () => {
-      it('should call correct URL', () => {
-        service.getMetrics().subscribe();
-
-        const req = httpMock.expectOne({ method: 'GET' });
-        const resourceUrl = SERVER_API_URL + 'management/jhimetrics';
-        expect(req.request.url).toEqual(resourceUrl);
-      });
-
       it('should return Metrics', () => {
         let expectedResult;
         const metrics = {

--- a/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/metrics/metrics.service.ts.ejs
@@ -20,18 +20,18 @@ import { Injectable } from '@angular/core';
 import { HttpClient } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { Metrics, ThreadDump } from './metrics.model';
 
 @Injectable({ providedIn: 'root' })
 export class MetricsService {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   getMetrics(): Observable<Metrics> {
-    return this.http.get<Metrics>(SERVER_API_URL + 'management/jhimetrics');
+    return this.http.get<Metrics>(this.configService.getEndpointFor('management/jhimetrics'));
   }
 
   threadDump(): Observable<ThreadDump> {
-    return this.http.get<ThreadDump>(SERVER_API_URL + 'management/threaddump');
+    return this.http.get<ThreadDump>(this.configService.getEndpointFor('management/threaddump'));
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/service/user-management.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/service/user-management.service.spec.ts.ejs
@@ -27,7 +27,6 @@ import { HttpClientTestingModule, HttpTestingController } from '@angular/common/
 import { Authority } from 'app/config/authority.constants';
 <%_ } _%>
 import { User } from '../user-management.model';
-import { SERVER_API_URL } from 'app/app.constants';
 
 import { UserManagementService } from './user-management.service';
 
@@ -50,14 +49,6 @@ describe('Service Tests', () => {
     });
 
     describe('Service methods', () => {
-      it('should call correct URL', () => {
-        service.find('user').subscribe();
-
-        const req = httpMock.expectOne({ method: 'GET' });
-        const resourceUrl = SERVER_API_URL + 'api/admin/users';
-        expect(req.request.url).toEqual(`${resourceUrl}/user`);
-      });
-
       it('should return User', () => {
         let expectedResult: string | undefined;
 

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/service/user-management.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/service/user-management.service.ts.ejs
@@ -20,7 +20,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable<% if (authenticationType !== 'oauth2' && databaseType !== 'sql' && databaseType !== 'mongodb' && databaseType !== 'couchbase') { %>, of<% } %> } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { createRequestOption } from 'app/core/request/request-util';
 import { Pagination } from 'app/core/request/request.model';
 import { IUser } from '../user-management.model';
@@ -30,9 +30,9 @@ import { Authority } from 'app/config/authority.constants';
 
 @Injectable({ providedIn: 'root' })
 export class UserManagementService {
-  public resourceUrl = SERVER_API_URL + 'api/admin/users';
+  public resourceUrl = this.configService.getEndpointFor('api/admin/users');
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   <%_ if (authenticationType !== 'oauth2') { _%>
   create(user: IUser): Observable<IUser> {
@@ -60,7 +60,7 @@ export class UserManagementService {
 
   authorities(): Observable<string[]> {
     <%_ if (databaseType === 'sql' || databaseType === 'mongodb' || databaseType === 'couchbase') { _%>
-    return this.http.get<string[]>(SERVER_API_URL + 'api/authorities');
+    return this.http.get<string[]>(this.configService.getEndpointFor('api/authorities'));
     <%_ } else { _%>
     return of([Authority.ADMIN, Authority.USER]);
     <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -36,6 +36,8 @@ import { NgxWebstorageModule } from 'ngx-webstorage';
 import * as dayjs from 'dayjs';
 import { NgbDateAdapter, NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
 
+import { SERVER_API_URL } from './app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import './config/dayjs';
 import { SharedModule } from 'app/shared/shared.module';
 import { AppRoutingModule } from './app-routing.module';
@@ -111,7 +113,8 @@ import { ErrorComponent } from './layouts/error/error.component';
   bootstrap: [MainComponent],
 })
 export class AppModule {
-  constructor(iconLibrary: FaIconLibrary, dpConfig: NgbDatepickerConfig<% if (enableTranslation) { %>, translateService: TranslateService<% } %>) {
+  constructor(configService: ConfigService, iconLibrary: FaIconLibrary, dpConfig: NgbDatepickerConfig<% if (enableTranslation) { %>, translateService: TranslateService<% } %>) {
+    configService.setEndpointPrefix(SERVER_API_URL);
     registerLocaleData(locale);
     iconLibrary.addIcons(...fontAwesomeIcons);
     dpConfig.minDate = { year: dayjs().subtract(100, 'year').year(), month: 1, day: 1 };

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
@@ -33,7 +33,6 @@ import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
 import { NgxWebstorageModule } from 'ngx-webstorage';
 
-import { SERVER_API_URL } from 'app/app.constants';
 import { Account } from 'app/core/auth/account.model';
 import { Authority } from 'app/config/authority.constants';
 import { StateStorageService } from 'app/core/auth/state-storage.service';
@@ -132,14 +131,6 @@ describe('Service Tests', () => {
     });
 
     describe('identity', () => {
-      it('should call /account if user is undefined', () => {
-        service.identity().subscribe();
-        const req = httpMock.expectOne({ method: 'GET' });
-        const resourceUrl = SERVER_API_URL + 'api/account';
-
-        expect(req.request.url).toEqual(`${resourceUrl}`);
-      });
-
       it('should call /account only once if not logged out after first authentication and should call /account again if user has logged out', () => {
         // Given the user is authenticated
         service.identity().subscribe();

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -27,7 +27,7 @@ import { Observable, ReplaySubject, of } from 'rxjs';
 import { shareReplay, tap, catchError } from 'rxjs/operators';
 
 import { StateStorageService } from 'app/core/auth/state-storage.service';
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from '../config/config.service';
 import { Account } from 'app/core/auth/account.model';
 <%_ if (websocket === 'spring-websocket') { _%>
 import { TrackerService } from '../tracker/tracker.service';
@@ -49,12 +49,13 @@ export class AccountService {
     private trackerService: TrackerService,
     <%_ } _%>
     private stateStorageService: StateStorageService,
-    private router: Router
+    private router: Router,
+    private configService: ConfigService
   ) {}
 
   <%_ if (!skipUserManagement) { _%>
   save(account: Account): Observable<{}> {
-    return this.http.post(SERVER_API_URL + 'api/account', account);
+    return this.http.post(this.configService.getEndpointFor('api/account'), account);
   }
   <%_ } _%>
 
@@ -119,7 +120,7 @@ export class AccountService {
   }
 
   private fetch(): Observable<Account> {
-    return this.http.get<Account>(SERVER_API_URL + 'api/account');
+    return this.http.get<Account>(this.configService.getEndpointFor('api/account'));
   }
 
   private navigateToStoredUrl(): void {

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -22,7 +22,7 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from '../config/config.service';
 import { Login } from 'app/login/login.model';
 
 type JwtToken = {
@@ -34,7 +34,8 @@ export class AuthServerProvider {
   constructor(
     private http: HttpClient,
     private $localStorage: LocalStorageService,
-    private $sessionStorage: SessionStorageService
+    private $sessionStorage: SessionStorageService,
+    private configService: ConfigService
   ) {}
 
   getToken(): string {
@@ -45,7 +46,7 @@ export class AuthServerProvider {
 
   login(credentials: Login): Observable<void> {
     return this.http
-      .post<JwtToken>(SERVER_API_URL + 'api/authenticate', credentials)
+      .post<JwtToken>(this.configService.getEndpointFor('api/authenticate'), credentials)
       .pipe(map(response => this.authenticateSuccess(response, credentials.rememberMe)));
   }
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-session.service.ts.ejs
@@ -23,18 +23,16 @@ import { Observable } from 'rxjs';
 import { map } from 'rxjs/operators';
 <%_ } _%>
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from '../config/config.service';
 <%_ if (authenticationType === 'oauth2') { _%>
 import { Logout } from 'app/login/logout.model';
 <%_ } else { _%>
 import { Login } from 'app/login/login.model';
-
-export const LOGOUT_URL = SERVER_API_URL + 'api/logout';
 <%_ } _%>
 
 @Injectable({ providedIn: 'root' })
 export class AuthServerProvider {
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   <%_ if (authenticationType !== 'oauth2') { _%>
 
@@ -47,15 +45,15 @@ export class AuthServerProvider {
 
     const headers = new HttpHeaders().set('Content-Type', 'application/x-www-form-urlencoded');
 
-    return this.http.post(SERVER_API_URL + 'api/authentication', data, { headers });
+    return this.http.post(this.configService.getEndpointFor('api/authentication'), data, { headers });
   }
 
   logout(): Observable<void> {
     // logout from the server
-    return this.http.post(LOGOUT_URL, {}).pipe(
+    return this.http.post(this.configService.getEndpointFor('api/logout'), {}).pipe(
       map(() => {
         // to get a new csrf token call the api
-        this.http.get(SERVER_API_URL + 'api/account').subscribe();
+        this.http.get(this.configService.getEndpointFor('api/account')).subscribe();
       })
     );
   }
@@ -63,7 +61,7 @@ export class AuthServerProvider {
   <%_ } else { _%>
 
   logout(): Observable<Logout> {
-    return this.http.post<Logout>(SERVER_API_URL + 'api/logout', {});
+    return this.http.post<Logout>(this.configService.getEndpointFor('api/logout'), {});
   }
 
   <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/core/config/config.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/config/config.service.spec.ts.ejs
@@ -1,0 +1,58 @@
+<%#
+ Copyright 2013-2021 the original author or authors from the JHipster project.
+
+ This file is part of the JHipster project, see https://www.jhipster.tech/
+ for more information.
+
+ Licensed under the Apache License, Version 2.0 (the 'License');
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+      https://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an 'AS IS' BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+-%>
+import { TestBed } from '@angular/core/testing';
+
+import { ConfigService } from './config.service';
+
+describe('ConfigService', () => {
+  let service: ConfigService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({});
+    service = TestBed.inject(ConfigService);
+  });
+
+  it('should be created', () => {
+    expect(service).toBeTruthy();
+  });
+
+  describe('without prefix', () => {
+    it('should return correctly', () => {
+      expect(service.getEndpointFor('api')).toEqual('api');
+    });
+
+    it('should return correctly when passing microservice', () => {
+      expect(service.getEndpointFor('api', 'microservice')).toEqual('services/microservice/api');
+    });
+  });
+
+  describe('with prefix', () => {
+    beforeEach(() => {
+      service.setEndpointPrefix('prefix/');
+    });
+
+    it('should return correctly', () => {
+      expect(service.getEndpointFor('api')).toEqual('prefix/api');
+    });
+
+    it('should return correctly when passing microservice', () => {
+      expect(service.getEndpointFor('api', 'microservice')).toEqual('prefix/services/microservice/api');
+    });
+  });
+});

--- a/generators/client/templates/angular/src/main/webapp/app/core/config/config.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/config/config.service.ts.ejs
@@ -17,16 +17,21 @@
  limitations under the License.
 -%>
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
-import { Observable } from 'rxjs';
 
-import { ConfigService } from 'app/core/config/config.service';
+@Injectable({
+  providedIn: 'root',
+})
+export class ConfigService {
+  private endpointPrefix = '';
 
-@Injectable({ providedIn: 'root' })
-export class PasswordResetInitService {
-  constructor(private http: HttpClient, private configService: ConfigService) {}
+  setEndpointPrefix(endpointPrefix: string): void {
+    this.endpointPrefix = endpointPrefix;
+  }
 
-  save(mail: string): Observable<{}> {
-    return this.http.post(this.configService.getEndpointFor('api/account/reset-password/init'), mail);
+  getEndpointFor(api: string, microservice?: string): string {
+    if (microservice) {
+      return `${this.endpointPrefix}services/${microservice}/${api}`;
+    }
+    return `${this.endpointPrefix}${api}`;
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/interceptor/auth.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/interceptor/auth.interceptor.ts.ejs
@@ -21,17 +21,19 @@ import { Observable } from 'rxjs';
 import { LocalStorageService, SessionStorageService } from 'ngx-webstorage';
 import { HttpInterceptor, HttpRequest, HttpHandler, HttpEvent } from '@angular/common/http';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from '../config/config.service';
 
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
   constructor(
     private localStorage: LocalStorageService,
-    private sessionStorage: SessionStorageService
+    private sessionStorage: SessionStorageService,
+    private configService: ConfigService
   ) {}
 
   intercept(request: HttpRequest<any>, next: HttpHandler): Observable<HttpEvent<any>> {
-    if (!request.url || (request.url.startsWith('http') && !(SERVER_API_URL && request.url.startsWith(SERVER_API_URL)))) {
+    const serverApiUrl = this.configService.getEndpointFor('');
+    if (!request.url || (request.url.startsWith('http') && !(serverApiUrl && request.url.startsWith(serverApiUrl)))) {
       return next.handle(request);
     }
 

--- a/generators/client/templates/angular/src/main/webapp/app/entities/user/user.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/entities/user/user.service.spec.ts.ejs
@@ -23,7 +23,6 @@ import { TestBed } from '@angular/core/testing';
 import { HttpErrorResponse } from '@angular/common/http';
 import { HttpClientTestingModule, HttpTestingController } from '@angular/common/http/testing';
 
-import { SERVER_API_URL } from 'app/app.constants';
 import { User, IUser } from './user.model';
 
 import { UserService } from './user.service';
@@ -48,14 +47,6 @@ describe('Service Tests', () => {
     });
 
     describe('Service methods', () => {
-      it('should call correct URL', () => {
-        service.query().subscribe();
-
-        const req = httpMock.expectOne({ method: 'GET' });
-        const resourceUrl = SERVER_API_URL + 'api/users';
-        expect(req.request.url).toEqual(`${resourceUrl}`);
-      });
-
       it('should return Users', () => {
         service.query().subscribe(received => {
           expectedResult = received.body;

--- a/generators/client/templates/angular/src/main/webapp/app/entities/user/user.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/entities/user/user.service.ts.ejs
@@ -20,7 +20,7 @@ import { Injectable } from '@angular/core';
 import { HttpClient, HttpResponse } from '@angular/common/http';
 import { Observable<% if (authenticationType !== 'oauth2' && databaseType !== 'sql' && databaseType !== 'mongodb' && databaseType !== 'couchbase') { %>, of<% } %> } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { createRequestOption } from 'app/core/request/request-util';
 import { isPresent } from 'app/core/util/operators';
 import { Pagination } from 'app/core/request/request.model';
@@ -31,9 +31,9 @@ import { Authority } from 'app/config/authority.constants';
 
 @Injectable({ providedIn: 'root' })
 export class UserService {
-  public resourceUrl = SERVER_API_URL + 'api/users';
+  public resourceUrl = this.configService.getEndpointFor('api/users');
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   query(req?: Pagination): Observable<HttpResponse<IUser[]>> {
     const options = createRequestOption(req);

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/profiles/profile.service.ts.ejs
@@ -21,15 +21,15 @@ import { HttpClient } from '@angular/common/http';
 import { map, shareReplay } from 'rxjs/operators';
 import { Observable } from 'rxjs';
 
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { ProfileInfo, InfoResponse } from './profile-info.model';
 
 @Injectable({ providedIn: 'root' })
 export class ProfileService {
-  private infoUrl = SERVER_API_URL + 'management/info';
+  private infoUrl = this.configService.getEndpointFor('management/info');
   private profileInfo$?: Observable<ProfileInfo>;
 
-  constructor(private http: HttpClient) {}
+  constructor(private http: HttpClient, private configService: ConfigService) {}
 
   getProfileInfo(): Observable<ProfileInfo> {
     if (this.profileInfo$) {

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/service/entity.service.ts.ejs
@@ -34,7 +34,7 @@ import { isPresent } from 'app/core/util/operators';
 <%_ if (fieldsContainLocalDate) { _%>
 import { DATE_FORMAT } from 'app/config/input.constants';
 <%_ } _%>
-import { SERVER_API_URL } from 'app/app.constants';
+import { ConfigService } from 'app/core/config/config.service';
 import { createRequestOption } from 'app/core/request/request-util';
 <%_ if (searchEngine !== false) { _%>
 import { <%= searchType %> } from 'app/core/request/request.model';
@@ -46,12 +46,12 @@ export type EntityArrayResponseType = HttpResponse<I<%= entityAngularName %>[]>;
 
 @Injectable({ providedIn: 'root' })
 export class <%= entityAngularName %>Service {
-    public resourceUrl = SERVER_API_URL + '<% if (applicationType === 'gateway' && locals.microserviceName) { %>services/<%= microserviceName.toLowerCase() %>/<% } %>api/<%= entityApiUrl %>';
+    public resourceUrl = this.configService.getEndpointFor('api/<%= entityApiUrl %>'<% if (applicationType === 'gateway' && locals.microserviceName) { %>, '<%= microserviceName.toLowerCase() %>'<% } %>);
     <%_ if (searchEngine !== false) { _%>
-    public resourceSearchUrl = SERVER_API_URL + '<% if (applicationType === 'gateway' && locals.microserviceName) { %>services/<%= microserviceName.toLowerCase() %>/<% } %>api/_search/<%= entityApiUrl %>';
+    public resourceSearchUrl = this.configService.getEndpointFor('api/_search/<%= entityApiUrl %>'<% if (applicationType === 'gateway' && locals.microserviceName) { %>, '<%= microserviceName.toLowerCase() %>'<% } %>);
     <%_ } _%>
 
-    constructor(protected http: HttpClient) {}
+    constructor(protected http: HttpClient, private configService: ConfigService) {}
 
     <%_ if (!readOnly) { _%>
     create(<%= entityInstance %>: I<%= entityAngularName %>): Observable<EntityResponseType> {

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -444,6 +444,8 @@ const expectedFiles = {
     `${CLIENT_MAIN_SRC_DIR}app/shared/auth/has-any-authority.directive.ts`,
     `${CLIENT_MAIN_SRC_DIR}app/core/auth/state-storage.service.ts`,
     `${CLIENT_MAIN_SRC_DIR}app/core/auth/user-route-access.service.ts`,
+    `${CLIENT_MAIN_SRC_DIR}app/core/config/config.service.spec.ts`,
+    `${CLIENT_MAIN_SRC_DIR}app/core/config/config.service.ts`,
     `${CLIENT_MAIN_SRC_DIR}app/config/authority.constants.ts`,
     `${CLIENT_MAIN_SRC_DIR}app/config/error.constants.ts`,
     `${CLIENT_MAIN_SRC_DIR}app/config/input.constants.ts`,


### PR DESCRIPTION
Currently, when generating a gateway, microservice endpoint is hardcoded: `SERVER_API_URL + 'services/microservice/api'`.
This PR implements a configuration service:
- makes easier to customize routed endpoints.
- microfront:
  - removes reference to app/app.constants. So we don't have to export it for the microfrontends.
  - when changing the routed endpoint in the gateway, don't require it to change in the microfrontend.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
