### PR TITLE
downgrade org.springframework.data:spring-data-neo4j to 6.0.3

### DIFF
--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -398,6 +398,14 @@ dependencies {
     <%_ if (databaseType === 'neo4j') { _%>
     implementation "org.springframework.boot:spring-boot-starter-data-neo4j"
     implementation "eu.michael-simons.neo4j:neo4j-migrations-spring-boot-starter"
+    <%_ if (reactive) { _%>
+    // See https://github.com/jhipster/generator-jhipster/issues/14196
+    implementation('org.springframework.data:spring-data-neo4j') {
+        version {
+            strictly '6.0.3'
+        }
+    }
+    <%_ } _%>
     // This is done here explicitly as dependency resolution seems to have changed recently such that the validation starter
     // and therefore hibernate validators is not included anymore
     implementation "org.springframework.boot:spring-boot-starter-validation"

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -176,6 +176,14 @@
                 <type>pom</type>
                 <scope>import</scope>
             </dependency>
+<%_ if (reactive) { _%>
+            <!-- See https://github.com/jhipster/generator-jhipster/issues/14196 -->
+            <dependency>
+                <groupId>org.springframework.data</groupId>
+                <artifactId>spring-data-neo4j</artifactId>
+                <version>6.0.3</version>
+            </dependency>
+<%_ } _%>
             <!-- jhipster-needle-maven-add-dependency-management -->
         </dependencies>
     </dependencyManagement>


### PR DESCRIPTION
This downgrades `org.springframework.data:spring-data-neo4j` to 6.0.3 instead of the managed 6.0.5 which seems to have a blocking call inside `ReactiveNeo4jTemplate`.

updates #14196

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
