### PR TITLE
Better portability for shebang of integrations tests scripts

### DIFF
--- a/test-integration/generate-sample.sh
+++ b/test-integration/generate-sample.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 
@@ -12,7 +12,7 @@ function usage() {
     me=$(basename "$0")
     echo
     echo "Usage: $me generate <destination> <sample_name> [sql|sqllight|sqlfull|micro|mongodb|cassandra|couchbase] | list"
-    echo 
+    echo
     echo "Examples:"
     echo "$me generate /tmp/ngx-default/ ngx-default sql"
     echo "$me generate /tmp/ngx-default/ ngx-session-cassandra-fr cassandra"
@@ -26,7 +26,7 @@ function generateProject() {
     echo "JHI_FOLDER_APP=$JHI_FOLDER_APP"
     echo "JHI_APP=$JHI_APP"
     echo "JHI_ENTITY=$JHI_ENTITY"
-    
+
     if [ ! -d "$JHI_FOLDER_APP" ]; then
         echo "*** Create $JHI_FOLDER_APP"
         mkdir -p "$JHI_FOLDER_APP"

--- a/test-integration/scripts/00-init-env.sh
+++ b/test-integration/scripts/00-init-env.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 JHI_DETECTED_DIR="$( cd "$( dirname $( dirname $( dirname "${BASH_SOURCE[0]}" ) ) )" >/dev/null 2>&1 && pwd )"
 

--- a/test-integration/scripts/01-display-configuration.sh
+++ b/test-integration/scripts/01-display-configuration.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $(dirname $0)/00-init-env.sh
 

--- a/test-integration/scripts/02-display-tools.sh
+++ b/test-integration/scripts/02-display-tools.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 git version
 java -version

--- a/test-integration/scripts/03-system.sh
+++ b/test-integration/scripts/03-system.sh
@@ -1,4 +1,3 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 sudo /etc/init.d/mysql stop
-  

--- a/test-integration/scripts/04-git-config.sh
+++ b/test-integration/scripts/04-git-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/10-install-jhipster.sh
+++ b/test-integration/scripts/10-install-jhipster.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/11-generate-config.sh
+++ b/test-integration/scripts/11-generate-config.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 #-------------------------------------------------------------------------------
 # Eg: 11-generate-config.sh ./ ngx-default sqlfull

--- a/test-integration/scripts/11-generate-entities.sh
+++ b/test-integration/scripts/11-generate-entities.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 if [[ -a $(dirname $0)/00-init-env.sh ]]; then

--- a/test-integration/scripts/12-generate-project.sh
+++ b/test-integration/scripts/12-generate-project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/13-replace-version-generated-project.sh
+++ b/test-integration/scripts/13-replace-version-generated-project.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/14-jhipster-info.sh
+++ b/test-integration/scripts/14-jhipster-info.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/20-docker-compose.sh
+++ b/test-integration/scripts/20-docker-compose.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/20-no-memory-limit-elasticsearch.sh
+++ b/test-integration/scripts/20-no-memory-limit-elasticsearch.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/21-tests-backend.sh
+++ b/test-integration/scripts/21-tests-backend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/22-tests-frontend.sh
+++ b/test-integration/scripts/22-tests-frontend.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/23-package.sh
+++ b/test-integration/scripts/23-package.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 source $(dirname $0)/00-init-env.sh

--- a/test-integration/scripts/24-tests-e2e.sh
+++ b/test-integration/scripts/24-tests-e2e.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $(dirname $0)/00-init-env.sh
 

--- a/test-integration/scripts/25-sonar-analyze.sh
+++ b/test-integration/scripts/25-sonar-analyze.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 source $(dirname $0)/00-init-env.sh
 
@@ -20,7 +20,7 @@ elif [[ $JHI_SONAR = 1 ]]; then
     ./mvnw -ntp --batch-mode initialize org.jacoco:jacoco-maven-plugin:prepare-agent sonar:sonar \
         -Dsonar.host.url=http://localhost:9001 \
         -Dsonar.projectKey=JHipsterSonar
-        
+
     sleep 30
     docker-compose -f src/main/docker/sonar.yml logs
     echo "*** Sonar results:"


### PR DESCRIPTION
Some Linux distributions don't have bash available at /bin/bash, e.g. Nixos that I'm using.
Using /usr/bin/env is more portable
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
