### PR TITLE
Unify Cassandra date-time JDL types with common-databases JDL types

### DIFF
--- a/generators/entity-server/templates/src/main/resources/config/cql/changelog/added_entity.cql.ejs
+++ b/generators/entity-server/templates/src/main/resources/config/cql/changelog/added_entity.cql.ejs
@@ -41,6 +41,8 @@ CREATE TABLE IF NOT EXISTS <%= entityInstance %> (
     <%= fieldName %> date,
     <%_ } else if (fieldType === 'Instant') { _%>
     <%= fieldName %> timestamp,
+    <%_ } else if (fieldType === 'Duration') { _%>
+    <%= fieldName %> text,
     <%_ } else if (fieldType === 'ZonedDateTime') { _%>
     <%= fieldName %> tuple<timestamp,varchar>,
     <%_ } else if (fieldType === 'Boolean') { _%>

--- a/generators/entity/prompts.js
+++ b/generators/entity/prompts.js
@@ -652,7 +652,7 @@ function askForField() {
         },
         {
           value: 'LocalDate',
-          name: 'LocalDate (Warning: only compatible with Cassandra v3)',
+          name: 'LocalDate',
         },
         {
           value: 'Instant',
@@ -661,6 +661,14 @@ function askForField() {
         {
           value: 'ZonedDateTime',
           name: 'ZonedDateTime',
+        },
+        {
+          value: 'Duration',
+          name: 'Duration',
+        },
+        {
+          value: 'enum',
+          name: 'Enumeration (Java enum type)',
         },
         {
           value: 'Boolean',

--- a/jdl/jhipster/field-types.js
+++ b/jdl/jhipster/field-types.js
@@ -71,11 +71,12 @@ const CassandraTypes = {
   DOUBLE: 'Double',
   ENUM: 'Enum',
   BOOLEAN: 'Boolean',
-  DATE: 'Date',
-  UUID: 'UUID',
+  LOCAL_DATE: 'LocalDate',
   INSTANT: 'Instant',
-  BYTE_BUFFER: 'ByteBuffer',
+  DURATION: 'Duration',
   ZONED_DATE_TIME: 'ZonedDateTime',
+  UUID: 'UUID',
+  BYTE_BUFFER: 'ByteBuffer',
 };
 
 const CassandraValidations = {
@@ -87,11 +88,12 @@ const CassandraValidations = {
   Double: new Set([REQUIRED, UNIQUE, MIN, MAX]),
   Enum: new Set([REQUIRED, UNIQUE]),
   Boolean: new Set([REQUIRED, UNIQUE]),
-  Date: new Set([REQUIRED, UNIQUE]),
   UUID: new Set([REQUIRED, UNIQUE]),
+  LocalDate: new Set([REQUIRED, UNIQUE]),
   Instant: new Set([REQUIRED, UNIQUE]),
-  ByteBuffer: new Set([REQUIRED, UNIQUE, MINBYTES, MAXBYTES]),
+  Duration: new Set([REQUIRED, UNIQUE]),
   ZonedDateTime: new Set([REQUIRED, UNIQUE]),
+  ByteBuffer: new Set([REQUIRED, UNIQUE, MINBYTES, MAXBYTES]),
 };
 
 module.exports = {

--- a/jdl/jhipster/field-types.js
+++ b/jdl/jhipster/field-types.js
@@ -69,6 +69,7 @@ const CassandraTypes = {
   BIG_DECIMAL: 'BigDecimal',
   FLOAT: 'Float',
   DOUBLE: 'Double',
+  ENUM: 'Enum',
   BOOLEAN: 'Boolean',
   DATE: 'Date',
   UUID: 'UUID',
@@ -84,6 +85,7 @@ const CassandraValidations = {
   BigDecimal: new Set([REQUIRED, UNIQUE, MIN, MAX]),
   Float: new Set([REQUIRED, UNIQUE, MIN, MAX]),
   Double: new Set([REQUIRED, UNIQUE, MIN, MAX]),
+  Enum: new Set([REQUIRED, UNIQUE]),
   Boolean: new Set([REQUIRED, UNIQUE]),
   Date: new Set([REQUIRED, UNIQUE]),
   UUID: new Set([REQUIRED, UNIQUE]),
@@ -113,7 +115,7 @@ function isCassandraType(type) {
   if (!type) {
     throw new Error('The passed type must not be nil.');
   }
-  return _.snakeCase(type).toUpperCase() in CassandraTypes && !(type instanceof JDLEnum);
+  return _.snakeCase(type).toUpperCase() in CassandraTypes || type instanceof JDLEnum;
 }
 
 function isBlobType(type) {

--- a/test-integration/samples/.jhipster/CassTestEntity.json
+++ b/test-integration/samples/.jhipster/CassTestEntity.json
@@ -128,12 +128,21 @@
       "fieldValidateRulesMax": 100
     },
     {
-      "fieldName": "dateField",
-      "fieldType": "Date"
+      "fieldName": "localDateField",
+      "fieldType": "LocalDate"
     },
     {
-      "fieldName": "dateRequiredField",
-      "fieldType": "Date",
+      "fieldName": "localDateRequiredField",
+      "fieldType": "LocalDate",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "instantDateField",
+      "fieldType": "Instant"
+    },
+    {
+      "fieldName": "instantRequiredField",
+      "fieldType": "Instant",
       "fieldValidateRules": ["required"]
     },
     {
@@ -143,6 +152,15 @@
     {
       "fieldName": "zonedDateTimeRequiredField",
       "fieldType": "ZonedDateTime",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "durationDateField",
+      "fieldType": "Duration"
+    },
+    {
+      "fieldName": "durationRequiredField",
+      "fieldType": "Duration",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestEntity.json
+++ b/test-integration/samples/.jhipster/CassTestEntity.json
@@ -128,6 +128,17 @@
       "fieldValidateRulesMax": 100
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "localDateField",
       "fieldType": "LocalDate"
     },
@@ -170,17 +181,6 @@
     {
       "fieldName": "booleanRequiredField",
       "fieldType": "Boolean",
-      "fieldValidateRules": ["required"]
-    },
-    {
-      "fieldName": "enumTom",
-      "fieldType": "EnumFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
-    },
-    {
-      "fieldName": "enumRequiredTom",
-      "fieldType": "EnumRequiredFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestEntity.json
+++ b/test-integration/samples/.jhipster/CassTestEntity.json
@@ -155,6 +155,17 @@
       "fieldValidateRules": ["required"]
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "picture",
       "fieldType": "ByteBuffer",
       "fieldTypeBlobContent": "image",

--- a/test-integration/samples/.jhipster/CassTestMapstructEntity.json
+++ b/test-integration/samples/.jhipster/CassTestMapstructEntity.json
@@ -128,12 +128,21 @@
       "fieldValidateRulesMax": 100
     },
     {
-      "fieldName": "dateField",
-      "fieldType": "Date"
+      "fieldName": "localDateField",
+      "fieldType": "LocalDate"
     },
     {
-      "fieldName": "dateRequiredField",
-      "fieldType": "Date",
+      "fieldName": "localDateRequiredField",
+      "fieldType": "LocalDate",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "instantDateField",
+      "fieldType": "Instant"
+    },
+    {
+      "fieldName": "instantRequiredField",
+      "fieldType": "Instant",
       "fieldValidateRules": ["required"]
     },
     {
@@ -143,6 +152,15 @@
     {
       "fieldName": "zonedDateTimeRequiredField",
       "fieldType": "ZonedDateTime",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "durationDateField",
+      "fieldType": "Duration"
+    },
+    {
+      "fieldName": "durationRequiredField",
+      "fieldType": "Duration",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestMapstructEntity.json
+++ b/test-integration/samples/.jhipster/CassTestMapstructEntity.json
@@ -128,6 +128,17 @@
       "fieldValidateRulesMax": 100
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "localDateField",
       "fieldType": "LocalDate"
     },
@@ -170,17 +181,6 @@
     {
       "fieldName": "booleanRequiredField",
       "fieldType": "Boolean",
-      "fieldValidateRules": ["required"]
-    },
-    {
-      "fieldName": "enumTom",
-      "fieldType": "EnumFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
-    },
-    {
-      "fieldName": "enumRequiredTom",
-      "fieldType": "EnumRequiredFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestMapstructEntity.json
+++ b/test-integration/samples/.jhipster/CassTestMapstructEntity.json
@@ -155,6 +155,17 @@
       "fieldValidateRules": ["required"]
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "picture",
       "fieldType": "ByteBuffer",
       "fieldTypeBlobContent": "image",

--- a/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
@@ -128,12 +128,21 @@
       "fieldValidateRulesMax": 100
     },
     {
-      "fieldName": "dateField",
-      "fieldType": "Date"
+      "fieldName": "localDateField",
+      "fieldType": "LocalDate"
     },
     {
-      "fieldName": "dateRequiredField",
-      "fieldType": "Date",
+      "fieldName": "localDateRequiredField",
+      "fieldType": "LocalDate",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "instantDateField",
+      "fieldType": "Instant"
+    },
+    {
+      "fieldName": "instantRequiredField",
+      "fieldType": "Instant",
       "fieldValidateRules": ["required"]
     },
     {
@@ -143,6 +152,15 @@
     {
       "fieldName": "zonedDateTimeRequiredField",
       "fieldType": "ZonedDateTime",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "durationDateField",
+      "fieldType": "Duration"
+    },
+    {
+      "fieldName": "durationRequiredField",
+      "fieldType": "Duration",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
@@ -128,6 +128,17 @@
       "fieldValidateRulesMax": 100
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "localDateField",
       "fieldType": "LocalDate"
     },
@@ -170,17 +181,6 @@
     {
       "fieldName": "booleanRequiredField",
       "fieldType": "Boolean",
-      "fieldValidateRules": ["required"]
-    },
-    {
-      "fieldName": "enumTom",
-      "fieldType": "EnumFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
-    },
-    {
-      "fieldName": "enumRequiredTom",
-      "fieldType": "EnumRequiredFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceClassEntity.json
@@ -155,6 +155,17 @@
       "fieldValidateRules": ["required"]
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "picture",
       "fieldType": "ByteBuffer",
       "fieldTypeBlobContent": "image",

--- a/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
@@ -128,12 +128,21 @@
       "fieldValidateRulesMax": 100
     },
     {
-      "fieldName": "dateField",
-      "fieldType": "Date"
+      "fieldName": "localDateField",
+      "fieldType": "LocalDate"
     },
     {
-      "fieldName": "dateRequiredField",
-      "fieldType": "Date",
+      "fieldName": "localDateRequiredField",
+      "fieldType": "LocalDate",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "instantDateField",
+      "fieldType": "Instant"
+    },
+    {
+      "fieldName": "instantRequiredField",
+      "fieldType": "Instant",
       "fieldValidateRules": ["required"]
     },
     {
@@ -143,6 +152,15 @@
     {
       "fieldName": "zonedDateTimeRequiredField",
       "fieldType": "ZonedDateTime",
+      "fieldValidateRules": ["required"]
+    },
+    {
+      "fieldName": "durationDateField",
+      "fieldType": "Duration"
+    },
+    {
+      "fieldName": "durationRequiredField",
+      "fieldType": "Duration",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
@@ -128,6 +128,17 @@
       "fieldValidateRulesMax": 100
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "localDateField",
       "fieldType": "LocalDate"
     },
@@ -170,17 +181,6 @@
     {
       "fieldName": "booleanRequiredField",
       "fieldType": "Boolean",
-      "fieldValidateRules": ["required"]
-    },
-    {
-      "fieldName": "enumTom",
-      "fieldType": "EnumFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
-    },
-    {
-      "fieldName": "enumRequiredTom",
-      "fieldType": "EnumRequiredFieldClass",
-      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
       "fieldValidateRules": ["required"]
     },
     {

--- a/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
+++ b/test-integration/samples/.jhipster/CassTestServiceImplEntity.json
@@ -155,6 +155,17 @@
       "fieldValidateRules": ["required"]
     },
     {
+      "fieldName": "enumTom",
+      "fieldType": "EnumFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3"
+    },
+    {
+      "fieldName": "enumRequiredTom",
+      "fieldType": "EnumRequiredFieldClass",
+      "fieldValues": "ENUM_VALUE_1,ENUM_VALUE_2,ENUM_VALUE_3",
+      "fieldValidateRules": ["required"]
+    },
+    {
       "fieldName": "picture",
       "fieldType": "ByteBuffer",
       "fieldTypeBlobContent": "image",

--- a/test/jdl/jhipster/field-types.spec.js
+++ b/test/jdl/jhipster/field-types.spec.js
@@ -75,8 +75,8 @@ describe('FieldTypes', () => {
       });
     });
     context('when passing an enum', () => {
-      it('should return false', () => {
-        expect(FieldTypes.isCassandraType(new JDLEnum({ name: 'MyEnum' }))).to.be.false;
+      it('should return true', () => {
+        expect(FieldTypes.isCassandraType(new JDLEnum({ name: 'MyEnum' }))).to.be.true;
       });
     });
   });

--- a/test/jdl/jhipster/field-types.spec.js
+++ b/test/jdl/jhipster/field-types.spec.js
@@ -39,7 +39,7 @@ describe('FieldTypes', () => {
     });
     context('when passing a false type', () => {
       it('should return false', () => {
-        expect(FieldTypes.isCommonDBType(FieldTypes.CassandraTypes.DATE)).to.be.false;
+        expect(FieldTypes.isCommonDBType(FieldTypes.CassandraTypes.BYTE_BUFFER)).to.be.false;
       });
     });
     context('when passing a valid type', () => {
@@ -66,7 +66,7 @@ describe('FieldTypes', () => {
     });
     context('when passing a false type', () => {
       it('should return false', () => {
-        expect(FieldTypes.isCassandraType(FieldTypes.CommonDBTypes.LOCAL_DATE)).to.be.false;
+        expect(FieldTypes.isCassandraType(FieldTypes.CommonDBTypes.ANY_BLOB)).to.be.false;
       });
     });
     context('when passing a valid type', () => {


### PR DESCRIPTION
- Update JDL to enable enumerations with Cassandra. This is already supported by generator-jhipster since #10414
-  Unify Cassandra date-time JDL types with common-databases JDL types:
    - remove Date type, redundant with Instant type
    - add LocalDate type
    - add Duration type

Fixes #14026
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
