### PR TITLE
correct neo4j uri

### DIFF
--- a/generators/kubernetes/templates/deployment.yml.ejs
+++ b/generators/kubernetes/templates/deployment.yml.ejs
@@ -172,7 +172,7 @@ spec:
           value: "mongodb://<% for (let i = 0; i < app.dbPeerCount; i++) { %><%= app.baseName.toLowerCase() %>-mongodb-<%= i %>.<%= app.baseName.toLowerCase() %>-mongodb.<%= kubernetesNamespace %>:27017<% if (app.reactive) { %>/?waitQueueMultiple=1000<% } %><% if (i < (app.dbPeerCount-1)) { %>,<% }} %>"
         <%_ } _%>
         <%_ if (app.prodDatabaseType === 'neo4j') { _%>
-        - name: ORG_NEO4J_DRIVER_URI
+        - name: SPRING_NEO4J_URI
           value: bolt://<%= app.baseName.toLowerCase() %>-neo4j.<%= kubernetesNamespace %>.svc.cluster.local:7687
         <%_ } _%>
         <%_ if (app.prodDatabaseType === 'couchbase') { _%>

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -48,7 +48,7 @@ services:
       - SPRING_DATA_MONGODB_DATABASE=<%= baseName %>
       <%_ } _%>
       <%_ if (prodDatabaseType === 'neo4j') { _%>
-      - ORG_NEO4J_DRIVER_URI=bolt://<%= baseName.toLowerCase() %>-neo4j:7687
+      - SPRING_NEO4J_URI=bolt://<%= baseName.toLowerCase() %>-neo4j:7687
       <%_ } _%>
       <%_ if (prodDatabaseType === 'couchbase') { _%>
       - SPRING_COUCHBASE_BOOTSTRAP_HOSTS=<%= baseName.toLowerCase() %>-couchbase

--- a/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-dev.yml.ejs
@@ -65,14 +65,6 @@ management:
 <%_ if (databaseType === 'neo4j') { _%>
 org:
   neo4j:
-    driver:
-      pool:
-        metrics-enabled: true
-      uri: bolt://localhost:7687
-      # Uncomment to use an authenticated connection
-      # authentication:
-      #   username: neo4j
-      #   password: secret
     migrations:
       locations-to-scan:
       packages-to-scan: <%= packageName %>.config.neo4j
@@ -93,6 +85,16 @@ spring:
   jackson:
     serialization:
       indent-output: true
+  <%_ if (databaseType === 'neo4j') { _%>
+  neo4j:
+    pool:
+      metrics-enabled: true
+    uri: bolt://localhost:7687
+    # Uncomment to use an authenticated connection
+    # authentication:
+    #   username: neo4j
+    #   password: secret
+  <%_ } _%>
   <%_ if (serviceDiscoveryType === 'consul') { _%>
   cloud:
     consul:

--- a/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application-prod.yml.ejs
@@ -57,11 +57,6 @@ org:
     driver:
       pool:
         metrics-enabled: true
-      uri: bolt://localhost:7687
-      # Uncomment to use an authenticated connection
-      # authentication:
-      #   username: neo4j
-      #   password: secret
     migrations:
       locations-to-scan:
       packages-to-scan: <%= packageName %>.config.neo4j
@@ -79,6 +74,16 @@ spring:
       enabled: false
     livereload:
       enabled: false
+  <%_ if (databaseType === 'neo4j') { _%>
+  neo4j:
+    pool:
+      metrics-enabled: true
+    uri: bolt://localhost:7687
+    # Uncomment to use an authenticated connection
+    # authentication:
+    #   username: neo4j
+    #   password: secret
+  <%_ } _%>
   <%_ if (serviceDiscoveryType === 'eureka') { _%>
   cloud:
     config:

--- a/generators/server/templates/src/test/java/package/AbstractNeo4jIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/AbstractNeo4jIT.java.ejs
@@ -34,7 +34,7 @@ public class AbstractNeo4jIT implements BeforeAllCallback {
         if (!started.get()) {
             neo4jContainer.start();
             System.setProperty(
-                "org.neo4j.driver.uri",
+                "spring.neo4j.uri",
                 neo4jContainer.getBoltUrl()
             );
             started.set(true);


### PR DESCRIPTION
We still use the old properties for spring data neo4j. This updates to the [new properties](https://docs.spring.io/spring-data/neo4j/docs/6.0.3/reference/html/#configure-spring-boot-project) and should fix #13890 .

closes #13890

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
