### PR TITLE
Polishing the Entity Criteria

### DIFF
--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -81,8 +81,8 @@ const serverFiles = {
       path: SERVER_MAIN_SRC_DIR,
       templates: [
         {
-          file: 'package/service/dto/EntityCriteria.java',
-          renameTo: generator => `${generator.packageFolder}/service/dto/${generator.entityClass}Criteria.java`,
+          file: 'package/service/criteria/EntityCriteria.java',
+          renameTo: generator => `${generator.packageFolder}/service/criteria/${generator.entityClass}Criteria.java`,
         },
         {
           file: 'package/service/EntityQueryService.java',

--- a/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/EntityQueryService.java.ejs
@@ -48,7 +48,7 @@ import <%= packageName %>.domain.<%= asEntity(entityClass) %>;
 import <%= packageName %>.domain.*; // for static metamodels
 import <%= packageName %>.repository.<%= entityClass %>Repository;<% if (searchEngine === 'elasticsearch') { %>
 import <%= packageName %>.repository.search.<%= entityClass %>SearchRepository;<% } %>
-import <%= packageName %>.service.dto.<%= entityClass %>Criteria;
+import <%= packageName %>.service.criteria.<%= entityClass %>Criteria;
 <%_ if (dto === 'mapstruct') { _%>
 import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
 import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;

--- a/generators/entity-server/templates/src/main/java/package/service/criteria/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/criteria/EntityCriteria.java.ejs
@@ -124,6 +124,13 @@ public class <%= entityClass %>Criteria implements Serializable, Criteria {
         return <%= filterVariable.name %>;
     }
 
+    public <%- filterVariable.filterType %> <%= filterVariable.name %>() {
+        if (<%= filterVariable.name %> == null) {
+            <%= filterVariable.name %> = new <%- filterVariable.filterType %>();
+        }
+        return <%= filterVariable.name %>;
+    }
+
     public void set<%= filterVariable.fieldInJavaBeanMethod %>(<%- filterVariable.filterType %> <%= filterVariable.name %>) {
         this.<%= filterVariable.name %> = <%= filterVariable.name %>;
     }

--- a/generators/entity-server/templates/src/main/java/package/service/criteria/EntityCriteria.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/service/criteria/EntityCriteria.java.ejs
@@ -1,4 +1,4 @@
-package <%= packageName %>.service.dto;
+package <%= packageName %>.service.criteria;
 
 import java.io.Serializable;
 import java.util.Objects;

--- a/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/web/rest/EntityResource.java.ejs
@@ -54,7 +54,7 @@ import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
     <%_ } _%>
 <%_ } _%>
 <%_ if (jpaMetamodelFiltering) {  _%>
-import <%= packageName %>.service.dto.<%= entityClass %>Criteria;
+import <%= packageName %>.service.criteria.<%= entityClass %>Criteria;
 import <%= packageName %>.service.<%= entityClass %>QueryService;
 <%_ } _%>
 

--- a/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
+++ b/generators/entity-server/templates/src/test/java/package/web/rest/EntityResourceIT.java.ejs
@@ -94,7 +94,7 @@ import <%= packageName %>.service.dto.<%= asDto(entityClass) %>;
 import <%= packageName %>.service.mapper.<%= entityClass %>Mapper;
 <%_ } _%>
 <%_ if (jpaMetamodelFiltering) { _%>
-import <%= packageName %>.service.dto.<%= entityClass %>Criteria;
+import <%= packageName %>.service.criteria.<%= entityClass %>Criteria;
 import <%= packageName %>.service.<%= entityClass %>QueryService;
 <%_ } _%>
 


### PR DESCRIPTION
This is two smallish change, to enhance the experience using the entity criterias.
* Move the criteria objects into a separate package - which is not a big thing, but previously the DTOs and the criteria objects were in the same package, which seemed a bit messy.
* Adding fluent methods for the individual filters. Previously - due to limitations in generics usage, you had to write something like this:
`        
criteria.setProjectId((UUIDFilter) new UUIDFilter().setEquals(uuid));
` 
Which is a bit verbose, after this change, you can write:
`        
criteria.projectId().setEquals(uuid);
`
---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
