### PR TITLE
Correct api base name in kafkaResourceIT reactive tests

### DIFF
--- a/generators/server/templates/src/test/java/package/web/rest/KafkaResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/KafkaResourceIT.java.ejs
@@ -102,7 +102,7 @@ class <%= upperFirstCamelCase(baseName) %>KafkaResourceIT {
             .andExpect(status().isOk())
             .andExpect(content().contentType(MediaType.APPLICATION_JSON));
         <%_ } else { _%>
-        client.post().uri("/api/jhipster-kafka/publish/topic-produce?message=value-produce")
+        client.post().uri("/api/<%= dasherizedBaseName %>-kafka/publish/topic-produce?message=value-produce")
             .exchange()
             .expectStatus().isOk()
             .expectHeader().contentType(MediaType.APPLICATION_JSON);
@@ -140,7 +140,7 @@ class <%= upperFirstCamelCase(baseName) %>KafkaResourceIT {
         }
         fail("Expected content data:value-consume not received");
         <%_ } else { _%>
-        String value = client.get().uri("/api/jhipster-kafka/consume?topic=topic-consume")
+        String value = client.get().uri("/api/<%= dasherizedBaseName %>-kafka/consume?topic=topic-consume")
             .accept(MediaType.TEXT_EVENT_STREAM)
             .exchange()
             .expectStatus().isOk()


### PR DESCRIPTION
When generating a reactive service (e.g. gateway), api base name in KafkaResourceIT tests does not match the actual api base name, which leads to integration tests fail eventually.

In generated Resource class, api is:
```
@RestController
@RequestMapping("/api/<%= dasherizedBaseName %>-kafka")
public class <%= upperFirstCamelCase(baseName) %>KafkaResource {

    @PostMapping("/publish/{topic}")
    public ........
```

in generated rest tests, it was :
```
    @Test
    void producesMessages()<% if (!reactive) { %> throws Exception<% } %> {
        <%_ if (!reactive) { _%>
        restMockMvc.perform(post("/api/<%= dasherizedBaseName %>-kafka/publish/topic-produce?message=value-produce"))
            .andExpect(status().isOk())
            .andExpect(content().contentType(MediaType.APPLICATION_JSON));
        <%_ } else { _%>
        client.post().uri("/api/jhipster-kafka/publish/topic-produce?message=value-produce")
            .exchange()
            .expectStatus().isOk()
            .expectHeader().contentType(MediaType.APPLICATION_JSON);
        <%_ } _%>
        ......
    }
```

When non-reactive, the api path is right though. The path should be nothing to do with if reactive or not.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
