### PR TITLE
Bump npm version to 7.6.1 and use npm version from constants.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -79,7 +79,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version: [14.15.0]
-        npm_version: [7.6.0]
         os: [ubuntu-20.04]
         cache: [angular]
         app-type:
@@ -241,8 +240,8 @@ jobs:
             ${{ runner.os }}-cypress-
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
-      - name: 'TOOLS: install npm@${{ matrix.npm_version }}'
-        run: npm install -g npm@${{ matrix.npm_version }}
+      - name: 'TOOLS: install required npm'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - name: 'TOOLS: configure tools installed by the system'
         run: $JHI_SCRIPTS/03-system.sh
       - name: 'TOOLS: configure git'

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -35,14 +35,13 @@ jobs:
       matrix:
         node_version: [14.15.0]
         os: [ubuntu-20.04]
-        npm_version: [7.6.0]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ matrix.node_version }}
-      - name: 'install npm@${{ matrix.npm_version }}'
-        run: npm install -g npm@${{ matrix.npm_version }}
+      - name: 'install required npm version'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - run: git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue) <%an>%Creset' --abbrev-commit
         shell: bash
       - name: Config git variables

--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -74,7 +74,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version: [14.15.0]
-        npm_version: [7.6.0]
         os: [ubuntu-20.04]
         app-type:
           - liquibase-jdl-rename-field
@@ -149,8 +148,8 @@ jobs:
             ${{ runner.os }}-e2e-${{ matrix.app-type }}-
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
-      - name: 'TOOLS: install npm@${{ matrix.npm_version }}'
-        run: npm install -g npm@${{ matrix.npm_version }}
+      - name: 'TOOLS: install required npm'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - name: 'TOOLS: configure tools installed by the system'
         run: $JHI_SCRIPTS/03-system.sh
       - name: 'TOOLS: configure git'

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -79,7 +79,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version: [14.15.0]
-        npm_version: [7.6.0]
         os: [ubuntu-20.04]
         cache: [react]
         app-type:
@@ -223,8 +222,8 @@ jobs:
             ${{ runner.os }}-cypress-
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
-      - name: 'TOOLS: install npm@${{ matrix.npm_version }}'
-        run: npm install -g npm@${{ matrix.npm_version }}
+      - name: 'TOOLS: install required npm'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - name: 'TOOLS: configure tools installed by the system'
         run: $JHI_SCRIPTS/03-system.sh
       - name: 'TOOLS: configure git'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -79,7 +79,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version: [14.15.0]
-        npm_version: [7.6.0]
         os: [ubuntu-20.04]
         cache: [vue]
         app-type:
@@ -221,8 +220,8 @@ jobs:
             ${{ runner.os }}-cypress-
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
-      - name: 'TOOLS: install npm@${{ matrix.npm_version }}'
-        run: npm install -g npm@${{ matrix.npm_version }}
+      - name: 'TOOLS: install required npm'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - name: 'TOOLS: configure tools installed by the system'
         run: $JHI_SCRIPTS/03-system.sh
       - name: 'TOOLS: configure git'

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -78,7 +78,6 @@ jobs:
       fail-fast: false
       matrix:
         node_version: [14.15.0]
-        npm_version: [7.6.0]
         os: [ubuntu-20.04]
         cache: [webflux]
         app-type:
@@ -227,8 +226,8 @@ jobs:
             ${{ runner.os }}-cypress-
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
-      - name: 'TOOLS: install npm@${{ matrix.npm_version }}'
-        run: npm install -g npm@${{ matrix.npm_version }}
+      - name: 'TOOLS: install required npm'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - name: 'TOOLS: configure tools installed by the system'
         run: $JHI_SCRIPTS/03-system.sh
       - name: 'TOOLS: configure git'

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -16,7 +16,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-const semver = require('semver');
 const validationOptions = require('../jdl/jhipster/validations');
 const applicationOptions = require('../jdl/jhipster/application-options');
 const databaseTypes = require('../jdl/jhipster/database-types');
@@ -28,7 +27,7 @@ const JAVA_VERSION = '11'; // Java version is forced to be 11. We keep the varia
 
 // Version of Node, NPM
 const NODE_VERSION = '14.15.0';
-const NPM_VERSION = '7.6.0';
+const NPM_VERSION = '7.6.1';
 const OPENAPI_GENERATOR_CLI_VERSION = '1.0.13-4.3.1';
 
 const GRADLE_VERSION = '6.8.2';
@@ -39,8 +38,7 @@ const JHIPSTER_DEPENDENCIES_VERSION = '7.0.0-SNAPSHOT';
 // The spring-boot version should match the one managed by https://mvnrepository.com/artifact/tech.jhipster/jhipster-dependencies/JHIPSTER_DEPENDENCIES_VERSION
 const SPRING_BOOT_VERSION = '2.4.3';
 const LIQUIBASE_VERSION = '4.2.2';
-const liquibaseSemVer = semver.parse(LIQUIBASE_VERSION);
-const LIQUIBASE_DTD_VERSION = `${liquibaseSemVer.major}.${liquibaseSemVer.minor}`;
+const LIQUIBASE_DTD_VERSION = LIQUIBASE_VERSION.split('.', 3).slice(0, 2).join('.');
 const HIBERNATE_VERSION = '5.4.28.Final';
 
 const JACOCO_VERSION = '0.8.6';

--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -47,7 +47,7 @@ if [[ "$JHI_REPO" == *"/generator-jhipster" ]]; then
 
     cd "$JHI_HOME"
     git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue)<%an>%Creset' --abbrev-commit
-
+    npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
     npm ci
     npm install -g "$JHI_HOME"
 elif [[ "$JHI_GEN_BRANCH" == "release" ]]; then

--- a/test/generator-constants.spec.js
+++ b/test/generator-constants.spec.js
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2013-2021 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const assert = require('assert');
+const semver = require('semver');
+const { LIQUIBASE_VERSION, LIQUIBASE_DTD_VERSION } = require('../generators/generator-constants');
+
+describe('generator-constants', () => {
+  it('LIQUIBASE_DTD_VERSION', () => {
+    const liquibaseSemVer = semver.parse(LIQUIBASE_VERSION);
+    assert.equal(LIQUIBASE_DTD_VERSION, `${liquibaseSemVer.major}.${liquibaseSemVer.minor}`);
+  });
+});


### PR DESCRIPTION
PR https://github.com/jhipster/generator-jhipster/pull/14187 recreated package-lock.json with npm 7.
npm 6 `npm ci` prints a warning about lockversion 2, let's switch others CIs to npm 7.

Remaining tasks for https://github.com/jhipster/generator-jhipster/issues/12747
- Install npm using constants version.
  - GitHub action
  - build scripts used by (jhipster-bom)

- Missing to update daily builds. After approval.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
