### PR TITLE
supress detailed debug logging of handler mappings for reactive apps

### DIFF
--- a/generators/server/templates/src/main/resources/logback-spring.xml.ejs
+++ b/generators/server/templates/src/main/resources/logback-spring.xml.ejs
@@ -155,7 +155,11 @@
     <!-- See https://github.com/jhipster/generator-jhipster/issues/13835 -->
     <logger name="Validator" level="INFO"/>
     <!-- See https://github.com/jhipster/generator-jhipster/issues/14444 -->
+    <%_ if (!reactive) { _%>
     <logger name="_org.springframework.web.servlet.HandlerMapping.Mappings" level="INFO"/>
+    <%_ } else { _%>
+    <logger name="_org.springframework.web.reactive.HandlerMapping.Mappings" level="INFO"/>
+    <%_ } _%>
     <!-- jhipster-needle-logback-add-log - JHipster will add a new log with level -->
 
     <!-- https://logback.qos.ch/manual/configuration.html#shutdownHook and https://jira.qos.ch/browse/LOGBACK-1090 -->


### PR DESCRIPTION
Following https://github.com/jhipster/generator-jhipster/pull/15004. Suppressing noisy logs for reactive applications as the handler are different 

relates to #14444

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
