### PR TITLE
Fixes #13995: OpenAPI modelPackage

### DIFF
--- a/generators/server/templates/gradle/swagger.gradle.ejs
+++ b/generators/server/templates/gradle/swagger.gradle.ejs
@@ -27,7 +27,7 @@ openApiGenerate {
     inputSpec = "$rootDir/src/main/resources/swagger/api.yml".toString()
     outputDir = "$buildDir/openapi".toString()
     apiPackage = "<%= packageName %>.web.api"
-    modelPackage = "<%= packageName %>.web.api.model"
+    modelPackage = "<%= packageName %>.service.api.dto"
     apiFilesConstrainedTo = [""]
     modelFilesConstrainedTo = [""]
     supportingFilesConstrainedTo = ["ApiUtil.java"]

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1423,7 +1423,7 @@
                                 <inputSpec>${project.basedir}/<%= SERVER_MAIN_RES_DIR %>swagger/api.yml</inputSpec>
                                 <generatorName>spring</generatorName>
                                 <apiPackage><%= packageName %>.web.api</apiPackage>
-                                <modelPackage><%= packageName %>.web.api.model</modelPackage>
+                                <modelPackage><%= packageName %>.service.api.dto</modelPackage>
                                 <supportingFilesToGenerate>ApiUtil.java</supportingFilesToGenerate>
                                 <importMappings>Problem=org.zalando.problem.Problem</importMappings>
                                 <skipValidateSpec>false</skipValidateSpec>


### PR DESCRIPTION
The OpenAPI model should be generated in the package service.dto

From
`<modelPackage>*.web.api.model</modelPackage>`
To
`<modelPackage>*.service.dto</modelPackage>`
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
