### PR TITLE
Disable fork for deployments.

### DIFF
--- a/cli/import-jdl.js
+++ b/cli/import-jdl.js
@@ -259,7 +259,7 @@ const generateDeploymentFiles = ({ processor, deployment }) => {
   const cwd = path.join(processor.pwd, deploymentType);
   logger.debug(`Child process will be triggered for ${jhipsterCli} with cwd: ${cwd}`);
 
-  return runGenerator(deploymentType, { cwd, fork: true }, { force: true, ...processor.options, skipPrompts: true });
+  return runGenerator(deploymentType, { cwd, fork: false }, { force: true, ...processor.options, skipPrompts: true });
 };
 
 /**
@@ -469,13 +469,10 @@ class JDLProcessor {
           throw error;
         }
       };
-      if (this.interactive) {
-        // Queue callGenerator in chain
-        return this.importState.exportedDeployments.reduce((promise, deployment) => {
-          return promise.then(() => callGenerator(deployment));
-        }, Promise.resolve());
-      }
-      return Promise.all(this.importState.exportedDeployments.map(callGenerator));
+      // Queue callGenerator in chain
+      return this.importState.exportedDeployments.reduce((promise, deployment) => {
+        return promise.then(() => callGenerator(deployment));
+      }, Promise.resolve());
     };
 
     return callDeploymentGenerator();

--- a/test/cli/import-jdl.spec.js
+++ b/test/cli/import-jdl.spec.js
@@ -123,7 +123,7 @@ describe('JHipster generator import jdl', () => {
 
     it('calls generator in order', () => {
       expect(subGenCallParams.count).to.equal(5);
-      expect(subGenCallParams.commands).to.eql(['app', 'app', 'app', 'docker-compose', 'kubernetes']);
+      expect(subGenCallParams.commands).to.eql(['app', 'app', 'app', 'jhipster:docker-compose', 'jhipster:kubernetes']);
       expect(subGenCallParams.options[0]).to.eql([
         '--reproducible',
         '--force',
@@ -132,7 +132,13 @@ describe('JHipster generator import jdl', () => {
         '--no-insight',
         '--from-jdl',
       ]);
-      expect(subGenCallParams.options[3]).to.eql(['--force', '--skip-install', '--no-insight', '--skip-prompts', '--from-jdl']);
+      expect(subGenCallParams.options[3]).to.eql({
+        force: true,
+        skipInstall: true,
+        fromJdl: true,
+        noInsight: true,
+        skipPrompts: true,
+      });
     });
   });
 
@@ -623,10 +629,16 @@ describe('JHipster generator import jdl', () => {
       ]);
     });
     it('calls deployment generator', () => {
-      const invokedSubgens = ['docker-compose', 'kubernetes', 'openshift'];
+      const invokedSubgens = ['jhipster:docker-compose', 'jhipster:kubernetes', 'jhipster:openshift'];
       expect(subGenCallParams.commands).to.eql(invokedSubgens);
       expect(subGenCallParams.count).to.equal(invokedSubgens.length);
-      expect(subGenCallParams.options[0]).to.eql(['--force', '--skip-install', '--no-skip-git', '--skip-prompts', '--from-jdl']);
+      expect(subGenCallParams.options[0]).to.eql({
+        force: true,
+        skipInstall: true,
+        skipGit: false,
+        fromJdl: true,
+        skipPrompts: true,
+      });
     });
   });
 
@@ -645,7 +657,7 @@ describe('JHipster generator import jdl', () => {
 
       it('calls generator in order', () => {
         expect(subGenCallParams.count).to.equal(5);
-        expect(subGenCallParams.commands).to.eql(['app', 'app', 'app', 'docker-compose', 'kubernetes']);
+        expect(subGenCallParams.commands).to.eql(['app', 'app', 'app', 'jhipster:docker-compose', 'jhipster:kubernetes']);
         expect(subGenCallParams.options[0]).to.eql([
           '--reproducible',
           '--force',
@@ -655,14 +667,14 @@ describe('JHipster generator import jdl', () => {
           '--no-skip-git',
           '--from-jdl',
         ]);
-        expect(subGenCallParams.options[3]).to.eql([
-          '--force',
-          '--skip-install',
-          '--no-insight',
-          '--no-skip-git',
-          '--skip-prompts',
-          '--from-jdl',
-        ]);
+        expect(subGenCallParams.options[3]).to.eql({
+          force: true,
+          skipInstall: true,
+          skipGit: false,
+          noInsight: true,
+          fromJdl: true,
+          skipPrompts: true,
+        });
       });
     });
     describe('creates config files', () => {


### PR DESCRIPTION
Problem: when executing jdl with a custom blueprint option (from app generator) like `jhipster jdl microservice.jdl --blueprints kotlin --skip-ktlint-format`, jdl command with fork serializes options back to cli options and executes deployments generators using cli with every option (eg: jhipster docker-compose --blueprints kotlin --skip-ktlint-format), causing an unknown option error.

Fork is supposed to run multiples generators in parallel making it faster, but deployments are small and will not have a big impact on the execution time.

Drop fork support for deployments, preventing the unknown option error.

Closes https://github.com/jhipster/generator-jhipster/issues/14870.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
