### PR TITLE
Enable webpack cache at production builds for react and vue.

### DIFF
--- a/generators/client/templates/react/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.common.js.ejs
@@ -61,6 +61,21 @@ const getTsLoaderRule = env => {
 module.exports = options => merge(
 // jhipster-needle-add-webpack-config - JHipster will add custom config
 {
+  cache: {
+    // 1. Set cache type to filesystem
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../<%= buildDir %>webpack'),
+    buildDependencies: {
+      // 2. Add your config as buildDependency to get cache invalidation on config change
+      config: [
+        __filename,
+        path.resolve(__dirname, `webpack.${options.env == 'development' ? 'dev' : 'prod'}.js`),
+        path.resolve(__dirname, 'utils.js'),
+        path.resolve(__dirname, '../postcss.config.js'),
+        path.resolve(__dirname, '../tsconfig.json')
+      ],
+    },
+  },
   resolve: {
     extensions: [
       '.js', '.jsx', '.ts', '.tsx', '.json'

--- a/generators/client/templates/react/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.dev.js.ejs
@@ -30,21 +30,6 @@ const commonConfig = require('./webpack.common.js');
 const ENV = 'development';
 
 module.exports = (options) => webpackMerge(commonConfig({ env: ENV }), {
-  cache: {
-    // 1. Set cache type to filesystem
-    type: 'filesystem',
-    cacheDirectory: path.resolve(__dirname, '../<%= buildDir %>webpack'),
-    buildDependencies: {
-      // 2. Add your config as buildDependency to get cache invalidation on config change
-      config: [
-        __filename,
-        path.resolve(__dirname, 'webpack.common.js'),
-        path.resolve(__dirname, 'utils.js'),
-        path.resolve(__dirname, '../postcss.config.js'),
-        path.resolve(__dirname, '../tsconfig.json')
-      ],
-    },
-  },
   devtool: 'cheap-module-source-map', // https://reactjs.org/docs/cross-origin-errors.html
   mode: ENV,
   entry: [

--- a/generators/client/templates/react/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/react/webpack/webpack.prod.js.ejs
@@ -32,14 +32,13 @@ const ENV = 'production';
 module.exports = webpackMerge(commonConfig({ env: ENV }), {
   // devtool: 'source-map', // Enable source maps. Please note that this will slow down the build
   mode: ENV,
-  cache: false,
   entry: {
     main: './<%= MAIN_SRC_DIR %>app/index'
   },
   output: {
     path: utils.root('<%= DIST_DIR %>'),
-    filename: 'app/[name].[hash].bundle.js',
-    chunkFilename: 'app/[name].[hash].chunk.js'
+    filename: 'app/[name].[contenthash].bundle.js',
+    chunkFilename: 'app/[name].[chunkhash].chunk.js'
   },
   module: {
     rules: [
@@ -104,8 +103,8 @@ module.exports = webpackMerge(commonConfig({ env: ENV }), {
   plugins: [
     new MiniCssExtractPlugin({
       // Options similar to the same options in webpackOptions.output
-      filename: 'content/[name].[hash].css',
-      chunkFilename: 'content/[name].[hash].css'
+      filename: 'content/[name].[contenthash].css',
+      chunkFilename: 'content/[name].[chunkhash].css'
     }),
     new webpack.LoaderOptionsPlugin({
       minimize: true,

--- a/generators/client/templates/vue/webpack/webpack.common.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.common.js.ejs
@@ -12,7 +12,7 @@ function resolve(dir) {
   return path.join(__dirname, '..', dir);
 }
 
-module.exports = merge(
+module.exports = env => merge(
 // jhipster-needle-add-webpack-config - JHipster will add custom config
 {
   mode: 'development',
@@ -37,6 +37,21 @@ module.exports = merge(
       net: 'empty',
       tls: 'empty',
       child_process: 'empty',
+    },
+  },
+  cache: {
+    // 1. Set cache type to filesystem
+    type: 'filesystem',
+    cacheDirectory: path.resolve(__dirname, '../<%= buildDir %>webpack'),
+    buildDependencies: {
+      // 2. Add your config as buildDependency to get cache invalidation on config change
+      config: [
+        __filename,
+        path.resolve(__dirname, `webpack.${env.env == 'development' ? 'dev' : 'prod'}.js`),
+        path.resolve(__dirname, 'utils.js'),
+        path.resolve(__dirname, '../.postcssrc.js'),
+        path.resolve(__dirname, '../tsconfig.json')
+      ],
     },
   },
   module: {

--- a/generators/client/templates/vue/webpack/webpack.dev.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.dev.js.ejs
@@ -18,7 +18,6 @@
 -%>
 'use strict';
 const BrowserSyncPlugin = require('browser-sync-webpack-plugin');
-const path = require('path');
 const portfinder = require('portfinder');
 const webpack = require('webpack');
 const { merge: webpackMerge } = require('webpack-merge');
@@ -26,11 +25,12 @@ const HtmlWebpackPlugin = require('html-webpack-plugin');
 
 const utils = require('./vue.utils');
 const config = require('./env');
-const baseWebpackConfig = require('./webpack.common');
+const commonConfig = require('./webpack.common');
 const jhiUtils = require('./utils.js');
+const MODE = 'development';
 
-module.exports = webpackMerge(baseWebpackConfig, {
-  mode: 'development',
+module.exports = env => webpackMerge(commonConfig({ env: MODE }), {
+  mode: MODE,
   module: {
     rules: utils.styleLoaders({ sourceMap: config.dev.cssSourceMap, usePostCSS: true })
   },
@@ -42,26 +42,11 @@ module.exports = webpackMerge(baseWebpackConfig, {
   },
   output: {
     path: jhiUtils.root('<%= DIST_DIR %>'),
-    filename: 'app/[name].bundle.js',
+    filename: 'app/[contenthash].bundle.js',
     chunkFilename: 'app/[id].chunk.js'
   },
   optimization: {
     moduleIds: 'named',
-  },
-  cache: {
-    // 1. Set cache type to filesystem
-    type: 'filesystem',
-    cacheDirectory: path.resolve(__dirname, '../<%= buildDir %>webpack'),
-    buildDependencies: {
-      // 2. Add your config as buildDependency to get cache invalidation on config change
-      config: [
-        __filename,
-        path.resolve(__dirname, 'webpack.common.js'),
-        path.resolve(__dirname, 'utils.js'),
-        path.resolve(__dirname, '../.postcssrc.js'),
-        path.resolve(__dirname, '../tsconfig.json')
-      ],
-    },
   },
   devServer: {
     contentBase: './<%= DIST_DIR %>',

--- a/generators/client/templates/vue/webpack/webpack.prod.js.ejs
+++ b/generators/client/templates/vue/webpack/webpack.prod.js.ejs
@@ -17,24 +17,25 @@
  limitations under the License.
 -%>
 'use strict';
-const utils = require('./vue.utils');
 const webpack = require('webpack');
-const config = require('./env');
 const webpackMerge = require('webpack-merge').merge;
-const baseWebpackConfig = require('./webpack.common');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
 const MiniCssExtractPlugin = require('mini-css-extract-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
 const WorkboxPlugin = require('workbox-webpack-plugin');
 const TerserPlugin = require('terser-webpack-plugin');
 const ForkTsCheckerWebpackPlugin = require('fork-ts-checker-webpack-plugin');
+
+const utils = require('./vue.utils');
+const config = require('./env');
+const baseWebpackConfig = require('./webpack.common');
 const jhiUtils = require('./utils.js');
 
 const env = require('./prod.env');
+const MODE = 'production';
 
-const webpackConfig = webpackMerge(baseWebpackConfig, {
-  mode: 'production',
-  cache: false,
+const webpackConfig = {
+  mode: MODE,
   module: {
     rules: utils.styleLoaders({
       sourceMap: config.build.productionSourceMap,
@@ -49,8 +50,8 @@ const webpackConfig = webpackMerge(baseWebpackConfig, {
   },
   output: {
     path: jhiUtils.root('<%= DIST_DIR %>'),
-    filename: 'app/[name].[hash].bundle.js',
-    chunkFilename: 'app/[id].[hash].chunk.js'
+    filename: 'app/[name].[contenthash].bundle.js',
+    chunkFilename: 'app/[id].[chunkhash].chunk.js'
   },
   optimization: {
     moduleIds: 'deterministic',
@@ -153,7 +154,7 @@ const webpackConfig = webpackMerge(baseWebpackConfig, {
       exclude: [/swagger-ui/]
     })
   ]
-});
+};
 
 if (config.build.productionGzip) {
   const CompressionWebpackPlugin = require('compression-webpack-plugin');
@@ -174,4 +175,4 @@ if (config.build.bundleAnalyzerReport) {
   webpackConfig.plugins.push(new BundleAnalyzerPlugin());
 }
 
-module.exports = webpackConfig;
+module.exports = webpackMerge(baseWebpackConfig({ env: MODE }), webpackConfig);


### PR DESCRIPTION
Related to https://github.com/jhipster/generator-jhipster/issues/14566.

Reduces React and Vue builds by ~1m.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
