### PR TITLE
Fix "table name is too long for Oracle" error when --skipCheckLengthOfIdentifier config is true

### DIFF
--- a/generators/generator-base.js
+++ b/generators/generator-base.js
@@ -2466,6 +2466,7 @@ templates: ${JSON.stringify(existingTemplates, null, 2)}`;
     dest.entitySuffix = config.entitySuffix;
     dest.dtoSuffix = config.dtoSuffix;
     dest.skipUserManagement = config.skipUserManagement;
+    dest.skipCheckLengthOfIdentifier = config.skipCheckLengthOfIdentifier;
 
     dest.skipServer = config.skipServer;
     dest.skipCommitHook = config.skipCommitHook;


### PR DESCRIPTION
Fix jhipster/generator-jhipster#14932

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
