### PR TITLE
update gradle node plugin to 3.0.1

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -31,7 +31,7 @@ const NODE_VERSION = '14.15.0';
 const NPM_VERSION = '7.5.2';
 const OPENAPI_GENERATOR_CLI_VERSION = '1.0.13-4.3.1';
 
-const GRADLE_VERSION = '6.8.1';
+const GRADLE_VERSION = '6.8.2';
 const JIB_VERSION = '2.7.1';
 
 // Libraries version

--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -60,7 +60,7 @@ cassandraDriverVersion=4.6.1
 jibPluginVersion=<%= JIB_VERSION %>
 gitPropertiesPluginVersion=2.2.4
 <%_ if (!skipClient) { _%>
-gradleNodePluginVersion=3.0.0-rc7
+gradleNodePluginVersion=3.0.1
 <%_ } _%>
 <%_ if (databaseType === 'sql' && !reactive) { _%>
 liquibasePluginVersion=2.0.4


### PR DESCRIPTION
Update gradle node plugin from latest RC to latest release version 3.0.1

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
