### PR TITLE
Publish test results on Azure pipeline generator

### DIFF
--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -82,6 +82,13 @@ jobs:
       command: 'custom'
       customCommand: ' run ci:backend:test'
     displayName: 'TESTS: backend'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '**/TEST-*.xml'
+      searchFolder: '$(Build.SourcesDirectory)/<%= buildDir %>test-results'
+    condition: succeededOrFailed()
+    displayName: 'TESTS: publish test results'
   <%_ } _%>
 <%_ if (!skipClient) { _%>
   - task: Npm@1
@@ -89,6 +96,12 @@ jobs:
       command: 'custom'
       customCommand: ' run ci:frontend:test'
     displayName: 'TESTS: frontend'
+  - task: PublishTestResults@2
+    inputs:
+      testResultsFormat: 'JUnit'
+      testResultsFiles: '$(Build.SourcesDirectory)/<%= buildDir %>test-results/TESTS-results-jest.xml'
+    condition: succeededOrFailed()
+    displayName: 'TESTS: publish test results'
 <%_ } _%>
 <%_ if (!skipServer) { _%>
   - task: Npm@1
@@ -119,6 +132,12 @@ jobs:
   <%= commented %>    CYPRESS_ENABLE_RECORD: <%= cicdIntegrationsCypressDashboard %>
   <%= commented %>    CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
   <%= commented %>    CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
+  <%= commented %>- task: PublishPipelineArtifact@1
+  <%= commented %>  inputs:
+  <%= commented %>    artifactName: 'cypress-screenshots'
+  <%= commented %>    targetPath: '$(Build.SourcesDirectory)/<%= buildDir %>cypress/screenshots'
+  <%= commented %>  condition: failed()
+  <%= commented %>  displayName: 'E2E: Publish Cypress Screenshots'
   <%_ } _%>
   <%= commented %>- task: Npm@1
   <%= commented %>  inputs:

--- a/test/__snapshots__/ci-cd.spec.js.snap
+++ b/test/__snapshots__/ci-cd.spec.js.snap
@@ -70,11 +70,24 @@ Object {
           command: \\"custom\\"
           customCommand: \\" run ci:backend:test\\"
         displayName: \\"TESTS: backend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"**/TEST-*.xml\\"
+          searchFolder: \\"$(Build.SourcesDirectory)/build/test-results\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
           customCommand: \\" run ci:frontend:test\\"
         displayName: \\"TESTS: frontend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"$(Build.SourcesDirectory)/build/test-results/TESTS-results-jest.xml\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -99,6 +112,12 @@ Object {
           CYPRESS_ENABLE_RECORD: false
           CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
           CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: \\"cypress-screenshots\\"
+          targetPath: \\"$(Build.SourcesDirectory)/build/cypress/screenshots\\"
+        condition: failed()
+        displayName: \\"E2E: Publish Cypress Screenshots\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -192,11 +211,24 @@ Object {
           command: \\"custom\\"
           customCommand: \\" run ci:backend:test\\"
         displayName: \\"TESTS: backend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"**/TEST-*.xml\\"
+          searchFolder: \\"$(Build.SourcesDirectory)/build/test-results\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
           customCommand: \\" run ci:frontend:test\\"
         displayName: \\"TESTS: frontend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"$(Build.SourcesDirectory)/build/test-results/TESTS-results-jest.xml\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -221,6 +253,12 @@ Object {
           CYPRESS_ENABLE_RECORD: false
           CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
           CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: \\"cypress-screenshots\\"
+          targetPath: \\"$(Build.SourcesDirectory)/build/cypress/screenshots\\"
+        condition: failed()
+        displayName: \\"E2E: Publish Cypress Screenshots\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -302,11 +340,24 @@ Object {
           command: \\"custom\\"
           customCommand: \\" run ci:backend:test\\"
         displayName: \\"TESTS: backend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"**/TEST-*.xml\\"
+          searchFolder: \\"$(Build.SourcesDirectory)/target/test-results\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
           customCommand: \\" run ci:frontend:test\\"
         displayName: \\"TESTS: frontend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"$(Build.SourcesDirectory)/target/test-results/TESTS-results-jest.xml\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -331,6 +382,12 @@ Object {
           CYPRESS_ENABLE_RECORD: true
           CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
           CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: \\"cypress-screenshots\\"
+          targetPath: \\"$(Build.SourcesDirectory)/target/cypress/screenshots\\"
+        condition: failed()
+        displayName: \\"E2E: Publish Cypress Screenshots\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -424,11 +481,24 @@ Object {
           command: \\"custom\\"
           customCommand: \\" run ci:backend:test\\"
         displayName: \\"TESTS: backend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"**/TEST-*.xml\\"
+          searchFolder: \\"$(Build.SourcesDirectory)/target/test-results\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
           customCommand: \\" run ci:frontend:test\\"
         displayName: \\"TESTS: frontend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"$(Build.SourcesDirectory)/target/test-results/TESTS-results-jest.xml\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -453,6 +523,12 @@ Object {
           CYPRESS_ENABLE_RECORD: false
           CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
           CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: \\"cypress-screenshots\\"
+          targetPath: \\"$(Build.SourcesDirectory)/target/cypress/screenshots\\"
+        condition: failed()
+        displayName: \\"E2E: Publish Cypress Screenshots\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -534,11 +610,24 @@ Object {
           command: \\"custom\\"
           customCommand: \\" run ci:backend:test\\"
         displayName: \\"TESTS: backend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"**/TEST-*.xml\\"
+          searchFolder: \\"$(Build.SourcesDirectory)/target/test-results\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
           customCommand: \\" run ci:frontend:test\\"
         displayName: \\"TESTS: frontend\\"
+      - task: PublishTestResults@2
+        inputs:
+          testResultsFormat: \\"JUnit\\"
+          testResultsFiles: \\"$(Build.SourcesDirectory)/target/test-results/TESTS-results-jest.xml\\"
+        condition: succeededOrFailed()
+        displayName: \\"TESTS: publish test results\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"
@@ -563,6 +652,12 @@ Object {
           CYPRESS_ENABLE_RECORD: false
           CYPRESS_PROJECT_ID: $(CYPRESS_PROJECT_ID)
           CYPRESS_RECORD_KEY: $(CYPRESS_RECORD_KEY)
+      - task: PublishPipelineArtifact@1
+        inputs:
+          artifactName: \\"cypress-screenshots\\"
+          targetPath: \\"$(Build.SourcesDirectory)/target/cypress/screenshots\\"
+        condition: failed()
+        displayName: \\"E2E: Publish Cypress Screenshots\\"
       - task: Npm@1
         inputs:
           command: \\"custom\\"


### PR DESCRIPTION
Upates Azure DevOps subgenerator:

- Publish test results for backend and frontend tests
- Publish Cypress screenshots if E2E tests failed

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
