### PR TITLE
[react] Fix Sonar properties

### DIFF
--- a/generators/common/index.js
+++ b/generators/common/index.js
@@ -51,6 +51,7 @@ module.exports = class JHipsterCommonGenerator extends BaseBlueprintGenerator {
         this.TEST_DIR = constants.TEST_DIR;
         this.SERVER_MAIN_RES_DIR = constants.SERVER_MAIN_RES_DIR;
         this.ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
+        this.REACT = constants.SUPPORTED_CLIENT_FRAMEWORKS.REACT;
 
         // Make documentation URL available in templates
         this.DOCUMENTATION_URL = constants.JHIPSTER_DOCUMENTATION_URL;

--- a/generators/common/templates/sonar-project.properties.ejs
+++ b/generators/common/templates/sonar-project.properties.ejs
@@ -7,6 +7,8 @@ sonar.host.url=http://localhost:9001
 
 <%_ if (!skipClient && clientFramework === ANGULAR) { _%>
 sonar.test.inclusions=<%= TEST_DIR %>**/*.*, <%= CLIENT_MAIN_SRC_DIR %>app/**/*.spec.ts
+<%_ } else if (!skipClient && clientFramework === REACT) { _%>
+sonar.test.inclusions=<%= TEST_DIR %>**/*.*, <%= CLIENT_MAIN_SRC_DIR %>app/**/*.spec.ts, <%= CLIENT_MAIN_SRC_DIR %>app/**/*.spec.tsx
 <%_ } else { _%>
 sonar.tests=<%= TEST_DIR %>
 <%_ } _%>


### PR DESCRIPTION
Follow up to #13425

Without this change SonarQube task fails with error "Error during parsing of generic test execution report" because report contains tests from paths which are not declared as test paths in `sonar-project.properties`.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
