### PR TITLE
Update PULL_REQUEST_TEMPLATE.md

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -8,7 +8,8 @@ Please make sure the below checklist is followed for Pull Requests.
 
 - [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
 - [ ] Tests are added where necessary
-- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
+- [ ] The JDL part is updated if necessary
+- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
 - [ ] Documentation is added/updated where necessary
 - [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed
 


### PR DESCRIPTION
Added a checkbox for when there should be a change in the JDL part of the code

Following #14817, I've noticed the JDL-related deployment options were really out of date.
That bothers me because it means changes regarding deployment configuration generation were made, and the JDL part was left behind, which can frustrates users.

The goal of this PR is to try to remedy this situation by adding a checkbox in our PR template so that people who make PRs think about whether their PRs should also update the JDL part.
For those who are familiar with the concept for "Definition of Done", this shouldn't surprise you ;) 

cc @jhipster/developers WDYT?

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [X] Tests are added where necessary
- [X] [jhipster-online](https://github.com/jhipster/jhipster-online) was updated if necessary
- [X] Documentation is added/updated where necessary
- [X] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.