### PR TITLE
Fix upgrade @vue/test-utils from 1.1.2 to 1.1.3

### DIFF
--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -31,7 +31,7 @@
     "@vue/cli-plugin-eslint": "4.5.11",
     "@vue/cli-plugin-typescript": "4.5.11",
     "@vue/cli-service": "4.5.11",
-    "@vue/test-utils": "1.1.2",
+    "@vue/test-utils": "1.1.3",
     "autoprefixer": "10.2.4",
     "babel-core": "7.0.0-bridge.0",
     "browser-sync": "2.26.14",

--- a/generators/client/templates/vue/src/test/javascript/spec/app/admin/metrics/metrics-modal.component.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/admin/metrics/metrics-modal.component.spec.ts.ejs
@@ -22,8 +22,8 @@ describe('Metrics Component', () => {
   });
   
   describe('init', () => {
-    it('should count the numbers of each thread type', () => {
-      wrapper.setProps({
+    it('should count the numbers of each thread type', async () => {
+      await wrapper.setProps({
         threadDump: [
           { name: 'test1', threadState: 'RUNNABLE' },
           { name: 'test2', threadState: 'WAITING' },


### PR DESCRIPTION
Fix upgrade dependabot https://github.com/jhipster/generator-jhipster/pull/13844

Solution: https://vue-test-utils.vuejs.org/api/wrapper-array/setprops.html

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
