### PR TITLE
Fix 'publish docker' stage in Jenkinsfile

### DIFF
--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -184,10 +184,10 @@ node {
 <%= gitLabIndent %>        // A pre-requisite to this step is to setup authentication to the docker registry
     <%_ if (buildToolMaven) { _%>
 <%= gitLabIndent %>        // https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#authentication-methods
-<%= gitLabIndent %>        sh "./mvnw -ntp jib:build"
+<%= gitLabIndent %>        sh "./mvnw -ntp -Pprod verify jib:build"
     <%_ } else if (buildToolGradle) { _%>
 <%= gitLabIndent %>        // https://github.com/GoogleContainerTools/jib/tree/master/jib-gradle-plugin#authentication-methods
-<%= gitLabIndent %>        sh "./gradlew jib"
+<%= gitLabIndent %>        sh "./gradlew bootJar jib -Pprod -PnodeInstall --no-daemon"
     <%_ } _%>
 <%= gitLabIndent %>    }
 <%_ } _%>

--- a/test/__snapshots__/ci-cd.spec.js.snap
+++ b/test/__snapshots__/ci-cd.spec.js.snap
@@ -2866,7 +2866,7 @@ node {
     stage('publish docker') {
         // A pre-requisite to this step is to setup authentication to the docker registry
         // https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#authentication-methods
-        sh \\"./mvnw -ntp jib:build\\"
+        sh \\"./mvnw -ntp -Pprod verify jib:build\\"
     }
 }
 ",
@@ -3355,7 +3355,7 @@ node {
     stage('publish docker') {
         // A pre-requisite to this step is to setup authentication to the docker registry
         // https://github.com/GoogleContainerTools/jib/tree/master/jib-maven-plugin#authentication-methods
-        sh \\"./mvnw -ntp jib:build\\"
+        sh \\"./mvnw -ntp -Pprod verify jib:build\\"
     }
 }
 ",


### PR DESCRIPTION
<!--
PR description.
-->

Updating the CI-CD generator Jenkinsfile.

- This fixes the node install bug for Gradle
- use prod builds
- and use the same commands described in [the docs](https://www.jhipster.tech/docker-compose/#3).

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
