### PR TITLE
Improve faker seed for better reproducibility.

### DIFF
--- a/generators/bootstrap/index.js
+++ b/generators/bootstrap/index.js
@@ -282,7 +282,6 @@ module.exports = class extends BaseGenerator {
     });
     this.configOptions.sharedEntities.User = user;
 
-    user.resetFakerSeed();
     const liquibaseFakeData = oauth2
       ? []
       : [

--- a/generators/database-changelog-liquibase/index.js
+++ b/generators/database-changelog-liquibase/index.js
@@ -98,15 +98,6 @@ module.exports = class extends BaseBlueprintGenerator {
         }
       },
 
-      setupReproducibility() {
-        if (this.jhipsterConfig.skipServer || this.entity.skipServer) {
-          return;
-        }
-
-        // In order to have consistent results with Faker, restart seed with current entity name hash.
-        this.entity.resetFakerSeed();
-      },
-
       prepareFakeData() {
         const databaseChangelog = this.databaseChangelog;
         this.entity.liquibaseFakeData = [];

--- a/generators/entity-client/files.js
+++ b/generators/entity-client/files.js
@@ -435,13 +435,6 @@ function addSampleRegexTestingStrings(generator) {
 
 function writeFiles() {
   return {
-    setupReproducibility() {
-      if (this.skipClient) return;
-
-      // In order to have consistent results with Faker, restart seed with current entity name hash.
-      this.resetFakerSeed();
-    },
-
     writeClientFiles() {
       if (this.skipClient) return undefined;
       if (this.protractorTests) {

--- a/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
@@ -16,7 +16,6 @@ import {
 
 const baseApi = (applicationTypeGateway && locals.microserviceName) ? 'services/' + microserviceName.toLowerCase() + '/api/' : 'api/';
 
-resetFakerSeed('entity-cypress');
 const entityFakeData = generateFakeData('cypress');
 const requiredRelationships = relationships.filter(rel => rel.relationshipRequired || rel.id);
 // We cannot generate a required entity with required relationship.

--- a/generators/entity-server/files.js
+++ b/generators/entity-server/files.js
@@ -265,13 +265,6 @@ module.exports = {
 
 function writeFiles() {
   return {
-    setupReproducibility() {
-      if (this.skipServer) return;
-
-      // In order to have consistent results with Faker, restart seed with current entity name hash.
-      this.resetFakerSeed();
-    },
-
     writeServerFiles() {
       if (this.skipServer) return undefined;
 

--- a/generators/utils.js
+++ b/generators/utils.js
@@ -283,6 +283,16 @@ function renderContent(source, generator, context, options, cb) {
     context: generator,
     ...options,
   };
+  if (context.entityClass) {
+    const basename = path.basename(source);
+    if (context.configOptions && context.configOptions.sharedEntities) {
+      Object.values(context.configOptions.sharedEntities).forEach(entity => {
+        entity.resetFakerSeed(`${context.entityClass}-${basename}`);
+      });
+    } else if (context.resetFakerSeed) {
+      context.resetFakerSeed(basename);
+    }
+  }
   const promise = ejs.renderFile(generator.templatePath(source), context, options);
   if (cb) {
     return promise

--- a/test/entity.spec.js
+++ b/test/entity.spec.js
@@ -821,11 +821,11 @@ describe('JHipster generator for entity', () => {
         it('creates reproducible backend test', () => {
           assert.fileContent(
             `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIT.java`,
-            /DEFAULT_NUMBER_PATTERN_REQUIRED = "66225"/
+            /DEFAULT_NUMBER_PATTERN_REQUIRED = "03126"/
           );
           assert.fileContent(
             `${SERVER_TEST_SRC_DIR}com/mycompany/myapp/web/rest/FooResourceIT.java`,
-            /UPDATED_NUMBER_PATTERN_REQUIRED = "24"/
+            /UPDATED_NUMBER_PATTERN_REQUIRED = "557"/
           );
         });
       });


### PR DESCRIPTION
Currently, reproducibility depends on factors like order of entity generation.
Eg: Adding a new entity may change source of others entities, and regenerating just after, changes again.

With this PR, reproducibility is done for each file. The source should change only if the entity changes or the source file changes.

Closes https://github.com/jhipster/generator-jhipster/issues/14549
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
