### PR TITLE
[Vue] Remove condition to import bootstrap-variables in vendor.scss

### DIFF
--- a/generators/client/templates/vue/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/client/templates/vue/src/main/webapp/content/scss/vendor.scss.ejs
@@ -23,9 +23,7 @@ put Sass variables here:
 eg $input-color: red;
 ****************************/
 // Override Boostrap variables
-<%_ if (clientTheme === 'none') { _%>
 @import "bootstrap-variables";
-<%_ } _%>
 // Import Bootstrap source files from node_modules
 <%_ if (clientTheme !== 'none') { _%>
 @import "~bootswatch/dist/<%= clientTheme %>/variables";


### PR DESCRIPTION
Fix #14294 

With Angular, we always do `@import 'bootstrap-variables';` on `vendor.scss` https://github.com/jhipster/generator-jhipster/blob/77288374cf16ec4f74e5ba132a24ad00ceb8bdc5/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs#L29 but not with Vue (there is a condition). I don't know why https://github.com/jhipster/generator-jhipster/commit/00c1a2eae1bd47ee7d755b5b0c396d7ef665a113#diff-91bb2f362ad6ae20a3d2f82daaf5cc7e0f76d3e1c7c1e3b525c56e396d0007b1

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
