### PR TITLE
Unknown field "replica" - typo

### DIFF
--- a/generators/kubernetes/templates/monitoring/jhipster-prometheus-cr.yml.ejs
+++ b/generators/kubernetes/templates/monitoring/jhipster-prometheus-cr.yml.ejs
@@ -60,7 +60,7 @@ metadata:
   name: jhipster-prometheus
   namespace: <%= kubernetesNamespace %>
 spec:
-  replica: 1
+  replicas: 1
   serviceAccountName: jhipster-prometheus-sa
   serviceMonitorSelector:
     matchLabels:


### PR DESCRIPTION
The is a typo in this templete, replica should be replicas, error log for kubectl apply -f jhipster-prometheus-cr.yml:

error: error validating "jhipster-prometheus-cr.yml": error validating data: ValidationError(Prometheus.spec): unknown field "replica" in com.coreos.monitoring.v1.Prometheus.spec; if you choose to ignore these errors, turn validation off with --validate=false

The valid field name is "replicas" as per the documentation: https://docs.openshift.com/container-platform/4.4/rest_api/monitoring_apis/prometheus-monitoring-coreos-com-v1.html 
After changing that line the deployment succeeds.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
