### PR TITLE
Move project name out from init generator.

### DIFF
--- a/cli/commands.js
+++ b/cli/commands.js
@@ -63,7 +63,7 @@ const defaultCommands = {
     desc: 'Display information about your current project and system',
   },
   init: {
-    desc: 'Init project',
+    desc: 'Init project (alpha)',
   },
   jdl: {
     alias: 'import-jdl',
@@ -160,7 +160,7 @@ const defaultCommands = {
     desc: 'Create a new page. (Supports vue clients)',
   },
   'project-name': {
-    desc: 'Configure project name',
+    desc: 'Configure project name (alpha)',
   },
   run: {
     desc: 'Run a module or custom generator',

--- a/cli/commands.js
+++ b/cli/commands.js
@@ -159,6 +159,9 @@ const defaultCommands = {
   page: {
     desc: 'Create a new page. (Supports vue clients)',
   },
+  'project-name': {
+    desc: 'Configure project name',
+  },
   run: {
     desc: 'Run a module or custom generator',
     argument: ['[generator]'],

--- a/generators/config.js
+++ b/generators/config.js
@@ -16,15 +16,12 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Required config to be skipped */
-const requiredConfig = {};
+const { requiredConfig: initRequiredConfig, defaultConfig: initDefaultConfig } = require('./init/config');
+const { requiredConfig: projectNameRequiredConfig, defaultConfig: projectNameDefaultConfig } = require('./project-name/config');
 
-/** Init default config for templates */
-const defaultConfig = {
-  ...requiredConfig,
-  prettierDefaultIndent: 2,
-  prettierJavaIndent: 4,
-  skipCommitHook: false,
+module.exports = {
+  initDefaultConfig,
+  initRequiredConfig,
+  projectNameDefaultConfig,
+  projectNameRequiredConfig,
 };
-
-module.exports = { requiredConfig, defaultConfig };

--- a/generators/generator-list.js
+++ b/generators/generator-list.js
@@ -45,6 +45,7 @@ const Generators = {
   GENERATOR_INIT: 'init',
   GENERATOR_LANGUAGES: 'languages',
   GENERATOR_PAGE: 'page',
+  GENERATOR_PROJECT_NAME: 'project-name',
   GENERATOR_SERVER: 'server',
 };
 

--- a/generators/init/options.js
+++ b/generators/init/options.js
@@ -18,18 +18,6 @@
  */
 
 module.exports.options = {
-  'jhipster-version': {
-    desc: 'Force jhipsterVersion for reproducibility',
-    type: String,
-    hide: true,
-    scope: 'storage',
-  },
-  'base-name': {
-    desc: 'Application base name',
-    type: String,
-    scope: 'storage',
-    hide: true,
-  },
   'skip-commit-hook': {
     desc: 'Skip adding husky commit hooks',
     type: Boolean,

--- a/generators/options.js
+++ b/generators/options.js
@@ -17,6 +17,7 @@
  * limitations under the License.
  */
 const { options: initOptions } = require('./init/options');
+const { options: projectNameOptions } = require('./project-name/options');
 
 const commonOptions = {
   defaults: {
@@ -28,4 +29,5 @@ const commonOptions = {
 module.exports = {
   commonOptions,
   initOptions,
+  projectNameOptions,
 };

--- a/generators/project-name/config.js
+++ b/generators/project-name/config.js
@@ -16,15 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+const { version: jhipsterVersion } = require('../../package.json');
+
 /** Required config to be skipped */
-const requiredConfig = {};
+const requiredConfig = {
+  jhipsterVersion,
+  projectName: 'JHipster project',
+};
 
 /** Init default config for templates */
 const defaultConfig = {
   ...requiredConfig,
-  prettierDefaultIndent: 2,
-  prettierJavaIndent: 4,
-  skipCommitHook: false,
 };
 
 module.exports = { requiredConfig, defaultConfig };

--- a/generators/project-name/index.js
+++ b/generators/project-name/index.js
@@ -1,0 +1,151 @@
+/**
+ * Copyright 2013-2021 the original author or authors from the JHipster project.
+ *
+ * This file is part of the JHipster project, see https://www.jhipster.tech/
+ * for more information.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/* eslint-disable consistent-return */
+const chalk = require('chalk');
+
+const BaseBlueprintGenerator = require('../generator-base-blueprint');
+const { GENERATOR_PROJECT } = require('../generator-list');
+const { defaultConfig } = require('./config');
+
+module.exports = class extends BaseBlueprintGenerator {
+  constructor(args, opts) {
+    super(args, opts, { unique: 'namespace' });
+
+    this.registerCommonOptions();
+    this.registerProjectNameOptions();
+
+    if (this.options.help) return;
+
+    if (this.options.defaults) {
+      this.configureProjectName();
+    }
+
+    if (!this.fromBlueprint) {
+      this.instantiateBlueprints(GENERATOR_PROJECT);
+    }
+  }
+
+  _initializing() {
+    return {
+      validateFromCli() {
+        this.checkInvocationFromCLI();
+      },
+      sayHello() {
+        if (!this.showHello()) return;
+        this.log(chalk.white('⬢ Welcome to the JHipster Project Name ⬢'));
+      },
+      loadRuntimeOptions() {
+        this.loadRuntimeOptions();
+      },
+      // TODO move to prompting once queueing composed generator before current support is added.
+      async showPrompts() {
+        if (this.options.defaults || this.options.skipPrompts || (this.existingModularProject && !this.options.askAnswered)) return;
+        await this.prompt(
+          [
+            {
+              name: 'projectName',
+              when: () => !this.abort,
+              type: 'input',
+              message: 'What is the project name of your application?',
+              default: () => this._getDefaultProjectName(),
+            },
+            {
+              name: 'baseName',
+              when: () => !this.abort,
+              type: 'input',
+              validate: input => this._validateBaseName(input),
+              message: 'What is the base name of your application?',
+              default: () => this.getDefaultAppName(),
+            },
+          ],
+          this.config
+        );
+      },
+    };
+  }
+
+  get initializing() {
+    if (this.fromBlueprint) return;
+    return this._initializing();
+  }
+
+  _prompting() {
+    return {};
+  }
+
+  get prompting() {
+    if (this.fromBlueprint) return;
+    return this._prompting();
+  }
+
+  _configuring() {
+    return {
+      configure() {
+        this.configureProjectName();
+      },
+    };
+  }
+
+  get configuring() {
+    if (this.fromBlueprint) return;
+    return this._configuring();
+  }
+
+  _loading() {
+    return {
+      loadConfig() {
+        this.loadProjectNameConfig();
+      },
+    };
+  }
+
+  get loading() {
+    if (this.fromBlueprint) return;
+    return this._loading();
+  }
+
+  /*
+   * Start of local public API, blueprints may override to customize the generator behavior.
+   */
+
+  /**
+   * @returns default app name
+   */
+  _getDefaultProjectName() {
+    return defaultConfig.projectName;
+  }
+
+  /**
+   * Validates baseName
+   * @param String input - Base name to be checked
+   * @returns Boolean
+   */
+  _validateBaseName(input) {
+    if (!/^([a-zA-Z0-9_]*)$/.test(input)) {
+      return 'Your base name cannot contain special characters or a blank space';
+    }
+    if (/_/.test(input)) {
+      return 'Your base name cannot contain underscores as this does not meet the URI spec';
+    }
+    if (input === 'application') {
+      return "Your base name cannot be named 'application' as this is a reserved name for Spring Boot";
+    }
+    return true;
+  }
+};

--- a/generators/project-name/options.js
+++ b/generators/project-name/options.js
@@ -16,15 +16,17 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-/** Required config to be skipped */
-const requiredConfig = {};
 
-/** Init default config for templates */
-const defaultConfig = {
-  ...requiredConfig,
-  prettierDefaultIndent: 2,
-  prettierJavaIndent: 4,
-  skipCommitHook: false,
+module.exports.options = {
+  'jhipster-version': {
+    desc: 'Force jhipsterVersion for reproducibility',
+    type: String,
+    hide: true,
+    scope: 'storage',
+  },
+  'base-name': {
+    desc: 'Application base name',
+    type: String,
+    scope: 'storage',
+  },
 };
-
-module.exports = { requiredConfig, defaultConfig };

--- a/test/init/__snapshots__/init.spec.js.snap
+++ b/test/init/__snapshots__/init.spec.js.snap
@@ -5,9 +5,9 @@ Object {
   ".yo-rc.json": Object {
     "contents": "{
   \\"generator-jhipster\\": {
-    \\"baseName\\": \\"BeautifulProject\\",
+    \\"baseName\\": \\"existing\\",
     \\"jhipsterVersion\\": \\"0.0.0\\",
-    \\"projectName\\": \\"Beautiful Project\\",
+    \\"projectName\\": \\"JHipster project\\",
     \\"prettierDefaultIndent\\": 4,
     \\"prettierJavaIndent\\": 2
   }
@@ -42,10 +42,26 @@ Object {
     "contents": "{
   \\"generator-jhipster\\": {
     \\"jhipsterVersion\\": \\"0.0.0\\",
-    \\"projectName\\": \\"Beautiful Project\\",
-    \\"baseName\\": \\"BeautifulProject\\",
+    \\"baseName\\": \\"jhipster\\",
+    \\"projectName\\": \\"JHipster project\\",
     \\"prettierDefaultIndent\\": 4,
     \\"prettierJavaIndent\\": 2
+  }
+}
+",
+    "stateCleared": "modified",
+  },
+}
+`;
+
+exports[`JHipster init generator with custom prompt values and defaults option should not write custom config to .yo-rc.json 1`] = `
+Object {
+  ".yo-rc.json": Object {
+    "contents": "{
+  \\"generator-jhipster\\": {
+    \\"jhipsterVersion\\": \\"0.0.0\\",
+    \\"baseName\\": \\"jhipster\\",
+    \\"projectName\\": \\"JHipster project\\"
   }
 }
 ",

--- a/test/project-name/project-name.spec.js
+++ b/test/project-name/project-name.spec.js
@@ -1,0 +1,88 @@
+const path = require('path');
+const expect = require('expect');
+
+const { skipPrettierHelpers: helpers } = require('../utils/utils');
+const { requiredConfig, defaultConfig } = require('../../generators/project-name/config');
+const { GENERATOR_JHIPSTER } = require('../../generators/generator-constants');
+
+const projectNameGeneratorPath = path.join(__dirname, '../../generators/project-name');
+
+const testDefaultConfig = { ...requiredConfig, jhipsterVersion: '0.0.0' };
+
+describe('JHipster project-name generator', () => {
+  describe('with defaults option', () => {
+    let runResult;
+    before(async () => {
+      runResult = await helpers.run(projectNameGeneratorPath).withOptions({ defaults: true });
+    });
+    it('should write config to .yo-rc.json', () => {
+      runResult.assertJsonFileContent('.yo-rc.json', { [GENERATOR_JHIPSTER]: testDefaultConfig });
+    });
+    it('should load default config into the generator', () => {
+      expect(runResult.generator).toMatchObject({ ...defaultConfig, ...testDefaultConfig });
+    });
+  });
+  describe('with skipPrompts option', () => {
+    let runResult;
+    before(async () => {
+      runResult = await helpers.run(projectNameGeneratorPath).withOptions({ skipPrompts: true });
+    });
+    it('should write config to .yo-rc.json', () => {
+      runResult.assertJsonFileContent('.yo-rc.json', { [GENERATOR_JHIPSTER]: testDefaultConfig });
+    });
+    it('should load default config into the generator', () => {
+      expect(runResult.generator).toMatchObject({ ...defaultConfig, ...testDefaultConfig });
+    });
+  });
+  describe('with custom prompt values', () => {
+    let runResult;
+    const promptValues = {
+      projectName: 'Beautiful Project',
+      baseName: 'BeautifulProject',
+    };
+    describe('and default options', () => {
+      before(async () => {
+        runResult = await helpers.run(projectNameGeneratorPath).withPrompts(promptValues);
+      });
+      it('should write custom config to .yo-rc.json', () => {
+        runResult.assertJsonFileContent('.yo-rc.json', { [GENERATOR_JHIPSTER]: promptValues });
+      });
+    });
+    describe('and skipPrompts option', () => {
+      let runResult;
+      before(async () => {
+        runResult = await helpers
+          .run(projectNameGeneratorPath)
+          .withOptions({ skipPrompts: true, baseName: 'jhipster' })
+          .withPrompts(promptValues);
+      });
+      it('should write default values to .yo-rc.json', () => {
+        runResult.assertJsonFileContent('.yo-rc.json', { [GENERATOR_JHIPSTER]: testDefaultConfig });
+      });
+    });
+    describe('and existing config', () => {
+      let runResult;
+      before(async () => {
+        runResult = await helpers
+          .run(projectNameGeneratorPath)
+          .withOptions({ localConfig: { baseName: 'existing' } })
+          .withPrompts(promptValues);
+      });
+      it('should not write custom prompt values', () => {
+        runResult.assertJsonFileContent('.yo-rc.json', { [GENERATOR_JHIPSTER]: testDefaultConfig });
+      });
+    });
+    describe('and askAnswered option on an exiting project', () => {
+      let runResult;
+      before(async () => {
+        runResult = await helpers
+          .run(projectNameGeneratorPath)
+          .withOptions({ askAnswered: true, localConfig: { baseName: 'existing' } })
+          .withPrompts(promptValues);
+      });
+      it('should write custom prompt values', () => {
+        runResult.assertJsonFileContent('.yo-rc.json', { [GENERATOR_JHIPSTER]: promptValues });
+      });
+    });
+  });
+});


### PR DESCRIPTION
Project name and base name are required by every generator.
Split them in another generator, this will allow others generators to don't depend on init generator.

Related to https://github.com/jhipster/generator-jhipster/pull/15540 and https://github.com/jhipster/generator-jhipster/issues/15490
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
