### PR TITLE
Fixes angular duplicated navbar element generation.

### DIFF
--- a/generators/bootstrap/index.js
+++ b/generators/bootstrap/index.js
@@ -36,7 +36,7 @@ const { STRING: TYPE_STRING, LONG: TYPE_LONG } = CommonDBTypes;
 
 module.exports = class extends BaseGenerator {
   constructor(args, options) {
-    super(args, options, { unique: 'namespace' });
+    super(args, options, { unique: 'namespace', customCommitTask: true });
 
     /*
      * When testing a generator with yeoman-test using 'withLocalConfig(localConfig)', it instantiates the

--- a/generators/client/needle-api/needle-client-angular.js
+++ b/generators/client/needle-api/needle-client-angular.js
@@ -92,6 +92,7 @@ module.exports = class extends needleClientBase {
       modulePath,
       importNeedle
     );
+    importRewriteFileModel.prettierAware = true;
     this.addBlockContentToFile(importRewriteFileModel, errorMessage);
 
     const moduleRewriteFileModel = this._generateRewriteFileModelAddModule(appName, angularName, modulePath, moduleNeedle);
@@ -155,15 +156,17 @@ module.exports = class extends needleClientBase {
   ) {
     const errorMessage = `${chalk.yellow('Reference to ') + routerName} ${chalk.yellow('not added to menu.\n')}`;
     const entityMenuPath = `${this.CLIENT_MAIN_SRC_DIR}app/layouts/navbar/navbar.component.html`;
+    const routerLink = `routerLink="${routerName}"`;
     const entityEntry =
       // prettier-ignore
       this.generator.stripMargin(`|<li>
-                             |                        <a class="dropdown-item" routerLink="${routerName}" routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="collapseNavbar()">
+                             |                        <a class="dropdown-item" ${routerLink} routerLinkActive="active" [routerLinkActiveOptions]="{ exact: true }" (click)="collapseNavbar()">
                              |                            <fa-icon icon="asterisk" [fixedWidth]="true"></fa-icon>
                              |                            <span${enableTranslation ? ` ${jhiPrefix}Translate="global.menu.entities.${entityTranslationKeyMenu}"` : ''}>${entityTranslationValue}</span>
                              |                        </a>
                              |                    </li>`);
     const rewriteFileModel = this.generateFileModel(entityMenuPath, 'jhipster-needle-add-entity-to-menu', entityEntry);
+    rewriteFileModel.regexp = routerLink;
 
     this.addBlockContentToFile(rewriteFileModel, errorMessage);
   }
@@ -171,14 +174,16 @@ module.exports = class extends needleClientBase {
   addElementToMenu(routerName, iconName, enableTranslation, translationKeyMenu = routerName, jhiPrefix = 'jhi') {
     const errorMessage = `${chalk.yellow('Reference to ') + routerName} ${chalk.yellow('not added to menu.\n')}`;
     const entityMenuPath = `${this.CLIENT_MAIN_SRC_DIR}app/layouts/navbar/navbar.component.html`;
+    const routerLink = `routerLink="${routerName}"`;
     // prettier-ignore
     const entityEntry = `<li class="nav-item" routerLinkActive="active" [routerLinkActiveOptions]="{exact: true}">
-                                <a class="nav-link" routerLink="${routerName}" (click)="collapseNavbar()">
+                                <a class="nav-link" ${routerLink} (click)="collapseNavbar()">
                                     <fa-icon icon="${iconName}" [fixedWidth]="true"></fa-icon>
                                     <span${enableTranslation ? ` ${jhiPrefix}Translate="global.menu.${translationKeyMenu}"` : ''}>${_.startCase(routerName)}</span>
                                 </a>
                             </li>`;
     const rewriteFileModel = this.generateFileModel(entityMenuPath, 'jhipster-needle-add-element-to-menu', entityEntry);
+    rewriteFileModel.regexp = routerLink;
 
     this.addBlockContentToFile(rewriteFileModel, errorMessage);
     this.addIcon(iconName);
@@ -187,14 +192,16 @@ module.exports = class extends needleClientBase {
   addElementToAdminMenu(routerName, iconName, enableTranslation, translationKeyMenu = routerName, jhiPrefix = 'jhi') {
     const errorMessage = `${chalk.yellow('Reference to ') + routerName} ${chalk.yellow('not added to admin menu.\n')}`;
     const navbarAdminPath = `${this.CLIENT_MAIN_SRC_DIR}app/layouts/navbar/navbar.component.html`;
+    const routerLink = `routerLink="${routerName}"`;
     // prettier-ignore
     const entityEntry = `<li>
-                        <a class="dropdown-item" routerLink="${routerName}" routerLinkActive="active" (click)="collapseNavbar()">
+                        <a class="dropdown-item" ${routerLink} routerLinkActive="active" (click)="collapseNavbar()">
                             <fa-icon icon="${iconName}" [fixedWidth]="true"></fa-icon>
                             <span${enableTranslation ? ` ${jhiPrefix}Translate="global.menu.admin.${translationKeyMenu}"` : ''}>${_.startCase(routerName)}</span>
                         </a>
                     </li>`;
     const rewriteFileModel = this.generateFileModel(navbarAdminPath, 'jhipster-needle-add-element-to-admin-menu', entityEntry);
+    rewriteFileModel.regexp = routerLink;
 
     this.addBlockContentToFile(rewriteFileModel, errorMessage);
     this.addIcon(iconName);
@@ -218,6 +225,7 @@ module.exports = class extends needleClientBase {
             |      },`
     );
     const rewriteFileModel = this.generateFileModel(filePath, needleName, routingEntry);
+    rewriteFileModel.prettierAware = true;
     this.addBlockContentToFile(rewriteFileModel, errorMessage);
   }
 

--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -391,11 +391,11 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
   addEntityToMenu(
     routerName,
     enableTranslation,
-    clientFramework,
+    clientFramework = this.clientFramework,
     entityTranslationKeyMenu = _.camelCase(routerName),
     entityTranslationValue = _.startCase(routerName)
   ) {
-    if (this.clientFramework === ANGULAR) {
+    if (clientFramework === ANGULAR) {
       this.needleApi.clientAngular.addEntityToMenu(
         routerName,
         enableTranslation,
@@ -403,9 +403,9 @@ module.exports = class JHipsterBaseGenerator extends PrivateBase {
         entityTranslationValue,
         this.jhiPrefix
       );
-    } else if (this.clientFramework === REACT) {
+    } else if (clientFramework === REACT) {
       this.needleApi.clientReact.addEntityToMenu(routerName, enableTranslation, entityTranslationKeyMenu, entityTranslationValue);
-    } else if (this.clientFramework === VUE) {
+    } else if (clientFramework === VUE) {
       this.needleApi.clientVue.addEntityToMenu(routerName, enableTranslation, entityTranslationKeyMenu, entityTranslationValue);
     }
   }


### PR DESCRIPTION
Allows to customize already applied needled detection.
- `prettierAware`: prettier formatting takes line width into account.
Needles must test for dynamic empty space/line breaks count.
- `regexp`: custom detection when testing the entire content is not a good approach, and there is a simpler test to use.

Related to https://github.com/jhipster/generator-jhipster/issues/14388.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
