### PR TITLE
Add watch build script for angular frontend

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -178,11 +178,13 @@
     "pretest": "<%= clientPackageManager %> run lint",
     "test": "ng test --coverage --log-heap-usage -w=2",
     "test:watch": "<%= clientPackageManager %> run test -- --watch",
+    "watch": "concurrently 'npm run webapp:hmr' 'npm run backend:start'",
     "webapp:build": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:dev",
     "webapp:build:dev": "ng build",
     "webapp:build:prod": "ng build --prod",
     "webapp:dev": "ng serve",
     "webapp:dev-verbose": "ng serve --verbose",
+    "webapp:hmr": "ng serve --hmr",
     "webapp:prod": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:prod",
     "webapp:test": "<%= clientPackageManager %> run test"
   },

--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -178,7 +178,7 @@
     "pretest": "<%= clientPackageManager %> run lint",
     "test": "ng test --coverage --log-heap-usage -w=2",
     "test:watch": "<%= clientPackageManager %> run test -- --watch",
-    "watch": "concurrently 'npm run webapp:hmr' 'npm run backend:start'",
+    "watch": "concurrently 'npm run webapp:hmr'<% if(!skipServer) { %> 'npm run backend:start'<% } %>",
     "webapp:build": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:dev",
     "webapp:build:dev": "ng build",
     "webapp:build:prod": "ng build --prod",

--- a/generators/client/templates/angular/webpack/webpack.custom.js.ejs
+++ b/generators/client/templates/angular/webpack/webpack.custom.js.ejs
@@ -31,7 +31,7 @@ const ESLintPlugin = require('eslint-webpack-plugin');
 
 const tls = process.env.TLS;
 
-module.exports = (config, options) => {
+module.exports = (config, options, targetOptions) => {
   // PLUGINS
   if (config.mode === 'development') {
     config.plugins.push(
@@ -42,14 +42,25 @@ module.exports = (config, options) => {
       new WebpackNotifierPlugin({
         title: '<%= humanizedBaseName %>',
         contentImage: path.join(__dirname, 'logo-jhipster.png'),
-      }),
+      })
+    );
+    if (!process.env.JHI_DISABLE_WEBPACK_LOGS) {
+      config.plugins.push(
+        new SimpleProgressWebpackPlugin({
+          format: 'compact',
+        })
+      );
+    }
+  }
+  if (targetOptions.target === 'serve' || config.watch) {
+    config.plugins.push(
       new BrowserSyncPlugin(
         {
           host: 'localhost',
           port: 9000,
           https: tls,
           proxy: {
-            target: `http${tls ? 's' : ''}://localhost:4200`,
+            target: `http${tls ? 's' : ''}://localhost:${targetOptions.target === 'serve' ? '4200' : '<%= serverPort %>'}`,
             <%_ if (websocket === 'spring-websocket') { _%>
             ws: true,
             <%_ } _%>
@@ -72,18 +83,10 @@ module.exports = (config, options) => {
           */
         },
         {
-          reload: false,
+          reload: targetOptions.target === 'build', // enabled for build --watch
         }
       )
     );
-
-    if (!process.env.JHI_DISABLE_WEBPACK_LOGS) {
-      config.plugins.push(
-        new SimpleProgressWebpackPlugin({
-          format: 'compact',
-        })
-      );
-    }
   }
 
   if (config.mode === 'production') {

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -336,8 +336,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
   _postWriting() {
     return {
       packageJsonScripts() {
-        const packageJsonStorage = this.createStorage('package.json');
-        const packageJsonConfigStorage = packageJsonStorage.createStorage('config').createProxy();
+        const packageJsonConfigStorage = this.packageJson.createStorage('config').createProxy();
         packageJsonConfigStorage.backend_port = this.serverPort;
         packageJsonConfigStorage.packaging = process.env.JHI_WAR === '1' ? 'war' : 'jar';
         if (process.env.JHI_PROFILE) {
@@ -345,8 +344,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
         }
       },
       packageJsonDockerScripts() {
-        const packageJsonStorage = this.createStorage('package.json');
-        const scriptsStorage = packageJsonStorage.createStorage('scripts');
+        const scriptsStorage = this.packageJson.createStorage('scripts');
         const databaseType = this.jhipsterConfig.databaseType;
         const dockerAwaitScripts = [];
         if (databaseType === 'sql') {
@@ -415,8 +413,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
         });
       },
       packageJsonBackendScripts() {
-        const packageJsonStorage = this.createStorage('package.json');
-        const scriptsStorage = packageJsonStorage.createStorage('scripts');
+        const scriptsStorage = this.packageJson.createStorage('scripts');
         const javaCommonLog = `-Dlogging.level.ROOT=OFF -Dlogging.level.org.zalando=OFF -Dlogging.level.tech.jhipster=OFF -Dlogging.level.${this.jhipsterConfig.packageName}=OFF`;
         const javaTestLog =
           '-Dlogging.level.org.springframework=OFF -Dlogging.level.org.springframework.web=OFF -Dlogging.level.org.springframework.security=OFF';
@@ -428,6 +425,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
             'backend:info': './mvnw -ntp enforcer:display-info --batch-mode',
             'backend:doc:test': './mvnw -ntp javadoc:javadoc --batch-mode',
             'backend:nohttp:test': './mvnw -ntp checkstyle:check --batch-mode',
+            'backend:start': './mvnw -P-webapp',
             'java:jar': './mvnw -ntp verify -DskipTests --batch-mode',
             'java:war': './mvnw -ntp verify -DskipTests --batch-mode -Pwar',
             'java:docker': './mvnw -ntp verify -DskipTests jib:dockerBuild',
@@ -440,6 +438,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
             'backend:info': './gradlew -v',
             'backend:doc:test': `./gradlew javadoc ${excludeWebapp}`,
             'backend:nohttp:test': `./gradlew checkstyleNohttp ${excludeWebapp}`,
+            'backend:start': './gradlew',
             'java:jar': './gradlew bootJar -x test -x integrationTest',
             'java:war': './gradlew bootWar -Pwar -x test -x integrationTest',
             'java:docker': './gradlew bootJar jibDockerBuild',


### PR DESCRIPTION
- Disable browser sync for 'ng build' without --watch
- Use backend server port when executing 'ng build --watch'

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
