### PR TITLE
Move e2e scripts from client sub generator to server sub generator

### DIFF
--- a/generators/client/index.js
+++ b/generators/client/index.js
@@ -349,16 +349,6 @@ module.exports = class JHipsterClientGenerator extends BaseBlueprintGenerator {
           scriptsStorage.set('ci:frontend:build', 'npm run webapp:build:$npm_package_config_default_environment');
           scriptsStorage.set('ci:frontend:test', 'npm run ci:frontend:build && npm test');
         }
-
-        if (scriptsStorage.get('e2e')) {
-          scriptsStorage.set({
-            'ci:server:await':
-              'echo "Waiting for server at port $npm_package_config_backend_port to start" && wait-on http-get://localhost:$npm_package_config_backend_port/management/health && echo "Server at port $npm_package_config_backend_port started"',
-            'pree2e:headless': 'npm run ci:server:await',
-            'ci:e2e:run': 'concurrently -k -s first "npm run ci:e2e:server:start" "npm run e2e:headless"',
-            'e2e:dev': 'concurrently -k -s first "./mvnw" "e2e"',
-          });
-        }
       },
     };
   }

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -464,6 +464,19 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
           'ci:e2e:server:start': `java -jar ${e2ePackage}.$npm_package_config_packaging --spring.profiles.active=$npm_package_config_default_environment ${javaCommonLog} ${javaTestLog} --logging.level.org.springframework.web=ERROR`,
         });
       },
+      packageJsonE2eScripts() {
+        const scriptsStorage = this.packageJson.createStorage('scripts');
+        const buildCmd = this.jhipsterConfig.buildTool === 'gradle' ? 'gradlew' : 'mvnw';
+        if (scriptsStorage.get('e2e')) {
+          scriptsStorage.set({
+            'ci:server:await':
+              'echo "Waiting for server at port $npm_package_config_backend_port to start" && wait-on http-get://localhost:$npm_package_config_backend_port/management/health && echo "Server at port $npm_package_config_backend_port started"',
+            'pree2e:headless': 'npm run ci:server:await',
+            'ci:e2e:run': 'concurrently -k -s first "npm run ci:e2e:server:start" "npm run e2e:headless"',
+            'e2e:dev': `concurrently -k -s first "./${buildCmd}" "npm run e2e"`,
+          });
+        }
+      },
     };
   }
 


### PR DESCRIPTION
This allows to respect `buildTool` variable so that for Gradle users is generated `gradlew` instead of `mvnw`.
Also fixed `e2e:dev` command second part, using `npm run e2e` instead of `e2e`.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
