### PR TITLE
Remove mysql root user setting

### DIFF
--- a/generators/kubernetes/templates/db/mysql.yml.ejs
+++ b/generators/kubernetes/templates/db/mysql.yml.ejs
@@ -64,8 +64,6 @@ spec:
       - name: mysql
         image: <%= DOCKER_MYSQL %>
         env:
-        - name: MYSQL_USER
-          value: root
         - name: MYSQL_ALLOW_EMPTY_PASSWORD
           value: 'yes'
         - name: MYSQL_DATABASE

--- a/generators/server/templates/src/main/docker/app.yml.ejs
+++ b/generators/server/templates/src/main/docker/app.yml.ejs
@@ -105,7 +105,6 @@ services:
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/mysql/:/var/lib/mysql/
     environment:
-      - MYSQL_USER=root
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=<%= baseName.toLowerCase() %>
     # If you want to expose these ports outside your dev PC,
@@ -120,7 +119,6 @@ services:
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/mysql/:/var/lib/mysql/
     environment:
-      - MYSQL_USER=root
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=<%= baseName.toLowerCase() %>
     # If you want to expose these ports outside your dev PC,

--- a/generators/server/templates/src/main/docker/mariadb.yml.ejs
+++ b/generators/server/templates/src/main/docker/mariadb.yml.ejs
@@ -24,7 +24,6 @@ services:
     # volumes:
     #   - ~/volumes/jhipster/<%= baseName %>/mysql/:/var/lib/mysql/
     environment:
-      - MYSQL_USER=root
       - MYSQL_ALLOW_EMPTY_PASSWORD=yes
       - MYSQL_DATABASE=<%= baseName.toLowerCase() %>
     # If you want to expose these ports outside your dev PC,

--- a/test/templates/compose/01-gateway/src/main/docker/app.yml
+++ b/test/templates/compose/01-gateway/src/main/docker/app.yml
@@ -13,7 +13,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/jhgate/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=jhgate
         ports:

--- a/test/templates/compose/01-gateway/src/main/docker/mysql.yml
+++ b/test/templates/compose/01-gateway/src/main/docker/mysql.yml
@@ -5,7 +5,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/jhgate/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=jhgate
         ports:

--- a/test/templates/compose/02-mysql/src/main/docker/app.yml
+++ b/test/templates/compose/02-mysql/src/main/docker/app.yml
@@ -11,7 +11,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/msmysql/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=msmysql
         ports:

--- a/test/templates/compose/02-mysql/src/main/docker/mysql.yml
+++ b/test/templates/compose/02-mysql/src/main/docker/mysql.yml
@@ -5,7 +5,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/msmysql/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=msmysql
         ports:

--- a/test/templates/compose/07-mariadb/src/main/docker/app.yml
+++ b/test/templates/compose/07-mariadb/src/main/docker/app.yml
@@ -11,7 +11,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/msmysql/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=msmysql
         ports:

--- a/test/templates/compose/07-mariadb/src/main/docker/mariadb.yml
+++ b/test/templates/compose/07-mariadb/src/main/docker/mariadb.yml
@@ -5,7 +5,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/msmysql/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=msmysql
         ports:

--- a/test/templates/compose/08-monolith/src/main/docker/app.yml
+++ b/test/templates/compose/08-monolith/src/main/docker/app.yml
@@ -13,7 +13,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/sampleMysql/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=samplemysql
         ports:

--- a/test/templates/compose/08-monolith/src/main/docker/mysql.yml
+++ b/test/templates/compose/08-monolith/src/main/docker/mysql.yml
@@ -5,7 +5,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/sampleMysql/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=samplemysql
         ports:

--- a/test/templates/compose/09-kafka/src/main/docker/app.yml
+++ b/test/templates/compose/09-kafka/src/main/docker/app.yml
@@ -21,7 +21,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/sampleKafka/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=samplekafka
         ports:

--- a/test/templates/compose/09-kafka/src/main/docker/mysql.yml
+++ b/test/templates/compose/09-kafka/src/main/docker/mysql.yml
@@ -5,7 +5,6 @@ services:
         # volumes:
         #     - ~/volumes/jhipster/sampleKafka/mysql/:/var/lib/mysql/
         environment:
-            - MYSQL_USER=root
             - MYSQL_ALLOW_EMPTY_PASSWORD=yes
             - MYSQL_DATABASE=samplekafka
         ports:


### PR DESCRIPTION
Setting `MYSQL_USER` to `root` seems to fail with latest mySQL version being used when deployed as container

There are two more places where this is set for openshift but to non-root values so I guess that should be fine

here is the error I got

```
kubectl logs product-mysql-55fbb8fdd8-6dbwc -n jhipster         
2021-03-27 13:52:40+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.
2021-03-27 13:52:40+00:00 [Note] [Entrypoint]: Switching to dedicated user 'mysql'
2021-03-27 13:52:40+00:00 [Note] [Entrypoint]: Entrypoint script for MySQL Server 8.0.23-1debian10 started.
2021-03-27 13:52:40+00:00 [ERROR] [Entrypoint]: MYSQL_USER="root", MYSQL_USER and MYSQL_PASSWORD are for configuring a regular user and cannot be used for the root user
    Remove MYSQL_USER="root" and use one of the following to control the root user password:
    - MYSQL_ROOT_PASSWORD
    - MYSQL_ALLOW_EMPTY_PASSWORD
    - MYSQL_RANDOM_ROOT_PASSWORD
``` 

@jhipster/developers I also did the same for MariaDB but not usre about that can someone take a second look as well
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
