### PR TITLE
start h2 console in reactive environments

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.html.ejs
@@ -137,7 +137,7 @@
           <!-- jhipster-needle-add-element-to-admin-menu - JHipster will add entities to the admin menu here -->
           <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory' || devDatabaseType === 'couchbase') { _%>
           <li *ngIf="!inProduction">
-            <a class="dropdown-item" href="<% if (devDatabaseType === 'couchbase') { %>http://localhost:8091/<% } else { %>./h2-console<% } %>" target="_tab" (click)="collapseNavbar()">
+            <a class="dropdown-item" href="<% if (devDatabaseType === 'couchbase') { %>http://localhost:8091/<% } else if (reactive) { %> http://localhost:8092/ <% } else { %>./h2-console<% } %>" target="_tab" (click)="collapseNavbar()">
               <fa-icon icon="database" [fixedWidth]="true"></fa-icon>
               <span <%= jhiPrefix %>Translate="global.menu.admin.database">Database</span>
             </a>

--- a/generators/client/templates/react/src/main/webapp/app/shared/layout/menus/admin.tsx.ejs
+++ b/generators/client/templates/react/src/main/webapp/app/shared/layout/menus/admin.tsx.ejs
@@ -52,7 +52,7 @@ const openAPIItem = (
 
 <% if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory') { %>
 const databaseItem = (
-  <DropdownItem tag="a" href="./h2-console" target="_tab">
+  <DropdownItem tag="a" href="<% if (reactive) { %>http://localhost:8092/<% } else { %>./h2-console"<% } %> target="_tab">
     <FontAwesomeIcon icon="database" fixedWidth /> <Translate contentKey="global.menu.admin.database">Database</Translate>
   </DropdownItem>
 );

--- a/generators/client/templates/vue/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/core/jhi-navbar/jhi-navbar.vue.ejs
@@ -88,7 +88,7 @@
             <span v-text="$t('global.menu.admin.apidocs')">API</span>
           </b-dropdown-item>
           <%_ if (devDatabaseType === 'h2Disk' || devDatabaseType === 'h2Memory' || devDatabaseType === 'couchbase') { _%>
-          <b-dropdown-item v-if="!inProduction"  href='<% if (devDatabaseType === 'couchbase') { %>http://localhost:8091/<% } else { %>./h2-console<% } %>' target="_tab">
+          <b-dropdown-item v-if="!inProduction"  href='<% if (devDatabaseType === 'couchbase') { %>http://localhost:8092/<% } else if (reactive) { %>http://localhost:8092/<% } else { %>./h2-console<% } %>' target="_tab">
             <font-awesome-icon icon="database" />
             <span v-text="$t('global.menu.admin.database')">Database</span>
           </b-dropdown-item>

--- a/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/WebConfigurer.java.ejs
@@ -25,7 +25,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import tech.jhipster.config.JHipsterConstants;
 <%_ } _%>
 import tech.jhipster.config.JHipsterProperties;
-<%_ if (['h2Disk', 'h2Memory'].includes(devDatabaseType) && !reactive) { _%>
+<%_ if (['h2Disk', 'h2Memory'].includes(devDatabaseType)) { _%>
 import tech.jhipster.config.h2.H2ConfigurationHelper;
 <%_ } _%>
 <%_ if (!skipClient && reactive) { _%>
@@ -53,7 +53,7 @@ import org.springframework.core.annotation.Order;
 import org.springframework.data.web.ReactivePageableHandlerMethodArgumentResolver;
 import org.springframework.data.web.ReactiveSortHandlerMethodArgumentResolver;
 <%_ } _%>
-<%_ if (!reactive) { _%>
+<%_ if (!reactive || (['h2Disk', 'h2Memory'].includes(devDatabaseType) && reactive)) { _%>
 import org.springframework.core.env.Environment;
 import org.springframework.core.env.Profiles;
 <%_ } _%>
@@ -104,12 +104,19 @@ public class WebConfigurer implements <% if (!reactive) { %>ServletContextInitia
     <%_ } _%>
     private final JHipsterProperties jHipsterProperties;
 
-    public WebConfigurer(<% if (!reactive) { %>Environment env, <% } %>JHipsterProperties jHipsterProperties) {
+    public WebConfigurer(<% if (!reactive || (['h2Disk', 'h2Memory'].includes(devDatabaseType) && reactive)) { %>Environment env, <% } %>JHipsterProperties jHipsterProperties) {
         <%_ if (!reactive) { _%>
         this.env = env;
         <%_ } _%>
         this.jHipsterProperties = jHipsterProperties;
+        <%_ if (['h2Disk', 'h2Memory'].includes(devDatabaseType) && reactive) { _%>
+        if (env.acceptsProfiles(Profiles.of(JHipsterConstants.SPRING_PROFILE_DEVELOPMENT))) {
+            H2ConfigurationHelper.initH2Console();
+        }
+        <%_ } _%>  
     }
+
+
     <%_ if (!reactive) { _%>
 
     @Override

--- a/generators/server/templates/src/main/resources/h2.server.properties.ejs
+++ b/generators/server/templates/src/main/resources/h2.server.properties.ejs
@@ -6,5 +6,5 @@
 0=JHipster H2 (Disk)|org.h2.Driver|jdbc\:h2\:file\:./<%= BUILD_DIR %>h2db/db/<%= lowercaseBaseName %>|<%= baseName %>
 <%_ } _%>
 webAllowOthers=true
-webPort=8082
+webPort=8092
 webSSL=false


### PR DESCRIPTION
This PR requires https://github.com/jhipster/jhipster-bom/pull/165. It starts the h2 web server console. I have changed the console port from 8082 to 8092 to minimize the possibility for overlapping ports in a micro-service environment.

closes #13699 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
