### PR TITLE
Fix visualization of large images on angular

### DIFF
--- a/generators/client/templates/angular/src/main/webapp/app/core/util/data-util.service.spec.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/data-util.service.spec.ts.ejs
@@ -41,11 +41,12 @@ describe('Data Utils Service Test', () => {
       const newWindow = { ...window };
       newWindow.document.write = jest.fn();
       window.open = jest.fn(() => newWindow);
+      window.URL.createObjectURL = jest.fn();
       // 'JHipster' in base64 is 'SkhpcHN0ZXI='
       const data = 'SkhpcHN0ZXI=';
       const contentType = 'text/plain';
       service.openFile(data, contentType);
-      expect(newWindow.document.write).toHaveBeenCalledWith(expect.stringContaining('src="data:text/plain;base64,SkhpcHN0ZXI="'));
+      expect(window.open).toHaveBeenCalledTimes(1);
     });
   });
 });

--- a/generators/client/templates/angular/src/main/webapp/app/core/util/data-util.service.ts.ejs
+++ b/generators/client/templates/angular/src/main/webapp/app/core/util/data-util.service.ts.ejs
@@ -47,28 +47,27 @@ export class DataUtils {
    */
   openFile(data: string, contentType: string | null | undefined): void {
     contentType = contentType ?? '';
+    
+    const byteCharacters = atob(data);
+    const byteNumbers = new Array(byteCharacters.length);
+    for (let i = 0; i < byteCharacters.length; i++) {
+      byteNumbers[i] = byteCharacters.charCodeAt(i);
+    }
+    const byteArray = new Uint8Array(byteNumbers);
+    const blob = new Blob([byteArray], {
+      type: contentType,
+    });
     // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
     if (window.navigator.msSaveOrOpenBlob) {
       // To support IE
-      const byteCharacters = atob(data);
-      const byteNumbers = new Array(byteCharacters.length);
-      for (let i = 0; i < byteCharacters.length; i++) {
-        byteNumbers[i] = byteCharacters.charCodeAt(i);
-      }
-      const byteArray = new Uint8Array(byteNumbers);
-      const blob = new Blob([byteArray], {
-        type: contentType,
-      });
       window.navigator.msSaveOrOpenBlob(blob);
     } else {
       // Other browsers
-      const fileURL = `data:${contentType};base64,${data}`;
-      const win = window.open();
-      win?.document.write(
-        '<iframe src="' +
-          fileURL +
-          '" frameborder="0" style="border:0; top:0; left:0; bottom:0; right:0; width:100%; height:100%;" allowfullscreen></iframe>'
-      );
+      const fileURL = window.URL.createObjectURL(blob);
+      const win = window.open(fileURL);
+      win!.onload = function() {
+        URL.revokeObjectURL(fileURL);
+      }  
     }
   }
 

--- a/generators/entity-client/templates/angular/src/main/webapp/app/entities/detail/entity-management-detail.component.spec.ts.ejs
+++ b/generators/entity-client/templates/angular/src/main/webapp/app/entities/detail/entity-management-detail.component.spec.ts.ejs
@@ -85,6 +85,11 @@ describe('Component Tests', () => {
 
         describe('openFile', () => {
             it('Should call openFile from DataUtils', () => {
+                const newWindow = { ...window };
+                newWindow.document.write = jest.fn();
+                window.open = jest.fn(() => newWindow);
+                window.onload = jest.fn(() => newWindow);
+                window.URL.createObjectURL = jest.fn();
                 // GIVEN
                 jest.spyOn(dataUtils, 'openFile');
                 const fakeContentType = 'fake content type';


### PR DESCRIPTION
<!--
PR description.
-->

Big images not are loaded after click on it on chrome 91.0.4472.124 or Microsoft Edge 91.0.864.67 under windows 10. Works fine on Firefox.

The error can be reproduced with this project.
https://github.com/CGarces/testimgJHipster
Fails with the bigger image at fake data, the others works fine.
https://github.com/CGarces/testimgJHipster/tree/main/src/main/resources/config/liquibase/fake-data/blob
And can be fixed with this patch
https://github.com/CGarces/testimgJHipster/compare/fix_img?expand=1

The error only happens if is loaded by the openFile function. 

The proposed solution just works for me on angular, I haven't test the issue on other web frameworks. I don't know why the iframe is needed, please give me some background about that to improve the PR.

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
