### PR TITLE
Implement a cache workflow

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -19,8 +19,6 @@
 
 name: Angular
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches-ignore:
       - 'dependabot/**'
@@ -201,26 +199,22 @@ jobs:
       - name: 'SETUP: load npm cache'
         uses: actions/cache@v2.1.4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load maven cache'
-        if: "!contains(matrix.app-type, 'gradle')"
         uses: actions/cache@v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
-      - name: 'SETUP: load jhipster-bom maven cache'
-        if: contains(matrix.app-type, 'gradle')
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
-          restore-keys: |
-            ${{ runner.os }}-maven-jhipster-bom-
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load gradle cache'
         if: contains(matrix.app-type, 'gradle')
         uses: actions/cache@v2.1.4
@@ -228,17 +222,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+          key: ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: 'SETUP: load e2e cache'
-        if: matrix.e2e == 1
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.cache/Cypress/
-          key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
       - name: 'TOOLS: configure tools installed by the system'

--- a/.github/workflows/cache.yml
+++ b/.github/workflows/cache.yml
@@ -1,0 +1,224 @@
+#
+# Copyright 2013-2021 the original author or authors from the JHipster project.
+#
+# This file is part of the JHipster project, see https://www.jhipster.tech/
+# for more information.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+name: Build cache
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+env:
+  JHI_LIB_REPO: https://github.com/jhipster/jhipster-bom.git
+  JHI_LIB_BRANCH: main
+  JHI_GEN_REPO: https://github.com/jhipster/generator-jhipster.git
+  JHI_GEN_BRANCH: main
+  SPRING_OUTPUT_ANSI_ENABLED: ALWAYS
+  SPRING_JPA_SHOW_SQL: false
+  JHI_DISABLE_WEBPACK_LOGS: true
+  JHI_E2E_HEADLESS: true
+  JHI_HOME: ${{ github.workspace }}/generator-jhipster
+  JHI_SCRIPTS: ${{ github.workspace }}/generator-jhipster/test-integration/scripts
+  JHI_JDL_SAMPLES: ${{ github.workspace }}/generator-jhipster/test-integration/jdl-samples
+  JHI_FOLDER_APP: ${{ github.workspace }}/app
+  NG_CLI_ANALYTICS: 'false'
+  JHI_GITHUB_CI: true
+  FORCE_COLOR: 1
+  SPRING_PROFILES_ACTIVE: testcontainers
+  # https://github.com/actions/virtual-environments/issues/1499#issuecomment-689467080
+  MAVEN_OPTS: >-
+    -Dhttp.keepAlive=false
+    -Dmaven.wagon.http.pool=false
+    -Dmaven.wagon.httpconnectionManager.ttlSeconds=120
+jobs:
+  npm_cache:
+    name: Create NPM cache
+    runs-on: ubuntu-20.04
+    steps:
+      - name: 'SETUP: Checkout generator-jhipster'
+        uses: actions/checkout@v2
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14
+      - name: 'SETUP: Get date for cache key'
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      - name: 'SETUP: load npm cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
+
+      - name: 'Install generator-jhipster npm version'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
+      - name: Cache generator-jhipster node_modules
+        run: npm ci
+        continue-on-error: true
+      - name: Cache last released generator-jhipster
+        run: npm install -g generator-jhipster@latest
+        continue-on-error: true
+      - name: Cache common node_modules
+        run: npm install
+        continue-on-error: true
+        working-directory: generators/common/templates/
+      - name: Cache angular node_modules
+        run: npm install
+        continue-on-error: true
+        working-directory: generators/client/templates/angular
+      - name: Cache client common node_modules
+        run: |
+          npm install
+          npx cypress install
+        continue-on-error: true
+        working-directory: generators/client/templates/common
+      - name: Cache react node_modules
+        run: npm install --legacy-peer-deps
+        continue-on-error: true
+        working-directory: generators/client/templates/react
+      - name: Cache vue node_modules
+        run: npm install
+        continue-on-error: true
+        working-directory: generators/client/templates/vue
+
+  maven_cache:
+    name: Create Maven cache
+    if: always()
+    needs: npm_cache
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/app
+    steps:
+      - name: 'SETUP: Checkout generator-jhipster'
+        uses: actions/checkout@v2
+        with:
+          path: generator-jhipster
+      - name: 'SETUP: Create required structure'
+        run: |
+          mkdir app
+        working-directory: ${{ github.workspace }}
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11.x'
+      - name: 'SETUP: Get date for cache key'
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      - name: 'SETUP: load npm cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-cache
+          restore-keys: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
+      - name: 'SETUP: load maven cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
+      - name: 'Install generator-jhipster npm version'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
+
+      - name: 'GENERATION: install JHipster'
+        run: $JHI_SCRIPTS/10-install-jhipster.sh
+      - name: 'GENERATION: copy jdl'
+        run: |
+          ls $JHI_JDL_SAMPLES
+          ls $JHI_JDL_SAMPLES/cache/
+          cp $JHI_JDL_SAMPLES/cache/*.jdl .
+      - name: 'GENERATION: project'
+        run: jhipster jdl *.jdl --skip-jhipster-dependencies --skip-install --workspaces
+      - name: 'GENERATION: replace version in generated project'
+        run: $JHI_SCRIPTS/13-replace-version-generated-project.sh
+      - name: Install workspaces deps
+        run: npm install
+      - name: Build cache
+        run: npm run backend:build-cache || true
+        continue-on-error: true
+
+  gradle_cache:
+    name: Create Gradle cache
+    if: always()
+    needs: [npm_cache, maven_cache]
+    runs-on: ubuntu-20.04
+    defaults:
+      run:
+        working-directory: ${{ github.workspace }}/app
+    steps:
+      - name: 'SETUP: Checkout generator-jhipster'
+        uses: actions/checkout@v2
+        with:
+          path: generator-jhipster
+      - name: 'SETUP: Create required structure'
+        run: |
+          mkdir app
+        working-directory: ${{ github.workspace }}
+      - uses: actions/setup-node@v2.1.5
+        with:
+          node-version: 14
+      - uses: actions/setup-java@v2
+        with:
+          distribution: 'adopt'
+          java-version: '11.x'
+      - name: 'SETUP: Get date for cache key'
+        id: get-date
+        run: |
+          echo "::set-output name=date::$(/bin/date -u "+%Y%m%d")"
+      - name: 'SETUP: load npm cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-cache
+          restore-keys: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
+      - name: 'SETUP: load maven cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
+      - name: 'SETUP: load gradle cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}
+      - name: 'Install generator-jhipster npm version'
+        run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
+
+      - name: 'GENERATION: install JHipster'
+        run: $JHI_SCRIPTS/10-install-jhipster.sh
+      - name: 'GENERATION: copy jdl'
+        run: cp $JHI_JDL_SAMPLES/cache/*.jdl .
+      - name: 'GENERATION: project'
+        run: jhipster jdl *.jdl --skip-jhipster-dependencies --skip-install --build gradle --workspaces
+      - name: 'GENERATION: replace version in generated project'
+        run: $JHI_SCRIPTS/13-replace-version-generated-project.sh
+      - name: Install workspaces deps
+        run: npm install
+      - name: Build cache
+        run: npm run backend:build-cache || true
+        continue-on-error: true

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -35,11 +35,22 @@ jobs:
       matrix:
         node_version: [14.16.0]
         os: [ubuntu-20.04]
+        cache: [other]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@v2.1.5
         with:
           node-version: ${{ matrix.node_version }}
+      - name: 'SETUP: load npm cache'
+        uses: actions/cache@v2.1.4
+        with:
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
       - name: 'install required npm version'
         run: npm install -g npm@$(node -e "console.log(require('./generators/generator-constants').NPM_VERSION);")
       - run: git --no-pager log -n 10 --graph --pretty='%Cred%h%Creset -%C(yellow)%d%Creset %s %Cgreen(%cr) %C(bold blue) <%an>%Creset' --abbrev-commit

--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -75,6 +75,7 @@ jobs:
       matrix:
         node_version: [14.16.0]
         os: [ubuntu-20.04]
+        cache: [angular]
         app-type:
           - liquibase-jdl-rename-field
         include:
@@ -118,17 +119,22 @@ jobs:
       - name: 'SETUP: load npm cache'
         uses: actions/cache@v2.1.4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load maven cache'
         uses: actions/cache@v2.1.4
         with:
           path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
+          key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
           restore-keys: |
-            ${{ runner.os }}-maven-${{ matrix.app-type }}-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load gradle cache'
         if: contains(matrix.app-type, 'gradle')
         uses: actions/cache@v2.1.4
@@ -136,17 +142,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+          key: ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-${{ matrix.app-type }}-
-      - name: 'SETUP: load e2e cache'
-        if: matrix.e2e == 1
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.cache/Cypress/
-          key: ${{ runner.os }}-e2e-${{ matrix.app-type }}-${{ hashFiles('generator-jhipster/**/package.json.ejs') }}
-          restore-keys: |
-            ${{ runner.os }}-e2e-${{ matrix.app-type }}-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
       - name: 'TOOLS: configure tools installed by the system'

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -19,8 +19,6 @@
 
 name: React
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches-ignore:
       - 'dependabot/**'
@@ -183,26 +181,22 @@ jobs:
       - name: 'SETUP: load npm cache'
         uses: actions/cache@v2.1.4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load maven cache'
-        if: "!contains(matrix.app-type, 'gradle')"
         uses: actions/cache@v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
-      - name: 'SETUP: load jhipster-bom maven cache'
-        if: contains(matrix.app-type, 'gradle')
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
-          restore-keys: |
-            ${{ runner.os }}-maven-jhipster-bom-
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load gradle cache'
         if: contains(matrix.app-type, 'gradle')
         uses: actions/cache@v2.1.4
@@ -210,17 +204,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+          key: ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: 'SETUP: load e2e cache'
-        if: matrix.e2e == 1
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.cache/Cypress/
-          key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
       - name: 'TOOLS: configure tools installed by the system'

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -19,8 +19,6 @@
 
 name: Vue
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches-ignore:
       - 'dependabot/**'
@@ -181,26 +179,22 @@ jobs:
       - name: 'SETUP: load npm cache'
         uses: actions/cache@v2.1.4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load maven cache'
-        if: "!contains(matrix.app-type, 'gradle')"
         uses: actions/cache@v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
-      - name: 'SETUP: load jhipster-bom maven cache'
-        if: contains(matrix.app-type, 'gradle')
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
-          restore-keys: |
-            ${{ runner.os }}-maven-jhipster-bom-
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load gradle cache'
         if: contains(matrix.app-type, 'gradle')
         uses: actions/cache@v2.1.4
@@ -208,17 +202,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+          key: ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: 'SETUP: load e2e cache'
-        if: matrix.e2e == 1
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.cache/Cypress/
-          key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
       - name: 'TOOLS: configure tools installed by the system'

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -19,8 +19,6 @@
 
 name: Webflux
 on:
-  schedule:
-    - cron: '0 0 * * *'
   push:
     branches-ignore:
       - 'dependabot/**'
@@ -79,7 +77,7 @@ jobs:
       matrix:
         node_version: [14.16.0]
         os: [ubuntu-20.04]
-        cache: [webflux]
+        cache: [angular]
         app-type:
           - webflux-mongodb
           - webflux-mongodb-es-session
@@ -187,26 +185,22 @@ jobs:
       - name: 'SETUP: load npm cache'
         uses: actions/cache@v2.1.4
         with:
-          path: ~/.npm
-          key: ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json.ejs') }}
+          path: |
+            ~/.npm
+            ~/.cache/Cypress/
+          key: ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-${{ hashFiles('generator-jhipster/package-lock.json', 'generator-jhipster/**/package.json') }}
           restore-keys: |
-            ${{ runner.os }}-node-${{ matrix.cache }}-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-${{ matrix.cache }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-node-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load maven cache'
-        if: "!contains(matrix.app-type, 'gradle')"
         uses: actions/cache@v2.1.4
         with:
           path: ~/.m2/repository
           key: ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/pom.xml.ejs') }}
           restore-keys: |
             ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}-
-      - name: 'SETUP: load jhipster-bom maven cache'
-        if: contains(matrix.app-type, 'gradle')
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.m2/repository
-          key: ${{ runner.os }}-maven-jhipster-bom-${{ steps.get-date.outputs.date }}-
-          restore-keys: |
-            ${{ runner.os }}-maven-jhipster-bom-
+            ${{ runner.os }}-maven-${{ steps.get-date.outputs.date }}
       - name: 'SETUP: load gradle cache'
         if: contains(matrix.app-type, 'gradle')
         uses: actions/cache@v2.1.4
@@ -214,17 +208,10 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
-          key: ${{ runner.os }}-gradle-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
+          key: ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-${{ hashFiles('generator-jhipster/**/build.gradle.ejs') }}
           restore-keys: |
-            ${{ runner.os }}-gradle-
-      - name: 'SETUP: load e2e cache'
-        if: matrix.e2e == 1
-        uses: actions/cache@v2.1.4
-        with:
-          path: ~/.cache/Cypress/
-          key: ${{ runner.os }}-cypress-${{ hashFiles('generator-jhipster/client/common/package.json') }}
-          restore-keys: |
-            ${{ runner.os }}-cypress-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}-
+            ${{ runner.os }}-gradle-${{ steps.get-date.outputs.date }}
       - name: 'ENV: display variables'
         run: $JHI_SCRIPTS/01-display-configuration.sh
       - name: 'TOOLS: configure tools installed by the system'

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -430,6 +430,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
             'java:war': './mvnw -ntp verify -DskipTests --batch-mode -Pwar',
             'java:docker': './mvnw -ntp verify -DskipTests jib:dockerBuild',
             'backend:unit:test': `./mvnw -ntp -P-webapp verify --batch-mode ${javaCommonLog} ${javaTestLog}`,
+            'backend:build-cache': './mvnw dependency:go-offline',
           });
         } else if (buildTool === 'gradle') {
           const excludeWebapp = this.jhipsterConfig.skipClient ? '' : '-x webapp';
@@ -444,6 +445,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
             'java:docker': './gradlew bootJar jibDockerBuild',
             'backend:unit:test': `./gradlew test integrationTest ${excludeWebapp} ${javaCommonLog} ${javaTestLog}`,
             'postci:e2e:package': 'cp build/libs/*SNAPSHOT.$npm_package_config_packaging e2e.$npm_package_config_packaging',
+            'backend:build-cache': 'npm run backend:info && npm run backend:nohttp:test && npm run ci:e2e:package',
           });
         }
 

--- a/generators/workspaces/index.js
+++ b/generators/workspaces/index.js
@@ -171,7 +171,7 @@ module.exports = class extends BaseBlueprintGenerator {
             'ci:e2e:package': 'npm run ci:docker:build --workspaces --if-present && npm run java:docker --workspaces --if-present',
             'ci:e2e:run': 'npm run e2e:headless --workspaces --if-present',
             ...this._getOtherScripts(),
-            ...this._createConcurrentyScript('watch'),
+            ...this._createConcurrentyScript('watch', 'backend:build-cache'),
             ...this._createWorkspacesScript('ci:backend:test', 'ci:frontend:test', 'webapp:test'),
           },
         });

--- a/test-integration/jdl-samples/cache/cache.jdl
+++ b/test-integration/jdl-samples/cache/cache.jdl
@@ -1,0 +1,75 @@
+application {
+  config {
+    baseName app1
+    packageName com.example.app1
+    applicationType monolith
+    prodDatabaseType postgresql
+    searchEngine elasticsearch
+    messageBroker kafka
+    websocket spring-websocket
+    serviceDiscoveryType consul
+    cacheProvider ehcache
+    authenticationType session
+    testFrameworks [gatling]
+    creationTimestamp 1617901618891
+  }
+}
+
+application {
+  config {
+    baseName app2
+    packageName com.example.app2
+    applicationType microservice
+    prodDatabaseType mysql
+    serviceDiscoveryType eureka
+    cacheProvider caffeine
+    authenticationType oauth2
+    creationTimestamp 1617901618892
+  }
+}
+
+application {
+  config {
+    baseName app3
+    packageName com.example.app3
+    applicationType microservice
+    databaseType mongodb
+    cacheProvider hazelcast
+    authenticationType jwt
+    creationTimestamp 1617901618893
+  }
+}
+
+application {
+  config {
+    baseName app4
+    packageName com.example.app4
+    applicationType microservice
+    databaseType cassandra
+    cacheProvider infinispan
+    creationTimestamp 1617901618894
+  }
+}
+
+application {
+  config {
+    baseName app5
+    packageName com.example.app6
+    applicationType microservice
+    prodDatabaseType mariadb
+    cacheProvider memcached
+    creationTimestamp 1617901618895
+  }
+}
+
+application {
+  config {
+    baseName app6
+    packageName com.example.app6
+    applicationType gateway
+    prodDatabaseType postgresql
+    serviceDiscoveryType eureka
+    authenticationType oauth2
+    creationTimestamp 1617901618896
+  }
+}


### PR DESCRIPTION
Implement a workflow exclusive to build our cache.
- npm: use our dependabots package.json for a more complete cache.
- maven: generate applications with most of our options and build the cache with go-offline goal.
- Gradle: use same applications from maven and execute some operations to build the cache.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
