### PR TITLE
JWTRelay allow no authorization header

### DIFF
--- a/generators/server/templates/src/main/java/package/security/jwt/JWTRelayGatewayFilterFactory.java.ejs
+++ b/generators/server/templates/src/main/java/package/security/jwt/JWTRelayGatewayFilterFactory.java.ejs
@@ -52,6 +52,9 @@ public class JWTRelayGatewayFilterFactory extends AbstractGatewayFilterFactory<O
 
     private String extractJWTToken(ServerHttpRequest request) {
         String bearerToken = request.getHeaders().getFirst(AUTHORIZATION_HEADER);
+        if (bearerToken == null) {
+            return null;
+        }
         if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
             return bearerToken.substring(7);
         }


### PR DESCRIPTION
When relay requests, gateways should not assume that there is always authorization header. There are scenarios that services expose endpoints that allow anonymous access, which in most cases contain no authorization header. Current behavior of throwing an exception is not quite reasonable IMHO.

e.g. In my case, I use a user service instead of gateway to provide authentication service thus I permit all visits to /services/user/api/authenticate, no authorization header needed of course. 

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
