### PR TITLE
Allow env variables to override Cypress credentials

### DIFF
--- a/generators/client/templates/vue/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/e2e/modules/account/account.spec.ts.ejs
@@ -132,8 +132,8 @@ describe('Account', () => {
       signInPage = await navBarPage.getSignInPage();
       expect(await signInPage.getTitle()).to.eq(loginPageTitle);
 
-      await signInPage.username.sendKeys('admin');
-      await signInPage.password.sendKeys('admin');
+      await signInPage.username.sendKeys(username);
+      await signInPage.password.sendKeys(password);
       await signInPage.loginButton.click();
 
       await waitUntilHidden(signInPage.loginForm);
@@ -208,8 +208,8 @@ describe('Account', () => {
         signInPage = await navBarPage.getSignInPage();
         expect(await signInPage.getTitle()).to.eq(loginPageTitle);
 
-        await signInPage.username.sendKeys('admin');
-        await signInPage.password.sendKeys('admin');
+        await signInPage.username.sendKeys(username);
+        await signInPage.password.sendKeys(password);
         await signInPage.loginButton.click();
 
         await waitUntilHidden(signInPage.loginForm);
@@ -235,8 +235,8 @@ describe('Account', () => {
         signInPage = await navBarPage.getSignInPage();
         expect(await signInPage.getTitle()).to.eq(loginPageTitle);
 
-        await signInPage.username.sendKeys('admin');
-        await signInPage.password.sendKeys('admin');
+        await signInPage.username.sendKeys(username);
+        await signInPage.password.sendKeys(password);
         await signInPage.loginButton.click();
 
         await waitUntilHidden(signInPage.loginForm);
@@ -249,7 +249,7 @@ describe('Account', () => {
         passwordPage = await navBarPage.getPasswordPage();
         expect(await passwordPage.getTitle()).to.eq(passwordPageTitle);
 
-        await passwordPage.autoChangePassword('admin', 'new_password', 'new_password');
+        await passwordPage.autoChangePassword(password, 'new_password', 'new_password');
 
         await waitUntilDisplayed(passwordPage.successAlert);
         expect(await passwordPage.successAlert.isDisplayed()).to.be.true;
@@ -262,7 +262,7 @@ describe('Account', () => {
         signInPage = await navBarPage.getSignInPage();
         expect(await signInPage.getTitle()).to.eq(loginPageTitle);
 
-        await signInPage.username.sendKeys('admin');
+        await signInPage.username.sendKeys(username);
         await signInPage.password.sendKeys('new_password');
         await signInPage.loginButton.click();
 
@@ -274,7 +274,7 @@ describe('Account', () => {
         // change back to default
         passwordPage = await navBarPage.getPasswordPage();
         expect(await passwordPage.getTitle()).to.eq(passwordPageTitle);
-        await passwordPage.autoChangePassword('new_password', 'admin', 'admin');
+        await passwordPage.autoChangePassword('new_password', password, password);
 
         await waitUntilDisplayed(passwordPage.successAlert);
         expect(await passwordPage.successAlert.isDisplayed()).to.be.true;
@@ -326,8 +326,8 @@ describe('Account', () => {
         signInPage = await navBarPage.getSignInPage();
         expect(await signInPage.getTitle()).to.eq(loginPageTitle);
 
-        await signInPage.username.sendKeys('admin');
-        await signInPage.password.sendKeys('admin');
+        await signInPage.username.sendKeys(username);
+        await signInPage.password.sendKeys(password);
         await signInPage.loginButton.click();
 
         await waitUntilHidden(signInPage.loginForm);
@@ -359,8 +359,8 @@ describe('Account', () => {
         signInPage = await navBarPage.getSignInPage();
         expect(await signInPage.getTitle()).to.eq(loginPageTitle);
 
-        await signInPage.username.sendKeys('admin');
-        await signInPage.password.sendKeys('admin');
+        await signInPage.username.sendKeys(username);
+        await signInPage.password.sendKeys(password);
         await signInPage.loginButton.click();
 
         await waitUntilHidden(signInPage.loginForm);

--- a/generators/cypress/templates/src/test/javascript/cypress/integration/account/login-page.spec.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/integration/account/login-page.spec.ts.ejs
@@ -25,6 +25,9 @@ import {
 } from '../../support/commands';
 
 describe('login modal', () => {
+  const username = Cypress.env('E2E_USERNAME') ?? 'admin';
+  const password = Cypress.env('E2E_PASSWORD') ?? 'admin';
+
   before(() => {
     cy.window().then(win => {
       win.sessionStorage.clear();
@@ -63,7 +66,7 @@ describe('login modal', () => {
   });
 
   it('errors when password is incorrect', () => {
-    cy.get(usernameLoginSelector).type('admin');
+    cy.get(usernameLoginSelector).type(username);
     cy.get(passwordLoginSelector).type('bad-password');
     cy.get(submitLoginSelector).click();
     cy.wait('@authenticate').then(({ request, response }) => expect(response.statusCode).to.equal(401));
@@ -73,8 +76,8 @@ describe('login modal', () => {
   });
 
   it('go to login page when successfully logs in', () => {
-    cy.get(usernameLoginSelector).type('admin');
-    cy.get(passwordLoginSelector).type('admin');
+    cy.get(usernameLoginSelector).type(username);
+    cy.get(passwordLoginSelector).type(password);
     cy.get(submitLoginSelector).click();
     cy.wait('@authenticate').then(({ request, response }) => expect(response.statusCode).to.equal(200));
     cy.hash().should('eq', '');

--- a/generators/cypress/templates/src/test/javascript/cypress/integration/account/reset-password-page.spec.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/integration/account/reset-password-page.spec.ts.ejs
@@ -26,6 +26,8 @@ import {
 } from '../../support/commands';
 
 describe('forgot your password', () => {
+  const username = Cypress.env('E2E_USERNAME') ?? 'admin';
+
   before(() => {
     cy.window().then((win) => {
       win.sessionStorage.clear()
@@ -36,7 +38,7 @@ describe('forgot your password', () => {
     cy.clearCookies();
     cy.visit('');
     cy.clickOnLoginItem();
-    cy.get(usernameLoginSelector).type('admin');
+    cy.get(usernameLoginSelector).type(username);
     cy.get(forgetYourPasswordSelector).click();
   });
 

--- a/generators/cypress/templates/src/test/javascript/cypress/integration/account/settings-page.spec.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/integration/account/settings-page.spec.ts.ejs
@@ -24,6 +24,9 @@ import {
 } from '../../support/commands';
 
 describe('/account/settings', () => {
+  const username = Cypress.env('E2E_USERNAME') ?? 'admin';
+  const password = Cypress.env('E2E_PASSWORD') ?? 'admin';
+
   before(() => {
     cy.window().then((win) => {
       win.sessionStorage.clear()
@@ -67,7 +70,7 @@ describe('/account/settings', () => {
     // add an email for admin account
     cy.clickOnLogoutItem();
     cy.visit('');
-    cy.login('admin', 'admin');
+    cy.login(username, password);
     cy.clickOnSettingsItem();
     cy.get(emailSettingsSelector).clear().type('admin@localhost.fr');
     cy.get(submitSettingsSelector).click({force: true});

--- a/generators/cypress/templates/src/test/javascript/cypress/integration/administration/administration.spec.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/integration/administration/administration.spec.ts.ejs
@@ -31,11 +31,14 @@ import {
 } from '../../support/commands';
 
 describe('/admin', () => {
+  const username = Cypress.env('E2E_USERNAME') ?? 'admin';
+  const password = Cypress.env('E2E_PASSWORD') ?? 'admin';
+
 <%_ if (authenticationTypeOauth2) { _%>
   beforeEach(() => {
     cy.getOauth2Data();
     cy.get('@oauth2Data').then(oauth2Data => {
-      cy.oauthLogin(oauth2Data, Cypress.env('E2E_USERNAME') || "admin", Cypress.env('E2E_PASSWORD') || "admin");
+      cy.oauthLogin(oauth2Data, username, password);
     });
   });
 
@@ -55,7 +58,7 @@ describe('/admin', () => {
   <%_ } _%>
     cy.clearCookies();
     cy.visit('');
-    cy.login('admin', 'admin');
+    cy.login(username, password);
   });
 <%_ } _%>
 

--- a/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
+++ b/generators/entity-client/templates/common/src/test/javascript/cypress/integration/entity/entity.spec.ts.ejs
@@ -26,12 +26,14 @@ describe('<%= entityClass %> e2e test', () => {
 
   const <%= entityInstance %>PageUrl = '/<%= entityUrl %>';
   const <%= entityInstance %>PageUrlPattern = new RegExp('/<%= entityUrl %>(\\?.*)?$');
+  const username = Cypress.env('E2E_USERNAME') ?? 'admin';
+  const password = Cypress.env('E2E_PASSWORD') ?? 'admin';
 
 <%_ if (authenticationTypeOauth2) { _%>
   beforeEach(() => {
     cy.getOauth2Data();
     cy.get('@oauth2Data').then(oauth2Data => {
-      cy.oauthLogin(oauth2Data, Cypress.env('E2E_USERNAME') || "admin", Cypress.env('E2E_PASSWORD') || "admin");
+      cy.oauthLogin(oauth2Data, username, password);
     });
     cy.intercept('GET', '/<%= baseApi + entityApiUrl %>').as('entitiesRequest');
     cy.visit('');
@@ -50,7 +52,7 @@ describe('<%= entityClass %> e2e test', () => {
       win.sessionStorage.clear()
     });
     cy.visit('');
-    cy.login('admin', 'admin');
+    cy.login(username, password);
     cy.get(entityItemSelector).should('exist');
   });
 <%_ } _%>

--- a/generators/page/templates/vue/src/test/javascript/e2e/pages/page.spec.ts.ejs
+++ b/generators/page/templates/vue/src/test/javascript/e2e/pages/page.spec.ts.ejs
@@ -27,11 +27,13 @@ const expect = chai.expect;
 describe('<%= pageName %> e2e test', () => {
   let navBarPage: NavBarPage;
   let page: <%= pageName %>ComponentsPage;
+  const username = process.env.E2E_USERNAME ?? 'admin';
+  const password = process.env.E2E_PASSWORD ?? 'admin';
 
   before(async () => {
     await browser.get('/');
     navBarPage = new NavBarPage();
-    await navBarPage.login('admin', 'admin');
+    await navBarPage.login(username, password);
   });
 
   after(async () => {


### PR DESCRIPTION
With Protractor, we allow username/password to be overridden by environment variables. We should do the same for Cypress.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
