### PR TITLE
add SpringValidatorAdapter.validate in Blockhound

### DIFF
--- a/generators/server/templates/src/test/java/package/config/JHipsterBlockHoundIntegration.java.ejs
+++ b/generators/server/templates/src/test/java/package/config/JHipsterBlockHoundIntegration.java.ejs
@@ -27,6 +27,7 @@ public class JHipsterBlockHoundIntegration implements BlockHoundIntegration {
         // Workaround until https://github.com/reactor/reactor-core/issues/2137 is fixed
         builder.allowBlockingCallsInside("reactor.core.scheduler.BoundedElasticScheduler$BoundedState", "dispose");
         builder.allowBlockingCallsInside("reactor.core.scheduler.BoundedElasticScheduler", "schedule");
+        builder.allowBlockingCallsInside("org.springframework.validation.beanvalidation.SpringValidatorAdapter", "validate");
     }
 
 }


### PR DESCRIPTION
Add the method `SpringValidatorAdapter.validate` in `JHipsterBlockHoundIntegration`

Fix  #14326

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
