### PR TITLE
Adjusts workflows filters.

### DIFF
--- a/.github/workflows/angular.yml
+++ b/.github/workflows/angular.yml
@@ -28,6 +28,7 @@ on:
       - 'dependabot/**'
       - 'skip_ci*'
     paths-ignore:
+      - 'package*.json'
       - 'generators/*client/templates/react/**'
       - 'generators/*client/templates/vue/**'
   pull_request:

--- a/.github/workflows/jdl.yml
+++ b/.github/workflows/jdl.yml
@@ -27,6 +27,8 @@ on:
     branches-ignore:
       - 'dependabot/**'
       - 'skip_ci*'
+    paths-ignore:
+      - 'package*.json'
   pull_request:
     types: [closed, opened, synchronize, reopened]
     branches:

--- a/.github/workflows/react.yml
+++ b/.github/workflows/react.yml
@@ -28,6 +28,7 @@ on:
       - 'dependabot/**'
       - 'skip_ci*'
     paths-ignore:
+      - 'package*.json'
       - 'generators/*client/templates/angular/**'
       - 'generators/*client/templates/vue/**'
   pull_request:

--- a/.github/workflows/vue.yml
+++ b/.github/workflows/vue.yml
@@ -28,6 +28,7 @@ on:
       - 'dependabot/**'
       - 'skip_ci*'
     paths-ignore:
+      - 'package*.json'
       - 'generators/*client/templates/angular/**'
       - 'generators/*client/templates/react/**'
   pull_request:

--- a/.github/workflows/webflux.yml
+++ b/.github/workflows/webflux.yml
@@ -28,6 +28,7 @@ on:
       - 'dependabot/**'
       - 'skip_ci*'
     paths-ignore:
+      - 'package*.json'
       - 'generators/*client/templates/react/**'
       - 'generators/*client/templates/vue/**'
   pull_request:

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -19,7 +19,8 @@
 trigger:
   branches:
     exclude:
-      - dependabot/*
+      - dependabot/npm_and_yarn/generators/*
+      - dependabot/github_actions/*
 jobs:
   - job: Test
     condition: not(contains(variables['System.PullRequest.SourceBranch'], 'dependabot'))


### PR DESCRIPTION
Dependabot at root package.json is unlikely to break a specific application/workflow. It will break the generation.
Testing a few builds is enough.
- Enable at azure for PR and merge.
- Disable at gh actions for merge, PR is disabled already.

Related to https://github.com/jhipster/generator-jhipster/issues/14566.
<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
