### PR TITLE
Use HMR by default in Angular

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -168,8 +168,7 @@
     "e2e:update-webdriver": "webdriver-manager update --gecko false",
     <%_ } _%>
     "jest": "jest --coverage --logHeapUsage --maxWorkers=2 --config jest.conf.js",
-    "start": "<%= clientPackageManager %> run webapp:dev",
-    "start-hmr": "ng serve --hmr",
+    "start": "ng serve --hmr",
     "start-tls": "<%= clientPackageManager %> run webapp:dev -- --env.tls",
     <%_ if (skipServer) { _%>
     "sonar": "sonar-scanner",
@@ -179,13 +178,12 @@
     "pretest": "<%= clientPackageManager %> run lint",
     "test": "ng test --coverage --log-heap-usage -w=2",
     "test:watch": "<%= clientPackageManager %> run test -- --watch",
-    "watch": "concurrently 'npm run webapp:hmr'<% if(!skipServer) { %> 'npm run backend:start'<% } %>",
+    "watch": "concurrently npm:start<% if(!skipServer) { %> npm:backend:start<% } %>",
     "webapp:build": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:dev",
     "webapp:build:dev": "ng build",
     "webapp:build:prod": "ng build --prod",
     "webapp:dev": "ng serve",
     "webapp:dev-verbose": "ng serve --verbose",
-    "webapp:hmr": "ng serve --hmr",
     "webapp:prod": "<%= clientPackageManager %> run clean-www && <%= clientPackageManager %> run webapp:build:prod",
     "webapp:test": "<%= clientPackageManager %> run test"
   },

--- a/generators/common/templates/README.md.ejs
+++ b/generators/common/templates/README.md.ejs
@@ -94,14 +94,6 @@ auto-refreshes when files change on your hard drive.
 <%_ } _%>
 <%= clientPackageManager %> start
 ```
-<%_ if (clientFrameworkAngular) { _%>
-
-If you want to use [HMR](https://webpack.js.org/guides/hot-module-replacement) for instant page updates and data + scroll position preservation on file changes then instead of `<%= clientPackageManager %> start` run
-
-```
-<%= clientPackageManager %> run start-hmr
-```
-<%_ } _%>
 
 <%= clientPackageMngrName %> is also used to manage CSS and JavaScript dependencies used in this application. You can upgrade dependencies by
 specifying a newer version in [package.json](package.json). You can also run `<%= clientPackageManager %> update` and `<%= clientPackageManager %> install` to manage dependencies.

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -438,7 +438,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
             'backend:info': './gradlew -v',
             'backend:doc:test': `./gradlew javadoc ${excludeWebapp}`,
             'backend:nohttp:test': `./gradlew checkstyleNohttp ${excludeWebapp}`,
-            'backend:start': './gradlew',
+            'backend:start': './gradlew -x webapp',
             'java:jar': './gradlew bootJar -x test -x integrationTest',
             'java:war': './gradlew bootWar -Pwar -x test -x integrationTest',
             'java:docker': './gradlew bootJar jibDockerBuild',

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -438,7 +438,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
             'backend:info': './gradlew -v',
             'backend:doc:test': `./gradlew javadoc ${excludeWebapp}`,
             'backend:nohttp:test': `./gradlew checkstyleNohttp ${excludeWebapp}`,
-            'backend:start': './gradlew -x webapp',
+            'backend:start': `./gradlew ${excludeWebapp}`,
             'java:jar': './gradlew bootJar -x test -x integrationTest',
             'java:war': './gradlew bootWar -Pwar -x test -x integrationTest',
             'java:docker': './gradlew bootJar jibDockerBuild',


### PR DESCRIPTION
Also simplify `watch` script and optimize `backend:start` script for `Gradle` (exclude `webapp` task as this is done for `Maven`).

HMR by default was requested in https://github.com/jhipster/generator-jhipster/pull/13118#issuecomment-732024690 and in https://github.com/jhipster/generator-jhipster/issues/14028#issuecomment-784388044

And follow up to #14524

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
