### PR TITLE
Expose public api for blueprint and modules.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,0 +1,41 @@
+const constants = require('../generators/generator-constants');
+
+const GeneratorBase = require('../generators/generator-base');
+const GeneratorBaseBlueprint = require('../generators/generator-base-blueprint');
+
+const AppGenerator = require('../generators/app');
+const ClientGenerator = require('../generators/client');
+const CommonGenerator = require('../generators/common');
+const CypressGenerator = require('../generators/cypress');
+const EntitiesGenerator = require('../generators/entities');
+const EntitiesClientGenerator = require('../generators/entities-client');
+const EntityGenerator = require('../generators/entity');
+const EntityClientGenerator = require('../generators/entity-client');
+const EntityServerGenerator = require('../generators/entity-server');
+const LanguagesGenerator = require('../generators/languages');
+const PageGenerator = require('../generators/page');
+const ServerGenerator = require('../generators/server');
+const SpringControllerGenerator = require('../generators/spring-controller');
+const SpringServiceGenerator = require('../generators/spring-service');
+
+module.exports = {
+  constants,
+
+  GeneratorBase,
+  GeneratorBaseBlueprint,
+
+  AppGenerator,
+  ClientGenerator,
+  CommonGenerator,
+  CypressGenerator,
+  EntitiesGenerator,
+  EntitiesClientGenerator,
+  EntityGenerator,
+  EntityClientGenerator,
+  EntityServerGenerator,
+  LanguagesGenerator,
+  PageGenerator,
+  ServerGenerator,
+  SpringControllerGenerator,
+  SpringServiceGenerator,
+};

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "email": "",
     "url": "https://github.com/jdubois"
   },
-  "main": "cli/index.js",
+  "main": "lib/index.js",
   "bin": {
     "jhipster": "cli/jhipster.js"
   },
@@ -42,6 +42,7 @@
     "cli",
     "generators",
     "jdl",
+    "lib",
     "utils"
   ],
   "scripts": {


### PR DESCRIPTION
Allows
```
const {AppGenerator, constants } = require('generator-jhipster');
```
instead of
```
const AppGenerator = require('generator-jhipster/generators/app');
const constants = require('generator-jhipster/generators/generator-constants');
```
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
