### PR TITLE
refine webpack task input for gradle caching

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -149,6 +149,8 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
         this.JACKSON_DATABIND_NULLABLE_VERSION = constants.JACKSON_DATABIND_NULLABLE_VERSION;
 
         this.ANGULAR = constants.SUPPORTED_CLIENT_FRAMEWORKS.ANGULAR;
+        this.VUE = constants.SUPPORTED_CLIENT_FRAMEWORKS.VUE;
+        this.REACT = constants.SUPPORTED_CLIENT_FRAMEWORKS.REACT;
 
         this.packagejs = packagejs;
       },

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -48,21 +48,35 @@ bootRun {
 
 <%_ if (!skipClient) { _%>
 task webapp(type: NpmTask) {
+    inputs.property('appVersion', project.version)
     inputs.files("package-lock.json")
+        .withPropertyName('package-lock')
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.files("build.gradle")
+        .withPropertyName('build.gradle')
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ if (clientFramework === ANGULAR) { _%>
     inputs.files("angular.json")
+        .withPropertyName('angular.json')
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir("<%= CLIENT_WEBPACK_DIR %>")
+        .withPropertyName("<%= CLIENT_WEBPACK_DIR %>")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ } _%>
     inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
+        .withPropertyName("webapp-sources")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ if (clientFramework !== ANGULAR) { _%>
 
     def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>")
     webpackDevFiles.exclude("webpack.prod.js")
     inputs.files(webpackDevFiles)
+        .withPropertyName("webpack-client-dir")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ } _%>
 
     outputs.dir("<%= CLIENT_DIST_DIR %>")
+        .withPropertyName("webapp-build-dir")
 
     dependsOn npmInstall
 

--- a/generators/server/templates/gradle/profile_dev.gradle.ejs
+++ b/generators/server/templates/gradle/profile_dev.gradle.ejs
@@ -59,22 +59,32 @@ task webapp(type: NpmTask) {
     inputs.files("angular.json")
         .withPropertyName('angular.json')
         .withPathSensitivity(PathSensitivity.RELATIVE)
+    inputs.files("tsconfig.json", "tsconfig.app.json")
+        .withPropertyName("tsconfig")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
     inputs.dir("<%= CLIENT_WEBPACK_DIR %>")
         .withPropertyName("<%= CLIENT_WEBPACK_DIR %>")
         .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ } _%>
     inputs.dir("<%= CLIENT_MAIN_SRC_DIR %>")
-        .withPropertyName("webapp-sources")
+        .withPropertyName("webapp-source-dir")
         .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ if (clientFramework !== ANGULAR) { _%>
+    inputs.files("tsconfig.json")
+        .withPropertyName("tsconfig")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
 
     def webpackDevFiles = fileTree("<%= CLIENT_WEBPACK_DIR %>")
     webpackDevFiles.exclude("webpack.prod.js")
     inputs.files(webpackDevFiles)
-        .withPropertyName("webpack-client-dir")
+        .withPropertyName("webpack-dir")
         .withPathSensitivity(PathSensitivity.RELATIVE)
     <%_ } _%>
-
+    <%_ if (clientFramework === VUE) { _%>
+    inputs.files(".postcssrc")
+        .withPropertyName("postcssrc")
+        .withPathSensitivity(PathSensitivity.RELATIVE)
+    <%_ } _%>
     outputs.dir("<%= CLIENT_DIST_DIR %>")
         .withPropertyName("webapp-build-dir")
 


### PR DESCRIPTION
This PR sets names and relative path properties for webpack task inputs in gradle. With this it is in general possible to cache the task (still missing the cache buster being the hash of all i18n files instead of timestamp). This was found during our evaluation of gradle enterprise. 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
