### PR TITLE
add prefix in generated eager relationship queries

### DIFF
--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -52,6 +52,24 @@ module.exports = class extends BaseBlueprintGenerator {
     return this._initializing();
   }
 
+  _preparing() {
+    return {
+      processDerivedPrimaryKeyFields() {
+        const entity = this.entity;
+        if (isReservedTableName(entity.entityInstance, entity.prodDatabaseType) && entity.jhiPrefix) {
+          entity.entityInstanceDbSafe = `${entity.jhiPrefix}${entity.entityClass}`;
+        } else {
+          entity.entityInstanceDbSafe = entity.entityInstance;
+        }
+      },
+    };
+  }
+
+  get preparing() {
+    if (useBlueprints) return;
+    return this._preparing();
+  }
+
   // Public API method used by the getter and also by Blueprints
   _preparingFields() {
     return {

--- a/generators/entity-server/index.js
+++ b/generators/entity-server/index.js
@@ -54,7 +54,7 @@ module.exports = class extends BaseBlueprintGenerator {
 
   _preparing() {
     return {
-      processDerivedPrimaryKeyFields() {
+      validateDatabaseSafety() {
         const entity = this.entity;
         if (isReservedTableName(entity.entityInstance, entity.prodDatabaseType) && entity.jhiPrefix) {
           entity.entityInstanceDbSafe = `${entity.jhiPrefix}${entity.entityClass}`;

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -85,23 +85,23 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     <%_ if (relationshipsContainEagerLoad) {
         if (databaseType === 'sql') { _%>
 
-    @Query(value = "select distinct <%= entityInstance %> from <%= persistClass %> <%= entityInstance %><%
+    @Query(value = "select distinct <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %><%
     for (const relationship of relationships) {
-        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationship.reference.name %><% }
+        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceHql %>.<%= relationship.reference.name %><% }
     } %>",
-        countQuery = "select count(distinct <%= entityInstance %>) from <%= persistClass %> <%= entityInstance %>")
+        countQuery = "select count(distinct <%= entityInstanceHql %>) from <%= persistClass %> <%= entityInstanceHql %>")
     Page<<%= persistClass %>> findAllWithEagerRelationships(Pageable pageable);
 
-    @Query("select distinct <%= entityInstance %> from <%= persistClass %> <%= entityInstance %><%
+    @Query("select distinct <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %><%
     for (const relationship of relationships) {
-        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationship.reference.name %><% }
+        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceHql %>.<%= relationship.reference.name %><% }
     } %>")
     List<<%= persistClass %>> findAllWithEagerRelationships();
 
-    @Query("select <%= entityInstance %> from <%= persistClass %> <%= entityInstance %><%
+    @Query("select <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %><%
     for (const relationship of relationships) {
-        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstance %>.<%= relationship.reference.name %><% }
-    } %> where <%= entityInstance %>.id =:id")
+        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceHql %>.<%= relationship.reference.name %><% }
+    } %> where <%= entityInstanceHql %>.id =:id")
     Optional<<%= persistClass %>> findOneWithEagerRelationships(@Param("id") <%= primaryKey.type %> id);
     <%_
         } else if (databaseType === 'mongodb' || databaseType === 'couchbase')  { _%>

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -79,7 +79,7 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     <%_ for (const relationship of relationships) {
         if (relationship.relationshipType === 'many-to-one' && relationship.otherEntityName === 'user' && databaseType === 'sql') { _%>
 
-    @Query("select <%= entityInstance %> from <%= persistClass %> <%= entityInstance %> where <%= entityInstance %>.<%= relationship.relationshipFieldName %>.login = ?#{principal.<% if (authenticationType === 'oauth2') { %>preferredUsername<% } else { %>username<% } %>}")
+    @Query("select <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %> where <%= entityInstanceHql %>.<%= relationship.relationshipFieldName %>.login = ?#{principal.<% if (authenticationType === 'oauth2') { %>preferredUsername<% } else { %>username<% } %>}")
     List<<%= persistClass %>> findBy<%= relationship.relationshipNameCapitalized %>IsCurrentUser();
     <%_ } } _%>
     <%_ if (relationshipsContainEagerLoad) {

--- a/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/repository/EntityRepository.java.ejs
@@ -79,29 +79,29 @@ public interface <%= entityClass %>Repository extends <% if (databaseType === 's
     <%_ for (const relationship of relationships) {
         if (relationship.relationshipType === 'many-to-one' && relationship.otherEntityName === 'user' && databaseType === 'sql') { _%>
 
-    @Query("select <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %> where <%= entityInstanceHql %>.<%= relationship.relationshipFieldName %>.login = ?#{principal.<% if (authenticationType === 'oauth2') { %>preferredUsername<% } else { %>username<% } %>}")
+    @Query("select <%= entityInstanceDbSafe %> from <%= persistClass %> <%= entityInstanceDbSafe %> where <%= entityInstanceDbSafe %>.<%= relationship.relationshipFieldName %>.login = ?#{principal.<% if (authenticationType === 'oauth2') { %>preferredUsername<% } else { %>username<% } %>}")
     List<<%= persistClass %>> findBy<%= relationship.relationshipNameCapitalized %>IsCurrentUser();
     <%_ } } _%>
     <%_ if (relationshipsContainEagerLoad) {
         if (databaseType === 'sql') { _%>
 
-    @Query(value = "select distinct <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %><%
+    @Query(value = "select distinct <%= entityInstanceDbSafe %> from <%= persistClass %> <%= entityInstanceDbSafe %><%
     for (const relationship of relationships) {
-        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceHql %>.<%= relationship.reference.name %><% }
+        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceDbSafe %>.<%= relationship.reference.name %><% }
     } %>",
-        countQuery = "select count(distinct <%= entityInstanceHql %>) from <%= persistClass %> <%= entityInstanceHql %>")
+        countQuery = "select count(distinct <%= entityInstanceDbSafe %>) from <%= persistClass %> <%= entityInstanceDbSafe %>")
     Page<<%= persistClass %>> findAllWithEagerRelationships(Pageable pageable);
 
-    @Query("select distinct <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %><%
+    @Query("select distinct <%= entityInstanceDbSafe %> from <%= persistClass %> <%= entityInstanceDbSafe %><%
     for (const relationship of relationships) {
-        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceHql %>.<%= relationship.reference.name %><% }
+        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceDbSafe %>.<%= relationship.reference.name %><% }
     } %>")
     List<<%= persistClass %>> findAllWithEagerRelationships();
 
-    @Query("select <%= entityInstanceHql %> from <%= persistClass %> <%= entityInstanceHql %><%
+    @Query("select <%= entityInstanceDbSafe %> from <%= persistClass %> <%= entityInstanceDbSafe %><%
     for (const relationship of relationships) {
-        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceHql %>.<%= relationship.reference.name %><% }
-    } %> where <%= entityInstanceHql %>.id =:id")
+        if (relationship.relationshipEagerLoad) { %> left join fetch <%= entityInstanceDbSafe %>.<%= relationship.reference.name %><% }
+    } %> where <%= entityInstanceDbSafe %>.id =:id")
     Optional<<%= persistClass %>> findOneWithEagerRelationships(@Param("id") <%= primaryKey.type %> id);
     <%_
         } else if (databaseType === 'mongodb' || databaseType === 'couchbase')  { _%>

--- a/utils/relationship.js
+++ b/utils/relationship.js
@@ -188,11 +188,6 @@ function prepareRelationshipForTemplates(entityWithConfig, relationship, generat
     const otherEntityTableName = relationship.otherEntityTableName;
     relationship.otherEntityTableName = `${jhiTablePrefix}_${otherEntityTableName}`;
   }
-  if (isReservedTableName(entityWithConfig.entityInstance, entityWithConfig.prodDatabaseType) && jhiTablePrefix) {
-    entityWithConfig.entityInstanceHql = `${jhiTablePrefix}${entityName}`;
-  } else {
-    entityWithConfig.entityInstanceHql = entityWithConfig.entityInstance;
-  }
 
   if (relationship.otherEntityAngularName === undefined) {
     if (generator.isBuiltInUser(otherEntityName)) {

--- a/utils/relationship.js
+++ b/utils/relationship.js
@@ -191,9 +191,8 @@ function prepareRelationshipForTemplates(entityWithConfig, relationship, generat
   if (isReservedTableName(entityWithConfig.entityInstance, entityWithConfig.prodDatabaseType) && jhiTablePrefix) {
     entityWithConfig.entityInstanceHql = `${jhiTablePrefix}${entityName}`;
   } else {
-    entityWithConfig.entityInstanceHql = entityWithConfig.entityInstance
+    entityWithConfig.entityInstanceHql = entityWithConfig.entityInstance;
   }
-  
 
   if (relationship.otherEntityAngularName === undefined) {
     if (generator.isBuiltInUser(otherEntityName)) {

--- a/utils/relationship.js
+++ b/utils/relationship.js
@@ -188,6 +188,12 @@ function prepareRelationshipForTemplates(entityWithConfig, relationship, generat
     const otherEntityTableName = relationship.otherEntityTableName;
     relationship.otherEntityTableName = `${jhiTablePrefix}_${otherEntityTableName}`;
   }
+  if (isReservedTableName(entityWithConfig.entityInstance, entityWithConfig.prodDatabaseType) && jhiTablePrefix) {
+    entityWithConfig.entityInstanceHql = `${jhiTablePrefix}${entityName}`;
+  } else {
+    entityWithConfig.entityInstanceHql = entityWithConfig.entityInstance
+  }
+  
 
   if (relationship.otherEntityAngularName === undefined) {
     if (generator.isBuiltInUser(otherEntityName)) {


### PR DESCRIPTION
<!--
PR description.
-->

Closes #14626 

When using a table name with an SQL keyword (example: `Order`), the generated query throws an exception:

Example:

```java
    @Query("select distinct order from Order order left join fetch order.products")
    List<Order> findAllWithEagerRelationships();
```

Produces the following error:

```
Caused by: org.hibernate.hql.internal.ast.QuerySyntaxException: unexpected token: order near line 1, column 17 [select distinct order from com.mycompany.myapp.domain.Order order left join fetch order.products]
        at org.hibernate.hql.internal.ast.QuerySyntaxException.convert(QuerySyntaxException.java:74)
        at org.hibernate.hql.internal.ast.ErrorTracker.throwQueryException(ErrorTracker.java:93)
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.parse(QueryTranslatorImpl.java:301)
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.doCompile(QueryTranslatorImpl.java:189)
        at org.hibernate.hql.internal.ast.QueryTranslatorImpl.compile(QueryTranslatorImpl.java:144)
        at org.hibernate.engine.query.spi.HQLQueryPlan.<init>(HQLQueryPlan.java:113)
        at org.hibernate.engine.query.spi.HQLQueryPlan.<init>(HQLQueryPlan.java:73)
        at org.hibernate.engine.query.spi.QueryPlanCache.getHQLQueryPlan(QueryPlanCache.java:162)
        at org.hibernate.internal.AbstractSharedSessionContract.getQueryPlan(AbstractSharedSessionContract.java:613)
        at org.hibernate.internal.AbstractSharedSessionContract.createQuery(AbstractSharedSessionContract.java:725)
        ... 71 common frames omitted
```

This PR adds the prefix to the instance name in such case (`order` -> `jhiOrder`):

```java
    @Query("select distinct jhiOrder from Order jhiOrder left join fetch jhiOrder.products")
    List<Order> findAllWithEagerRelationships();
```


<details>
  <summary>Tested with the following jdl</summary>

```  
entity Product {
    name String
}

entity Client {
    name String
}

entity Order {
    name String
}

entity Left {
    name String
}

relationship ManyToMany {
    Order{product(name)} to  Product{order} 
    Product{desc(name)} to  Left{product} 
    Client{product(name)} to  Product{product} 
    Left{client(name)} to Client{desc(name)} 
}

relationship ManyToOne {
    Order{user(login)} to  User
    Left{user(login)} to  User
}
```

</details>

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
