### PR TITLE
Fix dependabot p-queue ignored version

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,11 +8,10 @@ updates:
     labels:
       - 'theme: jhipster-internals'
       - 'theme: dependencies'
-    ignored_updates:
-      - match:
-          dependency_name: 'p-queue'
-          # ESM only version
-          version_requirement: '>=7'
+    ignore:
+      # ESM only version
+      - dependency-name: 'p-queue'
+        versions: '>=7'
 
   - package-ecosystem: 'npm'
     directory: '/generators/client/templates/angular/'


### PR DESCRIPTION
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
