### PR TITLE
Cancel outdated workflow runs.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -18,6 +18,9 @@
 #
 
 name: Angular
+concurrency:
+  group: angular-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -19,7 +19,8 @@
 
 name: Angular
 concurrency:
-  group: angular-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: angular-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -18,6 +18,9 @@
 #
 
 name: Generator
+concurrency:
+  group: generator-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/generator.yml
+++ b/.github/workflows/generator.yml
@@ -19,7 +19,8 @@
 
 name: Generator
 concurrency:
-  group: generator-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: generator-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -18,6 +18,9 @@
 #
 
 name: 'Validate Gradle Wrapper'
+concurrency:
+  group: gradle-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -19,7 +19,8 @@
 
 name: 'Validate Gradle Wrapper'
 concurrency:
-  group: gradle-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: gradle-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -18,6 +18,9 @@
 #
 
 name: Incremental Changelog
+concurrency:
+  group: incremental-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/incremental-changelog.yml
+++ b/.github/workflows/incremental-changelog.yml
@@ -19,7 +19,8 @@
 
 name: Incremental Changelog
 concurrency:
-  group: incremental-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: incremental-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -18,6 +18,9 @@
 #
 
 name: JDL tests
+concurrency:
+  group: jdl-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -19,7 +19,8 @@
 
 name: JDL tests
 concurrency:
-  group: jdl-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: jdl-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/label-cleanup.yml
+++ b/.github/workflows/label-cleanup.yml
@@ -19,7 +19,7 @@
 
 name: Cleanup Labels
 on:
-  issues: { types: closed }
+  issues: { types: [closed] }
 jobs:
   remove-labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -18,6 +18,9 @@
 #
 
 name: React
+concurrency:
+  group: react-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -19,7 +19,8 @@
 
 name: React
 concurrency:
-  group: react-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: react-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/triage.yml
+++ b/.github/workflows/triage.yml
@@ -19,7 +19,7 @@
 
 name: Triage issues
 on:
-  issues: { types: opened }
+  issues: { types: [opened] }
 jobs:
   apply-label:
     runs-on: ubuntu-latest

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -19,7 +19,8 @@
 
 name: Vue
 concurrency:
-  group: vue-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: vue-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -18,6 +18,9 @@
 #
 
 name: Vue
+concurrency:
+  group: vue-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -19,7 +19,8 @@
 
 name: Webflux
 concurrency:
-  group: webflux-${{ github.head_ref || github.sha }}
+  # Group PRs by head_ref, push to main branch by commit id, and others branch by ref.
+  group: webflux-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}
   cancel-in-progress: true
 on:
   push:

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -18,6 +18,9 @@
 #
 
 name: Webflux
+concurrency:
+  group: webflux-${{ github.head_ref || github.sha }}
+  cancel-in-progress: true
 on:
   push:
     branches-ignore:


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/15205 and https://github.com/jhipster/generator-jhipster/issues/14566.

Using group name as `worflowName-${{ github.head_ref || (github.ref == 'refs/heads/main' && github.sha) || github.ref }}`.
PRs should resolve as `worflowName-refs/heads/branchName`
Push events to main should resolve as `worflowName-commitHash`, so will not cancel running workflows.
Push events to others branches should resolve as `worflowName-refs/heads/branchName`.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
