### PR TITLE
app startup show default profiles when no active profiles set

### DIFF
--- a/generators/server/templates/src/main/java/package/Application.java.ejs
+++ b/generators/server/templates/src/main/java/package/Application.java.ejs
@@ -108,7 +108,8 @@ public class <%= mainClass %> {
             hostAddress,
             serverPort,
             contextPath,
-            env.getActiveProfiles());
+            env.getActiveProfiles().length == 0 ? env.getDefaultProfiles() : env.getActiveProfiles()
+        );
         <%_ if (serviceDiscoveryType && (applicationType === 'microservice' || applicationType === 'gateway')) { _%>
 
         String configServerStatus = env.getProperty("configserver.status");


### PR DESCRIPTION
Current App.logApplicationStartup() show 'active' profiles by calling Environment.getActiveProfiles(), which is empty if there is no active profiles explicitly set.

According to [Spring docs of Environment](https://docs.spring.io/spring-framework/docs/current/javadoc-api/org/springframework/core/env/Environment.html#getActiveProfiles--):
- Environment.getActiveProfiles() returns the set of profiles explicitly made active for this environment. 
- Environment.getDefaultProfiles() returns the set of profiles to be active by default when no active profiles have been set explicitly.

This change is to  show  default profiles when active profile is empty.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
