### PR TITLE
Revert conf to 9.0.1

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,6 +8,10 @@ updates:
     labels:
       - 'theme: jhipster-internals'
       - 'theme: dependencies'
+    ignore:
+      # Ignore updates to conf due to dependency resolution problems
+      # See https://github.com/jhipster/generator-jhipster/issues/14492
+      - dependency-name: 'conf'
 
   - package-ecosystem: 'npm'
     directory: '/generators/client/templates/angular/'

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "chalk": "4.1.0",
     "chevrotain": "9.0.0",
     "commander": "7.2.0",
-    "conf": "9.0.2",
+    "conf": "9.0.1",
     "didyoumean": "1.2.1",
     "ejs": "3.1.6",
     "faker": "5.5.1",


### PR DESCRIPTION
Fixes https://github.com/jhipster/generator-jhipster/issues/14492.

ajv-format broke compatibility with npm@6/npm@7 with legacy-peer-deps at https://github.com/ajv-validator/ajv-formats/pull/15.
conf@9.0.2 only change is add ajv-format dependency at https://github.com/sindresorhus/conf/pull/144

Pin conf to 9.0.1 so ajv-format is not pulled to our dependency tree.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
