### PR TITLE
Fix readiness include

### DIFF
--- a/generators/server/templates/src/main/resources/config/application.yml.ejs
+++ b/generators/server/templates/src/main/resources/config/application.yml.ejs
@@ -115,7 +115,7 @@ management:
       liveness:
         include: livenessState
       readiness:
-        include: readinessState<% if (databaseType === 'sql') { %>,datasource<% } %>
+        include: readinessState<% if (databaseType === 'sql') { %>,db<% } %>
     mail:
       enabled: false # When using the MailService, configure an SMTP server and set this to true
   metrics:


### PR DESCRIPTION
<!--
PR description.
-->

According to [the documentation](https://docs.spring.io/spring-boot/docs/current/reference/html/actuator.html#actuator.endpoints.health.auto-configured-health-indicators) the indicator for the Database should be `db`.

But I think the best way would be to remove this configuration entirely. Because Spring automatically includes them:

> The following HealthIndicators are auto-configured by Spring Boot when appropriate

What to you think?

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
