### PR TITLE
Improve maven up-to-date.

### DIFF
--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -252,6 +252,7 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
       loadSharedConfig() {
         this.loadAppConfig();
         this.loadClientConfig();
+        this.loadDerivedClientConfig();
         this.loadServerConfig();
         this.loadTranslationConfig();
       },

--- a/generators/server/templates/pom.xml.ejs
+++ b/generators/server/templates/pom.xml.ejs
@@ -1544,10 +1544,21 @@
                         <version>${checksum-maven-plugin.version}</version>
                         <executions>
                             <execution>
+                                <id>create-pre-compiled-webapp-checksum</id>
                                 <goals>
                                     <goal>files</goal>
                                 </goals>
                                 <phase>generate-resources</phase>
+                            </execution>
+                            <execution>
+                                <id>create-compiled-webapp-checksum</id>
+                                <goals>
+                                    <goal>files</goal>
+                                </goals>
+                                <phase>compile</phase>
+                                <configuration>
+                                    <csvSummaryFile>checksums.csv.old</csvSummaryFile>
+                                </configuration>
                             </execution>
                         </executions>
                         <configuration>
@@ -1556,8 +1567,20 @@
                                     <directory>${project.basedir}</directory>
                                     <includes>
                                         <include><%= MAIN_DIR %>webapp/**/*.*</include>
+                                        <include>target/classes/static/**/*.*</include>
+                                        <include>package-lock.json</include>
                                         <include>package.json</include>
                                         <include>webpack/*.*</include>
+                                        <include>tsconfig.json</include>
+<%_ if (clientFrameworkAngular) { _%>
+                                        <include>tsconfig.app.json</include>
+<%_ } _%>
+<%_ if (clientFrameworkReact) { _%>
+                                        <include>.postcss.config.js</include>
+<%_ } _%>
+<%_ if (clientFrameworkVue) { _%>
+                                        <include>.postcssrc.js</include>
+<%_ } _%>
                                     </includes>
                                     <excludes>
                                         <exclude>**/app/**/service-worker.js</exclude>
@@ -1595,7 +1618,6 @@
                                                 <filesmatch file1="${project.build.directory}/checksums.csv" file2="${project.build.directory}/checksums.csv.old" />
                                             </and>
                                         </condition>
-                                        <copy file="${project.build.directory}/checksums.csv" tofile="${project.build.directory}/checksums.csv.old"/>
                                     </target>
                                     <exportAntProperties>true</exportAntProperties>
                                 </configuration>


### PR DESCRIPTION
This PR splits maven up-to-date checksum into 2.
1. Generate a checksum to compare against reference.
2. Generate a complete checksum (generated webapp included) for reference.

Fixes problems where the generated webapp mutated but not the source.
Eg: `./mvn -Pprod`, `npm run clean-www`, `jhipster --with-entities`.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
