### PR TITLE
fix: add missing allowed ordered properties

### DIFF
--- a/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
+++ b/generators/server/templates/src/main/java/package/web/rest/UserResource.java.ejs
@@ -127,7 +127,8 @@ import static org.elasticsearch.index.query.QueryBuilders.*;
 @RequestMapping("/api/admin")
 public class UserResource {
     <%_ if (authenticationType !== 'oauth2') { _%>
-    private static final List<String> ALLOWED_ORDERED_PROPERTIES = Collections.unmodifiableList(Arrays.asList("id", "login", "firstName", "lastName", "email", "activated", "langKey"));
+    private static final List<String> ALLOWED_ORDERED_PROPERTIES = Collections.unmodifiableList(Arrays.asList(
+    "id", "login", "firstName", "lastName", "email", "activated", "langKey", "createdBy", "createdDate", "lastModifiedBy", "lastModifiedDate"));
     <%_ } _%>
 
     private final Logger log = LoggerFactory.getLogger(UserResource.class);


### PR DESCRIPTION
Add "createdBy", "createdDate", "lastModifiedBy" and "lastModifiedDate" to the allowlist of properties that can be sort in the Users list. (Otherwise a 400 is thrown when calling the sort)