### PR TITLE
Add support to run modules using jhipster command

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -152,6 +152,10 @@ const defaultCommands = {
   page: {
     desc: 'Create a new page. (Supports vue clients)',
   },
+  run: {
+    desc: 'Run a module or custom generator',
+    argument: ['[generator]'],
+  },
   'spring-service': {
     alias: 'service',
     desc: 'Create a new Spring service bean',

--- a/cli/environment-builder.js
+++ b/cli/environment-builder.js
@@ -115,6 +115,7 @@ module.exports = class EnvironmentBuilder {
    * @private
    * Lookup current loaded blueprints.
    *
+   * @param {Object} [options] - forwarded to Environment lookup.
    * @return {EnvironmentBuilder} this for chaining.
    */
   _lookupBlueprints(options) {
@@ -123,6 +124,18 @@ module.exports = class EnvironmentBuilder {
       // Lookup for blueprints.
       this.env.lookup({ ...options, filterPaths: true, packagePatterns: allBlueprints });
     }
+    return this;
+  }
+
+  /**
+   * Lookup for generators.
+   *
+   * @param {string[]} [generators] - generators to lookup.
+   * @param {Object} [options] - forwarded to Environment lookup.
+   * @return {EnvironmentBuilder} this for chaining.
+   */
+  lookupGenerators(generators, options = {}) {
+    this.env.lookup({ filterPaths: true, ...options, packagePatterns: generators });
     return this;
   }
 

--- a/cli/jhipster-command.js
+++ b/cli/jhipster-command.js
@@ -76,7 +76,7 @@ class JHipsterCommand extends Command {
    */
   _parseCommand(operands, unknown) {
     if (this._lazyBuildCommandCallBack) {
-      this._lazyBuildCommandCallBack();
+      this._lazyBuildCommandCallBack(operands, unknown);
     }
     return super._parseCommand(operands, unknown);
   }

--- a/test/cli/cli.spec.js
+++ b/test/cli/cli.spec.js
@@ -460,4 +460,104 @@ describe('jhipster cli', () => {
       });
     });
   });
+
+  describe('jhipster run', () => {
+    describe('running jhipster built-in generators', () => {
+      describe('jhipster:app', () => {
+        let stdout;
+        let exitCode;
+        before(done => {
+          const forked = fork(jhipsterCli, ['run', 'jhipster:app', '--help'], { stdio: 'pipe' });
+          forked.on('exit', code => {
+            exitCode = code;
+            stdout = forked.stdout.read().toString();
+            done();
+          });
+        });
+
+        it('should print usage', () => {
+          expect(stdout.includes('Usage: cli run jhipster:app [options]')).to.be.true;
+        });
+        it('should print options', () => {
+          expect(stdout.includes('--application-type <value>')).to.be.true;
+        });
+        it('should exit with code 0', () => {
+          expect(exitCode).to.equal(0);
+        });
+      });
+    });
+    describe('custom generator', () => {
+      describe('--help', () => {
+        let stdout;
+        let exitCode;
+        beforeEach(done => {
+          const tmpdir = process.cwd();
+          copyBlueprint(path.join(__dirname, '../templates/blueprint-cli'), tmpdir, 'cli');
+          lnYeoman(tmpdir);
+          const forked = fork(jhipsterCli, ['run', 'cli:foo', '--help'], { stdio: 'pipe', cwd: tmpdir });
+          forked.on('exit', code => {
+            exitCode = code;
+            stdout = forked.stdout.read().toString();
+            done();
+          });
+        });
+
+        it('should print usage', () => {
+          expect(stdout.includes('Usage: cli run cli:foo [options]')).to.be.true;
+        });
+        it('should print options', () => {
+          expect(stdout.includes('--foo-bar')).to.be.true;
+          expect(stdout.includes('Sample option')).to.be.true;
+        });
+        it('should exit with code 0', () => {
+          expect(exitCode).to.equal(0);
+        });
+      });
+      describe('running it', () => {
+        let stdout;
+        let exitCode;
+        beforeEach(done => {
+          const tmpdir = process.cwd();
+          copyBlueprint(path.join(__dirname, '../templates/blueprint-cli'), tmpdir, 'cli');
+          lnYeoman(tmpdir);
+          const forked = fork(jhipsterCli, ['run', 'cli:foo', '--foo-bar'], { stdio: 'pipe', cwd: tmpdir });
+          forked.on('exit', code => {
+            exitCode = code;
+            stdout = forked.stdout.read().toString();
+            done();
+          });
+        });
+
+        it('should print runtime log', () => {
+          expect(stdout.includes('Running foo')).to.be.true;
+          expect(stdout.includes('Running bar')).to.be.true;
+        });
+        it('should exit with code 0', () => {
+          expect(exitCode).to.equal(0);
+        });
+      });
+    });
+    describe('non existing generator', () => {
+      describe('--help', () => {
+        let stderr;
+        let exitCode;
+        before(done => {
+          const tmpdir = process.cwd();
+          const forked = fork(jhipsterCli, ['run', 'non-existing', '--help'], { stdio: 'pipe', cwd: tmpdir });
+          forked.on('exit', code => {
+            exitCode = code;
+            stderr = forked.stderr.read().toString();
+            done();
+          });
+        });
+
+        it('should print error', () => {
+          expect(stderr.includes('Generator jhipster-non-existing not found.')).to.be.true;
+        });
+        it('should exit with code 1', () => {
+          expect(exitCode).to.equal(1);
+        });
+      });
+    });
+  });
 });

--- a/test/templates/blueprint-cli/generators/foo/index.js
+++ b/test/templates/blueprint-cli/generators/foo/index.js
@@ -1,13 +1,22 @@
 const Generator = require('yeoman-generator');
 
 module.exports = class extends Generator {
-    initializing() {
-        /* eslint-disable no-console */
-        console.log('Running foo');
-        if (this.options.fooBar) {
-            /* eslint-disable no-console */
-            console.log('Running bar');
-            console.log(this.options.fooBar);
-        }
+  constructor(args, opts) {
+    super(args, opts);
+
+    this.option('foo-bar', {
+      desc: 'Sample option',
+      type: Boolean,
+    });
+  };
+
+  initializing() {
+    /* eslint-disable no-console */
+    console.log('Running foo');
+    if (this.options.fooBar) {
+      /* eslint-disable no-console */
+      console.log('Running bar');
+      console.log(this.options.fooBar);
     }
+  }
 };


### PR DESCRIPTION
Run a module using `jhipster run your-favorite-module`.

Closes https://github.com/jhipster/generator-jhipster/issues/13068.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
