### PR TITLE
Disable Couchbase and move WebFlux and Infinispan out of beta

### DIFF
--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -150,7 +150,7 @@ function askForServerSideOpts() {
         }); */
         opts.push({
           value: 'neo4j',
-          name: 'Neo4j',
+          name: '[BETA] Neo4j',
         });
         opts.push({
           value: 'no',

--- a/generators/server/prompts.js
+++ b/generators/server/prompts.js
@@ -44,7 +44,7 @@ function askForServerSideOpts() {
       when: () => ['monolith', 'microservice'].includes(applicationType),
       type: 'confirm',
       name: 'reactive',
-      message: '[Beta] Do you want to make it reactive with Spring WebFlux?',
+      message: 'Do you want to make it reactive with Spring WebFlux?',
       default: serverDefaultConfig.reactive,
     },
     {
@@ -143,13 +143,14 @@ function askForServerSideOpts() {
             name: 'Cassandra',
           });
         }
-        opts.push({
+        // Couchbase is broken, see https://github.com/jhipster/generator-jhipster/pull/14184 for more information.
+        /* opts.push({
           value: 'couchbase',
-          name: '[BROKEN] Couchbase',
-        });
+          name: 'Couchbase',
+        }); */
         opts.push({
           value: 'neo4j',
-          name: '[BETA] Neo4j',
+          name: 'Neo4j',
         });
         opts.push({
           value: 'no',
@@ -205,7 +206,7 @@ function askForServerSideOpts() {
         },
         {
           value: 'infinispan',
-          name: '[BETA] Infinispan (hybrid cache, for multiple nodes)',
+          name: 'Infinispan (hybrid cache, for multiple nodes)',
         },
         {
           value: 'memcached',


### PR DESCRIPTION
Disable Couchbase as a prompt so v7 does not prompt users. Can be re-enabled once [Couchbase for Spring Boot 2.4](https://github.com/jhipster/generator-jhipster/pull/14184) is fixed.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed