### PR TITLE
Fix: bump typescript from 4.1.5 to 4.2.3 in /generators/client/templates/vue

### DIFF
--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -71,7 +71,7 @@
     "eslint": "7.21.0",
     "eslint-plugin-prettier": "3.3.1",
     "eslint-plugin-vue": "7.7.0",
-    "typescript": "4.1.5",
+    "typescript": "4.2.3",
     "url-loader": "4.1.1",
     "webpack": "5.24.3",
     "webpack-bundle-analyzer": "4.4.0",

--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1492,7 +1492,7 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
 
     try {
       // Add i18n config snippets for all languages
-      let i18nConfig = 'const dateTimeFormats = {\n';
+      let i18nConfig = 'const dateTimeFormats: DateTimeFormats = {\n';
       if (this.enableTranslation) {
         languages.forEach((ln, i) => {
           i18nConfig += this.generateDateTimeFormat(ln, i, languages.length);


### PR DESCRIPTION
Fix https://github.com/jhipster/generator-jhipster/pull/14174

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
