### PR TITLE
Fix wrong otherEntityName in relationship setter

### DIFF
--- a/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
+++ b/generators/entity-server/templates/src/main/java/package/domain/Entity.java.ejs
@@ -685,11 +685,11 @@ _%>
             this.<%= relationshipFieldName %>.set<%= otherEntityRelationshipNameCapitalized %>(null);
       <%_ } _%>
         }
-        if (<%= relationshipFieldName %> != null) {
+        if (<%= otherEntityName %> != null) {
       <%_ if (relationship.otherRelationship.reference.collection) { _%>
-            <%= relationshipFieldName %>.add<%= otherEntityRelationshipNameCapitalized %>(this);
+            <%= otherEntityName %>.add<%= otherEntityRelationshipNameCapitalized %>(this);
       <%_ } else { _%>
-            <%= relationshipFieldName %>.set<%= otherEntityRelationshipNameCapitalized %>(this);
+            <%= otherEntityName %>.set<%= otherEntityRelationshipNameCapitalized %>(this);
       <%_ } _%>
         }
     <%_ } _%>


### PR DESCRIPTION
I ran into this bug in one of my project, generated code is:  
```
    @JsonIgnoreProperties(value = { "student" }, allowSetters = true)
    @OneToOne(mappedBy = "student")
    private StudentForeignerInfo foreignerInfo;

    ......

    public void setForeignerInfo(StudentForeignerInfo studentForeignerInfo) {
        if (this.foreignerInfo != null) {
            this.foreignerInfo.setStudent(null);
        }
        if (foreignerInfo != null) {
            foreignerInfo.setStudent(this);
        }
        this.foreignerInfo = studentForeignerInfo;
    }
```
should be:  
```
    @JsonIgnoreProperties(value = { "student" }, allowSetters = true)
    @OneToOne(mappedBy = "student")
    private StudentForeignerInfo foreignerInfo;

    ......

    public void setForeignerInfo(StudentForeignerInfo studentForeignerInfo) {
        if (this.foreignerInfo != null) {
            this.foreignerInfo.setStudent(null);
        }
        if (studentForeignerInfo != null) {         // have to fix here
            studentForeignerInfo.setStudent(this);   // and here
        }
        this.foreignerInfo = studentForeignerInfo;
    }
```

In default case where name of $otherEntityName equals to name of $relationshipFieldName, the setter works well.   

However if name of $otherEntityName is customized, '$relationshipFieldName' will actually be explained as 'this.$relationshipFieldName' which was just set parent to null at the preceding line but again set back to 'this', this logic is apparently wrong.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
