### PR TITLE
Handle swagger with compression for reactive gateway

### DIFF
--- a/generators/server/templates/src/main/java/package/web/filter/ModifyServersOpenApiFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/filter/ModifyServersOpenApiFilter.java.ejs
@@ -5,8 +5,16 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-import java.nio.charset.Charset;
+
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import java.util.Objects;
+import java.util.zip.GZIPInputStream;
+import java.util.zip.GZIPOutputStream;
+
 import org.reactivestreams.Publisher;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
@@ -15,6 +23,7 @@ import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.core.io.buffer.DataBufferFactory;
 import org.springframework.core.io.buffer.DataBufferUtils;
 import org.springframework.core.io.buffer.DefaultDataBufferFactory;
+import org.springframework.http.HttpHeaders;
 import org.springframework.http.server.reactive.ServerHttpResponse;
 import org.springframework.http.server.reactive.ServerHttpResponseDecorator;
 import org.springframework.stereotype.Component;
@@ -73,7 +82,7 @@ public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
 
         @Override
         public Mono<Void> writeWith(Publisher<? extends DataBuffer> body) {
-            this.rewritedBody = "";
+            rewritedBody = "";
             if (body instanceof Flux) {
                 Flux<? extends DataBuffer> fluxBody = (Flux<? extends DataBuffer>) body;
 
@@ -91,7 +100,7 @@ public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
 
             // release memory
             DataBufferUtils.release(join);
-            String strBody = new String(content, Charset.forName("UTF-8"));
+            String strBody = contentToString(content);
 
             try {
                 // create custom server
@@ -106,12 +115,66 @@ public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
                 servers.add(serversToJson);
                 ((ObjectNode) jsonBody).set("servers", servers);
 
-                this.rewritedBody = jsonBody.toString();
-                originalResponse.getHeaders().setContentLength(this.rewritedBody.getBytes().length);
+                rewritedBody = jsonBody.toString();
+                return rewritedBodyToDataBuffer();
             } catch (JsonProcessingException e) {
                 e.printStackTrace();
             }
-            return bufferFactory.wrap(this.rewritedBody.getBytes());
+            return join;
+        }
+
+        private DataBuffer rewritedBodyToDataBuffer() {
+            if(isZippedResponse()) {
+                byte[] zippedBody = zipContent(rewritedBody);
+                originalResponse.getHeaders().setContentLength(zippedBody.length);
+                return bufferFactory.wrap(zippedBody);
+            } else {
+                originalResponse.getHeaders().setContentLength(rewritedBody.getBytes().length);
+                return bufferFactory.wrap(rewritedBody.getBytes());
+            }
+        }
+
+        private String contentToString(byte[] content) {
+            if(isZippedResponse()) {
+                byte[] unzippedContent = unzipContent(content);
+                return new String(unzippedContent, StandardCharsets.UTF_8);
+            } else {
+                return new String(content, StandardCharsets.UTF_8);
+            }
+        }
+
+        private boolean isZippedResponse() {
+            if (originalResponse.getHeaders().isEmpty() ||
+                originalResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING) == null) {
+                return false;
+            }
+            return Objects.requireNonNull(originalResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING)).contains("gzip");
+        }
+
+        private byte[] unzipContent(byte[] content) {
+            try {
+                GZIPInputStream gzipInputStream = new GZIPInputStream(new ByteArrayInputStream(content));
+                byte[] unzippedContent = gzipInputStream.readAllBytes();
+                gzipInputStream.close();
+                return unzippedContent;
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return content;
+        }
+
+        private byte[] zipContent(String content) {
+            try {
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream(content.length());
+                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
+                gzipOutputStream.write(content.getBytes(StandardCharsets.UTF_8));
+                gzipOutputStream.flush();
+                gzipOutputStream.close();
+                return byteArrayOutputStream.toByteArray();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return content.getBytes();
         }
     }
 }

--- a/generators/server/templates/src/main/java/package/web/filter/ModifyServersOpenApiFilter.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/filter/ModifyServersOpenApiFilter.java.ejs
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ArrayNode;
 import com.fasterxml.jackson.databind.node.ObjectNode;
-
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -14,8 +13,9 @@ import java.util.List;
 import java.util.Objects;
 import java.util.zip.GZIPInputStream;
 import java.util.zip.GZIPOutputStream;
-
 import org.reactivestreams.Publisher;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.cloud.gateway.filter.GlobalFilter;
 import org.springframework.core.Ordered;
@@ -33,6 +33,8 @@ import reactor.core.publisher.Mono;
 
 @Component
 public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
+
+    private static final Logger log = LoggerFactory.getLogger(ModifyServersOpenApiFilter.class);
 
     @Override
     public Mono<Void> filter(ServerWebExchange exchange, GatewayFilterChain chain) {
@@ -118,37 +120,33 @@ public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
                 rewritedBody = jsonBody.toString();
                 return rewritedBodyToDataBuffer();
             } catch (JsonProcessingException e) {
-                e.printStackTrace();
+                log.error("Error when modify servers from api-doc of {}: {}", path, e.getMessage());
             }
             return join;
         }
 
         private DataBuffer rewritedBodyToDataBuffer() {
-            if(isZippedResponse()) {
+            if (isZippedResponse()) {
                 byte[] zippedBody = zipContent(rewritedBody);
                 originalResponse.getHeaders().setContentLength(zippedBody.length);
                 return bufferFactory.wrap(zippedBody);
-            } else {
-                originalResponse.getHeaders().setContentLength(rewritedBody.getBytes().length);
-                return bufferFactory.wrap(rewritedBody.getBytes());
             }
+            originalResponse.getHeaders().setContentLength(rewritedBody.getBytes().length);
+            return bufferFactory.wrap(rewritedBody.getBytes());
         }
 
         private String contentToString(byte[] content) {
-            if(isZippedResponse()) {
+            if (isZippedResponse()) {
                 byte[] unzippedContent = unzipContent(content);
                 return new String(unzippedContent, StandardCharsets.UTF_8);
-            } else {
-                return new String(content, StandardCharsets.UTF_8);
             }
+            return new String(content, StandardCharsets.UTF_8);
         }
 
         private boolean isZippedResponse() {
-            if (originalResponse.getHeaders().isEmpty() ||
-                originalResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING) == null) {
-                return false;
-            }
-            return Objects.requireNonNull(originalResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING)).contains("gzip");
+            return !originalResponse.getHeaders().isEmpty() &&
+                originalResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING) != null &&
+                Objects.requireNonNull(originalResponse.getHeaders().get(HttpHeaders.CONTENT_ENCODING)).contains("gzip");
         }
 
         private byte[] unzipContent(byte[] content) {
@@ -158,7 +156,7 @@ public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
                 gzipInputStream.close();
                 return unzippedContent;
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Error when unzip content during modify servers from api-doc of {}: {}", path, e.getMessage());
             }
             return content;
         }
@@ -172,7 +170,7 @@ public class ModifyServersOpenApiFilter implements GlobalFilter, Ordered {
                 gzipOutputStream.close();
                 return byteArrayOutputStream.toByteArray();
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Error when zip content during modify servers from api-doc of {}: {}", path, e.getMessage());
             }
             return content.getBytes();
         }

--- a/generators/server/templates/src/test/java/package/web/filter/ModifyServersOpenApiFilterTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/filter/ModifyServersOpenApiFilterTest.java.ejs
@@ -4,10 +4,16 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.Mockito.*;
 
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.core.io.buffer.DataBuffer;
 import org.springframework.http.HttpHeaders;
@@ -17,13 +23,9 @@ import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
 
-import java.io.ByteArrayOutputStream;
-import java.io.IOException;
-import java.nio.charset.StandardCharsets;
-import java.util.zip.GZIPOutputStream;
-
 class ModifyServersOpenApiFilterTest {
 
+    private static final Logger log = LoggerFactory.getLogger(ModifyServersOpenApiFilterTest.class);
     private final GatewayFilterChain filterChain = mock(GatewayFilterChain.class);
     private final ArgumentCaptor<ServerWebExchange> captor = ArgumentCaptor.forClass(ServerWebExchange.class);
 
@@ -82,13 +84,11 @@ class ModifyServersOpenApiFilterTest {
 
         @Test
         void shouldRewriteBodyWhenBodyIsFluxAndResponseIsNotZipped() {
-            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = spy(
-                modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
+            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
                     path,
                     exchange.getResponse(),
                     exchange.getResponse().bufferFactory()
-                )
-            );
+                );
 
             byte[] bytes = "{}".getBytes();
             DataBuffer body = exchange.getResponse().bufferFactory().wrap(bytes);
@@ -103,13 +103,11 @@ class ModifyServersOpenApiFilterTest {
         @Test
         void shouldRewriteBodyWhenBodyIsFluxAndResponseIsZipped() {
             exchange.getResponse().getHeaders().set(HttpHeaders.CONTENT_ENCODING, "gzip");
-            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = spy(
-                modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
+            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
                     path,
                     exchange.getResponse(),
                     exchange.getResponse().bufferFactory()
-                )
-            );
+                );
 
             byte[] bytes = zipContent();
             DataBuffer body = exchange.getResponse().bufferFactory().wrap(bytes);
@@ -123,13 +121,11 @@ class ModifyServersOpenApiFilterTest {
 
         @Test
         void shouldNotRewriteBodyWhenBodyIsNotFlux() {
-            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = spy(
-                modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
+            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
                     path,
                     exchange.getResponse(),
                     exchange.getResponse().bufferFactory()
-                )
-            );
+                );
 
             byte[] bytes = "{}".getBytes();
             DataBuffer body = exchange.getResponse().bufferFactory().wrap(bytes);
@@ -146,7 +142,7 @@ class ModifyServersOpenApiFilterTest {
                 gzipOutputStream.close();
                 return byteArrayOutputStream.toByteArray();
             } catch (IOException e) {
-                e.printStackTrace();
+                log.error("Error in test when zip content during modify servers from api-doc of {}: {}", path, e.getMessage());
             }
             return "{}".getBytes();
         }

--- a/generators/server/templates/src/test/java/package/web/filter/ModifyServersOpenApiFilterTest.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/filter/ModifyServersOpenApiFilterTest.java.ejs
@@ -10,11 +10,17 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 import org.springframework.cloud.gateway.filter.GatewayFilterChain;
 import org.springframework.core.io.buffer.DataBuffer;
+import org.springframework.http.HttpHeaders;
 import org.springframework.mock.http.server.reactive.MockServerHttpRequest;
 import org.springframework.mock.web.server.MockServerWebExchange;
 import org.springframework.web.server.ServerWebExchange;
 import reactor.core.publisher.Flux;
 import reactor.core.publisher.Mono;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.zip.GZIPOutputStream;
 
 class ModifyServersOpenApiFilterTest {
 
@@ -75,7 +81,7 @@ class ModifyServersOpenApiFilterTest {
         private final ModifyServersOpenApiFilter modifyServersOpenApiFilter = new ModifyServersOpenApiFilter();
 
         @Test
-        void shouldRewriteBodyWhenBodyIsFlux() {
+        void shouldRewriteBodyWhenBodyIsFluxAndResponseIsNotZipped() {
             ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = spy(
                 modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
                     path,
@@ -91,8 +97,28 @@ class ModifyServersOpenApiFilterTest {
                 interceptor
                     .getRewritedBody()
                     .contains("\"servers\":[{\"url\":\"/services/service-test/instance-test\",\"description\":\"added by global filter\"}]")
-            )
-                .isTrue();
+            ).isTrue();
+        }
+
+        @Test
+        void shouldRewriteBodyWhenBodyIsFluxAndResponseIsZipped() {
+            exchange.getResponse().getHeaders().set(HttpHeaders.CONTENT_ENCODING, "gzip");
+            ModifyServersOpenApiFilter.ModifyServersOpenApiInterceptor interceptor = spy(
+                modifyServersOpenApiFilter.createModifyServersOpenApiInterceptor(
+                    path,
+                    exchange.getResponse(),
+                    exchange.getResponse().bufferFactory()
+                )
+            );
+
+            byte[] bytes = zipContent();
+            DataBuffer body = exchange.getResponse().bufferFactory().wrap(bytes);
+            interceptor.writeWith(Flux.just(body)).subscribe();
+            assertThat(
+                interceptor
+                    .getRewritedBody()
+                    .contains("\"servers\":[{\"url\":\"/services/service-test/instance-test\",\"description\":\"added by global filter\"}]")
+            ).isTrue();
         }
 
         @Test
@@ -108,7 +134,21 @@ class ModifyServersOpenApiFilterTest {
             byte[] bytes = "{}".getBytes();
             DataBuffer body = exchange.getResponse().bufferFactory().wrap(bytes);
             interceptor.writeWith(Mono.just(body)).subscribe();
-            assertThat(interceptor.getRewritedBody().contains("")).isTrue();
+            assertThat(interceptor.getRewritedBody()).isEmpty();
+        }
+
+        private byte[] zipContent() {
+            try {
+                ByteArrayOutputStream byteArrayOutputStream = new ByteArrayOutputStream("{}".length());
+                GZIPOutputStream gzipOutputStream = new GZIPOutputStream(byteArrayOutputStream);
+                gzipOutputStream.write("{}".getBytes(StandardCharsets.UTF_8));
+                gzipOutputStream.flush();
+                gzipOutputStream.close();
+                return byteArrayOutputStream.toByteArray();
+            } catch (IOException e) {
+                e.printStackTrace();
+            }
+            return "{}".getBytes();
         }
     }
 }


### PR DESCRIPTION
Handle swagger with compression for reactive gateway when using prod profile and compression is true here
```
server:
  port: 8081
  shutdown: graceful # see https://docs.spring.io/spring-boot/docs/current/reference/html/spring-boot-features.html#boot-features-graceful-shutdown
  compression:
    enabled: true
```
Fix #14198 
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
