### PR TITLE
Prefixing npm command with sh in Jenkinsfile

### DIFF
--- a/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
+++ b/generators/ci-cd/templates/jenkins/Jenkinsfile.ejs
@@ -79,8 +79,8 @@ node {
 <%= indent %>    stage('frontend tests') {
 <%= indent %>        try {
         <%_ if (insideDocker) { _%>
-<%= indent %>           npm install
-<%= indent %>           npm test
+<%= indent %>           sh "npm install"
+<%= indent %>           sh "npm test"
         <%_ } else { _%>
 <%= indent %>            sh "./mvnw -ntp com.github.eirslett:frontend-maven-plugin:<%= clientPackageManager %> -Dfrontend.<%= clientPackageManager %>.arguments='run <%= frontTestCommand %>'"
         <%_ } _%>


### PR DESCRIPTION
<!--
PR description.
-->
Prefixing npm commands with 'sh' ensures compatibility with the jenkins environment
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
