### PR TITLE
categorize changes in release drafter config

### DIFF
--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -2,3 +2,22 @@ template: |
   ## What’s Changed
 
   $CHANGES
+
+categories:
+  - title: 💎 Features & Enhancements
+    labels:
+      - 'area: enhancement :wrench:'
+      - 'changes: major :star:'
+      - 'changes: minor'
+  - title: 🐞 Bug Fixes
+    label: 'area: bug'
+  - title: 🖥️ Frontend
+    labels:
+      - 'theme: front'
+      - 'theme: vue'
+      - 'theme: angular'
+      - 'theme: react'
+  - title: 📝 Documentation
+    label: 'area: documentation:books:'
+  - title: 📦 Dependency updates
+    label: 'theme: dependencies'


### PR DESCRIPTION
The current view when looking at the release page here on github is not very nice to read. I know the primary source for our changelogs is the website, but I think a little more structure here makes sense. 

This PR creates a first categorization for pull requests. Most important the dependency updates are separated from other features. 

[ci-skip] [skip-ci]
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
