### PR TITLE
Move npm to dependabot and revert npm and cypress.

### DIFF
--- a/generators/client/templates/common/package.json
+++ b/generators/client/templates/common/package.json
@@ -1,6 +1,6 @@
 {
   "devDependencies": {
-    "cypress": "6.8.0",
+    "cypress": "6.6.0",
     "puppeteer": "8.0.0"
   },
   "dependencies": {

--- a/generators/common/templates/package.json
+++ b/generators/common/templates/package.json
@@ -1,8 +1,9 @@
 {
   "devDependencies": {
     "concurrently": "6.0.0",
-    "wait-on": "5.3.0",
     "husky": "4.3.8",
-    "lint-staged": "10.5.4"
+    "lint-staged": "10.5.4",
+    "npm": "7.7.0",
+    "wait-on": "5.3.0"
   }
 }

--- a/generators/common/templates/package.json
+++ b/generators/common/templates/package.json
@@ -3,7 +3,7 @@
     "concurrently": "6.0.0",
     "husky": "4.3.8",
     "lint-staged": "10.5.4",
-    "npm": "7.7.0",
+    "npm": "7.6.3",
     "wait-on": "5.3.0"
   }
 }

--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -19,13 +19,14 @@
 const validationOptions = require('../jdl/jhipster/validations');
 const databaseTypes = require('../jdl/jhipster/database-types');
 const { ANGULAR_X, REACT, VUE } = require('../jdl/jhipster/client-framework-types');
+const commonPackageJson = require('./common/templates/package.json');
 
 // Version of Java
 const JAVA_VERSION = '11'; // Java version is forced to be 11. We keep the variable as it might be useful in the future.
 
 // Version of Node, NPM
 const NODE_VERSION = '14.16.0';
-const NPM_VERSION = '7.7.0';
+const NPM_VERSION = commonPackageJson.devDependencies.npm;
 const OPENAPI_GENERATOR_CLI_VERSION = '1.0.13-4.3.1';
 
 const GRADLE_VERSION = '6.8.3';


### PR DESCRIPTION
- Move npm to dependabot
- Revert npm to 7.6.3, version 7.7.0 is quite buggy.
- Revert cypress to 6.6.0. cypress >= 6.7.0 seems to be not stable with our current implementation.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
