### PR TITLE
Vue: Upgrade Typescript / Remove IE support to open file?

### DIFF
--- a/generators/client/templates/vue/package.json
+++ b/generators/client/templates/vue/package.json
@@ -68,7 +68,7 @@
     "eslint": "6.8.0",
     "eslint-plugin-prettier": "3.4.1",
     "eslint-plugin-vue": "7.17.0",
-    "typescript": "4.3.5",
+    "typescript": "4.4.2",
     "url-loader": "4.1.1",
     "webpack": "5.51.1",
     "webpack-bundle-analyzer": "4.4.2",

--- a/generators/client/templates/vue/src/main/webapp/app/shared/data/data-utils.service.ts.ejs
+++ b/generators/client/templates/vue/src/main/webapp/app/shared/data/data-utils.service.ts.ejs
@@ -44,25 +44,18 @@ export default class JhiDataUtils extends Vue {
    * Method to open file
    */
   openFile(contentType, data) {
-    if (window.navigator && window.navigator.msSaveOrOpenBlob) {
-      // To support IE and Edge
-      const byteCharacters = atob(data);
-      const byteNumbers = new Array(byteCharacters.length);
-      for (let i = 0; i < byteCharacters.length; i++) {
-        byteNumbers[i] = byteCharacters.charCodeAt(i);
-      }
-      const byteArray = new Uint8Array(byteNumbers);
-      const blob = new Blob([byteArray], {
-        type: contentType
-      });
-      window.navigator.msSaveOrOpenBlob(blob);
-    } else {
-      // Other browsers
-      const fileURL = `data:${contentType};base64,${data}`;
-      const win = window.open();
-      win.document.write(
-        '<iframe src="' + fileURL + '" frameborder="0" style="border:0; top:0px; left:0px; bottom:0px; right:0px; width:100%; height:100%;" allowfullscreen></iframe>');
+    const byteCharacters = atob(data);
+    const byteNumbers = new Array(byteCharacters.length);
+    for (let i = 0; i < byteCharacters.length; i++) {
+      byteNumbers[i] = byteCharacters.charCodeAt(i);
     }
+    const byteArray = new Uint8Array(byteNumbers);
+    const blob = new Blob([byteArray], {
+      type: contentType
+    });
+    const objectURL = URL.createObjectURL(blob);
+    const win = window.open(objectURL);
+    win!.onload = () => URL.revokeObjectURL(objectURL);
   }
 
   /**

--- a/generators/client/templates/vue/src/test/javascript/spec/app/shared/data/data-utils.service.spec.ts.ejs
+++ b/generators/client/templates/vue/src/test/javascript/spec/app/shared/data/data-utils.service.spec.ts.ejs
@@ -34,15 +34,15 @@ describe('Formatter i18n', () => {
   });
 
   it('should open file', () => {
-    let result = null;
-    window.open = jest.fn().mockImplementationOnce(() => {
-      return {'document': {write: data => result = data}};
+    window.open = jest.fn().mockReturnValue({});
+    const objectURL = 'blob:http://localhost:9000/xxx';
+    URL.createObjectURL = jest.fn().mockImplementationOnce(() => {
+      return objectURL;
     });
 
     dataUtilsService.openFile('text', 'data');
-    expect(result).toBe('<iframe src="data:text;base64,data" frameborder="0"' +
-      ' style="border:0; top:0px; left:0px; bottom:0px; right:0px; width:100%; ' +
-      'height:100%;" allowfullscreen></iframe>');
+
+    expect(window.open).toBeCalledWith(objectURL);
   });
 
   it('should check text ends with suffix', () => {


### PR DESCRIPTION
Fix: https://github.com/jhipster/generator-jhipster/pull/16071

But **IE support** is removed, is it a good solution?

**msSaveOrOpenBlob** is deprecated https://developer.mozilla.org/en-US/docs/Web/API/Navigator/msSaveOrOpenBlob

![image](https://user-images.githubusercontent.com/9989211/131226623-b4e992ba-1a11-44a2-b6ed-0d76e7f6b242.png)

---

Please make sure the below checklist is followed for Pull Requests.

- [x] [All continuous integration tests](https://github.com/jhipster/generator-jhipster/actions) are green
- [x] Tests are added where necessary
- [x] The JDL part is updated if necessary
- [x] [jhipster-online](https://github.com/jhipster/jhipster-online) is updated if necessary
- [x] Documentation is added/updated where necessary
- [x] Coding Rules & Commit Guidelines as per our [CONTRIBUTING.md document](https://github.com/jhipster/generator-jhipster/blob/main/CONTRIBUTING.md) are followed

When you are still working on the PR, consider converting it to Draft (bellow reviewers) and adding `skip-ci` label, you can still see CI build result at your branch.

<!--
Please also reference the issue number in a commit message to [automatically close the related GitHub issue](https://help.github.com/articles/closing-issues-via-commit-messages/)

Note: It is also possible to add `[skip ci]` or `[ci skip]` to your commit message to skip continuous integration tests
-->
