### PR TITLE
persist --skip-client or --skip-server cli options to .jhipster/*.json configuration files

### DIFF
--- a/generators/entity/index.js
+++ b/generators/entity/index.js
@@ -984,6 +984,12 @@ class EntityGenerator extends BaseBlueprintGenerator {
         this.entityConfig.clientRootFolder = context.options.clientRootFolder;
       }
     }
+    if (context.options.skipClient !== undefined) {
+      this.entityConfig.skipClient = context.options.skipClient;
+    }
+    if (context.options.skipServer !== undefined) {
+      this.entityConfig.skipServer = context.options.skipServer;
+    }
     dest.experimental = context.options.experimental;
 
     dest.entityTableName = generator.getTableName(context.options.tableName || dest.name);


### PR DESCRIPTION
persist --skip-client or --skip-server cli options to .jhipster/*.json configuration files

add skipClient or skipServer options to .jhipster/*.json files on entity creation via cli options. When these entities are regenerated, will have their desired options skipped

Fix #15366
---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.
