### PR TITLE
replace spring-cloud-hystrix with spring-cloud-resilience4j

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -458,7 +458,11 @@ dependencies {
     <%_ } _%>
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway') { _%>
     implementation "org.springframework.cloud:spring-cloud-starter"
-    implementation "org.springframework.cloud:spring-cloud-starter-netflix-hystrix"
+    <%_ if (reactive) { _%>
+    implementation "org.springframework.cloud:spring-cloud-starter-circuitbreaker-reactor-resilience4j"
+    <%_ } else { _%>
+    implementation "org.springframework.cloud:spring-cloud-starter-circuitbreaker-resilience4j"
+    <%_ } _%>
     implementation "org.springframework.retry:spring-retry"
     <%_ } _%>
     <%_ if (serviceDiscoveryType) { _%>

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -482,6 +482,11 @@ dependencies {
     <%_ if (applicationType === 'microservice' || applicationType === 'gateway') { _%>
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
     <%_ } _%>
+    <%_ if (applicationTypeGateway || (applicationTypeMicroservice && reactive)) { _%>
+    implementation "com.playtika.reactivefeign:feign-reactor-webclient:3.1.1"
+    implementation "com.playtika.reactivefeign:feign-reactor-cloud:3.1.1"
+    implementation "com.playtika.reactivefeign:feign-reactor-spring-configuration:3.1.1"
+    <%_ } _%>
     implementation "org.springframework.security:spring-security-config"
     <%_ if (!reactive) { _%><%# Can remove when Spring Security 5.5 is released https://github.com/spring-projects/spring-security/issues/8958 -%>
     implementation "org.springframework.security:spring-security-data"

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -483,9 +483,9 @@ dependencies {
     implementation "org.springframework.cloud:spring-cloud-starter-openfeign"
     <%_ } _%>
     <%_ if (applicationTypeGateway || (applicationTypeMicroservice && reactive)) { _%>
-    implementation "com.playtika.reactivefeign:feign-reactor-webclient:3.1.1"
-    implementation "com.playtika.reactivefeign:feign-reactor-cloud:3.1.1"
-    implementation "com.playtika.reactivefeign:feign-reactor-spring-configuration:3.1.1"
+    implementation "com.playtika.reactivefeign:feign-reactor-webclient"
+    implementation "com.playtika.reactivefeign:feign-reactor-cloud"
+    implementation "com.playtika.reactivefeign:feign-reactor-spring-configuration"
     <%_ } _%>
     implementation "org.springframework.security:spring-security-config"
     <%_ if (!reactive) { _%><%# Can remove when Spring Security 5.5 is released https://github.com/spring-projects/spring-security/issues/8958 -%>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -799,10 +799,17 @@
             <groupId>org.springframework.cloud</groupId>
             <artifactId>spring-cloud-starter</artifactId>
         </dependency>
+<%_ if (reactive) { _%>
         <dependency>
             <groupId>org.springframework.cloud</groupId>
-            <artifactId>spring-cloud-starter-netflix-hystrix</artifactId>
+            <artifactId>spring-cloud-starter-circuitbreaker-reactor-resilience4j</artifactId>
         </dependency>
+<%_ } else { _%>
+        <dependency>
+            <groupId>org.springframework.cloud</groupId>
+            <artifactId>spring-cloud-starter-circuitbreaker-resilience4j</artifactId>
+        </dependency>
+<%_ } _%>    
         <dependency>
             <groupId>org.springframework.retry</groupId>
             <artifactId>spring-retry</artifactId>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -853,6 +853,23 @@
             <artifactId>spring-cloud-starter-openfeign</artifactId>
         </dependency>
 <%_ } _%>
+<%_ if (applicationTypeGateway || (applicationTypeMicroservice && reactive)) { _%>
+        <dependency>
+            <groupId>com.playtika.reactivefeign</groupId>
+            <artifactId>feign-reactor-webclient</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.playtika.reactivefeign</groupId>
+            <artifactId>feign-reactor-cloud</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+        <dependency>
+            <groupId>com.playtika.reactivefeign</groupId>
+            <artifactId>feign-reactor-spring-configuration</artifactId>
+            <version>3.1.1</version>
+        </dependency>
+<%_ } _%>
 <%_ if (!reactive) { _%><%# Can remove when Spring Security 5.5 is released https://github.com/spring-projects/spring-security/issues/8958 %>
         <dependency>
             <groupId>org.springframework.security</groupId>

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -857,17 +857,14 @@
         <dependency>
             <groupId>com.playtika.reactivefeign</groupId>
             <artifactId>feign-reactor-webclient</artifactId>
-            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.playtika.reactivefeign</groupId>
             <artifactId>feign-reactor-cloud</artifactId>
-            <version>3.1.1</version>
         </dependency>
         <dependency>
             <groupId>com.playtika.reactivefeign</groupId>
             <artifactId>feign-reactor-spring-configuration</artifactId>
-            <version>3.1.1</version>
         </dependency>
 <%_ } _%>
 <%_ if (!reactive) { _%><%# Can remove when Spring Security 5.5 is released https://github.com/spring-projects/spring-security/issues/8958 %>

--- a/generators/server/templates/src/main/java/package/config/FeignConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/FeignConfiguration.java.ejs
@@ -23,9 +23,14 @@ import org.springframework.cloud.openfeign.FeignClientsConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Import;
-
+<%_ if (reactive) { _%>
+import reactivefeign.spring.config.EnableReactiveFeignClients;
+<%_ } _%>
 @Configuration
 @EnableFeignClients(basePackages = "<%= packageName %>")
+<%_ if (reactive) { _%>
+@EnableReactiveFeignClients(basePackages = "<%= packageName %>")
+<%_ } _%>
 @Import(FeignClientsConfiguration.class)
 public class FeignConfiguration {
 

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -60,38 +60,17 @@ eureka:
 <%_ } _%>
 <%_ if (applicationTypeGateway) { _%>
 
-# See https://github.com/Netflix/Hystrix/wiki/Configuration
-hystrix:
-  command:
-    default:
-      execution:
-        isolation:
-          thread:
-            timeoutInMilliseconds: 10000
 
 <%_ } _%>
 <%_ if (applicationTypeMicroservice) { _%>
 feign:
-  hystrix:
+  circuitbreaker:
     enabled: true
   # client:
   #   config:
   #     default:
   #       connectTimeout: 5000
   #       readTimeout: 5000
-
-# See https://github.com/Netflix/Hystrix/wiki/Configuration
-hystrix:
-  command:
-    default:
-      execution:
-        isolation:
-          strategy: SEMAPHORE
-          # See https://github.com/spring-cloud/spring-cloud-netflix/issues/1330
-          # thread:
-          #   timeoutInMilliseconds: 10000
-  shareSecurityContext: true
-
 <%_ } _%>
 management:
   endpoints:

--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -58,11 +58,19 @@ eureka:
       git-branch: ${git.branch:}
       context-path: ${server.servlet.context-path:}
 <%_ } _%>
-<%_ if (applicationTypeGateway) { _%>
-
-
+<%_ if (applicationTypeGateway || (applicationTypeMicroservice && reactive)) { _%>
+reactive:
+  feign:
+    circuit:
+      breaker:
+        enabled: true
+  # client:
+  #   config:
+  #     default:
+  #       connectTimeout: 5000
+  #       readTimeout: 5000
 <%_ } _%>
-<%_ if (applicationTypeMicroservice) { _%>
+<%_ if (applicationTypeMicroservice && !reactive) { _%>
 feign:
   circuitbreaker:
     enabled: true


### PR DESCRIPTION
This PR is an incomplete approach to replace spring cloud hystrix with spring cloud resilience4j. Open things:

* Health indicator or not. By default health indicators are disabled, see [here for the reason](https://resilience4j.readme.io/docs/getting-started-3#health-endpoint).
* OpenFeign does not yet support webflux/reactive. We use it in the gateway (which is now reactive only) and for reactive microservices. [Spring suggest](https://docs.spring.io/spring-cloud-openfeign/docs/current/reference/html/#reactive-support) to use https://github.com/Playtika/feign-reactive until spring cloud can support it via open feign. What should we do?
* I have create a "reactive microservice sample" via `jhipster jdl reactive-ms` and at least everything seems to work well

updates #14031



---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
