### PR TITLE
allow javadoc comments before and after enum values

### DIFF
--- a/jdl/parsing/jdl-parser.js
+++ b/jdl/parsing/jdl-parser.js
@@ -351,14 +351,20 @@ module.exports = class JDLParser extends CstParser {
 
   enumProp() {
     this.RULE('enumProp', () => {
-      this.CONSUME(LexerTokens.NAME, { LABEL: 'enumPropKey' });
       this.OPTION(() => {
+        this.CONSUME(LexerTokens.JAVADOC);
+      });
+      this.CONSUME(LexerTokens.NAME, { LABEL: 'enumPropKey' });
+      this.OPTION1(() => {
         this.CONSUME(LexerTokens.LPAREN);
         this.OR([
           { ALT: () => this.CONSUME2(LexerTokens.STRING, { LABEL: 'enumPropValueWithQuotes' }) },
           { ALT: () => this.CONSUME3(LexerTokens.NAME, { LABEL: 'enumPropValue' }) },
         ]);
         this.CONSUME(LexerTokens.RPAREN);
+      });
+      this.OPTION2(() => {
+        this.CONSUME1(LexerTokens.JAVADOC);
       });
     });
   }

--- a/test/jdl/grammar/grammar.spec.js
+++ b/test/jdl/grammar/grammar.spec.js
@@ -1060,6 +1060,146 @@ entity A {
         });
       });
     });
+
+    context('without custom values but with comments', () => {
+      let parsedEnum;
+
+      before(() => {
+        const content = parseFromContent(
+          `enum MyEnum {
+            /** some comment */FRANCE /** some comment */,
+            /** some comment */ ITALY /** some comment */,
+                                        ENGLAND /** some comment */,
+                                        ICELAND/** some comment */,
+            /** some comment */IRELAND,
+            /** some comment */ CANADA
+}
+`
+        );
+        parsedEnum = content.enums[0];
+      });
+
+      it('should parse it', () => {
+        expect(parsedEnum).to.deep.equal({
+          name: 'MyEnum',
+          values: [
+            {
+              key: 'FRANCE',
+            },
+            {
+              key: 'ITALY',
+            },
+            {
+              key: 'ENGLAND',
+            },
+            {
+              key: 'ICELAND',
+            },
+            {
+              key: 'IRELAND',
+            },
+            {
+              key: 'CANADA',
+            },
+          ],
+        });
+      });
+    });
+
+    context('with custom values containing spaces and with comments', () => {
+      let parsedEnum;
+
+      before(() => {
+        const content = parseFromContent(
+          `enum MyEnum {
+            /** some comment */FRANCE ("cheese and wine country") /** some comment */,
+            /** some comment */ ITALY /** some comment */,
+                                        ENGLAND ("not a tea country") /** some comment */,
+                                        ICELAND/** some comment */,
+            /** some comment */IRELAND,
+            /** some comment */ CANADA
+}
+`
+        );
+        parsedEnum = content.enums[0];
+      });
+
+      it('should parse it', () => {
+        expect(parsedEnum).to.deep.equal({
+          name: 'MyEnum',
+          values: [
+            {
+              key: 'FRANCE',
+              value: 'cheese and wine country',
+            },
+            {
+              key: 'ITALY',
+            },
+            {
+              key: 'ENGLAND',
+              value: 'not a tea country',
+            },
+            {
+              key: 'ICELAND',
+            },
+            {
+              key: 'IRELAND',
+            },
+            {
+              key: 'CANADA',
+            },
+          ],
+        });
+      });
+    });
+
+    context('with custom values containing underscores and with comments', () => {
+      let parsedEnum;
+
+      before(() => {
+        const content = parseFromContent(
+          `enum MyEnum {
+            /** some comment */FRANCE ("cheese_and_wine_country") /** some comment */,
+            /** some comment */ ITALY /** some comment */,
+                                        ENGLAND ("not_a_tea_country") /** some comment */,
+                                        ICELAND/** some comment */,
+            /** some comment */IRELAND,
+            /** some comment */ CANADA
+}
+`
+        );
+        parsedEnum = content.enums[0];
+      });
+
+      it('should parse it', () => {
+        expect(parsedEnum).to.deep.equal({
+          name: 'MyEnum',
+          values: [
+            {
+              key: 'FRANCE',
+              value: 'cheese_and_wine_country',
+            },
+            {
+              key: 'ITALY',
+            },
+            {
+              key: 'ENGLAND',
+              value: 'not_a_tea_country',
+            },
+            {
+              key: 'ICELAND',
+            },
+            {
+              key: 'IRELAND',
+            },
+            {
+              key: 'CANADA',
+            },
+          ],
+        });
+      });
+    });
+
     context('without values', () => {
       context('without spaces', () => {
         let parsedEnum;


### PR DESCRIPTION
Fix #15185

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
