### PR TITLE
[angular] Polish, add tests and improve automatic language change logic

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/app.module.ts.ejs
@@ -32,7 +32,7 @@ import { CookieService } from 'ngx-cookie-service';
 <%_ if (enableTranslation) { _%>
 import { TranslateModule, TranslateService, TranslateLoader, MissingTranslationHandler } from '@ngx-translate/core';
 <%_ } _%>
-import { NgxWebstorageModule } from 'ngx-webstorage';
+import { NgxWebstorageModule<% if (enableTranslation) { %>, SessionStorageService<% } %> } from 'ngx-webstorage';
 import * as dayjs from 'dayjs';
 import { NgbDateAdapter, NgbDatepickerConfig } from '@ng-bootstrap/ng-bootstrap';
 
@@ -113,14 +113,16 @@ import { ErrorComponent } from './layouts/error/error.component';
   bootstrap: [MainComponent],
 })
 export class AppModule {
-  constructor(applicationConfigService: ApplicationConfigService, iconLibrary: FaIconLibrary, dpConfig: NgbDatepickerConfig<% if (enableTranslation) { %>, translateService: TranslateService<% } %>) {
+  constructor(applicationConfigService: ApplicationConfigService, iconLibrary: FaIconLibrary, dpConfig: NgbDatepickerConfig<% if (enableTranslation) { %>, translateService: TranslateService, sessionStorageService: SessionStorageService<% } %>) {
     applicationConfigService.setEndpointPrefix(SERVER_API_URL);
     registerLocaleData(locale);
     iconLibrary.addIcons(...fontAwesomeIcons);
     dpConfig.minDate = { year: dayjs().subtract(100, 'year').year(), month: 1, day: 1 };
 <%_ if (enableTranslation) { _%>
     translateService.setDefaultLang('<%= nativeLanguage %>');
-    translateService.use('<%= nativeLanguage %>');
+    // if user have changed language and navigates away from the application and back to the application then use previously choosed language
+    const langKey = sessionStorageService.retrieve('locale') || '<%= nativeLanguage %>';
+    translateService.use(langKey);
 <%_ } _%>
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
@@ -31,7 +31,7 @@ import { TestBed } from '@angular/core/testing';
 <%_ if (enableTranslation) { _%>
 import { TranslateService } from '@ngx-translate/core';
 <%_ } _%>
-import { NgxWebstorageModule } from 'ngx-webstorage';
+import { NgxWebstorageModule<% if (enableTranslation) { %>, SessionStorageService<% } %> } from 'ngx-webstorage';
 
 import { Account } from 'app/core/auth/account.model';
 import { Authority } from 'app/config/authority.constants';
@@ -64,6 +64,10 @@ describe('Service Tests', () => {
 <%_ if (communicationSpringWebsocket) { _%>
     let mockTrackerService: TrackerService;
 <%_ } _%>
+<%_ if (enableTranslation) { _%>
+    let mockTranslateService: TranslateService;
+    let sessionStorageService: SessionStorageService;
+<%_ } _%>
 
     beforeEach(() => {
       TestBed.configureTestingModule({
@@ -86,6 +90,10 @@ describe('Service Tests', () => {
       mockRouter = TestBed.inject(Router);
 <%_ if (communicationSpringWebsocket) { _%>
       mockTrackerService = TestBed.inject(TrackerService);
+<%_ } _%>
+<%_ if (enableTranslation) { _%>
+      mockTranslateService = TestBed.inject(TranslateService);
+      sessionStorageService = TestBed.inject(SessionStorageService);
 <%_ } _%>
     });
 
@@ -151,6 +159,34 @@ describe('Service Tests', () => {
         httpMock.expectOne({ method: 'GET' });
       });
 
+<%_ if (enableTranslation) { _%>
+      describe('should change the language on authentication if necessary', () => {
+        it('should change language if user has not changed language manually', () => {
+          // GIVEN
+          sessionStorageService.retrieve = jest.fn(key => (key === 'locale' ? undefined : 'otherSessionStorageValue'));
+
+          // WHEN
+          service.identity().subscribe();
+          httpMock.expectOne({ method: 'GET' }).flush({ ...accountWithAuthorities([]), langKey: 'accountLang' });
+
+          // THEN
+          expect(mockTranslateService.use).toHaveBeenCalledWith('accountLang');
+        });
+
+        it('should not change language if user has changed language manually', () => {
+          // GIVEN
+          sessionStorageService.retrieve = jest.fn(key => (key === 'locale' ? 'sessionLang' : undefined));
+
+          // WHEN
+          service.identity().subscribe();
+          httpMock.expectOne({ method: 'GET' }).flush({ ...accountWithAuthorities([]), langKey: 'accountLang' });
+
+          // THEN
+          expect(mockTranslateService.use).not.toHaveBeenCalled();
+        });
+      });
+
+<%_ } _%>
       describe('navigateToStoredUrl', () => {
         it('should navigate to the previous stored url post successful authentication', () => {
           // GIVEN

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.spec.ts.ejs
@@ -39,6 +39,9 @@ import { StateStorageService } from 'app/core/auth/state-storage.service';
 <%_ if (communicationSpringWebsocket) { _%>
 import { TrackerService } from 'app/core/tracker/tracker.service';
 <%_ } _%>
+<%_ if (!skipUserManagement) { _%>
+import { ApplicationConfigService } from 'app/core/config/application-config.service';
+<%_ } _%>
 
 import { AccountService } from './account.service';
 
@@ -58,6 +61,9 @@ function accountWithAuthorities(authorities: string[]): Account {
 describe('Service Tests', () => {
   describe('Account Service', () => {
     let service: AccountService;
+<%_ if (!skipUserManagement) { _%>
+    let applicationConfigService: ApplicationConfigService;
+<%_ } _%>
     let httpMock: HttpTestingController;
     let mockStorageService: StateStorageService;
     let mockRouter: Router;
@@ -85,6 +91,9 @@ describe('Service Tests', () => {
       });
 
       service = TestBed.inject(AccountService);
+<%_ if (!skipUserManagement) { _%>
+      applicationConfigService = TestBed.inject(ApplicationConfigService);
+<%_ } _%>
       httpMock = TestBed.inject(HttpTestingController);
       mockStorageService = TestBed.inject(StateStorageService);
       mockRouter = TestBed.inject(Router);
@@ -101,6 +110,23 @@ describe('Service Tests', () => {
       httpMock.verify();
     });
 
+<%_ if (!skipUserManagement) { _%>
+  describe('save', () => {
+    it('should call account saving endpoint with correct values', () => {
+      // GIVEN
+      const account = accountWithAuthorities([]);
+
+      // WHEN
+      service.save(account).subscribe();
+      const testRequest = httpMock.expectOne({ method: 'POST', url: applicationConfigService.getEndpointFor('api/account') });
+      testRequest.flush({});
+
+      // THEN
+      expect(testRequest.request.body).toEqual(account);
+    });
+  });
+
+<%_ } _%>
     describe('authenticate', () => {
       it('authenticationState should emit null if input is null', () => {
         // GIVEN

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -91,9 +91,9 @@ export class AccountService {
 <%_ if (enableTranslation) { _%>
           // After retrieve the account info, the language will be changed to
           // the user's preferred language configured in the account setting
-          if (account?.langKey) {
-            const langKey = this.sessionStorageService.retrieve('locale') ?? account.langKey;
-            this.translateService.use(langKey);
+          // unless user have choosed other language in the current session
+          if (!this.sessionStorageService.retrieve('locale') && account) {
+            this.translateService.use(account.langKey);
           }
 <%_ } _%>
 

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/account.service.ts.ejs
@@ -42,7 +42,7 @@ export class AccountService {
   constructor(
 <%_ if (enableTranslation) { _%>
     private translateService: TranslateService,
-    private sessionStorage: SessionStorageService,
+    private sessionStorageService: SessionStorageService,
 <%_ } _%>
     private http: HttpClient,
 <%_ if (communicationSpringWebsocket) { _%>
@@ -92,7 +92,7 @@ export class AccountService {
           // After retrieve the account info, the language will be changed to
           // the user's preferred language configured in the account setting
           if (account?.langKey) {
-            const langKey = this.sessionStorage.retrieve('locale') ?? account.langKey;
+            const langKey = this.sessionStorageService.retrieve('locale') ?? account.langKey;
             this.translateService.use(langKey);
           }
 <%_ } _%>

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/auth-jwt.service.ts.ejs
@@ -33,14 +33,14 @@ type JwtToken = {
 export class AuthServerProvider {
   constructor(
     private http: HttpClient,
-    private $localStorage: LocalStorageService,
-    private $sessionStorage: SessionStorageService,
+    private localStorageService: LocalStorageService,
+    private sessionStorageService: SessionStorageService,
     private applicationConfigService: ApplicationConfigService
   ) {}
 
   getToken(): string {
-    const tokenInLocalStorage: string | null = this.$localStorage.retrieve('authenticationToken');
-    const tokenInSessionStorage: string | null = this.$sessionStorage.retrieve('authenticationToken');
+    const tokenInLocalStorage: string | null = this.localStorageService.retrieve('authenticationToken');
+    const tokenInSessionStorage: string | null = this.sessionStorageService.retrieve('authenticationToken');
     return tokenInLocalStorage ?? tokenInSessionStorage ?? '';
   }
 
@@ -52,8 +52,8 @@ export class AuthServerProvider {
 
   logout(): Observable<void> {
     return new Observable(observer => {
-      this.$localStorage.clear('authenticationToken');
-      this.$sessionStorage.clear('authenticationToken');
+      this.localStorageService.clear('authenticationToken');
+      this.sessionStorageService.clear('authenticationToken');
       observer.complete();
     });
   }
@@ -61,11 +61,11 @@ export class AuthServerProvider {
   private authenticateSuccess(response: JwtToken, rememberMe: boolean): void {
     const jwt = response.id_token;
     if (rememberMe) {
-      this.$localStorage.store('authenticationToken', jwt);
-      this.$sessionStorage.clear('authenticationToken');
+      this.localStorageService.store('authenticationToken', jwt);
+      this.sessionStorageService.clear('authenticationToken');
     } else {
-      this.$sessionStorage.store('authenticationToken', jwt);
-      this.$localStorage.clear('authenticationToken');
+      this.sessionStorageService.store('authenticationToken', jwt);
+      this.localStorageService.clear('authenticationToken');
     }
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/auth/state-storage.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/auth/state-storage.service.ts.ejs
@@ -23,17 +23,17 @@ import { SessionStorageService } from 'ngx-webstorage';
 export class StateStorageService {
   private previousUrlKey = 'previousUrl';
 
-  constructor(private $sessionStorage: SessionStorageService) {}
+  constructor(private sessionStorageService: SessionStorageService) {}
 
   storeUrl(url: string): void {
-    this.$sessionStorage.store(this.previousUrlKey, url);
+    this.sessionStorageService.store(this.previousUrlKey, url);
   }
 
   getUrl(): string | null {
-    return this.$sessionStorage.retrieve(this.previousUrlKey) as string | null;
+    return this.sessionStorageService.retrieve(this.previousUrlKey) as string | null;
   }
 
   clearUrl(): void {
-    this.$sessionStorage.clear(this.previousUrlKey);
+    this.sessionStorageService.clear(this.previousUrlKey);
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/core/interceptor/auth.interceptor.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/interceptor/auth.interceptor.ts.ejs
@@ -26,8 +26,8 @@ import { ApplicationConfigService } from '../config/application-config.service';
 @Injectable()
 export class AuthInterceptor implements HttpInterceptor {
   constructor(
-    private localStorage: LocalStorageService,
-    private sessionStorage: SessionStorageService,
+    private localStorageService: LocalStorageService,
+    private sessionStorageService: SessionStorageService,
     private applicationConfigService: ApplicationConfigService
   ) {}
 
@@ -37,7 +37,7 @@ export class AuthInterceptor implements HttpInterceptor {
       return next.handle(request);
     }
 
-    const token: string | null = this.localStorage.retrieve('authenticationToken') ?? this.sessionStorage.retrieve('authenticationToken');
+    const token: string | null = this.localStorageService.retrieve('authenticationToken') ?? this.sessionStorageService.retrieve('authenticationToken');
     if (token) {
       request = request.clone({
         setHeaders: {

--- a/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/layouts/navbar/navbar.component.ts.ejs
@@ -51,7 +51,7 @@ export class NavbarComponent implements OnInit {
     private loginService: LoginService,
 <%_ if (enableTranslation) { _%>
     private translateService: TranslateService,
-    private sessionStorage: SessionStorageService,
+    private sessionStorageService: SessionStorageService,
 <%_ } _%>
     private accountService: AccountService,
     private profileService: ProfileService,
@@ -72,7 +72,7 @@ export class NavbarComponent implements OnInit {
 
 <%_ if (enableTranslation) { _%>
   changeLanguage(languageKey: string): void {
-    this.sessionStorage.store('locale', languageKey);
+    this.sessionStorageService.store('locale', languageKey);
     this.translateService.use(languageKey);
   }
 <%_ } _%>


### PR DESCRIPTION
Uses similar style for `SessionStorageService` and `LocalStorageService` variable names:
* using `sessionStorageService` and `localStorageService` everywhere
* previously also `sessionStorage`, `$sessionStorage`, `localStorage` and `$localStorage` was used, names `$sessionStorage` and `$localStorage` are probably AngularJs relicts

Adds more tests to `AccountService`.

Improves automatic language change logic:
* previously when navigating away and back to application then chosen language was reapplied only if valid authentication existed
* now previously chosen language is reapplied also if user is not authenticated

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
