### PR TITLE
activate api-docs profile in dev mode by default

### DIFF
--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -79,11 +79,6 @@ org:
       installed-by: <%= baseName %>
 <%_ } _%>
 spring:
-  profiles:
-    include:
-      - api-docs
-      # Uncomment to activate TLS for the dev profile
-      #- tls
   devtools:
     restart:
       enabled: true

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -206,7 +206,13 @@ spring:
     # The commented value for `active` can be replaced with valid Spring profiles to load.
     # Otherwise, it will be filled in by <%= buildTool %> when building the JAR file
     # Either way, it can be overridden by `--spring.profiles.active` value passed in the commandline or `-Dspring.profiles.active` set in `JAVA_OPTS`
-    active: #spring.profiles.active#
+    active: #spring.profiles.active#    
+    group:            
+      dev: 
+        - dev
+        - api-docs
+        # Uncomment to activate TLS for the dev profile
+        #- tls
   jmx:
     enabled: false
   <%_ if (databaseType === 'sql' && !reactive) { _%>


### PR DESCRIPTION
Now running `./gradlew` or `./mvnw` activates profiles `dev, api-docs` again. Running `./gradlew -Pprod` or `./mvnw -Pprod` activates `prod` profile only.

closes #13857 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
