### PR TITLE
downgrade gradle

### DIFF
--- a/generators/generator-constants.js
+++ b/generators/generator-constants.js
@@ -29,7 +29,7 @@ const NODE_VERSION = '14.16.0';
 const NPM_VERSION = commonPackageJson.devDependencies.npm;
 const OPENAPI_GENERATOR_CLI_VERSION = '1.0.13-4.3.1';
 
-const GRADLE_VERSION = '7.1';
+const GRADLE_VERSION = '7.0.2';
 const JIB_VERSION = '3.1.1';
 
 // Libraries version

--- a/generators/server/templates/build.gradle.ejs
+++ b/generators/server/templates/build.gradle.ejs
@@ -600,6 +600,7 @@ dependencies {
     <%_ if (cacheProvider === 'redis') { %>
     testImplementation "org.testcontainers:testcontainers"
     <%_ } _%>
+    developmentOnly "org.springframework.boot:spring-boot-devtools:${springBootVersion}"
     //jhipster-needle-gradle-dependency - JHipster will add additional dependencies here
 }
 


### PR DESCRIPTION
Downgrade gradle to see if its related. Moving spring boot devtools to main build files as development only ensures its not packaged in the executable jar.

updates #15359

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
