### PR TITLE
Add baseUrl and type to tsconfig and update jest config

### DIFF
--- a/generators/client/templates/angular/jest.conf.js.ejs
+++ b/generators/client/templates/angular/jest.conf.js.ejs
@@ -18,19 +18,19 @@
 -%>
 const { pathsToModuleNameMapper } = require('ts-jest/utils')
 
-const { compilerOptions } = require('./tsconfig.json');
+const { compilerOptions: { paths = {}, baseUrl = './' } } = require('./tsconfig.json');
 const environment = require('./webpack/environment');
 
 module.exports = {
   globals: {
     ...environment,
   },
-  roots: ['<rootDir>', `<rootDir>/${compilerOptions.baseUrl}`],
-  modulePaths: [`<rootDir>/${compilerOptions.baseUrl}`],
+  roots: ['<rootDir>', `<rootDir>/${baseUrl}`],
+  modulePaths: [`<rootDir>/${baseUrl}`],
   setupFiles: ['jest-date-mock'],
   cacheDirectory: '<rootDir>/<%= BUILD_DIR %>jest-cache',
   coverageDirectory: '<rootDir>/<%= BUILD_DIR %>test-results/',
-  moduleNameMapper: pathsToModuleNameMapper(compilerOptions.paths, { prefix: `<rootDir>/${compilerOptions.baseUrl}/` }),
+  moduleNameMapper: pathsToModuleNameMapper(paths, { prefix: `<rootDir>/${baseUrl}/` }),
   reporters: ['default', ['jest-junit', { outputDirectory: '<rootDir>/<%= BUILD_DIR %>test-results/', outputName: 'TESTS-results-jest.xml' }]],
   testResultsProcessor: 'jest-sonar-reporter',
   testMatch: ['<rootDir>/<%= CLIENT_MAIN_SRC_DIR %>app/**/@(*.)@(spec.ts)'],

--- a/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
+++ b/generators/client/templates/angular/src/main/webapp/content/scss/vendor.scss.ejs
@@ -34,7 +34,7 @@ eg $input-color: red;
 <%_ } _%>
 
 <%_ if (enableI18nRTL) { _%>
-@import '<%= CLIENT_MAIN_SRC_DIR %>content/scss/rtl.scss';
+@import 'content/scss/rtl.scss';
 <%_ } _%>
 
 /* jhipster-needle-scss-add-vendor JHipster will add new css style */

--- a/generators/client/templates/angular/tsconfig.e2e.json.ejs
+++ b/generators/client/templates/angular/tsconfig.e2e.json.ejs
@@ -18,6 +18,7 @@
 -%>
 {
   "extends": "./tsconfig.json",
+  "include": ["./<%= TEST_SRC_DIR %>**/*.ts"],
   "compilerOptions": {
     "module": "commonjs"
   }

--- a/generators/client/templates/angular/tsconfig.json.ejs
+++ b/generators/client/templates/angular/tsconfig.json.ejs
@@ -18,7 +18,7 @@
 -%>
 {
   "compilerOptions": {
-    "baseUrl": "./",
+    "baseUrl": "<%= CLIENT_MAIN_SRC_DIR %>",
     "outDir": "./<%= DIST_DIR %>",
     "forceConsistentCasingInFileNames": true,
     "strict": true,
@@ -28,9 +28,6 @@
 <%_ if (protractorTests) { // Prevents Jest and Mocha types conflicts. See https://github.com/jhipster/generator-jhipster/pull/13083 _%>
     "skipLibCheck": true,
 <%_ } _%>
-    "paths": {
-      "app/*": ["<%= CLIENT_MAIN_SRC_DIR %>app/*"]
-    },
     "declaration": false,
     "downlevelIteration": true,
     "experimentalDecorators": true,
@@ -46,7 +43,4 @@
     "strictTemplates": true,
     "preserveWhitespaces": true
   }
-<%_ if (cypressTests) { _%>
-  ,"exclude": ["<%= CLIENT_TEST_SRC_DIR %>cypress"]
-<%_ } _%>
 }


### PR DESCRIPTION
- Set baseUrl at tsconfig.json.
https://www.typescriptlang.org/docs/handbook/module-resolution.html#base-url
`Setting baseUrl informs the compiler where to find modules. All module imports with non-relative names are assumed to be relative to the baseUrl.`
- Set types at tsconfig.json to ['node'].
https://www.typescriptlang.org/tsconfig#types
- Update jest.conf and other configs following above changes.


<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
