### PR TITLE
vue: Fix conflicting HtmlWebpackPlugin between webpack.common and webpack.prod.

### DIFF
--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -73,7 +73,7 @@
     "eslint-plugin-vue": "7.6.0",
     "typescript": "4.1.5",
     "url-loader": "4.1.1",
-    "webpack": "5.21.2",
+    "webpack": "5.22.0",
     "webpack-bundle-analyzer": "4.4.0",
     "webpack-cli": "4.5.0",
     "webpack-dev-server": "3.11.2",

--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -41,7 +41,7 @@
     "file-loader": "6.2.0",
     "fork-ts-checker-webpack-plugin": "6.1.0",
     "friendly-errors-webpack-plugin": "1.7.0",
-    "html-webpack-plugin": "4.5.1",
+    "html-webpack-plugin": "5.1.0",
     "jest": "26.6.3",
     "jest-junit": "12.0.0",
     "jest-serializer-vue": "2.0.2",

--- a/generators/client/templates/vue/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.common.js.ejs
@@ -1,12 +1,11 @@
 'use strict';
 const path = require('path');
-const vueLoaderConfig = require('./loader.conf');
 const { VueLoaderPlugin } = require('vue-loader');
 const CopyWebpackPlugin = require('copy-webpack-plugin');
 <%_ if (enableTranslation) { _%>
 const MergeJsonWebpackPlugin = require('merge-jsons-webpack-plugin');
 <%_ } _%>
-const HtmlWebpackPlugin = require('html-webpack-plugin');
+const vueLoaderConfig = require('./loader.conf');
 
 function resolve(dir) {
   return path.join(__dirname, '..', dir);
@@ -108,14 +107,6 @@ module.exports = {
         // jhipster-needle-add-assets-to-webpack - JHipster will add/remove third-party resources in this array
         { from: './<%= CLIENT_MAIN_SRC_DIR %>robots.txt', to: 'robots.txt' },
       ]
-    }),
-    // https://github.com/ampedandwired/html-webpack-plugin
-    new HtmlWebpackPlugin({
-      base: '/',
-      template: './<%= MAIN_SRC_DIR %>index.html',
-      chunks: ['vendors', 'main', 'global'],
-      chunksSortMode: 'manual',
-      inject: true
     })<% if (enableTranslation) { %>,
     new MergeJsonWebpackPlugin({
       output: {

--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -17,16 +17,19 @@
  limitations under the License.
 -%>
 'use strict';
-const utils = require('./vue.utils');
-const webpack = require('webpack');
-const config = require('../config');
-const webpackMerge = require('webpack-merge').merge;
-const path = require('path');
-const baseWebpackConfig = require('./webpack.common');
+const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
 const FriendlyErrorsPlugin = require('friendly-errors-webpack-plugin');
 const portfinder = require('portfinder');
+const path = require('path');
+const webpack = require('webpack');
+const { merge: webpackMerge } = require('webpack-merge');
+const HtmlWebpackPlugin = require('html-webpack-plugin');
+
+const utils = require('./vue.utils');
+const config = require('../config');
+const baseWebpackConfig = require('./webpack.common');
 const jhiUtils = require('./utils.js');
-const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
+
 const HOST = process.env.HOST;
 const PORT = process.env.PORT && Number(process.env.PORT);
 
@@ -91,6 +94,13 @@ module.exports = webpackMerge(baseWebpackConfig, {
     }),
     new webpack.HotModuleReplacementPlugin(),
     new webpack.NoEmitOnErrorsPlugin(),
+    new HtmlWebpackPlugin({
+      base: '/',
+      template: './<%= MAIN_SRC_DIR %>index.html',
+      chunks: ['vendors', 'main', 'global'],
+      chunksSortMode: 'manual',
+      inject: true
+    }),
     new BrowserSyncPlugin(
       {
         host: 'localhost',


### PR DESCRIPTION
~Possibly related to https://github.com/jhipster/generator-jhipster/issues/13862~.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
