### PR TITLE
[React] Downgrade webpack-dev-server (error)

### DIFF
--- a/generators/client/templates/react/package.json
+++ b/generators/client/templates/react/package.json
@@ -85,7 +85,7 @@
     "typescript": "4.3.5",
     "webpack": "5.51.1",
     "webpack-cli": "4.8.0",
-    "webpack-dev-server": "4.0.0",
+    "webpack-dev-server": "3.11.2",
     "webpack-merge": "5.8.0",
     "webpack-notifier": "1.13.0",
     "workbox-webpack-plugin": "6.2.4"


### PR DESCRIPTION
Revert https://github.com/jhipster/generator-jhipster/commit/3e25a056b38d60285397155e478fcbc7286178e1#diff-45ad775caf02ce958066eda2b4a911763e810750a9dfaf3ca618a09306bbed87

`npm start` not working with the new version
![image](https://user-images.githubusercontent.com/9989211/130365834-78ac632c-2367-4ae0-936c-c50402daadbd.png)

Without `--inline`, there is an other error
![image](https://user-images.githubusercontent.com/9989211/130365854-cdf686f2-dad1-4f4f-825b-87ab188cfeb1.png)

Need a fix to upgrade
Doc is here https://github.com/webpack/webpack-dev-server/blob/master/migration-v4.md

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
