### PR TITLE
Drop .npmrc from angular.

### DIFF
--- a/generators/cleanup.js
+++ b/generators/cleanup.js
@@ -295,6 +295,7 @@ function cleanupOldFiles(generator) {
     if (generator.jhipsterConfig.clientFramework === ANGULAR) {
       generator.removeFile(`${ANGULAR_DIR}core/config/config.service.ts`);
       generator.removeFile(`${ANGULAR_DIR}core/config/config.service.spec.ts`);
+      generator.removeFile('.npmrc');
     }
   }
 }

--- a/generators/client/files-angular.js
+++ b/generators/client/files-angular.js
@@ -28,7 +28,6 @@ const files = {
   common: [
     {
       templates: [
-        '.npmrc',
         'package.json',
         'tsconfig.json',
         'tsconfig.app.json',

--- a/generators/client/templates/angular/.npmrc.ejs
+++ b/generators/client/templates/angular/.npmrc.ejs
@@ -1,1 +1,0 @@
-legacy-peer-deps = true

--- a/test/utils/expected-files.js
+++ b/test/utils/expected-files.js
@@ -384,7 +384,6 @@ const expectedFiles = {
     'angular.json',
     'ngsw-config.json',
     '.eslintrc.json',
-    '.npmrc',
     'package.json',
     '.browserslistrc',
     `${CLIENT_MAIN_SRC_DIR}main.ts`,


### PR DESCRIPTION
`legacy-peer-deps` option should not be required for angular anymore.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
