### PR TITLE
Add support for force-insights option

### DIFF
--- a/cli/program.js
+++ b/cli/program.js
@@ -45,6 +45,7 @@ const createProgram = () => {
         '--blueprints <value>',
         'A comma separated list of one or more generator blueprints to use for the sub generators, e.g. --blueprints kotlin,vuejs'
       )
+      .option('--force-insight', 'Force insight')
       .option('--no-insight', 'Disable insight')
       // Conflicter options
       .option('--force', 'Override every file', false)


### PR DESCRIPTION
Somehow we have missed supporting the force-insights option. This adds the force-insights option back to the generator. Otherwise passing this option results in a error; 

```
sudharaka@sudharaka-XPS-8700:~/IdeaProjects/GeneratedApplications/jhipsterTest$ jhipster --force-insights
INFO! Using JHipster version installed globally
error: unknown option '--force-insights'
sudharaka@sudharaka-XPS-8700:~/IdeaProjects/GeneratedApplications/jhipsterTest$
```
JHipster Online is also effected by this error which I've opened a PR as well; https://github.com/jhipster/jhipster-online/pull/291

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
