### PR TITLE
adapt java version check to support jdk > 12

### DIFF
--- a/generators/generator-base-private.js
+++ b/generators/generator-base-private.js
@@ -887,11 +887,17 @@ module.exports = class JHipsterBasePrivateGenerator extends Generator {
       } else {
         const javaVersion = stderr.match(/(?:java|openjdk) version "(.*)"/)[1];
         if (
-          !javaVersion.match(new RegExp('12'.replace('.', '\\.'))) &&
-          !javaVersion.match(new RegExp('11'.replace('.', '\\.'))) &&
-          !javaVersion.match(new RegExp(constants.JAVA_VERSION.replace('.', '\\.')))
+          !javaVersion.match(new RegExp('16')) &&
+          !javaVersion.match(new RegExp('15')) &&
+          !javaVersion.match(new RegExp('14')) &&
+          !javaVersion.match(new RegExp('13')) &&
+          !javaVersion.match(new RegExp('12')) &&
+          !javaVersion.match(new RegExp('11')) &&
+          !javaVersion.match(new RegExp('1.8'.replace('.', '\\.')))
         ) {
-          this.warning(`Java 8, 11, or 12 are not found on your computer. Your Java version is: ${chalk.yellow(javaVersion)}`);
+          this.warning(
+            `Java 8, 11, 12, 13, 14, 15 or 16 are not found on your computer. Your Java version is: ${chalk.yellow(javaVersion)}`
+          );
         }
       }
       done();


### PR DESCRIPTION
Just a small fix to correct the java version check of the generator to be aligned with the support on maven/gradle side.

![image](https://user-images.githubusercontent.com/203401/116811416-75aa7600-ab49-11eb-9b00-d1fb8f60b50a.png)


---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
