### PR TITLE
Fix typo Lighthoyse -> Lighthouse

### DIFF
--- a/generators/cypress/templates/src/test/javascript/cypress/integration/lighthouse.audits.ts.ejs
+++ b/generators/cypress/templates/src/test/javascript/cypress/integration/lighthouse.audits.ts.ejs
@@ -16,13 +16,13 @@
  See the License for the specific language governing permissions and
  limitations under the License.
 -%>
-describe('Lighthoyse Audits', () => {
-    beforeEach(() => { 
+describe('Lighthouse Audits', () => {
+    beforeEach(() => {
       cy.visit('/');
     });
 
     it('homepage', () => {
-      const customThresholds = {  
+      const customThresholds = {
         performance: 80,
         accessibility: 90,
         seo: 90,


### PR DESCRIPTION
<!--
PR description.
-->
This PR fixes typo in Lighthouse Audits cypress integration test declaration. It also removes unnecessary white spaces at the end of the line accordingly to .editorconfig.

---

Please make sure the below checklist is followed for Pull Requests.

- [ ] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [ ] Tests are added where necessary
- [ ] The JDL part is updated if necessary
- [ ] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [ ] Documentation is added/updated where necessary
- [ ] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
