### PR TITLE
verify if secondLetter isn't empty  #14189

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -1668,7 +1668,7 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
    */
   javaBeanCase(beanName) {
     const secondLetter = beanName.charAt(1);
-    if (secondLetter === secondLetter.toUpperCase()) {
+    if (secondLetter && secondLetter === secondLetter.toUpperCase()) {
       return beanName;
     }
     return _.upperFirst(beanName);


### PR DESCRIPTION
fixes #14189  by adding condition that checks if secondLetter is not empty

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
