### PR TITLE
Enable Cypress Dashboard for ngx-default

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -101,6 +101,7 @@ jobs:
             war: 0
             e2e: 1
             testcontainers: 1
+            enableCypressDashboard: 1
           - app-type: ngx-default-additional
             jhi-app-type: ngx-default
             entity: none
@@ -330,6 +331,10 @@ jobs:
         id: e2e
         if: steps.tests-should-be-skipped.outputs.skip-tests != 'true'
         run: npm run ci:e2e:run --if-present
+        env:
+          CYPRESS_ENABLE_RECORD: ${{ matrix.enableCypressDashboard }}
+          CYPRESS_PROJECT_ID: ${{ matrix.app-type }}_CYPRESS_PROJECT_ID
+          CYPRESS_RECORD_KEY: ${{ matrix.app-type }}_CYPRESS_RECORD_KEY
       - name: 'E2E: Teardown'
         if: always() && matrix.e2e == 1 && steps.tests-should-be-skipped.outputs.skip-tests != 'true'
         run: npm run ci:e2e:teardown


### PR DESCRIPTION
Following https://github.com/jhipster/generator-jhipster/pull/13717

This is a first try to record the Cypress tests in the Dashboard app. Enable it only for ngx-default and check if it works. 

I'm not sure how we should retrieve the env variable names dynamically (2 per project we want to record).


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
