### PR TITLE
[Angular] Fix warning dayjs

### DIFF
--- a/generators/client/templates/angular/angular.json.ejs
+++ b/generators/client/templates/angular/angular.json.ejs
@@ -38,6 +38,9 @@
         "build": {
           "builder": "@angular-builders/custom-webpack:browser",
           "options": {
+            "allowedCommonJsDependencies": [
+              "dayjs"
+            ],
             "customWebpackConfig": {
               "path": "./webpack/webpack.custom.js"
             },


### PR DESCRIPTION
Remove this warning:

```
Warning: /Users/quentinmonmert/Docs/JHipster/app-angular/src/main/webapp/app/config/dayjs.ts depends on 'dayjs/locale/fr'. CommonJS or AMD dependencies can cause optimization bailouts.
For more info see: https://angular.io/guide/build#configuring-commonjs-dependencies
``` 

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
