### PR TITLE
print sponsor message instead of twice the success message

### DIFF
--- a/cli/utils.js
+++ b/cli/utils.js
@@ -144,7 +144,7 @@ const doneFactory = (successMsg, sponsorMsg) => {
 const printSuccess = () => {
   if (process.exitCode === undefined || process.exitCode === 0) {
     logger.log(chalk.green.bold(SUCCESS_MESSAGE));
-    logger.log(chalk.cyan.bold(SUCCESS_MESSAGE));
+    logger.log(chalk.cyan.bold(SPONSOR_MESSAGE));
   } else {
     logger.error(`ERROR! JHipster finished with code ${process.exitCode}`);
   }


### PR DESCRIPTION
Now prints the sponsor message again instead of twice the sucess message when doing `jhipster jdl default` for example.

closes #14329

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
