### PR TITLE
[angular] Fix infinite scroll sort if search is done 

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/configuration/configuration.component.html.ejs
@@ -26,7 +26,7 @@
 
   <table class="table table-striped table-bordered table-responsive d-table" aria-describedby="spring-configuration">
     <thead>
-      <tr <%= jhiPrefix %>Sort predicate="prefix" [(ascending)]="beansAscending" [callback]="filterAndSortBeans.bind(this)">
+      <tr <%= jhiPrefix %>Sort predicate="prefix" [(ascending)]="beansAscending" (sortChange)="filterAndSortBeans()">
         <th <%= jhiPrefix %>SortBy="prefix" scope="col" class="w-40">
           <span <%= jhiPrefix %>Translate="configuration.table.prefix">Prefix</span> <fa-icon icon="sort"></fa-icon>
         </th>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/logs/logs.component.html.ejs
@@ -26,7 +26,7 @@
 
   <table class="table table-sm table-striped table-bordered" aria-describedby="logs-page-heading">
     <thead>
-      <tr <%= jhiPrefix %>Sort [(predicate)]="orderProp" [(ascending)]="ascending" [callback]="filterAndSort.bind(this)">
+      <tr <%= jhiPrefix %>Sort [(predicate)]="orderProp" [(ascending)]="ascending" (sortChange)="filterAndSort()">
         <th <%= jhiPrefix %>SortBy="name" scope="col"><span <%= jhiPrefix %>Translate="logs.table.name">Name</span> <fa-icon icon="sort"></fa-icon></th>
         <th <%= jhiPrefix %>SortBy="level" scope="col"><span <%= jhiPrefix %>Translate="logs.table.level">Level</span> <fa-icon icon="sort"></fa-icon></th>
       </tr>

--- a/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.html.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/admin/user-management/list/user-management.component.html.ejs
@@ -38,7 +38,7 @@
   <div class="table-responsive" *ngIf="users">
     <table class="table table-striped" aria-describedby="user-management-page-heading">
       <thead>
-        <tr<% if (!databaseTypeCassandra) { %> <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"<% } %>>
+        <tr<% if (!databaseTypeCassandra) { %> <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="transition()"<% } %>>
           <th scope="col"<% if (!databaseTypeCassandra) { %> <%= jhiPrefix %>SortBy="id"<% } %>>
             <span <%= jhiPrefix %>Translate="global.field.id">ID</span><% if (databaseType !== 'cassandra') { %> <fa-icon icon="sort"></fa-icon><% } %>
           </th>

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
@@ -30,7 +30,7 @@ import { SortDirective } from './sort.directive';
     <table>
       <thead>
         <tr <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
-          <th <%= jhiPrefix %>SortBy="name">ID<fa-icon [icon]="'sort'"></fa-icon></th>
+          <th <%= jhiPrefix %>SortBy="name">ID<fa-icon *ngIf="sortAllowed" [icon]="'sort'"></fa-icon></th>
         </tr>
       </thead>
     </table>
@@ -39,6 +39,7 @@ import { SortDirective } from './sort.directive';
 class TestSortByDirectiveComponent {
   predicate?: string;
   ascending?: boolean;
+  sortAllowed = true;
   transition = jest.fn();
 
   constructor(library: FaIconLibrary) {
@@ -59,21 +60,6 @@ describe('Directive: SortByDirective', () => {
     fixture = TestBed.createComponent(TestSortByDirectiveComponent);
     component = fixture.componentInstance;
     tableHead = fixture.debugElement.query(By.directive(SortByDirective));
-  });
-
-  it('should initialize predicate, order, icon when initial component predicate is _score', () => {
-    // GIVEN
-    component.predicate = '_score';
-    const sortByDirective = tableHead.injector.get(SortByDirective);
-
-    // WHEN
-    fixture.detectChanges();
-
-    // THEN
-    expect(sortByDirective.<%= jhiPrefix %>SortBy).toEqual('name');
-    expect(component.predicate).toEqual('_score');
-    expect(sortByDirective.iconComponent?.icon).toEqual('sort');
-    expect(component.transition).toHaveBeenCalledTimes(0);
   });
 
   it('should initialize predicate, order, icon when initial component predicate differs from column predicate', () => {
@@ -108,25 +94,6 @@ describe('Directive: SortByDirective', () => {
     expect(component.transition).toHaveBeenCalledTimes(0);
   });
 
-  it('should initialize predicate, order, icon when initial component predicate is _score and user clicks on column header', () => {
-    // GIVEN
-    component.predicate = '_score';
-    component.ascending = true;
-    const sortByDirective = tableHead.injector.get(SortByDirective);
-
-    // WHEN
-    fixture.detectChanges();
-    tableHead.triggerEventHandler('click', null);
-    fixture.detectChanges();
-
-    // THEN
-    expect(sortByDirective.<%= jhiPrefix %>SortBy).toEqual('name');
-    expect(component.predicate).toEqual('_score');
-    expect(component.ascending).toEqual(true);
-    expect(sortByDirective.iconComponent?.icon).toEqual('sort');
-    expect(component.transition).toHaveBeenCalledTimes(0);
-  });
-
   it('should update component predicate, order, icon when user clicks on column header', () => {
     // GIVEN
     component.predicate = 'name';
@@ -154,7 +121,6 @@ describe('Directive: SortByDirective', () => {
     // WHEN
     fixture.detectChanges();
 
-    // WHEN
     tableHead.triggerEventHandler('click', null);
     fixture.detectChanges();
 
@@ -166,5 +132,23 @@ describe('Directive: SortByDirective', () => {
     expect(component.ascending).toEqual(true);
     expect(sortByDirective.iconComponent?.icon).toEqual(faSortUp.iconName);
     expect(component.transition).toHaveBeenCalledTimes(2);
+  });
+
+  it('should not run sorting on click if sorting icon is hidden', () => {
+    // GIVEN
+    component.predicate = 'id';
+    component.ascending = false;
+    component.sortAllowed = false;
+
+    // WHEN
+    fixture.detectChanges();
+
+    tableHead.triggerEventHandler('click', null);
+    fixture.detectChanges();
+
+    // THEN
+    expect(component.predicate).toEqual('id');
+    expect(component.ascending).toEqual(false);
+    expect(component.transition).not.toHaveBeenCalled();
   });
 });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.spec.ts.ejs
@@ -29,7 +29,7 @@ import { SortDirective } from './sort.directive';
   template: `
     <table>
       <thead>
-        <tr <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)">
+        <tr <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="transition($event)">
           <th <%= jhiPrefix %>SortBy="name">ID<fa-icon *ngIf="sortAllowed" [icon]="'sort'"></fa-icon></th>
         </tr>
       </thead>
@@ -110,6 +110,7 @@ describe('Directive: SortByDirective', () => {
     expect(component.ascending).toEqual(false);
     expect(sortByDirective.iconComponent?.icon).toEqual(faSortDown.iconName);
     expect(component.transition).toHaveBeenCalledTimes(1);
+    expect(component.transition).toHaveBeenCalledWith({ predicate: 'name', ascending: false });
   });
 
   it('should update component predicate, order, icon when user double clicks on column header', () => {
@@ -132,6 +133,8 @@ describe('Directive: SortByDirective', () => {
     expect(component.ascending).toEqual(true);
     expect(sortByDirective.iconComponent?.icon).toEqual(faSortUp.iconName);
     expect(component.transition).toHaveBeenCalledTimes(2);
+    expect(component.transition).toHaveBeenNthCalledWith(1, { predicate: 'name', ascending: false });
+    expect(component.transition).toHaveBeenNthCalledWith(2, { predicate: 'name', ascending: true });
   });
 
   it('should not run sorting on click if sorting icon is hidden', () => {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.ts.ejs
@@ -28,7 +28,7 @@ import { SortDirective } from './sort.directive';
   selector: '[<%= jhiPrefix %>SortBy]',
 })
 export class SortByDirective<T> implements AfterContentInit, OnDestroy {
-  @Input() <%= jhiPrefix %>SortBy?: T;
+  @Input() <%= jhiPrefix %>SortBy!: T;
 
   @ContentChild(FaIconComponent, { static: false })
   iconComponent?: FaIconComponent;

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort-by.directive.ts.ejs
@@ -30,7 +30,7 @@ import { SortDirective } from './sort.directive';
 export class SortByDirective<T> implements AfterContentInit, OnDestroy {
   @Input() <%= jhiPrefix %>SortBy?: T;
 
-  @ContentChild(FaIconComponent, { static: true })
+  @ContentChild(FaIconComponent, { static: false })
   iconComponent?: FaIconComponent;
 
   sortIcon = faSort;
@@ -46,7 +46,9 @@ export class SortByDirective<T> implements AfterContentInit, OnDestroy {
 
   @HostListener('click')
   onClick(): void {
-    this.sort.sort(this.<%= jhiPrefix %>SortBy);
+    if (this.iconComponent) {
+      this.sort.sort(this.<%= jhiPrefix %>SortBy);
+    }
   }
 
   ngAfterContentInit(): void {

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
@@ -26,7 +26,8 @@ import { SortDirective } from './sort.directive';
   template: `
     <table>
       <thead>
-        <tr <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"></tr>
+        <tr id="withoutCallback" <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending"></tr>
+        <tr id="withCallback" <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"></tr>
       </thead>
     </table>
   `,
@@ -41,6 +42,7 @@ describe('Directive: SortDirective', () => {
   let component: TestSortDirectiveComponent;
   let fixture: ComponentFixture<TestSortDirectiveComponent>;
   let tableRow: DebugElement;
+  let tableRowWithoutCallback: DebugElement;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -48,7 +50,8 @@ describe('Directive: SortDirective', () => {
     });
     fixture = TestBed.createComponent(TestSortDirectiveComponent);
     component = fixture.componentInstance;
-    tableRow = fixture.debugElement.query(By.directive(SortDirective));
+    tableRow = fixture.debugElement.query(By.css('#withCallback'));
+    tableRowWithoutCallback = fixture.debugElement.query(By.css('#withoutCallback'));
   });
 
   it('should update predicate, order and invoke callback function', () => {
@@ -98,5 +101,19 @@ describe('Directive: SortDirective', () => {
     expect(component.ascending).toEqual(true);
     expect(component.transition).toHaveBeenCalled();
     expect(component.transition).toHaveBeenCalledTimes(2);
+  });
+
+  it('should work if no callback is declared', () => {
+    // GIVEN
+    const sortDirective = tableRowWithoutCallback.injector.get(SortDirective);
+
+    // WHEN
+    fixture.detectChanges();
+    sortDirective.sort('ID');
+
+    // THEN
+    expect(component.predicate).toEqual('ID');
+    expect(component.ascending).toEqual(true);
+    expect(component.transition).not.toHaveBeenCalled();
   });
 });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.spec.ts.ejs
@@ -26,8 +26,7 @@ import { SortDirective } from './sort.directive';
   template: `
     <table>
       <thead>
-        <tr id="withoutCallback" <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending"></tr>
-        <tr id="withCallback" <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="transition.bind(this)"></tr>
+        <tr <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="transition($event)"></tr>
       </thead>
     </table>
   `,
@@ -42,7 +41,6 @@ describe('Directive: SortDirective', () => {
   let component: TestSortDirectiveComponent;
   let fixture: ComponentFixture<TestSortDirectiveComponent>;
   let tableRow: DebugElement;
-  let tableRowWithoutCallback: DebugElement;
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -50,11 +48,10 @@ describe('Directive: SortDirective', () => {
     });
     fixture = TestBed.createComponent(TestSortDirectiveComponent);
     component = fixture.componentInstance;
-    tableRow = fixture.debugElement.query(By.css('#withCallback'));
-    tableRowWithoutCallback = fixture.debugElement.query(By.css('#withoutCallback'));
+    tableRow = fixture.debugElement.query(By.directive(SortDirective));
   });
 
-  it('should update predicate, order and invoke callback function', () => {
+  it('should update predicate, order and invoke sortChange function', () => {
     // GIVEN
     const sortDirective = tableRow.injector.get(SortDirective);
 
@@ -65,8 +62,8 @@ describe('Directive: SortDirective', () => {
     // THEN
     expect(component.predicate).toEqual('ID');
     expect(component.ascending).toEqual(true);
-    expect(component.transition).toHaveBeenCalled();
     expect(component.transition).toHaveBeenCalledTimes(1);
+    expect(component.transition).toHaveBeenCalledWith({ predicate: 'ID', ascending: true });
   });
 
   it('should change sort order to descending when same field is sorted again', () => {
@@ -82,8 +79,9 @@ describe('Directive: SortDirective', () => {
     // THEN
     expect(component.predicate).toEqual('ID');
     expect(component.ascending).toEqual(false);
-    expect(component.transition).toHaveBeenCalled();
     expect(component.transition).toHaveBeenCalledTimes(2);
+    expect(component.transition).toHaveBeenNthCalledWith(1, { predicate: 'ID', ascending: true });
+    expect(component.transition).toHaveBeenNthCalledWith(2, { predicate: 'ID', ascending: false });
   });
 
   it('should change sort order to ascending when different field is sorted', () => {
@@ -99,21 +97,8 @@ describe('Directive: SortDirective', () => {
     // THEN
     expect(component.predicate).toEqual('NAME');
     expect(component.ascending).toEqual(true);
-    expect(component.transition).toHaveBeenCalled();
     expect(component.transition).toHaveBeenCalledTimes(2);
-  });
-
-  it('should work if no callback is declared', () => {
-    // GIVEN
-    const sortDirective = tableRowWithoutCallback.injector.get(SortDirective);
-
-    // WHEN
-    fixture.detectChanges();
-    sortDirective.sort('ID');
-
-    // THEN
-    expect(component.predicate).toEqual('ID');
-    expect(component.ascending).toEqual(true);
-    expect(component.transition).not.toHaveBeenCalled();
+    expect(component.transition).toHaveBeenNthCalledWith(1, { predicate: 'ID', ascending: true });
+    expect(component.transition).toHaveBeenNthCalledWith(2, { predicate: 'NAME', ascending: true });
   });
 });

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.ts.ejs
@@ -40,19 +40,18 @@ export class SortDirective<T> {
     this.ascendingChange.emit(ascending);
   }
 
-  @Input() callback?: () => void;
-
   @Output() predicateChange = new EventEmitter<T>();
   @Output() ascendingChange = new EventEmitter<boolean>();
+  @Output() sortChange = new EventEmitter<{ predicate: T; ascending: boolean }>();
 
   private _predicate?: T;
   private _ascending?: boolean;
 
-  sort(field?: T): void {
+  sort(field: T): void {
     this.ascending = field !== this.predicate ? true : !this.ascending;
     this.predicate = field;
     this.predicateChange.emit(field);
     this.ascendingChange.emit(this.ascending);
-    this.callback?.();
+    this.sortChange.emit({ predicate: this.predicate, ascending: this.ascending });
   }
 }

--- a/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/shared/sort/sort.directive.ts.ejs
@@ -49,12 +49,10 @@ export class SortDirective<T> {
   private _ascending?: boolean;
 
   sort(field?: T): void {
-    if (String(this.predicate) !== '_score') {
-      this.ascending = field !== this.predicate ? true : !this.ascending;
-      this.predicate = field;
-      this.predicateChange.emit(field);
-      this.ascendingChange.emit(this.ascending);
-      this.callback?.();
-    }
+    this.ascending = field !== this.predicate ? true : !this.ascending;
+    this.predicate = field;
+    this.predicateChange.emit(field);
+    this.ascendingChange.emit(this.ascending);
+    this.callback?.();
   }
 }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.html.ejs
@@ -80,7 +80,7 @@ _%>
             <thead>
                 <tr<% if (!paginationNo) { %> <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="<%= !paginationInfiniteScroll ? 'loadPage.bind(this)' : 'reset.bind(this)'%>"<% } %>>
 <%_ for (const field of fields.filter(field => !field.hidden)) { _%>
-                    <th scope="col"<% if (!paginationNo) { %> <%= jhiPrefix %>SortBy="<%= field.fieldName %>"<% } %>><span <%= jhiPrefix %>Translate="<%= field.fieldTranslationKey %>"><%= field.fieldNameHumanized %></span><% if (!paginationNo) { %> <fa-icon icon="sort"></fa-icon><% } %></th>
+                    <th scope="col"<% if (!paginationNo) { %> <%= jhiPrefix %>SortBy="<%= field.fieldName %>"<% } %>><span <%= jhiPrefix %>Translate="<%= field.fieldTranslationKey %>"><%= field.fieldNameHumanized %></span><% if (!paginationNo) { %> <fa-icon <% if (searchEngine && !field.fieldTypeBoolean && !field.fieldTypeNumeric && !field.fieldTypeTemporal) { %>*ngIf="!currentSearch" <% } %>icon="sort"></fa-icon><% } %></th>
 <%_ } _%>
 <%_ for (const relationship of relationships) { _%>
     <%_ if (relationship.relationshipManyToOne

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.html.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.html.ejs
@@ -78,7 +78,7 @@ _%>
     <div class="table-responsive" id="entities" *ngIf="<%= entityInstancePlural %> && <%= entityInstancePlural %>.length > 0">
         <table class="table table-striped" aria-describedby="page-heading">
             <thead>
-                <tr<% if (!paginationNo) { %> <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" [callback]="<%= !paginationInfiniteScroll ? 'loadPage.bind(this)' : 'reset.bind(this)'%>"<% } %>>
+                <tr<% if (!paginationNo) { %> <%= jhiPrefix %>Sort [(predicate)]="predicate" [(ascending)]="ascending" (sortChange)="<%= !paginationInfiniteScroll ? 'loadPage()' : 'reset()'%>"<% } %>>
 <%_ for (const field of fields.filter(field => !field.hidden)) { _%>
                     <th scope="col"<% if (!paginationNo) { %> <%= jhiPrefix %>SortBy="<%= field.fieldName %>"<% } %>><span <%= jhiPrefix %>Translate="<%= field.fieldTranslationKey %>"><%= field.fieldNameHumanized %></span><% if (!paginationNo) { %> <fa-icon <% if (searchEngine && !field.fieldTypeBoolean && !field.fieldTypeNumeric && !field.fieldTypeTemporal) { %>*ngIf="!currentSearch" <% } %>icon="sort"></fa-icon><% } %></th>
 <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/entity-management.component.ts.ejs
@@ -16,6 +16,12 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
+<%_
+  const notSortableFieldsAfterSearch = !searchEngine ? '' : fields
+      .filter(field => !field.hidden && !field.fieldTypeBoolean && !field.fieldTypeNumeric && !field.fieldTypeTemporal)
+      .map(field => `'${field.fieldName}'`)
+      .join(', ');
+_%>
 import { Component, OnInit } from '@angular/core';
 import { <%_ if (!paginationNo) { _%>HttpHeaders, <% } %>HttpResponse } from '@angular/common/http';
 <%_ if (paginationPagination) { _%>
@@ -49,9 +55,9 @@ import { ParseLinks } from 'app/core/util/parse-links.service';
 })
 export class <%= entityAngularName %>Component implements OnInit {
 <%_ if (paginationPagination) { _%>
-<%- include('pagination-template'); -%>
+<%- include('pagination-template', { notSortableFieldsAfterSearch: notSortableFieldsAfterSearch }); -%>
 <%_ } else if (paginationInfiniteScroll) { _%>
-<%- include('infinite-scroll-template'); -%>
+<%- include('infinite-scroll-template', { notSortableFieldsAfterSearch: notSortableFieldsAfterSearch }); -%>
 <%_ } else if (paginationNo) { _%>
 <%- include('no-pagination-template'); -%>
 <%_ } _%>

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/infinite-scroll-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/infinite-scroll-template.ejs
@@ -108,13 +108,12 @@
             last: 0
         };
         this.page = 0;
-        if (query) {
-            this.predicate = '_score';
-            this.ascending = false;
-        } else {
+    <%_ if (notSortableFieldsAfterSearch) { _%>
+        if (query && [<%- notSortableFieldsAfterSearch %>].includes(this.predicate)) {
             this.predicate = '<%- primaryKey.name %>';
             this.ascending = true;
         }
+    <%_ } _%>
         this.currentSearch = query;
         this.loadAll();
     }

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/pagination-template.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/list/pagination-template.ejs
@@ -85,6 +85,12 @@
 
 <%_ if (searchEngine) { _%>
     search(query: string): void {
+    <%_ if (notSortableFieldsAfterSearch) { _%>
+        if (query && [<%- notSortableFieldsAfterSearch %>].includes(this.predicate)) {
+            this.predicate = '<%- primaryKey.name %>';
+            this.ascending = true;
+        }
+    <%_ } _%>
         this.currentSearch = query;
         this.loadPage(1);
     }


### PR DESCRIPTION
Fix #14138

As by default Elasticsearch can order by `numeric`, `boolean` and `datetime` fields then allowing to sort only by those fields after searching.

The second commit increases test coverage of the changed sort directive.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
