### PR TITLE
update openapi generator to version 5.1.1

### DIFF
--- a/generators/server/templates/gradle.properties.ejs
+++ b/generators/server/templates/gradle.properties.ejs
@@ -70,7 +70,7 @@ liquibasePluginVersion=2.0.4
 <%_ } _%>
 sonarqubePluginVersion=3.2.0
 <%_ if (enableSwaggerCodegen) { _%>
-openapiPluginVersion=4.3.1
+openapiPluginVersion=5.1.1
 <%_ } _%>
 noHttpPluginVersion=0.0.8
 checkstyleVersion=8.42

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -164,7 +164,7 @@
         <jib-maven-plugin.version><%= JIB_VERSION %></jib-maven-plugin.version>
         <lifecycle-mapping.version>1.0.0</lifecycle-mapping.version>
 <%_ if (enableSwaggerCodegen) { _%>
-        <openapi-generator-maven-plugin.version>4.3.1</openapi-generator-maven-plugin.version>
+        <openapi-generator-maven-plugin.version>5.1.1</openapi-generator-maven-plugin.version>
 <%_ } _%>
         <properties-maven-plugin.version>1.0.0</properties-maven-plugin.version>
         <sonar-maven-plugin.version>3.9.0.2155</sonar-maven-plugin.version>


### PR DESCRIPTION
Related with https://github.com/jhipster/generator-jhipster/issues/14287

- Updates the version of openapi generator maven plugin for server side code generation.
- Does not update the version of the npm package for client side code generation. Versioning has changed, I have to dig into it (see Configuration section in https://www.npmjs.com/package/@openapitools/openapi-generator-cli)

I was thinking about 2 separate PRs, but if you folks think it should be done here I'll keep this PR to fix the client too. 

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
