### PR TITLE
cache frontend application files

### DIFF
--- a/generators/server/templates/src/main/java/package/config/StaticResourcesWebConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/StaticResourcesWebConfiguration.java.ejs
@@ -33,8 +33,8 @@ import java.util.concurrent.TimeUnit;
 @Profile({JHipsterConstants.SPRING_PROFILE_PRODUCTION})
 public class StaticResourcesWebConfiguration implements WebMvcConfigurer {
 
-    protected static final String[] RESOURCE_LOCATIONS = new String[]{"classpath:/static/app/", "classpath:/static/content/", "classpath:/static/i18n/"};
-    protected static final String[] RESOURCE_PATHS = new String[]{"/app/*", "/content/*", "/i18n/*"};
+    protected static final String[] RESOURCE_LOCATIONS = new String[]{"classpath:/static/", "classpath:/static/content/", "classpath:/static/i18n/"};
+    protected static final String[] RESOURCE_PATHS = new String[]{"/*.js", "/*.css", "/*.svg", "/*.png", "*.ico", "/content/*", "/i18n/*"};
 
     private final JHipsterProperties jhipsterProperties;
 

--- a/generators/server/templates/src/main/java/package/config/StaticResourcesWebConfiguration.java.ejs
+++ b/generators/server/templates/src/main/java/package/config/StaticResourcesWebConfiguration.java.ejs
@@ -34,7 +34,7 @@ import java.util.concurrent.TimeUnit;
 public class StaticResourcesWebConfiguration implements WebMvcConfigurer {
 
     protected static final String[] RESOURCE_LOCATIONS = new String[]{"classpath:/static/", "classpath:/static/content/", "classpath:/static/i18n/"};
-    protected static final String[] RESOURCE_PATHS = new String[]{"/*.js", "/*.css", "/*.svg", "/*.png", "*.ico", "/content/*", "/i18n/*"};
+    protected static final String[] RESOURCE_PATHS = new String[]{"/*.js", "/*.css", "/*.svg", "/*.png", "*.ico", "/content/**", "/i18n/*"};
 
     private final JHipsterProperties jhipsterProperties;
 


### PR DESCRIPTION
Caching is now working as expected. It really seems like a bug introduced when the app was directly compiled to `/static` instead of `/static/app`. 

You can see the first requests load the files with correct caching headers while the reload serves everything from cache.

![image](https://user-images.githubusercontent.com/203401/120034476-678f2e80-bffd-11eb-9009-d9fa4e117194.png)

closes #15126

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
