### PR TITLE
AWS: wrong dbEngine for PostgreSQL

### DIFF
--- a/generators/aws/index.js
+++ b/generators/aws/index.js
@@ -80,7 +80,7 @@ module.exports = class extends BaseBlueprintGenerator {
             this.dbEngine = MYSQL;
             break;
           case POSTGRESQL:
-            this.dbEngine = POSTGRESQL;
+            this.dbEngine = 'postgres';
             break;
           default:
             this.error('Sorry deployment for this database is not possible');


### PR DESCRIPTION
The right value of `dbEngine` is "postgres" not  "postgresql" as [documented in AWS](https://docs.aws.amazon.com/cli/latest/reference/rds/create-db-instance.html#options).

I haven't tested it with AWS, I only did a code review and saw which commit introduced the regression: 972b1e87e8d5fe09942705c2da29de555e349685

Fix: #15151

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
