### PR TITLE
OIDC /userinfo lookup improvements

### DIFF
--- a/generators/server/files.js
+++ b/generators/server/files.js
@@ -556,12 +556,7 @@ const serverFiles = {
       ],
     },
     {
-      condition: generator =>
-        !generator.reactive &&
-        generator.authenticationType === 'oauth2' &&
-        (generator.applicationType === 'monolith' ||
-          generator.applicationType === 'microservice' ||
-          generator.applicationType === 'gateway'),
+      condition: generator => !generator.reactive && generator.authenticationType === 'oauth2' && generator.applicationType === 'monolith',
       path: SERVER_MAIN_SRC_DIR,
       templates: [
         {
@@ -571,12 +566,7 @@ const serverFiles = {
       ],
     },
     {
-      condition: generator =>
-        !generator.reactive &&
-        generator.authenticationType === 'oauth2' &&
-        (generator.applicationType === 'monolith' ||
-          generator.applicationType === 'microservice' ||
-          generator.applicationType === 'gateway'),
+      condition: generator => !generator.reactive && generator.authenticationType === 'oauth2' && generator.applicationType === 'monolith',
       path: SERVER_TEST_SRC_DIR,
       templates: [
         {

--- a/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/SecurityConfiguration.java.ejs
@@ -92,7 +92,7 @@ import <%= packageName %>.security.oauth2.JwtGrantedAuthorityConverter;
     <%_ if (authenticationType === 'jwt' && applicationType !== 'microservice') { _%>
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
     <%_ } _%>
-    <%_ if (authenticationType === 'oauth2' && (applicationType === 'monolith' || applicationType === 'microservice' || applicationType === 'gateway')) { _%>
+    <%_ if (authenticationType === 'oauth2' && applicationType === 'monolith') { _%>
 import org.springframework.security.oauth2.client.registration.ClientRegistrationRepository;
 import org.springframework.boot.web.client.RestTemplateBuilder;
 import <%= packageName %>.security.oauth2.CustomClaimConverter;
@@ -345,7 +345,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         <%_ } _%>
 
     @Bean
-    JwtDecoder jwtDecoder(<%_ if (authenticationType === 'oauth2' && applicationType === 'microservice') { _%>ClientRegistrationRepository clientRegistrationRepository, RestTemplateBuilder restTemplateBuilder<%_ } _%>) {
+    JwtDecoder jwtDecoder(<%_ if (authenticationType === 'oauth2' && applicationType === 'monolith') { _%>ClientRegistrationRepository clientRegistrationRepository, RestTemplateBuilder restTemplateBuilder<%_ } _%>) {
         NimbusJwtDecoder jwtDecoder = (NimbusJwtDecoder) JwtDecoders.fromOidcIssuerLocation(issuerUri);
 
         OAuth2TokenValidator<Jwt> audienceValidator = new AudienceValidator(jHipsterProperties.getSecurity().getOauth2().getAudience());
@@ -353,7 +353,7 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         OAuth2TokenValidator<Jwt> withAudience = new DelegatingOAuth2TokenValidator<>(withIssuer, audienceValidator);
 
         jwtDecoder.setJwtValidator(withAudience);
-        <%_ if (authenticationType === 'oauth2' && applicationType === 'microservice') { _%>
+        <%_ if (authenticationType === 'oauth2' && applicationType === 'monolith') { _%>
         jwtDecoder.setClaimSetConverter(new CustomClaimConverter(clientRegistrationRepository.findByRegistrationId("oidc"), restTemplateBuilder.build()));
         <%_ } _%>
 


### PR DESCRIPTION
This changes things so microservices don't have a `CustomClaimConverter` for looking up a user's attributes. It should only be at the gateway or monolith level. Since it wasn't implemented for reactive, this means it only applies to non-reactive monoliths now. FYI @Falydoor. 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

