### PR TITLE
Improvements to npm install

### DIFF
--- a/generators/client/templates/angular/package.json.ejs
+++ b/generators/client/templates/angular/package.json.ejs
@@ -99,6 +99,7 @@
     "@angular/compiler-cli": "<%= dependabotPackageJson.dependencies['@angular/common'] %>",
     "@angular-builders/custom-webpack": "<%= dependabotPackageJson.devDependencies['@angular-builders/custom-webpack'] %>",
     "@angular-builders/jest": "<%= dependabotPackageJson.devDependencies['@angular-builders/jest'] %>",
+    "@angular-devkit/build-angular": "<%= dependabotPackageJson.devDependencies['@angular/cli'] %>",
     "@angular/service-worker": "<%= dependabotPackageJson.dependencies['@angular/common'] %>",
     "@angular-eslint/eslint-plugin": "<%= dependabotPackageJson.devDependencies['@angular-eslint/eslint-plugin'] %>",
     "@types/jest": "<%= dependabotPackageJson.devDependencies['@types/jest'] %>",

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -18,7 +18,6 @@
  */
 /* eslint-disable consistent-return */
 const chalk = require('chalk');
-const { stat } = require('fs').promises;
 const _ = require('lodash');
 const os = require('os');
 const prompts = require('./prompts');
@@ -69,25 +68,9 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
           ) {
             return defaultInstallTask();
           }
-          const newInstall = await stat(this.destinationPath('package-lock.json'))
-            .then(
-              () => false,
-              () => stat(this.destinationPath('node_modules'))
-            )
-            .then(
-              () => false,
-              () => true
-            );
           const gradle = buildTool === GRADLE;
           const command = gradle ? './gradlew' : './npmw';
-          let args;
-          if (gradle) {
-            args = ['npmInstall'];
-          } else if (newInstall) {
-            args = ['dedupe'];
-          } else {
-            args = ['install'];
-          }
+          const args = gradle ? ['npmInstall'] : ['install'];
 
           try {
             await this.spawnCommand(command, args, { preferLocal: true });

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -24,7 +24,6 @@ const prompts = require('./prompts');
 const { GENERATOR_COMMON, GENERATOR_LANGUAGES, GENERATOR_SERVER } = require('../generator-list');
 const databaseTypes = require('../../jdl/jhipster/database-types');
 const { OAUTH2, SESSION } = require('../../jdl/jhipster/authentication-types');
-const { GRADLE, MAVEN } = require('../../jdl/jhipster/build-tool-types');
 const { CASSANDRA, COUCHBASE, MARIADB, MSSQL, MYSQL, ORACLE, POSTGRESQL, SQL } = require('../../jdl/jhipster/database-types');
 const { CAFFEINE, EHCACHE, HAZELCAST, INFINISPAN, MEMCACHED, REDIS } = require('../../jdl/jhipster/cache-types');
 const BaseBlueprintGenerator = require('../generator-base-blueprint');

--- a/generators/server/index.js
+++ b/generators/server/index.js
@@ -18,6 +18,7 @@
  */
 /* eslint-disable consistent-return */
 const chalk = require('chalk');
+const { stat } = require('fs').promises;
 const _ = require('lodash');
 const os = require('os');
 const prompts = require('./prompts');
@@ -68,9 +69,25 @@ module.exports = class JHipsterServerGenerator extends BaseBlueprintGenerator {
           ) {
             return defaultInstallTask();
           }
+          const newInstall = await stat(this.destinationPath('package-lock.json'))
+            .then(
+              () => false,
+              () => stat(this.destinationPath('node_modules'))
+            )
+            .then(
+              () => false,
+              () => true
+            );
           const gradle = buildTool === GRADLE;
           const command = gradle ? './gradlew' : './npmw';
-          const args = gradle ? ['npmInstall'] : ['install'];
+          let args;
+          if (gradle) {
+            args = ['npmInstall'];
+          } else if (newInstall) {
+            args = ['dedupe'];
+          } else {
+            args = ['install'];
+          }
 
           try {
             await this.spawnCommand(command, args, { preferLocal: true });


### PR DESCRIPTION
- Convert customInstallTask to async.
- Only execute customInstallTask for maven and gradle. Custom blueprint build tool?
- Add dependency on @angular-devkit/build-angular, currently it's a transient dependency been resolved to latest.
- ~Execute `npm dedupe` instead of `npm install` at new projects, dedupe resolves better our dependencies (probably due to bugs at npm).~
Gradle needs a custom task, which I don't know enough.

<!--
PR description.
-->

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
