### PR TITLE
Correctly set the spring context-path for api-docs

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -56,6 +56,7 @@ eureka:
       git-version: ${git.commit.id.describe:}
       git-commit: ${git.commit.id.abbrev:}
       git-branch: ${git.branch:}
+      context-path: ${server.servlet.context-path:}
 <%_ } _%>
 <%_ if (applicationType === 'gateway') { _%>
 
@@ -330,7 +331,8 @@ jhipster:
   mail:
     from: <%= baseName %>@localhost
   api-docs:
-    default-include-pattern: /api/.*
+    default-include-pattern: ${server.servlet.context-path:}/api/.*
+    management-include-pattern: ${server.servlet.context-path:}/management/.*
     title: <%= baseName %> API
     description: <%= baseName %> API documentation
     version: 0.0.1

--- a/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/bootstrap.yml.ejs
@@ -45,6 +45,8 @@ spring:
           - git-version=${git.commit.id.describe:}
           - git-commit=${git.commit.id.abbrev:}
           - git-branch=${git.branch:}
+          - context-path=${server.servlet.context-path:}
+
       host: localhost
       port: 8500
     <%_ } _%>


### PR DESCRIPTION
This is an alternative to #12923 that wanted to support monolith's frontend with a custom context-path as a minimal support for JHipster 7. So This will only work for the back-end part.

With @pascalgrimaud we realized that there are many places where we should set the context-path for the UI including `cypress.json`, webpack, and this cannot be set dynamically so it would need to be a generator option.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
