### PR TITLE
Download Chrome quietly on pipeline

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -92,7 +92,7 @@ jobs:
           versionSpec: '$(JHI_NODE_VERSION)'
         displayName: 'TOOLS: install Node.js'
       - script: |
-          wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+          wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
           sudo apt install ./google-chrome-stable_current_amd64.deb
         displayName: 'TOOLS: install google-chrome-stable'
 

--- a/generators/ci-cd/templates/azure-pipelines.yml.ejs
+++ b/generators/ci-cd/templates/azure-pipelines.yml.ejs
@@ -44,7 +44,7 @@ jobs:
   <%= commented %>  inputs:
   <%= commented %>    targetType: 'inline'
   <%= commented %>    script: |
-  <%= commented %>      wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+  <%= commented %>      wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
   <%= commented %>      sudo apt install ./google-chrome-stable_current_amd64.deb
   <%= commented %>  displayName: 'TOOLS: install Chrome'
 <%_ } _%>

--- a/test/__snapshots__/ci-cd.spec.js.snap
+++ b/test/__snapshots__/ci-cd.spec.js.snap
@@ -54,7 +54,7 @@ Object {
         inputs:
           targetType: \\"inline\\"
           script: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo apt install ./google-chrome-stable_current_amd64.deb
         displayName: \\"TOOLS: install Chrome\\"
       #----------------------------------------------------------------------
@@ -183,7 +183,7 @@ Object {
         inputs:
           targetType: \\"inline\\"
           script: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo apt install ./google-chrome-stable_current_amd64.deb
         displayName: \\"TOOLS: install Chrome\\"
       #----------------------------------------------------------------------
@@ -324,7 +324,7 @@ Object {
         inputs:
           targetType: \\"inline\\"
           script: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo apt install ./google-chrome-stable_current_amd64.deb
         displayName: \\"TOOLS: install Chrome\\"
       #----------------------------------------------------------------------
@@ -453,7 +453,7 @@ Object {
         inputs:
           targetType: \\"inline\\"
           script: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo apt install ./google-chrome-stable_current_amd64.deb
         displayName: \\"TOOLS: install Chrome\\"
       #----------------------------------------------------------------------
@@ -594,7 +594,7 @@ Object {
         inputs:
           targetType: \\"inline\\"
           script: |
-            wget https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
+            wget -q https://dl.google.com/linux/direct/google-chrome-stable_current_amd64.deb
             sudo apt install ./google-chrome-stable_current_amd64.deb
         displayName: \\"TOOLS: install Chrome\\"
       #----------------------------------------------------------------------


### PR DESCRIPTION
<!--
PR description.
-->

Uses `-q` flag on wget to download Chrome quietly. Otherwise ~1000 lines of download progress are printed.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
