### PR TITLE
Replace deprecated API for Kafka testcontainer

### DIFF
--- a/generators/server/templates/src/test/java/package/web/rest/KafkaResourceIT.java.ejs
+++ b/generators/server/templates/src/test/java/package/web/rest/KafkaResourceIT.java.ejs
@@ -36,6 +36,7 @@ import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.test.web.reactive.server.WebTestClient;
 <%_ } _%>
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.utility.DockerImageName;
 
 import java.time.Duration;
 import java.util.Collections;
@@ -72,7 +73,7 @@ class <%= upperFirstCamelCase(baseName) %>KafkaResourceIT {
     private static void startTestcontainer() {
         // TODO: withNetwork will need to be removed soon
         // See discussion at https://github.com/jhipster/generator-jhipster/issues/11544#issuecomment-609065206
-        kafkaContainer = new KafkaContainer("<%= KAFKA_VERSION %>").withNetwork(null);
+        kafkaContainer = new KafkaContainer(DockerImageName.parse("<%= DOCKER_KAFKA %>")).withNetwork(null);
         kafkaContainer.start();
     }
 
@@ -170,4 +171,3 @@ class <%= upperFirstCamelCase(baseName) %>KafkaResourceIT {
         return consumerProps;
     }
 }
-


### PR DESCRIPTION
<!--
PR description.
-->

Replace deprecated Java API for Kafka testcontainer and use the `DockerImageName` class.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
